### PR TITLE
Fix #460 - Trip Status activity started from Vehicle marker tap now shows select…

### DIFF
--- a/onebusaway-android/src/amazon/java/org/onebusaway/android/map/googlemapsv2/VehicleOverlay.java
+++ b/onebusaway-android/src/amazon/java/org/onebusaway/android/map/googlemapsv2/VehicleOverlay.java
@@ -26,6 +26,21 @@
  */
 package org.onebusaway.android.map.googlemapsv2;
 
+import android.app.Activity;
+import android.content.Context;
+import android.content.res.Resources;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.graphics.drawable.GradientDrawable;
+import android.location.Location;
+import android.os.Handler;
+import android.support.v4.util.LruCache;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.ImageView;
+import android.widget.TextView;
+
 import com.amazon.geo.mapsv2.AmazonMap;
 import com.amazon.geo.mapsv2.model.BitmapDescriptor;
 import com.amazon.geo.mapsv2.model.BitmapDescriptorFactory;
@@ -44,21 +59,6 @@ import org.onebusaway.android.ui.TripDetailsActivity;
 import org.onebusaway.android.util.MathUtils;
 import org.onebusaway.android.util.UIUtils;
 
-import android.app.Activity;
-import android.content.Context;
-import android.content.res.Resources;
-import android.graphics.Bitmap;
-import android.graphics.BitmapFactory;
-import android.graphics.drawable.GradientDrawable;
-import android.location.Location;
-import android.os.Handler;
-import android.support.v4.util.LruCache;
-import android.util.Log;
-import android.view.LayoutInflater;
-import android.view.View;
-import android.widget.ImageView;
-import android.widget.TextView;
-
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -69,6 +69,10 @@ import java.util.concurrent.TimeUnit;
  * A map overlay that shows vehicle positions on the map
  */
 public class VehicleOverlay implements AmazonMap.OnInfoWindowClickListener {
+
+    interface Controller {
+        String getFocusedStopId();
+    }
 
     private static final String TAG = "VehicleOverlay";
 
@@ -81,6 +85,8 @@ public class VehicleOverlay implements AmazonMap.OnInfoWindowClickListener {
     private ObaTripsForRouteResponse mLastResponse;
 
     private CustomInfoWindowAdapter mCustomInfoWindowAdapter;
+
+    private Controller mController;
 
     private static final int NORTH = 0;
 
@@ -105,7 +111,7 @@ public class VehicleOverlay implements AmazonMap.OnInfoWindowClickListener {
     private static Bitmap[] vehicle_icons = new Bitmap[NUM_DIRECTIONS];  // Black vehicle icons
 
     private static LruCache<String, Bitmap> mVehicleColoredIconCache;
-            // Colored versions of vehicle_icons
+    // Colored versions of vehicle_icons
 
     /**
      * If a vehicle moves less than this distance (in meters), it will be animated, otherwise it
@@ -121,6 +127,10 @@ public class VehicleOverlay implements AmazonMap.OnInfoWindowClickListener {
         // Set adapter for custom info window that appears when tapping on vehicle markers
         mCustomInfoWindowAdapter = new CustomInfoWindowAdapter(mActivity);
         mMap.setInfoWindowAdapter(mCustomInfoWindowAdapter);
+    }
+
+    public void setController(Controller controller) {
+        mController = controller;
     }
 
     /**
@@ -257,7 +267,8 @@ public class VehicleOverlay implements AmazonMap.OnInfoWindowClickListener {
 
     /**
      * Add a Bitmap for a colored vehicle icon to the cache
-     * @param key Key for the Bitmap to be added, created by createBitmapCacheKey(halfWind, colorResource)
+     *
+     * @param key    Key for the Bitmap to be added, created by createBitmapCacheKey(halfWind, colorResource)
      * @param bitmap Bitmap to be added that is a colored version of the core black vehicle icons
      */
     private void addBitmapToCache(String key, Bitmap bitmap) {
@@ -269,6 +280,7 @@ public class VehicleOverlay implements AmazonMap.OnInfoWindowClickListener {
 
     /**
      * Get a Bitmap for a colored vehicle icon from the cache
+     *
      * @param key Key for the Bitmap, created by createBitmapCacheKey(halfWind, colorResource)
      * @return Bitmap that is a colored version of the core black vehicle icons corresponding to the given key
      */
@@ -279,9 +291,10 @@ public class VehicleOverlay implements AmazonMap.OnInfoWindowClickListener {
     /**
      * Creates a key for the vehicle colored icons cache, based on the halfWind (direction) and
      * colorResource
-     * @param halfWind an index between 0 and numHalfWinds-1 that can be used to retrieve
-     * the direction name for that heading (known as "boxing the compass", down to the half-wind
-     * level).
+     *
+     * @param halfWind      an index between 0 and numHalfWinds-1 that can be used to retrieve
+     *                      the direction name for that heading (known as "boxing the compass", down to the half-wind
+     *                      level).
      * @param colorResource the color resource ID for the schedule deviation
      * @return a String key for this direction and color vehicle bitmap icon
      */
@@ -296,7 +309,12 @@ public class VehicleOverlay implements AmazonMap.OnInfoWindowClickListener {
 
         // Show trip details screen for the vehicle associated with this marker
         ObaTripStatus status = mMarkerData.getStatusFromMarker(marker);
-        TripDetailsActivity.start(mActivity, status.getActiveTripId());
+
+        if (mController != null && mController.getFocusedStopId() != null) {
+            TripDetailsActivity.start(mActivity, status.getActiveTripId(), mController.getFocusedStopId());
+        } else {
+            TripDetailsActivity.start(mActivity, status.getActiveTripId());
+        }
     }
 
     private void setupMarkerData() {
@@ -400,18 +418,18 @@ public class VehicleOverlay implements AmazonMap.OnInfoWindowClickListener {
         /**
          * Places a marker on the map for this vehicle, and adds it to our marker HashMap
          *
-         * @param l Location to add the marker at
+         * @param l          Location to add the marker at
          * @param isRealtime true if the marker shown indicate real-time info, false if it should indicate schedule
-         * @param status   the vehicles status to add to the map
-         * @param response the response which contained the provided status
+         * @param status     the vehicles status to add to the map
+         * @param response   the response which contained the provided status
          */
         private void addMarkerToMap(Location l, boolean isRealtime, ObaTripStatus status,
-                ObaTripsForRouteResponse response) {
+                                    ObaTripsForRouteResponse response) {
 
             Marker m = mMap.addMarker(new MarkerOptions()
-                            .position(MapHelpV2.makeLatLng(l))
-                            .title(status.getVehicleId())
-                            .icon(getVehicleIcon(isRealtime, status, response))
+                    .position(MapHelpV2.makeLatLng(l))
+                    .title(status.getVehicleId())
+                    .icon(getVehicleIcon(isRealtime, status, response))
             );
             mVehicleMarkers.put(status.getActiveTripId(), m);
             mVehicles.put(m, status);
@@ -428,7 +446,7 @@ public class VehicleOverlay implements AmazonMap.OnInfoWindowClickListener {
          * @param response   response containing the provided status
          */
         private void updateMarker(Marker m, Location l, boolean isRealtime, ObaTripStatus status,
-                ObaTripsForRouteResponse response) {
+                                  ObaTripsForRouteResponse response) {
             boolean showInfo = m.isInfoWindowShown();
             m.setIcon(getVehicleIcon(isRealtime, status, response));
             // Update Hashmap with newest status - needed to show info when tapping on marker
@@ -452,8 +470,8 @@ public class VehicleOverlay implements AmazonMap.OnInfoWindowClickListener {
          * Removes any markers that don't currently represent active vehicles running a route
          *
          * @param activeTripIds a set of active tripIds that are currently running the routes.  Any
-         *                         markers for tripIds that aren't in this set will be removed
-         *                         from the map.
+         *                      markers for tripIds that aren't in this set will be removed
+         *                      from the map.
          * @return the number of removed markers
          */
         private int removeInactiveMarkers(HashSet<String> activeTripIds) {
@@ -506,7 +524,7 @@ public class VehicleOverlay implements AmazonMap.OnInfoWindowClickListener {
          * @return an icon for the vehicle that should be shown on the map
          */
         private BitmapDescriptor getVehicleIcon(boolean isRealtime, ObaTripStatus status,
-                ObaTripsForRouteResponse response) {
+                                                ObaTripsForRouteResponse response) {
             int colorResource;
             Resources r = Application.get().getResources();
 

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/BaseMapFragment.java
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/BaseMapFragment.java
@@ -16,6 +16,25 @@
  */
 package org.onebusaway.android.map.googlemapsv2;
 
+import android.app.Activity;
+import android.app.Dialog;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.content.Intent;
+import android.graphics.drawable.Drawable;
+import android.location.Location;
+import android.os.Bundle;
+import android.os.Handler;
+import android.provider.Settings;
+import android.support.v4.graphics.drawable.DrawableCompat;
+import android.support.v7.app.AlertDialog;
+import android.text.TextUtils;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Toast;
+
 import com.google.android.gms.maps.CameraUpdateFactory;
 import com.google.android.gms.maps.LocationSource;
 import com.google.android.gms.maps.OnMapReadyCallback;
@@ -46,25 +65,6 @@ import org.onebusaway.android.util.LocationHelper;
 import org.onebusaway.android.util.LocationUtils;
 import org.onebusaway.android.util.UIUtils;
 
-import android.app.Activity;
-import android.app.Dialog;
-import android.content.Context;
-import android.content.DialogInterface;
-import android.content.Intent;
-import android.graphics.drawable.Drawable;
-import android.location.Location;
-import android.os.Bundle;
-import android.os.Handler;
-import android.provider.Settings;
-import android.support.v4.graphics.drawable.DrawableCompat;
-import android.support.v7.app.AlertDialog;
-import android.text.TextUtils;
-import android.util.Log;
-import android.view.LayoutInflater;
-import android.view.View;
-import android.view.ViewGroup;
-import android.widget.Toast;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -91,7 +91,8 @@ public class BaseMapFragment extends SupportMapFragment
         MapModeController.ObaMapView,
         LocationSource, LocationHelper.Listener,
         com.google.android.gms.maps.GoogleMap.OnCameraChangeListener,
-        StopOverlay.OnFocusChangedListener, OnMapReadyCallback {
+        StopOverlay.OnFocusChangedListener, OnMapReadyCallback,
+        VehicleOverlay.Controller {
 
     public static final String TAG = "BaseMapFragment";
 
@@ -172,7 +173,7 @@ public class BaseMapFragment extends SupportMapFragment
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
-            Bundle savedInstanceState) {
+                             Bundle savedInstanceState) {
         View v = super.onCreateView(inflater, container, savedInstanceState);
 
         mMap = getMap();
@@ -337,6 +338,7 @@ public class BaseMapFragment extends SupportMapFragment
         Activity a = getActivity();
         if (mVehicleOverlay == null && a != null) {
             mVehicleOverlay = new VehicleOverlay(a, mMap);
+            mVehicleOverlay.setController(this);
         }
     }
 
@@ -518,7 +520,7 @@ public class BaseMapFragment extends SupportMapFragment
     final Handler mStopChangedHandler = new Handler();
 
     public void onFocusChanged(final ObaStop stop, final HashMap<String, ObaRoute> routes,
-            final Location location) {
+                               final Location location) {
         // Run in a separate thread, to avoid blocking UI for long running events
         mStopChangedHandler.post(new Runnable() {
             public void run() {
@@ -526,6 +528,7 @@ public class BaseMapFragment extends SupportMapFragment
                     mFocusStopId = stop.getId();
                     //Log.d(TAG, "Focused changed to " + stop.getName());
                 } else {
+                    mFocusStopId = null;
                     //Log.d(TAG, "Removed focus");
                 }
 
@@ -642,7 +645,7 @@ public class BaseMapFragment extends SupportMapFragment
      */
     @Override
     public void setMapCenter(Location location, boolean animateToLocation,
-            boolean overlayExpanded) {
+                             boolean overlayExpanded) {
         if (mMap != null) {
             CameraPosition cp = mMap.getCameraPosition();
 
@@ -778,7 +781,7 @@ public class BaseMapFragment extends SupportMapFragment
      */
     @Override
     public void zoomIncludeClosestVehicle(HashSet<String> routeIds,
-            ObaTripsForRouteResponse response) {
+                                          ObaTripsForRouteResponse response) {
         if (mMap == null) {
             return;
         }
@@ -816,6 +819,7 @@ public class BaseMapFragment extends SupportMapFragment
 
     /**
      * Clears any stop markers from the map
+     *
      * @param clearFocusedStop true to clear the currently focused stop, false to leave it on map
      */
     @Override
@@ -876,6 +880,14 @@ public class BaseMapFragment extends SupportMapFragment
     @Override
     public void postInvalidate() {
         // Do nothing - calling `this.postInvalidate()` causes a StackOverflowError
+    }
+
+    //
+    // VehicleOverlay.Controller
+    //
+    @Override
+    public String getFocusedStopId() {
+        return mFocusStopId;
     }
 
     //


### PR DESCRIPTION
As per issue #460, when a vehicle marker is tapped while a stop is selected, the stop marker shows up in Trip Status activity.
![1](https://cloud.githubusercontent.com/assets/933657/14578834/3878c910-0362-11e6-81b8-b135f0940fc4.png)
![2](https://cloud.githubusercontent.com/assets/933657/14578833/38773942-0362-11e6-9f47-595efcf7a163.png)

