### PR TITLE
Update Android Gradle Plugin

### DIFF
--- a/onebusaway-android/build.gradle
+++ b/onebusaway-android/build.gradle
@@ -19,7 +19,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.11.+'
+        classpath 'com.android.tools.build:gradle:0.12.+'
     }
 }
 apply plugin: 'android'


### PR DESCRIPTION
Required for Android Studio (Beta) 0.8.X.
