### PR TITLE
Fix #562 - Redirect old seattlebusbot packages to open legacy shortcuts

### DIFF
--- a/onebusaway-android/src/main/AndroidManifest.xml
+++ b/onebusaway-android/src/main/AndroidManifest.xml
@@ -69,12 +69,24 @@
                 <action android:name="android.intent.action.MAIN"/>
             </intent-filter>
         </activity>
+        <activity
+                android:name="com.joulespersecond.seattlebusbot.ArrivalsListActivity"
+                android:launchMode="singleTop">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN"/>
+            </intent-filter>
+        </activity>
         <activity android:name="org.onebusaway.android.ui.StopInfoActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
             </intent-filter>
         </activity>
         <activity android:name="org.onebusaway.android.ui.RouteInfoActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN"/>
+            </intent-filter>
+        </activity>
+        <activity android:name="com.joulespersecond.seattlebusbot.RouteInfoActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
             </intent-filter>
@@ -93,6 +105,14 @@
             <intent-filter>
                 <action android:name="android.intent.action.CREATE_SHORTCUT"/>
                 <category android:name="android.intent.category.DEFAULT"/>
+            </intent-filter>
+        </activity>
+
+        <activity
+                android:name="com.joulespersecond.seattlebusbot.MyStopsActivity"
+                android:label="@string/stop_shortcut">
+            <intent-filter>
+                <action android:name="android.intent.action.CREATE_SHORTCUT"/>
             </intent-filter>
         </activity>
         <activity
@@ -117,6 +137,13 @@
             <intent-filter>
                 <action android:name="android.intent.action.CREATE_SHORTCUT"/>
                 <category android:name="android.intent.category.DEFAULT"/>
+            </intent-filter>
+        </activity>
+        <activity
+                android:name="com.joulespersecond.seattlebusbot.MyRoutesActivity"
+                android:label="@string/route_shortcut">
+            <intent-filter>
+                <action android:name="android.intent.action.CREATE_SHORTCUT"/>
             </intent-filter>
         </activity>
         <activity

--- a/onebusaway-android/src/main/java/com/joulespersecond/seattlebusbot/ArrivalsListActivity.java
+++ b/onebusaway-android/src/main/java/com/joulespersecond/seattlebusbot/ArrivalsListActivity.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2016 University of South Florida
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.joulespersecond.seattlebusbot;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v7.app.AppCompatActivity;
+
+/**
+ * Activity package names were refactored from com.joulespersecond.seattlebusbot to
+ * org.onebusaway.android.ui after application version 1.7.9. When a user creates a shortcut with an
+ * older version of OBA, the legacy shortcuts won't run when they upgrade the app to version 2.
+ *
+ * See issue #562 (https://github.com/OneBusAway/onebusaway-android/issues/562#issuecomment-229048016)
+ * for more details.
+ */
+@Deprecated
+public class ArrivalsListActivity extends AppCompatActivity {
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        Intent intent = getIntent();
+        intent.setClass(this, org.onebusaway.android.ui.ArrivalsListActivity.class);
+        startActivity(intent);
+        finish();
+    }
+}

--- a/onebusaway-android/src/main/java/com/joulespersecond/seattlebusbot/MyRoutesActivity.java
+++ b/onebusaway-android/src/main/java/com/joulespersecond/seattlebusbot/MyRoutesActivity.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2016 University of South Florida
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.joulespersecond.seattlebusbot;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v7.app.AppCompatActivity;
+
+/**
+ * Activity package names were refactored from com.joulespersecond.seattlebusbot to
+ * org.onebusaway.android.ui after application version 1.7.9. When a user creates a shortcut with an
+ * older version of OBA, the legacy shortcuts won't run when they upgrade the app to version 2.
+ *
+ * See issue #562 (https://github.com/OneBusAway/onebusaway-android/issues/562#issuecomment-229048016)
+ * for more details.
+ */
+@Deprecated
+public class MyRoutesActivity extends AppCompatActivity {
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        Intent intent = getIntent();
+        intent.setClass(this, org.onebusaway.android.ui.MyRoutesActivity.class);
+        startActivity(intent);
+        finish();
+    }
+}

--- a/onebusaway-android/src/main/java/com/joulespersecond/seattlebusbot/MyStopsActivity.java
+++ b/onebusaway-android/src/main/java/com/joulespersecond/seattlebusbot/MyStopsActivity.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2016 University of South Florida
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.joulespersecond.seattlebusbot;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v7.app.AppCompatActivity;
+
+/**
+ * Activity package names were refactored from com.joulespersecond.seattlebusbot to
+ * org.onebusaway.android.ui after application version 1.7.9. When a user creates a shortcut with an
+ * older version of OBA, the legacy shortcuts won't run when they upgrade the app to version 2.
+ *
+ * See issue #562 (https://github.com/OneBusAway/onebusaway-android/issues/562#issuecomment-229048016)
+ * for more details.
+ */
+@Deprecated
+public class MyStopsActivity extends AppCompatActivity {
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        Intent intent = getIntent();
+        intent.setClass(this, org.onebusaway.android.ui.MyStopsActivity.class);
+        startActivity(intent);
+        finish();
+    }
+}

--- a/onebusaway-android/src/main/java/com/joulespersecond/seattlebusbot/RouteInfoActivity.java
+++ b/onebusaway-android/src/main/java/com/joulespersecond/seattlebusbot/RouteInfoActivity.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2016 University of South Florida
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.joulespersecond.seattlebusbot;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v7.app.AppCompatActivity;
+
+/**
+ * Activity package names were refactored from com.joulespersecond.seattlebusbot to
+ * org.onebusaway.android.ui after application version 1.7.9. When a user creates a shortcut with an
+ * older version of OBA, the legacy shortcuts won't run when they upgrade the app to version 2.
+ *
+ * See issue #562 (https://github.com/OneBusAway/onebusaway-android/issues/562#issuecomment-229048016)
+ * for more details.
+ */
+@Deprecated
+public class RouteInfoActivity extends AppCompatActivity {
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        Intent intent = getIntent();
+        intent.setClass(this, org.onebusaway.android.ui.RouteInfoActivity.class);
+        startActivity(intent);
+        finish();
+    }
+}


### PR DESCRIPTION
This PR implements a workaround solution to open legacy shortcuts. Following old packages redirected to their newer versions:


From             |  To
:-------------------------:|:-------------------------:
com.joulespersecond.seattlebusbot.ArrivalsListActivity | org.onebusaway.android.ui.ArrivalsListActivity
com.joulespersecond.seattlebusbot.MyRoutesActivity | org.onebusaway.android.ui.MyRoutesActivity
com.joulespersecond.seattlebusbot.MyStopsActivity | org.onebusaway.android.ui.MyStopsActivity
com.joulespersecond.seattlebusbot.RouteInfoActivity | org.onebusaway.android.ui.RouteInfoActivity

With this patch we are able to open the following legacy shortcuts:

![device-2016-06-28-114542](https://cloud.githubusercontent.com/assets/2777974/16422329/fb1f0158-3d25-11e6-878a-fe632b8b6c5c.png)

cc'd @barbeau 
