### PR TITLE
Fix #549 - Add region name and auto region select to feedback email body

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/io/ObaAnalytics.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/io/ObaAnalytics.java
@@ -15,12 +15,6 @@
  */
 package org.onebusaway.android.io;
 
-import android.app.Activity;
-import android.content.Context;
-import android.content.SharedPreferences;
-import android.location.Location;
-import android.support.v4.app.Fragment;
-
 import com.google.android.gms.analytics.GoogleAnalytics;
 import com.google.android.gms.analytics.HitBuilders;
 import com.google.android.gms.analytics.Tracker;
@@ -28,9 +22,13 @@ import com.google.android.gms.analytics.Tracker;
 import org.onebusaway.android.BuildConfig;
 import org.onebusaway.android.R;
 import org.onebusaway.android.app.Application;
-import org.onebusaway.android.io.elements.ObaRegion;
+import org.onebusaway.android.util.RegionUtils;
 
-import java.security.MessageDigest;
+import android.app.Activity;
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.location.Location;
+import android.support.v4.app.Fragment;
 
 /**
  * Analytics class for tracking the app
@@ -111,7 +109,7 @@ public class ObaAnalytics {
         if (isAnalyticsActive()) {
             Tracker tracker = Application.get().getTracker(Application.TrackerName.APP_TRACKER);
             Tracker tracker2 = Application.get().getTracker(Application.TrackerName.GLOBAL_TRACKER);
-            String obaRegionName = getObaRegionName();
+            String obaRegionName = RegionUtils.getObaRegionName();
 
             tracker.send(new HitBuilders.EventBuilder()
                     .setCategory(category)
@@ -219,24 +217,5 @@ public class ObaAnalytics {
     private static Boolean isAnalyticsActive() {
         SharedPreferences settings = Application.getPrefs();
         return settings.getBoolean(Application.get().getString(R.string.preferences_key_analytics), Boolean.TRUE);
-    }
-
-    private static String getObaRegionName() {
-        String regionName = null;
-        ObaRegion region = Application.get().getCurrentRegion();
-        if (region != null && region.getName() != null) {
-            regionName = region.getName();
-        } else if (Application.get().getCustomApiUrl() != null) {
-            MessageDigest digest;
-            try {
-                digest = MessageDigest.getInstance("SHA-1");
-                digest.update(Application.get().getCustomApiUrl().getBytes());
-                regionName = Application.get().getString(R.string.analytics_label_custom_url) +
-                        ": " + Application.getHex(digest.digest());
-            } catch (Exception e) {
-                regionName = Application.get().getString(R.string.analytics_label_custom_url);
-            }
-        }
-        return regionName;
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/ReportTypeListFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/ReportTypeListFragment.java
@@ -21,6 +21,7 @@ import org.onebusaway.android.io.ObaAnalytics;
 import org.onebusaway.android.io.elements.ObaRegion;
 import org.onebusaway.android.ui.MaterialListAdapter;
 import org.onebusaway.android.ui.MaterialListItem;
+import org.onebusaway.android.util.RegionUtils;
 import org.onebusaway.android.util.UIUtils;
 
 import android.content.res.TypedArray;
@@ -128,6 +129,7 @@ public class ReportTypeListFragment extends ListFragment implements AdapterView.
             String email = getString(R.string.ri_app_feedback_email);
             String locationString = getActivity().getIntent()
                     .getStringExtra(BaseReportActivity.LOCATION_STRING);
+
             UIUtils.sendEmail(getActivity(), email, locationString);
 
             ObaAnalytics.reportEventWithCategory(ObaAnalytics.ObaEventCategory.UI_ACTION.toString(),

--- a/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/dialog/CustomerServiceDialog.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/dialog/CustomerServiceDialog.java
@@ -16,6 +16,7 @@
 package org.onebusaway.android.report.ui.dialog;
 
 import org.onebusaway.android.R;
+import org.onebusaway.android.app.Application;
 import org.onebusaway.android.io.ObaAnalytics;
 import org.onebusaway.android.io.elements.ObaAgency;
 import org.onebusaway.android.io.elements.ObaAgencyWithCoverage;
@@ -23,6 +24,7 @@ import org.onebusaway.android.io.request.ObaAgenciesWithCoverageRequest;
 import org.onebusaway.android.io.request.ObaAgenciesWithCoverageResponse;
 import org.onebusaway.android.report.ui.BaseReportActivity;
 import org.onebusaway.android.util.ArrayAdapter;
+import org.onebusaway.android.util.RegionUtils;
 import org.onebusaway.android.util.UIUtils;
 
 import android.content.Context;
@@ -123,6 +125,7 @@ public class CustomerServiceDialog extends DialogFragment implements
                     public void onClick(View view) {
                         String locationString = getActivity().getIntent().
                                 getStringExtra(BaseReportActivity.LOCATION_STRING);
+
                         UIUtils.sendEmail(getActivity(), agency.getEmail(), locationString);
 
                         ObaAnalytics.reportEventWithCategory(ObaAnalytics.ObaEventCategory.UI_ACTION.toString(),

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/RegionUtils.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/RegionUtils.java
@@ -33,6 +33,7 @@ import android.location.Location;
 import android.net.Uri;
 import android.util.Log;
 
+import java.security.MessageDigest;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.util.ArrayList;
@@ -111,6 +112,35 @@ public class RegionUtils {
             }
         }
         return closestRegion;
+    }
+
+    /**
+     * Get the region name if it is available. If there is a custom url instead of a region from
+     * the region api, then hash the custom url and return it.
+     *
+     * @return regionName
+     */
+    public static String getObaRegionName() {
+        String regionName = null;
+        ObaRegion region = Application.get().getCurrentRegion();
+        if (region != null && region.getName() != null) {
+            regionName = region.getName();
+        } else if (Application.get().getCustomApiUrl() != null) {
+            regionName = createHashCode(Application.get().getCustomApiUrl().getBytes());
+        }
+        return regionName;
+    }
+
+    private static String createHashCode(byte[] bytes) {
+        MessageDigest digest;
+        try {
+            digest = MessageDigest.getInstance("SHA-1");
+            digest.update(bytes);
+            return Application.get().getString(R.string.analytics_label_custom_url) +
+                    ": " + Application.getHex(digest.digest());
+        } catch (Exception e) {
+            return Application.get().getString(R.string.analytics_label_custom_url);
+        }
     }
 
     /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/UIUtils.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/UIUtils.java
