### PR TITLE
Fix #558 - Add AlarmReceiver for legacy reminders

### DIFF
--- a/onebusaway-android/src/main/AndroidManifest.xml
+++ b/onebusaway-android/src/main/AndroidManifest.xml
@@ -230,6 +230,14 @@
                 <action android:name="android.intent.action.TIMEZONE_CHANGED"/>
             </intent-filter>
         </receiver>
+        <!-- Legacy Receiver for backwards-compatibility support with v1.x - See Issue #558 -->
+        <receiver android:name="com.joulespersecond.seattlebusbot.AlarmReceiver">
+            <intent-filter>
+                <!-- Should match constants for actions defined in TripService -->
+                <action android:name="com.joulespersecond.seattlebusbot.action.SCHEDULE"/>
+                <action android:name="com.joulespersecond.seattlebusbot.action.POLL"/>
+            </intent-filter>
+        </receiver>
 
         <meta-data
                 android:name="com.google.android.gms.version"

--- a/onebusaway-android/src/main/java/com/joulespersecond/seattlebusbot/AlarmReceiver.java
+++ b/onebusaway-android/src/main/java/com/joulespersecond/seattlebusbot/AlarmReceiver.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.onebusaway.android.tripservice;
+package com.joulespersecond.seattlebusbot;
 
 import org.onebusaway.android.util.ReminderUtils;
 
@@ -26,16 +26,16 @@ import android.util.Log;
 /**
  * Responsible for receiving Intents from the Android platform related to scheduled reminders.
  *
- * TODO - We should be extending the support library version of WakefulBroadcastReceiver and
- * starting the service using startWakefulService().  See #493 for details.
+ * Used to provide backwards compatibility with reminders created with v1.x - see Issue #558.
  */
+@Deprecated
 public class AlarmReceiver extends BroadcastReceiver {
 
-    private static final String TAG = "AlarmReceiver";
+    private static final String TAG = "LegacyAlarmReceiver";
 
     @Override
     public void onReceive(Context context, Intent intent) {
-        Log.d(TAG, "Received alarm");
+        Log.d(TAG, "Received legacy alarm");
         ReminderUtils.startReminderService(context, intent, TAG);
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/ReminderUtils.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/ReminderUtils.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2016 University of South Florida (sjbarbeau@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.util;
+
+import org.onebusaway.android.tripservice.TripService;
+
+import android.content.Context;
+import android.content.Intent;
+import android.os.PowerManager;
+
+/**
+ * Utilities to assist in the registering of reminder alarms for arriving/departing buses
+ */
+public class ReminderUtils {
+
+    /**
+     * Starts the TripService service to schedule/poll/notify/cancel alarms for the "My Reminders"
+     * feature.  This is called from a BroadcastReceiver triggered by an Intent registered with
+     * Android.
+     *
+     * For now, just forward anything to the TripService. Eventually, we can distinguish by action
+     * or Content URI. Also, handle CPU wake locking..
+     *
+     * TODO - We should be extending the support library version of WakefulBroadcastReceiver and
+     * starting the service using startWakefulService().  See #493 for details.
+     *
+     * @param context Context from which to start the reminder service
+     * @param intent  Intent received by the BroadcastReceiver
+     * @param TAG     class name (or other tag) for debugging purposes.
+     */
+    public static void startReminderService(Context context, Intent intent, String TAG) {
+        PowerManager pm = (PowerManager) context.getSystemService(Context.POWER_SERVICE);
+        PowerManager.WakeLock lock = pm.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, TAG);
+        lock.acquire(10 * 1000);
+        Intent tripService = new Intent(context, TripService.class);
+        tripService.setAction(intent.getAction());
+        tripService.setData(intent.getData());
+        context.startService(tripService);
+    }
+}


### PR DESCRIPTION
~~*Please do not merge*~~

~~Initial WIP for fixing legacy reminders.  I haven't tested this yet, but will soon, and would welcome testing by others.~~

I don't believe a legacy BootReceiver is needed, as that is scheduled by the system.

cc @cagryInside 
