### PR TITLE
WIP - Optional current stop marker in StopOverlay

### DIFF
--- a/onebusaway-android/src/amazon/java/org/onebusaway/android/map/googlemapsv2/BaseMapFragment.java
+++ b/onebusaway-android/src/amazon/java/org/onebusaway/android/map/googlemapsv2/BaseMapFragment.java
@@ -146,8 +146,9 @@ public class BaseMapFragment extends SupportMapFragment
          *
          * @param stop   the ObaStop that obtained focus, or null if no stop is in focus
          * @param routes a HashMap of all route display names that serve this stop - key is routeId
+         * @param location the user touch location on the map
          */
-        void onFocusChanged(ObaStop stop, HashMap<String, ObaRoute> routes);
+        void onFocusChanged(ObaStop stop, HashMap<String, ObaRoute> routes, Location location);
     }
 
     @Override
@@ -408,7 +409,7 @@ public class BaseMapFragment extends SupportMapFragment
     //
     final Handler mStopChangedHandler = new Handler();
 
-    public void onFocusChanged(final ObaStop stop, final HashMap<String, ObaRoute> routes) {
+    public void onFocusChanged(final ObaStop stop, final HashMap<String, ObaRoute> routes, final Location location) {
         // Run in a separate thread, to avoid blocking UI for long running events
         mStopChangedHandler.post(new Runnable() {
             public void run() {
@@ -422,7 +423,7 @@ public class BaseMapFragment extends SupportMapFragment
                 }
 
                 // Pass overlay focus event up to listeners for this fragment
-                mOnFocusChangedListener.onFocusChanged(stop, routes);
+                mOnFocusChangedListener.onFocusChanged(stop, routes, location);
             }
         });
     }

--- a/onebusaway-android/src/amazon/java/org/onebusaway/android/map/googlemapsv2/StopOverlay.java
+++ b/onebusaway-android/src/amazon/java/org/onebusaway/android/map/googlemapsv2/StopOverlay.java
@@ -116,7 +116,7 @@ public class StopOverlay implements AmazonMap.OnMarkerClickListener, AmazonMap.O
          * @param stop   the ObaStop that obtained focus, or null if no stop is in focus
          * @param routes a HashMap of all route display names that serve this stop - key is routeId
          */
-        void onFocusChanged(ObaStop stop, HashMap<String, ObaRoute> routes);
+        void onFocusChanged(ObaStop stop, HashMap<String, ObaRoute> routes, Location location);
     }
 
     public StopOverlay(Activity activity, AmazonMap map) {
@@ -630,19 +630,20 @@ public class StopOverlay implements AmazonMap.OnMarkerClickListener, AmazonMap.O
         HashMap<String, ObaRoute> routes = mMarkerData.getCachedRoutes();
 
         // Notify listener
-        mOnFocusChangedListener.onFocusChanged(stop, routes);
+        mOnFocusChangedListener.onFocusChanged(stop, routes, stop.getLocation());
     }
 
     @Override
     public void onMapClick(LatLng latLng) {
         Log.d(TAG, "Map clicked");
 
-        // Only notify focus changed the first time the map is clicked away from a stop marker
         if (mMarkerData.getFocus() != null) {
             mMarkerData.removeFocus();
-            // Notify listener
-            mOnFocusChangedListener.onFocusChanged(null, null);
         }
+        // Set map clicked location
+        Location location = LocationUtil.makeLocation(latLng.latitude, latLng.longitude);
+        // Notify focus changed every time the map is clicked away from a stop marker
+        mOnFocusChangedListener.onFocusChanged(null, null, location);
     }
 
     private void setupMarkerData() {

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/BaseMapFragment.java
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/BaseMapFragment.java
@@ -145,8 +145,9 @@ public class BaseMapFragment extends SupportMapFragment
          *
          * @param stop   the ObaStop that obtained focus, or null if no stop is in focus
          * @param routes a HashMap of all route display names that serve this stop - key is routeId
+         * @param location the user touch location on the map
          */
-        void onFocusChanged(ObaStop stop, HashMap<String, ObaRoute> routes);
+        void onFocusChanged(ObaStop stop, HashMap<String, ObaRoute> routes, Location location);
     }
 
     @Override
@@ -407,7 +408,7 @@ public class BaseMapFragment extends SupportMapFragment
     //
     final Handler mStopChangedHandler = new Handler();
 
