### PR TITLE
Add google analytics to Save/Restore storage action

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/io/backup/RestorePreference.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/io/backup/RestorePreference.java
@@ -16,6 +16,7 @@
 package org.onebusaway.android.io.backup;
 
 import org.onebusaway.android.R;
+import org.onebusaway.android.io.ObaAnalytics;
 
 import android.app.AlertDialog;
 import android.content.Context;
@@ -86,6 +87,9 @@ public class RestorePreference extends Preference {
 
     void doRestore() {
         Context context = getContext();
+        ObaAnalytics.reportEventWithCategory(ObaAnalytics.ObaEventCategory.UI_ACTION.toString(),
+                context.getString(R.string.analytics_action_button_press),
+                context.getString(R.string.analytics_label_button_press_restore_preference));
         try {
             Backup.restore(context);
             Toast.makeText(context,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/io/backup/SavePreference.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/io/backup/SavePreference.java
@@ -16,6 +16,7 @@
 package org.onebusaway.android.io.backup;
 
 import org.onebusaway.android.R;
+import org.onebusaway.android.io.ObaAnalytics;
 
 import android.content.Context;
 import android.os.Environment;
@@ -57,12 +58,14 @@ public class SavePreference extends Preference {
     @Override
     protected void onClick() {
         Context context = getContext();
+        ObaAnalytics.reportEventWithCategory(ObaAnalytics.ObaEventCategory.UI_ACTION.toString(),
+                context.getString(R.string.analytics_action_button_press),
+                context.getString(R.string.analytics_label_button_press_save_preference));
         try {
             Backup.backup(context);
             Toast.makeText(context,
                     context.getString(R.string.preferences_db_saved),
                     Toast.LENGTH_LONG).show();
-
         } catch (IOException e) {
             Toast.makeText(context,
                     context.getString(R.string.preferences_db_save_error, e.getMessage()),

--- a/onebusaway-android/src/main/res/values/donottranslate.xml
+++ b/onebusaway-android/src/main/res/values/donottranslate.xml
@@ -105,6 +105,8 @@
     <string name="analytics_label_experimental">Show Experimental Regions:\u0020</string>
     <string name="analytics_label_button_press_auto">Set region automatically</string>
     <string name="analytics_label_button_press_manual">Set region manually</string>
+    <string name="analytics_label_button_press_save_preference">Clicked Save to Storage</string>
+    <string name="analytics_label_button_press_restore_preference">Clicked Restore from Storage</string>
     <string name="analytics_label_edit_field">Edited Bookmark</string>
     <string name="analytics_label_edit_field_bookmark_delete">Edited Bookmark Group Deleted</string>
     <string name="analytics_label_set_region">Set Region:\u0020</string>


### PR DESCRIPTION
New Analytics messages were added for `Save to Storage` and `Restore from Storage` buttons in `Settings`:

Event Category  | Event Action | Event Label |
| ------------- | ------------- | ------------- |
| ui_action  | button_press  | Clicked Save to Storage |
| ui_action  | button_press  | Clicked Restore from Storage |