### PR TITLE
Fix #622 - Add a custom trip planning API URL setting

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/app/Application.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/app/Application.java
@@ -281,6 +281,10 @@ public class Application extends android.app.Application {
     }
 
     public synchronized void setCurrentRegion(ObaRegion region) {
+        setCurrentRegion(region, true);
+    }
+
+    public synchronized void setCurrentRegion(ObaRegion region, boolean regionChanged) {
         if (region != null) {
             // First set it in preferences, then set it in OBA.
             ObaApi.getDefaultContext().setRegion(region);
@@ -288,6 +292,10 @@ public class Application extends android.app.Application {
                     .saveLong(mPrefs, getString(R.string.preference_key_region), region.getId());
             //We're using a region, so clear the custom API URL preference
             setCustomApiUrl(null);
+            if (regionChanged && region.getOtpBaseUrl() != null) {
+                setCustomOtpApiUrl(null);
+                setUseOldOtpApiUrlVersion(false);
+            }
         } else {
             //User must have just entered a custom API URL via Preferences, so clear the region info
             ObaApi.getDefaultContext().setRegion(null);
@@ -345,6 +353,48 @@ public class Application extends android.app.Application {
      */
     public void setCustomApiUrl(String url) {
         PreferenceUtils.saveString(getString(R.string.preference_key_oba_api_url), url);
+    }
+
+    /**
+     * Returns the custom OTP URL if the user has set a custom API URL manually via Preferences, or
+     * null
+     * if it has not been set
+     *
+     * @return the custom URL if the user has set a custom API URL manually via Preferences, or null
+     * if it has not been set
+     */
+    public String getCustomOtpApiUrl() {
+        SharedPreferences preferences = getPrefs();
+        return preferences.getString(getString(R.string.preference_key_otp_api_url), null);
+    }
+
+    /**
+     * Sets the custom OTP URL used to reach a OBA REST API server that is not available via the
+     * Regions
+     * REST API
+     *
+     * @param url the custom URL
+     */
+    public void setCustomOtpApiUrl(String url) {
+        PreferenceUtils.saveString(getString(R.string.preference_key_otp_api_url), url);
+    }
+
+    /**
+     * @return true if the OTP url version is old, or false  if it has not been set
+     */
+    public boolean getUseOldOtpApiUrlVersion() {
+        SharedPreferences preferences = getPrefs();
+        return preferences.getBoolean(getString(R.string.preference_key_otp_api_url_version), false);
+    }
+
+    /**
+     * Sets the OTP Api url version
+     *
+     * @param useOldOtpApiUrlVersion indicates that if otp url structure belongs to older version
+     */
+    public void setUseOldOtpApiUrlVersion(boolean useOldOtpApiUrlVersion) {
+        PreferenceUtils.saveBoolean(getString(R.string.preference_key_otp_api_url_version),
+                useOldOtpApiUrlVersion);
     }
 
     private static final String HEXES = "0123456789abcdef";

--- a/onebusaway-android/src/main/java/org/onebusaway/android/region/ObaRegionsTask.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/region/ObaRegionsTask.java
@@ -193,7 +193,7 @@ public class ObaRegionsTask extends AsyncTask<Void, Integer, ArrayList<ObaRegion
             } else if (Application.get().getCurrentRegion() != null && closestRegion != null
                     && Application.get().getCurrentRegion().equals(closestRegion)) {
                 // Don't change the region - just refresh with latest Regions API contents
-                Application.get().setCurrentRegion(closestRegion);
+                Application.get().setCurrentRegion(closestRegion, false);
                 doCallback(false);
             } else {
                 doCallback(false);

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/NavigationDrawerFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/NavigationDrawerFragment.java
@@ -34,6 +34,7 @@ import android.support.v4.widget.DrawerLayout;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.ActionBarDrawerToggle;
 import android.support.v7.app.AppCompatActivity;
+import android.text.TextUtils;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.MenuItem;
@@ -349,8 +350,9 @@ public class NavigationDrawerFragment extends Fragment {
         mNavDrawerItems.add(NAVDRAWER_ITEM_STARRED_STOPS);
         mNavDrawerItems.add(NAVDRAWER_ITEM_MY_REMINDERS);
 
-        if (Application.get().getCurrentRegion() != null &&
-            Application.get().getCurrentRegion().getOtpBaseUrl() != null) {
+        if ((Application.get().getCurrentRegion() != null &&
+                !TextUtils.isEmpty(Application.get().getCurrentRegion().getOtpBaseUrl())) ||
+                !TextUtils.isEmpty(Application.get().getCustomOtpApiUrl())) {
             mNavDrawerItems.add(NAVDRAWER_ITEM_PLAN_TRIP);
         }
 

--- a/onebusaway-android/src/main/res/values/donottranslate.xml
+++ b/onebusaway-android/src/main/res/values/donottranslate.xml
@@ -23,6 +23,8 @@
     <!-- Preference keys -->
     <string name="preference_key_region">preference_region</string>
     <string name="preference_key_oba_api_url">preferences_oba_api_url</string>
+    <string name="preference_key_otp_api_url">preferences_otp_api_url</string>
+    <string name="preference_key_otp_api_url_version">preferences_otp_api_url_structure</string>
     <string name="preference_key_last_region_update">preference_last_region_update</string>
     <string name="preference_key_auto_select_region">preference_auto_select_region</string>
     <string name="preference_key_experimental_regions">preference_experimental_regions</string>

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -76,6 +76,8 @@
     </string>
     <string name="custom_api_url_error">Invalid URL. Please enter a working OneBusAway server.
     </string>
+    <string name="custom_otp_api_url_error">Invalid URL. Please enter a working OpenTripPlanner server.
+    </string>
     <string name="direction_n">Northbound</string>
     <string name="direction_ne">Northeast bound</string>
     <string name="direction_e">Eastbound</string>
@@ -564,11 +566,16 @@
     <string name="preferences_arrival_info_style_options_a">OneBusAway classic</string>
     <string name="preferences_arrival_info_style_options_b">Cards</string>
 
+    <string name="preferences_otp_api_servername_title">OpenTripPlanner API Server</string>
+    <string name="preferences_otp_api_servername_summary">Determines the server used in OpenTripPlanner
+        API calls
+    </string>
     <string name="preferences_oba_api_servername_title">OneBusAway API Server</string>
     <string name="preferences_oba_api_servername_summary">Determines the server used in OneBusAway
         API calls
     </string>
     <string name="preferences_oba_api_servername_hint">example.onebusaway.org</string>
+    <string name="preferences_otp_api_servername_hint">example.opentripplanner.org/otp</string>
     <string name="preferences_save_title">Save to storage</string>
     <string name="preferences_save_summary">Saves your starred and recent stops and routes</string>
     <string name="preferences_restore_title">Restore from storage</string>

--- a/onebusaway-android/src/main/res/xml/preferences.xml
+++ b/onebusaway-android/src/main/res/xml/preferences.xml
@@ -84,6 +84,12 @@
                         android:inputType="text|textNoSuggestions"
                         android:hint="@string/preferences_oba_api_servername_hint"
                         android:key="@string/preference_key_oba_api_url"/>
+                <EditTextPreference
+                        android:title="@string/preferences_otp_api_servername_title"
+                        android:summary="@string/preferences_otp_api_servername_summary"
+                        android:inputType="text|textNoSuggestions"
+                        android:hint="@string/preferences_otp_api_servername_hint"
+                        android:key="@string/preference_key_otp_api_url"/>
             </PreferenceCategory>
         </PreferenceScreen>
     </PreferenceCategory>


### PR DESCRIPTION
Added a new field to set OTP API Url.

**Screenshots:**
![device-2016-07-28-120207](https://cloud.githubusercontent.com/assets/2777974/17224217/06cc2868-54ce-11e6-8949-2e0a93afd011.png) ![device-2016-07-28-120253](https://cloud.githubusercontent.com/assets/2777974/17224218/06cc57b6-54ce-11e6-92f6-b5dc52eddbec.png)

**Behavior:**

1. Redraw navigation drawer after setting the custom url
1. When there is a custom otp url, if a user selects  a new region 
   1. If the region has otp url then custom url will be canceled.
   1. If the region hasn't otp url then custom url will remain.
 
cc'd @barbeau 