-    public void onFocusChanged(final ObaStop stop, final HashMap<String, ObaRoute> routes) {
+    public void onFocusChanged(final ObaStop stop, final HashMap<String, ObaRoute> routes, final Location location) {
         // Run in a separate thread, to avoid blocking UI for long running events
         mStopChangedHandler.post(new Runnable() {
             public void run() {
@@ -421,7 +422,7 @@ public class BaseMapFragment extends SupportMapFragment
                 }
 
                 // Pass overlay focus event up to listeners for this fragment
-                mOnFocusChangedListener.onFocusChanged(stop, routes);
+                mOnFocusChangedListener.onFocusChanged(stop, routes, location);
             }
         });
     }

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/BaseMapFragment.java
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/BaseMapFragment.java
@@ -254,7 +254,12 @@ public class BaseMapFragment extends SupportMapFragment
 
     public void setupStopOverlay() {
         if (mStopOverlay == null) {
-            mStopOverlay = new StopOverlay(getActivity(), mMap);
+            // TODO - allow setting boolean value for managing current stop marker in StopOverlay
+            // We can allow external classes to set this via an Intent to BaseMapFragment
+            // See ArrivalListFragment.IntentBuilder for an example of passing a stopId via Intent
+            // We can implement an BaseMapFragment.IntentBuilder to pass the boolean value for
+            // showing current stop marker as part of the stop overlay
+            mStopOverlay = new StopOverlay(getActivity(), mMap, true);
             mStopOverlay.setOnFocusChangeListener(this);
         }
     }

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/StopOverlay.java
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/StopOverlay.java
@@ -24,8 +24,8 @@ import com.google.android.gms.maps.model.Marker;
 import com.google.android.gms.maps.model.MarkerOptions;
 
 import org.onebusaway.android.R;
-import org.onebusaway.android.io.ObaAnalytics;
 import org.onebusaway.android.app.Application;
+import org.onebusaway.android.io.ObaAnalytics;
 import org.onebusaway.android.io.elements.ObaReferences;
 import org.onebusaway.android.io.elements.ObaRoute;
 import org.onebusaway.android.io.elements.ObaStop;
@@ -41,9 +41,9 @@ import android.graphics.Matrix;
 import android.graphics.Paint;
 import android.graphics.Path;
 import android.graphics.Point;
-import android.location.Location;
 import android.graphics.Shader;
 import android.graphics.drawable.Drawable;
+import android.location.Location;
 import android.os.Build;
 import android.os.Handler;
 import android.os.SystemClock;
@@ -106,6 +106,8 @@ public class StopOverlay implements GoogleMap.OnMarkerClickListener, GoogleMap.O
 
     OnFocusChangedListener mOnFocusChangedListener;
 
