### PR TITLE
Fix #614 - Make trip planning immediately available after app update

### DIFF
--- a/onebusaway-android/src/amazon/java/org/onebusaway/android/map/googlemapsv2/BaseMapFragment.java
+++ b/onebusaway-android/src/amazon/java/org/onebusaway/android/map/googlemapsv2/BaseMapFragment.java
@@ -544,25 +544,6 @@ public class BaseMapFragment extends SupportMapFragment
                                 mapCenter.getLongitude() == 0.0))) {
             zoomToRegion();
         }
-
-        // If region changed and was auto-selected, show user what region we're using
-        if (currentRegionChanged
-                && Application.getPrefs()
-                .getBoolean(getString(R.string.preference_key_auto_select_region), true)
-                && Application.get().getCurrentRegion() != null
-                && mRunning
-                && UIUtils.canManageDialog(getActivity())) {
-            Toast.makeText(getActivity(),
-                    getString(R.string.region_region_found,
-                            Application.get().getCurrentRegion().getName()),
-                    Toast.LENGTH_LONG
-            ).show();
-        }
-
-        // If region changed and in HomeActivity, redraw nav drawer (possible add Plan a Trip).
-        if (currentRegionChanged && getActivity() instanceof HomeActivity) {
-            ((HomeActivity) getActivity()).redrawNavigationDrawerFragment();
-        }
     }
 
     public void setOnFocusChangeListener(OnFocusChangedListener onFocusChangedListener) {

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/BaseMapFragment.java
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/BaseMapFragment.java
@@ -45,7 +45,6 @@ import org.onebusaway.android.map.MapParams;
 import org.onebusaway.android.map.RouteMapController;
 import org.onebusaway.android.map.StopMapController;
 import org.onebusaway.android.region.ObaRegionsTask;
-import org.onebusaway.android.ui.HomeActivity;
 import org.onebusaway.android.util.LocationHelper;
 import org.onebusaway.android.util.LocationUtils;
 import org.onebusaway.android.util.PreferenceUtils;
@@ -532,25 +531,6 @@ public class BaseMapFragment extends SupportMapFragment
                         (mapCenter != null && mapCenter.getLatitude() == 0.0 &&
                                 mapCenter.getLongitude() == 0.0))) {
             zoomToRegion();
-        }
-
-        // If region changed and was auto-selected, show user what region we're using
-        if (currentRegionChanged
-                && Application.getPrefs()
-                .getBoolean(getString(R.string.preference_key_auto_select_region), true)
-                && Application.get().getCurrentRegion() != null
-                && mRunning
-                && UIUtils.canManageDialog(getActivity())) {
-            Toast.makeText(getActivity(),
-                    getString(R.string.region_region_found,
-                            Application.get().getCurrentRegion().getName()),
-                    Toast.LENGTH_LONG
-            ).show();
-        }
-
-        // If region changed and in HomeActivity, redraw nav drawer (possible add Plan a Trip).
-        if (currentRegionChanged && getActivity() instanceof HomeActivity) {
-            ((HomeActivity) getActivity()).redrawNavigationDrawerFragment();
         }
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/io/backup/RestorePreference.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/io/backup/RestorePreference.java
@@ -29,6 +29,8 @@ import android.util.AttributeSet;
 import android.widget.Toast;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 public class RestorePreference extends Preference {
 
@@ -97,14 +99,16 @@ public class RestorePreference extends Preference {
 
             Context activityContext = getContext();
             if (activityContext != null) {
-                ObaRegionsTask task = new ObaRegionsTask(activityContext, new ObaRegionsTask.Callback() {
+                List<ObaRegionsTask.Callback> callbacks = new ArrayList<>();
+                callbacks.add(new ObaRegionsTask.Callback() {
                     @Override
                     public void onRegionTaskFinished(boolean currentRegionChanged) {
                         Toast.makeText(context,
                                 R.string.preferences_db_restored,
                                 Toast.LENGTH_LONG).show();
                     }
-                }, true, true);
+                });
+                ObaRegionsTask task = new ObaRegionsTask(activityContext, callbacks, true, true);
                 task.setProgressDialogMessage(context.getString(R.string.preferences_restore_loading));
                 task.execute();
             }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/PreferencesActivity.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/PreferencesActivity.java
@@ -55,6 +55,8 @@ import android.widget.Toast;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
 
 public class PreferencesActivity extends PreferenceActivity
         implements Preference.OnPreferenceClickListener, OnPreferenceChangeListener,
@@ -352,7 +354,9 @@ public class PreferencesActivity extends PreferenceActivity
             which will survive orientation changes.
             */
             setProgressBarIndeterminateVisibility(true);
-            ObaRegionsTask task = new ObaRegionsTask(this, this, true, false);
+            List<ObaRegionsTask.Callback> callbacks = new ArrayList<>();
+            callbacks.add(this);
+            ObaRegionsTask task = new ObaRegionsTask(this, callbacks, true, false);
             task.execute();
 
             // Wait to change the region preference description until the task callback


### PR DESCRIPTION
* Alter ObaRegionsTask to take in multiple Callbacks
* Make HomeActivity one of these Callbacks, and move the code to refresh the navigation drawer to execute after the Regions API refresh in HomeActivity.onRegionChanged(), but only if the region changed OR the app was just updated.  This also removes the tight coupling between BaseMapFragment and HomeActivity for refreshing the navigation drawer, so the drawer will be refreshed even if the user doesn't have the "Nearby" (BaseMapFragment) screen shown
* "What's New" dialog is now triggered after the Regions API is refreshed in HomeActivity.onRegionChanged(), so it can use the new contents of the Regions API to control whether trip planning is shown as a new feature (it's currently only available in Tampa)
* Move code to show Toast on region change from BaseMapFragment to HomeActivity so this Toast will be shown even if the user doesn't have the "Nearby" (BaseMapFragment) screen visible

@sdjacobs Could you please take a look at this to make sure I'm not missing anything?