### PR TITLE
remove mock location permission

### DIFF
--- a/onebusaway-android/src/main/AndroidManifest.xml
+++ b/onebusaway-android/src/main/AndroidManifest.xml
@@ -27,7 +27,6 @@
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
-    <uses-permission android:name="android.permission.ACCESS_MOCK_LOCATION"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
     <uses-permission android:name="android.permission.WAKE_LOCK"/>


### PR DESCRIPTION
Remove mock location permission as per Android Studio's recommendation. People can either add it when needed for testing or create a debug-specific manifest.

Related to #61. 
