### PR TITLE
Update Gradle, Android Gradle plugin, and Android build tools versions.

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Dec 22 10:09:07 PST 2013
+#Mon Mar 24 16:56:11 EDT 2014
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.9-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-1.11-all.zip

--- a/onebusaway-android/build.gradle
+++ b/onebusaway-android/build.gradle
@@ -19,7 +19,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.7.1+'
+        classpath 'com.android.tools.build:gradle:0.9.+'
     }
 }
 apply plugin: 'android'
@@ -30,7 +30,7 @@ repositories {
 
 android {
     compileSdkVersion "Google Inc.:Google APIs:17"
-    buildToolsVersion "17.0.0"
+    buildToolsVersion "19.0.0"
 
     defaultConfig {
         minSdkVersion 8


### PR DESCRIPTION
These changes are needed for the project to build under the latest version of Android Studio (v0.5.2).
