### PR TITLE
Fix #517 - Restore zoom level and location on orientation change in route map view

### DIFF
--- a/onebusaway-android/src/amazon/java/org/onebusaway/android/map/googlemapsv2/BaseMapFragment.java
+++ b/onebusaway-android/src/amazon/java/org/onebusaway/android/map/googlemapsv2/BaseMapFragment.java
@@ -333,6 +333,12 @@ public class BaseMapFragment extends SupportMapFragment
         outState.putInt(MapParams.MAP_PADDING_BOTTOM, mMapPaddingBottom);
     }
 
+    @Override
+    public void onViewStateRestored(Bundle savedInstanceState) {
+        mController.onViewStateRestored(savedInstanceState);
+        super.onViewStateRestored(savedInstanceState);
+    }
+
     public boolean isRouteDisplayed() {
         return (mController != null) &&
                 MapParams.MODE_ROUTE.equals(mController.getMode());

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/BaseMapFragment.java
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/BaseMapFragment.java
@@ -322,6 +322,12 @@ public class BaseMapFragment extends SupportMapFragment
         outState.putInt(MapParams.MAP_PADDING_BOTTOM, mMapPaddingBottom);
     }
 
+    @Override
+    public void onViewStateRestored(Bundle savedInstanceState) {
+        mController.onViewStateRestored(savedInstanceState);
+        super.onViewStateRestored(savedInstanceState);
+    }
+
     public boolean isRouteDisplayed() {
         return (mController != null) &&
                 MapParams.MODE_ROUTE.equals(mController.getMode());

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapModeController.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapModeController.java
@@ -192,6 +192,8 @@ public interface MapModeController {
 
     void onSaveInstanceState(Bundle outState);
 
+    void onViewStateRestored(Bundle savedInstanceState);
+
     /**
      * Called when we have the user's location,
      * or when they explicitly said to go to their location.

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.java
@@ -26,6 +26,7 @@ import org.onebusaway.android.io.request.ObaStopsForRouteResponse;
 import org.onebusaway.android.io.request.ObaTripsForRouteRequest;
 import org.onebusaway.android.io.request.ObaTripsForRouteResponse;
 import org.onebusaway.android.map.googlemapsv2.BaseMapFragment;
+import org.onebusaway.android.util.LocationUtils;
 import org.onebusaway.android.util.UIUtils;
 
 import android.app.Activity;
@@ -211,6 +212,32 @@ public class RouteMapController implements MapModeController {
         outState.putString(MapParams.ROUTE_ID, mRouteId);
         outState.putBoolean(MapParams.ZOOM_TO_ROUTE, mZoomToRoute);
         outState.putBoolean(MapParams.ZOOM_INCLUDE_CLOSEST_VEHICLE, mZoomIncludeClosestVehicle);
+
+        Location centerLocation = mFragment.getMapView().getMapCenterAsLocation();
+        outState.putDouble(MapParams.CENTER_LAT, centerLocation.getLatitude());
+        outState.putDouble(MapParams.CENTER_LON, centerLocation.getLongitude());
+        outState.putFloat(MapParams.ZOOM, mFragment.getMapView().getZoomLevelAsFloat());
+    }
+
+    @Override
+    public void onViewStateRestored(Bundle savedInstanceState) {
+        String stopId = savedInstanceState.getString(MapParams.STOP_ID);
+        if (stopId == null) {
+            // If there is no focused stop then restore the map state otherwise
+            // let the BaseMapFragment to handle map state with focused stop
+
+            float mapZoom = savedInstanceState.getFloat(MapParams.ZOOM, MapParams.DEFAULT_ZOOM);
+            if (mapZoom != MapParams.DEFAULT_ZOOM) {
+                mFragment.getMapView().setZoom(mapZoom);
+            }
+
+            double lat = savedInstanceState.getDouble(MapParams.CENTER_LAT);
+            double lon = savedInstanceState.getDouble(MapParams.CENTER_LON);
+            if (lat != 0.0d && lon != 0.0d) {
+                Location location = LocationUtils.makeLocation(lat, lon);
+                mFragment.getMapView().setMapCenter(location, false, false);
+            }
+        }
     }
 
     @Override

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/StopMapController.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/StopMapController.java
@@ -245,6 +245,12 @@ public class StopMapController implements MapModeController,
     }
 
     @Override
+    public void onViewStateRestored(Bundle savedInstanceState) {
+        // We don't need to handle the view state here. This is already been handled in HomeActivity
+        // when the bus stop is selected on the map
+    }
+
+    @Override
     public void onLocation() {
         refresh();
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.java
@@ -885,7 +885,7 @@ public class HomeActivity extends AppCompatActivity
 
             // Since mFocusedStop was null, the layout changed, and we should recenter map on stop
             if (mMapFragment != null && mSlidingPanel != null) {
-                mMapFragment.setMapCenter(mFocusedStop.getLocation(), true,
+                mMapFragment.setMapCenter(mFocusedStop.getLocation(), false,
                         mSlidingPanel.getPanelState() == SlidingUpPanelLayout.PanelState.ANCHORED);
             }
 


### PR DESCRIPTION
This pr fixes the map restore problem on orientation change in `RouteMapController`.

Results:

![device-2016-06-16-002114](https://cloud.githubusercontent.com/assets/2777974/16105526/3e0bb942-3359-11e6-813c-fd2b46d0c9ee.png)
![device-2016-06-16-002221](https://cloud.githubusercontent.com/assets/2777974/16105527/3e17d0a6-3359-11e6-8542-6ccb9c23fed0.png)


![device-2016-06-16-002645](https://cloud.githubusercontent.com/assets/2777974/16105542/47e9b658-3359-11e6-9130-210a749946e1.png)
![device-2016-06-16-002719](https://cloud.githubusercontent.com/assets/2777974/16105543/47eb4086-3359-11e6-9264-0fb04ded0452.png)

**P.S.:** This PR requires the `BaseMapFragment` to set `mFocusStopId` to `null` when the stop focus is gone. This development has already been done in this PR https://github.com/OneBusAway/onebusaway-android/pull/463. Therefore, I need to rebase this PR on top of the master branch after the PR https://github.com/OneBusAway/onebusaway-android/pull/463 is merged.

