### PR TITLE
Fix #519 - Move open311 questions above issue description

### DIFF
--- a/onebusaway-android/src/main/res/layout/open311_issue.xml
+++ b/onebusaway-android/src/main/res/layout/open311_issue.xml
@@ -25,6 +25,14 @@
             android:layout_height="wrap_content"
             android:id="@+id/ri_contents">
 
+        <LinearLayout
+                android:orientation="vertical"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:id="@+id/ri_info_layout">
+
+        </LinearLayout>
+
         <FrameLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -68,29 +76,21 @@
                     android:background="@color/light_gray"
                     android:id="@+id/ri_imageView"
                     style="@style/MaterialItem"/>
-                <Button
-                        android:layout_width="120dp"
-                        android:layout_height="32dp"
-                        android:layout_marginLeft="176dp"
-                        android:background="@color/material_background"
-                        android:text="@string/ri_button_image"
-                        android:textSize="15sp"
-                        android:textStyle="bold"
-                        android:textAppearance="?android:attr/textAppearanceMedium"
-                        android:textColor="@android:color/black"
-                        android:layout_gravity="top"
-                        android:id="@+id/ri_attach_image"
-                        />
+            <Button
+                    android:layout_width="120dp"
+                    android:layout_height="32dp"
+                    android:layout_marginLeft="176dp"
+                    android:background="@color/material_background"
+                    android:text="@string/ri_button_image"
+                    android:textSize="15sp"
+                    android:textStyle="bold"
+                    android:textAppearance="?android:attr/textAppearanceMedium"
+                    android:textColor="@android:color/black"
+                    android:layout_gravity="top"
+                    android:id="@+id/ri_attach_image"
+            />
 
         </FrameLayout>
-
-        <LinearLayout
-                android:orientation="vertical"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:id="@+id/ri_info_layout">
-
-        </LinearLayout>
 
         <FrameLayout
                 android:layout_width="match_parent"
@@ -99,7 +99,7 @@
                 android:orientation="horizontal">
 
             <ImageView style="@style/MaterialSmallIcon"
-                       android:layout_marginTop="12dp"
+                       android:layout_marginTop="18dp"
                        android:src="@drawable/ic_incognito"
                        android:id="@+id/ri_ic_anonymous"/>
 
@@ -113,7 +113,7 @@
                     android:textSize="15sp"
                     android:textStyle="bold"
                     android:textColor="@android:color/black"
-                    />
+            />
 
 
         </FrameLayout>
@@ -137,7 +137,7 @@
                     android:ems="10"
                     android:id="@+id/rici_name_editText"
                     style="@style/MaterialItem"
-                    />
+            />
 
 
         </FrameLayout>
@@ -177,7 +177,7 @@
                     android:ems="10"
                     android:hint="@string/ri_user_email_hint"
                     style="@style/MaterialItem"
-                    android:id="@+id/rici_email_editText" />
+                    android:id="@+id/rici_email_editText"/>
 
         </FrameLayout>
 
@@ -199,7 +199,7 @@
                     android:ems="10"
                     android:hint="@string/ri_user_phone_hint"
                     style="@style/MaterialItem"
-                    android:id="@+id/rici_phone_editText" />
+                    android:id="@+id/rici_phone_editText"/>
 
         </FrameLayout>
 


### PR DESCRIPTION
In issue reporting screen, if an open311 available for the region,  `issue description` field moved below the open311 questions.

Transit related issue:

![device-2016-05-26-221612](https://cloud.githubusercontent.com/assets/2777974/15595845/764485c4-2390-11e6-9978-56f80d0595fc.png)

Non-transit issue:

![device-2016-05-26-221852](https://cloud.githubusercontent.com/assets/2777974/15595855/800cfbf4-2390-11e6-98f2-c27feadbf427.png)

cc'd @barbeau 