### PR TITLE
Add trip details information

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/util/test/UIUtilTest.java
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/util/test/UIUtilTest.java
@@ -131,7 +131,7 @@ public class UIUtilTest extends ObaTestCase {
         String[] array = getContext().getResources().getStringArray(options);
         assertEquals(array[0], "Add star to route");
         assertEquals(array[1], "Set a reminder");
-        assertEquals(array[2], "Show route information");
+        assertEquals(array[2], "Show trip details");
         assertEquals(array[3], "Show only this route");
         assertEquals(array[4], "Show route schedule");
         assertEquals(array[5], "Report problem with trip");
@@ -143,7 +143,7 @@ public class UIUtilTest extends ObaTestCase {
         array = getContext().getResources().getStringArray(options);
         assertEquals(array[0], "Add star to route");
         assertEquals(array[1], "Edit this reminder");
-        assertEquals(array[2], "Show route information");
+        assertEquals(array[2], "Show trip details");
         assertEquals(array[3], "Show only this route");
         assertEquals(array[4], "Show route schedule");
         assertEquals(array[5], "Report problem with trip");
@@ -177,7 +177,7 @@ public class UIUtilTest extends ObaTestCase {
         array = getContext().getResources().getStringArray(options);
         assertEquals(array[0], "Add star to route");
         assertEquals(array[1], "Set a reminder");
-        assertEquals(array[2], "Show route information");
+        assertEquals(array[2], "Show trip details");
         assertEquals(array[3], "Show only this route");
         assertEquals(array[4], "Report problem with trip");
 
@@ -188,7 +188,7 @@ public class UIUtilTest extends ObaTestCase {
         array = getContext().getResources().getStringArray(options);
         assertEquals(array[0], "Add star to route");
         assertEquals(array[1], "Edit this reminder");
-        assertEquals(array[2], "Show route information");
+        assertEquals(array[2], "Show trip details");
         assertEquals(array[3], "Show only this route");
         assertEquals(array[4], "Report problem with trip");
 
@@ -204,7 +204,7 @@ public class UIUtilTest extends ObaTestCase {
         array = getContext().getResources().getStringArray(options);
         assertEquals(array[0], "Remove star from route");
         assertEquals(array[1], "Set a reminder");
-        assertEquals(array[2], "Show route information");
+        assertEquals(array[2], "Show trip details");
         assertEquals(array[3], "Show only this route");
         assertEquals(array[4], "Show route schedule");
         assertEquals(array[5], "Report problem with trip");
@@ -216,7 +216,7 @@ public class UIUtilTest extends ObaTestCase {
         array = getContext().getResources().getStringArray(options);
         assertEquals(array[0], "Remove star from route");
         assertEquals(array[1], "Edit this reminder");
-        assertEquals(array[2], "Show route information");
+        assertEquals(array[2], "Show trip details");
         assertEquals(array[3], "Show only this route");
         assertEquals(array[4], "Show route schedule");
         assertEquals(array[5], "Report problem with trip");
@@ -230,7 +230,7 @@ public class UIUtilTest extends ObaTestCase {
         array = getContext().getResources().getStringArray(options);
         assertEquals(array[0], "Remove star from route");
         assertEquals(array[1], "Set a reminder");
-        assertEquals(array[2], "Show route information");
+        assertEquals(array[2], "Show trip details");
         assertEquals(array[3], "Show only this route");
         assertEquals(array[4], "Report problem with trip");
 
@@ -241,7 +241,7 @@ public class UIUtilTest extends ObaTestCase {
         array = getContext().getResources().getStringArray(options);
         assertEquals(array[0], "Remove star from route");
         assertEquals(array[1], "Edit this reminder");
-        assertEquals(array[2], "Show route information");
+        assertEquals(array[2], "Show trip details");
         assertEquals(array[3], "Show only this route");
         assertEquals(array[4], "Report problem with trip");
     }

--- a/onebusaway-android/src/main/AndroidManifest.xml
+++ b/onebusaway-android/src/main/AndroidManifest.xml
@@ -81,6 +81,11 @@
         </activity>
         <activity android:name="org.onebusaway.android.ui.TripInfoActivity"/>
         <activity android:name=".ui.MyRemindersActivity"/>
+        <activity android:name="org.onebusaway.android.ui.TripDetailsActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN"/>
+            </intent-filter>
+        </activity>
 
         <activity
                 android:name="org.onebusaway.android.ui.MyStopsActivity"

--- a/onebusaway-android/src/main/java/org/onebusaway/android/io/request/ObaTripDetailsResponse.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/io/request/ObaTripDetailsResponse.java
@@ -61,7 +61,7 @@ public final class ObaTripDetailsResponse extends ObaResponseWithRefs
     }
 
     @Override
-    protected ObaReferences getRefs() {
+    public ObaReferences getRefs() {
         return data.references;
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListFragment.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2012-2015 Paul Watts (paulcwatts@gmail.com), University of South Florida
- * and individual contributors.
+ * Copyright (C) 2012-2015 Paul Watts (paulcwatts@gmail.com), University of South Florida,
+ * Benjamin Du (bendu@me.com), and individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -625,7 +625,7 @@ public class ArrivalsListFragment extends ListFragment
                 } else if (which == 1) {
                     goToTrip(arrivalInfo);
                 } else if (which == 2) {
-                    goToRoute(arrivalInfo);
+                    goToTripDetails(arrivalInfo);
                 } else if (which == 3) {
                     ArrayList<String> routes = new ArrayList<String>(1);
                     routes.add(arrivalInfo.getInfo().getRouteId());
@@ -1160,6 +1160,11 @@ public class ArrivalsListFragment extends ListFragment
                 mStop.getName(),
                 stopInfo.getScheduledDepartureTime(),
                 stopInfo.getHeadsign());
+    }
+
+    private void goToTripDetails(ArrivalInfo stop) {
+        TripDetailsActivity.start(getActivity(),
+                stop.getInfo().getTripId(), stop.getInfo().getStopId());
     }
 
     private void goToRoute(ArrivalInfo stop) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/TripDetailsActivity.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/TripDetailsActivity.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2012-2015 Paul Watts (paulcwatts@gmail.com), University of South Florida,
+ * Benjamin Du (bendu@me.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui;
+
+import org.onebusaway.android.io.ObaAnalytics;
+import org.onebusaway.android.util.FragmentUtils;
+import org.onebusaway.android.util.UIHelp;
+
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.support.v4.app.FragmentManager;
+import android.support.v7.app.AppCompatActivity;
+import android.view.MenuItem;
+
+public class TripDetailsActivity extends AppCompatActivity {
+
+    public static class Builder {
+
+        private Context mContext;
+
+        private Intent mIntent;
+
+        public Builder(Context context, String tripId) {
+            mContext = context;
+            mIntent = new Intent(context, TripDetailsActivity.class);
+            mIntent.putExtra(TripDetailsListFragment.TRIP_ID, tripId);
+        }
+
+        public Builder setStopId(String stopId) {
+            mIntent.putExtra(TripDetailsListFragment.STOP_ID, stopId);
+            return this;
+        }
+
+        public Builder setUpMode(String mode) {
+            mIntent.putExtra(NavHelp.UP_MODE, mode);
+            return this;
+        }
+
+        public Intent getIntent() {
+            return mIntent;
+        }
+
+        public void start() {
+            mContext.startActivity(mIntent);
+        }
+    }
+
+    public static void start(Context context, String tripId) {
+        new Builder(context, tripId).start();
+    }
+
+    public static void start(Context context, String tripId, String stopId) {
+        new Builder(context, tripId).setStopId(stopId).start();
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        UIHelp.setupActionBar(this);
+
+        FragmentManager fm = getSupportFragmentManager();
+
+        if (fm.findFragmentById(android.R.id.content) == null) {
+            TripDetailsListFragment list = new TripDetailsListFragment();
+            list.setArguments(FragmentUtils.getIntentArgs(getIntent()));
+
+            fm.beginTransaction().add(android.R.id.content, list).commit();
+        }
+    }
+
+    @Override
+    protected void onStart() {
+        super.onStart();
+        ObaAnalytics.reportActivityStart(this);
+    }
+
+    @Override
+    protected void onStop() {
+        super.onStop();
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (item.getItemId() == android.R.id.home) {
+            NavHelp.goUp(this);
+            return true;
+        }
+        return false;
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/TripDetailsListFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/TripDetailsListFragment.java
@@ -1,0 +1,497 @@
+/*
+ * Copyright (C) 2012-2015 Paul Watts (paulcwatts@gmail.com), University of South Florida,
+ * Benjamin Du (bendu@me.com), and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui;
+
+import org.onebusaway.android.R;
+import org.onebusaway.android.io.ObaApi;
+import org.onebusaway.android.io.elements.ObaReferences;
+import org.onebusaway.android.io.elements.ObaRoute;
+import org.onebusaway.android.io.elements.ObaStop;
+import org.onebusaway.android.io.elements.ObaTrip;
+import org.onebusaway.android.io.elements.ObaTripSchedule;
+import org.onebusaway.android.io.elements.ObaTripStatus;
+import org.onebusaway.android.io.request.ObaTripDetailsRequest;
+import org.onebusaway.android.io.request.ObaTripDetailsResponse;
+import org.onebusaway.android.util.UIHelp;
+
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.os.Handler;
+import android.support.v4.app.LoaderManager;
+import android.support.v4.content.AsyncTaskLoader;
+import android.support.v4.content.Loader;
+import android.text.format.DateUtils;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.AdapterView;
+import android.widget.BaseAdapter;
+import android.widget.ListAdapter;
+import android.widget.ListView;
+import android.widget.TextView;
+
+public class TripDetailsListFragment extends ListFragment {
+
+    private static final String TAG = "TripDetailsListFragment";
+
+    public static final String TRIP_ID = ".TripId";
+
+    public static final String STOP_ID = ".StopId";
+
+    private static final long REFRESH_PERIOD = 60 * 1000;
+
+    private static final int TRIP_DETAILS_LOADER = 0;
+
+    private String mTripId;
+
+    private String mStopId;
+
+    private ObaTripDetailsResponse mTripInfo;
+
+    private TripDetailsAdapter mAdapter;
+
+    private final TripDetailsLoaderCallback mTripDetailsCallback = new TripDetailsLoaderCallback();
+
+    /**
+     * Builds an intent used to set the trip and stop for the ArrivalListFragment directly
+     * (i.e., when ArrivalsListActivity is not used)
+     */
+    public static class IntentBuilder {
+
+        private Intent mIntent;
+
+        public IntentBuilder(Context context, String tripId) {
+            mIntent = new Intent(context, TripDetailsListFragment.class);
+            mIntent.putExtra(TripDetailsListFragment.TRIP_ID, tripId);
+        }
+
+        public IntentBuilder setStopId(String stopId) {
+            mIntent.putExtra(TripDetailsListFragment.STOP_ID, stopId);
+            return this;
+        }
+
+        public Intent build() {
+            return mIntent;
+        }
+    }
+
+    @Override
+    public void onActivityCreated(Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+
+        // Start out with a progress indicator.
+        setListShown(false);
+
+        // We have a menu item to show in action bar.
+        setHasOptionsMenu(true);
+
+        getListView().setOnItemClickListener(mClickListener);
+
+        Bundle args = getArguments();
+        mTripId = args.getString(TRIP_ID);
+        if (mTripId == null) {
+            Log.e(TAG, "TripId is null");
+            throw new RuntimeException("TripId should not be null");
+        }
+
+        mStopId = args.getString(STOP_ID);
+
+        getLoaderManager().initLoader(TRIP_DETAILS_LOADER, null, mTripDetailsCallback);
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater,
+                             ViewGroup root, Bundle savedInstanceState) {
+        if (root == null) {
+            // Currently in a layout without a container, so no
+            // reason to create our view.
+            return null;
+        }
+        return inflater.inflate(R.layout.trip_details, null);
+    }
+
+    @Override
+    public void onPause() {
+        mRefreshHandler.removeCallbacks(mRefresh);
+        super.onPause();
+    }
+
+    @Override
+    public void onResume() {
+        // Try to show any old data just in case we're coming out of sleep
+        TripDetailsLoader loader = getTripDetailsLoader();
+        if (loader != null) {
+            ObaTripDetailsResponse lastGood = loader.getLastGoodResponse();
+            if (lastGood != null) {
+                setTripDetails(lastGood);
+            }
+        }
+
+        getLoaderManager().restartLoader(TRIP_DETAILS_LOADER, null, mTripDetailsCallback);
+
+        // If our timer would have gone off, then refresh.
+        long lastResponseTime = getTripDetailsLoader().getLastResponseTime();
+        long newPeriod = Math.min(REFRESH_PERIOD, (lastResponseTime + REFRESH_PERIOD)
+                - System.currentTimeMillis());
+        // Wait at least one second at least, and the full minute at most.
+        //Log.d(TAG, "Refresh period:" + newPeriod);
+        if (newPeriod <= 0) {
+            refresh();
+        } else {
+            mRefreshHandler.postDelayed(mRefresh, newPeriod);
+        }
+
+        super.onResume();
+    }
+
+    //
+    // Action Bar / Options Menu
+    //
+    @Override
+    public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
+        inflater.inflate(R.menu.trip_details, menu);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        final int id = item.getItemId();
+        if (id == R.id.refresh) {
+            refresh();
+            return true;
+        }
+        return false;
+    }
+
+    private void setTripDetails(ObaTripDetailsResponse data) {
+        mTripInfo = data;
+
+        final int code = mTripInfo.getCode();
+        if (code == ObaApi.OBA_OK) {
+            setEmptyText("");
+        } else {
+            setEmptyText(UIHelp.getRouteErrorString(getActivity(), code));
+            return;
+        }
+
+        setUpHeader();
+        final ListView listView = getListView();
+
+        if (mAdapter == null) {  // first time displaying list
+            mAdapter = new TripDetailsAdapter();
+            setListAdapater(mAdapter);
+
+            // Scroll to stop if we have the stopId available
+            if (mStopId != null) {
+                final int stopIndex = findIndexForStop(mTripInfo.getSchedule().getStopTimes(), mStopId);
+                if (stopIndex != -1) {
+                    listView.post(new Runnable() {
+                        @Override
+                        public void run() {
+                            listView.setSelection(stopIndex);
+                        }
+                    });
+                }
+            }
+        } else {  // refresh, keep scroll position
+            int index = listView.getFirstVisiblePosition();
+            View v = listView.getChildAt(0);
+            int top = (v == null) ? 0 : v.getTop();
+
+            mAdapter.notifyDataSetChanged();
+            listView.setSelectionFromTop(index, top);
+        }
+    }
+
+    private void setUpHeader() {
+        ObaTripStatus status = mTripInfo.getStatus();
+        ObaReferences refs = mTripInfo.getRefs();
+
+        Context context = getActivity();
+
+        String tripId = status.getActiveTripId();
+        ObaTrip trip = refs.getTrip(tripId);
+        ObaRoute route = refs.getRoute(trip.getRouteId());
+        TextView shortName = (TextView) getView().findViewById(R.id.short_name);
+        shortName.setText(route.getShortName());
+
+        TextView longName = (TextView) getView().findViewById(R.id.long_name);
+        longName.setText(trip.getHeadsign());
+
+        TextView agency = (TextView) getView().findViewById(R.id.agency);
+        agency.setText(refs.getAgency(route.getAgencyId()).getName());
+
+        String vehicleId = status.getVehicleId();
+        TextView vehicleView = (TextView) getView().findViewById(R.id.vehicle);
+        if (vehicleId != null && !vehicleId.equals("")) {
+            vehicleView.setText(context.getString(R.string.trip_details_vehicle, vehicleId));
+            vehicleView.setVisibility(View.VISIBLE);
+        } else {
+            vehicleView.setText(null);
+            vehicleView.setVisibility(View.GONE);
+        }
+
+        TextView vehicleDeviation = (TextView) getView().findViewById(R.id.status);
+        if (status.isPredicted()) {
+            long deviation = status.getScheduleDeviation();
+            long minutes = Math.abs(deviation) / 60;
+            long seconds = Math.abs(deviation) % 60;
+            String lastUpdate = DateUtils.formatDateTime(getActivity(),
+                    status.getLastUpdateTime(),
+                    DateUtils.FORMAT_SHOW_TIME |
+                            DateUtils.FORMAT_NO_NOON |
+                            DateUtils.FORMAT_NO_MIDNIGHT
+            );
+            if (deviation >= 0) {
+                if (deviation < 60) {
+                    vehicleDeviation.setText(context.getString(R.string.trip_details_real_time_sec_late, seconds, lastUpdate));
+                } else {
+                    vehicleDeviation.setText(
+                            context.getString(R.string.trip_details_real_time_min_sec_late,
+                                    minutes, seconds, lastUpdate));
+                }
+            } else {
+                if (deviation > -60) {
+                    vehicleDeviation.setText(context.getString(R.string.trip_details_real_time_sec_early, seconds, lastUpdate));
+                } else {
+                    vehicleDeviation.setText(context.getString(R.string.trip_details_real_time_min_sec_early, minutes, seconds, lastUpdate));
+                }
+            }
+        } else {
+            vehicleDeviation.setText(context.getString(R.string.trip_details_scheduled_data));
+        }
+    }
+
+    private int findIndexForStop(ObaTripSchedule.StopTime[] stopTimes, String stopId) {
+        for (int i = 0; i < stopTimes.length; i++) {
+            if (stopId.equals(stopTimes[i].getStopId())) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private void setListAdapater(ListAdapter adapater) {
+        ListView list = getListView();
+
+        if (list != null) {
+            list.setAdapter(adapater);
+            setListShown(true);
+        }
+    }
+
+    private void showArrivals(String stopId) {
+        new ArrivalsListActivity.Builder(getActivity(), stopId)
+                .setUpMode(NavHelp.UP_MODE_BACK).start();
+    }
+
+    private final AdapterView.OnItemClickListener mClickListener = new AdapterView.OnItemClickListener() {
+        @Override
+        public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
+            ObaTripSchedule.StopTime time = mTripInfo.getSchedule().getStopTimes()[position];
+            showArrivals(time.getStopId());
+        }
+    };
+
+    private final Handler mRefreshHandler = new Handler();
+
+    private final Runnable mRefresh = new Runnable() {
+        public void run() {
+            refresh();
+        }
+    };
+
+    private TripDetailsLoader getTripDetailsLoader() {
+        // If the Fragment hasn't been attached to an Activity yet, return null
+        if (!isAdded()) {
+            return null;
+        }
+
+        Loader<ObaTripDetailsResponse> l =
+                getLoaderManager().getLoader(TRIP_DETAILS_LOADER);
+        return (TripDetailsLoader) l;
+    }
+
+    private void refresh() {
+        if (isAdded()) {
+            UIHelp.showProgress(this, true);
+            getTripDetailsLoader().onContentChanged();
+        }
+    }
+
+    private final class TripDetailsLoaderCallback
+            implements LoaderManager.LoaderCallbacks<ObaTripDetailsResponse> {
+
+        @Override
+        public Loader<ObaTripDetailsResponse> onCreateLoader(int id, Bundle args) {
+            return new TripDetailsLoader(getActivity(), mTripId);
+        }
+
+        @Override
+        public void onLoadFinished(Loader<ObaTripDetailsResponse> loader,
+                                   ObaTripDetailsResponse data) {
+            setTripDetails(data);
+
+            // Post an update
+            mRefreshHandler.postDelayed(mRefresh, REFRESH_PERIOD);
+        }
+
+        @Override
+        public void onLoaderReset(Loader<ObaTripDetailsResponse> loader) {
+            // Nothing to do right here...
+        }
+    }
+
+    private final static class TripDetailsLoader extends AsyncTaskLoader<ObaTripDetailsResponse> {
+
+        private final String mTripId;
+
+        private ObaTripDetailsResponse mLastGoodResponse;
+
+        private long mLastResponseTime = 0;
+
+        private long mLastGoodResponseTime = 0;
+
+        TripDetailsLoader(Context context, String tripId) {
+            super(context);
+            mTripId = tripId;
+        }
+
+        @Override
+        public void onStartLoading() {
+            forceLoad();
+        }
+
+        @Override
+        public ObaTripDetailsResponse loadInBackground() {
+            return ObaTripDetailsRequest.newRequest(getContext(), mTripId).call();
+        }
+
+        @Override
+        public void deliverResult(ObaTripDetailsResponse data) {
+            mLastResponseTime = System.currentTimeMillis();
+            if (data.getCode() == ObaApi.OBA_OK) {
+                mLastGoodResponse = data;
+                mLastGoodResponseTime = mLastResponseTime;
+            }
+            super.deliverResult(data);
+        }
+
+        public long getLastResponseTime() {
+            return mLastResponseTime;
+        }
+
+        public ObaTripDetailsResponse getLastGoodResponse() {
+            return mLastGoodResponse;
+        }
+
+        public long getLastGoodResponseTime() {
+            return mLastGoodResponseTime;
+        }
+    }
+
+    private final class TripDetailsAdapter extends BaseAdapter {
+
+        LayoutInflater mInflater;
+
+        ObaTripSchedule mSchedule;
+        ObaReferences mRefs;
+        ObaTripStatus mStatus;
+
+        int mNextStopIndex;
+
+        public TripDetailsAdapter() {
+            this.mInflater = LayoutInflater.from(TripDetailsListFragment.this.getActivity());
+
+            updateData();
+        }
+
+        private void updateData() {
+            this.mSchedule = mTripInfo.getSchedule();
+            this.mRefs = mTripInfo.getRefs();
+            this.mStatus = mTripInfo.getStatus();
+
+            String stopId = mStatus.getNextStop();
+
+            int i;
+            for (i = 0; i < mSchedule.getStopTimes().length; i++) {
+                ObaTripSchedule.StopTime time = mSchedule.getStopTimes()[i];
+                if (time.getStopId().equals(stopId)) {
+                    break;
+                }
+            }
+            mNextStopIndex = i;
+        }
+
+        @Override
+        public void notifyDataSetChanged() {
+            updateData();
+            super.notifyDataSetChanged();
+        }
+
+        @Override
+        public int getCount() {
+            return mSchedule.getStopTimes().length;
+        }
+
+        @Override
+        public Object getItem(int position) {
+            return mSchedule.getStopTimes()[position];
+        }
+
+        @Override
+        public long getItemId(int position) {
+            return position;
+        }
+
+        @Override
+        public View getView(int position, View convertView, ViewGroup parent) {
+            if (convertView == null) {
+                convertView = mInflater.inflate(R.layout.trip_details_listitem, parent, false);
+            }
+
+            ObaTripSchedule.StopTime stopTime = mSchedule.getStopTimes()[position];
+            ObaStop stop = mRefs.getStop(stopTime.getStopId());
+
+            TextView name = (TextView) convertView.findViewById(R.id.stop_name);
+            name.setText(stop.getName());
+
+            TextView time = (TextView) convertView.findViewById(R.id.time);
+            time.setText(DateUtils.formatDateTime(getActivity(),
+                    mStatus.getServiceDate() + stopTime.getArrivalTime() * 1000
+                            + mStatus.getScheduleDeviation() * 1000,
+                    DateUtils.FORMAT_SHOW_TIME |
+                            DateUtils.FORMAT_NO_NOON |
+                            DateUtils.FORMAT_NO_MIDNIGHT
+            ));
+
+            if (position < mNextStopIndex) {  // bus passed stop
+                name.setTextColor(getResources().getColor(R.color.trip_details_passed));
+                time.setTextColor(getResources().getColor(R.color.trip_details_passed));
+            } else {
+                name.setTextColor(getResources().getColor(R.color.trip_details_not_passed));
+                time.setTextColor(getResources().getColor(R.color.trip_details_not_passed));
+            }
+
+            return convertView;
+        }
+    }
+}

--- a/onebusaway-android/src/main/res/layout/trip_details.xml
+++ b/onebusaway-android/src/main/res/layout/trip_details.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2010-2015 Paul Watts (paulcwatts@gmail.com), Benjamin Du (bendu@me.com)
+    and individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              android:orientation="vertical"
+              android:layout_width="fill_parent"
+              android:layout_height="fill_parent">
+
+    <include layout="@layout/trip_details_head"/>
+    <include layout="@layout/loading"/>
+
+    <FrameLayout
+            android:id="@+id/listContainer"
+            android:layout_width="fill_parent"
+            android:layout_height="fill_parent">
+        <ListView android:id="@id/android:list"
+                  style="@style/HeaderList"
+                  android:layout_width="fill_parent"
+                  android:layout_height="fill_parent"/>
+
+        <TextView android:id="@+id/internalEmpty"
+                  style="@style/ListHintText"
+                  android:layout_width="fill_parent"
+                  android:layout_height="wrap_content"/>
+    </FrameLayout>
+</LinearLayout>

--- a/onebusaway-android/src/main/res/layout/trip_details_head.xml
+++ b/onebusaway-android/src/main/res/layout/trip_details_head.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2010-2015 Paul Watts (paulcwatts@gmail.com), Benjamin Du (bendu@me.com)
+    and individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<TableLayout xmlns:android="http://schemas.android.com/apk/res/android"
+             style="@style/HeaderItem"
+             android:layout_width="fill_parent"
+             android:layout_height="wrap_content"
+             android:orientation="vertical">
+    <TableRow>
+        <TextView
+                android:id="@+id/short_name"
+                style="@style/RouteInfoShortName"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:layout_column="0"
+                android:singleLine="false">
+        </TextView>
+        <LinearLayout
+                android:orientation="vertical"
+                android:layout_gravity="center_vertical"
+                android:layout_column="1"
+                android:layout_weight="1">
+            <TextView
+                    android:id="@+id/long_name"
+                    style="@style/RouteInfoLongName"
+                    android:layout_width="fill_parent"
+                    android:layout_height="wrap_content">
+            </TextView>
+            <TextView
+                    android:id="@+id/agency"
+                    style="@style/TripDetailsAgency"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content">
+            </TextView>
+            <TextView
+                    android:id="@+id/vehicle"
+                    style="@style/TripDetailsVehicle"
+                    android:layout_width="fill_parent"
+                    android:layout_height="wrap_content">
+            </TextView>
+            <TextView
+                    android:id="@+id/status"
+                    style="@style/TripDetailsStatus"
+                    android:layout_width="fill_parent"
+                    android:layout_height="wrap_content">
+            </TextView>
+        </LinearLayout>
+    </TableRow>
+</TableLayout>

--- a/onebusaway-android/src/main/res/layout/trip_details_listitem.xml
+++ b/onebusaway-android/src/main/res/layout/trip_details_listitem.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2010-2015 Paul Watts (paulcwatts@gmail.com), Benjamin Du (bendu@me.com),
+    and individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              style="@style/ListItem"
+              android:layout_width="fill_parent"
+              android:layout_height="wrap_content"
+              android:orientation="vertical">
+    <TextView
+            android:id="@+id/stop_name"
+            style="@style/Line1Text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"/>
+    <TextView
+            android:id="@+id/time"
+            style="@style/Line2Text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"/>
+</LinearLayout>

--- a/onebusaway-android/src/main/res/menu/trip_details.xml
+++ b/onebusaway-android/src/main/res/menu/trip_details.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2010-2015 Paul Watts (paulcwatts@gmail.com), Benjamin Du (bendu@me.com)
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<menu xmlns:onebusaway="http://schemas.android.com/apk/res-auto"
+      xmlns:android="http://schemas.android.com/apk/res/android">
+    <group
+            android:id="@+id/trip_details_menu_group">
+        <item android:id="@+id/refresh"
+              android:title="@string/stop_info_option_refresh"
+              android:icon="@drawable/ic_action_navigation_refresh"
+              onebusaway:showAsAction="ifRoom"/>
+    </group>
+</menu>

--- a/onebusaway-android/src/main/res/values/arrays.xml
+++ b/onebusaway-android/src/main/res/values/arrays.xml
@@ -29,7 +29,7 @@
     <string-array name="stop_item_options">
         <item>Add star to route</item>
         <item>Set a reminder</item>
-        <item>Show route information</item>
+        <item>Show trip details</item>
         <item>Show only this route</item>
         <item>Show route schedule</item>
         <item>Report problem with trip</item>
@@ -37,7 +37,7 @@
     <string-array name="stop_item_options_edit">
         <item>Add star to route</item>
         <item>Edit this reminder</item>
-        <item>Show route information</item>
+        <item>Show trip details</item>
         <item>Show only this route</item>
         <item>Show route schedule</item>
         <item>Report problem with trip</item>
@@ -45,21 +45,21 @@
     <string-array name="stop_item_options_noschedule">
         <item>Add star to route</item>
         <item>Set a reminder</item>
-        <item>Show route information</item>
+        <item>Show trip details</item>
         <item>Show only this route</item>
         <item>Report problem with trip</item>
     </string-array>
     <string-array name="stop_item_options_edit_noschedule">
         <item>Add star to route</item>
         <item>Edit this reminder</item>
-        <item>Show route information</item>
+        <item>Show trip details</item>
         <item>Show only this route</item>
         <item>Report problem with trip</item>
     </string-array>
     <string-array name="stop_item_options_favorite">
         <item>Remove star from route</item>
         <item>Set a reminder</item>
-        <item>Show route information</item>
+        <item>Show trip details</item>
         <item>Show only this route</item>
         <item>Show route schedule</item>
         <item>Report problem with trip</item>
@@ -67,7 +67,7 @@
     <string-array name="stop_item_options_edit_favorite">
         <item>Remove star from route</item>
         <item>Edit this reminder</item>
-        <item>Show route information</item>
+        <item>Show trip details</item>
         <item>Show only this route</item>
         <item>Show route schedule</item>
         <item>Report problem with trip</item>
@@ -75,14 +75,14 @@
     <string-array name="stop_item_options_noschedule_favorite">
         <item>Remove star from route</item>
         <item>Set a reminder</item>
-        <item>Show route information</item>
+        <item>Show trip details</item>
         <item>Show only this route</item>
         <item>Report problem with trip</item>
     </string-array>
     <string-array name="stop_item_options_edit_noschedule_favorite">
         <item>Remove star from route</item>
         <item>Edit this reminder</item>
-        <item>Show route information</item>
+        <item>Show trip details</item>
         <item>Show only this route</item>
         <item>Report problem with trip</item>
     </string-array>

--- a/onebusaway-android/src/main/res/values/colors.xml
+++ b/onebusaway-android/src/main/res/values/colors.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Copyright (C) 2010-2014 Paul Watts (paulcwatts@gmail.com)
+<!-- Copyright (C) 2010-2014 Paul Watts (paulcwatts@gmail.com), Benjamin Du (bendu@me.com),
     and individual contributors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
@@ -63,4 +63,8 @@
     <color name="alert_error">#FFC4C4</color>
     <color name="alert_warning">#FFFF99</color>
     <color name="alert_info">@color/theme_primary_dark</color>
+
+    <!-- Trip details colors -->
+    <color name="trip_details_passed">@color/body_text_3</color>
+    <color name="trip_details_not_passed">@color/body_text_2</color>
 </resources>

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?><!-- Copyright (C) 2010-2014 Paul Watts (paulcwatts@gmail.com)
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2010-2015 Paul Watts (paulcwatts@gmail.com), Benjamin Du (bendu@me.com)
     and individual contributors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
@@ -464,4 +465,15 @@
     <!-- Navigation Drawer -->
     <string name="navigation_drawer_open">Open navigation drawer</string>
     <string name="navigation_drawer_close">Close navigation drawer</string>
+
+    <!-- Trip Details -->
+    <string name="trip_details_vehicle">Vehicle: %1$s</string>
+    <string name="trip_details_scheduled_data">Scheduled data</string>
+    <string name="trip_details_real_time_sec_late">%1$d sec late (Last update: %2$s)</string>
+    <string name="trip_details_real_time_min_sec_late">%1$d min %2$d sec late (Last update: %3$s)
+    </string>
+    <string name="trip_details_real_time_sec_early">%1$d sec early (Last update: %2$s)</string>
+    <string name="trip_details_real_time_min_sec_early">%1$d min %2$d sec early (Last update:
+        %3$s)
+    </string>
 </resources>

--- a/onebusaway-android/src/main/res/values/styles.xml
+++ b/onebusaway-android/src/main/res/values/styles.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Copyright (C) 2010-2014 Paul Watts (paulcwatts@gmail.com)
+<!-- Copyright (C) 2010-2014 Paul Watts (paulcwatts@gmail.com), Benjamin Du (bendu@me.com),
     and individual contributors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
@@ -195,5 +195,20 @@
         <item name="android:paddingBottom">2dp</item>
         <item name="android:paddingLeft">5dp</item>
         <item name="android:paddingRight">5dp</item>
+    </style>
+
+    <!-- Trip details -->
+    <style name="TripDetailsAgency">
+        <item name="android:textSize">12sp</item>
+        <item name="android:textStyle">bold</item>
+        <item name="android:textColor">@color/header_text_color</item>
+    </style>
+    <style name="TripDetailsVehicle">
+        <item name="android:textSize">12sp</item>
+        <item name="android:textColor">@color/header_text_color</item>
+    </style>
+    <style name="TripDetailsStatus">
+        <item name="android:textSize">12sp</item>
+        <item name="android:textColor">@color/header_text_color</item>
     </style>
 </resources>


### PR DESCRIPTION
Added a trip details for an individual trip accessible from the arrivals list view to resolve #120

![showtripdetails](https://cloud.githubusercontent.com/assets/5668844/9979162/9c3afdd8-5f11-11e5-9674-c1b8ca334dbe.PNG)
I replaced "Show Route Information" with "Show trip details", making the route information inaccessible from the arrivals list. The route information is still used when searching for a particular route number though.

![obafeaturescreenshot](https://cloud.githubusercontent.com/assets/5668844/9979170/0e9c7afa-5f12-11e5-9eb1-8d0f80625f35.PNG)
For the trip details, the times for stops the bus should have already passed are in bold, while the ones the bus has not visited are normal font weight.

![realtime](https://cloud.githubusercontent.com/assets/5668844/9979175/a212f520-5f12-11e5-954e-6948589c7a9d.PNG)
Header when there's realtime schedule deviation/vehicle data.
