### PR TITLE
Fix #571 - Add null check to oba references to prevent NPE 

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/Open311ProblemFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/Open311ProblemFragment.java
@@ -551,7 +551,9 @@ public class Open311ProblemFragment extends BaseReportFragment implements
 
                 sb.append(getResources().getString(R.string.ri_append_service_date,
                         dateFormat.format(new Date(mArrivalInfo.getServiceDate()))));
-                sb.append(getResources().getString(R.string.ri_append_agency_name, mAgencyName));
+                if (mAgencyName != null) {
+                    sb.append(getResources().getString(R.string.ri_append_agency_name, mAgencyName));
+                }
                 sb.append(getResources().getString(R.string.ri_append_gtfs_stop_id, obaStop.getId()));
 
                 sb.append(getResources().getString(R.string.ri_append_route_id, mArrivalInfo.getRouteId()));

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListFragment.java
@@ -739,8 +739,12 @@ public class ArrivalsListFragment extends ListFragment
                 } else if ((!hasUrl && which == 5) || (hasUrl && which == 6)) {
                     // Find agency name
                     String routeId = arrivalInfo.getInfo().getRouteId();
-                    String agencyId = mObaReferences.getRoute(routeId).getAgencyId();
-                    String agencyName = mObaReferences.getAgency(agencyId).getName();
+                    String agencyName = null;
+
+                    if (mObaReferences != null) {
+                        String agencyId = mObaReferences.getRoute(routeId).getAgencyId();
+                        agencyName = mObaReferences.getAgency(agencyId).getName();
+                    }
 
                     Intent intent = makeIntent(getActivity(), mStop.getId(), mStop.getName(),
                             mStop.getStopCode(), mStop.getLatitude(), mStop.getLongitude());


### PR DESCRIPTION
If the `obaReferences` and `agencyName` are null then do not show `agencyName` in issue reporting fields.

![screen shot 2016-07-01 at 3 27 00 pm](https://cloud.githubusercontent.com/assets/2777974/16532604/f2de04da-3fa0-11e6-8da0-a6f95b2182d5.png)  ![screen shot 2016-07-01 at 3 27 09 pm](https://cloud.githubusercontent.com/assets/2777974/16532603/f2da480e-3fa0-11e6-9169-9a97773ab362.png)
