### PR TITLE
Fix #89 - Add support for experimental servers.

### DIFF
--- a/onebusaway-android/src/main/java/com/joulespersecond/oba/elements/ObaRegion.java
+++ b/onebusaway-android/src/main/java/com/joulespersecond/oba/elements/ObaRegion.java
@@ -90,4 +90,9 @@ public interface ObaRegion {
      * @return The Twitter URL for the region
      */
     public String getTwitterUrl();
+
+    /**
+     * @return true if this server is experimental, false if its production.
+     */
+    public boolean getExperimental();
 }

--- a/onebusaway-android/src/main/java/com/joulespersecond/oba/elements/ObaRegionElement.java
+++ b/onebusaway-android/src/main/java/com/joulespersecond/oba/elements/ObaRegionElement.java
@@ -77,6 +77,7 @@ public class ObaRegionElement implements ObaRegion {
     private final boolean supportsObaRealtimeApis;
     private final boolean supportsSiriRealtimeApis;
     private final String twitterUrl;
+    private final boolean experimental;
 
     ObaRegionElement() {
         id = 0;
@@ -91,6 +92,7 @@ public class ObaRegionElement implements ObaRegion {
         supportsObaRealtimeApis = false;
         supportsSiriRealtimeApis = false;
         twitterUrl = "";
+        experimental = true;
     }
 
     public ObaRegionElement(long id,
@@ -104,7 +106,8 @@ public class ObaRegionElement implements ObaRegion {
             boolean supportsObaDiscoveryApis,
             boolean supportsObaRealtimeApis,
             boolean supportsSiriRealtimeApis,
-            String twitterUrl) {
+            String twitterUrl,
+            boolean experimental) {
         this.id = id;
         this.regionName = name;
         this.active = active;
@@ -117,6 +120,7 @@ public class ObaRegionElement implements ObaRegion {
         this.supportsObaRealtimeApis = supportsObaRealtimeApis;
         this.supportsSiriRealtimeApis = supportsSiriRealtimeApis;
         this.twitterUrl = twitterUrl;
+        this.experimental = experimental;
     }
 
     @Override
@@ -178,7 +182,10 @@ public class ObaRegionElement implements ObaRegion {
     public String getTwitterUrl() {        
         return twitterUrl;
     }
-    
+
+    @Override
+    public boolean getExperimental() { return experimental; }
+
     @Override
     public int hashCode() {
         final int prime = 31;
@@ -215,6 +222,7 @@ public class ObaRegionElement implements ObaRegion {
                 + ", supportsObaRealtimeApis=" + supportsObaRealtimeApis
                 + ", supportsSiriRealtimeApis=" + supportsSiriRealtimeApis
                 + ", twitterUrl=" + twitterUrl
+                + ", experimental=" + experimental
                 + "]";
     }      
 }

--- a/onebusaway-android/src/main/java/com/joulespersecond/oba/provider/ObaContract.java
+++ b/onebusaway-android/src/main/java/com/joulespersecond/oba/provider/ObaContract.java
@@ -352,6 +352,14 @@ public final class ObaContract {
          * </P>
          */
         public static final String TWITTER_URL = "twitter_url";
+
+        /**
+         * Whether or not the server is experimental (i.e., not production).
+         * <P>
+         * Type: BOOLEAN
+         * </P>
+         */
+        public static final String EXPERIMENTAL = "experimental";
     }
 
     protected interface RegionBoundsColumns {
@@ -908,7 +916,8 @@ public final class ObaContract {
                 SUPPORTS_OBA_DISCOVERY,
                 SUPPORTS_OBA_REALTIME,
                 SUPPORTS_SIRI_REALTIME,
-                TWITTER_URL
+                TWITTER_URL,
+                EXPERIMENTAL
             };
 
             Cursor c = cr.query(buildUri((int)id), PROJECTION, null, null, null);
@@ -929,7 +938,8 @@ public final class ObaContract {
                             c.getInt(6) > 0,            // Supports Oba Discovery
                             c.getInt(7) > 0,            // Supports Oba Realtime
                             c.getInt(8) > 0,            // Supports Siri Realtime
-                            c.getString(9)              // Twitter URL
+                            c.getString(9),              // Twitter URL
+                            c.getInt(10) > 0               // Experimental
                         );
                 } finally {
                     c.close();

--- a/onebusaway-android/src/main/java/com/joulespersecond/oba/provider/ObaProvider.java
+++ b/onebusaway-android/src/main/java/com/joulespersecond/oba/provider/ObaProvider.java
@@ -35,7 +35,7 @@ public class ObaProvider extends ContentProvider {
     private static final String DATABASE_NAME = "com.joulespersecond.seattlebusbot.db";
 
     private class OpenHelper extends SQLiteOpenHelper {
-        private static final int DATABASE_VERSION = 19;
+        private static final int DATABASE_VERSION = 20;
 
         public OpenHelper(Context context) {
             super(context, DATABASE_NAME, null, DATABASE_VERSION);
@@ -167,6 +167,12 @@ public class ObaProvider extends ContentProvider {
                 db.execSQL(
                         "ALTER TABLE " + ObaContract.Regions.PATH +
                             " ADD COLUMN " + ObaContract.Regions.TWITTER_URL + " VARCHAR");
+                ++oldVersion;
+            }
+            if (oldVersion == 19) {
+                db.execSQL(
+                        "ALTER TABLE " + ObaContract.Regions.PATH +
+                                " ADD COLUMN " + ObaContract.Regions.EXPERIMENTAL + " INTEGER");
             }
         }
 
@@ -332,6 +338,7 @@ public class ObaProvider extends ContentProvider {
         sRegionsProjectionMap.put(ObaContract.Regions.SUPPORTS_OBA_REALTIME,    ObaContract.Regions.SUPPORTS_OBA_REALTIME);
         sRegionsProjectionMap.put(ObaContract.Regions.SUPPORTS_SIRI_REALTIME,   ObaContract.Regions.SUPPORTS_SIRI_REALTIME);
         sRegionsProjectionMap.put(ObaContract.Regions.TWITTER_URL,   ObaContract.Regions.TWITTER_URL);
+        sRegionsProjectionMap.put(ObaContract.Regions.EXPERIMENTAL,   ObaContract.Regions.EXPERIMENTAL);
 
         sRegionBoundsProjectionMap = new HashMap<String, String>();
         sRegionBoundsProjectionMap.put(ObaContract.RegionBounds._ID,       ObaContract.RegionBounds._ID);

--- a/onebusaway-android/src/main/java/com/joulespersecond/oba/region/ExperimentalRegionsPreference.java
+++ b/onebusaway-android/src/main/java/com/joulespersecond/oba/region/ExperimentalRegionsPreference.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright (C) 2013 University of South Florida (sjbarbeau@gmail.com).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.joulespersecond.oba.region;
+
+import android.app.AlertDialog;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.content.res.TypedArray;
+import android.os.Parcel;
+import android.os.Parcelable;
+import android.preference.CheckBoxPreference;
+import android.preference.Preference;
+import android.util.AttributeSet;
+
+import com.joulespersecond.seattlebusbot.Application;
+import com.joulespersecond.seattlebusbot.PreferenceHelp;
+import com.joulespersecond.seattlebusbot.R;
+
+/**
+ * Custom preference to handle enabling and disabling experimental
+ * (i.e., non-production) OBA regions
+ *
+ * Code for saving/restoring state based on example at:
+ * http://developer.android.com/guide/topics/ui/settings.html
+ *
+ * and Android internal YesNoPreference:
+ * https://github.com/android/platform_frameworks_base/blob/master/core/java/com/android/internal/preference/YesNoPreference.java
+ *
+ * @author Sean Barbeau
+ */
+public class ExperimentalRegionsPreference extends CheckBoxPreference {
+
+    private boolean mCurrentValue;
+    private final boolean DEFAULT_VALUE = false;
+
+    //
+    // Needed constructors.
+    //
+    public ExperimentalRegionsPreference(Context context) {
+        super(context);
+        initCheckedState();
+    }
+
+    public ExperimentalRegionsPreference(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        initCheckedState();
+    }
+
+    public ExperimentalRegionsPreference(Context context, AttributeSet attrs, int defStyle) {
+        super(context, attrs, defStyle);
+        initCheckedState();
+    }
+
+    protected void initCheckedState(){
+        setChecked(Application.getPrefs().getBoolean(getContext().getString(R.string.preference_key_experimental_regions), DEFAULT_VALUE));
+    }
+
+    @Override
+    public boolean isPersistent() {
+        return true;
+    }
+
+    @Override
+    protected void onClick() {
+        if (!isChecked()) {
+            /*
+            Warn the user before enabling, since experimental regions
+            may not have real-time info or may be unavailable.
+            */
+            AlertDialog dialog = new AlertDialog.Builder(getContext())
+                    .setMessage(R.string.preferences_experimental_regions_enable_warning)
+                    .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
+                        @Override
+                        public void onClick(DialogInterface dialog, int which) {
+                            dialog.dismiss();
+                            setValue(true);
+                        }
+                    })
+                    .setNegativeButton(android.R.string.cancel, new DialogInterface.OnClickListener() {
+                        @Override
+                        public void onClick(DialogInterface dialog, int which) {
+                            dialog.dismiss();
+                        }
+                    })
+                    .create();
+            dialog.show();
+        } else {
+            if (Application.get().getCurrentRegion() != null &&
+                    Application.get().getCurrentRegion().getExperimental()) {
+                // If the user is currently using an experimental region, warn that it won't be available
+                AlertDialog dialog = new AlertDialog.Builder(getContext())
+                        .setMessage(R.string.preferences_experimental_regions_disable_warning)
+                        .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
+                            @Override
+                            public void onClick(DialogInterface dialog, int which) {
+                                dialog.dismiss();
+                                // Set the region info to null, so we no longer use the current experimental region
+                                Application.get().setCurrentRegion(null);
+                                setValue(false);
+                            }
+                        })
+                        .setNegativeButton(android.R.string.cancel, new DialogInterface.OnClickListener() {
+                            @Override
+                            public void onClick(DialogInterface dialog, int which) {
+                                dialog.dismiss();
+                            }
+                        })
+                        .create();
+                dialog.show();
+            } else {
+                setValue(false);
+            }
+        }
+    }
+
+    /**
+     * Sets the experimental regions preference (both user interface and shared preference value) to the input value
+     * @param newValue true if the preference should be set to true, false if it should be set to false
+     */
+    public void setValue(boolean newValue) {
+        mCurrentValue = newValue;
+        setChecked(newValue);
+        PreferenceHelp.saveBoolean(getContext().getString(R.string.preference_key_experimental_regions), newValue);
+    }
+
+    @Override
+    protected void onSetInitialValue(boolean restorePersistedValue, Object defaultValue) {
+        if (restorePersistedValue) {
+            // Restore existing state
+            mCurrentValue = this.getPersistedBoolean(mCurrentValue);
+        } else {
+            // Set default state from the XML attribute
+            mCurrentValue = (Boolean) defaultValue;
+            persistBoolean(mCurrentValue);
+        }
+    }
+
+    @Override
+    protected Object onGetDefaultValue(TypedArray a, int index) {
+        return a.getBoolean(index, DEFAULT_VALUE);
+    }
+
+    @Override
+    protected Parcelable onSaveInstanceState() {
+        final Parcelable superState = super.onSaveInstanceState();
+
+        // Create instance of custom BaseSavedState
+        final SavedState myState = new SavedState(superState);
+        // Set the state's value with the class member that holds current setting value
+        myState.value = mCurrentValue;
+        return myState;
+    }
+
+    @Override
+    protected void onRestoreInstanceState(Parcelable state) {
+        // Check whether we saved the state in onSaveInstanceState
+        if (state == null || !state.getClass().equals(SavedState.class)) {
+            // Didn't save the state, so call superclass
+            super.onRestoreInstanceState(state);
+            return;
+        }
+
+        // Cast state to custom BaseSavedState and pass to superclass
+        SavedState myState = (SavedState) state;
+        super.onRestoreInstanceState(myState.getSuperState());
+
+        // Set this Preference to reflect the restored state
+        setValue(myState.value);
+    }
+
+    /**
+     * Used to handle onSaveInstanceState()/onRestoreInstanceState properly, based on example
+     * at http://developer.android.com/guide/topics/ui/settings.html
+     */
+    private static class SavedState extends Preference.BaseSavedState {
+        // Member that holds the setting's value
+        boolean value;
+
+        public SavedState(Parcelable superState) {
+            super(superState);
+        }
+
+        public SavedState(Parcel source) {
+            super(source);
+            // Get the current preference's value
+            value = source.readByte() != 0;
+        }
+
+        @Override
+        public void writeToParcel(Parcel dest, int flags) {
+            super.writeToParcel(dest, flags);
+            // Write the preference's value
+            dest.writeByte((byte) (value ? 1 : 0));
+        }
+
+        // Standard creator object using an instance of this class
+        public static final Parcelable.Creator<SavedState> CREATOR =
+                new Parcelable.Creator<SavedState>() {
+
+                    public SavedState createFromParcel(Parcel in) {
+                        return new SavedState(in);
+                    }
+
+                    public SavedState[] newArray(int size) {
+                        return new SavedState[size];
+                    }
+                };
+    }
+}

--- a/onebusaway-android/src/main/java/com/joulespersecond/oba/request/ObaRegionsRequest.java
+++ b/onebusaway-android/src/main/java/com/joulespersecond/oba/request/ObaRegionsRequest.java
@@ -38,14 +38,11 @@ public final class ObaRegionsRequest extends RequestBase implements
     // This currently has a very simple builder because you can't do much with this "API"
     //
     public static class Builder {
-        private static Uri URI = Uri.parse("http://regions.onebusaway.org/regions.json");
+        private static Uri URI = Uri.parse("http://regions.onebusaway.org/regions-v3.json");
 
-        public Builder(Context context) {
-            //super(context);
-        }
+        public Builder(Context context) {}
         
         public Builder(Context context, Uri uri) {
-            //super(context);
             URI = uri;
         }
 
@@ -68,7 +65,7 @@ public final class ObaRegionsRequest extends RequestBase implements
      * the requester to set the URI to retrieve the regions info
      * from
      * @param context The package context.
-     * @param uri URI to the regions.json file
+     * @param uri URI to the regions file
      * @return The new request instance.
      */
     public static ObaRegionsRequest newRequest(Context context, Uri uri) {
@@ -93,7 +90,7 @@ public final class ObaRegionsRequest extends RequestBase implements
     private ObaRegionsResponse getRegionFromResource(){
         ObaRegionsResponse response = null;
         
-        InputStream is = Application.get().getApplicationContext().getResources().openRawResource(R.raw.regions);                        
+        InputStream is = Application.get().getApplicationContext().getResources().openRawResource(R.raw.regions_v3);
         ObaApi.SerializationHandler handler = ObaApi.getSerializer(ObaRegionsResponse.class);
         response = handler.deserialize(new InputStreamReader(is), ObaRegionsResponse.class);
         if (response == null) {

--- a/onebusaway-android/src/main/java/com/joulespersecond/seattlebusbot/PreferencesActivity.java
+++ b/onebusaway-android/src/main/java/com/joulespersecond/seattlebusbot/PreferencesActivity.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2010 Brian Ferris (bdferris@onebusaway.org)
+ * Copyright (C) 2010-2013 Brian Ferris (bdferris@onebusaway.org)
+ * and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,39 +17,71 @@
 package com.joulespersecond.seattlebusbot;
 
 import com.actionbarsherlock.app.SherlockPreferenceActivity;
+import com.actionbarsherlock.view.Window;
+import com.joulespersecond.oba.region.ObaRegionsTask;
+
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.preference.Preference;
 import android.preference.Preference.OnPreferenceChangeListener;
 import android.text.TextUtils;
 import android.util.Log;
+import android.widget.Toast;
 
 public class PreferencesActivity extends SherlockPreferenceActivity
-            implements Preference.OnPreferenceClickListener, OnPreferenceChangeListener {
+            implements Preference.OnPreferenceClickListener, OnPreferenceChangeListener,
+            SharedPreferences.OnSharedPreferenceChangeListener, ObaRegionsTask.Callback {
     private static final String TAG = "PreferencesActivity";
     
     Preference regionPref;
-    Preference customApiUrlpref;
-    Preference autoSelectRegion;
-    
+    Preference customApiUrlPref;
+
     boolean autoSelectInitialValue;  //Save initial value so we can compare to current value in onDestroy()
     
     // Soo... we can use SherlockPreferenceActivity to display the
     // action bar, but we can't use a PreferenceFragment?
     @SuppressWarnings("deprecation")
     public void onCreate(Bundle savedInstanceState) {
+        requestWindowFeature(Window.FEATURE_INDETERMINATE_PROGRESS);
         super.onCreate(savedInstanceState);
         UIHelp.setupActionBar(getSupportActionBar());
+        setSupportProgressBarIndeterminate(true);
+
         addPreferencesFromResource(R.xml.preferences);
 
         regionPref = findPreference(getString(R.string.preference_key_region));
         regionPref.setOnPreferenceClickListener(this);
         
-        customApiUrlpref = findPreference(getString(R.string.preference_key_oba_api_url));
-        customApiUrlpref.setOnPreferenceChangeListener(this);
-                                
-        SharedPreferences settings = Application.getPrefs();        
-        autoSelectInitialValue = settings.getBoolean(getString(R.string.preference_key_auto_select_region), true);         
+        customApiUrlPref = findPreference(getString(R.string.preference_key_oba_api_url));
+        customApiUrlPref.setOnPreferenceChangeListener(this);
+
+        SharedPreferences settings = Application.getPrefs();
+        autoSelectInitialValue = settings.getBoolean(getString(R.string.preference_key_auto_select_region), true);
+
+        settings.registerOnSharedPreferenceChangeListener(this);
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        changePreferenceSummary(getString(R.string.preference_key_region));
+    }
+
+    /**
+     * Changes the summary of a preference based on a given preference key
+     * @param preferenceKey preference key that triggers a change in summary
+     */
+    private void changePreferenceSummary(String preferenceKey) {
+        // Change the current region summary and server API URL summary
+        if (preferenceKey.equalsIgnoreCase(getString(R.string.preference_key_region)) || preferenceKey.equalsIgnoreCase(getString(R.string.preference_key_oba_api_url))) {
+            if (Application.get().getCurrentRegion() != null) {
+                regionPref.setSummary(getString(R.string.preferences_region_summary, Application.get().getCurrentRegion().getName()));
+                customApiUrlPref.setSummary(getString(R.string.preferences_oba_api_servername_summary));
+            } else {
+                regionPref.setSummary(getString(R.string.preferences_region_summary_custom_api));
+                customApiUrlPref.setSummary(Application.get().getCustomApiUrl());
+            }
+        }
     }
 
     @Override
@@ -61,7 +94,7 @@ public class PreferencesActivity extends SherlockPreferenceActivity
 
     @Override
     public boolean onPreferenceChange(Preference preference, Object newValue) {
-        if (preference.equals(customApiUrlpref) && newValue instanceof String) {
+        if (preference.equals(customApiUrlPref) && newValue instanceof String) {
             String apiUrl = (String) newValue;
                                     
             if(!TextUtils.isEmpty(apiUrl)){
@@ -73,7 +106,7 @@ public class PreferencesActivity extends SherlockPreferenceActivity
                 if (BuildConfig.DEBUG) { Log.d(TAG, "User entered blank API URL, re-initializing regions..."); }
                 NavHelp.goHome(this);
             }
-        }  
+        }
         return true;
     }
     
@@ -89,5 +122,53 @@ public class PreferencesActivity extends SherlockPreferenceActivity
             NavHelp.goHome(this);
         }        
         super.onDestroy();
+    }
+
+    @Override
+    public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
+        SharedPreferences settings = Application.getPrefs();
+        // Listening to changes to a custom Preference doesn't seem to work, so we can listen to changes to the shared pref value instead
+        if (key.equals(getString(R.string.preference_key_experimental_regions))) {
+            boolean experimentalServers = settings.getBoolean(getString(R.string.preference_key_experimental_regions), false);
+            if (BuildConfig.DEBUG) { Log.d(TAG, "Experimental regions shared preference changed to " + experimentalServers); }
+
+            /*
+            Force a refresh of the regions list, but don't using blocking progress dialog
+            inside the ObaRegionsTask AsyncTask.
+            We need to use our own Action Bar progress bar here so its linked to this activity,
+            which will survive orientation changes.
+            */
+            setSupportProgressBarIndeterminateVisibility(true);
+            ObaRegionsTask task = new ObaRegionsTask(this, this, true, false);
+            task.execute();
+
+            // Wait to change the region preference description until the task callback
+        } else if (key.equals(getString(R.string.preference_key_oba_api_url))) {
+            // Change the region preference description to show we're not using a region
+            changePreferenceSummary(key);
+        }
+    }
+
+    //
+    // Region Task Callback
+    //
+    public void onTaskFinished(boolean currentRegionChanged) {
+        setSupportProgressBarIndeterminateVisibility(false);
+
+        if (currentRegionChanged) {
+            // If region was auto-selected, show user the region we're using
+            if (Application.getPrefs().getBoolean(getString(R.string.preference_key_auto_select_region), true)
+                    && Application.get().getCurrentRegion() != null) {
+                Toast.makeText(this,
+                        getString(R.string.region_region_found, Application.get().getCurrentRegion().getName()),
+                        Toast.LENGTH_LONG).show();
+            }
+
+            // Update the preference summary to show the newly selected region
+            changePreferenceSummary(getString(R.string.preference_key_region));
+
+            // Since the current region was updated as a result of enabling/disabling experimental servers, go home
+            NavHelp.goHome(this);
+        }
     }
 }

--- a/onebusaway-android/src/main/java/com/joulespersecond/seattlebusbot/map/BaseMapActivity.java
+++ b/onebusaway-android/src/main/java/com/joulespersecond/seattlebusbot/map/BaseMapActivity.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2011 Paul Watts (paulcwatts@gmail.com) and individual contributors.
+ * Copyright (C) 2011-2013 Paul Watts (paulcwatts@gmail.com)
+ * and individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -366,9 +367,18 @@ abstract public class BaseMapActivity extends SherlockMapActivity
     // Region Task Callback
     //
     @Override
-    public void onRegionUpdated(){
-        //Update map after a new region has been selected
+    public void onTaskFinished(boolean currentRegionChanged){
+        // Update map after a new region has been selected
         setMyLocation();
+
+        // If region changed and was auto-selected, show user what region we're using
+        if (currentRegionChanged
+                && Application.getPrefs().getBoolean(getString(R.string.preference_key_auto_select_region), true)
+                && Application.get().getCurrentRegion() != null) {
+            Toast.makeText(this,
+                    getString(R.string.region_region_found,Application.get().getCurrentRegion().getName()),
+                    Toast.LENGTH_LONG).show();
+        }
     }
 
     //
@@ -521,7 +531,9 @@ abstract public class BaseMapActivity extends SherlockMapActivity
         AlertDialog.Builder builder = new AlertDialog.Builder(this)
             .setTitle(R.string.main_outofrange_title)
             .setIcon(android.R.drawable.ic_dialog_map)
-            .setMessage(R.string.main_outofrange)
+            .setMessage(getString(R.string.main_outofrange,
+                    Application.get().getCurrentRegion() != null ?
+                            Application.get().getCurrentRegion().getName():""))
             .setPositiveButton(R.string.main_outofrange_yes,
                 new DialogInterface.OnClickListener() {
                     @Override

--- a/onebusaway-android/src/main/res/raw/regions_v3.json
+++ b/onebusaway-android/src/main/res/raw/regions_v3.json
@@ -1,0 +1,296 @@
+{
+  "code": 200, 
+  "text": "OK", 
+  "version": 3, 
+  "data": {
+    "list": [
+      {
+        "siriBaseUrl": null, 
+        "obaVersionInfo": "1.1.11-SNAPSHOT|1|1|11|SNAPSHOT|6950d86123a7a9e5f12065bcbec0c516f35d86d9", 
+        "supportsSiriRealtimeApis": false, 
+        "language": "en_US", 
+        "twitterUrl": "http://mobile.twitter.com/OBA_tampa", 
+        "supportsObaRealtimeApis": true, 
+        "bounds": [
+          {
+            "lat": 27.976910500000002, 
+            "latSpan": 0.5424609999999994, 
+            "lon": -82.445851, 
+            "lonSpan": 0.576357999999999
+          }
+        ], 
+        "supportsObaDiscoveryApis": true, 
+        "contactEmail": "onebusaway@gohart.org", 
+        "stopInfoUrl": null, 
+        "active": true, 
+        "facebookUrl": "", 
+        "obaBaseUrl": "http://api.tampa.onebusaway.org/api/", 
+        "id": 0, 
+        "experimental": false, 
+        "regionName": "Tampa"
+      }, 
+      {
+        "siriBaseUrl": null, 
+        "obaVersionInfo": "1.1.7|1|1|7||c8ee3d4906dd55ecafdd124f31f39c0f54a37b52", 
+        "supportsSiriRealtimeApis": false, 
+        "language": "en_US", 
+        "twitterUrl": "http://mobile.twitter.com/oba_pugetsound", 
+        "supportsObaRealtimeApis": true, 
+        "bounds": [
+          {
+            "lat": 47.221315, 
+            "latSpan": 0.33704, 
+            "lon": -122.4051325, 
+            "lonSpan": 0.440483
+          }, 
+          {
+            "lat": 47.5607395, 
+            "latSpan": 0.743251, 
+            "lon": -122.1462785, 
+            "lonSpan": 0.720901
+          }, 
+          {
+            "lat": 47.556288, 
+            "latSpan": 0.090694, 
+            "lon": -122.4013255, 
+            "lonSpan": 0.126793
+          }, 
+          {
+            "lat": 47.093563, 
+            "latSpan": 0.320892, 
+            "lon": -122.701637, 
+            "lonSpan": 0.55098
+          }, 
+          {
+            "lat": 47.5346090123, 
+            "latSpan": 0.889378024643, 
+            "lon": -122.3294835, 
+            "lonSpan": 0.621109
+          }, 
+          {
+            "lat": 47.9747595, 
+            "latSpan": 1.336481, 
+            "lon": -122.8512, 
+            "lonSpan": 1.0904
+          }, 
+          {
+            "lat": 47.6204755, 
+            "latSpan": 0.014397, 
+            "lon": -122.335392, 
+            "lonSpan": 0.00635600000001
+          }, 
+          {
+            "lat": 47.64585, 
+            "latSpan": 0.0669, 
+            "lon": -122.2963, 
+            "lonSpan": 0.0802
+          }, 
+          {
+            "lat": 47.9347358907, 
+            "latSpan": 0.68796117128, 
+            "lon": -121.993246104, 
+            "lonSpan": 0.784555996061
+          }
+        ], 
+        "supportsObaDiscoveryApis": true, 
+        "contactEmail": "onebusaway@soundtransit.org", 
+        "stopInfoUrl": "http://stopinfo.pugetsound.onebusaway.org", 
+        "active": true, 
+        "facebookUrl": "https://www.facebook.com/pages/OneBusAway/216091804930", 
+        "obaBaseUrl": "http://api.pugetsound.onebusaway.org/", 
+        "id": 1, 
+        "experimental": false, 
+        "regionName": "Puget Sound"
+      }, 
+      {
+        "siriBaseUrl": "http://bustime.mta.info/api/", 
+        "obaVersionInfo": "", 
+        "supportsSiriRealtimeApis": true, 
+        "language": "en_US", 
+        "twitterUrl": "http://mobile.twitter.com/nyctbusstop", 
+        "supportsObaRealtimeApis": false, 
+        "bounds": [
+          {
+            "lat": 40.707678, 
+            "latSpan": 0.4093900000000019, 
+            "lon": -74.01768100000001, 
+            "lonSpan": 0.4686659999999989
+          }, 
+          {
+            "lat": 40.8192825, 
+            "latSpan": 0.228707, 
+            "lon": -73.89908199999999, 
+            "lonSpan": 0.23146799999999246
+          }
+        ], 
+        "supportsObaDiscoveryApis": true, 
+        "contactEmail": "MTABusTime@mtahq.org", 
+        "stopInfoUrl": null, 
+        "active": true, 
+        "facebookUrl": "https://www.facebook.com/pages/MTA-New-York-City-Transit/232635164606", 
+        "obaBaseUrl": "http://bustime.mta.info/", 
+        "id": 2, 
+        "experimental": false, 
+        "regionName": "MTA New York"
+      }, 
+      {
+        "siriBaseUrl": null, 
+        "obaVersionInfo": "1.1.8-SNAPSHOT|1|1|8|SNAPSHOT|877d870ac5c5f64607113d08d6d362925839719e", 
+        "supportsSiriRealtimeApis": false, 
+        "language": "en_US", 
+        "twitterUrl": "http://mobile.twitter.com/OBA_atlanta", 
+        "supportsObaRealtimeApis": true, 
+        "bounds": [
+          {
+            "lat": 33.7901797681045, 
+            "latSpan": 0.002537628406997783, 
+            "lon": -84.39483216212469, 
+            "lonSpan": 0.016058977126604645
+          }, 
+          {
+            "lat": 33.84859251766493, 
+            "latSpan": 0.006806584025866869, 
+            "lon": -84.36189486914657, 
+            "lonSpan": 0.035245473959491846
+          }, 
+          {
+            "lat": 34.22444908498577, 
+            "latSpan": 0.06626826841780087, 
+            "lon": -84.48419886031866, 
+            "lonSpan": 0.051677923063323306
+          }, 
+          {
+            "lat": 33.78784752284655, 
+            "latSpan": 0.026695928046905237, 
+            "lon": -84.31082746240949, 
+            "lonSpan": 0.028927748099008
+          }, 
+          {
+            "lat": 33.8079649176, 
+            "latSpan": 0.8443565223999983, 
+            "lon": -84.34070523855, 
+            "lonSpan": 0.8666740198999889
+          }, 
+          {
+            "lat": 33.7842061834795, 
+            "latSpan": 0.030916824823002287, 
+            "lon": -84.36385552465549, 
+            "lonSpan": 0.08416295068897739
+          }, 
+          {
+            "lat": 33.8105225, 
+            "latSpan": 0.5874290000000002, 
+            "lon": -84.37966800000001, 
+            "lonSpan": 0.5820399999999921
+          }
+        ], 
+        "supportsObaDiscoveryApis": true, 
+        "contactEmail": "onebusaway@ce.gatech.edu", 
+        "stopInfoUrl": null, 
+        "active": true, 
+        "facebookUrl": "https://www.facebook.com/pages/ObaAtlanta/136662306506627", 
+        "obaBaseUrl": "http://onebusaway.gatech.edu/api/", 
+        "id": 3, 
+        "experimental": false, 
+        "regionName": "Atlanta"
+      }, 
+      {
+        "siriBaseUrl": "http://oba.mobilitylab.org/nextgen/api/", 
+        "obaVersionInfo": "1.1.11-SNAPSHOT|1|1|11|SNAPSHOT|70fe470458e6b54078e567e0f008a161938a7468", 
+        "supportsSiriRealtimeApis": true, 
+        "language": "en_US", 
+        "twitterUrl": "http://mobile.twitter.com/mobilitylabteam", 
+        "supportsObaRealtimeApis": true, 
+        "bounds": [
+          {
+            "lat": 39.1922654372773, 
+            "latSpan": 0.19698666650759833, 
+            "lon": -76.7851586402455, 
+            "lonSpan": 0.23177524413500805
+          }, 
+          {
+            "lat": 37.187614999999994, 
+            "latSpan": 0.13692999999999955, 
+            "lon": -80.41169, 
+            "lonSpan": 0.08337999999999113
+          }, 
+          {
+            "lat": 38.8941925, 
+            "latSpan": 0.06883300000000503, 
+            "lon": -77.0180425, 
+            "lonSpan": 0.10683699999999874
+          }, 
+          {
+            "lat": 39.0963510360948, 
+            "latSpan": 0.23640594282640137, 
+            "lon": -76.7502984250321, 
+            "lonSpan": 0.35456249746140145
+          }, 
+          {
+            "lat": 39.406371749910775, 
+            "latSpan": 0.23433081571348424, 
+            "lon": -77.80964031815529, 
+            "lonSpan": 0.36454707384109497
+          }, 
+          {
+            "lat": 38.882281, 
+            "latSpan": 0.08580200000000104, 
+            "lon": -77.107778, 
+            "lonSpan": 0.1089900000000057
+          }, 
+          {
+            "lat": 38.7269105, 
+            "latSpan": 0.4100249999999974, 
+            "lon": -77.29476, 
+            "lonSpan": 0.6090959999999939
+          }, 
+          {
+            "lat": 38.960672, 
+            "latSpan": 1.2862760000000009, 
+            "lon": -77.0174175, 
+            "lonSpan": 1.8884749999999997
+          }, 
+          {
+            "lat": 38.895090499999995, 
+            "latSpan": 0.5927969999999974, 
+            "lon": -77.059198, 
+            "lonSpan": 0.7805180000000007
+          }, 
+          {
+            "lat": 39.1120985, 
+            "latSpan": 0.35281899999999666, 
+            "lon": -77.17786100000001, 
+            "lonSpan": 0.48159600000001035
+          }, 
+          {
+            "lat": 38.852059, 
+            "latSpan": 0.32038200000000217, 
+            "lon": -77.257233, 
+            "lonSpan": 0.4162059999999883
+          }, 
+          {
+            "lat": 39.4302745, 
+            "latSpan": 0.10931300000000022, 
+            "lon": -77.40370949999999, 
+            "lonSpan": 0.12437899999999047
+          }, 
+          {
+            "lat": 38.598434499999996, 
+            "latSpan": 0.5997209999999953, 
+            "lon": -77.2656675, 
+            "lonSpan": 0.5209109999999981
+          }
+        ], 
+        "supportsObaDiscoveryApis": true, 
+        "contactEmail": "paul.mackie@mobilitylab.org", 
+        "stopInfoUrl": null, 
+        "active": true, 
+        "facebookUrl": "https://www.facebook.com/218056428212495", 
+        "obaBaseUrl": "http://oba.mobilitylab.org/", 
+        "id": 4, 
+        "experimental": true, 
+        "regionName": "Washington, D.C. (beta)"
+      }
+    ]
+  }
+}

--- a/onebusaway-android/src/main/res/values/do_not_translate.xml
+++ b/onebusaway-android/src/main/res/values/do_not_translate.xml
@@ -22,5 +22,6 @@
     <string name="preference_key_oba_api_url">preferences_oba_api_url</string>
     <string name="preference_key_last_region_update">preference_last_region_update</string>  
     <string name="preference_key_auto_refresh_regions">preference_auto_refresh_regions</string>
-    <string name="preference_key_auto_select_region">preference_auto_select_region</string>        
+    <string name="preference_key_auto_select_region">preference_auto_select_region</string>
+    <string name="preference_key_experimental_regions">preference_experimental_regions</string>
 </resources>

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -68,7 +68,7 @@
     <string name="main_waiting_for_location">Trying to get a fix on your location&#8230;</string>
     <string name="main_location_unavailable">Unable to get your location.</string>
     <string name="main_outofrange_title">Out of range</string>
-    <string name="main_outofrange">You are out of OneBusAway\'s service area.\n\nGo there now?</string>
+    <string name="main_outofrange">You are out of the %1$s service area.\n\nGo there now?</string>
     <string name="main_outofrange_yes">Take me there</string>
     <string name="main_outofrange_no">Stay where I am</string>
 
@@ -228,6 +228,7 @@
     <string name ="region_detecting_server">Finding your transit services&#8230;</string>
     <string name ="region_choose_region">Choose region</string>
     <string name ="region_disabled_auto_selection">Disabled automatic region selection. You can enable in Preferences.</string>
+    <string name ="region_region_found">Found %1$s region</string>
 
     <!--  Bug report -->
     <string name="bug_report_subject">OneBusAway: Feedback</string>
@@ -239,7 +240,8 @@
     <string name="preferences_category_backup">Backup</string>
     <string name="preferences_category_advanced">Advanced</string>
     <string name="preferences_region_title">Your region</string>
-    <string name="preferences_region_summary">The transit region used by the app</string>
+    <string name="preferences_region_summary">%1$s is currently selected</string>
+    <string name="preferences_region_summary_custom_api">A custom API server is being used</string>
     <string name="preferences_auto_refresh_regions_title">Auto-refresh region list</string>
     <string name="preferences_auto_refresh_regions_summary">Automatically updates region info weekly</string>
     <string name="preferences_auto_select_region_title">Automatic region</string>
@@ -257,4 +259,9 @@
     <string name="preferences_db_restore_warning">This will wipe out any existing data! Go ahead?</string>
     <string name="preferences_db_restored">Restore successful! Please restart OneBusAway.</string>
     <string name="preferences_db_restore_error">Unable to restore: %1$s</string>
+
+    <string name="preferences_experimental_regions_title">Experimental Regions</string>
+    <string name="preferences_experimental_regions_summary">Enables regions that may be unstable</string>
+    <string name="preferences_experimental_regions_enable_warning">Experimental regions may be unstable and without real-time info! Go ahead?</string>
+    <string name="preferences_experimental_regions_disable_warning">Your current experimental region won\'t be available! Go ahead?</string>
 </resources>

--- a/onebusaway-android/src/main/res/xml/preferences.xml
+++ b/onebusaway-android/src/main/res/xml/preferences.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Copyright (C) 2010 Brian Ferris (bdferris@onebusaway.org)
+<!-- Copyright (C) 2010-2013 Brian Ferris (bdferris@onebusaway.org)
+     and individual contributors
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.
@@ -43,6 +44,9 @@
             android:summary="@string/preferences_restore_summary"/>
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/preferences_category_advanced">
+        <com.joulespersecond.oba.region.ExperimentalRegionsPreference
+            android:title="@string/preferences_experimental_regions_title"
+            android:summary="@string/preferences_experimental_regions_summary" />
         <EditTextPreference
             android:title="@string/preferences_oba_api_servername_title"
             android:summary="@string/preferences_oba_api_servername_summary"            


### PR DESCRIPTION
As specified in #89, this patch:
1. Consumes a new experimental boolean value for each region from the new Regions API v3
2. Only uses servers with experimental set to false AND active set to true, by default
3. Allows the user to opt-in to including experimental servers (i.e., experimental set to true) for manual or automatic selection, via a preference

I've also discretely surfaced the currently selected region in a few places in the UI, so its more obvious to the user when an incorrect region is selected (we've had several users contact us that were connected to the wrong region due to location errors, and evidently didn't realize this, and didn't realize they could change the region in the preferences).

Upon initial startup following the `Finding transit services...` dialog, and at any time when a region is automatically chosen and changes from the previous value, a Toast saying `Found X region` is shown to the user:

![image](https://f.cloud.github.com/assets/928045/1694026/98109db4-5e99-11e3-899b-15b78e5802eb.png)

After a region is selected, if the user is out of range of the selected region, the dialog now names the region specifically (vs. the old dialog that said generically "You're out of the OneBusAway service area"):
![image](https://f.cloud.github.com/assets/928045/1694134/8e782356-5e9b-11e3-9598-5b30d8b37297.png)

I've also updated the Region preference to show the currently selected region in the summary of the preference, which is the currently suggested best-practice for Android preferences:

![image](https://f.cloud.github.com/assets/928045/1694047/f16026e6-5e99-11e3-88c0-af426f7781b9.png)

When a custom API URL is entered, the summary for the Region and OneBusAway API Server preferences is also changed to reflect that the app is using the entered API, instead of a chosen region:

![image](https://f.cloud.github.com/assets/928045/1694057/244ae4f6-5e9a-11e3-8f62-ecfce3ae169f.png)

@paulcwatts please review and make sure you're ok with the text that is displayed, and general behavior.  I would suggest putting this out in a beta release to let @kurtraschke test locally with the experimental D.C. instance (if he has access to an Android device) before doing a public release on Google Play.  I've tested from Tampa, including setting Tampa as an experimental region in my own Region API to see how it would react to me being closest to an experimental region, on a Samsung Galaxy S3 w/ Android 4.3 and everything seems fine, but it would be good to have a few others test as well.

And btw, Android Studio is very nice.  Seems fairly stable, I've only encountered a few bugs (cut/paste clipboard history going wild, some resource string values being displayed incorrectly in the code folding).  Will definitely be moving my other apps to Android Studio as time allows.
