### PR TITLE
Fix #486 - Trip headsign disappears on orientation change

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/InfrastructureIssueActivity.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/InfrastructureIssueActivity.java
@@ -38,7 +38,6 @@ import org.onebusaway.android.util.LocationUtils;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
-import android.graphics.Typeface;
 import android.location.Address;
 import android.location.Geocoder;
 import android.location.Location;
@@ -1008,7 +1007,7 @@ public class InfrastructureIssueActivity extends BaseReportActivity implements
     }
 
     private void showStopProblemFragment(ObaStop obaStop) {
-        ReportStopProblemFragment.show(this, obaStop, R.id.ri_report_stop_problem, false, this);
+        ReportStopProblemFragment.show(this, obaStop, R.id.ri_report_stop_problem, this);
     }
 
     private void showTripProblemFragment(ObaStop obaStop) {
@@ -1016,7 +1015,7 @@ public class InfrastructureIssueActivity extends BaseReportActivity implements
             showArrivalListFragment(obaStop);
         } else {
             // Show default trip problem issue reporting
-            ReportTripProblemFragment.show(this, mArrivalInfo, R.id.ri_report_stop_problem, false, this);
+            ReportTripProblemFragment.show(this, mArrivalInfo, R.id.ri_report_stop_problem, this);
             mArrivalInfo = null;
         }
     }
@@ -1039,16 +1038,13 @@ public class InfrastructureIssueActivity extends BaseReportActivity implements
 
         removeFragmentByTag(SimpleArrivalListFragment.TAG);
 
-        addTripName(obaArrivalInfo.getHeadsign());
-
         if (mSelectedTransitService != null &&
                 ReportConstants.DYNAMIC_TRANSIT_SERVICE_TRIP.equals(mSelectedTransitService.getType())) {
             // Show open311 defined issue reporting service
             showOpen311ProblemFragment(mSelectedTransitService, obaArrivalInfo);
         } else {
             // Show default trip problem issue reporting
-            ReportTripProblemFragment.show(this, obaArrivalInfo, R.id.ri_report_stop_problem, false,
-                    this);
+            ReportTripProblemFragment.show(this, obaArrivalInfo, R.id.ri_report_stop_problem, this);
         }
     }
 
@@ -1091,21 +1087,6 @@ public class InfrastructureIssueActivity extends BaseReportActivity implements
         removeFragmentByTag(SimpleArrivalListFragment.TAG);
 
         ((LinearLayout) findViewById(R.id.ri_report_stop_problem)).removeAllViews();
-    }
-
-    private void addTripName(String text) {
-        LayoutInflater inflater = LayoutInflater.from(this);
-        RelativeLayout layout = (RelativeLayout) inflater.inflate(R.layout.report_issue_description_item, null, false);
-
-        LinearLayout linear = (LinearLayout) findViewById(R.id.ri_report_stop_problem);
-        TextView tv = ((TextView) layout.findViewById(R.id.riii_textView));
-        tv.setText(text);
-        tv.setTypeface(null, Typeface.NORMAL);
-
-        linear.addView(layout);
-
-        ((ImageView) layout.findViewById(R.id.ic_action_info)).setColorFilter(
-                getResources().getColor(R.color.material_gray));
     }
 
     public IssueLocationHelper getIssueLocationHelper() {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/Open311ProblemFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/Open311ProblemFragment.java
@@ -41,6 +41,7 @@ import android.database.Cursor;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Color;
+import android.graphics.Typeface;
 import android.graphics.drawable.BitmapDrawable;
 import android.location.Location;
 import android.net.Uri;
@@ -752,6 +753,10 @@ public class Open311ProblemFragment extends BaseReportFragment implements
             addDescriptionText(mService.getDescription());
         }
 
