### PR TITLE
Updating to Android Studio 0.4.0, Gradle 1.9

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Nov 06 17:42:35 EST 2013
+#Sun Dec 22 10:09:07 PST 2013
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.8-bin.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-1.9-all.zip

--- a/onebusaway-android/build.gradle
+++ b/onebusaway-android/build.gradle
@@ -19,7 +19,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.6.+'
+        classpath 'com.android.tools.build:gradle:0.7.1+'
     }
 }
 apply plugin: 'android'
@@ -35,6 +35,12 @@ android {
     defaultConfig {
         minSdkVersion 8
         targetSdkVersion 17
+    }
+
+    // http://stackoverflow.com/questions/20673625/gradle-0-7-0-duplicate-files-during-packaging-of-apk
+    packagingOptions {
+        exclude 'META-INF/LICENSE'
+        exclude 'META-INF/NOTICE'
     }
 
     if (project.hasProperty("secure.properties")


### PR DESCRIPTION
Android Studio 0.4.0 requires Gradle 1.9, which requires the Android
wrapper 0.7+, and 0.7.1 adds a bug fix that eliminates duplicate files.
