### PR TITLE
improve visibility of testing details

### DIFF
--- a/BETA_TESTING.md
+++ b/BETA_TESTING.md
@@ -1,6 +1,6 @@
-# Beta Testing OneBusAway Android
+# Testing OneBusAway Android
 
-We provide early access to new versions of OneBusAway Android via Google Play's [beta testing](https://developer.android.com/distribute/googleplay/developer-console.html#alpha-beta) platform.  This helps us get feedback on bug fixes and new features before they are distributed to all users.
+We provide early access to new versions of OneBusAway Android via Google Play's [beta & alpha testing](https://developer.android.com/distribute/googleplay/developer-console.html#alpha-beta) platform. This helps us get feedback on bug fixes and new features before they are distributed to all users.
 
 Please note that these versions are not as heavily tested as production releases and, as a result, may not be as stable.
 
@@ -10,7 +10,7 @@ Please note that these versions are not as heavily tested as production releases
 2. Go to https://play.google.com/apps/testing/com.joulespersecond.seattlebusbot and opt in for testing (using the same Google account)
 3. Download the app from [Google Play](https://play.google.com/store/apps/details?id=com.joulespersecond.seattlebusbot) (using the same Google account) - you'll now have access to the beta version!
 
-You only have to complete the above steps once.  Unless you opt-out (using the same link in #2 above), you'll continue to receive new beta versions as they are released.
+You only have to complete the above steps once. Unless you opt-out (using the same link in #2 above), you'll continue to receive new beta versions as they are released.
 
 Please note that you need to use the same Google account for all three steps above, or you won't get access to the beta.
 
@@ -18,7 +18,7 @@ Note that as a beta tester you'll automatically get production releases too.
 
 ## Register as an alpha tester
 
-We also offer very early access to new OneBusAway releases in alpha versions.  Please note that these early versions will likely still contain bugs and will not be as polished as beta or production releases.  However, if you're willing to put up with these quirks, we'd love to get feedback on early designs and new features.
+We also offer very early access to new OneBusAway releases in alpha versions. Please note that these early versions will likely still contain bugs and will not be as polished as beta or production releases. However, if you're willing to put up with these quirks, we'd love to get feedback on early designs and new features.
 
 To register for alpha versions, the process is basically the same as the beta registration, but the first step involves signing up for a different community:
 
@@ -26,7 +26,7 @@ To register for alpha versions, the process is basically the same as the beta re
 2. Go to https://play.google.com/apps/testing/com.joulespersecond.seattlebusbot and opt in for testing (using the same Google account)
 3. Download the app from [Google Play](https://play.google.com/store/apps/details?id=com.joulespersecond.seattlebusbot) (using the same Google account) - you'll now have access to the alpha version!
 
-You only have to complete the above steps once.  Unless you opt-out (using the same link in #2 above), you'll continue to receive new alpha versions as they are released.
+You only have to complete the above steps once. Unless you opt-out (using the same link in #2 above), you'll continue to receive new alpha versions as they are released.
 
 Please note that you need to use the same Google account for all three steps above, or you won't get access to the alpha.
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ OneBusAway for Android provides:
 
 OneBusAway for Android automatically keeps track of your most used stops and routes, and allows you to put shortcuts on your phone's home screen for any stop or route you choose.
 
+## Testing
+
+Get early access to new OneBusAway Android versions! See our [Testing Guide](https://github.com/OneBusAway/onebusaway-android/blob/master/TESTING.md) for details.
+
 ## Build Setup
 
 We use [Gradle build flavors](http://developer.android.com/tools/building/configuring-gradle.html#workBuildVariants) to enable a number of different build variants of OneBusAway Android.
@@ -71,10 +75,6 @@ key.alias=<key_alias_name>
 ```
 
 Note that the paths in these files always use the Unix path separator `/`, even on Windows. If you use the Windows path separator `\` you will get the error `No value has been specified for property 'signingConfig.keyAlias'.`
-
-### Beta testing
-
-Get early access to new OneBusAway Android versions!  See our [Beta Testing Guide](https://github.com/OneBusAway/onebusaway-android/blob/master/BETA_TESTING.md) for details.
 
 ### Updating the Amazon Maps API library
 


### PR DESCRIPTION
Replaces #361

* Move testing details closer to top of readme
* Change wording from "beta testing" to testing since there is alpha and
beta testing options
* Cleans up double spaces because they are not rendered as double in Markdown or HTML and are not needed because the font already makes the space the desired width :)