### PR TITLE
Fix #313 - Implement tutorial via ShowcaseView library

### DIFF
--- a/onebusaway-android/build.gradle
+++ b/onebusaway-android/build.gradle
@@ -293,6 +293,8 @@ dependencies {
     compile 'com.sothree.slidinguppanel:library:3.1.1'
     // For sorting alphanumeric route names
     compile 'org.onebusaway.util:comparators:1.0.0'
+    // For tutorial (ShowcaseView) library
+    compile 'com.github.amlcurran.showcaseview:library:5.4.0'
     // Google Play Services Maps (only for Google flavor)
     googleCompile 'com.google.android.gms:play-services-maps:8.3.0'
     // Amazon Maps (only for Amazon flavor)

--- a/onebusaway-android/src/amazon/java/org/onebusaway/android/map/googlemapsv2/VehicleOverlay.java
+++ b/onebusaway-android/src/amazon/java/org/onebusaway/android/map/googlemapsv2/VehicleOverlay.java
@@ -42,6 +42,7 @@ import org.onebusaway.android.io.request.ObaTripsForRouteResponse;
 import org.onebusaway.android.ui.ArrivalInfo;
 import org.onebusaway.android.ui.TripDetailsActivity;
 import org.onebusaway.android.util.MathUtils;
+import org.onebusaway.android.util.ShowcaseViewUtils;
 import org.onebusaway.android.util.UIUtils;
 
 import android.app.Activity;
@@ -53,6 +54,7 @@ import android.graphics.drawable.GradientDrawable;
 import android.location.Location;
 import android.os.Handler;
 import android.support.v4.util.LruCache;
+import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -686,6 +688,9 @@ public class VehicleOverlay implements AmazonMap.OnInfoWindowClickListener {
                 mMarkerRefreshHandler.removeCallbacks(mMarkerRefresh);
                 mMarkerRefreshHandler.postDelayed(mMarkerRefresh, MARKER_REFRESH_PERIOD);
             }
+
+            ShowcaseViewUtils.showTutorial(ShowcaseViewUtils.TUTORIAL_VEHICLE_INFO_WINDOW,
+                    (AppCompatActivity) mActivity, null);
 
             return view;
         }

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/VehicleOverlay.java
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/VehicleOverlay.java
@@ -31,6 +31,7 @@ import org.onebusaway.android.io.request.ObaTripsForRouteResponse;
 import org.onebusaway.android.ui.ArrivalInfo;
 import org.onebusaway.android.ui.TripDetailsActivity;
 import org.onebusaway.android.util.MathUtils;
+import org.onebusaway.android.util.ShowcaseViewUtils;
 import org.onebusaway.android.util.UIUtils;
 
 import android.app.Activity;
@@ -42,6 +43,7 @@ import android.graphics.drawable.GradientDrawable;
 import android.location.Location;
 import android.os.Handler;
 import android.support.v4.util.LruCache;
+import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -675,6 +677,9 @@ public class VehicleOverlay implements GoogleMap.OnInfoWindowClickListener {
                 mMarkerRefreshHandler.removeCallbacks(mMarkerRefresh);
                 mMarkerRefreshHandler.postDelayed(mMarkerRefresh, MARKER_REFRESH_PERIOD);
             }
+
+            ShowcaseViewUtils.showTutorial(ShowcaseViewUtils.TUTORIAL_VEHICLE_INFO_WINDOW,
+                    (AppCompatActivity) mActivity, null);
 
             return view;
         }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListFragment.java
