### PR TITLE
Fix arrivals list stop name while loading from the trip details list.

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/TripDetailsListFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/TripDetailsListFragment.java
@@ -355,16 +355,22 @@ public class TripDetailsListFragment extends ListFragment {
         return null;
     }
 
-    private void showArrivals(String stopId) {
+    private void showArrivals(String stopId, String stopName, String stopDirection) {
         new ArrivalsListActivity.Builder(getActivity(), stopId)
-                .setUpMode(NavHelp.UP_MODE_BACK).start();
+                .setUpMode(NavHelp.UP_MODE_BACK)
+                .setStopName(stopName)
+                .setStopDirection(stopDirection)
+                .start();
     }
 
     private final AdapterView.OnItemClickListener mClickListener = new AdapterView.OnItemClickListener() {
         @Override
         public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
             ObaTripSchedule.StopTime time = mTripInfo.getSchedule().getStopTimes()[position];
-            showArrivals(time.getStopId());
+            ObaReferences refs = mTripInfo.getRefs();
+            String stopId = time.getStopId();
+            ObaStop stop = refs.getStop(stopId);
+            showArrivals(stopId, stop.getName(), stop.getDirection());
         }
     };
 


### PR DESCRIPTION
While loading the arrivals list for a particular stop from the trip details view, the stop name is shown as "University Area Transit Center", when it should be shown as the proper name as the stop. The name gets corrected after the arrivals list is fully loaded, but this should eliminate any confusion that may occur on a slow network.