### PR TITLE
Fix #478 - Force update oba regions on restore from storage

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/io/backup/SavePreference.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/io/backup/SavePreference.java
@@ -16,6 +16,7 @@
 package org.onebusaway.android.io.backup;
 
 import org.onebusaway.android.R;
+import org.onebusaway.android.app.Application;
 import org.onebusaway.android.io.ObaAnalytics;
 
 import android.content.Context;
@@ -57,7 +58,7 @@ public class SavePreference extends Preference {
 
     @Override
     protected void onClick() {
-        Context context = getContext();
+        Context context = Application.get().getApplicationContext();
         ObaAnalytics.reportEventWithCategory(ObaAnalytics.ObaEventCategory.UI_ACTION.toString(),
                 context.getString(R.string.analytics_action_button_press),
                 context.getString(R.string.analytics_label_button_press_save_preference));

--- a/onebusaway-android/src/main/java/org/onebusaway/android/region/ObaRegionsTask.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/region/ObaRegionsTask.java
@@ -71,6 +71,8 @@ public class ObaRegionsTask extends AsyncTask<Void, Integer, ArrayList<ObaRegion
 
     private ProgressDialog mProgressDialog;
 
+    private String mProgressDialogMessage;
+
     private ObaRegionsTask.Callback mCallback;
 
     private final boolean mForceReload;
@@ -118,8 +120,11 @@ public class ObaRegionsTask extends AsyncTask<Void, Integer, ArrayList<ObaRegion
     @Override
     protected void onPreExecute() {
         if (mShowProgressDialog && UIUtils.canManageDialog(mContext)) {
+            if (mProgressDialogMessage == null){
+                mProgressDialogMessage = mContext.getString(R.string.region_detecting_server);
+            }
             mProgressDialog = ProgressDialog.show(mContext, "",
-                    mContext.getString(R.string.region_detecting_server), true);
+                    mProgressDialogMessage, true);
             mProgressDialog.setIndeterminate(true);
             mProgressDialog.setCancelable(false);
             mProgressDialog.show();
@@ -264,5 +269,9 @@ public class ObaRegionsTask extends AsyncTask<Void, Integer, ArrayList<ObaRegion
         };
         mPauseForCallbackHandler.postDelayed(mPauseForCallback,
                 CALLBACK_DELAY);
+    }
+
+    public void setProgressDialogMessage(String progressDialogMessage) {
+        mProgressDialogMessage = progressDialogMessage;
     }
 }

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -522,6 +522,7 @@
     <string name="preferences_db_save_error">Unable to save: %1$s</string>
     <string name="preferences_db_restore_warning">This will wipe out any existing data! Go ahead?
     </string>
+    <string name="preferences_restore_loading">Restoring from storage&#8230;</string>
     <string name="preferences_db_restored">Restore successful! Please restart OneBusAway.</string>
     <string name="preferences_db_restore_error">Unable to restore: %1$s</string>
 


### PR DESCRIPTION
We are calling `ObaRegionsTask` with `force update` option when restoring a database from the storage.

**Test Case**
1) Put it under the new [db.backup.zip](https://github.com/OneBusAway/onebusaway-android/files/303162/db.backup.zip) under `\Internal storage\OBABackups` which has different region name:

![device-2016-06-07-130034](https://cloud.githubusercontent.com/assets/2777974/15867955/8e637d0a-2cb3-11e6-968c-85e2f546ef66.png)

2) Click `restore from storage` :

![device-2016-06-07-130642](https://cloud.githubusercontent.com/assets/2777974/15868017/d85a06fe-2cb3-11e6-9f82-6afdb9fee9ea.png)

3) Make sure `ObaRegionsTask` was executed successfully by looking the region names:

![device-2016-06-07-133044](https://cloud.githubusercontent.com/assets/2777974/15868073/1a7effbc-2cb4-11e6-9b11-1fefe9634326.png)

cc'd @barbeau 