@@ -1029,8 +1029,6 @@ public class ArrivalsListFragment extends ListFragment
 
         if (currentValue.equalsIgnoreCase(styles[0])) {
             // Currently we're sorting by ETA - change to sorting by route
-            Toast.makeText(getActivity(), r.getString(R.string.stop_info_option_sort_route),
-                    Toast.LENGTH_SHORT).show();
             newValue = 1;
             //Analytics
             ObaAnalytics.reportEventWithCategory(ObaAnalytics.ObaEventCategory.UI_ACTION.toString(),
@@ -1039,8 +1037,6 @@ public class ArrivalsListFragment extends ListFragment
         } else {
             // Currently we're sorting by route - change to sorting by eta
             newValue = 0;
-            Toast.makeText(getActivity(), r.getString(R.string.stop_info_option_sort_eta),
-                    Toast.LENGTH_SHORT).show();
             //Analytics
             ObaAnalytics.reportEventWithCategory(ObaAnalytics.ObaEventCategory.UI_ACTION.toString(),
                     getActivity().getString(R.string.analytics_action_button_press),

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/MyListFragmentBase.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/MyListFragmentBase.java
@@ -67,7 +67,7 @@ abstract class MyListFragmentBase extends ListFragment
         }
     }
 
-    private SimpleCursorAdapter mAdapter;
+    protected SimpleCursorAdapter mAdapter;
 
     private Observer mObserver;
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/MyStarredStopsFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/MyStarredStopsFragment.java
@@ -20,6 +20,7 @@ import org.onebusaway.android.app.Application;
 import org.onebusaway.android.io.ObaAnalytics;
 import org.onebusaway.android.provider.ObaContract;
 import org.onebusaway.android.util.PreferenceUtils;
+import org.onebusaway.android.util.ShowcaseViewUtils;
 
 import android.content.DialogInterface;
 import android.database.Cursor;
@@ -28,6 +29,7 @@ import android.os.Bundle;
 import android.support.v4.content.CursorLoader;
 import android.support.v4.content.Loader;
 import android.support.v7.app.AlertDialog;
+import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 import android.view.ContextMenu;
 import android.view.ContextMenu.ContextMenuInfo;
@@ -64,6 +66,33 @@ public class MyStarredStopsFragment extends MyStopListFragmentBase {
     public void onActivityCreated(Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
         setHasOptionsMenu(true);
+        showStarredStopsTutorials();
+    }
+
+
+    @Override
+    public void onHiddenChanged(boolean hidden) {
+        super.onHiddenChanged(hidden);
+        if (!hidden) {
+            showStarredStopsTutorials();
+        }
+    }
+
+    /**
+     * Show the sort starred stops tutorial if we have more than 1 starred stop
+     */
+    private void showStarredStopsTutorials() {
+        if (!isVisible()) {
+            return;
+        }
+        if (mAdapter.getCount() > 0) {
+            ShowcaseViewUtils.showTutorial(ShowcaseViewUtils.TUTORIAL_STARRED_STOPS_SHORTCUT,
+                    (AppCompatActivity) getActivity(), null);
+        }
+        if (mAdapter.getCount() > 1) {
+            ShowcaseViewUtils.showTutorial(ShowcaseViewUtils.TUTORIAL_STARRED_STOPS_SORT,
+                    (AppCompatActivity) getActivity(), null);
+        }
     }
 
     @Override

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/NavigationDrawerFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/NavigationDrawerFragment.java
@@ -57,12 +57,6 @@ public class NavigationDrawerFragment extends Fragment {
      */
     private static final String STATE_SELECTED_POSITION = "selected_navigation_drawer_position";
 
-    /**
-     * Per the design guidelines, you should show the drawer on launch until the user manually
-     * expands it. This shared preference tracks this.
-     */
-    private static final String PREF_USER_LEARNED_DRAWER = "navigation_drawer_learned";
-
     // symbols for navdrawer items (indices must correspond to array below). This is
     // not a list of items that are necessarily *present* in the Nav Drawer; rather,
     // it's a list of all possible items.
@@ -132,8 +126,6 @@ public class NavigationDrawerFragment extends Fragment {
 
     private boolean mFromSavedInstanceState;
 
-    private boolean mUserLearnedDrawer;
-
     public NavigationDrawerFragment() {
     }
 
@@ -144,7 +136,6 @@ public class NavigationDrawerFragment extends Fragment {
         // Read in the flag indicating whether or not the user has demonstrated awareness of the
         // drawer. See PREF_USER_LEARNED_DRAWER for details.
         SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(getActivity());
-        mUserLearnedDrawer = sp.getBoolean(PREF_USER_LEARNED_DRAWER, false);
 
         if (savedInstanceState != null) {
             mCurrentSelectedPosition = savedInstanceState.getInt(STATE_SELECTED_POSITION);
@@ -240,24 +231,9 @@ public class NavigationDrawerFragment extends Fragment {
                     return;
                 }
 
-                if (!mUserLearnedDrawer) {
-                    // The user manually opened the drawer; store this flag to prevent auto-showing
-                    // the navigation drawer automatically in the future.
-                    mUserLearnedDrawer = true;
-                    SharedPreferences sp = PreferenceManager
-                            .getDefaultSharedPreferences(getActivity());
-                    sp.edit().putBoolean(PREF_USER_LEARNED_DRAWER, true).apply();
-                }
-
                 getActivity().supportInvalidateOptionsMenu(); // calls onPrepareOptionsMenu()
             }
         };
-
-        // If the user hasn't 'learned' about the drawer, open it to introduce them to the drawer,
-        // per the navigation drawer design guidelines.
-        if (!mUserLearnedDrawer && !mFromSavedInstanceState) {
-            mDrawerLayout.openDrawer(mFragmentContainerView);
-        }
 
         // Defer code dependent on restoration of previous instance state.
         mDrawerLayout.post(new Runnable() {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/PreferencesActivity.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/PreferencesActivity.java
@@ -24,6 +24,7 @@ import org.onebusaway.android.app.Application;
 import org.onebusaway.android.io.ObaAnalytics;
 import org.onebusaway.android.region.ObaRegionsTask;
 import org.onebusaway.android.util.BuildFlavorUtils;
+import org.onebusaway.android.util.ShowcaseViewUtils;
 
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -64,6 +65,8 @@ public class PreferencesActivity extends PreferenceActivity
 
     Preference analyticsPref;
 
+    Preference tutorialPref;
+
     Preference donatePref;
 
     Preference poweredByObaPref;
@@ -91,6 +94,9 @@ public class PreferencesActivity extends PreferenceActivity
 
         analyticsPref = findPreference(getString(R.string.preferences_key_analytics));
         analyticsPref.setOnPreferenceChangeListener(this);
+
+        tutorialPref = findPreference(getString(R.string.preference_key_tutorial));
+        tutorialPref.setOnPreferenceClickListener(this);
 
         donatePref = findPreference(getString(R.string.preferences_key_donate));
         donatePref.setOnPreferenceClickListener(this);
@@ -227,6 +233,12 @@ public class PreferencesActivity extends PreferenceActivity
         Log.d(TAG, "preference - " + pref.getKey());
         if (pref.equals(regionPref)) {
             RegionsActivity.start(this);
+        } else if (pref.equals(tutorialPref)) {
+            ObaAnalytics.reportEventWithCategory(ObaAnalytics.ObaEventCategory.UI_ACTION.toString(),
+                    getString(R.string.analytics_action_button_press),
+                    getString(R.string.analytics_label_button_press_tutorial));
+            ShowcaseViewUtils.resetAllTutorials();
+            NavHelp.goHome(this);
         } else if (pref.equals(donatePref)) {
             ObaAnalytics.reportEventWithCategory(ObaAnalytics.ObaEventCategory.UI_ACTION.toString(),
                     getString(R.string.analytics_action_button_press),

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/ShowcaseViewUtils.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/ShowcaseViewUtils.java
@@ -1,0 +1,325 @@
+package org.onebusaway.android.util;
+
+import com.github.amlcurran.showcaseview.OnShowcaseEventListener;
+import com.github.amlcurran.showcaseview.ShowcaseView;
+import com.github.amlcurran.showcaseview.targets.Target;
+import com.github.amlcurran.showcaseview.targets.ViewTarget;
+
+import org.onebusaway.android.R;
+import org.onebusaway.android.app.Application;
+import org.onebusaway.android.io.request.ObaArrivalInfoResponse;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.content.res.Resources;
+import android.graphics.drawable.Drawable;
+import android.os.Build;
+import android.support.annotation.DrawableRes;
+import android.support.v4.content.res.ResourcesCompat;
+import android.support.v7.app.AppCompatActivity;
+import android.text.Spannable;
+import android.text.SpannableString;
+import android.text.style.ImageSpan;
+import android.view.ViewGroup;
+import android.widget.RelativeLayout;
+
+/**
+ * A class containing utility methods related to showing a tutorial to users for how to use various
+ * OBA features, using the ShowcaseView library (https://github.com/amlcurran/ShowcaseView).
+ */
+public class ShowcaseViewUtils {
+
+    public static final String TUTORIAL_WELCOME = ".tutorial_welcome";
+
+    public static final String TUTORIAL_ARRIVAL_HEADER_ARRIVAL_INFO
+            = ".tutorial_arrival_header_arrival_info";
+
+    public static final String TUTORIAL_ARRIVAL_HEADER_STAR_STOP
+            = ".tutorial_arrival_header_star_stop";
+
+    public static final String TUTORIAL_ARRIVAL_HEADER_SLIDING_PANEL
+            = ".tutorial_arrival_header_sliding_panel";
+
+    public static final String TUTORIAL_ARRIVAL_INFO_MORE = ".tutorial_arrival_info_more";
+
+    public static final String TUTORIAL_ARRIVAL_SORT = ".tutorial_arrival_sort";
+
+    public static final String TUTORIAL_ARRIVAL_HEADER_STAR_ROUTE
+            = ".tutorial_arrival_header_star_route";
+
+    public static final String TUTORIAL_RECENT_STOPS_ROUTES = ".tutorial_recent_stops_routes";
+
+    public static final String TUTORIAL_ARRIVAL_STYLE_B_SHOW_ROUTE
+            = ".tutorial_arrival_style_b_show_route_items";
+
+    public static final String TUTORIAL_VEHICLE_ICONS = ".tutorial_vehicle_icons";
+
+    public static final String TUTORIAL_VEHICLE_INFO_WINDOW = ".tutorial_vehicle_info_window";
+
+    public static final String TUTORIAL_STARRED_STOPS_SORT = ".tutorial_starred_stops_sort";
+
+    public static final String TUTORIAL_STARRED_STOPS_SHORTCUT = ".tutorial_starred stops_shortcut";
+
+    private static ShowcaseView mShowcaseView;
+
+    /**
+     * Returns true if this API level supports the ShowcaseView library tutorials, false if it does
+     * not
+     *
+     * @return true if this API level supports the ShowcaseView library tutorials, false if it does
+     * not
+     */
+    public static boolean supportsShowcaseView() {
+        // ShowcaseView only works on API Level >= 11
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB;
+    }
+
+    /**
+     * Shows the tutorial for the specified tutorialType.  This method handles checking to see if
+     * other ShowcaseViews are already being shown, as well as if this tutorial has already been
+     * shown - if either of these cases are true, this method is a no-op.
+     *
+     * @param tutorialType type of tutorial to show, defined by the TUTORIAL_* constants in
+     *                     ShowcaseViewUtils
+     * @param activity     activity used to show the tutorial
+     * @param response     The response that contains arrival info, or null if this is not available.
+     *                     Some tutorials require that arrival info is showing - these tutorials
+     *                     will only be displayed if arrival info is provided in this parameter.
+     */
+    public synchronized static void showTutorial(String tutorialType,
+            final AppCompatActivity activity, final ObaArrivalInfoResponse response) {
+        if (!supportsShowcaseView() || activity == null) {
+            return;
+        }
+        if (isShowcaseViewShowing()
+                && !tutorialType.equals(TUTORIAL_ARRIVAL_HEADER_SLIDING_PANEL)) {
+            // Only tutorials that are chained (fired from listeners when another ShowcaseView
+            // closes) should pass this point - otherwise, return
+            return;
+        }
+
+        SharedPreferences settings = Application.getPrefs();
+        boolean showedTutorial = settings.getBoolean(tutorialType, false);
+        if (showedTutorial) {
+            // If we've already shown this tutorial to the user, do nothing
+            return;
+        }
+
+        Resources r = activity.getResources();
+        OnShowcaseEventListener listener = null;
+        boolean moveButtonLeft = false;
+
+        String title;
+        SpannableString text;
+        Target target = Target.NONE;
+
+        switch (tutorialType) {
+            case TUTORIAL_WELCOME:
+                title = r.getString(R.string.tutorial_welcome_title);
+                text = new SpannableString(r.getString(R.string.tutorial_welcome_text));
+                break;
+            case TUTORIAL_ARRIVAL_HEADER_ARRIVAL_INFO:
+                if (response == null) {
+                    throw new IllegalArgumentException(
+                            "ObaArrivalInfoResponse must be provided for the '" + tutorialType
+                                    + "' tutorial type.");
+                }
+                if (response.getArrivalInfo().length < 1) {
+                    // We need at least one arrival time
+                    return;
+                }
+                title = r.getString(R.string.tutorial_arrival_header_arrival_info_title);
+                text = new SpannableString(
+                        r.getString(R.string.tutorial_arrival_header_arrival_info_text));
+                target = new ViewTarget(R.id.eta_and_min, activity);
+                moveButtonLeft = true;
+                listener = new OnShowcaseEventListener() {
+                    @Override
+                    public void onShowcaseViewHide(ShowcaseView showcaseView) {
+                        showTutorial(TUTORIAL_ARRIVAL_HEADER_SLIDING_PANEL, activity, response);
+                    }
+
+                    @Override
+                    public void onShowcaseViewDidHide(ShowcaseView showcaseView) {
+                    }
+
+                    @Override
+                    public void onShowcaseViewShow(ShowcaseView showcaseView) {
+                    }
+                };
+                break;
+            case TUTORIAL_ARRIVAL_HEADER_STAR_STOP:
+                title = r.getString(R.string.tutorial_arrival_header_star_stop_title);
+                text = new SpannableString(
+                        r.getString(R.string.tutorial_arrival_header_star_stop_text));
+                target = new ViewTarget(R.id.stop_favorite, activity);
+                break;
+            case TUTORIAL_ARRIVAL_HEADER_SLIDING_PANEL:
+                title = r.getString(R.string.tutorial_arrival_header_sliding_panel_title);
+                text = new SpannableString(
+                        r.getString(R.string.tutorial_arrival_header_sliding_panel_text));
+                target = new ViewTarget(R.id.expand_collapse, activity);
+                moveButtonLeft = true;
+                break;
+            case TUTORIAL_ARRIVAL_INFO_MORE:
+                if (response == null) {
+                    throw new IllegalArgumentException(
+                            "ObaArrivalInfoResponse must be provided for the '" + tutorialType
+                                    + "' tutorial type.");
+                }
+                if (response.getArrivalInfo().length < 1) {
+                    // We need at least one arrival time
+                    return;
+                }
+                title = r.getString(R.string.tutorial_arrival_info_more_title);
+                text = new SpannableString(
+                        r.getString(R.string.tutorial_arrival_info_more_text));
+                target = new ViewTarget(R.id.eta_more_vert, activity);
+                moveButtonLeft = true;
+                break;
+            case TUTORIAL_ARRIVAL_SORT:
+                title = r.getString(R.string.tutorial_arrival_sort_title);
+                text = new SpannableString(r.getString(R.string.tutorial_arrival_sort_text));
+                addIcon(activity, text, R.drawable.ic_action_content_sort);
+                break;
+            case TUTORIAL_ARRIVAL_HEADER_STAR_ROUTE:
+                if (response == null) {
+                    throw new IllegalArgumentException(
+                            "ObaArrivalInfoResponse must be provided for the '" + tutorialType
+                                    + "' tutorial type.");
+                }
+                if (response.getArrivalInfo().length < 1) {
+                    // We need at least one arrival time
+                    return;
+                }
+                title = r.getString(R.string.tutorial_arrival_header_star_route_title);
+                text = new SpannableString(
+                        r.getString(R.string.tutorial_arrival_header_star_route_text));
+                target = new ViewTarget(R.id.eta_route_favorite, activity);
+                break;
+            case TUTORIAL_RECENT_STOPS_ROUTES:
+                title = r.getString(R.string.tutorial_arrival_header_star_route_title);
+                text = new SpannableString(
+                        r.getString(R.string.tutorial_arrival_header_star_route_text));
+                addIcon(activity, text, R.drawable.ic_navigation_more_vert);
+                break;
+            case TUTORIAL_ARRIVAL_STYLE_B_SHOW_ROUTE:
+                if (response == null) {
+                    throw new IllegalArgumentException(
+                            "ObaArrivalInfoResponse must be provided for the '" + tutorialType
+                                    + "' tutorial type.");
+                }
+                if (response.getArrivalInfo().length < 1) {
+                    // We need at least one arrival time
+                    return;
+                }
+                title = r.getString(R.string.tutorial_arrival_style_b_show_route_title);
+                text = new SpannableString(
+                        r.getString(R.string.tutorial_arrival_style_b_show_route_text));
+                target = new ViewTarget(R.id.mapImageBtn, activity);
+                moveButtonLeft = true;
+                break;
+            case TUTORIAL_VEHICLE_ICONS:
+                title = r.getString(R.string.tutorial_vehicle_icons_title);
+                text = new SpannableString(r.getString(R.string.tutorial_vehicle_icons_text));
+                // No target, as we can't target map markers
+                break;
+            case TUTORIAL_VEHICLE_INFO_WINDOW:
+                title = r.getString(R.string.tutorial_vehicle_info_window_title);
+                text = new SpannableString(r.getString(R.string.tutorial_vehicle_info_window_text));
+                // No target, as we can't target custom map info window contents
+                break;
+            case TUTORIAL_STARRED_STOPS_SORT:
+                title = r.getString(R.string.tutorial_starred_stops_sort_title);
+                text = new SpannableString(r.getString(R.string.tutorial_starred_stops_sort_text));
+                addIcon(activity, text, R.drawable.ic_action_content_sort);
+                break;
+            case TUTORIAL_STARRED_STOPS_SHORTCUT:
+                title = r.getString(R.string.tutorial_starred_stops_shortcut_title);
+                text = new SpannableString(
+                        r.getString(R.string.tutorial_starred_stops_shortcut_text));
+                break;
+            default:
+                throw new IllegalArgumentException(
+                        "tutorialType must be one of the TUTORIAL_* constants in ShowcaseViewUtils");
+        }
+
+        mShowcaseView = new ShowcaseView.Builder(activity)
+                .setTarget(target)
+                .setStyle(R.style.CustomShowcaseTheme)
+                .setContentTitle(title)
+                .setContentText(text)
+                .build();
+        // If button should be positioned to the left, then set the parameters
+        if (moveButtonLeft) {
+            moveButtonLeft(activity, mShowcaseView);
+        }
+        if (listener != null) {
+            mShowcaseView.setOnShowcaseEventListener(listener);
+        }
+
+        // Set the preference for this tutorial type so it doesn't show again
+        PreferenceUtils.saveBoolean(tutorialType, true);
+    }
+
+    /**
+     * Returns true if the ShowcaseView is currently showing, false if it is not
+     *
+     * @return true if the ShowcaseView is currently showing, false if it is not
+     */
+    public static boolean isShowcaseViewShowing() {
+        return mShowcaseView != null && mShowcaseView.isShowing();
+    }
+
+    /**
+     * Adds the provided icon to the right side of the provided SpannableString
+     *
+     * @param text             SpannableString to add sort icon to
+     * @param drawableResource ID of the drawable resource to add to the right side of the
+     *                         SpannableString
+     */
+    private static void addIcon(Context context, SpannableString text,
+            @DrawableRes int drawableResource) {
+        Drawable d = ResourcesCompat.getDrawable(context.getResources(),
+                drawableResource, context.getTheme());
+        d.setBounds(0, 0, d.getIntrinsicWidth(), d.getIntrinsicHeight());
+        ImageSpan imageSpan = new ImageSpan(d, ImageSpan.ALIGN_BOTTOM);
+        text.setSpan(imageSpan, text.length() - 1, text.length(),
+                Spannable.SPAN_INCLUSIVE_INCLUSIVE);
+    }
+
+    /**
+     * Moves the button to acknowledge the ShowcaseView to be left aligned
+     *
+     * @param v ShowcaseView for which the button should be left aligned
+     */
+    private static void moveButtonLeft(Context context, ShowcaseView v) {
+        RelativeLayout.LayoutParams lp = new RelativeLayout.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT);
+        lp.addRule(RelativeLayout.ALIGN_PARENT_LEFT);
+        lp.addRule(RelativeLayout.ALIGN_PARENT_BOTTOM);
+        int p = UIUtils.dpToPixels(context, 12);
+        lp.setMargins(p, p, p, p);
+        v.setButtonPosition(lp);
+    }
+
+    /**
+     * Resets all tutorials so they are shown to the user again
+     */
+    public static void resetAllTutorials() {
+        PreferenceUtils.saveBoolean(TUTORIAL_WELCOME, false);
+        PreferenceUtils.saveBoolean(TUTORIAL_ARRIVAL_HEADER_ARRIVAL_INFO, false);
+        PreferenceUtils.saveBoolean(TUTORIAL_ARRIVAL_HEADER_STAR_STOP, false);
+        PreferenceUtils.saveBoolean(TUTORIAL_ARRIVAL_HEADER_SLIDING_PANEL, false);
+        PreferenceUtils.saveBoolean(TUTORIAL_ARRIVAL_INFO_MORE, false);
+        PreferenceUtils.saveBoolean(TUTORIAL_ARRIVAL_SORT, false);
+        PreferenceUtils.saveBoolean(TUTORIAL_ARRIVAL_HEADER_STAR_ROUTE, false);
+        PreferenceUtils.saveBoolean(TUTORIAL_RECENT_STOPS_ROUTES, false);
+        PreferenceUtils.saveBoolean(TUTORIAL_ARRIVAL_STYLE_B_SHOW_ROUTE, false);
+        PreferenceUtils.saveBoolean(TUTORIAL_VEHICLE_ICONS, false);
+        PreferenceUtils.saveBoolean(TUTORIAL_VEHICLE_INFO_WINDOW, false);
+        PreferenceUtils.saveBoolean(TUTORIAL_STARRED_STOPS_SORT, false);
+        PreferenceUtils.saveBoolean(TUTORIAL_STARRED_STOPS_SHORTCUT, false);
+    }
+}

--- a/onebusaway-android/src/main/res/values-fi/arrays.xml
+++ b/onebusaway-android/src/main/res/values-fi/arrays.xml
@@ -15,10 +15,17 @@
 -->
 <resources>
     <string-array name="main_help_options">
+        <item>Tutorial</item>
         <item>Twitter</item>
         <item>Tuetut liikennöitsijät</item>
         <item>Uutta?</item>
         <item>Ota yhteyttä</item>
+    </string-array>
+    <string-array name="main_help_options_no_contact_us">
+        <item>Tutorial</item>
+        <item>Twitter Feed</item>
+        <item>Supported Agencies</item>
+        <item>What\'s New?</item>
     </string-array>
     <string-array name="stop_item_options">
         <item>Aseta muistutus</item>

--- a/onebusaway-android/src/main/res/values/arrays.xml
+++ b/onebusaway-android/src/main/res/values/arrays.xml
@@ -16,12 +16,14 @@
 -->
 <resources>
     <string-array name="main_help_options">
+        <item>Show Tutorial</item>
         <item>Twitter Feed</item>
         <item>Supported Agencies</item>
         <item>What\'s New?</item>
         <item>Contact Us</item>
     </string-array>
     <string-array name="main_help_options_no_contact_us">
+        <item>Show Tutorial</item>
         <item>Twitter Feed</item>
         <item>Supported Agencies</item>
         <item>What\'s New?</item>

--- a/onebusaway-android/src/main/res/values/donottranslate.xml
+++ b/onebusaway-android/src/main/res/values/donottranslate.xml
@@ -34,6 +34,7 @@
     <string name="preference_key_arrival_info_style">preference_arrival_info_style</string>
     <string name="preference_key_show_negative_arrivals">preference_show_negative_arrivals</string>
     <string name="preference_key_default_stop_sort">preference_default_stop_sort</string>
+    <string name="preference_key_tutorial">preference_key_tutorial</string>
 
     <!-- Regions API URL -->
     <string name="regions_api_url">http://regions.onebusaway.org/regions-v3.json</string>
@@ -80,6 +81,7 @@
     <string name="analytics_label_button_press_nearby">Clicked Nearby Item Link</string>
     <string name="analytics_label_button_press_reminders">Clicked My Reminders Link</string>
     <string name="analytics_label_button_press_settings">Clicked Settings Link</string>
+    <string name="analytics_label_button_press_tutorial">Clicked Tutorial Link</string>
     <string name="analytics_label_button_press_donate">Clicked Donate Link</string>
     <string name="analytics_label_button_press_powered_by_oba">Clicked Powered By Oba Link</string>
     <string name="analytics_label_button_press_about">Clicked About</string>

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -101,13 +101,12 @@
     <string name="main_help_title">Help</string>
     <string name="main_help_whatsnew_title">What\'s New?</string>
     <string name="main_help_whatsnew">&#8226;\u0020
-        <b>Improved \"Show route on map\" interface</b>
-        - Route is now a layer on same map view.\n&#8226;\u0020
-        <b>Misc. usability improvements</b>
-        - Lots of small tweaks.\n&#8226;\u0020
-        <b>Accessibility improvements</b>
-        - Better labels for some components.\n&#8226;
-        <b>Bug fixes</b>
+        <b>Fresh new look</b>
+        - Yay material design!\n&#8226;\u0020
+        <b>Live buses on the map</b>
+        - Tap on arrival times and choose \"Show route on map\"!\n&#8226;\u0020
+        <b>Live trip status</b>
+        - Tap on arrival times and choose \"Show trip status\"!
     </string>
     <string name="main_help_close">Close</string>
     <string name="main_nolocation_title">Location not enabled</string>
@@ -476,6 +475,8 @@
     </string>
     <string name="preferences_analytics_title">Send anonymous usage data</string>
     <string name="preferences_analytics_summary">Help us improve the app</string>
+    <string name="preferences_tutorial_title">Show tutorial</string>
+    <string name="preferences_tutorial_summary">Show instructions for using this app</string>
     <string name="preferences_donate_title">Donate</string>
     <string name="preferences_donate_summary">Support the OneBusAway open-source project</string>
     <string name="preferences_powered_by_oba_title">Powered by OneBusAway</string>
@@ -524,6 +525,64 @@
         couldn\'t see you in the dark? Hold up your flashing Night Light and make yourself visible!
     </string>
     <string name="night_light_create_shortcut">Create shortcut</string>
+
+    <!-- Tutorials -->
+    <string name="tutorial_welcome_title">Welcome to OneBusAway!</string>
+    <string name="tutorial_welcome_text">Tap on a stop (green dot on the map) to see arrival
+        times.
+    </string>
+    <string name="tutorial_arrival_header_arrival_info_title">How long until your bus arrives?
+    </string>
+    <string name="tutorial_arrival_header_arrival_info_text">This long! Colored background tells you
+        if the bus is early (red) or late (blue). On time = green background. If we don\'t know
+        where the bus is, the scheduled time is shown (gray background).
+    </string>
+    <string name="tutorial_arrival_header_star_stop_title">Star your favorite stops</string>
+    <string name="tutorial_arrival_header_star_stop_text">Tap on the star to save your favorite
+        stops. Starred stops are available via the main navigation panel.
+    </string>
+    <string name="tutorial_arrival_header_sliding_panel_title">Slide up to show more arrivals
+    </string>
+    <string name="tutorial_arrival_header_sliding_panel_text">Tap on the arrow or drag the panel up
+        to see more arrivals for this stop.
+    </string>
+    <string name="tutorial_arrival_info_more_title">Use your transit super powers wisely!</string>
+    <string name="tutorial_arrival_info_more_text">Tap on the 3 dots to set reminders, star favorite
+        routes, view a route on the map, and more…
+    </string>
+    <string name="tutorial_arrival_sort_title">Sort by ETA or route</string>
+    <string name="tutorial_arrival_sort_text">Arrivals can be sorted by estimated arrival time, or
+        sorted/grouped by route using the "Sort" button at the top of the screen.
+    </string>
+    <string name="tutorial_arrival_header_star_route_title">Star your favorite routes</string>
+    <string name="tutorial_arrival_header_star_route_text">Tap on the star to pin your favorite
+        routes to the top of the sliding panel.
+    </string>
+    <string name="tutorial_recent_stops_routes_title">Recent stops and routes</string>
+    <string name="tutorial_recent_stops_routes_text">Stops and routes that you\'ve recent looked at
+        can be accessed via the "More" button.
+    </string>
+    <string name="tutorial_arrival_style_b_show_route_title">View live vehicle positions on the map
+    </string>
+    <string name="tutorial_arrival_style_b_show_route_text">Tap on the map icon to see your bus move
+        in real-time.
+    </string>
+    <string name="tutorial_vehicle_icons_title">Tap on vehicle icons to see details</string>
+    <string name="tutorial_vehicle_icons_text">Hint - Rotate the map using two fingers if you
+        accidentally tap on a nearby stop instead of the vehicle.
+    </string>
+    <string name="tutorial_vehicle_info_window_title">See live vehicle details</string>
+    <string name="tutorial_vehicle_info_window_text">Tap on the popup balloon to view the transit
+        line and real-time trip status for that vehicle.
+    </string>
+    <string name="tutorial_starred_stops_sort_title">Sort your starred stops</string>
+    <string name="tutorial_starred_stops_sort_text">Organize your favorite stops by name or
+        frequency of use with the "Sort" button at the top of the screen.
+    </string>
+    <string name="tutorial_starred_stops_shortcut_title">Save time with shortcuts</string>
+    <string name="tutorial_starred_stops_shortcut_text">Long-press on a stop to create a shortcut on
+        your home screen. Tap on the shortcut to instantly see arrivals!
+    </string>
 
     <!-- About -->
     <string name="title_activity_about">About</string>

--- a/onebusaway-android/src/main/res/values/styles.xml
+++ b/onebusaway-android/src/main/res/values/styles.xml
@@ -218,4 +218,21 @@
     </style>
     <style name="Theme.OneBusAway.AppBarOverlay" parent="ThemeOverlay.AppCompat.Dark.ActionBar"/>
     <style name="Theme.OneBusAway.PopupOverlay" parent="ThemeOverlay.AppCompat.Light"/>
+
+    <!-- Tutorial - ShowcaseView -->
+    <style name="CustomShowcaseTheme" parent="ShowcaseView">
+        <item name="sv_backgroundColor">#df4CAF50</item>
+        <item name="sv_showcaseColor">@color/theme_primary_dark</item>
+        <item name="sv_buttonText">Got it!</item>
+        <item name="sv_titleTextAppearance">@style/CustomTitle2</item>
+        <item name="sv_detailTextAppearance">@style/CustomText2</item>
+    </style>
+
+    <style name="CustomTitle2" parent="TextAppearance.ShowcaseView.Title.Light">
+        <item name="android:textColor">#deffffff</item>
+    </style>
+
+    <style name="CustomText2" parent="TextAppearance.ShowcaseView.Detail.Light">
+        <item name="android:textColor">#bfffffff</item>
+    </style>
 </resources>

--- a/onebusaway-android/src/main/res/xml/preferences.xml
+++ b/onebusaway-android/src/main/res/xml/preferences.xml
@@ -76,6 +76,10 @@
             android:summary="@string/preferences_analytics_summary"
             android:defaultValue="true"/>
         <Preference
+                android:key="@string/preference_key_tutorial"
+                android:title="@string/preferences_tutorial_title"
+                android:summary="@string/preferences_tutorial_summary"/>
+        <Preference
             android:key="@string/preferences_key_donate"
             android:title="@string/preferences_donate_title"
             android:summary="@string/preferences_donate_summary"/>


### PR DESCRIPTION
This PR replaces https://github.com/OneBusAway/onebusaway-android/pull/406 and fixes #313, as it builds on some initial code from the Proof-of-Concept there.

Note that because the ShowcaseView library only supports API Level 11 and greater, we won't show a tutorial on API Level 10 and under.

This also removes the auto-opening nav drawer, as its referenced in the tutorial.