### PR TITLE
Fix #579 - Center map on real-time location when available

### DIFF
--- a/onebusaway-android/src/amazon/java/org/onebusaway/android/map/googlemapsv2/BaseMapFragment.java
+++ b/onebusaway-android/src/amazon/java/org/onebusaway/android/map/googlemapsv2/BaseMapFragment.java
@@ -27,6 +27,7 @@
  */
 package org.onebusaway.android.map.googlemapsv2;
 
+import com.google.android.gms.common.api.GoogleApiClient;
 import com.amazon.geo.mapsv2.CameraUpdateFactory;
 import com.amazon.geo.mapsv2.LocationSource;
 import com.amazon.geo.mapsv2.OnMapReadyCallback;
@@ -188,6 +189,9 @@ public class BaseMapFragment extends SupportMapFragment
                              Bundle savedInstanceState) {
         View v = super.onCreateView(inflater, container, savedInstanceState);
 
+        mLocationHelper = new LocationHelper(getActivity());
+        mLocationHelper.registerListener(this);
+
         mMap = getMap();
 
         if (MapHelpV2.isMapsInstalled(getActivity())) {
@@ -202,9 +206,6 @@ public class BaseMapFragment extends SupportMapFragment
         } else {
             MapHelpV2.promptUserInstallMaps(getActivity());
         }
-
-        mLocationHelper = new LocationHelper(getActivity());
-        mLocationHelper.registerListener(this);
 
         // If we have a recent location, show this while we're waiting on the LocationHelper
         Location l = Application
@@ -286,7 +287,9 @@ public class BaseMapFragment extends SupportMapFragment
 
     @Override
     public void onPause() {
-        mLocationHelper.onPause();
+        if (mLocationHelper != null) {
+            mLocationHelper.onPause();
+        }
         if (mController != null) {
             mController.onPause();
         }
@@ -520,11 +523,15 @@ public class BaseMapFragment extends SupportMapFragment
             // Too early or late in the Fragment lifecycle to take any action
             return;
         }
-        if (currentRegionChanged
-                && Application
-                .getLastKnownLocation(this.getActivity(), mLocationHelper.getGoogleApiClient())
-                == null) {
-            // Move map view after a new region has been selected, if we don't have user location
+
+        Location l = Application
+                .getLastKnownLocation(getActivity(), mLocationHelper.getGoogleApiClient());
+        // If the region changed, and we don't have a location or the map center is still (0,0),
+        // then zoom to the region
+        if (currentRegionChanged &&
+                (l == null ||
+                        (getMapCenterAsLocation().getLatitude() == 0.0 &&
+                                getMapCenterAsLocation().getLongitude() == 0.0))) {
             zoomToRegion();
         }
 
@@ -573,25 +580,41 @@ public class BaseMapFragment extends SupportMapFragment
         });
     }
 
+    /**
+     * Sets the map view to the last available location
+     *
+     * @param useDefaultZoom    true if the CAMERA_DEFAULT_ZOOM should be used, false if the
+     *                          current
+     *                          zoom level should be kept
+     * @param animateToLocation true if the map should animate the transition to the new view, or
+     *                          false if it should snap to the new view without animation
+     * @return true if there was a a location to set the map view to, false if there was not
+     */
     @Override
     @SuppressWarnings("deprecation")
-    public void setMyLocation(boolean useDefaultZoom, boolean animateToLocation) {
+    public boolean setMyLocation(boolean useDefaultZoom, boolean animateToLocation) {
         if (!LocationUtils.isLocationEnabled(getActivity()) && mRunning && UIUtils.canManageDialog(
                 getActivity())) {
             showDialog(MapDialogFragment.NOLOCATION_DIALOG);
-            return;
+            return false;
         }
 
-        Location lastLocation = Application.getLastKnownLocation(this.getActivity(), null);
+        GoogleApiClient apiClient = null;
+        if (mLocationHelper != null) {
+            apiClient = mLocationHelper.getGoogleApiClient();
+        }
+
+        Location lastLocation = Application.getLastKnownLocation(getActivity(), apiClient);
         if (lastLocation == null) {
             Toast.makeText(getActivity(),
                     getResources()
                             .getString(R.string.main_waiting_for_location),
                     Toast.LENGTH_SHORT).show();
-            return;
+            return false;
         }
 
         setMyLocation(lastLocation, useDefaultZoom, animateToLocation);
+        return true;
     }
 
     private void setMyLocation(Location l, boolean useDefaultZoom, boolean animateToLocation) {
@@ -622,7 +645,7 @@ public class BaseMapFragment extends SupportMapFragment
         }
     }
 
