### PR TITLE
Prevent showing only one issue category for Problem Reporting

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/InfrastructureIssueActivity.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/InfrastructureIssueActivity.java
@@ -727,8 +727,9 @@ public class InfrastructureIssueActivity extends BaseReportActivity implements
         // Create the service list
         List<Service> serviceList = new ArrayList<>();
 
-        // Add services to list
-        if (services != null && services.isSuccess()) {
+        // Add services to list if service response is successful
+        if (services != null && services.isSuccess() &&
+                Open311Manager.isAreaManagedByOpen311(services.getServiceList())) {
             for (Service s: services.getServiceList()) {
                 if (s.getService_name() != null && s.getService_code() != null) {
                     serviceList.add(s);


### PR DESCRIPTION
If open311 endpoint returns only one issue category, we do not show it in the screen:
Before this improvement:
![device-2016-04-25-135307](https://cloud.githubusercontent.com/assets/2777974/14793421/15fadf12-0aed-11e6-90d0-0a8b8ce7a1e2.png)

After this improvement:
![device-2016-04-25-135145](https://cloud.githubusercontent.com/assets/2777974/14793414/07bf507c-0aed-11e6-9cdd-54f4b73ff5b6.png)

cc'd @barbeau 