### PR TITLE
Update to Android Studio 0.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
 
 android:
   components:
-    - build-tools-19.0.3
+    - build-tools-19.1.0
     # For Google Maps API v1
     - addon-google_apis-google-$ANDROID_API_LEVEL
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Mar 24 16:56:11 EDT 2014
+#Thu Jun 12 10:01:28 EDT 2014
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.11-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-1.12-all.zip

--- a/onebusaway-android/build.gradle
+++ b/onebusaway-android/build.gradle
@@ -19,7 +19,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:0.11.+'
     }
 }
 apply plugin: 'android'
@@ -30,7 +30,7 @@ repositories {
 
 android {
     compileSdkVersion "Google Inc.:Google APIs:17"
-    buildToolsVersion "19.0.3"
+    buildToolsVersion "19.1.0"
 
     defaultConfig {
         minSdkVersion 8


### PR DESCRIPTION
Requires update to 0.11 Android Gradle plugin, which requires 19.1.0 build tools.  Also bumps Gradle wrapper to 1.12.