+        if (mArrivalInfo != null && ServiceUtils.isTransitTripServiceByType(mService.getType())) {
+            createTripHeadsign(mArrivalInfo.getHeadsign());
+        }
+
         for (Open311Attribute open311Attribute : serviceDescription.getAttributes()) {
             if (!Boolean.valueOf(open311Attribute.getVariable())) {
                 addDescriptionText(open311Attribute.getDescription());
@@ -932,6 +937,22 @@ public class Open311ProblemFragment extends BaseReportFragment implements
             mInfoLayout.addView(layout);
             mDynamicAttributeUIMap.put(open311Attribute.getCode(), cg);
         }
+    }
+
+    private void createTripHeadsign(String text) {
+        LayoutInflater inflater = LayoutInflater.from(getActivity());
+        RelativeLayout layout = (RelativeLayout) inflater.inflate(
+                R.layout.report_issue_description_item, null, false);
+
+        LinearLayout linear = (LinearLayout) findViewById(R.id.ri_report_stop_problem);
+        TextView tv = ((TextView) layout.findViewById(R.id.riii_textView));
+        tv.setText(MyTextUtils.toSentenceCase(text));
+        tv.setTypeface(null, Typeface.NORMAL);
+
+        linear.addView(layout, 0);
+
+        ((ImageView) layout.findViewById(R.id.ic_action_info)).setColorFilter(
+                getResources().getColor(R.color.material_gray));
     }
 
     private void clearInfoField() {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/ReportStopProblemFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/ReportStopProblemFragment.java
@@ -20,7 +20,6 @@ import org.onebusaway.android.app.Application;
 import org.onebusaway.android.io.ObaAnalytics;
 import org.onebusaway.android.io.elements.ObaStop;
 import org.onebusaway.android.io.request.ObaReportProblemWithStopRequest;
-import org.onebusaway.android.util.MyTextUtils;
 
 import android.content.Context;
 import android.location.Location;
@@ -43,34 +42,20 @@ public class ReportStopProblemFragment extends ReportProblemFragmentBase {
 
     public static final String STOP_NAME = ".StopName";
 
-    private static final String SHOW_STOP_NAME = ".ShowStopName";
-
     public static final String CODE = ".Code";
 
     public static final String USER_COMMENT = ".UserComment";
 
     public static final String TAG = "ReportStopProblemFragment";
 
-    public static void show(AppCompatActivity activity, ObaStop stop,
-                            ReportProblemFragmentCallback callback) {
-        show(activity, stop, null, callback);
-    }
-
-    public static void show(AppCompatActivity activity, ObaStop stop, Integer containerViewId,
-                            ReportProblemFragmentCallback callback) {
-        show(activity, stop, containerViewId, true, callback);
-    }
-
-    public static void show(AppCompatActivity activity, ObaStop stop, Integer containerViewId,
-                            boolean showStopName, ReportProblemFragmentCallback callback) {
+    public static void show(AppCompatActivity activity, ObaStop stop, Integer containerViewId
+            , ReportProblemFragmentCallback callback) {
         FragmentManager fm = activity.getSupportFragmentManager();
 
         Bundle args = new Bundle();
         args.putString(STOP_ID, stop.getId());
         // We don't use the stop name map here...we want the actual stop name.
         args.putString(STOP_NAME, stop.getName());
-
-        args.putBoolean(SHOW_STOP_NAME, showStopName);
 
         // Create the list fragment and add it as our sole content.
         ReportStopProblemFragment content = new ReportStopProblemFragment();
@@ -98,20 +83,7 @@ public class ReportStopProblemFragment extends ReportProblemFragmentBase {
 
     @Override
     public void onViewCreated(View view, Bundle savedInstanceState) {
-        // Set the stop name.
-        Bundle args = getArguments();
-        final TextView stopName = (TextView) view.findViewById(R.id.stop_name);
-        stopName.setText(MyTextUtils.toTitleCase(args.getString(STOP_NAME)));
-
-        boolean showStopName = args.getBoolean(SHOW_STOP_NAME, true);
-
-        if (!showStopName) {
-            // Hide stop name header
-            view.findViewById(R.id.stop_info_header).setVisibility(View.GONE);
-        }
-        //
         // The code spinner
-        //
         mCodeView = (Spinner) view.findViewById(R.id.report_problem_code);
         ArrayAdapter<?> adapter = ArrayAdapter.createFromResource(
                 getActivity(), R.array.report_stop_problem_code,
@@ -148,8 +120,6 @@ public class ReportStopProblemFragment extends ReportProblemFragmentBase {
                 getResources().getColor(R.color.material_gray));
         ((ImageView) getActivity().findViewById(R.id.ic_action_info)).setColorFilter(
                 getResources().getColor(R.color.material_gray));
-        ((ImageView) getActivity().findViewById(R.id.ic_header_location)).setColorFilter(
-                getResources().getColor(android.R.color.white));
     }
 
     @Override

--- a/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/ReportTripProblemFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/ReportTripProblemFragment.java
@@ -44,9 +44,7 @@ public class ReportTripProblemFragment extends ReportProblemFragmentBase {
 
     public static final String STOP_ID = ".StopId";
 
-    public static final String TRIP_NAME = ".TripName";
-
-    private static final String SHOW_TRIP_NAME = ".ShowTripName";
+    public static final String TRIP_HEADSIGN = ".TripHeadsign";
 
     public static final String TRIP_SERVICE_DATE = ".ServiceDate";
 
@@ -63,23 +61,16 @@ public class ReportTripProblemFragment extends ReportProblemFragmentBase {
     public static final String TAG = "ReportTripProblemFragment";
 
     public static void show(AppCompatActivity activity, ObaArrivalInfo arrival,
-                            ReportProblemFragmentCallback callback) {
-        show(activity, arrival, null, true, callback);
-    }
-
-    public static void show(AppCompatActivity activity, ObaArrivalInfo arrival,
-                            Integer containerViewId, boolean showTripName,
+                            Integer containerViewId,
                             ReportProblemFragmentCallback callback) {
         FragmentManager fm = activity.getSupportFragmentManager();
 
         Bundle args = new Bundle();
         args.putString(TRIP_ID, arrival.getTripId());
         args.putString(STOP_ID, arrival.getStopId());
-        // We don't use the stop name map here...we want the actual stop name.
-        args.putString(TRIP_NAME, arrival.getHeadsign());
+        args.putString(TRIP_HEADSIGN, arrival.getHeadsign());
         args.putLong(TRIP_SERVICE_DATE, arrival.getServiceDate());
         args.putString(TRIP_VEHICLE_ID, arrival.getVehicleId());
-        args.putBoolean(SHOW_TRIP_NAME, showTripName);
 
         // Create the list fragment and add it as our sole content.
         ReportTripProblemFragment content = new ReportTripProblemFragment();
@@ -111,14 +102,8 @@ public class ReportTripProblemFragment extends ReportProblemFragmentBase {
     public void onViewCreated(View view, Bundle savedInstanceState) {
         // Set the stop name.
         Bundle args = getArguments();
-        final TextView tripName = (TextView) view.findViewById(R.id.trip_name);
-        tripName.setText(MyTextUtils.toTitleCase(args.getString(TRIP_NAME)));
-
-        boolean showStopName = args.getBoolean(SHOW_TRIP_NAME, true);
-        if (!showStopName){
-            // Hide trip name header
-            view.findViewById(R.id.trip_info_header).setVisibility(View.GONE);
-        }
+        final TextView tripHeadsign = (TextView) view.findViewById(R.id.report_problem_headsign);
+        tripHeadsign.setText(MyTextUtils.toTitleCase(args.getString(TRIP_HEADSIGN)));
 
         // TODO: Switch this based on the trip mode
         final int tripArray = R.array.report_trip_problem_code_bus;
@@ -178,11 +163,11 @@ public class ReportTripProblemFragment extends ReportProblemFragmentBase {
     }
 
     private void setupIconColors() {
-        ((ImageView) getActivity().findViewById(R.id.ic_header_location)).setColorFilter(
-                getResources().getColor(android.R.color.white));
         ((ImageView) getActivity().findViewById(R.id.ic_category)).setColorFilter(
                 getResources().getColor(R.color.material_gray));
         ((ImageView) getActivity().findViewById(R.id.ic_trip_info)).setColorFilter(
+                getResources().getColor(R.color.material_gray));
+        ((ImageView) getActivity().findViewById(R.id.ic_headsign_info)).setColorFilter(
                 getResources().getColor(R.color.material_gray));
     }
 

--- a/onebusaway-android/src/main/res/layout/report_stop_problem.xml
+++ b/onebusaway-android/src/main/res/layout/report_stop_problem.xml
@@ -23,42 +23,6 @@
             android:layout_width="fill_parent"
             android:layout_height="wrap_content">
 
-        <!-- Header aligned to top -->
-        <RelativeLayout
-                android:id="@+id/stop_info_header"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:background="@color/theme_primary_dark"
-                android:layout_alignParentTop="true"
-                android:animateLayoutChanges="true"
-                android:layout_marginBottom="16dp"
-                android:gravity="center">
-
-            <ImageView
-                    android:layout_width="20dp"
-                    android:layout_height="20dp"
-                    android:id="@+id/ic_header_location"
-                    android:src="@drawable/ic_drawer_maps_place"
-                    android:layout_alignParentTop="true"
-                    android:layout_toLeftOf="@+id/ri_info_text"
-                    android:layout_toStartOf="@+id/ri_info_text"
-                    android:layout_margin="4dp"
-                    />
-
-            <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="Fixed Header"
-                    android:id="@+id/stop_name"
-                    android:textColor="@android:color/white"
-                    android:textAppearance="?android:attr/textAppearanceMedium"
-                    android:textSize="16sp"
-                    android:textStyle="bold"
-                    android:layout_alignBottom="@+id/ic_header_location"
-                    android:layout_toRightOf="@+id/ic_header_location"
-                    android:layout_toEndOf="@+id/ic_header_location"/>
-        </RelativeLayout>
-
         <FrameLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/onebusaway-android/src/main/res/layout/report_trip_problem.xml
+++ b/onebusaway-android/src/main/res/layout/report_trip_problem.xml
@@ -24,41 +24,27 @@
             android:layout_width="fill_parent"
             android:layout_height="wrap_content">
 
-        <!-- Header aligned to top -->
-        <RelativeLayout
-                android:id="@+id/trip_info_header"
+        <FrameLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:background="@color/theme_primary_dark"
-                android:layout_alignParentTop="true"
-                android:animateLayoutChanges="true"
-                android:gravity="center"
-                android:layout_marginBottom="16dp">
+                style="@style/MaterialLayout"
+                android:orientation="horizontal">
 
-            <ImageView
-                    android:layout_width="20dp"
-                    android:layout_height="20dp"
-                    android:id="@+id/ic_header_location"
-                    android:src="@drawable/ic_drawer_maps_place"
-                    android:layout_alignParentTop="true"
-                    android:layout_toLeftOf="@+id/ri_info_text"
-                    android:layout_toStartOf="@+id/ri_info_text"
-                    android:layout_margin="4dp"
-                    />
+            <ImageView style="@style/MaterialSmallIcon"
+                       android:src="@drawable/ic_stop_info"
+                       android:id="@+id/ic_headsign_info"/>
 
             <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="Fixed Header"
-                    android:id="@+id/trip_name"
-                    android:textColor="@android:color/white"
+                    android:id="@+id/report_problem_headsign"
+                    style="@style/MaterialItem"
+                    android:textSize="15sp"
                     android:textAppearance="?android:attr/textAppearanceMedium"
-                    android:textSize="16sp"
-                    android:textStyle="bold"
-                    android:layout_alignBottom="@+id/ic_header_location"
-                    android:layout_toRightOf="@+id/ic_header_location"
-                    android:layout_toEndOf="@+id/ic_header_location"/>
-        </RelativeLayout>
+                    android:textColor="@android:color/black"
+            />
+
+        </FrameLayout>
 
         <FrameLayout
                 android:layout_width="match_parent"


### PR DESCRIPTION
This PR fixes the trip headsign problem on orientation change:

![device-2016-05-09-122955](https://cloud.githubusercontent.com/assets/2777974/15120088/0f2c268c-15e2-11e6-908c-d9eea7d41798.png)

![device-2016-05-09-123119](https://cloud.githubusercontent.com/assets/2777974/15120092/137f3e4a-15e2-11e6-810d-c3eee82c7453.png)

Furthermore, unnecessary header fields removed from `ReportTripProblemFragment` and `ReportStopProblemFragment` .