### PR TITLE
Fix #508 - Resize RouteShortName if it is more than 3 characters

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/util/test/UIUtilTest.java
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/util/test/UIUtilTest.java
@@ -1,5 +1,6 @@
 package org.onebusaway.android.util.test;
 
+import org.onebusaway.android.R;
 import org.onebusaway.android.app.Application;
 import org.onebusaway.android.io.elements.ObaAgency;
 import org.onebusaway.android.io.elements.ObaArrivalInfo;
@@ -16,6 +17,7 @@ import org.onebusaway.android.ui.ArrivalInfo;
 import org.onebusaway.android.util.UIUtils;
 
 import android.text.TextUtils;
+import android.widget.TextView;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -552,6 +554,25 @@ public class UIUtilTest extends ObaTestCase {
         assertEquals("On time", arrivalInfo.get(29).getStatusText());
         assertEquals("9 min delay", arrivalInfo.get(30).getStatusText());
         assertEquals("On time", arrivalInfo.get(31).getStatusText());
+    }
+
+    public void testMaybeShrinkRouteName() {
+        TextView tv = new TextView(getContext());
+
+        String routeShortName = "TST";
+        float textSize = tv.getTextSize();
+        UIUtils.maybeShrinkRouteName(getContext(), tv, routeShortName);
+        assertEquals(textSize, tv.getTextSize());
+
+        routeShortName = "Test";
+        UIUtils.maybeShrinkRouteName(getContext(), tv, routeShortName);
+        assertEquals(getContext().getResources().getDimension(R.dimen.route_name_text_size_medium),
+                tv.getTextSize());
+
+        routeShortName = "Test2";
+        UIUtils.maybeShrinkRouteName(getContext(), tv, routeShortName);
+        assertEquals(getContext().getResources().getDimension(R.dimen.route_name_text_size_small),
+                tv.getTextSize());
     }
 
     /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/SimpleArrivalListFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/SimpleArrivalListFragment.java
@@ -92,7 +92,7 @@ public class SimpleArrivalListFragment extends Fragment
         super.onSaveInstanceState(outState);
         if (mObaStop != null) {
             outState.putString(MapParams.STOP_ID, mObaStop.getId());
-        } else if (mBundleObaStopId != null ){
+        } else if (mBundleObaStopId != null) {
             outState.putString(MapParams.STOP_ID, mBundleObaStopId);
         }
     }
@@ -142,7 +142,7 @@ public class SimpleArrivalListFragment extends Fragment
     @Override
     public Loader<ObaArrivalInfoResponse> onCreateLoader(int id, Bundle args) {
         String stopId;
-        if (mObaStop == null){
+        if (mObaStop == null) {
             stopId = mBundleObaStopId;
         } else {
             stopId = mObaStop.getId();
@@ -195,7 +195,10 @@ public class SimpleArrivalListFragment extends Fragment
             view.findViewById(R.id.more_horizontal).setVisibility(View.INVISIBLE);
             view.findViewById(R.id.route_favorite).setVisibility(View.INVISIBLE);
 
-            route.setText(arrivalInfo.getShortName());
+            String routeShortName = arrivalInfo.getShortName();
+            route.setText(routeShortName);
+            UIUtils.maybeShrinkRouteName(getActivity(), route, routeShortName);
+
             destination.setText(MyTextUtils.toTitleCase(arrivalInfo.getHeadsign()));
             status.setText(stopInfo.getStatusText());
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListAdapterStyleA.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListAdapterStyleA.java
@@ -81,7 +81,10 @@ public class ArrivalsListAdapterStyleA extends ArrivalsListAdapterBase<ArrivalIn
                 R.drawable.focus_star_on :
                 R.drawable.focus_star_off);
 
-        route.setText(arrivalInfo.getShortName());
+        String shortName = arrivalInfo.getShortName();
+        route.setText(shortName);
+        UIUtils.maybeShrinkRouteName(getContext(), route, shortName);
+
         destination.setText(MyTextUtils.toTitleCase(arrivalInfo.getHeadsign()));
         status.setText(stopInfo.getStatusText());
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/UIUtils.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/UIUtils.java
@@ -17,8 +17,6 @@
 
 package org.onebusaway.android.util;
 
-import com.google.android.gms.common.api.GoogleApiClient;
-
 import org.onebusaway.android.R;
 import org.onebusaway.android.app.Application;
 import org.onebusaway.android.io.ObaApi;
@@ -50,7 +48,6 @@ import android.database.Cursor;
 import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.graphics.Rect;
-import android.location.Location;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.net.Uri;
@@ -69,6 +66,7 @@ import android.text.format.DateUtils;
 import android.text.method.LinkMovementMethod;
 import android.text.style.ClickableSpan;
 import android.util.Log;
+import android.util.TypedValue;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.MotionEvent;
@@ -1140,5 +1138,24 @@ public final class UIUtils {
                         DateUtils.FORMAT_NO_NOON |
                         DateUtils.FORMAT_NO_MIDNIGHT
         );
+    }
+
+    /**
+     * Set smaller text size if the route short name has more than 3 characters
+     *
+     * @param view Text view
+     * @param routeShortName Route short name
+     */
+    public static void maybeShrinkRouteName(Context context, TextView view, String routeShortName) {
+        if (routeShortName.length() < 4) {
+            // No-op if text is short enough to fit
+            return;
+        } else if (routeShortName.length() == 4) {
+            view.setTextSize(TypedValue.COMPLEX_UNIT_PX, context.getResources().
+                    getDimension(R.dimen.route_name_text_size_medium));
+        } else if (routeShortName.length() > 4) {
+            view.setTextSize(TypedValue.COMPLEX_UNIT_PX, context.getResources().
+                    getDimension(R.dimen.route_name_text_size_small));
+        }
     }
 }

--- a/onebusaway-android/src/main/res/values/dimens.xml
+++ b/onebusaway-android/src/main/res/values/dimens.xml
@@ -41,6 +41,9 @@
 
     <!-- Other misc items -->
     <dimen name="route_button_width">48sp</dimen>
+    <dimen name="route_name_text_size_small">24sp</dimen>
+    <dimen name="route_name_text_size_medium">30sp</dimen>
+
 
     <!-- Arrival List Header -->
     <dimen name="arrival_header_height_no_arrivals">50dp</dimen>


### PR DESCRIPTION
This PR resizes the `routeShortName` if it is longer than 3 characters.

**Methodology**
```
if (routeShortName.length() == 4) {
            view.setTextSize(30);
} else if (routeShortName.length() > 4) {
            view.setTextSize(24);
}
```

**Results**
![device-2016-05-23-150119](https://cloud.githubusercontent.com/assets/2777974/15481277/bb03224c-20f7-11e6-953c-960f7120345a.png)
![device-2016-05-23-150357](https://cloud.githubusercontent.com/assets/2777974/15481278/bb08a898-20f7-11e6-8c8d-f2f6b65f9cb8.png)
![device-2016-05-23-144612](https://cloud.githubusercontent.com/assets/2777974/15481292/c04c39f0-20f7-11e6-8b4e-dea49503b23d.png)
![device-2016-05-23-144526](https://cloud.githubusercontent.com/assets/2777974/15481293/c04ceb0c-20f7-11e6-9a3c-b86745b9826c.png)

cc'd @barbeau 