-    void zoomToRegion() {
+    public void zoomToRegion() {
         // If we have a region, then zoom to it.
         ObaRegion region = Application.get().getCurrentRegion();
 

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/util/test/UIUtilTest.java
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/util/test/UIUtilTest.java
@@ -10,6 +10,7 @@ import org.onebusaway.android.io.elements.ObaStop;
 import org.onebusaway.android.io.request.ObaArrivalInfoRequest;
 import org.onebusaway.android.io.request.ObaArrivalInfoResponse;
 import org.onebusaway.android.io.test.ObaTestCase;
+import org.onebusaway.android.map.MapParams;
 import org.onebusaway.android.mock.MockObaStop;
 import org.onebusaway.android.mock.MockRegion;
 import org.onebusaway.android.provider.ObaContract;
@@ -17,6 +18,8 @@ import org.onebusaway.android.ui.ArrivalInfo;
 import org.onebusaway.android.util.UIUtils;
 
 import android.graphics.Color;
+import android.location.Location;
+import android.os.Bundle;
 import android.support.v4.util.Pair;
 import android.text.TextUtils;
 import android.widget.TextView;
@@ -734,5 +737,44 @@ public class UIUtilTest extends ObaTestCase {
 
     private String formatTime(long time) {
         return UIUtils.formatTime(getContext(), time);
+    }
+
+    /**
+     * Tests getting map view center information from a bundle
+     */
+    public void testGetMapCenter() {
+        // Check null and empty bundles
+        Bundle b = null;
+        assertNull(UIUtils.getMapCenter(b));
+
+        b = new Bundle();
+        assertNull(UIUtils.getMapCenter(b));
+
+        // Check single params
+        b.putDouble(MapParams.CENTER_LAT, 0.0);
+        assertNull(UIUtils.getMapCenter(b));
+
+        b = new Bundle();
+        b.putDouble(MapParams.CENTER_LON, 0.0);
+        assertNull(UIUtils.getMapCenter(b));
+
+        // Check invalid lat/long
+        b = new Bundle();
+        b.putDouble(MapParams.CENTER_LAT, 0.0);
+        b.putDouble(MapParams.CENTER_LON, 0.0);
+        assertNull(UIUtils.getMapCenter(b));
+
+        // Check valid lat/long
+        final double lat = 28.343243;
+        final double lon = -87.234234;
+
+        b = new Bundle();
+        b.putDouble(MapParams.CENTER_LAT, lat);
+        b.putDouble(MapParams.CENTER_LON, lon);
+        Location l = UIUtils.getMapCenter(b);
+        assertNotNull(l);
+
+        assertEquals(lat, l.getLatitude());
+        assertEquals(lon, l.getLongitude());
     }
 }

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/BaseMapFragment.java
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/BaseMapFragment.java
@@ -16,6 +16,7 @@
  */
 package org.onebusaway.android.map.googlemapsv2;
 
+import com.google.android.gms.common.api.GoogleApiClient;
 import com.google.android.gms.maps.CameraUpdateFactory;
 import com.google.android.gms.maps.LocationSource;
 import com.google.android.gms.maps.OnMapReadyCallback;
@@ -177,6 +178,9 @@ public class BaseMapFragment extends SupportMapFragment
                              Bundle savedInstanceState) {
         View v = super.onCreateView(inflater, container, savedInstanceState);
 
+        mLocationHelper = new LocationHelper(getActivity());
+        mLocationHelper.registerListener(this);
+
         mMap = getMap();
 
         if (MapHelpV2.isMapsInstalled(getActivity())) {
@@ -191,9 +195,6 @@ public class BaseMapFragment extends SupportMapFragment
         } else {
             MapHelpV2.promptUserInstallMaps(getActivity());
         }
-
-        mLocationHelper = new LocationHelper(getActivity());
-        mLocationHelper.registerListener(this);
 
         // If we have a recent location, show this while we're waiting on the LocationHelper
         Location l = Application
@@ -275,7 +276,9 @@ public class BaseMapFragment extends SupportMapFragment
 
     @Override
     public void onPause() {
-        mLocationHelper.onPause();
+        if (mLocationHelper != null) {
+            mLocationHelper.onPause();
+        }
         if (mController != null) {
             mController.onPause();
         }
@@ -509,11 +512,15 @@ public class BaseMapFragment extends SupportMapFragment
             // Too early or late in the Fragment lifecycle to take any action
             return;
         }
-        if (currentRegionChanged
-                && Application
-                .getLastKnownLocation(this.getActivity(), mLocationHelper.getGoogleApiClient())
-                == null) {
-            // Move map view after a new region has been selected, if we don't have user location
+
+        Location l = Application
+                .getLastKnownLocation(getActivity(), mLocationHelper.getGoogleApiClient());
+        // If the region changed, and we don't have a location or the map center is still (0,0),
+        // then zoom to the region
+        if (currentRegionChanged &&
+                (l == null ||
+                        (getMapCenterAsLocation().getLatitude() == 0.0 &&
+                                getMapCenterAsLocation().getLongitude() == 0.0))) {
             zoomToRegion();
         }
 
@@ -562,25 +569,41 @@ public class BaseMapFragment extends SupportMapFragment
         });
     }
 
+    /**
+     * Sets the map view to the last available location
+     *
+     * @param useDefaultZoom    true if the CAMERA_DEFAULT_ZOOM should be used, false if the
+     *                          current
+     *                          zoom level should be kept
+     * @param animateToLocation true if the map should animate the transition to the new view, or
+     *                          false if it should snap to the new view without animation
+     * @return true if there was a a location to set the map view to, false if there was not
+     */
     @Override
     @SuppressWarnings("deprecation")
