### PR TITLE
Fix #428 - Set the map vehicle marker zIndex to be on top of stop markers

### DIFF
--- a/onebusaway-android/src/amazon/java/org/onebusaway/android/map/googlemapsv2/ProprietaryMapHelpV2.java
+++ b/onebusaway-android/src/amazon/java/org/onebusaway/android/map/googlemapsv2/ProprietaryMapHelpV2.java
@@ -15,6 +15,7 @@
  */
 package org.onebusaway.android.map.googlemapsv2;
 
+import com.amazon.geo.mapsv2.model.Marker;
 import com.amazon.geo.mapsv2.util.AmazonMapsRuntimeUtil;
 import com.amazon.geo.mapsv2.util.ConnectionResult;
 
@@ -67,5 +68,17 @@ public class ProprietaryMapHelpV2 {
         public void onClick(View v) {
            /* unused */
         }
+    }
+
+    /**
+     * This method is a no-op because there is no such corresponding Marker.setZIndex() method on
+     * Amazon Maps v2 as of Aug 8th 2016.  However, this method must exist for the code in
+     * VehicleOverlay to remain the same on both the Amazon and Google build variants.
+     *
+     * @param m      marker to set the zIndex for
+     * @param zIndex zIndex to set on the given marker (default is 0)
+     */
+    public static void setZIndex(Marker m, float zIndex) {
+        // Do nothing - no Marker.setZIndex() method on Amazon Maps v2
     }
 }

--- a/onebusaway-android/src/amazon/java/org/onebusaway/android/map/googlemapsv2/VehicleOverlay.java
+++ b/onebusaway-android/src/amazon/java/org/onebusaway/android/map/googlemapsv2/VehicleOverlay.java
@@ -120,6 +120,11 @@ public class VehicleOverlay implements AmazonMap.OnInfoWindowClickListener {
      */
     private static final double MAX_VEHICLE_ANIMATION_DISTANCE = 400;
 
+    /**
+     * z-index used to show vehicle markers on top of stop markers (default marker z-index is 0)
+     */
+    private static final float VEHICLE_MARKER_Z_INDEX = 1;
+
     public VehicleOverlay(Activity activity, AmazonMap map) {
         mActivity = activity;
         mMap = map;
@@ -434,6 +439,7 @@ public class VehicleOverlay implements AmazonMap.OnInfoWindowClickListener {
                     .title(status.getVehicleId())
                     .icon(getVehicleIcon(isRealtime, status, response))
             );
+            ProprietaryMapHelpV2.setZIndex(m, VEHICLE_MARKER_Z_INDEX);
             mVehicleMarkers.put(status.getActiveTripId(), m);
             mVehicles.put(m, status);
         }

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/ProprietaryMapHelpV2.java
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/ProprietaryMapHelpV2.java
@@ -19,6 +19,7 @@ import com.google.android.gms.location.places.Place;
 import com.google.android.gms.location.places.ui.PlaceAutocomplete;
 import com.google.android.gms.maps.model.LatLng;
 import com.google.android.gms.maps.model.LatLngBounds;
+import com.google.android.gms.maps.model.Marker;
 
 import org.onebusaway.android.R;
 import org.onebusaway.android.directions.util.CustomAddress;
@@ -164,4 +165,13 @@ public class ProprietaryMapHelpV2 {
         }
     }
 
+    /**
+     * Sets the zIndex for the given marker to the given zIndex.  This is in ProprietaryMapHelpV2
+     * because there is no such corresponding Marker.setZIndex() method on Amazon Maps v2.
+     * @param m marker to set the zIndex for
+     * @param zIndex zIndex to set on the given marker (default is 0)
+     */
+    public static void setZIndex(Marker m, float zIndex) {
+        m.setZIndex(zIndex);
+    }
 }

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/VehicleOverlay.java
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/VehicleOverlay.java
@@ -109,6 +109,11 @@ public class VehicleOverlay implements GoogleMap.OnInfoWindowClickListener {
      */
     private static final double MAX_VEHICLE_ANIMATION_DISTANCE = 400;
 
+    /**
+     * z-index used to show vehicle markers on top of stop markers (default marker z-index is 0)
+     */
+    private static final float VEHICLE_MARKER_Z_INDEX = 1;
+
     public VehicleOverlay(Activity activity, GoogleMap map) {
         mActivity = activity;
         mMap = map;
@@ -423,6 +428,7 @@ public class VehicleOverlay implements GoogleMap.OnInfoWindowClickListener {
                     .title(status.getVehicleId())
                     .icon(getVehicleIcon(isRealtime, status, response))
             );
+            ProprietaryMapHelpV2.setZIndex(m, VEHICLE_MARKER_Z_INDEX);
             mVehicleMarkers.put(status.getActiveTripId(), m);
             mVehicles.put(m, status);
         }


### PR DESCRIPTION
* There is no Marker.setZIndex() method on Amazon Maps v2, so the actual code to set the zIndex is located in ProprietaryMapHelpV2.  On Google variants it sets the zIndex, while on the Amazon variants it is a no-op.