### PR TITLE
WIP - Fix #444 - Simplify route polylines before they are drawn on the map

### DIFF
--- a/onebusaway-android/build.gradle
+++ b/onebusaway-android/build.gradle
@@ -281,6 +281,8 @@ dependencies {
     }
     // Google Play Services Location (we need this on Amazon flavor too)
     compile 'com.google.android.gms:play-services-location:8.3.0'
+    // Map utils - polyline simplification
+    compile 'com.google.maps.android:android-maps-utils:0.4.3'
     // Support libraries
     compile 'com.android.support:cardview-v7:22.2.1'
     compile 'com.android.support:design:22.2.1'

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/BaseMapFragment.java
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/BaseMapFragment.java
@@ -27,6 +27,7 @@ import com.google.android.gms.maps.model.LatLngBounds;
 import com.google.android.gms.maps.model.Polyline;
 import com.google.android.gms.maps.model.PolylineOptions;
 import com.google.android.gms.maps.model.VisibleRegion;
+import com.google.maps.android.PolyUtil;
 
 import org.onebusaway.android.R;
 import org.onebusaway.android.app.Application;
@@ -53,8 +54,10 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.graphics.drawable.Drawable;
 import android.location.Location;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
+import android.os.SystemClock;
 import android.provider.Settings;
 import android.support.v4.graphics.drawable.DrawableCompat;
 import android.support.v7.app.AlertDialog;
@@ -65,6 +68,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Toast;
 
+import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -705,28 +709,69 @@ public class BaseMapFragment extends SupportMapFragment
         return mMap.getCameraPosition().zoom;
     }
 
+    final Handler mRouteOverlayHandler = new Handler();
+
     @Override
-    public void setRouteOverlay(int lineOverlayColor, ObaShape[] shapes) {
+    public void setRouteOverlay(final int lineOverlayColor, final ObaShape[] shapes) {
         if (mMap != null) {
-            mLineOverlay.clear();
-            PolylineOptions lineOptions;
+            mRouteOverlayHandler.removeCallbacks(null);
 
-            int totalPoints = 0;
+            // Simplifying route polylines can take a reasonable amount of time, so run in separate thread
+            mRouteOverlayHandler.post(new Runnable() {
+                @Override
+                public void run() {
+                    mLineOverlay.clear();
+                    PolylineOptions lineOptions;
 
-            for (ObaShape s : shapes) {
-                lineOptions = new PolylineOptions();
-                lineOptions.color(lineOverlayColor);
+                    int totalPoints = 0;
+                    List original = new ArrayList<>();
+                    int totalSimplified = 0;
+                    List simplified;
+                    double tolerance = 2; // meters
+                    long totalTime = 0;
 
-                for (Location l : s.getPoints()) {
-                    lineOptions.add(MapHelpV2.makeLatLng(l));
+                    for (ObaShape s : shapes) {
+                        lineOptions = new PolylineOptions();
+                        lineOptions.color(lineOverlayColor);
+
+                        for (Location l : s.getPoints()) {
+                            original.add(MapHelpV2.makeLatLng(l));
+                        }
+
+                        long startTime = Long.MAX_VALUE, endTime = Long.MAX_VALUE;
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+                            startTime = SystemClock.elapsedRealtimeNanos();
+                        }
+
+                        simplified = PolyUtil.simplify(original, tolerance);
+
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+                            endTime = SystemClock.elapsedRealtimeNanos();
+                            totalTime += endTime - startTime;
+                            Log.d(TAG, "Polyline simplify time: " + TimeUnit.MILLISECONDS
+                                    .convert(endTime - startTime, TimeUnit.NANOSECONDS) + "ms");
+                        }
+
+                        lineOptions.addAll(simplified);
+                        // Add the line to the map, and keep a reference in the ArrayList
+                        mLineOverlay.add(mMap.addPolyline(lineOptions));
+
+                        totalSimplified += simplified.size();
+                        totalPoints += original.size();
+                    }
+
+                    float savings = (1 - ((float) totalSimplified / totalPoints));
+                    Log.d(TAG, "Total simplified points for route polylines = " + totalSimplified);
+                    Log.d(TAG, "Total points for route polylines = " + totalPoints);
+                    Log.d(TAG, "Polyline % savings (with tolerance of " + tolerance + "m) =  "
+                            + MessageFormat.format(
+                            "{0,number,#.##%}", savings));
+                    Log.d(TAG, "Total polyline simplify time: " + TimeUnit.MILLISECONDS
+                            .convert(totalTime, TimeUnit.NANOSECONDS) + "ms");
                 }
-                // Add the line to the map, and keep a reference in the ArrayList
-                mLineOverlay.add(mMap.addPolyline(lineOptions));
+            });
 
-                totalPoints += lineOptions.getPoints().size();
-            }
 
-            Log.d(TAG, "Total points for route polylines = " + totalPoints);
         }
     }
 


### PR DESCRIPTION
_Please don't merge_

From #444:

> I'm seeing strange artifacts that shouldn't exist, such as the line across the middle of the route below:
> 
> ![image](https://cloud.githubusercontent.com/assets/928045/13851366/3fb57e98-ec34-11e5-9496-c1584285646f.png)
> 
> This is with a relatively small tolerance of 2m, which shouldn't result in drastic changes to the line shape, although it does result in substantial savings on points:
> 
> This needs a little more work before it can be merged to resolve the artifact issues with the line crossing the middle of the map - we simplify several polylines for a given route, so I'm not sure if its smaller lines that are getting messed up by simplification, or what.
