### PR TITLE
Fix  #213 - Google analytics implementations for donate link and opt-out...

### DIFF
--- a/onebusaway-android/src/main/java/com/joulespersecond/oba/ObaAnalytics.java
+++ b/onebusaway-android/src/main/java/com/joulespersecond/oba/ObaAnalytics.java
@@ -103,22 +103,24 @@ public class ObaAnalytics {
      * @param label    label name
      */
     public static void reportEventWithCategory(String category, String action, String label) {
-        Tracker tracker = Application.get().getTracker(Application.TrackerName.APP_TRACKER);
-        Tracker tracker2 = Application.get().getTracker(Application.TrackerName.GLOBAL_TRACKER);
-        String obaRegionName = getObaRegionName();
+        if (isAnalyticsActive()) {
+            Tracker tracker = Application.get().getTracker(Application.TrackerName.APP_TRACKER);
+            Tracker tracker2 = Application.get().getTracker(Application.TrackerName.GLOBAL_TRACKER);
+            String obaRegionName = getObaRegionName();
 
-        tracker.send(new HitBuilders.EventBuilder()
-                .setCategory(category)
-                .setAction(action)
-                .setLabel(label)
-                .setCustomDimension(1, obaRegionName)
-                .build());
-        tracker2.send(new HitBuilders.EventBuilder()
-                .setCategory(category)
-                .setAction(action)
-                .setLabel(label)
-                .setCustomDimension(1, obaRegionName)
-                .build());
+            tracker.send(new HitBuilders.EventBuilder()
+                    .setCategory(category)
+                    .setAction(action)
+                    .setLabel(label)
+                    .setCustomDimension(1, obaRegionName)
+                    .build());
+            tracker2.send(new HitBuilders.EventBuilder()
+                    .setCategory(category)
+                    .setAction(action)
+                    .setLabel(label)
+                    .setCustomDimension(1, obaRegionName)
+                    .build());
+        }
     }
 
     /**
@@ -129,87 +131,72 @@ public class ObaAnalytics {
      * @param stopLocation tapped stop location
      */
     public static void trackBusStopDistance(String stopId, Location myLocation, Location stopLocation) {
-        if (myLocation == null) {
-            return;
-        }
-        if (myLocation.getAccuracy() < LOCATION_ACCURACY_THRESHOLD) {
-            float distanceInMeters = myLocation.distanceTo(stopLocation);
-            ObaStopDistance stopDistance = null;
-            String obaRegionName = getObaRegionName();
-
-            if (distanceInMeters < ObaStopDistance.DISTANCE_1.getDistanceInMeters()) {
-                stopDistance = ObaStopDistance.DISTANCE_1;
-            } else if (distanceInMeters < ObaStopDistance.DISTANCE_2.getDistanceInMeters()) {
-                stopDistance = ObaStopDistance.DISTANCE_2;
-            } else if (distanceInMeters < ObaStopDistance.DISTANCE_3.getDistanceInMeters()) {
-                stopDistance = ObaStopDistance.DISTANCE_3;
-            } else if (distanceInMeters < ObaStopDistance.DISTANCE_4.getDistanceInMeters()) {
-                stopDistance = ObaStopDistance.DISTANCE_4;
-            } else if (distanceInMeters < ObaStopDistance.DISTANCE_5.getDistanceInMeters()) {
-                stopDistance = ObaStopDistance.DISTANCE_5;
-            } else if (distanceInMeters < ObaStopDistance.DISTANCE_6.getDistanceInMeters()) {
-                stopDistance = ObaStopDistance.DISTANCE_6;
-            } else if (distanceInMeters < ObaStopDistance.DISTANCE_7.getDistanceInMeters()) {
-                stopDistance = ObaStopDistance.DISTANCE_7;
-            } else {
-                stopDistance = ObaStopDistance.DISTANCE_8;
+        if (isAnalyticsActive()) {
+            if (myLocation == null) {
+                return;
             }
+            if (myLocation.getAccuracy() < LOCATION_ACCURACY_THRESHOLD) {
+                float distanceInMeters = myLocation.distanceTo(stopLocation);
+                ObaStopDistance stopDistance = null;
 
-            Tracker tracker = Application.get().getTracker(Application.TrackerName.APP_TRACKER);
-            Tracker tracker2 = Application.get().getTracker(Application.TrackerName.GLOBAL_TRACKER);
+                if (distanceInMeters < ObaStopDistance.DISTANCE_1.getDistanceInMeters()) {
+                    stopDistance = ObaStopDistance.DISTANCE_1;
+                } else if (distanceInMeters < ObaStopDistance.DISTANCE_2.getDistanceInMeters()) {
+                    stopDistance = ObaStopDistance.DISTANCE_2;
+                } else if (distanceInMeters < ObaStopDistance.DISTANCE_3.getDistanceInMeters()) {
+                    stopDistance = ObaStopDistance.DISTANCE_3;
+                } else if (distanceInMeters < ObaStopDistance.DISTANCE_4.getDistanceInMeters()) {
+                    stopDistance = ObaStopDistance.DISTANCE_4;
+                } else if (distanceInMeters < ObaStopDistance.DISTANCE_5.getDistanceInMeters()) {
+                    stopDistance = ObaStopDistance.DISTANCE_5;
+                } else if (distanceInMeters < ObaStopDistance.DISTANCE_6.getDistanceInMeters()) {
+                    stopDistance = ObaStopDistance.DISTANCE_6;
+                } else if (distanceInMeters < ObaStopDistance.DISTANCE_7.getDistanceInMeters()) {
+                    stopDistance = ObaStopDistance.DISTANCE_7;
+                } else {
+                    stopDistance = ObaStopDistance.DISTANCE_8;
+                }
 
-            tracker.send(new HitBuilders.EventBuilder()
-                    .setCategory(ObaEventCategory.STOP_ACTION.toString())
-                    .setAction("Stop Id: " + stopId)
-                    .setLabel(stopDistance.toString())
-                    .setValue(1)
-                    .setCustomDimension(1, obaRegionName)
-                    .build());
-            tracker2.send(new HitBuilders.EventBuilder()
-                    .setCategory(ObaEventCategory.STOP_ACTION.toString())
-                    .setAction("Stop Id: " + stopId)
-                    .setLabel(stopDistance.toString())
-                    .setValue(1)
-                    .setCustomDimension(1, obaRegionName)
-                    .build());
+                reportEventWithCategory(ObaEventCategory.STOP_ACTION.toString(), "Stop Id: " + stopId,
+                        stopDistance.toString());
+            }
         }
-
     }
 
     /**
      * For reporting activities on Start
      *
-     * @param activity
+     * @param activity The activity being reported
      */
     public static void reportActivityStart(Activity activity) {
-        Tracker tracker = Application.get().getTracker(Application.TrackerName.APP_TRACKER);
-        tracker.setScreenName(activity.getClass().getSimpleName());
-        tracker.send(new HitBuilders.ScreenViewBuilder().build());
-        Tracker tracker2 = Application.get().getTracker(Application.TrackerName.GLOBAL_TRACKER);
-        tracker2.setScreenName(activity.getClass().getSimpleName());
-        tracker2.send(new HitBuilders.ScreenViewBuilder().build());
+        if (isAnalyticsActive()) {
+            Tracker tracker = Application.get().getTracker(Application.TrackerName.APP_TRACKER);
+            tracker.setScreenName(activity.getClass().getSimpleName());
+            tracker.send(new HitBuilders.ScreenViewBuilder().build());
+            Tracker tracker2 = Application.get().getTracker(Application.TrackerName.GLOBAL_TRACKER);
+            tracker2.setScreenName(activity.getClass().getSimpleName());
+            tracker2.send(new HitBuilders.ScreenViewBuilder().build());
+        }
     }
 
 
     /**
      * For reporting fragments on Start
      *
-     * @param fragment
+     * @param fragment The fragment being reported
      */
     public static void reportFragmentStart(Fragment fragment) {
-        Tracker tracker = Application.get().getTracker(Application.TrackerName.APP_TRACKER);
-        tracker.setScreenName(fragment.getClass().getSimpleName());
-        tracker.send(new HitBuilders.ScreenViewBuilder().build());
-        Tracker tracker2 = Application.get().getTracker(Application.TrackerName.GLOBAL_TRACKER);
-        tracker2.setScreenName(fragment.getClass().getSimpleName());
-        tracker2.send(new HitBuilders.ScreenViewBuilder().build());
+        if (isAnalyticsActive()) {
+            Tracker tracker = Application.get().getTracker(Application.TrackerName.APP_TRACKER);
+            tracker.setScreenName(fragment.getClass().getSimpleName());
+            tracker.send(new HitBuilders.ScreenViewBuilder().build());
+            Tracker tracker2 = Application.get().getTracker(Application.TrackerName.GLOBAL_TRACKER);
+            tracker2.setScreenName(fragment.getClass().getSimpleName());
+            tracker2.send(new HitBuilders.ScreenViewBuilder().build());
+        }
     }
 
     public static void initAnalytics(Context context) {
-        if (!isAnalyticsActive()) {
-            //Disable Google Analytics
-            GoogleAnalytics.getInstance(context).setAppOptOut(true);
-        }
         if (BuildConfig.DEBUG) {
             //Disables reporting when app runs on debug
             GoogleAnalytics.getInstance(context).setDryRun(true);

--- a/onebusaway-android/src/main/res/values/do_not_translate.xml
+++ b/onebusaway-android/src/main/res/values/do_not_translate.xml
@@ -52,6 +52,7 @@
     <string name="analytics_label_button_press_nearby">Clicked Nearby Item Link</string>
     <string name="analytics_label_button_press_reminders">Clicked My Reminders Link</string>
     <string name="analytics_label_button_press_settings">Clicked Settings Link</string>
+    <string name="analytics_label_button_press_donate">Clicked Donate Link</string>
     <string name="analytics_label_button_press_help">Clicked Help Link</string>
     <string name="analytics_label_button_press_feedback">Clicked Send Feedback Link</string>
     <string name="analytics_label_button_press_stopinfo">Loaded StopInfo from\u0020</string>
@@ -68,5 +69,6 @@
     <string name="analytics_label_report_problem">Reported Problem</string>
     <string name="analytics_label_talkback">Loaded view:\u0020</string>
     <string name="analytics_label_custom_url">Custom URL</string>
+    <string name="analytics_label_analytic_preference">Set Send anonymous usage data:\u0020</string>
 
 </resources>

--- a/onebusaway-android/src/main/res/xml/preferences.xml
+++ b/onebusaway-android/src/main/res/xml/preferences.xml
@@ -63,8 +63,6 @@
                 android:key="@string/preferences_key_donate"
                 android:title="@string/preferences_donate_title"
                 android:summary="@string/preferences_donate_summary">
-            <intent android:action="android.intent.action.VIEW"
-                    android:data="@string/donate_url"/>
         </Preference>
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/preferences_category_advanced">


### PR DESCRIPTION
### NOTE:
Google analytics' ```setAppOptOut()``` method removed for enabling/disabling the GA in the app. Because, when we send event before disabling the GA, the event doesn't show up in the GA admin. This issues also posted to stackoverflow:
http://stackoverflow.com/q/28688695/701325
http://stackoverflow.com/q/28701628/701325

Instead of using ```setAppOptOut()```, a workaround solution implemented. Simply before pushing any log to GA, we check if the GA is active in the app.
