### PR TITLE
clarify that app is for more than bus information

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is the official Android app for OneBusAway!
 
 OneBusAway for Android provides:
 
-1. Real-time bus arrival information for public transit
+1. Real-time arrival information for public transit
 2. A browse-able map of nearby stops
 3. A list of favorite bus stops
 4. Reminders to notify you when your bus is arriving


### PR DESCRIPTION
Remove word "bus" from "Real-time bus arrival information for public transit" to clarify that app has more than just bus data.