### PR TITLE
Fix #76 - Change message to user to "No arrivals in the next 35 minutes"

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -103,7 +103,7 @@
     <string name="stop_info_option_addstar">Add Star</string>
     <string name="stop_info_option_removestar">Remove Star</string>
     <string name="stop_info_option_reportproblem">Report Problem</string>
-    <string name="stop_info_nodata">There are no upcoming arrivals at this stop.</string>
+    <string name="stop_info_nodata">No arrivals in the next 35 minutes.</string>
     <string name="stop_info_item_options_title">Bus options</string>
     <string name="stop_info_filter_title">Show only these routes</string>
     <string name="stop_info_filter_header">Showing %1$d of %2$d routes</string>


### PR DESCRIPTION
when no arrivals are returned by the REST API.  35 minutes is the
arrivals-and-departures-for-stop REST API default value for minutesAfter
(see
http://developer.onebusaway.org/modules/onebusaway-application-modules/current/api/where/methods/arrivals-and-departures-for-stop.html).
