### PR TITLE
Fix #491: Opening Send Feedback then backing out then re-entering shows prompt again.

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/ReportActivity.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/ReportActivity.java
@@ -16,6 +16,13 @@
 
 package org.onebusaway.android.report.ui;
 
+import android.content.Context;
+import android.content.Intent;
+import android.location.Location;
+import android.os.Bundle;
+import android.view.MenuItem;
+import android.view.Window;
+
 import com.google.android.gms.common.api.GoogleApiClient;
 
 import org.onebusaway.android.BuildConfig;
@@ -31,13 +38,6 @@ import org.onebusaway.android.ui.PreferencesActivity;
 import org.onebusaway.android.util.BuildFlavorUtils;
 import org.onebusaway.android.util.LocationUtils;
 import org.onebusaway.android.util.PreferenceUtils;
-
-import android.content.Context;
-import android.content.Intent;
-import android.location.Location;
-import android.os.Bundle;
-import android.view.MenuItem;
-import android.view.Window;
 
 /**
  * Fragment Activity for handling all report
@@ -67,7 +67,6 @@ public class ReportActivity extends BaseReportActivity {
             if (showValidateRegionDialog(currentRegion)) {
                 RegionValidateDialog rvd = new RegionValidateDialog();
                 rvd.show(getSupportFragmentManager(), ReportConstants.TAG_REGION_VALIDATE_DIALOG);
-                PreferenceUtils.saveLong(ReportConstants.PREF_VALIDATED_REGION_ID, currentRegion.getId());
             } else {
                 createIssueTypeListFragment();
             }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/dialog/RegionValidateDialog.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/dialog/RegionValidateDialog.java
@@ -15,15 +15,17 @@
 */
 package org.onebusaway.android.report.ui.dialog;
 
-import org.onebusaway.android.R;
-import org.onebusaway.android.app.Application;
-import org.onebusaway.android.report.ui.ReportActivity;
-
 import android.app.AlertDialog;
 import android.app.Dialog;
 import android.content.DialogInterface;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
+
+import org.onebusaway.android.R;
+import org.onebusaway.android.app.Application;
+import org.onebusaway.android.report.constants.ReportConstants;
+import org.onebusaway.android.report.ui.ReportActivity;
+import org.onebusaway.android.util.PreferenceUtils;
 
 /**
  * Show to validate if the current user is in expected region
@@ -44,6 +46,8 @@ public class RegionValidateDialog extends BaseReportDialogFragment {
                 .setMessage(message.toString())
                 .setPositiveButton("YES", new DialogInterface.OnClickListener() {
                     public void onClick(DialogInterface dialog, int which) {
+                        long regionId = Application.get().getCurrentRegion().getId();
+                        PreferenceUtils.saveLong(ReportConstants.PREF_VALIDATED_REGION_ID, regionId);
                         ((ReportActivity) getActivity()).createIssueTypeListFragment();
                     }
                 })


### PR DESCRIPTION
Issue #491 fixed. Instead of the Validated Region ID preference being set instantly when the Dialog is showed, I added a member field to ReportActivity to keep track of the current region ID. In RegionDialog, once "Yes" is tapped, the validated region ID preference is set. 