### PR TITLE
Bump Travis ADB install timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
     - ANDROID_API_LEVEL=22
     - ANDROID_BUILD_TOOLS_VERSION=23.0.0
     - ANDROID_ABI=armeabi-v7a
-    - ADB_INSTALL_TIMEOUT=8 # minutes (2 minutes by default - see #247)
+    - ADB_INSTALL_TIMEOUT=10 # minutes (2 minutes by default - see #247)
 
 android:
   components:


### PR DESCRIPTION
We've been seeing a lot of build failures due to timeouts, so let's see if this fixes it.