### PR TITLE
Fix #608: hide trip planning preferences 

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/PreferencesActivity.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/PreferencesActivity.java
@@ -38,6 +38,7 @@ import android.preference.Preference;
 import android.preference.Preference.OnPreferenceChangeListener;
 import android.preference.PreferenceActivity;
 import android.preference.PreferenceCategory;
+import android.preference.PreferenceGroup;
 import android.preference.PreferenceScreen;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.widget.Toolbar;
@@ -157,6 +158,21 @@ public class PreferencesActivity extends PreferenceActivity
 
         changePreferenceSummary(getString(R.string.preference_key_region));
         changePreferenceSummary(getString(R.string.preference_key_preferred_units));
+
+        // Remove preferences for notifications if no trip planning
+        String otpBaseUrl = Application.get().getCurrentRegion().getOtpBaseUrl();
+        if (TextUtils.isEmpty(otpBaseUrl)) {
+            PreferenceCategory notifications = (PreferenceCategory)
+                    findPreference(getString(R.string.preference_key_notifications));
+
+            Preference tripPlan = findPreference(
+                    getString(R.string.preference_key_trip_plan_notifications));
+            notifications.removePreference(tripPlan);
+
+            if (notifications.getPreferenceCount() == 0) {
+                getPreferenceScreen().removePreference(notifications);
+            }
+        }
     }
 
     @Override

--- a/onebusaway-android/src/main/res/values/donottranslate.xml
+++ b/onebusaway-android/src/main/res/values/donottranslate.xml
@@ -39,6 +39,7 @@
     <string name="preference_key_tutorial_counter">preference_key_tutorial_counter</string>
     <string name="preference_key_show_tutorial_screens">preference_key_show_tutorial_screens
     </string>
+    <string name="preference_key_notifications">preference_key_notifications</string>
     <string name="preference_key_trip_plan_notifications">preference_key_trip_plan_notifications</string>
 
     <!-- Regions API URL -->

--- a/onebusaway-android/src/main/res/xml/preferences.xml
+++ b/onebusaway-android/src/main/res/xml/preferences.xml
@@ -51,7 +51,9 @@
                 android:defaultValue="@string/preferences_preferred_units_option_automatic">
         </ListPreference>
     </PreferenceCategory>
-    <PreferenceCategory android:title="@string/preferences_category_notifications">
+    <PreferenceCategory
+            android:key="@string/preference_key_notifications"
+            android:title="@string/preferences_category_notifications">
         <CheckBoxPreference
             android:key="@string/preference_key_trip_plan_notifications"
             android:title="@string/preferences_trip_plan_notifications_title"


### PR DESCRIPTION
Hide trip planning preferences for regions that do not have otpBaseUrl defined. If notifications category is now empty, hide that too.