### PR TITLE
Fix #163 - Add setting to change distance units

### DIFF
--- a/onebusaway-android/src/main/java/com/joulespersecond/seattlebusbot/PreferencesActivity.java
+++ b/onebusaway-android/src/main/java/com/joulespersecond/seattlebusbot/PreferencesActivity.java
@@ -16,18 +16,19 @@
  */
 package com.joulespersecond.seattlebusbot;
 
+import com.actionbarsherlock.app.SherlockPreferenceActivity;
+import com.actionbarsherlock.view.Window;
+import com.joulespersecond.oba.region.ObaRegionsTask;
+import com.joulespersecond.seattlebusbot.util.UIHelp;
+
 import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.preference.ListPreference;
 import android.preference.Preference;
 import android.preference.Preference.OnPreferenceChangeListener;
 import android.text.TextUtils;
 import android.util.Log;
 import android.widget.Toast;
-
-import com.actionbarsherlock.app.SherlockPreferenceActivity;
-import com.actionbarsherlock.view.Window;
-import com.joulespersecond.oba.region.ObaRegionsTask;
-import com.joulespersecond.seattlebusbot.util.UIHelp;
 
 public class PreferencesActivity extends SherlockPreferenceActivity
         implements Preference.OnPreferenceClickListener, OnPreferenceChangeListener,
@@ -41,6 +42,8 @@ public class PreferencesActivity extends SherlockPreferenceActivity
 
     boolean autoSelectInitialValue;
     //Save initial value so we can compare to current value in onDestroy()
+
+    ListPreference preferredUnits;
 
     // Soo... we can use SherlockPreferenceActivity to display the
     // action bar, but we can't use a PreferenceFragment?
@@ -63,6 +66,9 @@ public class PreferencesActivity extends SherlockPreferenceActivity
         autoSelectInitialValue = settings
                 .getBoolean(getString(R.string.preference_key_auto_select_region), true);
 
+        preferredUnits = (ListPreference) findPreference(
+                getString(R.string.preference_key_preferred_units));
+
         settings.registerOnSharedPreferenceChangeListener(this);
     }
 
