### PR TITLE
Use material design style in Supported Agencies View

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/ReportTypeListFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/ReportTypeListFragment.java
@@ -19,8 +19,8 @@ import org.onebusaway.android.R;
 import org.onebusaway.android.app.Application;
 import org.onebusaway.android.io.ObaAnalytics;
 import org.onebusaway.android.io.elements.ObaRegion;
-import org.onebusaway.android.report.ui.adapter.ReportTypeListAdapter;
-import org.onebusaway.android.report.ui.model.ReportTypeItem;
+import org.onebusaway.android.ui.MaterialListAdapter;
+import org.onebusaway.android.ui.MaterialListItem;
 import org.onebusaway.android.util.UIUtils;
 
 import android.content.res.TypedArray;
@@ -66,16 +66,16 @@ public class ReportTypeListFragment extends ListFragment implements AdapterView.
         }
 
         Boolean isEmailDefined = isEmailDefined();
-        List<ReportTypeItem> reportTypeItems = new ArrayList<>();
+        List<MaterialListItem> materialListItems = new ArrayList<>();
         for (int i = 0; i < reportTypes.length; i++) {
             //Don't show the send app feedback section if email is not defined for region
             if (!isEmailDefined && getString(R.string.rt_app_feedback).equals(reportTypes[i]))
                 continue;
-            ReportTypeItem item = new ReportTypeItem(reportTypes[i], reportDesc[i], reportIcons.getResourceId(i, -1));
-            reportTypeItems.add(item);
+            MaterialListItem item = new MaterialListItem(reportTypes[i], reportDesc[i], reportIcons.getResourceId(i, -1));
+            materialListItems.add(item);
         }
 
-        ReportTypeListAdapter adapter = new ReportTypeListAdapter(getActivity(), reportTypeItems);
+        MaterialListAdapter adapter = new MaterialListAdapter(getActivity(), materialListItems);
         setListAdapter(adapter);
         getListView().setOnItemClickListener(this);
     }
