### PR TITLE
Fix #544: Tapping on vehicle marker popup focuses on vehicle icon in TripDetailsListFragment.

### DIFF
--- a/onebusaway-android/src/amazon/java/org/onebusaway/android/map/googlemapsv2/VehicleOverlay.java
+++ b/onebusaway-android/src/amazon/java/org/onebusaway/android/map/googlemapsv2/VehicleOverlay.java
@@ -56,6 +56,7 @@ import org.onebusaway.android.io.elements.ObaTripStatus;
 import org.onebusaway.android.io.request.ObaTripsForRouteResponse;
 import org.onebusaway.android.ui.ArrivalInfo;
 import org.onebusaway.android.ui.TripDetailsActivity;
+import org.onebusaway.android.ui.TripDetailsListFragment;
 import org.onebusaway.android.util.MathUtils;
 import org.onebusaway.android.util.UIUtils;
 
@@ -311,9 +312,11 @@ public class VehicleOverlay implements AmazonMap.OnInfoWindowClickListener {
         ObaTripStatus status = mMarkerData.getStatusFromMarker(marker);
 
         if (mController != null && mController.getFocusedStopId() != null) {
-            TripDetailsActivity.start(mActivity, status.getActiveTripId(), mController.getFocusedStopId());
+            TripDetailsActivity.start(mActivity, status.getActiveTripId(),
+                    mController.getFocusedStopId(), TripDetailsListFragment.SCROLL_MODE_VEHICLE);
         } else {
-            TripDetailsActivity.start(mActivity, status.getActiveTripId());
+            TripDetailsActivity.start(mActivity, status.getActiveTripId(),
+                    TripDetailsListFragment.SCROLL_MODE_VEHICLE);
         }
     }
 

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/VehicleOverlay.java
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/VehicleOverlay.java
@@ -45,6 +45,7 @@ import org.onebusaway.android.io.elements.ObaTripStatus;
 import org.onebusaway.android.io.request.ObaTripsForRouteResponse;
 import org.onebusaway.android.ui.ArrivalInfo;
 import org.onebusaway.android.ui.TripDetailsActivity;
+import org.onebusaway.android.ui.TripDetailsListFragment;
 import org.onebusaway.android.util.MathUtils;
 import org.onebusaway.android.util.UIUtils;
 
@@ -300,9 +301,11 @@ public class VehicleOverlay implements GoogleMap.OnInfoWindowClickListener {
         ObaTripStatus status = mMarkerData.getStatusFromMarker(marker);
 
         if (mController != null && mController.getFocusedStopId() != null) {
-            TripDetailsActivity.start(mActivity, status.getActiveTripId(), mController.getFocusedStopId());
+            TripDetailsActivity.start(mActivity, status.getActiveTripId(),
+                    mController.getFocusedStopId(), TripDetailsListFragment.SCROLL_MODE_VEHICLE);
         } else {
-            TripDetailsActivity.start(mActivity, status.getActiveTripId());
+            TripDetailsActivity.start(mActivity, status.getActiveTripId(),
+                    TripDetailsListFragment.SCROLL_MODE_VEHICLE);
         }
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListFragment.java
@@ -1370,7 +1370,8 @@ public class ArrivalsListFragment extends ListFragment
 
     private void goToTripDetails(ArrivalInfo stop) {
         TripDetailsActivity.start(getActivity(),
-                stop.getInfo().getTripId(), stop.getInfo().getStopId());
+                stop.getInfo().getTripId(), stop.getInfo().getStopId(),
+                TripDetailsListFragment.SCROLL_MODE_STOP);
     }
 
     private void goToRoute(ArrivalInfo stop) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/TripDetailsActivity.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/TripDetailsActivity.java
@@ -46,6 +46,11 @@ public class TripDetailsActivity extends AppCompatActivity {
             return this;
         }
 
+        public Builder setScrollMode(String mode) {
+            mIntent.putExtra(TripDetailsListFragment.SCROLL_MODE, mode);
+            return this;
+        }
+
         public Builder setUpMode(String mode) {
             mIntent.putExtra(NavHelp.UP_MODE, mode);
             return this;
@@ -64,9 +69,14 @@ public class TripDetailsActivity extends AppCompatActivity {
         new Builder(context, tripId).start();
     }
 
-    public static void start(Context context, String tripId, String stopId) {
-        new Builder(context, tripId).setStopId(stopId).start();
+    public static void start(Context context, String tripId, String mode) {
+        new Builder(context, tripId).setScrollMode(mode).start();
     }
+
+    public static void start(Context context, String tripId, String stopId, String mode) {
+        new Builder(context, tripId).setStopId(stopId).setScrollMode(mode).start();
+    }
+
 
     @Override
     public void onCreate(Bundle savedInstanceState) {


### PR DESCRIPTION
If a vehicle marker popup is tapped, it attempts to focus on the stop with the bus icon first. If stop marker is selected, it attempts to focus on that selected stop.

Testing Done:
1. Selected stop, tapped "Show Route on Map", clicked vehicle overlay and tapped popup. Trip Details Activity opened with bus focused. Worked as wanted.
2. Selected stop, tapped "View Trip Details". Trip Details Activity opened with stop focused. Worked as wanted.
3. gradlew connectedObaGoogleDebugAndroidTest connectedObaAmazonDebugAndroidTest: Success.