### PR TITLE
Fix #70 - NPE in ObaRoutesForLocationRequest.Builder.  Sets cancelable

### DIFF
--- a/src/com/joulespersecond/oba/region/ObaRegionsTask.java
+++ b/src/com/joulespersecond/oba/region/ObaRegionsTask.java
@@ -165,6 +165,7 @@ public class ObaRegionsTask extends AsyncTask<Void, Integer, ArrayList<ObaRegion
 
         AlertDialog.Builder builder = new AlertDialog.Builder(mContext);
         builder.setTitle(mContext.getString(R.string.region_choose_region));
+        builder.setCancelable(false);
         builder.setItems(items, new DialogInterface.OnClickListener() {
 
             public void onClick(DialogInterface dialog, int item) {


### PR DESCRIPTION
to false for the manual region selection dialog to force the user to
pick a region, so even if location services fail and return null the app
can fall back to use the default location of the region (also, app
really isn't usable without picking a region).