-    public void setMyLocation(boolean useDefaultZoom, boolean animateToLocation) {
+    public boolean setMyLocation(boolean useDefaultZoom, boolean animateToLocation) {
         if (!LocationUtils.isLocationEnabled(getActivity()) && mRunning && UIUtils.canManageDialog(
                 getActivity())) {
             showDialog(MapDialogFragment.NOLOCATION_DIALOG);
-            return;
+            return false;
         }
 
-        Location lastLocation = Application.getLastKnownLocation(this.getActivity(), null);
+        GoogleApiClient apiClient = null;
+        if (mLocationHelper != null) {
+            apiClient = mLocationHelper.getGoogleApiClient();
+        }
+
+        Location lastLocation = Application.getLastKnownLocation(getActivity(), apiClient);
         if (lastLocation == null) {
             Toast.makeText(getActivity(),
                     getResources()
                             .getString(R.string.main_waiting_for_location),
                     Toast.LENGTH_SHORT).show();
-            return;
+            return false;
         }
 
         setMyLocation(lastLocation, useDefaultZoom, animateToLocation);
+        return true;
     }
 
     private void setMyLocation(Location l, boolean useDefaultZoom, boolean animateToLocation) {
@@ -611,7 +634,7 @@ public class BaseMapFragment extends SupportMapFragment
         }
     }
 
-    void zoomToRegion() {
+    public void zoomToRegion() {
         // If we have a region, then zoom to it.
         ObaRegion region = Application.get().getCurrentRegion();
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapModeController.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapModeController.java
@@ -66,9 +66,12 @@ public interface MapModeController {
 
         void showStops(List<ObaStop> stops, ObaReferences refs);
 
-        void setMyLocation(boolean useDefaultZoom, boolean animateToLocation);
+        boolean setMyLocation(boolean useDefaultZoom, boolean animateToLocation);
 
         void notifyOutOfRange();
+
+        // Zooms to the region bounds, if a region has been set
+        void zoomToRegion();
     }
 
     /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapParams.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapParams.java
@@ -28,6 +28,8 @@ public class MapParams {
 
     public static final String ROUTE_ID = ".RouteId";
 
+    public static final String DO_N0T_CENTER_ON_LOCATION = ".DoNotCenterOnLocation";
+
     public static final String CENTER_LAT = ".MapCenterLat";
 
     public static final String CENTER_LON = ".MapCenterLon";

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.java
@@ -302,6 +302,7 @@ public class RouteMapController implements MapModeController {
                     ObaMapView obaMapView = mFragment.getMapView();
                     // We want to preserve the current zoom and center.
                     Bundle bundle = new Bundle();
+                    bundle.putBoolean(MapParams.DO_N0T_CENTER_ON_LOCATION, true);
                     bundle.putFloat(MapParams.ZOOM, obaMapView.getZoomLevelAsFloat());
                     Location point = obaMapView.getMapCenterAsLocation();
                     bundle.putDouble(MapParams.CENTER_LAT, point.getLatitude());

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/UIUtils.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/UIUtils.java
@@ -25,6 +25,7 @@ import org.onebusaway.android.io.elements.ObaRegion;
 import org.onebusaway.android.io.elements.ObaRoute;
 import org.onebusaway.android.io.elements.ObaSituation;
 import org.onebusaway.android.io.elements.ObaStop;
+import org.onebusaway.android.map.MapParams;
 import org.onebusaway.android.provider.ObaContract;
 import org.onebusaway.android.ui.HomeActivity;
 import org.onebusaway.android.view.RealtimeIndicatorView;
@@ -49,10 +50,12 @@ import android.database.Cursor;
 import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.graphics.Rect;
+import android.location.Location;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.net.Uri;
 import android.os.Build;
+import android.os.Bundle;
 import android.os.Parcelable;
 import android.os.SystemClock;
 import android.provider.Settings;
@@ -1303,5 +1306,27 @@ public final class UIUtils {
         int g = Color.green(solidColor);
         int b = Color.blue(solidColor);
         return Color.argb(alpha, r, g, b);
+    }
+
+    /**
+     * Returns the location of the map center if it has been previously saved in the bundle, or
+     * null if it wasn't saved in the bundle.
+     *
+     * @param b bundle to check for the map center
+     * @return the location of the map center if it has been previously saved in the bundle, or null
+     * if it wasn't saved in the bundle.
+     */
+    public static Location getMapCenter(Bundle b) {
+        if (b == null) {
+            return null;
+        }
+        Location center = null;
+        double lat = b.getDouble(MapParams.CENTER_LAT);
+        double lon = b.getDouble(MapParams.CENTER_LON);
+
+        if (lat != 0.0 && lon != 0.0) {
+            center = LocationUtils.makeLocation(lat, lon);
+        }
+        return center;
     }
 }


### PR DESCRIPTION
* Centers on location if available, otherwise use last map view
* On initial run after installation, if location isn't available zoom to the region (after user picks region)