### PR TITLE
Issue #256 - StopProblem and TripProblem fragments can report issues without selecting a problem category

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/ReportProblemFragmentBase.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/ReportProblemFragmentBase.java
@@ -15,17 +15,6 @@
  */
 package org.onebusaway.android.ui;
 
-import com.google.android.gms.common.ConnectionResult;
-import com.google.android.gms.common.GooglePlayServicesUtil;
-import com.google.android.gms.common.api.GoogleApiClient;
-
-import org.onebusaway.android.R;
-import org.onebusaway.android.io.ObaAnalytics;
-import org.onebusaway.android.io.ObaApi;
-import org.onebusaway.android.io.request.ObaResponse;
-import org.onebusaway.android.util.LocationUtil;
-import org.onebusaway.android.util.UIHelp;
-
 import android.app.Activity;
 import android.content.Context;
 import android.os.Bundle;
@@ -40,7 +29,19 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.Spinner;
 import android.widget.Toast;
+
+import com.google.android.gms.common.ConnectionResult;
+import com.google.android.gms.common.GooglePlayServicesUtil;
+import com.google.android.gms.common.api.GoogleApiClient;
+
+import org.onebusaway.android.R;
+import org.onebusaway.android.io.ObaAnalytics;
+import org.onebusaway.android.io.ObaApi;
+import org.onebusaway.android.io.request.ObaResponse;
+import org.onebusaway.android.util.LocationUtil;
+import org.onebusaway.android.util.UIHelp;
 
 import java.util.concurrent.Callable;
 
@@ -54,6 +55,16 @@ public abstract class ReportProblemFragmentBase extends Fragment
      * GoogleApiClient being used for Location Services
      */
     GoogleApiClient mGoogleApiClient;
+
+    /**
+     * Displays the problem categories
+     */
+    Spinner mCodeView;
+
+    /**
+     * Stores the problem category codes
+     */
+    String[] SPINNER_TO_CODE;
 
     @Override
     public void onAttach(Activity activity) {
@@ -114,6 +125,17 @@ public abstract class ReportProblemFragmentBase extends Fragment
             sendReport();
         }
         return false;
+    }
+
+    /**
+     * Validates report arguments before submitting a problem
+     *
+     * @return false if the report is not valid
+     */
+    protected boolean isReportArgumentsValid() {
+        // Check if a user selects a problem category
+        String code = SPINNER_TO_CODE[mCodeView.getSelectedItemPosition()];
+        return code != null;
     }
 
     protected void sendReport() {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/ReportStopProblemFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/ReportStopProblemFragment.java
@@ -15,13 +15,6 @@
  */
 package org.onebusaway.android.ui;
 
-import org.onebusaway.android.R;
-import org.onebusaway.android.io.ObaAnalytics;
-import org.onebusaway.android.io.elements.ObaStop;
-import org.onebusaway.android.io.request.ObaReportProblemWithStopRequest;
-import org.onebusaway.android.util.LocationUtil;
-import org.onebusaway.android.util.MyTextUtils;
-
 import android.content.Context;
 import android.location.Location;
 import android.os.Bundle;
@@ -34,6 +27,14 @@ import android.view.inputmethod.InputMethodManager;
 import android.widget.ArrayAdapter;
 import android.widget.Spinner;
 import android.widget.TextView;
+import android.widget.Toast;
+
+import org.onebusaway.android.R;
+import org.onebusaway.android.io.ObaAnalytics;
+import org.onebusaway.android.io.elements.ObaStop;
+import org.onebusaway.android.io.request.ObaReportProblemWithStopRequest;
+import org.onebusaway.android.util.LocationUtil;
+import org.onebusaway.android.util.MyTextUtils;
 
 public class ReportStopProblemFragment extends ReportProblemFragmentBase {
 
@@ -62,8 +63,6 @@ public class ReportStopProblemFragment extends ReportProblemFragmentBase {
         ft.addToBackStack(null);
         ft.commit();
     }
-
-    private Spinner mCodeView;
 
     private TextView mUserComment;
 
@@ -100,6 +99,15 @@ public class ReportStopProblemFragment extends ReportProblemFragmentBase {
             CharSequence comment = savedInstanceState.getCharSequence(USER_COMMENT);
             mUserComment.setText(comment);
         }
+
+        SPINNER_TO_CODE = new String[]{
+                null,
+                ObaReportProblemWithStopRequest.NAME_WRONG,
+                ObaReportProblemWithStopRequest.NUMBER_WRONG,
+                ObaReportProblemWithStopRequest.LOCATION_WRONG,
+                ObaReportProblemWithStopRequest.ROUTE_OR_TRIP_MISSING,
+                ObaReportProblemWithStopRequest.OTHER
+        };
     }
 
     @Override
@@ -115,19 +123,17 @@ public class ReportStopProblemFragment extends ReportProblemFragmentBase {
         InputMethodManager imm = (InputMethodManager) getActivity().getSystemService(
                 Context.INPUT_METHOD_SERVICE);
         imm.hideSoftInputFromWindow(mUserComment.getWindowToken(), 0);
-        ObaAnalytics.reportEventWithCategory(ObaAnalytics.ObaEventCategory.SUBMIT.toString(),
-                getString(R.string.analytics_action_problem), getString(R.string.analytics_label_report_stop_problem));
-        super.sendReport();
-    }
 
-    private static final String[] SPINNER_TO_CODE = new String[]{
-            null,
-            ObaReportProblemWithStopRequest.NAME_WRONG,
-            ObaReportProblemWithStopRequest.NUMBER_WRONG,
-            ObaReportProblemWithStopRequest.LOCATION_WRONG,
-            ObaReportProblemWithStopRequest.ROUTE_OR_TRIP_MISSING,
-            ObaReportProblemWithStopRequest.OTHER
-    };
+        if (isReportArgumentsValid()) {
+            ObaAnalytics.reportEventWithCategory(ObaAnalytics.ObaEventCategory.SUBMIT.toString(),
+                    getString(R.string.analytics_action_problem), getString(R.string.analytics_label_report_stop_problem));
+            super.sendReport();
+        } else {
+            // Show error message if report arguments is not valid
+            Toast.makeText(getActivity(), getString(R.string.report_problem_invalid_argument),
+                    Toast.LENGTH_LONG).show();
+        }
+    }
 
     @Override
     protected ReportLoader createLoader(Bundle args) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/ReportTripProblemFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/ReportTripProblemFragment.java
