### PR TITLE
Fix #653 - Pass in Class instead of Activity reference for trip plan notification target

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/realtime/RealtimeServiceImpl.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/realtime/RealtimeServiceImpl.java
@@ -53,7 +53,7 @@ public class RealtimeServiceImpl implements RealtimeService {
 
     private AlarmManager mAlarmMgr;
 
-    private Activity mActivity;
+    private Class<? extends Activity> mNotificationTarget;
 
     private IntentFilter mIntentFilter;
 
@@ -69,8 +69,13 @@ public class RealtimeServiceImpl implements RealtimeService {
 
     private static final long DELAY_THRESHOLD_SEC = 120;
 
-    public RealtimeServiceImpl(Context context, Activity activity, Bundle bundle) {
-        mActivity = activity;
+    /**
+     * @param notificationTarget Activity Class that the trip plan change notification should
+     *                           target
+     */
+    public RealtimeServiceImpl(Context context, Class<? extends Activity> notificationTarget,
+            Bundle bundle) {
+        mNotificationTarget = notificationTarget;
         mApplicationContext = context;
         mAlarmMgr = (AlarmManager) mApplicationContext.getSystemService(Context.ALARM_SERVICE);
 
@@ -193,7 +198,7 @@ public class RealtimeServiceImpl implements RealtimeService {
     private void showNotification(ItineraryDescription description, int message) {
         String itineraryChange = getResources().getString(message);
 
-        Intent notificationIntentOpenApp = new Intent(mApplicationContext, mActivity.getClass());
+        Intent notificationIntentOpenApp = new Intent(mApplicationContext, mNotificationTarget);
         notificationIntentOpenApp.setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
         PendingIntent notificationOpenAppPendingIntent = PendingIntent
                 .getActivity(mApplicationContext,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/TripResultsFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/TripResultsFragment.java
@@ -100,7 +100,8 @@ public class TripResultsFragment extends Fragment {
         mOptions[1] = new RoutingOptionPicker(view, R.id.option2LinearLayout, R.id.option2Title, R.id.option2Duration, R.id.option2Interval);
         mOptions[2] = new RoutingOptionPicker(view, R.id.option3LinearLayout, R.id.option3Title, R.id.option3Duration, R.id.option3Interval);
 
-        mRealtimeService = new RealtimeServiceImpl(getActivity().getApplicationContext(), getActivity(), getArguments());
+        mRealtimeService = new RealtimeServiceImpl(getActivity().getApplicationContext(),
+                getActivity().getClass(), getArguments());
 
         int rank = getArguments().getInt(OTPConstants.SELECTED_ITINERARY); // defaults to 0
         mShowingMap = getArguments().getBoolean(OTPConstants.SHOW_MAP);


### PR DESCRIPTION
@sdjacobs Could you please take a look at this?

Goal is to avoid referencing the live Activity outside of it's lifecycle, after it's been killed.