### PR TITLE
Fix #165 and #167 - Update Google Play services to 5.0.89, update Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,13 @@ android:
     - build-tools-19.1.0
     # For Google Maps API v1
     - addon-google_apis-google-$ANDROID_API_LEVEL
+    # Google Play Services
+    - extra-google-google_play_services
+    # Support library
+    - extra-android-support
+    # Latest artifacts in local repository
+    - extra-google-m2repository
+    - extra-android-m2repository
 
 before_script:
   # Create and start emulator

--- a/onebusaway-android/build.gradle
+++ b/onebusaway-android/build.gradle
@@ -98,7 +98,7 @@ tasks.whenTaskAdded { theTask ->
 
 dependencies {
     compile fileTree(dir: 'libs', include: '*.jar')
-    compile 'com.google.android.gms:play-services:5.0.77'
+    compile 'com.google.android.gms:play-services:5.0.89'
     compile 'com.actionbarsherlock:actionbarsherlock:4.4.0@aar'
     compile 'com.android.support:support-v4:19.1.+'
     compile 'com.fasterxml.jackson.core:jackson-core:2.3.3'


### PR DESCRIPTION
Update Google Play Services to `com.google.android.gms:play-services:5.0.89`, and update Travis to always pull newest Android build artifacts (so it builds using Google Repository v11).  Fixes #165 and #167.  This PR replaces #166.
