### PR TITLE
Fix #290 - Always create new Notification objects (instead of re-using them) for reminders

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/tripservice/TaskContext.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/tripservice/TaskContext.java
@@ -19,11 +19,11 @@ import android.app.Notification;
 
 public interface TaskContext {
 
+    //TODO: See if this code is now unnecessary... It looks like the notification manager replaces this.
+
     public void setNotification(int id, Notification notification);
 
     public void cancelNotification(int id);
-
-    public Notification getNotification(int id);
 
     public void taskComplete();
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/tripservice/TripService.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/tripservice/TripService.java
@@ -111,6 +111,7 @@ public class TripService extends Service {
         public void taskComplete() {
             //Log.d(TAG, "Task complete: " + mStartId);
             // If we have notifications, then we can't stop ourselves.
+            //TODO: Is there actually a reason to not stop ourselves if we are no longer storing notifications?
             if (mNotifications.isEmpty()) {
                 stopSelfResult(mStartId);
             }
@@ -133,11 +134,6 @@ public class TripService extends Service {
                 //Log.d(TAG, "Stopping service");
                 stopSelf();
             }
-        }
-
-        @Override
-        public Notification getNotification(int id) {
-            return mNotifications.get(id);
         }
 
     }


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your pull request - thanks!

- [o] Sign the [electronic OBA ICLA](https://docs.google.com/forms/d/12jV-ByyN186MuPotMvxJtNKtSaGGTnEHm8rXomM2bm4/viewform)

- [o] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [o] Run the unit tests with `gradlew connectedObaGoogleDebugAndroidTest connectedObaAmazonDebugAndroidTest` to make sure you didn't break anything

- [o] If you have multiple commits please combine them into one commit by squashing them.