@@ -93,7 +93,7 @@ public class ReportTypeListFragment extends ListFragment implements AdapterView.
 
     @Override
     public void onItemClick(AdapterView<?> adapterView, View view, int i, long l) {
-        ReportTypeItem rti = (ReportTypeItem) getListView().getItemAtPosition(i);
+        MaterialListItem rti = (MaterialListItem) getListView().getItemAtPosition(i);
 
         if (getString(R.string.rt_customer_service).equals(rti.getTitle())) {
             goToCustomerServices();

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/AgenciesFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/AgenciesFragment.java
@@ -15,11 +15,11 @@
  */
 package org.onebusaway.android.ui;
 
+import org.onebusaway.android.R;
 import org.onebusaway.android.io.elements.ObaAgency;
 import org.onebusaway.android.io.elements.ObaAgencyWithCoverage;
 import org.onebusaway.android.io.request.ObaAgenciesWithCoverageRequest;
 import org.onebusaway.android.io.request.ObaAgenciesWithCoverageResponse;
-import org.onebusaway.android.util.ArrayAdapter;
 import org.onebusaway.android.util.UIUtils;
 
 import android.content.Context;
@@ -29,15 +29,16 @@ import android.support.v4.content.AsyncTaskLoader;
 import android.support.v4.content.Loader;
 import android.text.TextUtils;
 import android.view.View;
+import android.widget.ListAdapter;
 import android.widget.ListView;
-import android.widget.TextView;
 
-import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.List;
 
 public class AgenciesFragment extends ListFragment
         implements LoaderManager.LoaderCallbacks<ObaAgenciesWithCoverageResponse> {
 
-    private Adapter mAdapter;
+    private ListAdapter mAdapter;
 
     private ObaAgenciesWithCoverageResponse mResponse;
 
@@ -51,7 +52,8 @@ public class AgenciesFragment extends ListFragment
     @Override
     public void onListItemClick(ListView l, View v, int position, long id) {
         // Go to the URL
-        ObaAgency agency = mResponse.getAgency(mAdapter.getItem(position).getId());
+        MaterialListItem item = (MaterialListItem) mAdapter.getItem(position);
+        ObaAgency agency = mResponse.getAgency(item.getId());
         if (!TextUtils.isEmpty(agency.getUrl())) {
             UIUtils.goToUrl(getActivity(), agency.getUrl());
         }
@@ -64,12 +66,12 @@ public class AgenciesFragment extends ListFragment
 
     @Override
     public void onLoadFinished(Loader<ObaAgenciesWithCoverageResponse> l,
-            ObaAgenciesWithCoverageResponse result) {
+                               ObaAgenciesWithCoverageResponse result) {
         // Create our generic adapter
         mResponse = result;
-        mAdapter = new Adapter(getActivity());
+        List<MaterialListItem> materialListItems = createListItems(result);
+        mAdapter = new MaterialListAdapter(getContext(), materialListItems);
         setListAdapter(mAdapter);
-        mAdapter.setData(Arrays.asList(result.getAgencies()));
     }
 
     @Override
@@ -99,23 +101,15 @@ public class AgenciesFragment extends ListFragment
         }
     }
 
-    //
-    // Adapter
-    //
-    private class Adapter extends ArrayAdapter<ObaAgencyWithCoverage> {
-
-        Adapter(Context context) {
-            super(context, android.R.layout.simple_list_item_2);
+    private List<MaterialListItem> createListItems(ObaAgenciesWithCoverageResponse result) {
+        List<MaterialListItem> materialListItems = new ArrayList<>();
+        for (int i = 0; i < result.getAgencies().length; i++) {
+            ObaAgencyWithCoverage obaAgencyWithCoverage = result.getAgencies()[i];
+            ObaAgency agency = result.getAgency(obaAgencyWithCoverage.getId());
+            MaterialListItem item = new MaterialListItem(agency.getName(), agency.getUrl(),
+                    obaAgencyWithCoverage.getId(), R.drawable.ic_maps_directions_bus);
+            materialListItems.add(item);
         }
-
-        @Override
-        protected void initView(View view, ObaAgencyWithCoverage coverage) {
-            TextView text1 = (TextView) view.findViewById(android.R.id.text1);
-            TextView text2 = (TextView) view.findViewById(android.R.id.text2);
-
-            ObaAgency agency = mResponse.getAgency(coverage.getId());
-            text1.setText(agency.getName());
-            text2.setText(agency.getUrl());
-        }
+        return materialListItems;
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/MaterialListAdapter.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/MaterialListAdapter.java
@@ -13,10 +13,9 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-package org.onebusaway.android.report.ui.adapter;
+package org.onebusaway.android.ui;
 
 import org.onebusaway.android.R;
-import org.onebusaway.android.report.ui.model.ReportTypeItem;
 
 import android.app.Activity;
 import android.content.Context;
@@ -30,16 +29,14 @@ import android.widget.TextView;
 import java.util.List;
 
 /**
- * Adapter for report types
- *
- * @author Cagri Cetin
+ * Adapter for material design lists
  */
-public class ReportTypeListAdapter extends BaseAdapter {
+public class MaterialListAdapter extends BaseAdapter {
 
     Context context;
-    List<ReportTypeItem> rowItem;
+    List<MaterialListItem> rowItem;
 
-    public ReportTypeListAdapter(Context context, List<ReportTypeItem> rowItem) {
+    public MaterialListAdapter(Context context, List<MaterialListItem> rowItem) {
         this.context = context;
         this.rowItem = rowItem;
     }
@@ -64,7 +61,7 @@ public class ReportTypeListAdapter extends BaseAdapter {
         if (convertView == null) {
             LayoutInflater mInflater = (LayoutInflater) context
                     .getSystemService(Activity.LAYOUT_INFLATER_SERVICE);
-            convertView = mInflater.inflate(R.layout.report_type_list_item, null);
+            convertView = mInflater.inflate(R.layout.material_list_item, null);
         }
 
         ImageView imgIcon = (ImageView) convertView.findViewById(R.id.rtl_icon);
@@ -73,7 +70,7 @@ public class ReportTypeListAdapter extends BaseAdapter {
         TextView txtTitle = (TextView) convertView.findViewById(R.id.rtl_title);
         TextView txtDesc = (TextView) convertView.findViewById(R.id.rtl_desc);
 
-        ReportTypeItem rowPos = rowItem.get(position);
+        MaterialListItem rowPos = rowItem.get(position);
         // setting the image resource and title
         imgIcon.setImageResource(rowPos.getIcon());
         txtTitle.setText(rowPos.getTitle());

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/MaterialListItem.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/MaterialListItem.java
@@ -1,5 +1,5 @@
 /*
-* Copyright (C) 2014 University of South Florida (sjbarbeau@gmail.com)
+* Copyright (C) 2014-2016 University of South Florida (sjbarbeau@gmail.com)
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -13,21 +13,28 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-package org.onebusaway.android.report.ui.model;
+package org.onebusaway.android.ui;
 
 /**
- * Model for report type
- * @author Cagri Cetin
+ * A model object for MaterialListAdapter
  */
-public class ReportTypeItem {
+public class MaterialListItem {
 
     private String title;
     private String desc;
+    private String id;
     private int icon;
 
-    public ReportTypeItem(String title, String desc, int icon) {
+    public MaterialListItem(String title, String desc, int icon) {
         this.title = title;
         this.desc = desc;
+        this.icon = icon;
+    }
+
+    public MaterialListItem(String title, String desc, String id, int icon) {
+        this.title = title;
+        this.desc = desc;
+        this.id = id;
         this.icon = icon;
     }
 
@@ -54,5 +61,13 @@ public class ReportTypeItem {
 
     public void setIcon(int icon) {
         this.icon = icon;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
     }
 }

--- a/onebusaway-android/src/main/res/layout/material_list_item.xml
+++ b/onebusaway-android/src/main/res/layout/material_list_item.xml
@@ -33,8 +33,8 @@
 
             <ImageView
                     android:id="@+id/rtl_icon"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
+                    android:layout_width="40dp"
+                    android:layout_height="40dp"
                     android:maxHeight="40dp"
                     android:maxWidth="40dp"
                     style="@style/MaterialSmallIcon"


### PR DESCRIPTION
A material design list view was implemented for `supported agencies view`.
![device-2016-04-18-115227](https://cloud.githubusercontent.com/assets/2777974/14610490/1e0f62b8-055c-11e6-9d2c-5de8c89eeffe.png)
![device-2016-04-18-115058](https://cloud.githubusercontent.com/assets/2777974/14610491/1e204312-055c-11e6-874e-a2b256c8a9e1.png)
