### PR TITLE
Fix #287 - Better distinguish between arrivals/departures

### DIFF
--- a/onebusaway-android/src/amazon/java/org/onebusaway/android/map/googlemapsv2/VehicleOverlay.java
+++ b/onebusaway-android/src/amazon/java/org/onebusaway/android/map/googlemapsv2/VehicleOverlay.java
@@ -652,7 +652,7 @@ public class VehicleOverlay implements AmazonMap.OnInfoWindowClickListener {
                 statusView.setPadding(pSides, pTopBottom, pSides, pTopBottom);
             } else {
                 // Scheduled info
-                statusView.setText(r.getString(R.string.stop_info_scheduled_arrival));
+                statusView.setText(r.getString(R.string.stop_info_scheduled));
                 statusColor = R.color.stop_info_scheduled_time;
                 d.setColor(r.getColor(statusColor));
                 lastUpdatedView.setText(r.getString(R.string.vehicle_last_updated_scheduled));

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/io/test/ArrivalInfoRequestTest.java
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/io/test/ArrivalInfoRequestTest.java
@@ -161,6 +161,45 @@ public class ArrivalInfoRequestTest extends ObaTestCase {
         assertTrue(nearbyStops.size() > 0);
     }
 
+    public void testTotalStopsInTrip() throws Exception {
+        // Test by setting API directly
+        Application.get().setCustomApiUrl("api.tampa.onebusaway.org/api");
+
+        /**
+         * First test with a response from a server that supports the "totalStopsInTrip" field.
+         * In this case, it's for a fake stop 10000, and we use data for actual stop 6497 from
+         * the OBA Tampa server after it started supporting the field.
+         */
+        ObaArrivalInfoResponse response =
+                new ObaArrivalInfoRequest.Builder(getContext(),
+                        "Hillsborough Area Regional Transit_10000").build().call();
+        assertOK(response);
+
+        ObaArrivalInfo[] arrivals = response.getArrivalInfo();
+        assertNotNull(arrivals);
+        assertEquals(34, arrivals[0].getTotalStopsInTrip());
+        assertEquals(34, arrivals[1].getTotalStopsInTrip());
+        assertEquals(142, arrivals[2].getTotalStopsInTrip());
+        assertEquals(71, arrivals[3].getTotalStopsInTrip());
+        assertEquals(142, arrivals[4].getTotalStopsInTrip());
+        assertEquals(34, arrivals[5].getTotalStopsInTrip());
+        assertEquals(34, arrivals[6].getTotalStopsInTrip());
+        assertEquals(142, arrivals[7].getTotalStopsInTrip());
+
+        /**
+         * Now test with a response from a server that doesn't support the "totalStopsInTrip" field.
+         * In this case, it's a response from the OBA Tampa server prior to supporting the field.
+         */
+        response = new ObaArrivalInfoRequest.Builder(getContext(),
+                "Hillsborough Area Regional Transit_6497").build().call();
+        assertOK(response);
+
+        arrivals = response.getArrivalInfo();
+        assertEquals(0, arrivals[0].getTotalStopsInTrip());
+        assertEquals(0, arrivals[1].getTotalStopsInTrip());
+        assertEquals(0, arrivals[2].getTotalStopsInTrip());
+    }
+
     public void testNewRequestUsingCustomUrl() throws Exception {
         // Test by setting API directly
         Application.get().setCustomApiUrl("api.pugetsound.onebusaway.org");

--- a/onebusaway-android/src/androidTest/res/raw/arrivals_and_departurse_for_stop_total_stops_in_trip.json
+++ b/onebusaway-android/src/androidTest/res/raw/arrivals_and_departurse_for_stop_total_stops_in_trip.json
@@ -1,0 +1,915 @@
+{
+  "code": 200,
+  "currentTime": 1459259368018,
+  "data": {
+    "entry": {
+      "arrivalsAndDepartures": [
+        {
+          "arrivalEnabled": true,
+          "blockTripSequence": 3,
+          "departureEnabled": true,
+          "distanceFromStop": 3409.2837306353176,
+          "frequency": null,
+          "lastUpdateTime": 1459259325000,
+          "numberOfStopsAway": 13,
+          "predicted": true,
+          "predictedArrivalInterval": null,
+          "predictedArrivalTime": 1459260056000,
+          "predictedDepartureInterval": null,
+          "predictedDepartureTime": 1459260056000,
+          "routeId": "PSTA_32",
+          "routeLongName": "ST. PETERSBURG CIRCULATOR",
+          "routeShortName": "32",
+          "scheduledArrivalInterval": null,
+          "scheduledArrivalTime": 1459260000000,
+          "scheduledDepartureInterval": null,
+          "scheduledDepartureTime": 1459260000000,
+          "serviceDate": 1459224000000,
+          "situationIds": [],
+          "status": "default",
+          "stopId": "PSTA_1767",
+          "stopSequence": 33,
+          "totalStopsInTrip": 34,
+          "tripHeadsign": "DOWNTOWN ST PETERSBURG",
+          "tripId": "PSTA_1330213020",
+          "tripStatus": {
+            "activeTripId": "PSTA_1330213020",
+            "blockTripSequence": 3,
+            "closestStop": "PSTA_10067",
+            "closestStopTimeOffset": 29,
+            "distanceAlongTrip": 4100.757670214007,
+            "frequency": null,
+            "lastKnownDistanceAlongTrip": 0,
+            "lastKnownLocation": {
+              "lat": 27.764249801635742,
+              "lon": -82.63497924804688
+            },
+            "lastKnownOrientation": 0,
+            "lastLocationUpdateTime": 0,
+            "lastUpdateTime": 1459259325000,
+            "nextStop": "PSTA_10067",
+            "nextStopTimeOffset": 29,
+            "orientation": 90,
+            "phase": "in_progress",
+            "position": {
+              "lat": 27.766912280995722,
+              "lon": -82.63395
+            },
+            "predicted": true,
+            "scheduleDeviation": 56,
+            "scheduledDistanceAlongTrip": 4100.757670214007,
+            "serviceDate": 1459224000000,
+            "situationIds": [
+              "PSTA_13",
+              "PSTA_12"
+            ],
+            "status": "default",
+            "totalDistanceAlongTrip": 7511.998573846595,
+            "vehicleId": "PSTA_2510"
+          },
+          "vehicleId": "PSTA_2510"
+        },
+        {
+          "arrivalEnabled": true,
+          "blockTripSequence": 4,
+          "departureEnabled": true,
+          "distanceFromStop": 3413.5010092359444,
+          "frequency": null,
+          "lastUpdateTime": 1459259325000,
+          "numberOfStopsAway": 14,
+          "predicted": true,
+          "predictedArrivalInterval": null,
+          "predictedArrivalTime": 1459260300000,
+          "predictedDepartureInterval": null,
+          "predictedDepartureTime": 1459260300000,
+          "routeId": "PSTA_32",
+          "routeLongName": "ST. PETERSBURG CIRCULATOR",
+          "routeShortName": "32",
+          "scheduledArrivalInterval": null,
+          "scheduledArrivalTime": 1459260300000,
+          "scheduledDepartureInterval": null,
+          "scheduledDepartureTime": 1459260300000,
+          "serviceDate": 1459224000000,
+          "situationIds": [],
+          "status": "default",
+          "stopId": "PSTA_1767",
+          "stopSequence": 0,
+          "totalStopsInTrip": 34,
+          "tripHeadsign": "DOWNTOWN ST PETERSBURG",
+          "tripId": "PSTA_1330214020",
+          "tripStatus": {
+            "activeTripId": "PSTA_1330213020",
+            "blockTripSequence": 3,
+            "closestStop": "PSTA_10067",
+            "closestStopTimeOffset": 29,
+            "distanceAlongTrip": 4100.757670214007,
+            "frequency": null,
+            "lastKnownDistanceAlongTrip": 0,
+            "lastKnownLocation": {
+              "lat": 27.764249801635742,
+              "lon": -82.63497924804688
+            },
+            "lastKnownOrientation": 0,
+            "lastLocationUpdateTime": 0,
+            "lastUpdateTime": 1459259325000,
+            "nextStop": "PSTA_10067",
+            "nextStopTimeOffset": 29,
+            "orientation": 90,
+            "phase": "in_progress",
+            "position": {
+              "lat": 27.766912280995722,
+              "lon": -82.63395
+            },
+            "predicted": true,
+            "scheduleDeviation": 56,
+            "scheduledDistanceAlongTrip": 4100.757670214007,
+            "serviceDate": 1459224000000,
+            "situationIds": [
+              "PSTA_13",
+              "PSTA_12"
+            ],
+            "status": "default",
+            "totalDistanceAlongTrip": 7511.998573846595,
+            "vehicleId": "PSTA_2510"
+          },
+          "vehicleId": "PSTA_2510"
+        },
+        {
+          "arrivalEnabled": true,
+          "blockTripSequence": 1,
+          "departureEnabled": true,
+          "distanceFromStop": 9176.467693927974,
+          "frequency": null,
+          "lastUpdateTime": 1459259325000,
+          "numberOfStopsAway": 38,
+          "predicted": true,
+          "predictedArrivalInterval": null,
+          "predictedArrivalTime": 1459260701000,
+          "predictedDepartureInterval": null,
+          "predictedDepartureTime": 1459260701000,
+          "routeId": "PSTA_74",
+          "routeLongName": "ST PETERSBURG/INDIAN ROCKS",
+          "routeShortName": "74",
+          "scheduledArrivalInterval": null,
+          "scheduledArrivalTime": 1459259761000,
+          "scheduledDepartureInterval": null,
+          "scheduledDepartureTime": 1459259761000,
+          "serviceDate": 1459224000000,
+          "situationIds": [],
+          "status": "default",
+          "stopId": "PSTA_1767",
+          "stopSequence": 129,
+          "totalStopsInTrip": 142,
+          "tripHeadsign": "DOWNTOWN ST PETERSBURG",
+          "tripId": "PSTA_1332937020",
+          "tripStatus": {
+            "activeTripId": "PSTA_1332937020",
+            "blockTripSequence": 1,
+            "closestStop": "PSTA_745",
+            "closestStopTimeOffset": 3,
+            "distanceAlongTrip": 28281.354250220582,
+            "frequency": null,
+            "lastKnownDistanceAlongTrip": 0,
+            "lastKnownLocation": {
+              "lat": 27.842620849609375,
+              "lon": -82.64686584472656
+            },
+            "lastKnownOrientation": 0,
+            "lastLocationUpdateTime": 0,
+            "lastUpdateTime": 1459259325000,
+            "nextStop": "PSTA_745",
+            "nextStopTimeOffset": 3,
+            "orientation": 355.9143832202318,
+            "phase": "in_progress",
+            "position": {
+              "lat": 27.842516164830784,
+              "lon": -82.64670630763096
+            },
+            "predicted": true,
+            "scheduleDeviation": 940,
+            "scheduledDistanceAlongTrip": 28281.354250220582,
+            "serviceDate": 1459224000000,
+            "situationIds": [
+              "PSTA_13",
+              "PSTA_12"
+            ],
+            "status": "default",
+            "totalDistanceAlongTrip": 40262.018403075745,
+            "vehicleId": "PSTA_13106"
+          },
+          "vehicleId": "PSTA_13106"
+        },
+        {
+          "arrivalEnabled": true,
+          "blockTripSequence": 3,
+          "departureEnabled": true,
+          "distanceFromStop": 7353.385461270125,
+          "frequency": null,
+          "lastUpdateTime": 1459259325000,
+          "numberOfStopsAway": 31,
+          "predicted": true,
+          "predictedArrivalInterval": null,
+          "predictedArrivalTime": 1459260810000,
+          "predictedDepartureInterval": null,
+          "predictedDepartureTime": 1459260810000,
+          "routeId": "PSTA_5",
+          "routeLongName": "ST PETERSBURG/TYRONE SQUARE MALL",
+          "routeShortName": "5",
+          "scheduledArrivalInterval": null,
+          "scheduledArrivalTime": 1459260347000,
+          "scheduledDepartureInterval": null,
+          "scheduledDepartureTime": 1459260347000,
+          "serviceDate": 1459224000000,
+          "situationIds": [],
+          "status": "default",
+          "stopId": "PSTA_1767",
+          "stopSequence": 61,
+          "totalStopsInTrip": 71,
+          "tripHeadsign": "5 TH AVE N + 2ND ST",
+          "tripId": "PSTA_1329982020",
+          "tripStatus": {
+            "activeTripId": "PSTA_1329982020",
+            "blockTripSequence": 3,
+            "closestStop": "PSTA_3737",
+            "closestStopTimeOffset": 3,
+            "distanceAlongTrip": 7868.738187084942,
+            "frequency": null,
+            "lastKnownDistanceAlongTrip": 0,
+            "lastKnownLocation": {
+              "lat": 27.77818489074707,
+              "lon": -82.71224975585938
+            },
+            "lastKnownOrientation": 0,
+            "lastLocationUpdateTime": 0,
+            "lastUpdateTime": 1459259325000,
+            "nextStop": "PSTA_3737",
+            "nextStopTimeOffset": 3,
+            "orientation": 351.8698976462512,
+            "phase": "in_progress",
+            "position": {
+              "lat": 27.777092390851976,
+              "lon": -82.71195673596382
+            },
+            "predicted": true,
+            "scheduleDeviation": 463,
+            "scheduledDistanceAlongTrip": 7868.738187084942,
+            "serviceDate": 1459224000000,
+            "situationIds": [
+              "PSTA_13",
+              "PSTA_12"
+            ],
+            "status": "default",
+            "totalDistanceAlongTrip": 18013.911440837164,
+            "vehicleId": "PSTA_2511"
+          },
+          "vehicleId": "PSTA_2511"
+        },
+        {
+          "arrivalEnabled": true,
+          "blockTripSequence": 3,
+          "departureEnabled": true,
+          "distanceFromStop": 19423.26713833367,
+          "frequency": null,
+          "lastUpdateTime": 1459259325000,
+          "numberOfStopsAway": 64,
+          "predicted": true,
+          "predictedArrivalInterval": null,
+          "predictedArrivalTime": 1459262029000,
+          "predictedDepartureInterval": null,
+          "predictedDepartureTime": 1459262029000,
+          "routeId": "PSTA_74",
+          "routeLongName": "ST PETERSBURG/INDIAN ROCKS",
+          "routeShortName": "74",
+          "scheduledArrivalInterval": null,
+          "scheduledArrivalTime": 1459261561000,
+          "scheduledDepartureInterval": null,
+          "scheduledDepartureTime": 1459261561000,
+          "serviceDate": 1459224000000,
+          "situationIds": [],
+          "status": "default",
+          "stopId": "PSTA_1767",
+          "stopSequence": 129,
+          "totalStopsInTrip": 142,
+          "tripHeadsign": "DOWNTOWN ST PETERSBURG",
+          "tripId": "PSTA_1332938020",
+          "tripStatus": {
+            "activeTripId": "PSTA_1332938020",
+            "blockTripSequence": 3,
+            "closestStop": "PSTA_719",
+            "closestStopTimeOffset": 0,
+            "distanceAlongTrip": 18034.554805814885,
+            "frequency": null,
+            "lastKnownDistanceAlongTrip": 0,
+            "lastKnownLocation": {
+              "lat": 27.839107513427734,
+              "lon": -82.71088409423828
+            },
+            "lastKnownOrientation": 0,
+            "lastLocationUpdateTime": 0,
+            "lastUpdateTime": 1459259325000,
+            "nextStop": "PSTA_719",
+            "nextStopTimeOffset": 0,
+            "orientation": 0,
+            "phase": "in_progress",
+            "position": {
+              "lat": 27.83911,
+              "lon": -82.70795980207237
+            },
+            "predicted": true,
+            "scheduleDeviation": 468,
+            "scheduledDistanceAlongTrip": 18034.554805814885,
+            "serviceDate": 1459224000000,
+            "situationIds": [
+              "PSTA_13",
+              "PSTA_12"
+            ],
+            "status": "default",
+            "totalDistanceAlongTrip": 40262.018403075745,
+            "vehicleId": "PSTA_2606"
+          },
+          "vehicleId": "PSTA_2606"
+        },
+        {
+          "arrivalEnabled": true,
+          "blockTripSequence": 4,
+          "departureEnabled": true,
+          "distanceFromStop": 10923.542410085269,
+          "frequency": null,
+          "lastUpdateTime": 1459259325000,
+          "numberOfStopsAway": 47,
+          "predicted": true,
+          "predictedArrivalInterval": null,
+          "predictedArrivalTime": 1459262100000,
+          "predictedDepartureInterval": null,
+          "predictedDepartureTime": 1459262100000,
+          "routeId": "PSTA_32",
+          "routeLongName": "ST. PETERSBURG CIRCULATOR",
+          "routeShortName": "32",
+          "scheduledArrivalInterval": null,
+          "scheduledArrivalTime": 1459262100000,
+          "scheduledDepartureInterval": null,
+          "scheduledDepartureTime": 1459262100000,
+          "serviceDate": 1459224000000,
+          "situationIds": [],
+          "status": "default",
+          "stopId": "PSTA_1767",
+          "stopSequence": 33,
+          "totalStopsInTrip": 34,
+          "tripHeadsign": "DOWNTOWN ST PETERSBURG",
+          "tripId": "PSTA_1330214020",
+          "tripStatus": {
+            "activeTripId": "PSTA_1330213020",
+            "blockTripSequence": 3,
+            "closestStop": "PSTA_10067",
+            "closestStopTimeOffset": 29,
+            "distanceAlongTrip": 4100.757670214007,
+            "frequency": null,
+            "lastKnownDistanceAlongTrip": 0,
+            "lastKnownLocation": {
+              "lat": 27.764249801635742,
+              "lon": -82.63497924804688
+            },
+            "lastKnownOrientation": 0,
+            "lastLocationUpdateTime": 0,
+            "lastUpdateTime": 1459259325000,
+            "nextStop": "PSTA_10067",
+            "nextStopTimeOffset": 29,
+            "orientation": 90,
+            "phase": "in_progress",
+            "position": {
+              "lat": 27.766912280995722,
+              "lon": -82.63395
+            },
+            "predicted": true,
+            "scheduleDeviation": 56,
+            "scheduledDistanceAlongTrip": 4100.757670214007,
+            "serviceDate": 1459224000000,
+            "situationIds": [
+              "PSTA_13",
+              "PSTA_12"
+            ],
+            "status": "default",
+            "totalDistanceAlongTrip": 7511.998573846595,
+            "vehicleId": "PSTA_2510"
+          },
+          "vehicleId": "PSTA_2510"
+        },
+        {
+          "arrivalEnabled": true,
+          "blockTripSequence": 5,
+          "departureEnabled": true,
+          "distanceFromStop": 10927.759688685896,
+          "frequency": null,
+          "lastUpdateTime": 1459259325000,
+          "numberOfStopsAway": 48,
+          "predicted": true,
+          "predictedArrivalInterval": null,
+          "predictedArrivalTime": 1459262400000,
+          "predictedDepartureInterval": null,
+          "predictedDepartureTime": 1459262400000,
+          "routeId": "PSTA_32",
+          "routeLongName": "ST. PETERSBURG CIRCULATOR",
+          "routeShortName": "32",
+          "scheduledArrivalInterval": null,
+          "scheduledArrivalTime": 1459262400000,
+          "scheduledDepartureInterval": null,
+          "scheduledDepartureTime": 1459262400000,
+          "serviceDate": 1459224000000,
+          "situationIds": [],
+          "status": "default",
+          "stopId": "PSTA_1767",
+          "stopSequence": 0,
+          "totalStopsInTrip": 34,
+          "tripHeadsign": "DOWNTOWN ST PETERSBURG",
+          "tripId": "PSTA_1330215020",
+          "tripStatus": {
+            "activeTripId": "PSTA_1330213020",
+            "blockTripSequence": 3,
+            "closestStop": "PSTA_10067",
+            "closestStopTimeOffset": 29,
+            "distanceAlongTrip": 4100.757670214007,
+            "frequency": null,
+            "lastKnownDistanceAlongTrip": 0,
+            "lastKnownLocation": {
+              "lat": 27.764249801635742,
+              "lon": -82.63497924804688
+            },
+            "lastKnownOrientation": 0,
+            "lastLocationUpdateTime": 0,
+            "lastUpdateTime": 1459259325000,
+            "nextStop": "PSTA_10067",
+            "nextStopTimeOffset": 29,
+            "orientation": 90,
+            "phase": "in_progress",
+            "position": {
+              "lat": 27.766912280995722,
+              "lon": -82.63395
+            },
+            "predicted": true,
+            "scheduleDeviation": 56,
+            "scheduledDistanceAlongTrip": 4100.757670214007,
+            "serviceDate": 1459224000000,
+            "situationIds": [
+              "PSTA_13",
+              "PSTA_12"
+            ],
+            "status": "default",
+            "totalDistanceAlongTrip": 7511.998573846595,
+            "vehicleId": "PSTA_2510"
+          },
+          "vehicleId": "PSTA_2510"
+        },
+        {
+          "arrivalEnabled": true,
+          "blockTripSequence": 2,
+          "departureEnabled": true,
+          "distanceFromStop": 29138.52249669272,
+          "frequency": null,
+          "lastUpdateTime": 1459259325000,
+          "numberOfStopsAway": 97,
+          "predicted": true,
+          "predictedArrivalInterval": null,
+          "predictedArrivalTime": 1459263164000,
+          "predictedDepartureInterval": null,
+          "predictedDepartureTime": 1459263164000,
+          "routeId": "PSTA_74",
+          "routeLongName": "ST PETERSBURG/INDIAN ROCKS",
+          "routeShortName": "74",
+          "scheduledArrivalInterval": null,
+          "scheduledArrivalTime": 1459263361000,
+          "scheduledDepartureInterval": null,
+          "scheduledDepartureTime": 1459263361000,
+          "serviceDate": 1459224000000,
+          "situationIds": [],
+          "status": "default",
+          "stopId": "PSTA_1767",
+          "stopSequence": 129,
+          "totalStopsInTrip": 142,
+          "tripHeadsign": "DOWNTOWN ST PETERSBURG",
+          "tripId": "PSTA_1332939020",
+          "tripStatus": {
+            "activeTripId": "PSTA_1332939020",
+            "blockTripSequence": 2,
+            "closestStop": "PSTA_686",
+            "closestStopTimeOffset": -23,
+            "distanceAlongTrip": 8319.299447455836,
+            "frequency": null,
+            "lastKnownDistanceAlongTrip": 0,
+            "lastKnownLocation": {
+              "lat": 27.840002059936523,
+              "lon": -82.7929916381836
+            },
+            "lastKnownOrientation": 0,
+            "lastLocationUpdateTime": 0,
+            "lastUpdateTime": 1459259325000,
+            "nextStop": "PSTA_687",
+            "nextStopTimeOffset": 85,
+            "orientation": 0,
+            "phase": "in_progress",
+            "position": {
+              "lat": 27.83959,
+              "lon": -82.7898552447709
+            },
+            "predicted": true,
+            "scheduleDeviation": -197,
+            "scheduledDistanceAlongTrip": 8319.299447455836,
+            "serviceDate": 1459224000000,
+            "situationIds": [
+              "PSTA_13",
+              "PSTA_12"
+            ],
+            "status": "default",
+            "totalDistanceAlongTrip": 40262.018403075745,
+            "vehicleId": "PSTA_12103"
+          },
+          "vehicleId": "PSTA_12103"
+        }
+      ],
+      "nearbyStopIds": [],
+      "situationIds": [
+        "PSTA_13",
+        "PSTA_12"
+      ],
+      "stopId": "PSTA_1767"
+    },
+    "references": {
+      "agencies": [
+        {
+          "disclaimer": "",
+          "email": "cserv@psta.net",
+          "fareUrl": "",
+          "id": "PSTA",
+          "lang": "EN",
+          "name": "PSTA",
+          "phone": "(727) 540-1900",
+          "privateService": false,
+          "timezone": "America/New_York",
+          "url": "http://www.psta.net"
+        }
+      ],
+      "routes": [
+        {
+          "agencyId": "PSTA",
+          "color": "2E2EFE",
+          "description": "",
+          "id": "PSTA_5",
+          "longName": "ST PETERSBURG/TYRONE SQUARE MALL",
+          "shortName": "5",
+          "textColor": "FFFFFF",
+          "type": 3,
+          "url": ""
+        },
+        {
+          "agencyId": "PSTA",
+          "color": "2E2EFE",
+          "description": "",
+          "id": "PSTA_32",
+          "longName": "ST. PETERSBURG CIRCULATOR",
+          "shortName": "32",
+          "textColor": "FFFFFF",
+          "type": 3,
+          "url": ""
+        },
+        {
+          "agencyId": "PSTA",
+          "color": "2E2EFE",
+          "description": "",
+          "id": "PSTA_74",
+          "longName": "ST PETERSBURG/INDIAN ROCKS",
+          "shortName": "74",
+          "textColor": "FFFFFF",
+          "type": 3,
+          "url": ""
+        },
+        {
+          "agencyId": "PSTA",
+          "color": "2E2EFE",
+          "description": "",
+          "id": "PSTA_58",
+          "longName": "GATEWAY MALL/SEMINOLE MALL",
+          "shortName": "58",
+          "textColor": "FFFFFF",
+          "type": 3,
+          "url": ""
+        },
+        {
+          "agencyId": "PSTA",
+          "color": "2E2EFE",
+          "description": "",
+          "id": "PSTA_75",
+          "longName": "GATEWAY MALL/TYRONE SQUARE",
+          "shortName": "75",
+          "textColor": "FFFFFF",
+          "type": 3,
+          "url": ""
+        },
+        {
+          "agencyId": "PSTA",
+          "color": "2E2EFE",
+          "description": "",
+          "id": "PSTA_18",
+          "longName": "ST PETERSBURG/CLEARWATER",
+          "shortName": "18",
+          "textColor": "FFFFFF",
+          "type": 3,
+          "url": ""
+        }
+      ],
+      "situations": [
+        {
+          "activeWindows": [],
+          "allAffects": [
+            {
+              "agencyId": "PSTA",
+              "applicationId": "",
+              "directionId": "",
+              "routeId": "",
+              "stopId": "",
+              "tripId": ""
+            },
+            {
+              "agencyId": "PSTA",
+              "applicationId": "",
+              "directionId": "",
+              "routeId": "",
+              "stopId": "",
+              "tripId": ""
+            },
+            {
+              "agencyId": "PSTA",
+              "applicationId": "",
+              "directionId": "",
+              "routeId": "",
+              "stopId": "",
+              "tripId": ""
+            },
+            {
+              "agencyId": "PSTA",
+              "applicationId": "",
+              "directionId": "",
+              "routeId": "",
+              "stopId": "",
+              "tripId": ""
+            }
+          ],
+          "consequences": [],
+          "creationTime": 1458842289134,
+          "description": {
+            "lang": "en",
+            "value": "[Low] For route schedule information visit our web site at PSTA.net or contact the PSTA InfoLine at (727) 540-1900 or TDD only (727) 540-0603.: For route schedule information visit our web site at PSTA.net or contact the PSTA InfoLine at (727) 540-1900 or TDD only (727) 540-0603."
+          },
+          "id": "PSTA_13",
+          "publicationWindows": [],
+          "reason": "UNKNOWN_CAUSE",
+          "severity": "noImpact",
+          "summary": {
+            "lang": "en",
+            "value": "Shoppes at Park Place: For Route Schedule Information"
+          },
+          "url": null
+        },
+        {
+          "activeWindows": [],
+          "allAffects": [
+            {
+              "agencyId": "PSTA",
+              "applicationId": "",
+              "directionId": "",
+              "routeId": "",
+              "stopId": "",
+              "tripId": ""
+            },
+            {
+              "agencyId": "PSTA",
+              "applicationId": "",
+              "directionId": "",
+              "routeId": "",
+              "stopId": "",
+              "tripId": ""
+            },
+            {
+              "agencyId": "PSTA",
+              "applicationId": "",
+              "directionId": "",
+              "routeId": "",
+              "stopId": "",
+              "tripId": ""
+            },
+            {
+              "agencyId": "PSTA",
+              "applicationId": "",
+              "directionId": "",
+              "routeId": "",
+              "stopId": "",
+              "tripId": ""
+            }
+          ],
+          "consequences": [],
+          "creationTime": 1458842288796,
+          "description": {
+            "lang": "en",
+            "value": "[Low] For route schedule information visit our web site at PSTA.net or contact the PSTA InfoLine at (727) 540-1900 or TDD only (727) 540-0603.: For route schedule information visit our web site at PSTA.net or contact the PSTA InfoLine at (727) 540-1900 or TDD only (727) 540-0603."
+          },
+          "id": "PSTA_12",
+          "publicationWindows": [],
+          "reason": "UNKNOWN_CAUSE",
+          "severity": "noImpact",
+          "summary": {
+            "lang": "en",
+            "value": "Park Street Terminal West: For Route Schedule Information"
+          },
+          "url": null
+        }
+      ],
+      "stops": [
+        {
+          "code": "1200",
+          "direction": "E",
+          "id": "PSTA_1767",
+          "lat": 27.77638,
+          "locationType": 0,
+          "lon": -82.65355,
+          "name": "4TH AVE N + 15TH ST N",
+          "routeIds": [
+            "PSTA_5",
+            "PSTA_32",
+            "PSTA_74"
+          ],
+          "wheelchairBoarding": "UNKNOWN"
+        },
+        {
+          "code": "6523",
+          "direction": "W",
+          "id": "PSTA_10067",
+          "lat": 27.7672,
+          "locationType": 0,
+          "lon": -82.63522,
+          "name": "4TH AVE S + 2ND ST S",
+          "routeIds": [
+            "PSTA_32"
+          ],
+          "wheelchairBoarding": "UNKNOWN"
+        },
+        {
+          "code": "2958",
+          "direction": "E",
+          "id": "PSTA_745",
+          "lat": 27.84251,
+          "locationType": 0,
+          "lon": -82.64645,
+          "name": "77TH AVE N + DR MLK JR ST N",
+          "routeIds": [
+            "PSTA_58",
+            "PSTA_74",
+            "PSTA_75"
+          ],
+          "wheelchairBoarding": "UNKNOWN"
+        },
+        {
+          "code": "1264",
+          "direction": "E",
+          "id": "PSTA_3737",
+          "lat": 27.77708,
+          "locationType": 0,
+          "lon": -82.7118,
+          "name": "5TH AVE N + 58TH ST N",
+          "routeIds": [
+            "PSTA_5"
+          ],
+          "wheelchairBoarding": "UNKNOWN"
+        },
+        {
+          "code": "2859",
+          "direction": "E",
+          "id": "PSTA_719",
+          "lat": 27.83911,
+          "locationType": 0,
+          "lon": -82.70796,
+          "name": "PARK BLVD + 54TH ST",
+          "routeIds": [
+            "PSTA_74"
+          ],
+          "wheelchairBoarding": "UNKNOWN"
+        },
+        {
+          "code": "2910",
+          "direction": "SE",
+          "id": "PSTA_686",
+          "lat": 27.8397,
+          "locationType": 0,
+          "lon": -82.79164,
+          "name": "PARK BLVD + 110TH ST",
+          "routeIds": [
+            "PSTA_18",
+            "PSTA_58",
+            "PSTA_74"
+          ],
+          "wheelchairBoarding": "UNKNOWN"
+        },
+        {
+          "code": "2952",
+          "direction": "W",
+          "id": "PSTA_687",
+          "lat": 27.842,
+          "locationType": 0,
+          "lon": -82.78832,
+          "name": "JOHNSON BLVD + LIBERTY LN",
+          "routeIds": [
+            "PSTA_18",
+            "PSTA_58",
+            "PSTA_74"
+          ],
+          "wheelchairBoarding": "UNKNOWN"
+        }
+      ],
+      "trips": [
+        {
+          "blockId": "PSTA_16650702",
+          "directionId": "0",
+          "id": "PSTA_1330213020",
+          "routeId": "PSTA_32",
+          "routeShortName": "",
+          "serviceId": "PSTA_246",
+          "shapeId": "PSTA_32:01",
+          "timeZone": "",
+          "tripHeadsign": "DOWNTOWN ST PETERSBURG",
+          "tripShortName": ""
+        },
+        {
+          "blockId": "PSTA_16650702",
+          "directionId": "0",
+          "id": "PSTA_1330214020",
+          "routeId": "PSTA_32",
+          "routeShortName": "",
+          "serviceId": "PSTA_246",
+          "shapeId": "PSTA_32:01",
+          "timeZone": "",
+          "tripHeadsign": "DOWNTOWN ST PETERSBURG",
+          "tripShortName": ""
+        },
+        {
+          "blockId": "PSTA_16531302",
+          "directionId": "0",
+          "id": "PSTA_1332937020",
+          "routeId": "PSTA_74",
+          "routeShortName": "",
+          "serviceId": "PSTA_246",
+          "shapeId": "PSTA_74:01",
+          "timeZone": "",
+          "tripHeadsign": "DOWNTOWN ST PETERSBURG",
+          "tripShortName": ""
+        },
+        {
+          "blockId": "PSTA_16450502",
+          "directionId": "0",
+          "id": "PSTA_1329982020",
+          "routeId": "PSTA_5",
+          "routeShortName": "",
+          "serviceId": "PSTA_246",
+          "shapeId": "PSTA_5:01",
+          "timeZone": "",
+          "tripHeadsign": "5 TH AVE N + 2ND ST",
+          "tripShortName": ""
+        },
+        {
+          "blockId": "PSTA_16530202",
+          "directionId": "0",
+          "id": "PSTA_1332938020",
+          "routeId": "PSTA_74",
+          "routeShortName": "",
+          "serviceId": "PSTA_246",
+          "shapeId": "PSTA_74:01",
+          "timeZone": "",
+          "tripHeadsign": "DOWNTOWN ST PETERSBURG",
+          "tripShortName": ""
+        },
+        {
+          "blockId": "PSTA_16650702",
+          "directionId": "0",
+          "id": "PSTA_1330215020",
+          "routeId": "PSTA_32",
+          "routeShortName": "",
+          "serviceId": "PSTA_246",
+          "shapeId": "PSTA_32:01",
+          "timeZone": "",
+          "tripHeadsign": "DOWNTOWN ST PETERSBURG",
+          "tripShortName": ""
+        },
+        {
+          "blockId": "PSTA_16530902",
+          "directionId": "0",
+          "id": "PSTA_1332939020",
+          "routeId": "PSTA_74",
+          "routeShortName": "",
+          "serviceId": "PSTA_246",
+          "shapeId": "PSTA_74:01",
+          "timeZone": "",
+          "tripHeadsign": "DOWNTOWN ST PETERSBURG",
+          "tripShortName": ""
+        }
+      ]
+    }
+  },
+  "text": "OK",
+  "version": 2
+}

--- a/onebusaway-android/src/androidTest/res/raw/urimap.json
+++ b/onebusaway-android/src/androidTest/res/raw/urimap.json
@@ -12,6 +12,7 @@
     "/api/where/arrivals-and-departures-for-stop/1_75403.json": "arrivals_and_departures_for_stop_1_75403",
     "/api/api/where/arrivals-and-departures-for-stop/Hillsborough%20Area%20Regional%20Transit_1622.json": "arrivals_and_departures_for_stop_hart_1622_one_past_arrival",
     "/api/api/where/arrivals-and-departures-for-stop/Hillsborough%20Area%20Regional%20Transit_6497.json": "arrivals_and_departures_for_stop_hart_6497",
+    "/api/api/where/arrivals-and-departures-for-stop/Hillsborough%20Area%20Regional%20Transit_10000.json": "arrivals_and_departurse_for_stop_total_stops_in_trip",
     "/api/api/where/arrivals-and-departures-for-stop/PSTA_4077.json": "arrivals_and_departures_for_stop_psta_4077_alerts",
     "/api/api/where/arrivals-and-departures-for-stop/DART_4041.json": "arrivals_and_departures_for_stop_dart_4041_alerts",
 

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/VehicleOverlay.java
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/VehicleOverlay.java
@@ -641,7 +641,7 @@ public class VehicleOverlay implements GoogleMap.OnInfoWindowClickListener {
                 statusView.setPadding(pSides, pTopBottom, pSides, pTopBottom);
             } else {
                 // Scheduled info
-                statusView.setText(r.getString(R.string.stop_info_scheduled_arrival));
+                statusView.setText(r.getString(R.string.stop_info_scheduled));
                 statusColor = R.color.stop_info_scheduled_time;
                 d.setColor(r.getColor(statusColor));
                 lastUpdatedView.setText(r.getString(R.string.vehicle_last_updated_scheduled));

--- a/onebusaway-android/src/main/java/org/onebusaway/android/io/elements/ObaArrivalInfo.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/io/elements/ObaArrivalInfo.java
@@ -94,6 +94,8 @@ public final class ObaArrivalInfo {
 
     private final int stopSequence;
 
+    private final int totalStopsInTrip;
+
     private final int blockTripSequence;
 
     ObaArrivalInfo() {
@@ -120,6 +122,7 @@ public final class ObaArrivalInfo {
         arrivalEnabled = true;
         departureEnabled = true;
         stopSequence = 0;
+        totalStopsInTrip = 0;
         blockTripSequence = 0;
     }
 
@@ -283,11 +286,22 @@ public final class ObaArrivalInfo {
     }
 
     /**
-     * @return The index of the stop into the sequence of stops that
-     * make up the trip for this arrival.
+     * @return the index of the stop into the sequence of stops that make up the trip for this
+     * arrival. This value is 0-indexed, and is generated internally by OneBusAway (it is not the
+     * GTFS stop_sequence). The first stop in the trip will always have stopSequence = 0, while the
+     * last stop in the trip will always have stopSequence = totalStopsInTrip - 1.
      */
     public int getStopSequence() {
         return stopSequence;
+    }
+
+    /**
+     * @return the total number of stops visited on the trip for this arrival, or 0 if the server
+     * doesn't support this field. If the same stop is visited more than once in this trip, each
+     * visitation is counted towards the total.
+     */
+    public int getTotalStopsInTrip() {
+        return totalStopsInTrip;
     }
 
     /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListAdapterStyleA.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListAdapterStyleA.java
@@ -26,7 +26,6 @@ import android.content.Context;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.GradientDrawable;
 import android.support.v4.graphics.drawable.DrawableCompat;
-import android.text.format.DateUtils;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
@@ -54,7 +53,7 @@ public class ArrivalsListAdapterStyleA extends ArrivalsListAdapterBase<ArrivalIn
         if (arrivals != null) {
             ArrayList<ArrivalInfo> list =
                     ArrivalInfo.convertObaArrivalInfo(getContext(),
-                            arrivals, routesFilter, currentTime);
+                            arrivals, routesFilter, currentTime, false);
             setData(list);
         } else {
             setData(null);
@@ -118,12 +117,7 @@ public class ArrivalsListAdapterStyleA extends ArrivalsListAdapterBase<ArrivalIn
         int pTopBottom = UIUtils.dpToPixels(context, 2);
         status.setPadding(pSides, pTopBottom, pSides, pTopBottom);
 
-        time.setText(DateUtils.formatDateTime(context,
-                stopInfo.getDisplayTime(),
-                DateUtils.FORMAT_SHOW_TIME |
-                        DateUtils.FORMAT_NO_NOON |
-                        DateUtils.FORMAT_NO_MIDNIGHT
-        ));
+        time.setText(stopInfo.getTimeText());
 
         ContentValues values = null;
         if (mTripsForStop != null) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListAdapterStyleB.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListAdapterStyleB.java
@@ -73,7 +73,7 @@ public class ArrivalsListAdapterStyleB extends ArrivalsListAdapterBase<CombinedA
         if (arrivals != null) {
             ArrayList<ArrivalInfo> list =
                     ArrivalInfo.convertObaArrivalInfo(getContext(),
-                            arrivals, routesFilter, currentTime);
+                            arrivals, routesFilter, currentTime, true);
 
             // Sort list by route and headsign, in that order
             Collections.sort(list, new Comparator<ArrivalInfo>() {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListFragment.java
@@ -789,7 +789,7 @@ public class ArrivalsListFragment extends ListFragment
 
         if (mArrivalInfo != null) {
             list = ArrivalInfo.convertObaArrivalInfo(getActivity(), mArrivalInfo, mRoutesFilter,
-                    System.currentTimeMillis());
+                    System.currentTimeMillis(), true);
         }
         return list;
     }

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -132,6 +132,8 @@
 
     <!--  Stop Info -->
     <string name="stop_info_ontime">On time</string>
+    <string name="stop_info_arrived_ontime">Arrived on time</string>
+    <string name="stop_info_departed_ontime">Departed on time</string>
     <plurals name="stop_info_arrive_delayed">
         <item quantity="one">1 min delay</item>
         <!-- Entire element below should be on a single line if XML is reformatted - see #99 -->
@@ -164,8 +166,46 @@
             min early
         </item>
     </plurals>
+    <plurals name="stop_info_arrived_delayed">
+        <item quantity="one">Arrived 1 min late</item>
+        <!-- Entire element below should be on a single line if XML is reformatted - see #99 -->
+        <item quantity="other">Arrived
+            <xliff:g id="count">%d</xliff:g>
+            min late
+        </item>
+    </plurals>
+    <plurals name="stop_info_arrived_early">
+        <item quantity="one">Arrived 1 min early</item>
+        <!-- Entire element below should be on a single line if XML is reformatted - see #99 -->
+        <item quantity="other">Arrived
+            <xliff:g id="count">%d</xliff:g>
+            min early
+        </item>
+    </plurals>
+    <plurals name="stop_info_status_late_without_arrive_depart">
+        <item quantity="one">1 min late</item>
+        <!-- Entire element below should be on a single line if XML is reformatted - see #99 -->
+        <item quantity="other">
+            <xliff:g id="count">%d</xliff:g>
+            min late
+        </item>
+    </plurals>
+    <plurals name="stop_info_status_early_without_arrive_depart">
+        <item quantity="one">1 min early</item>
+        <!-- Entire element below should be on a single line if XML is reformatted - see #99 -->
+        <item quantity="other">
+            <xliff:g id="count">%d</xliff:g>
+            min early
+        </item>
+    </plurals>
     <string name="stop_info_scheduled_arrival">Scheduled arrival</string>
     <string name="stop_info_scheduled_departure">Scheduled departure</string>
+    <string name="stop_info_scheduled">Scheduled</string>
+    <string name="stop_info_time_arriving_at">Arriving at %1s</string>
+    <string name="stop_info_time_departing_at">Departing at %1s</string>
+    <string name="stop_info_time_arrived_at">Arrived at %1s</string>
+    <string name="stop_info_time_departed_at">Departed at %1s</string>
+
     <string name="stop_info_frequency_from">Every %1$d mins from %2$s</string>
     <string name="stop_info_frequency_until">Every %1$d mins until %2$s</string>
     <string name="stop_info_eta_now">NOW</string>


### PR DESCRIPTION
~~**Please don't merge**~~

This is a simple addition to the UI, just adding "Arriving at" or "Departing at" in front of the time (or the past tense as appropriate).

![image](https://cloud.githubusercontent.com/assets/928045/14055217/57ab6b74-f2b6-11e5-9928-d0fc400340e6.png)

TODO:

- [x] The logic surrounding marking an arrival/departure needs to be examined in case of loop routes
- [x] The status label wrongly says "departed" when it should actually be "arrived"
- [x] More testing to make sure we didn't miss anything else
- [x] Better method to control showing "arrival" or "departure" word in the status label Style A vs. Style B? (we only want to show "Scheduled" in Style A now, because right below it we're showing "arriving" or "departing" next to the time)
- [x] Unit tests for the wording logic would be nice