### PR TITLE
Fix #223 - Disable Lint checks on release builds

### DIFF
--- a/onebusaway-android/build.gradle
+++ b/onebusaway-android/build.gradle
@@ -43,6 +43,11 @@ android {
         exclude 'META-INF/NOTICE'
     }
 
+    // Don't run lint checks on release (see #223 - remove this when Android Studio 1.2 releases)
+    lintOptions {
+        checkReleaseBuilds false
+    }
+
     if (project.hasProperty("secure.properties")
             && new File(project.property("secure.properties")).exists()) {
 


### PR DESCRIPTION
* A workaround for Android Studio bug - see https://code.google.com/p/android/issues/detail?id=148912
* Should be removed when Android Studio bug is fixed (currently targeted for Android Studio 1.2)