### PR TITLE
Fix #264 - Fix stop/trip problem reporting API requests

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/io/test/ReportProblemWithStopRequestTest.java
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/io/test/ReportProblemWithStopRequestTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2016 University of South Florida (cagricetin@mail.usf.edu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.io.test;
+
+
+import org.onebusaway.android.UriAssert;
+import org.onebusaway.android.app.Application;
+import org.onebusaway.android.io.elements.ObaRegion;
+import org.onebusaway.android.io.request.ObaReportProblemWithStopRequest;
+import org.onebusaway.android.mock.MockRegion;
+
+import java.util.HashMap;
+
+public class ReportProblemWithStopRequestTest extends ObaTestCase {
+
+    public void testPugetSoundReportProblemRequestUsingRegion() {
+        // Test by setting region
+        ObaRegion ps = MockRegion.getPugetSound(getContext());
+        assertNotNull(ps);
+        Application.get().setCurrentRegion(ps);
+        _assertPugetSoundReportProblemRequest();
+    }
+
+    private void _assertPugetSoundReportProblemRequest() {
+        ObaReportProblemWithStopRequest.Builder builder =
+                new ObaReportProblemWithStopRequest.Builder(getContext(), "1_29261");
+        builder.setCode("stop_location_wrong")
+                .setUserLocation(28.0586583, -82.416445)
+                .setUserLocationAccuracy(22)
+                .setUserComment("test");
+
+        ObaReportProblemWithStopRequest request = builder.build();
+
+        UriAssert.assertUriMatch(
+                "http://api.pugetsound.onebusaway.org/api/where/report-problem-with-stop.json?" +
+                        "stopId=1_29261&code=stop_location_wrong&data=%7B%22code%22%3A%22stop_location_wrong%22%7D" +
+                        "&userComment=test&userLat=28.0586583&userLon=-82.416445&userLocationAccuracy=22&app_ver=58&" +
+                        "app_uid=fc35c268f18c0929249cdad89e8d5fcc&version=2&" +
+                        "key=v1_BktoDJ2gJlu6nLM6LsT9H8IUbWc%3DcGF1bGN3YXR0c0BnbWFpbC5jb20%3D",
+                new HashMap<String, String>() {{
+                    put("key", "*");
+                    put("version", "2");
+                }},
+                request
+        );
+    }
+
+    public void testHARTReportProblemRequestUsingRegion() {
+        // Test by setting region
+        ObaRegion ps = MockRegion.getTampa(getContext());
+        assertNotNull(ps);
+        Application.get().setCurrentRegion(ps);
+        _assertHARTReportProblemRequest();
+    }
+
+    private void _assertHARTReportProblemRequest() {
+        ObaReportProblemWithStopRequest.Builder builder =
+                new ObaReportProblemWithStopRequest.Builder(getContext(), "Hillsborough Area Regional Transit_4551");
+        builder.setCode("stop_location_wrong")
+                .setUserLocation(28.0586583, -82.416445)
+                .setUserLocationAccuracy(22)
+                .setUserComment("test");
+
+        ObaReportProblemWithStopRequest request = builder.build();
+
+        UriAssert.assertUriMatch(
+                "http://api.tampa.onebusaway.org/api/api/where/report-problem-with-stop.json?" +
+                        "stopId=Hillsborough%20Area%20Regional%20Transit_4551&code=stop_location_wrong&data=%7B%22code%22%3A%22stop_location_wrong%22%7D" +
+                        "&userComment=test&userLat=28.0586583&userLon=-82.416445&userLocationAccuracy=22&app_ver=58&" +
+                        "app_uid=fc35c268f18c0929249cdad89e8d5fcc&version=2&" +
+                        "key=v1_BktoDJ2gJlu6nLM6LsT9H8IUbWc%3DcGF1bGN3YXR0c0BnbWFpbC5jb20%3D",
+                new HashMap<String, String>() {{
+                    put("key", "*");
+                    put("version", "2");
+                }},
+                request
+        );
+    }
+
+    public void testStagingReportProblemRequestUsingRegionCustomUrl() {
+        // Test by setting custom region
+        Application.get().setCustomApiUrl("app.staging.obahart.org");
+        _assertStagingReportProblemRequestCustomUrl();
+    }
+
+    private void _assertStagingReportProblemRequestCustomUrl() {
+        ObaReportProblemWithStopRequest.Builder builder =
+                new ObaReportProblemWithStopRequest.Builder(getContext(), "Hillsborough Area Regional Transit_4551");
+        builder.setCode("stop_location_wrong")
+                .setUserLocation(28.0586583, -82.416445)
+                .setUserLocationAccuracy(22)
+                .setUserComment("test");
+
+        ObaReportProblemWithStopRequest request = builder.build();
+
+        UriAssert.assertUriMatch(
+                "http://app.staging.obahart.org/api/where/report-problem-with-stop.json?" +
+                        "stopId=Hillsborough%20Area%20Regional%20Transit_4551&code=stop_location_wrong&data=%7B%22code%22%3A%22stop_location_wrong%22%7D" +
+                        "&userComment=test&userLat=28.0586583&userLon=-82.416445&userLocationAccuracy=22&app_ver=58&" +
+                        "app_uid=fc35c268f18c0929249cdad89e8d5fcc&version=2&" +
+                        "key=v1_BktoDJ2gJlu6nLM6LsT9H8IUbWc%3DcGF1bGN3YXR0c0BnbWFpbC5jb20%3D",
+                new HashMap<String, String>() {{
+                    put("key", "*");
+                    put("version", "2");
+                }},
+                request
+        );
+    }
+}

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/io/test/ReportProblemWithTripRequestTest.java
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/io/test/ReportProblemWithTripRequestTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (C) 2016 University of South Florida (cagricetin@mail.usf.edu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.io.test;
+
+
+import org.onebusaway.android.UriAssert;
+import org.onebusaway.android.app.Application;
+import org.onebusaway.android.io.elements.ObaRegion;
+import org.onebusaway.android.io.request.ObaReportProblemWithTripRequest;
+import org.onebusaway.android.mock.MockRegion;
+
+import java.util.HashMap;
+
+public class ReportProblemWithTripRequestTest extends ObaTestCase {
+
+    public void testPugetSoundReportProblemRequestUsingRegion() {
+        // Test by setting region
+        ObaRegion ps = MockRegion.getPugetSound(getContext());
+        assertNotNull(ps);
+        Application.get().setCurrentRegion(ps);
+        _assertPugetSoundReportProblemRequest();
+    }
+
+    private void _assertPugetSoundReportProblemRequest() {
+        ObaReportProblemWithTripRequest.Builder builder =
+                new ObaReportProblemWithTripRequest.Builder(getContext(), "1_29261");
+        builder.setStopId("1_29262")
+                .setVehicleId("1_29263")
+                .setServiceDate(1456722000000l)
+                .setCode("vehicle_never_came")
+                .setUserLocation(28.0586583, -82.416445)
+                .setUserLocationAccuracy(22)
+                .setUserComment("test");
+
+        ObaReportProblemWithTripRequest request = builder.build();
+
+        UriAssert.assertUriMatch(
+                "http://api.pugetsound.onebusaway.org/api/where/report-problem-with-trip.json?" +
+                        "tripId=1_29261&" +
+                        "stopId=1_29262&" +
+                        "vehicleId=1_29263&" +
+                        "serviceDate=1456722000000&code=vehicle_never_came&" +
+                        "data=%7B%22code%22%3A%22vehicle_never_came%22%7D&" +
+                        "userComment=test&userLat=28.0586583&userLon=-82.416445&" +
+                        "userLocationAccuracy=23&userOnVehicle=false&app_ver=58&" +
+                        "app_uid=fc35c268f18c0929249cdad89e8d5fcc&version=2&" +
+                        "key=v1_BktoDJ2gJlu6nLM6LsT9H8IUbWc%3DcGF1bGN3YXR0c0BnbWFpbC5jb20%3D",
+                new HashMap<String, String>() {{
+                    put("key", "*");
+                    put("version", "2");
+                }},
+                request
+        );
+    }
+
+    public void testHARTReportProblemRequestUsingRegion() {
+        // Test by setting region
+        ObaRegion ps = MockRegion.getTampa(getContext());
+        assertNotNull(ps);
+        Application.get().setCurrentRegion(ps);
+        _assertHARTReportProblemRequest();
+    }
+
+    private void _assertHARTReportProblemRequest() {
+        ObaReportProblemWithTripRequest.Builder builder =
+                new ObaReportProblemWithTripRequest.Builder(getContext(), "Hillsborough Area Regional Transit_121133");
+        builder.setStopId("Hillsborough Area Regional Transit_4551")
+                .setVehicleId("Hillsborough Area Regional Transit_1018")
+                .setServiceDate(1456722000000l)
+                .setCode("vehicle_never_came")
+                .setUserLocation(28.0586583, -82.416445)
+                .setUserLocationAccuracy(22)
+                .setUserComment("test");
+
+        ObaReportProblemWithTripRequest request = builder.build();
+
+        UriAssert.assertUriMatch(
+                "http://api.tampa.onebusaway.org/api/api/where/report-problem-with-trip.json?" +
+                        "tripId=Hillsborough%20Area%20Regional%20Transit_121133&" +
+                        "stopId=Hillsborough Area Regional Transit_4551&" +
+                        "vehicleId=Hillsborough%20Area%20Regional%20Transit_1018&" +
+                        "serviceDate=1456722000000&code=vehicle_never_came&" +
+                        "data=%7B%22code%22%3A%22vehicle_never_came%22%7D&" +
+                        "userComment=test&userLat=28.0586583&userLon=-82.416445&" +
+                        "userLocationAccuracy=23&userOnVehicle=false&app_ver=58&" +
+                        "app_uid=fc35c268f18c0929249cdad89e8d5fcc&version=2&" +
+                        "key=v1_BktoDJ2gJlu6nLM6LsT9H8IUbWc%3DcGF1bGN3YXR0c0BnbWFpbC5jb20%3D",
+                new HashMap<String, String>() {{
+                    put("key", "*");
+                    put("version", "2");
+                }},
+                request
+        );
+    }
+
+    public void testStagingReportProblemRequestUsingRegionCustomUrl() {
+        // Test by setting custom region
+        Application.get().setCustomApiUrl("app.staging.obahart.org");
+        _assertStagingReportProblemRequestCustomUrl();
+    }
+
+    private void _assertStagingReportProblemRequestCustomUrl() {
+        ObaReportProblemWithTripRequest.Builder builder =
+                new ObaReportProblemWithTripRequest.Builder(getContext(), "Hillsborough Area Regional Transit_121133");
+        builder.setStopId("Hillsborough Area Regional Transit_4551")
+                .setVehicleId("Hillsborough Area Regional Transit_1018")
+                .setServiceDate(1456722000000l)
+                .setCode("vehicle_never_came")
+                .setUserLocation(28.0586583, -82.416445)
+                .setUserLocationAccuracy(22)
+                .setUserComment("test");
+
+        ObaReportProblemWithTripRequest request = builder.build();
+
+        UriAssert.assertUriMatch(
+                "http://app.staging.obahart.org/api/where/report-problem-with-trip.json?" +
+                        "tripId=Hillsborough%20Area%20Regional%20Transit_121133&" +
+                        "stopId=Hillsborough Area Regional Transit_4551&" +
+                        "vehicleId=Hillsborough%20Area%20Regional%20Transit_1018&" +
+                        "serviceDate=1456722000000&code=vehicle_never_came&" +
+                        "data=%7B%22code%22%3A%22vehicle_never_came%22%7D&" +
+                        "userComment=test&userLat=28.0586583&userLon=-82.416445&" +
+                        "userLocationAccuracy=23&userOnVehicle=false&app_ver=58&" +
+                        "app_uid=fc35c268f18c0929249cdad89e8d5fcc&version=2&" +
+                        "key=v1_BktoDJ2gJlu6nLM6LsT9H8IUbWc%3DcGF1bGN3YXR0c0BnbWFpbC5jb20%3D",
+                new HashMap<String, String>() {{
+                    put("key", "*");
+                    put("version", "2");
+                }},
+                request
+        );
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/io/JacksonSerializer.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/io/JacksonSerializer.java
@@ -118,6 +118,19 @@ public class JacksonSerializer implements ObaApi.SerializationHandler {
         }
     }
 
+    public <T> T deserializeFromResponse(String response, Class<T> cls) {
+        try {
+            return mMapper.readValue(response, cls);
+        } catch (JsonParseException e) {
+            Log.e(TAG, e.toString());
+        } catch (JsonMappingException e) {
+            Log.e(TAG, e.toString());
+        } catch (IOException e) {
+            Log.e(TAG, e.toString());
+        }
+        return null;
+    }
+
     public String serialize(Object obj) {
         StringWriter writer = new StringWriter();
         JsonGenerator jsonGenerator;

--- a/onebusaway-android/src/main/java/org/onebusaway/android/io/ObaApi.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/io/ObaApi.java
@@ -55,6 +55,8 @@ public final class ObaApi {
 
         <T> T deserialize(Reader reader, Class<T> cls);
 
+        <T> T deserializeFromResponse(String response, Class<T> cls);
+
         String serialize(Object obj);
 
         <T> T createFromError(Class<T> cls, int code, String error);

--- a/onebusaway-android/src/main/java/org/onebusaway/android/io/request/ObaReportProblemWithStopRequest.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/io/request/ObaReportProblemWithStopRequest.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2012 Paul Watts (paulcwatts@gmail.com)
+ * Copyright (C) 2012 - 2016 Paul Watts (paulcwatts@gmail.com)
+ * University of South Florida (cagricetin@mail.usf.edu)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,11 +50,12 @@ public final class ObaReportProblemWithStopRequest extends RequestBase
         super(uri, postData);
     }
 
-    public static class Builder extends RequestBase.PostBuilderBase {
+    public static class Builder extends RequestBase.BuilderBase {
 
         public Builder(Context context, String stopId) {
             super(context, BASE_PATH + "/report-problem-with-stop.json");
-            mPostData.appendQueryParameter("stopId", stopId);
+            mBuilder.appendQueryParameter("stopId", stopId);
+
         }
 
         /**
@@ -62,10 +64,10 @@ public final class ObaReportProblemWithStopRequest extends RequestBase
          * @param code The problem code.
          */
         public Builder setCode(String code) {
-            mPostData.appendQueryParameter("code", code);
+            mBuilder.appendQueryParameter("code", code);
             // This is also for the old, JSON-encoded "data" format of the API.
             String data = String.format("{\"code\":\"%s\"}", code);
-            mPostData.appendQueryParameter("data", data);
+            mBuilder.appendQueryParameter("data", data);
             return this;
         }
 
@@ -75,7 +77,7 @@ public final class ObaReportProblemWithStopRequest extends RequestBase
          * @param comment The user comment.
          */
         public Builder setUserComment(String comment) {
-            mPostData.appendQueryParameter("userComment", comment);
+            mBuilder.appendQueryParameter("userComment", comment);
             return this;
         }
 
@@ -86,8 +88,8 @@ public final class ObaReportProblemWithStopRequest extends RequestBase
          * @param lon The user's current location.
          */
         public Builder setUserLocation(double lat, double lon) {
-            mPostData.appendQueryParameter("userLat", String.valueOf(lat));
-            mPostData.appendQueryParameter("userLon", String.valueOf(lon));
+            mBuilder.appendQueryParameter("userLat", String.valueOf(lat));
+            mBuilder.appendQueryParameter("userLon", String.valueOf(lon));
             return this;
         }
 
@@ -97,18 +99,18 @@ public final class ObaReportProblemWithStopRequest extends RequestBase
          * @param meters The user's location accuracy in meters.
          */
         public Builder setUserLocationAccuracy(int meters) {
-            mPostData.appendQueryParameter("userLocationAccuracy", String.valueOf(meters));
+            mBuilder.appendQueryParameter("userLocationAccuracy", String.valueOf(meters));
             return this;
         }
 
         public ObaReportProblemWithStopRequest build() {
-            return new ObaReportProblemWithStopRequest(buildUri(), buildPostData());
+            return new ObaReportProblemWithStopRequest(buildUri(), null);
         }
     }
 
     @Override
     public ObaReportProblemWithStopResponse call() {
-        return callPostHack(ObaReportProblemWithStopResponse.class);
+        return call(ObaReportProblemWithStopResponse.class);
     }
 
     @Override

--- a/onebusaway-android/src/main/java/org/onebusaway/android/io/request/ObaReportProblemWithTripRequest.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/io/request/ObaReportProblemWithTripRequest.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2012 Paul Watts (paulcwatts@gmail.com)
+ * Copyright (C) 2012-2016 Paul Watts (paulcwatts@gmail.com)
+ * University of South Florida (cagricetin@mail.usf.edu)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,11 +52,11 @@ public final class ObaReportProblemWithTripRequest extends RequestBase
         super(uri, postData);
     }
 
-    public static class Builder extends RequestBase.PostBuilderBase {
+    public static class Builder extends RequestBase.BuilderBase {
 
         public Builder(Context context, String tripId) {
             super(context, BASE_PATH + "/report-problem-with-trip.json");
-            mPostData.appendQueryParameter("tripId", tripId);
+            mBuilder.appendQueryParameter("tripId", tripId);
         }
 
         /**
@@ -65,7 +66,7 @@ public final class ObaReportProblemWithTripRequest extends RequestBase
          * @param stopId The stop ID.
          */
         public Builder setStopId(String stopId) {
-            mPostData.appendQueryParameter("stopId", stopId);
+            mBuilder.appendQueryParameter("stopId", stopId);
             return this;
         }
 
@@ -75,7 +76,7 @@ public final class ObaReportProblemWithTripRequest extends RequestBase
          * @param serviceDate The service date.
          */
         public Builder setServiceDate(long serviceDate) {
-            mPostData.appendQueryParameter("serviceDate", String.valueOf(serviceDate));
+            mBuilder.appendQueryParameter("serviceDate", String.valueOf(serviceDate));
             return this;
         }
 
@@ -85,7 +86,7 @@ public final class ObaReportProblemWithTripRequest extends RequestBase
          * @param vehicleId The vehicle actively serving the trip.
          */
         public Builder setVehicleId(String vehicleId) {
-            mPostData.appendQueryParameter("vehicleId", vehicleId);
+            mBuilder.appendQueryParameter("vehicleId", vehicleId);
             return this;
         }
 
@@ -95,10 +96,10 @@ public final class ObaReportProblemWithTripRequest extends RequestBase
          * @param code The problem code.
          */
         public Builder setCode(String code) {
-            mPostData.appendQueryParameter("code", code);
+            mBuilder.appendQueryParameter("code", code);
             // This is also for the old, JSON-encoded "data" format of the API.
             String data = String.format("{\"code\":\"%s\"}", code);
-            mPostData.appendQueryParameter("data", data);
+            mBuilder.appendQueryParameter("data", data);
             return this;
         }
 
@@ -108,7 +109,7 @@ public final class ObaReportProblemWithTripRequest extends RequestBase
          * @param comment The user comment.
          */
         public Builder setUserComment(String comment) {
-            mPostData.appendQueryParameter("userComment", comment);
+            mBuilder.appendQueryParameter("userComment", comment);
             return this;
         }
 
@@ -119,8 +120,8 @@ public final class ObaReportProblemWithTripRequest extends RequestBase
          * @param lon The user's current location.
          */
         public Builder setUserLocation(double lat, double lon) {
-            mPostData.appendQueryParameter("userLat", String.valueOf(lat));
-            mPostData.appendQueryParameter("userLon", String.valueOf(lon));
+            mBuilder.appendQueryParameter("userLat", String.valueOf(lat));
+            mBuilder.appendQueryParameter("userLon", String.valueOf(lon));
             return this;
         }
 
@@ -130,7 +131,7 @@ public final class ObaReportProblemWithTripRequest extends RequestBase
          * @param meters The user's location accuracy in meters.
          */
         public Builder setUserLocationAccuracy(int meters) {
-            mPostData.appendQueryParameter("userLocationAccuracy", String.valueOf(meters));
+            mBuilder.appendQueryParameter("userLocationAccuracy", String.valueOf(meters));
             return this;
         }
 
@@ -142,7 +143,7 @@ public final class ObaReportProblemWithTripRequest extends RequestBase
          * @param onVehicle If the user is on the vehicle.
          */
         public Builder setUserOnVehicle(boolean onVehicle) {
-            mPostData.appendQueryParameter("userOnVehicle", String.valueOf(onVehicle));
+            mBuilder.appendQueryParameter("userOnVehicle", String.valueOf(onVehicle));
             return this;
         }
 
@@ -152,18 +153,18 @@ public final class ObaReportProblemWithTripRequest extends RequestBase
          * @param vehicleNumber The vehicle as reported by the user.
          */
         public Builder setUserVehicleNumber(String vehicleNumber) {
-            mPostData.appendQueryParameter("userVehicleNumber", vehicleNumber);
+            mBuilder.appendQueryParameter("userVehicleNumber", vehicleNumber);
             return this;
         }
 
         public ObaReportProblemWithTripRequest build() {
-            return new ObaReportProblemWithTripRequest(buildUri(), buildPostData());
+            return new ObaReportProblemWithTripRequest(buildUri(), null);
         }
     }
 
     @Override
     public ObaReportProblemWithTripResponse call() {
-        return callPostHack(ObaReportProblemWithTripResponse.class);
+        return call(ObaReportProblemWithTripResponse.class);
     }
 
     @Override

--- a/onebusaway-android/src/main/java/org/onebusaway/android/io/request/RequestBase.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/io/request/RequestBase.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2010-2012 Paul Watts (paulcwatts@gmail.com)
+ * Copyright (C) 2010-2016 Paul Watts (paulcwatts@gmail.com)
+ * University of South Florida (cagricetin@mail.usf.edu)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,10 +23,8 @@ import org.onebusaway.android.io.ObaContext;
 import android.content.Context;
 import android.net.Uri;
 import android.os.Build;
-import android.text.TextUtils;
 import android.util.Log;
 
-import java.io.BufferedReader;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.Reader;
@@ -158,39 +157,4 @@ public class RequestBase {
         }
     }
 
-    protected <T> T callPostHack(Class<T> cls) {
-        ObaApi.SerializationHandler handler = ObaApi.getSerializer(cls);
-        ObaConnection conn = null;
-        try {
-            conn = ObaApi.getDefaultContext().getConnectionFactory().newConnection(mUri);
-            BufferedReader reader = new BufferedReader(conn.post(mPostData), 8 * 1024);
-
-            String line;
-            StringBuffer text = new StringBuffer();
-            while ((line = reader.readLine()) != null) {
-                text.append(line + "\n");
-            }
-
-            String response = text.toString();
-            if (TextUtils.isEmpty(response)) {
-                return handler.createFromError(cls, ObaApi.OBA_OK, "OK");
-            } else {
-                // {"actionErrors":[],"fieldErrors":{"stopId":["requiredField.stopId"]}}
-                // TODO: Deserialize the JSON and check "fieldErrors"
-                // if this is empty, then it succeeded? Or check for an actual ObaResponse???
-                return handler.createFromError(cls, ObaApi.OBA_INTERNAL_ERROR, response);
-            }
-
-        } catch (FileNotFoundException e) {
-            Log.e(TAG, e.toString());
-            return handler.createFromError(cls, ObaApi.OBA_NOT_FOUND, e.toString());
-        } catch (IOException e) {
-            Log.e(TAG, e.toString());
-            return handler.createFromError(cls, ObaApi.OBA_IO_EXCEPTION, e.toString());
-        } finally {
-            if (conn != null) {
-                conn.disconnect();
-            }
-        }
-    }
 }


### PR DESCRIPTION
This PR fixes issue #264.  

Get requests are now used to report stop/trip problems instead of post requests. 