### PR TITLE
Fix #550 - Wrap very large system font to fit screen

### DIFF
--- a/onebusaway-android/src/main/res/layout/stop_list_item.xml
+++ b/onebusaway-android/src/main/res/layout/stop_list_item.xml
@@ -14,11 +14,12 @@
      limitations under the License.
 -->
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              style="@style/ListItem"
-              android:id="@+id/stop_list_container"
-              android:layout_width="fill_parent"
-                android:layout_height="77dp"
-              android:orientation="horizontal">
+                style="@style/ListItem"
+                android:id="@+id/stop_list_container"
+                android:layout_height="wrap_content"
+                android:layout_width="fill_parent"
+                android:minHeight="77dp"
+                android:orientation="horizontal">
     <ImageView
             android:id="@+id/stop_favorite"
             android:src="@drawable/ic_toggle_star"
@@ -47,7 +48,9 @@
                 style="@style/Line1Text"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_gravity="center_vertical"/>
+                android:layout_gravity="center_vertical"
+                android:ellipsize="end"
+                android:maxLines="1"/>
         <TextView
                 android:id="@+id/direction"
                 style="@style/Line2Text"


### PR DESCRIPTION
Starred stops text was clipped with "Very large" system font setting. This PR wraps the large text and fits to screen.

**My Starred Stops Screen:**

Before             |  After
:-------------------------:|:-------------------------:
![device-2016-06-27-120352](https://cloud.githubusercontent.com/assets/2777974/16387006/f962fd9e-3c60-11e6-8d79-0c8d636af354.png) | ![device-2016-06-27-120959](https://cloud.githubusercontent.com/assets/2777974/16387011/fe41fe46-3c60-11e6-9648-ed8ed6f881ff.png)

**Search Results Screen:**

Before             |  After
:-------------------------:|:-------------------------:
![device-2016-06-27-120535](https://cloud.githubusercontent.com/assets/2777974/16387020/12553dd0-3c61-11e6-8a1f-5c6e709d9cac.png) | ![device-2016-06-27-121028](https://cloud.githubusercontent.com/assets/2777974/16387024/173a29a0-3c61-11e6-9f86-3011e0401911.png)

PS: Tested on Nexus 6 w/ 5.96" screen