@@ -470,9 +470,33 @@ public final class UIUtils {
     /**
      * Opens email apps based on the given email address
      * @param email address
-     * @param location string that show the current location
+     * @param location string that shows the current location
      */
     public static void sendEmail(Context context, String email, String location) {
+        String obaRegionName = RegionUtils.getObaRegionName();
+        Boolean autoRegion = Application.get().getPrefs()
+                .getBoolean(context.getString(R.string.preference_key_auto_select_region),
+                        Boolean.FALSE);
+        String regionSelectionMethod;
+        if (autoRegion) {
+            regionSelectionMethod = context.getString(R.string.region_selected_auto);
+        } else {
+            regionSelectionMethod = context.getString(R.string.region_selected_manually);
+        }
+
+        UIUtils.sendEmail(context, email, location, obaRegionName, regionSelectionMethod);
+    }
+
+    /**
+     * Opens email apps based on the given email address
+     * @param email address
+     * @param location string that shows the current location
+     * @param regionName name of the current api region
+     * @param regionSelectionMethod string that shows if the current api region selected manually or
+     *                              automatically
+     */
+    private static void sendEmail(Context context, String email, String location, String regionName,
+                                 String regionSelectionMethod) {
         PackageManager pm = context.getPackageManager();
         PackageInfo appInfo;
         try {
@@ -489,6 +513,8 @@ public final class UIUtils {
                     Build.MODEL,
                     Build.VERSION.RELEASE,
                     Build.VERSION.SDK_INT,
+                    regionName,
+                    regionSelectionMethod,
                     location);
         } else {
             body = context.getString(R.string.bug_report_body_without_location,

--- a/onebusaway-android/src/main/res/values-es/strings.xml
+++ b/onebusaway-android/src/main/res/values-es/strings.xml
@@ -463,7 +463,7 @@
     <!--  Bug report -->
     <string name="bug_report_subject">OneBusAway Android: Comentarios</string>
     <string name="bug_report_body">¡Quejas, felicitaciones, o reporte de errores son bienvenidos!\n\n\nVersión de la App:
-        %1$s\nModelo: %2$s\nVersión SO: %3$s / %4$d\nLoc: %5$s
+        %1$s\nModelo: %2$s\nVersión SO: %3$s / %4$d\nRegion/API: %5$s (%6$s)\nLoc: %7$s
     </string>
     <string name="bug_report_body_without_location">¡Quejas, felicitaciones, o reporte de errores son bienvenidos!\n\n\nVersión de la App:
         %1$s\nModelo: %2$s\n nVersión SO: %3$s / %4$d

--- a/onebusaway-android/src/main/res/values-fi/strings.xml
+++ b/onebusaway-android/src/main/res/values-fi/strings.xml
@@ -456,7 +456,7 @@
     <!--  Bug report -->
     <string name="bug_report_subject">OneBusAway Android: Palaute</string>
     <string name="bug_report_body">Valitukset, kiitokset ja virheraportit ovat tervetulleita!\n\n\nApp Version:
-        %1$s\nModel: %2$s\nOS Versio: %3$s / %4$d\nLoc: %5$s
+        %1$s\nModel: %2$s\nOS Version: %3$s / %4$d\nRegion/API: %5$s (%6$s)\nLoc: %7$s
     </string>
     <string name="bug_report_error">Virheraporttia ei pystytä lähettämään: sopivaa ohjelmaa ei löytynyt.
     </string>

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -458,12 +458,14 @@
     <string name="region_disabled_auto_selection">Disabled automatic region selection. You can
         enable in Preferences.
     </string>
+    <string name="region_selected_auto">selected automatically</string>
+    <string name="region_selected_manually">selected manually</string>
     <string name="region_region_found">Found %1$s region</string>
 
     <!--  Bug report -->
     <string name="bug_report_subject">OneBusAway Android: Feedback</string>
     <string name="bug_report_body">Complaints, kudos, or bug reports are welcome!\n\n\nApp Version:
-        %1$s\nModel: %2$s\nOS Version: %3$s / %4$d\nLoc: %5$s
+        %1$s\nModel: %2$s\nOS Version: %3$s / %4$d\nRegion/API: %5$s (%6$s)\nLoc: %7$s
     </string>
     <string name="bug_report_body_without_location">Complaints, kudos, or bug reports are welcome!\n\n\nApp Version:
         %1$s\nModel: %2$s\nOS Version: %3$s / %4$d


### PR DESCRIPTION
Added region name and auto region selection info to message body:

![device-2016-06-27-105827](https://cloud.githubusercontent.com/assets/2777974/16384389/aa127d6e-3c56-11e6-8a80-350c16c6998c.png)
![device-2016-06-27-105922](https://cloud.githubusercontent.com/assets/2777974/16384390/aa1a314e-3c56-11e6-9a21-5c7936fa00af.png)
