### PR TITLE
Fix #112 - Add continuous integration via Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+language: java
+jdk: oraclejdk7
+
+before_install:
+    - chmod +x gradlew
+    - ANDROID_API_LEVEL=17
+    - ANDROID_SDK_TOOLS_VERSION=22.3
+    - ANDROID_BUILD_TOOLS_VERSION=19.0.0
+    - ANDROID_OS_VERSION=4.4.2
+
+    # Install Android SDK
+    - sudo apt-get update -qq
+    - if [ `uname -m` = x86_64 ]; then sudo apt-get install -qq --force-yes libgd2-xpm ia32-libs ia32-libs-multiarch > /dev/null; fi
+    - wget https://dl.google.com/android/android-sdk_r$ANDROID_SDK_TOOLS_VERSION-linux.tgz
+    - tar xzf android-sdk_r$ANDROID_SDK_TOOLS_VERSION-linux.tgz
+    - export ANDROID_HOME=$PWD/android-sdk-linux
+    - export PATH=${PATH}:${ANDROID_HOME}/tools:${ANDROID_HOME}/platform-tools
+
+    # Install Android build tools
+    - wget https://dl-ssl.google.com/android/repository/build-tools_r$ANDROID_BUILD_TOOLS_VERSION-linux.zip
+    - unzip build-tools_r$ANDROID_BUILD_TOOLS_VERSION-linux.zip -d $ANDROID_HOME
+    - mkdir -p $ANDROID_HOME/build-tools/
+    - mv $ANDROID_HOME/android-$ANDROID_OS_VERSION $ANDROID_HOME/build-tools/$ANDROID_BUILD_TOOLS_VERSION
+
+    # Install Android SDK components
+    - echo y | android update sdk --filter platform-tools,build-tools-$ANDROID_BUILD_TOOLS_VERSION,android-$ANDROID_API_LEVEL,addon-google_apis-google-$ANDROID_API_LEVEL,extra-android-m2repository,extra-android-support,extra-google-google_play_services,extra-google-m2repository --no-ui --force > /dev/null
+install:
+  - true
+script:
+    - TERM=dumb ./gradlew assembleDebug


### PR DESCRIPTION
Hopefully this builds - only questionable part is the Google APIs, everything else works on [OpenTripPlanner Android](https://travis-ci.org/CUTR-at-USF/OpenTripPlanner-for-Android).
