### PR TITLE
Fix #568 - Color-code Style B real-time arrival/departure times

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/util/test/UIUtilTest.java
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/util/test/UIUtilTest.java
@@ -16,6 +16,7 @@ import org.onebusaway.android.provider.ObaContract;
 import org.onebusaway.android.ui.ArrivalInfo;
 import org.onebusaway.android.util.UIUtils;
 
+import android.graphics.Color;
 import android.support.v4.util.Pair;
 import android.text.TextUtils;
 import android.widget.TextView;
@@ -708,6 +709,27 @@ public class UIUtilTest extends ObaTestCase {
         assertEquals(35, arrivalInfo.get(29).getEta());
         assertEquals(35, arrivalInfo.get(30).getEta());
         assertEquals(35, arrivalInfo.get(31).getEta());
+    }
+
+    public void testGetTransparentColor() {
+        String colorString = "#777777";
+        int alpha = 127;
+        int color = Color.parseColor(colorString);
+        int newColor = UIUtils.getTransparentColor(color, alpha);
+
+        int r = Color.red(color);
+        int g = Color.green(color);
+        int b = Color.blue(color);
+
+        int newR = Color.red(newColor);
+        int newG = Color.green(newColor);
+        int newB = Color.blue(newColor);
+        int newAlpha = Color.alpha(newColor);
+
+        assertEquals(r, newR);
+        assertEquals(g, newG);
+        assertEquals(b, newB);
+        assertEquals(alpha, newAlpha);
     }
 
     private String formatTime(long time) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListAdapterStyleB.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListAdapterStyleB.java
@@ -260,6 +260,9 @@ public class ArrivalsListAdapterStyleB extends ArrivalsListAdapterBase<CombinedA
                 alpha = (int) (.35f * 255);  // X percent transparency
             }
             d.setAlpha(alpha);
+            // Set text color w/ alpha, but increase it a bit to give text better contrast
+            estimatedView.setTextColor(UIUtils.getTransparentColor(
+                    context.getResources().getColor(colorCode), alpha * 2));
 
             // Set padding on status view
             int pSides = UIUtils.dpToPixels(context, 5);

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/UIUtils.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/UIUtils.java
@@ -1289,4 +1289,19 @@ public final class UIUtils {
                     getDimension(R.dimen.route_name_text_size_small));
         }
     }
+
+    /**
+     * Transforms a given opaque color into the same color but with the given alpha value
+     *
+     * @param solidColor hex color value that is completely opaque
+     * @param alpha      Specify an alpha value. 0 means fully transparent, and 255 means fully
+     *                   opaque.
+     * @return the provided color with the given alpha value
+     */
+    public static int getTransparentColor(int solidColor, int alpha) {
+        int r = Color.red(solidColor);
+        int g = Color.green(solidColor);
+        int b = Color.blue(solidColor);
+        return Color.argb(alpha, r, g, b);
+    }
 }

--- a/onebusaway-android/src/main/res/values/styles.xml
+++ b/onebusaway-android/src/main/res/values/styles.xml
@@ -166,21 +166,21 @@
     </style>
     <style name="ArrivalsListNextTimeETA">
         <item name="android:textSize">22sp</item>
-        <item name="android:textColor">@color/stop_info_scheduled_time</item>
+        <item name="android:textColor">@android:color/black</item>
         <item name="android:textStyle">bold</item>
     </style>
     <style name="ArrivalsListNextTimeSched">
         <item name="android:textSize">22sp</item>
-        <item name="android:textColor">@android:color/black</item>
-        <item name="android:textStyle">bold</item>
+        <item name="android:textColor">@color/stop_info_scheduled_time</item>
     </style>
     <style name="ArrivalsListSched">
-        <item name="android:textSize">12sp</item>
+        <item name="android:textSize">14sp</item>
         <item name="android:paddingTop">1dp</item>
         <item name="android:paddingBottom">1dp</item>
     </style>
     <style name="ArrivalsListETA">
-        <item name="android:textSize">12sp</item>
+        <item name="android:textSize">14sp</item>
+        <item name="android:textStyle">bold</item>
         <item name="android:textColor">@color/stop_info_scheduled_time</item>
         <item name="android:paddingTop">1dp</item>
         <item name="android:paddingBottom">1dp</item>


### PR DESCRIPTION
* Now matches Style A in color - scheduled is gray, late blue, on time green, and early red
* Add utility method and unit test for adding alpha value to an int color