### PR TITLE
Fix #201 - Add a donate link in preferences

### DIFF
--- a/onebusaway-android/src/main/res/values/do_not_translate.xml
+++ b/onebusaway-android/src/main/res/values/do_not_translate.xml
@@ -25,8 +25,11 @@
     <string name="preference_key_auto_select_region">preference_auto_select_region</string>
     <string name="preference_key_experimental_regions">preference_experimental_regions</string>
     <string name="preferences_key_analytics">preference_google_analytics</string>
+    <string name="preferences_key_donate">preference_donate</string>
     <string name="preference_key_preferred_units">preference_preferred_units</string>
 
+    <!-- Donate URL -->
+    <string name="donate_url">http://onebusaway.org/donate/</string>
 
     <!-- Oba Analytics Messages -->
     <string name="analytics_category_custom_region">CUSTOM</string>

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -280,8 +280,8 @@
     <string name="preferences_category_location">Location</string>
     <string name="preferences_category_display">Display</string>
     <string name="preferences_category_backup">Backup</string>
+    <string name="preferences_category_about">About</string>
     <string name="preferences_category_advanced">Advanced</string>
-    <string name="preferences_category_analytics">Analytics</string>
     <string name="preferences_region_title">Your region</string>
     <string name="preferences_region_summary">%1$s is currently selected</string>
     <string name="preferences_region_summary_custom_api">A custom API server is being used</string>
@@ -326,4 +326,6 @@
     </string>
     <string name="preferences_analytics_title">Send anonymous usage data</string>
     <string name="preferences_analytics_summary">Help us improve the app</string>
+    <string name="preferences_donate_title">Donate</string>
+    <string name="preferences_donate_summary">Support the OneBusAway open-source project</string>
 </resources>

--- a/onebusaway-android/src/main/res/xml/preferences.xml
+++ b/onebusaway-android/src/main/res/xml/preferences.xml
@@ -53,12 +53,19 @@
                 android:title="@string/preferences_restore_title"
                 android:summary="@string/preferences_restore_summary"/>
     </PreferenceCategory>
-    <PreferenceCategory android:title="@string/preferences_category_analytics">
+    <PreferenceCategory android:title="@string/preferences_category_about">
         <CheckBoxPreference
             android:key="@string/preferences_key_analytics"
             android:title="@string/preferences_analytics_title"
             android:summary="@string/preferences_analytics_summary"
             android:defaultValue="true"/>
+        <Preference
+                android:key="@string/preferences_key_donate"
+                android:title="@string/preferences_donate_title"
+                android:summary="@string/preferences_donate_summary">
+            <intent android:action="android.intent.action.VIEW"
+                    android:data="@string/donate_url"/>
+        </Preference>
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/preferences_category_advanced">
         <com.joulespersecond.oba.region.ExperimentalRegionsPreference


### PR DESCRIPTION
* Renames "Analytics" preference category to "About", and groups both analytics opt-out and donate preference under this

This adds the link to the master branch.  I'll merge this into develop as well.