### PR TITLE
Fix  #243 - Workaround solution for GoogleAnalytics.setDryRun(true) issue in Amazon Fire phones

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/io/ObaAnalytics.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/io/ObaAnalytics.java
@@ -46,6 +46,11 @@ public class ObaAnalytics {
     private static final float LOCATION_ACCURACY_THRESHOLD = 50f;
 
     /**
+     * Amazon devices manufacturer name
+     */
+    public static final String mAmazonManufacturer = "amazon";
+
+    /**
      * To measure the distance when the bus stop tapped.
      */
     public enum ObaStopDistance {
@@ -201,6 +206,11 @@ public class ObaAnalytics {
         if (BuildConfig.DEBUG) {
             //Disables reporting when app runs on debug
             GoogleAnalytics.getInstance(context).setDryRun(true);
+
+            // Workaround for #243- setDryRun(true) doesn't work on Fire Phone
+            if (android.os.Build.MANUFACTURER.toLowerCase().contains(mAmazonManufacturer)) {
+                GoogleAnalytics.getInstance(context).setAppOptOut(true);
+            }
         }
     }
 


### PR DESCRIPTION
GoogleAnalytics.setDryRun(true) doesn't work on Amazon Fire Phones. 

>public void setDryRun (boolean dryRun)
Toggles dry run mode. In dry run mode, the normal code paths are executed locally, but hits are not sent to Google Analytics servers. This is useful for debugging calls to the Google Analytics SDK without polluting recorded data.

Instead of ```setDryRun```, we implemented ```GoogleAnalytics.getInstance(context).setAppOptOut(true)``` method, which disables Google analytics reporting on Amazon fire phone devices.