@@ -70,6 +76,7 @@ public class PreferencesActivity extends SherlockPreferenceActivity
     protected void onResume() {
         super.onResume();
         changePreferenceSummary(getString(R.string.preference_key_region));
+        changePreferenceSummary(getString(R.string.preference_key_preferred_units));
     }
 
     /**
@@ -90,6 +97,9 @@ public class PreferencesActivity extends SherlockPreferenceActivity
                 regionPref.setSummary(getString(R.string.preferences_region_summary_custom_api));
                 customApiUrlPref.setSummary(Application.get().getCustomApiUrl());
             }
+        } else if (preferenceKey
+                .equalsIgnoreCase(getString(R.string.preference_key_preferred_units))) {
+            preferredUnits.setSummary(preferredUnits.getValue());
         }
     }
 
@@ -166,6 +176,9 @@ public class PreferencesActivity extends SherlockPreferenceActivity
             // Wait to change the region preference description until the task callback
         } else if (key.equals(getString(R.string.preference_key_oba_api_url))) {
             // Change the region preference description to show we're not using a region
+            changePreferenceSummary(key);
+        } else if (key.equalsIgnoreCase(getString(R.string.preference_key_preferred_units))) {
+            // Change the preferred units description
             changePreferenceSummary(key);
         }
     }

--- a/onebusaway-android/src/main/res/values/arrays.xml
+++ b/onebusaway-android/src/main/res/values/arrays.xml
@@ -91,4 +91,9 @@
         <item>The bus doesn\'t stop here</item>
         <item>Something else</item>
     </string-array>
+    <string-array name="preferred_units_options">
+        <item>@string/preferences_preferred_units_option_automatic</item>
+        <item>@string/preferences_preferred_units_option_metric</item>
+        <item>@string/preferences_preferred_units_option_imperial</item>
+    </string-array>
 </resources>

--- a/onebusaway-android/src/main/res/values/do_not_translate.xml
+++ b/onebusaway-android/src/main/res/values/do_not_translate.xml
@@ -24,4 +24,5 @@
     <string name="preference_key_auto_refresh_regions">preference_auto_refresh_regions</string>
     <string name="preference_key_auto_select_region">preference_auto_select_region</string>
     <string name="preference_key_experimental_regions">preference_experimental_regions</string>
+    <string name="preference_key_preferred_units">preference_preferred_units</string>
 </resources>

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -250,10 +250,18 @@
     <string name="report_problem_uservehicle_hint">optional</string>
 
     <!-- Region list -->
-    <plurals name="region_distance">
-        <item quantity="one">1 mile away</item>
+    <plurals name="region_distance_miles">
+    <item quantity="one">1 mile away</item>
         <!-- Entire element below should be on a single line if XML is reformatted - see #99 -->
         <item quantity="other"><xliff:g id="count">%s</xliff:g> miles away</item>
+    </plurals>
+    <plurals name="region_distance_kilometers">
+        <item quantity="one">1 kilometer away</item>
+        <!-- Entire element below should be on a single line if XML is reformatted - see #99 -->
+        <item quantity="other">
+            <xliff:g id="count">%s</xliff:g>
+            kilometers away
+        </item>
     </plurals>
     <string name="region_unavailable">unavailable</string>
     <string name="region_option_refresh">Refresh</string>
@@ -274,6 +282,7 @@
 
     <!-- Application Preferences -->
     <string name="preferences_category_location">Location</string>
+    <string name="preferences_category_display">Display</string>
     <string name="preferences_category_backup">Backup</string>
     <string name="preferences_category_advanced">Advanced</string>
     <string name="preferences_region_title">Your region</string>
@@ -287,6 +296,11 @@
     <string name="preferences_auto_select_region_summary">Set your current transit region based on
         your current location
     </string>
+
+    <string name="preferences_preferred_units_title">Preferred distance units</string>
+    <string name="preferences_preferred_units_option_automatic">Automatic</string>
+    <string name="preferences_preferred_units_option_metric">Metric (km, m)</string>
+    <string name="preferences_preferred_units_option_imperial">Imperial (mi, ft)</string>
 
     <string name="preferences_oba_api_servername_title">OneBusAway API Server</string>
     <string name="preferences_oba_api_servername_summary">Determines the server used in OneBusAway

--- a/onebusaway-android/src/main/res/xml/preferences.xml
+++ b/onebusaway-android/src/main/res/xml/preferences.xml
@@ -36,6 +36,15 @@
     		android:defaultValue="true"/>
     		 -->
     </PreferenceCategory>
+    <PreferenceCategory android:title="@string/preferences_category_display">
+        <ListPreference
+                android:key="@string/preference_key_preferred_units"
+                android:title="@string/preferences_preferred_units_title"
+                android:entries="@array/preferred_units_options"
+                android:entryValues="@array/preferred_units_options"
+                android:defaultValue="@string/preferences_preferred_units_option_automatic">
+        </ListPreference>
+    </PreferenceCategory>
     <PreferenceCategory android:title="@string/preferences_category_backup">
         <com.joulespersecond.seattlebusbot.backup.SavePreference
                 android:title="@string/preferences_save_title"


### PR DESCRIPTION
This includes an automatic option (default) that attempts to guess metric/imperial based on current locale (currently, it assumes Imperial for USA locale country setting and Metric for all others).  Automatic selection can be manually overridden by the user with explicit metric/imperial options.

Here's what the new preference category looks like:

![oba_preferred_units_resized](https://cloud.githubusercontent.com/assets/928045/3881073/7d8f4f76-218a-11e4-9936-100e009f002b.png)

... and here's the popup with options:
![oba_preferred_units_options_resized](https://cloud.githubusercontent.com/assets/928045/3881100/af886b48-218a-11e4-99a0-617505d389b4.png)

@paulcwatts This new preference didn't seem to fit cleanly into existing categories, so I created a new category "Display" for this, for lack of better ideas.  If you have suggestions for names, please let me know and I'll change the text.
