### PR TITLE
Update to #112 - Remove no-op install stage from Travis script, since pe...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,5 @@ android:
     # For Google Maps API v1
     - addon-google_apis-google-17
 
-install:
-  # Prevent `gradle assemble` from being invoked by overriding with no-op
-  - true
-
 script:
     - TERM=dumb ./gradlew assembleDebug -PdisablePreDex


### PR DESCRIPTION
...r https://github.com/travis-ci/travis-ci/issues/1395#issuecomment-42520643 the default install stage is no longer executed on Travis for Android projects.
