### PR TITLE
Fix #336 - Reduce GA data usage for develop branch

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/app/Application.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/app/Application.java
@@ -96,7 +96,6 @@ public class Application extends android.app.Application {
         initObaRegion();
 
         ObaAnalytics.initAnalytics(this);
-        reportAnalytics();
     }
 
     /**
@@ -436,37 +435,5 @@ public class Application extends android.app.Application {
             mTrackers.put(trackerId, t);
         }
         return mTrackers.get(trackerId);
-    }
-
-    private void reportAnalytics() {
-        if (getCustomApiUrl() == null && getCurrentRegion() != null) {
-            ObaAnalytics.reportEventWithCategory(ObaAnalytics.ObaEventCategory.APP_SETTINGS.toString(),
-                    getString(R.string.analytics_action_configured_region), getString(R.string.analytics_label_region)
-                            + getCurrentRegion().getName());
-        } else if (Application.get().getCustomApiUrl() != null) {
-            String customUrl = null;
-            MessageDigest digest = null;
-            try {
-                digest = MessageDigest.getInstance("SHA-1");
-                digest.update(getCustomApiUrl().getBytes());
-                customUrl = getString(R.string.analytics_label_custom_url) +
-                        ": " + getHex(digest.digest());
-            } catch (Exception e) {
-                customUrl = Application.get().getString(R.string.analytics_label_custom_url);
-            }
-            ObaAnalytics.reportEventWithCategory(ObaAnalytics.ObaEventCategory.APP_SETTINGS.toString(),
-                    getString(R.string.analytics_action_configured_region), getString(R.string.analytics_label_region)
-                            + customUrl);
-        }
-        Boolean experimentalRegions = getPrefs().getBoolean(getString(R.string.preference_key_experimental_regions),
-                Boolean.FALSE);
-        Boolean autoRegion = getPrefs().getBoolean(getString(R.string.preference_key_auto_select_region),
-                Boolean.FALSE);
-        ObaAnalytics.reportEventWithCategory(ObaAnalytics.ObaEventCategory.APP_SETTINGS.toString(),
-                getString(R.string.analytics_action_edit_general), getString(R.string.analytics_label_experimental)
-                        + (experimentalRegions ? "YES" : "NO"));
-        ObaAnalytics.reportEventWithCategory(ObaAnalytics.ObaEventCategory.APP_SETTINGS.toString(),
-                getString(R.string.analytics_action_edit_general), getString(R.string.analytics_label_region_auto)
-                        + (autoRegion ? "YES" : "NO"));
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.java
@@ -351,10 +351,6 @@ public class HomeActivity extends AppCompatActivity
                 if (mCurrentNavDrawerPosition != NAVDRAWER_ITEM_NEARBY) {
                     showMapFragment();
                     mCurrentNavDrawerPosition = item;
-                    ObaAnalytics.reportEventWithCategory(
-                            ObaAnalytics.ObaEventCategory.UI_ACTION.toString(),
-                            getString(R.string.analytics_action_button_press),
-                            getString(R.string.analytics_label_button_press_nearby));
                 }
                 break;
             case NAVDRAWER_ITEM_MY_REMINDERS:


### PR DESCRIPTION
Some app information reporting was disabled on startup in order to reduce data usage.

### Disabled reporting fields:
Event Category  | Event Action | Event Label |
| ------------- | ------------- | ------------- |
| app_settings  | configured_region  | API Region: Tampa (or other regions) |
| app_settings  | general  | Show Experimental Regions: NO |
| app_settings  | general  | Show Experimental Regions: YES |
| app_settings  | general  | Set Region Automatically: NO |
| app_settings  | general  | Set Region Automatically: YES |