### PR TITLE
Fix #162 - Use 'GoogleApiClient' with 'FusedLocationApi'

### DIFF
--- a/onebusaway-android/build.gradle
+++ b/onebusaway-android/build.gradle
@@ -114,7 +114,7 @@ tasks.whenTaskAdded { theTask ->
 
 dependencies {
     compile fileTree(dir: 'libs', include: '*.jar')
-    compile 'com.google.android.gms:play-services:6.1.71'
+    compile 'com.google.android.gms:play-services:6.5.87'
     compile 'com.android.support:appcompat-v7:21.0.3'
     compile 'commons-io:commons-io:2.4'
     // JSON data binding for OBA REST API responses

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/util/test/LocationUtilTest.java
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/util/test/LocationUtilTest.java
@@ -2,7 +2,7 @@ package org.onebusaway.android.util.test;
 
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GooglePlayServicesUtil;
-import com.google.android.gms.location.LocationClient;
+import com.google.android.gms.common.api.GoogleApiClient;
 
 import org.onebusaway.android.util.LocationUtil;
 import org.onebusaway.android.util.TestHelp;
@@ -23,9 +23,9 @@ public class LocationUtilTest extends AndroidTestCase {
     public static final long FRESH_LOCATION_THRESHOLD_MS = 1000 * 60 * 5;  // Within last 5 minutes
 
     /**
-     * Google Location Services
+     * GoogleApiClient being used for Location Services
      */
-    LocationClient mLocationClient;
+    GoogleApiClient mGoogleApiClient;
 
     @Override
     protected void setUp() throws Exception {
@@ -34,10 +34,8 @@ public class LocationUtilTest extends AndroidTestCase {
         // Init Google Play Services as early as possible in the Fragment lifecycle to give it time
         if (GooglePlayServicesUtil.isGooglePlayServicesAvailable(getContext())
                 == ConnectionResult.SUCCESS) {
-            LocationUtil.LocationServicesCallback locCallback
-                    = new LocationUtil.LocationServicesCallback();
-            mLocationClient = new LocationClient(getContext(), locCallback, locCallback);
-            mLocationClient.connect();
+            mGoogleApiClient = LocationUtil.getGoogleApiClientWithCallbacks(getContext());
+            mGoogleApiClient.connect();
         }
     }
 
@@ -45,9 +43,9 @@ public class LocationUtilTest extends AndroidTestCase {
     protected void tearDown() throws Exception {
         super.tearDown();
 
-        // Tear down LocationClient
-        if (mLocationClient != null && mLocationClient.isConnected()) {
-            mLocationClient.disconnect();
+        // Tear down GoogleApiClient
+        if (mGoogleApiClient != null && mGoogleApiClient.isConnected()) {
+            mGoogleApiClient.disconnect();
         }
     }
 
@@ -116,7 +114,7 @@ public class LocationUtilTest extends AndroidTestCase {
             /**
              * Could return either a fused or Location API v1 location
              */
-            loc = LocationUtil.getLocation2(getContext(), mLocationClient);
+            loc = LocationUtil.getLocation2(getContext(), mGoogleApiClient);
             assertNotNull(loc);
             Log.d(TAG,
                     "Location Provider for Location Services test is '" + loc.getProvider() + "'");

--- a/onebusaway-android/src/main/java/org/onebusaway/android/region/ObaRegionsTask.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/region/ObaRegionsTask.java
@@ -18,7 +18,7 @@ package org.onebusaway.android.region;
 
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GooglePlayServicesUtil;
-import com.google.android.gms.location.LocationClient;
+import com.google.android.gms.common.api.GoogleApiClient;
 
 import org.onebusaway.android.BuildConfig;
 import org.onebusaway.android.R;
@@ -77,9 +77,9 @@ public class ObaRegionsTask extends AsyncTask<Void, Integer, ArrayList<ObaRegion
     private final boolean mShowProgressDialog;
 
     /**
-     * Google Location Services
+     * GoogleApiClient being used for Location Services
      */
-    LocationClient mLocationClient;
+    GoogleApiClient mGoogleApiClient;
 
     /**
      * @param callback a callback will be made via this interface after the task is complete
@@ -109,10 +109,8 @@ public class ObaRegionsTask extends AsyncTask<Void, Integer, ArrayList<ObaRegion
         mShowProgressDialog = showProgressDialog;
         if (GooglePlayServicesUtil.isGooglePlayServicesAvailable(context)
                 == ConnectionResult.SUCCESS) {
-            LocationUtil.LocationServicesCallback locCallback
-                    = new LocationUtil.LocationServicesCallback();
-            mLocationClient = new LocationClient(context, locCallback, locCallback);
-            mLocationClient.connect();
+            mGoogleApiClient = LocationUtil.getGoogleApiClientWithCallbacks(context);
+            mGoogleApiClient.connect();
         }
     }
 
@@ -150,8 +148,8 @@ public class ObaRegionsTask extends AsyncTask<Void, Integer, ArrayList<ObaRegion
 
         if (settings
                 .getBoolean(mContext.getString(R.string.preference_key_auto_select_region), true)) {
-            // Pass in the LocationClient initialized in constructor
-            Location myLocation = LocationUtil.getLocation2(mContext, mLocationClient);
+            // Pass in the GoogleApiClient initialized in constructor
+            Location myLocation = LocationUtil.getLocation2(mContext, mGoogleApiClient);
 
             ObaRegion closestRegion = RegionUtils.getClosestRegion(results, myLocation);
 
@@ -190,8 +188,8 @@ public class ObaRegionsTask extends AsyncTask<Void, Integer, ArrayList<ObaRegion
         }
 
         // Tear down Location Services client
-        if (mLocationClient != null) {
-            mLocationClient.disconnect();
+        if (mGoogleApiClient != null) {
+            mGoogleApiClient.disconnect();
         }
 
         super.onPostExecute(results);

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.java
@@ -18,7 +18,7 @@ package org.onebusaway.android.ui;
 
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GooglePlayServicesUtil;
-import com.google.android.gms.location.LocationClient;
+import com.google.android.gms.common.api.GoogleApiClient;
 
 import com.sothree.slidinguppanel.SlidingUpPanelLayout;
 
@@ -122,9 +122,9 @@ public class HomeActivity extends ActionBarActivity
     private static final int MY_LOC_BTN_ANIM_DURATION = 100;  // ms
 
     /**
-     * Google Location Services
+     * GoogleApiClient being used for Location Services
      */
-    protected LocationClient mLocationClient;
+    protected GoogleApiClient mGoogleApiClient;
 
     // Bottom Sliding panel
     SlidingUpPanelLayout mSlidingPanel;
@@ -258,9 +258,9 @@ public class HomeActivity extends ActionBarActivity
     @Override
     public void onStart() {
         super.onStart();
-        // Make sure LocationClient is connected, if available
-        if (mLocationClient != null && !mLocationClient.isConnected()) {
-            mLocationClient.connect();
+        // Make sure GoogleApiClient is connected, if available
+        if (mGoogleApiClient != null && !mGoogleApiClient.isConnected()) {
+            mGoogleApiClient.connect();
         }
     }
 
@@ -276,9 +276,9 @@ public class HomeActivity extends ActionBarActivity
 
     @Override
     public void onStop() {
-        // Tear down LocationClient
-        if (mLocationClient != null && mLocationClient.isConnected()) {
-            mLocationClient.disconnect();
+        // Tear down GoogleApiClient
+        if (mGoogleApiClient != null && mGoogleApiClient.isConnected()) {
+            mGoogleApiClient.disconnect();
         }
         super.onStop();
     }
@@ -661,7 +661,7 @@ public class HomeActivity extends ActionBarActivity
     }
 
     private String getLocationString(Context context) {
-        Location loc = LocationUtil.getLocation2(context, mLocationClient);
+        Location loc = LocationUtil.getLocation2(context, mGoogleApiClient);
         return LocationUtil.printLocationDetails(loc);
     }
 
@@ -864,10 +864,8 @@ public class HomeActivity extends ActionBarActivity
         // Init Google Play Services as early as possible in the Fragment lifecycle to give it time
         if (GooglePlayServicesUtil.isGooglePlayServicesAvailable(this)
                 == ConnectionResult.SUCCESS) {
-            LocationUtil.LocationServicesCallback locCallback
-                    = new LocationUtil.LocationServicesCallback();
-            mLocationClient = new LocationClient(this, locCallback, locCallback);
-            mLocationClient.connect();
+            mGoogleApiClient = LocationUtil.getGoogleApiClientWithCallbacks(this);
+            mGoogleApiClient.connect();
         }
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/MySearchFragmentBase.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/MySearchFragmentBase.java
@@ -17,7 +17,7 @@ package org.onebusaway.android.ui;
 
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GooglePlayServicesUtil;
-import com.google.android.gms.location.LocationClient;
+import com.google.android.gms.common.api.GoogleApiClient;
 
 import org.onebusaway.android.R;
 import org.onebusaway.android.util.LocationUtil;
@@ -50,9 +50,9 @@ abstract class MySearchFragmentBase extends ListFragment
     private static final int DELAYED_SEARCH_TIMEOUT = 1000;
 
     /**
-     * Google Location Services
+     * GoogleApiClient being used for Location Services
      */
-    LocationClient mLocationClient;
+    GoogleApiClient mGoogleApiClient;
 
     @Override
     public void onAttach(Activity activity) {
@@ -61,10 +61,8 @@ abstract class MySearchFragmentBase extends ListFragment
         // Init Google Play Services as early as possible in the Fragment lifecycle to give it time
         if (GooglePlayServicesUtil.isGooglePlayServicesAvailable(getActivity())
                 == ConnectionResult.SUCCESS) {
-            LocationUtil.LocationServicesCallback locCallback
-                    = new LocationUtil.LocationServicesCallback();
-            mLocationClient = new LocationClient(getActivity(), locCallback, locCallback);
-            mLocationClient.connect();
+            mGoogleApiClient = LocationUtil.getGoogleApiClientWithCallbacks(getActivity());
+            mGoogleApiClient.connect();
         }
     }
 
@@ -93,17 +91,17 @@ abstract class MySearchFragmentBase extends ListFragment
     @Override
     public void onStart() {
         super.onStart();
-        // Make sure LocationClient is connected, if available
-        if (mLocationClient != null && !mLocationClient.isConnected()) {
-            mLocationClient.connect();
+        // Make sure GoogleApiClient is connected, if available
+        if (mGoogleApiClient != null && !mGoogleApiClient.isConnected()) {
+            mGoogleApiClient.connect();
         }
     }
 
     @Override
     public void onStop() {
-        // Tear down LocationClient
-        if (mLocationClient != null && mLocationClient.isConnected()) {
-            mLocationClient.disconnect();
+        // Tear down GoogleApiClient
+        if (mGoogleApiClient != null && mGoogleApiClient.isConnected()) {
+            mGoogleApiClient.disconnect();
         }
         super.onStop();
     }
@@ -216,7 +214,7 @@ abstract class MySearchFragmentBase extends ListFragment
             result = base.getSearchCenter();
         }
         if (result == null) {
-            result = LocationUtil.getLocation(act, mLocationClient);
+            result = LocationUtil.getLocation(act, mGoogleApiClient);
         }
         return result;
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/RegionsFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/RegionsFragment.java
@@ -17,7 +17,7 @@ package org.onebusaway.android.ui;
 
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GooglePlayServicesUtil;
-import com.google.android.gms.location.LocationClient;
+import com.google.android.gms.common.api.GoogleApiClient;
 
 import org.onebusaway.android.BuildConfig;
 import org.onebusaway.android.R;
@@ -79,9 +79,9 @@ public class RegionsFragment extends ListFragment
     private ObaRegion mCurrentRegion;
 
     /**
-     * Google Location Services
+     * GoogleApiClient being used for Location Services
      */
-    LocationClient mLocationClient;
+    GoogleApiClient mGoogleApiClient;
 
     @Override
     public void onAttach(Activity activity) {
@@ -90,10 +90,8 @@ public class RegionsFragment extends ListFragment
         // Init Google Play Services as early as possible in the Fragment lifecycle to give it time
         if (GooglePlayServicesUtil.isGooglePlayServicesAvailable(getActivity())
                 == ConnectionResult.SUCCESS) {
-            LocationUtil.LocationServicesCallback locCallback
-                    = new LocationUtil.LocationServicesCallback();
-            mLocationClient = new LocationClient(getActivity(), locCallback, locCallback);
-            mLocationClient.connect();
+            mGoogleApiClient = LocationUtil.getGoogleApiClientWithCallbacks(getActivity());
+            mGoogleApiClient.connect();
         }
 
         mLocale = Locale.getDefault();
@@ -108,7 +106,7 @@ public class RegionsFragment extends ListFragment
 
         setHasOptionsMenu(true);
 
-        mLocation = LocationUtil.getLocation2(getActivity(), mLocationClient);
+        mLocation = LocationUtil.getLocation2(getActivity(), mGoogleApiClient);
         mCurrentRegion = Application.get().getCurrentRegion();
 
         Bundle args = new Bundle();
@@ -157,17 +155,17 @@ public class RegionsFragment extends ListFragment
     @Override
     public void onStart() {
         super.onStart();
-        // Make sure LocationClient is connected, if available
-        if (mLocationClient != null && !mLocationClient.isConnected()) {
-            mLocationClient.connect();
+        // Make sure GoogleApiClient is connected, if available
+        if (mGoogleApiClient != null && !mGoogleApiClient.isConnected()) {
+            mGoogleApiClient.connect();
         }
     }
 
     @Override
     public void onStop() {
-        // Tear down LocationClient
-        if (mLocationClient != null && mLocationClient.isConnected()) {
-            mLocationClient.disconnect();
+        // Tear down GoogleApiClient
+        if (mGoogleApiClient != null && mGoogleApiClient.isConnected()) {
+            mGoogleApiClient.disconnect();
         }
         super.onStop();
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/ReportProblemFragmentBase.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/ReportProblemFragmentBase.java
@@ -17,7 +17,7 @@ package org.onebusaway.android.ui;
 
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GooglePlayServicesUtil;
-import com.google.android.gms.location.LocationClient;
+import com.google.android.gms.common.api.GoogleApiClient;
 
 import org.onebusaway.android.R;
 import org.onebusaway.android.io.ObaApi;
@@ -50,9 +50,9 @@ public abstract class ReportProblemFragmentBase extends Fragment
     private static final int REPORT_LOADER = 100;
 
     /**
-     * Google Location Services
+     * GoogleApiClient being used for Location Services
      */
-    LocationClient mLocationClient;
+    GoogleApiClient mGoogleApiClient;
 
     @Override
     public void onAttach(Activity activity) {
@@ -61,10 +61,8 @@ public abstract class ReportProblemFragmentBase extends Fragment
         // Init Google Play Services as early as possible in the Fragment lifecycle to give it time
         if (GooglePlayServicesUtil.isGooglePlayServicesAvailable(getActivity())
                 == ConnectionResult.SUCCESS) {
-            LocationUtil.LocationServicesCallback locCallback
-                    = new LocationUtil.LocationServicesCallback();
-            mLocationClient = new LocationClient(getActivity(), locCallback, locCallback);
-            mLocationClient.connect();
+            mGoogleApiClient = LocationUtil.getGoogleApiClientWithCallbacks(getActivity());
+            mGoogleApiClient.connect();
         }
     }
 
@@ -88,17 +86,17 @@ public abstract class ReportProblemFragmentBase extends Fragment
     @Override
     public void onStart() {
         super.onStart();
-        // Make sure LocationClient is connected, if available
-        if (mLocationClient != null && !mLocationClient.isConnected()) {
-            mLocationClient.connect();
+        // Make sure GoogleApiClient is connected, if available
+        if (mGoogleApiClient != null && !mGoogleApiClient.isConnected()) {
+            mGoogleApiClient.connect();
         }
     }
 
     @Override
     public void onStop() {
-        // Tear down LocationClient
-        if (mLocationClient != null && mLocationClient.isConnected()) {
-            mLocationClient.disconnect();
+        // Tear down GoogleApiClient
+        if (mGoogleApiClient != null && mGoogleApiClient.isConnected()) {
+            mGoogleApiClient.disconnect();
         }
         super.onStop();
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/ReportStopProblemFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/ReportStopProblemFragment.java
@@ -146,7 +146,7 @@ public class ReportStopProblemFragment extends ReportProblemFragmentBase {
         }
 
         // Location / Location accuracy
-        Location location = LocationUtil.getLocation2(getActivity(), mLocationClient);
+        Location location = LocationUtil.getLocation2(getActivity(), mGoogleApiClient);
         if (location != null) {
             builder.setUserLocation(location.getLatitude(), location.getLongitude());
             if (location.hasAccuracy()) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/ReportTripProblemFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/ReportTripProblemFragment.java
@@ -198,7 +198,7 @@ public class ReportTripProblemFragment extends ReportProblemFragmentBase {
         }
 
         // Location / Location accuracy
-        Location location = LocationUtil.getLocation2(getActivity(), mLocationClient);
+        Location location = LocationUtil.getLocation2(getActivity(), mGoogleApiClient);
         if (location != null) {
             builder.setUserLocation(location.getLatitude(), location.getLongitude());
             if (location.hasAccuracy()) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/SearchResultsFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/SearchResultsFragment.java
@@ -18,7 +18,7 @@ package org.onebusaway.android.ui;
 
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GooglePlayServicesUtil;
-import com.google.android.gms.location.LocationClient;
+import com.google.android.gms.common.api.GoogleApiClient;
 
 import org.onebusaway.android.R;
 import org.onebusaway.android.io.ObaApi;
@@ -88,9 +88,9 @@ public class SearchResultsFragment extends ListFragment
     private MyAdapter mAdapter;
 
     /**
-     * Google Location Services
+     * GoogleApiClient being used for Location Services
      */
-    LocationClient mLocationClient;
+    GoogleApiClient mGoogleApiClient;
 
     @Override
     public void onAttach(Activity activity) {
@@ -99,10 +99,8 @@ public class SearchResultsFragment extends ListFragment
         // Init Google Play Services as early as possible in the Fragment lifecycle to give it time
         if (GooglePlayServicesUtil.isGooglePlayServicesAvailable(getActivity())
                 == ConnectionResult.SUCCESS) {
-            LocationUtil.LocationServicesCallback locCallback
-                    = new LocationUtil.LocationServicesCallback();
-            mLocationClient = new LocationClient(getActivity(), locCallback, locCallback);
-            mLocationClient.connect();
+            mGoogleApiClient = LocationUtil.getGoogleApiClientWithCallbacks(getActivity());
+            mGoogleApiClient.connect();
         }
     }
 
@@ -119,17 +117,17 @@ public class SearchResultsFragment extends ListFragment
     @Override
     public void onStart() {
         super.onStart();
-        // Make sure LocationClient is connected, if available
-        if (mLocationClient != null && !mLocationClient.isConnected()) {
-            mLocationClient.connect();
+        // Make sure GoogleApiClient is connected, if available
+        if (mGoogleApiClient != null && !mGoogleApiClient.isConnected()) {
+            mGoogleApiClient.connect();
         }
     }
 
     @Override
     public void onStop() {
-        // Tear down LocationClient
-        if (mLocationClient != null && mLocationClient.isConnected()) {
-            mLocationClient.disconnect();
+        // Tear down GoogleApiClient
+        if (mGoogleApiClient != null && mGoogleApiClient.isConnected()) {
+            mGoogleApiClient.disconnect();
         }
         super.onStop();
     }
@@ -145,7 +143,7 @@ public class SearchResultsFragment extends ListFragment
     public Loader<SearchResponse> onCreateLoader(int id, Bundle args) {
         String query = args.getString(QUERY_TEXT);
         return new MyLoader(getActivity(), query,
-                LocationUtil.getLocation(getActivity(), mLocationClient));
+                LocationUtil.getLocation(getActivity(), mGoogleApiClient));
     }
 
     @Override


### PR DESCRIPTION
- With release of Google Play Services 6.5, LocationClient has been completely removed and got replaced by GoogleApiClient.
- Added a static method in LocationUtil to create a GoogleApiClient with callbacks: because bunch of classes uses the same code base.
- Fixed unit tests
