### PR TITLE
Fix #101 - Change "minute" to singular in message "X minute delay" for X...

### DIFF
--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -95,7 +95,7 @@
     <plurals name="stop_info_arrive_delayed">
         <item quantity="one">1 minute delay</item>
         <!-- Entire element below should be on a single line if XML is reformatted - see #99 -->
-        <item quantity="other"><xliff:g id="count">%d</xliff:g> minutes delay</item>
+        <item quantity="other"><xliff:g id="count">%d</xliff:g> minute delay</item>
     </plurals>
     <plurals name="stop_info_arrive_early">
         <item quantity="one">1 minute early</item>


### PR DESCRIPTION
... > 1.
