### PR TITLE
Add tutorial for non-transit problem categories

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/ShowcaseViewUtils.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/ShowcaseViewUtils.java
@@ -72,6 +72,9 @@ public class ShowcaseViewUtils {
 
     public static final String TUTORIAL_SEND_FEEDBACK = ".tutorial_send_feedback";
 
+    public static final String TUTORIAL_SEND_FEEDBACK_OPEN311_CATEGORIES
+            = ".tutorial_send_feedback_open311_categories";
+
     private static ShowcaseView mShowcaseView;
 
     /**
@@ -283,6 +286,12 @@ public class ShowcaseViewUtils {
                 text = new SpannableString(
                         r.getString(R.string.tutorial_send_feedback_text));
                 break;
+            case TUTORIAL_SEND_FEEDBACK_OPEN311_CATEGORIES:
+                title = r.getString(R.string.tutorial_send_feedback_transit_service_title);
+                text = new SpannableString(
+                        r.getString(R.string.tutorial_send_feedback_transit_service_text));
+                target = new ViewTarget(R.id.ri_spinnerServices, activity);
+                break;
             default:
                 throw new IllegalArgumentException(
                         "tutorialType must be one of the TUTORIAL_* constants in ShowcaseViewUtils");
@@ -384,5 +393,6 @@ public class ShowcaseViewUtils {
         PreferenceUtils.saveBoolean(TUTORIAL_ARRIVAL_ROUTE_FILTER, false);
         PreferenceUtils.saveBoolean(TUTORIAL_NIGHT_LIGHT, false);
         PreferenceUtils.saveBoolean(TUTORIAL_SEND_FEEDBACK, false);
+        PreferenceUtils.saveBoolean(TUTORIAL_SEND_FEEDBACK_OPEN311_CATEGORIES, false);
     }
 }

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -707,6 +707,10 @@
     <string name="tutorial_send_feedback_text">Help us improve OneBusAway! Tap on \"Send feedback\"
         in the main navigation panel.
     </string>
+    <string name="tutorial_send_feedback_transit_service_title">More than just transit</string>
+    <string name="tutorial_send_feedback_transit_service_text">You can report a variety of issue
+        types to your local government near this stop. Tap on the drop-down box to see a full list.
+    </string>
 
     <!-- About -->
     <string name="title_activity_about">About</string>


### PR DESCRIPTION
A tutorial view added for non-transit services.

![bc30fb04-15e3-11e6-9069-e09802c31d21](https://cloud.githubusercontent.com/assets/2777974/15149023/f28869c8-1695-11e6-973e-0658e0e9552d.png)

cc'd @barbeau 