### PR TITLE
Fix  #500 - Add analytics to the service alerts button

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListFragment.java
@@ -79,7 +79,9 @@ import android.widget.Toast;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 //
 // We don't use the ListFragment because the support library's version of
@@ -1612,6 +1614,7 @@ public class ArrivalsListFragment extends ListFragment
         @Override
         public void onClick() {
             SituationActivity.start(getActivity(), mSituation);
+            reportAnalytics(mSituation);
         }
 
         @Override
@@ -1635,6 +1638,20 @@ public class ArrivalsListFragment extends ListFragment
                 return false;
             }
             return true;
+        }
+    }
+
+    private void reportAnalytics(ObaSituation situation) {
+        ObaSituation.AllAffects[] allAffects = situation.getAllAffects();
+        Set<String> agencyIds = new HashSet<>();
+        for (int i = 0; i < allAffects.length; i++) {
+            agencyIds.add(allAffects[i].getAgencyId());
+        }
+
+        for (String agencyId : agencyIds) {
+            ObaAnalytics.reportEventWithCategory(ObaAnalytics.ObaEventCategory.UI_ACTION.toString(),
+                    getString(R.string.analytics_action_service_alerts),
+                    getString(R.string.analytics_label_service_alerts) + agencyId);
         }
     }
 

--- a/onebusaway-android/src/main/res/values/donottranslate.xml
+++ b/onebusaway-android/src/main/res/values/donottranslate.xml
@@ -62,6 +62,7 @@
     <string name="analytics_action_problem">report_problem</string>
     <string name="analytics_action_touch_exploration">touch_exploration_on</string>
     <string name="analytics_action_customer_service">customer_service</string>
+    <string name="analytics_action_service_alerts">service_alerts</string>
 
     <string name="analytics_label_region">API Region:\u0020</string>
     <string name="analytics_label_region_auto">Set Region Automatically:\u0020</string>
@@ -131,6 +132,7 @@
     <string name="analytics_label_analytic_preference">Set Send anonymous usage data:\u0020</string>
     <string name="analytics_label_show_departed_bus_preference">Show Departed Buses:\u0020</string>
     <string name="analytics_label_arrival_info_style">Set Arrival info style:\u0020</string>
+    <string name="analytics_label_service_alerts">Clicked Service Alerts from:\u0020</string>
 
     <!-- General strings -->
     <string name="http_prefix">http://</string>


### PR DESCRIPTION
Following analytics report was added when a `service alerts button` is clicked:

 Event Category  | Event Action | Event Label |
| ------------- | ------------- | ------------- |
| ui_action  | service_alerts  | Clicked Service Alerts from: PSTA |

Screenshot from GA console:

![untitled 2](https://cloud.githubusercontent.com/assets/2777974/15409931/1d28e1fc-1de5-11e6-96ba-5fa290bd3971.png)

cc'd @barbeau 