@@ -15,13 +15,6 @@
  */
 package org.onebusaway.android.ui;
 
-import org.onebusaway.android.R;
-import org.onebusaway.android.io.ObaAnalytics;
-import org.onebusaway.android.io.elements.ObaArrivalInfo;
-import org.onebusaway.android.io.request.ObaReportProblemWithTripRequest;
-import org.onebusaway.android.util.LocationUtil;
-import org.onebusaway.android.util.MyTextUtils;
-
 import android.content.Context;
 import android.location.Location;
 import android.os.Bundle;
@@ -35,6 +28,14 @@ import android.widget.ArrayAdapter;
 import android.widget.CheckBox;
 import android.widget.Spinner;
 import android.widget.TextView;
+import android.widget.Toast;
+
+import org.onebusaway.android.R;
+import org.onebusaway.android.io.ObaAnalytics;
+import org.onebusaway.android.io.elements.ObaArrivalInfo;
+import org.onebusaway.android.io.request.ObaReportProblemWithTripRequest;
+import org.onebusaway.android.util.LocationUtil;
+import org.onebusaway.android.util.MyTextUtils;
 
 public class ReportTripProblemFragment extends ReportProblemFragmentBase {
     //private static final String TAG = "ReportStopProblemFragment";
@@ -77,8 +78,6 @@ public class ReportTripProblemFragment extends ReportProblemFragmentBase {
         ft.addToBackStack(null);
         ft.commit();
     }
-
-    private Spinner mCodeView;
 
     private TextView mUserComment;
 
@@ -144,6 +143,16 @@ public class ReportTripProblemFragment extends ReportProblemFragmentBase {
             mUserVehicle.setText(num);
             mUserVehicle.setEnabled(onVehicle);
         }
+
+        SPINNER_TO_CODE = new String[]{
+                null,
+                ObaReportProblemWithTripRequest.VEHICLE_NEVER_CAME,
+                ObaReportProblemWithTripRequest.VEHICLE_CAME_EARLY,
+                ObaReportProblemWithTripRequest.VEHICLE_CAME_LATE,
+                ObaReportProblemWithTripRequest.WRONG_HEADSIGN,
+                ObaReportProblemWithTripRequest.VEHICLE_DOES_NOT_STOP_HERE,
+                ObaReportProblemWithTripRequest.OTHER
+        };
     }
 
     @Override
@@ -161,20 +170,16 @@ public class ReportTripProblemFragment extends ReportProblemFragmentBase {
         InputMethodManager imm = (InputMethodManager) getActivity().getSystemService(
                 Context.INPUT_METHOD_SERVICE);
         imm.hideSoftInputFromWindow(mUserComment.getWindowToken(), 0);
-        ObaAnalytics.reportEventWithCategory(ObaAnalytics.ObaEventCategory.SUBMIT.toString(),
-                getString(R.string.analytics_action_problem), getString(R.string.analytics_label_report_trip_problem));
-        super.sendReport();
+        if (isReportArgumentsValid()) {
+            ObaAnalytics.reportEventWithCategory(ObaAnalytics.ObaEventCategory.SUBMIT.toString(),
+                    getString(R.string.analytics_action_problem), getString(R.string.analytics_label_report_trip_problem));
+            super.sendReport();
+        } else {
+            // Show error message if report arguments is not valid
+            Toast.makeText(getActivity(), getString(R.string.report_problem_invalid_argument),
+                    Toast.LENGTH_LONG).show();
+        }
     }
-
-    private static final String[] SPINNER_TO_CODE = new String[]{
-            null,
-            ObaReportProblemWithTripRequest.VEHICLE_NEVER_CAME,
-            ObaReportProblemWithTripRequest.VEHICLE_CAME_EARLY,
-            ObaReportProblemWithTripRequest.VEHICLE_CAME_LATE,
-            ObaReportProblemWithTripRequest.WRONG_HEADSIGN,
-            ObaReportProblemWithTripRequest.VEHICLE_DOES_NOT_STOP_HERE,
-            ObaReportProblemWithTripRequest.OTHER
-    };
 
     @Override
     protected ReportLoader createLoader(Bundle args) {

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Copyright (C) 2010-2014 Paul Watts (paulcwatts@gmail.com)
+<?xml version="1.0" encoding="utf-8"?><!-- Copyright (C) 2010-2014 Paul Watts (paulcwatts@gmail.com)
     and individual contributors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
@@ -309,6 +308,7 @@
     <string name="report_problem_hint">Your reports help OneBusAway find and fix problems!</string>
     <string name="report_problem_sent">Report sent! Thank you!</string>
     <string name="report_problem_error">Unable to send the report. Try again?</string>
+    <string name="report_problem_invalid_argument">Please choose a problem category.</string>
     <!-- TODO: Modes -->
     <string name="report_problem_onvehicle_bus">Are you on this bus?</string>
     <string name="report_problem_vehiclenumber_bus">Bus number</string>


### PR DESCRIPTION
A stop and trip problem validation methods were implemented to prevent sending problems without choosing a problem category.