### PR TITLE
Bump Google Play Services to 9.2.0

### DIFF
--- a/onebusaway-android/build.gradle
+++ b/onebusaway-android/build.gradle
@@ -299,11 +299,11 @@ tasks.whenTaskAdded { theTask ->
 
 dependencies {
     // Google Play Services Analytics (we need this on Amazon flavor too)
-    compile('com.google.android.gms:play-services-analytics:9.0.1') {
+    compile('com.google.android.gms:play-services-analytics:9.2.0') {
         exclude module: 'play-services-ads' // See #342
     }
     // Google Play Services Location (we need this on Amazon flavor too)
-    compile 'com.google.android.gms:play-services-location:9.0.1'
+    compile 'com.google.android.gms:play-services-location:9.2.0'
     // Support libraries
     compile 'com.android.support:cardview-v7:23.4.0'
     compile 'com.android.support:design:23.4.0'
@@ -323,7 +323,9 @@ dependencies {
     // POJOs used for full data-binding via Jackson
     compile 'edu.usf.cutr.opentripplanner.android:opentripplanner-pojos:1.0.0-SNAPSHOT'
     // Google Play Services Maps (only for Google flavor)
-    googleCompile 'com.google.android.gms:play-services-maps:9.0.1'
+    googleCompile 'com.google.android.gms:play-services-maps:9.2.0'
+    // Google Play Services Places library is required by ProprietaryMapHelpV2
+    googleCompile 'com.google.android.gms:play-services-places:9.2.0'
     // Amazon Maps (only for Amazon flavor)
     amazonCompile 'com.amazon.android:amazon-maps-api:2.0'
 }

--- a/onebusaway-android/src/amazon/java/org/onebusaway/android/map/googlemapsv2/BaseMapFragment.java
+++ b/onebusaway-android/src/amazon/java/org/onebusaway/android/map/googlemapsv2/BaseMapFragment.java
@@ -194,17 +194,11 @@ public class BaseMapFragment extends SupportMapFragment
         mLocationHelper = new LocationHelper(getActivity());
         mLocationHelper.registerListener(this);
 
-        mMap = getMap();
-
         if (MapHelpV2.isMapsInstalled(getActivity())) {
-            if (mMap != null) {
-                initMap(savedInstanceState);
-            } else {
-                // Save the savedInstanceState
-                mLastSavedInstanceState = savedInstanceState;
-                // Register for an async callback when the map is ready
-                getMapAsync(this);
-            }
+            // Save the savedInstanceState
+            mLastSavedInstanceState = savedInstanceState;
+            // Register for an async callback when the map is ready
+            getMapAsync(this);
         } else {
             MapHelpV2.promptUserInstallMaps(getActivity());
         }
@@ -224,6 +218,7 @@ public class BaseMapFragment extends SupportMapFragment
 
     @Override
     public void onMapReady(com.amazon.geo.mapsv2.AmazonMap map) {
+        mMap = map;
         initMap(mLastSavedInstanceState);
     }
 

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/BaseMapFragment.java
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/BaseMapFragment.java
@@ -183,17 +183,11 @@ public class BaseMapFragment extends SupportMapFragment
         mLocationHelper = new LocationHelper(getActivity());
         mLocationHelper.registerListener(this);
 
-        mMap = getMap();
-
         if (MapHelpV2.isMapsInstalled(getActivity())) {
-            if (mMap != null) {
-                initMap(savedInstanceState);
-            } else {
-                // Save the savedInstanceState
-                mLastSavedInstanceState = savedInstanceState;
-                // Register for an async callback when the map is ready
-                getMapAsync(this);
-            }
+            // Save the savedInstanceState
+            mLastSavedInstanceState = savedInstanceState;
+            // Register for an async callback when the map is ready
+            getMapAsync(this);
         } else {
             MapHelpV2.promptUserInstallMaps(getActivity());
         }
@@ -213,6 +207,7 @@ public class BaseMapFragment extends SupportMapFragment
 
     @Override
     public void onMapReady(com.google.android.gms.maps.GoogleMap map) {
+        mMap = map;
         initMap(mLastSavedInstanceState);
     }
 


### PR DESCRIPTION
~~**Please do not merge**~~

In general we'll need to update to Google Play Services 9.2.0 at some point.  It's also needed if we want to take advantage of the marker z-index feature, such as to solve issues such as https://github.com/OneBusAway/onebusaway-android/issues/428.

The problem is that the synchronous `getMap()` method was removed in 9.2.0, and we now must always use the asynchronous `getMapAsync()` version instead - see the bottom section of this blog post:
http://googlegeodevelopers.blogspot.com/2016/06/marker-zindex-and-more-come-to-google.html

We already have this sketched out in our code (we try sync, and if that fails we fall back on async), and in the branch `mapAsync` and commit https://github.com/CUTR-at-USF/onebusaway-android/commit/845b022c788098639121155c48a98fd9989e0392 I've removed the synchronous version completely, and bumped to 9.2.0.  However, now I'm seeing a crash in `onViewRestored()`, I believe only when the app is completely destroyed and restarted (I don't have a device hooked up in front me of me now).

@cagryInside Would you mind taking a look at this?  Feel free to push more commits to the same `mapAsync` branch.