### PR TITLE
Fix #585 - Restore last used recent stops/routes tab

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/MyTabActivityBase.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/MyTabActivityBase.java
@@ -44,7 +44,7 @@ abstract class MyTabActivityBase extends AppCompatActivity {
 
     protected Location mSearchCenter;
 
-    private String mDefaultTab;
+    protected String mDefaultTab;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {


### PR DESCRIPTION
* To make this work in a backwards-compatible way, we override the tab save/restore behavior in our activity for recent stops and routes to use the tab text instead of the tab tag.  All other activities that extend MyTabActivityBase will work the same as before.