### PR TITLE
Update to #112 - Remove 'TERM=dumb` Travis command, since per https://gi...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ android:
     - addon-google_apis-google-17
 
 script:
-    - TERM=dumb ./gradlew assembleDebug -PdisablePreDex
+    - ./gradlew assembleDebug -PdisablePreDex


### PR DESCRIPTION
...thub.com/travis-ci/travis-ci/issues/2275 it is now included by default.
