### PR TITLE
Fix #336 - Reduce GA data usage for master branch

### DIFF
--- a/onebusaway-android/src/main/java/com/joulespersecond/oba/ObaAnalytics.java
+++ b/onebusaway-android/src/main/java/com/joulespersecond/oba/ObaAnalytics.java
@@ -62,7 +62,7 @@ public class ObaAnalytics {
         private final String stringValue;
         private final int distanceInMeters;
 
-        private ObaStopDistance(final String s, final int i) {
+        ObaStopDistance(final String s, final int i) {
             stringValue = s;
             distanceInMeters = i;
         }
@@ -87,7 +87,7 @@ public class ObaAnalytics {
 
         private final String stringValue;
 
-        private ObaEventCategory(final String s) {
+        ObaEventCategory(final String s) {
             stringValue = s;
         }
 
@@ -138,7 +138,7 @@ public class ObaAnalytics {
             }
             if (myLocation.getAccuracy() < LOCATION_ACCURACY_THRESHOLD) {
                 float distanceInMeters = myLocation.distanceTo(stopLocation);
-                ObaStopDistance stopDistance = null;
+                ObaStopDistance stopDistance;
 
                 if (distanceInMeters < ObaStopDistance.DISTANCE_1.getDistanceInMeters()) {
                     stopDistance = ObaStopDistance.DISTANCE_1;
@@ -218,7 +218,7 @@ public class ObaAnalytics {
         if (region != null && region.getName() != null) {
             regionName = region.getName();
         } else if (Application.get().getCustomApiUrl() != null) {
-            MessageDigest digest = null;
+            MessageDigest digest;
             try {
                 digest = MessageDigest.getInstance("SHA-1");
                 digest.update(Application.get().getCustomApiUrl().getBytes());

--- a/onebusaway-android/src/main/java/com/joulespersecond/seattlebusbot/Application.java
+++ b/onebusaway-android/src/main/java/com/joulespersecond/seattlebusbot/Application.java
@@ -73,7 +73,6 @@ public class Application extends android.app.Application {
         initObaRegion();
 
         ObaAnalytics.initAnalytics(this);
-        reportAnalytics();
     }
 
     @Override
@@ -247,38 +246,5 @@ public class Application extends android.app.Application {
             mTrackers.put(trackerId, t);
         }
         return mTrackers.get(trackerId);
-    }
-
-    private void reportAnalytics() {
-        if (getCustomApiUrl() == null && getCurrentRegion() != null) {
-            ObaAnalytics.reportEventWithCategory(ObaAnalytics.ObaEventCategory.APP_SETTINGS.toString(),
-                    getString(R.string.analytics_action_configured_region), getString(R.string.analytics_label_region)
-                            + getCurrentRegion().getName());
-        } else if (Application.get().getCustomApiUrl() != null) {
-            String customUrl = null;
-            MessageDigest digest = null;
-            try {
-                digest = MessageDigest.getInstance("SHA-1");
-                digest.update(getCustomApiUrl().getBytes());
-                customUrl = getString(R.string.analytics_label_custom_url) +
-                        ": " + getHex(digest.digest());
-            } catch (Exception e) {
-                customUrl = Application.get().getString(R.string.analytics_label_custom_url);
-            }
-            ObaAnalytics.reportEventWithCategory(ObaAnalytics.ObaEventCategory.APP_SETTINGS.toString(),
-                    getString(R.string.analytics_action_configured_region), getString(R.string.analytics_label_region)
-                            + customUrl);
-        }
-
-        Boolean experimentalRegions = getPrefs().getBoolean(getString(R.string.preference_key_experimental_regions),
-                Boolean.FALSE);
-        Boolean autoRegion = getPrefs().getBoolean(getString(R.string.preference_key_auto_select_region),
-                Boolean.FALSE);
-        ObaAnalytics.reportEventWithCategory(ObaAnalytics.ObaEventCategory.APP_SETTINGS.toString(),
-                getString(R.string.analytics_action_edit_general), getString(R.string.analytics_label_experimental)
-                        + (experimentalRegions ? "YES" : "NO"));
-        ObaAnalytics.reportEventWithCategory(ObaAnalytics.ObaEventCategory.APP_SETTINGS.toString(),
-                getString(R.string.analytics_action_edit_general), getString(R.string.analytics_label_region_auto)
-                        + (autoRegion ? "YES" : "NO"));
     }
 }


### PR DESCRIPTION
Some app information reporting was disabled on startup in order to reduce data usage.

### Disabled reporting fields:
Event Category  | Event Action | Event Label |
| ------------- | ------------- | ------------- |
| app_settings  | configured_region  | API Region: Tampa (or other regions) |
| app_settings  | general  | Show Experimental Regions: NO |
| app_settings  | general  | Show Experimental Regions: YES |
| app_settings  | general  | Set Region Automatically: NO |
| app_settings  | general  | Set Region Automatically: YES |