+    private boolean mShowCurrentStopMarker = true;
+
     public interface OnFocusChangedListener {
 
         /**
@@ -120,9 +122,16 @@ public class StopOverlay implements GoogleMap.OnMarkerClickListener, GoogleMap.O
         void onFocusChanged(ObaStop stop, HashMap<String, ObaRoute> routes, Location location);
     }
 
-    public StopOverlay(Activity activity, GoogleMap map) {
+    /**
+     * Instantiates a new StopOverlay
+     *
+     * @param showCurrentStopMarker true if this overlay should show a marker indicating the
+     *                              currently selected stop, false if it should not
+     */
+    public StopOverlay(Activity activity, GoogleMap map, boolean showCurrentStopMarker) {
         mActivity = activity;
         mMap = map;
+        mShowCurrentStopMarker = showCurrentStopMarker;
         loadIcons();
         mMap.setOnMarkerClickListener(this);
         mMap.setOnMapClickListener(this);
@@ -815,9 +824,12 @@ public class StopOverlay implements GoogleMap.OnMarkerClickListener, GoogleMap.O
             // corresponding stop marker (i.e., so its not identical to stop marker latitude)
             LatLng latLng = new LatLng(stop.getLatitude() - 0.000001, stop.getLongitude());
 
-            mCurrentFocusMarker = mMap.addMarker(new MarkerOptions()
-                            .position(latLng)
-            );
+            // If this overlay is supposed to manage the current stop marker, show it
+            if (mShowCurrentStopMarker) {
+                mCurrentFocusMarker = mMap.addMarker(new MarkerOptions()
+                                .position(latLng)
+                );
+            }
 
             // This doesn't look good since when bouncing, the focus marker is drawn behind
             // the bus stop marker.  If only we could control z-order...

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/StopOverlay.java
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/StopOverlay.java
@@ -115,8 +115,9 @@ public class StopOverlay implements GoogleMap.OnMarkerClickListener, GoogleMap.O
          *
          * @param stop   the ObaStop that obtained focus, or null if no stop is in focus
          * @param routes a HashMap of all route display names that serve this stop - key is routeId
+         * @param location the user touch location on the map
          */
-        void onFocusChanged(ObaStop stop, HashMap<String, ObaRoute> routes);
+        void onFocusChanged(ObaStop stop, HashMap<String, ObaRoute> routes, Location location);
     }
 
     public StopOverlay(Activity activity, GoogleMap map) {
@@ -608,19 +609,21 @@ public class StopOverlay implements GoogleMap.OnMarkerClickListener, GoogleMap.O
         HashMap<String, ObaRoute> routes = mMarkerData.getCachedRoutes();
 
         // Notify listener
-        mOnFocusChangedListener.onFocusChanged(stop, routes);
+        mOnFocusChangedListener.onFocusChanged(stop, routes, stop.getLocation());
     }
 
     @Override
     public void onMapClick(LatLng latLng) {
         Log.d(TAG, "Map clicked");
 
-        // Only notify focus changed the first time the map is clicked away from a stop marker
+
         if (mMarkerData.getFocus() != null) {
             mMarkerData.removeFocus();
-            // Notify listener
-            mOnFocusChangedListener.onFocusChanged(null, null);
         }
+        // Set map clicked location
+        Location location = LocationUtil.makeLocation(latLng.latitude, latLng.longitude);
+        // Notify focus changed every time the map is clicked away from a stop marker
+        mOnFocusChangedListener.onFocusChanged(null, null, location);
     }
 
     private void setupMarkerData() {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.java
@@ -16,30 +16,6 @@
  */
 package org.onebusaway.android.ui;
 
-import com.google.android.gms.common.ConnectionResult;
-import com.google.android.gms.common.GooglePlayServicesUtil;
-import com.google.android.gms.common.api.GoogleApiClient;
-
-import com.sothree.slidinguppanel.SlidingUpPanelLayout;
-
-import org.onebusaway.android.BuildConfig;
-import org.onebusaway.android.R;
-import org.onebusaway.android.app.Application;
-import org.onebusaway.android.io.ObaAnalytics;
-import org.onebusaway.android.io.elements.ObaRegion;
-import org.onebusaway.android.io.elements.ObaRoute;
-import org.onebusaway.android.io.elements.ObaStop;
-import org.onebusaway.android.io.request.ObaArrivalInfoResponse;
-import org.onebusaway.android.map.MapModeController;
-import org.onebusaway.android.map.MapParams;
-import org.onebusaway.android.map.googlemapsv2.BaseMapFragment;
-import org.onebusaway.android.region.ObaRegionsTask;
-import org.onebusaway.android.tripservice.TripService;
-import org.onebusaway.android.util.FragmentUtils;
-import org.onebusaway.android.util.LocationUtil;
-import org.onebusaway.android.util.PreferenceHelp;
-import org.onebusaway.android.util.UIHelp;
-
 import android.app.AlertDialog;
 import android.app.Dialog;
 import android.content.ActivityNotFoundException;
@@ -71,7 +47,29 @@ import android.widget.ImageButton;
 import android.widget.ListView;
 import android.widget.Toast;
 
-import java.security.MessageDigest;
+import com.google.android.gms.common.ConnectionResult;
+import com.google.android.gms.common.GooglePlayServicesUtil;
+import com.google.android.gms.common.api.GoogleApiClient;
+import com.sothree.slidinguppanel.SlidingUpPanelLayout;
+
+import org.onebusaway.android.BuildConfig;
+import org.onebusaway.android.R;
+import org.onebusaway.android.app.Application;
+import org.onebusaway.android.io.ObaAnalytics;
+import org.onebusaway.android.io.elements.ObaRegion;
+import org.onebusaway.android.io.elements.ObaRoute;
+import org.onebusaway.android.io.elements.ObaStop;
+import org.onebusaway.android.io.request.ObaArrivalInfoResponse;
+import org.onebusaway.android.map.MapModeController;
+import org.onebusaway.android.map.MapParams;
+import org.onebusaway.android.map.googlemapsv2.BaseMapFragment;
+import org.onebusaway.android.region.ObaRegionsTask;
+import org.onebusaway.android.tripservice.TripService;
+import org.onebusaway.android.util.FragmentUtils;
+import org.onebusaway.android.util.LocationUtil;
+import org.onebusaway.android.util.PreferenceHelp;
+import org.onebusaway.android.util.UIHelp;
+
 import java.util.Date;
 import java.util.HashMap;
 
@@ -586,9 +584,10 @@ public class HomeActivity extends ActionBarActivity
      *
      * @param stop   the ObaStop that obtained focus, or null if no stop is in focus
      * @param routes a HashMap of all route display names that serve this stop - key is routeId
+     * @param location the user touch location on the map
      */
     @Override
-    public void onFocusChanged(ObaStop stop, HashMap<String, ObaRoute> routes) {
+    public void onFocusChanged(ObaStop stop, HashMap<String, ObaRoute> routes, Location location) {
         // Check to see if we're already focused on this same stop - if so, we shouldn't do anything
         if (mFocusedStopId != null && stop != null &&
                 mFocusedStopId.equalsIgnoreCase(stop.getId())) {


### PR DESCRIPTION
@cagryInside Here's a sketch of what I had in mind for being able to use the BaseMapFragment in the Send Feedback screen in addition to the HomeActivity.  This allows setting a boolean value to define whether the StopOverlay manages the current stop marker.  If false, then it doesn't add the marker to the map.  See the TODO statement for details on how we can set this via an Intent to BaseMapFragment.

**Please don't merge.**