### PR TITLE
Fix #627 - Add stop direction with stop name

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListHeader.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListHeader.java
@@ -146,6 +146,8 @@ class ArrivalsListHeader {
 
     private TextView mNameView;
 
+    private TextView mDirectionView;
+
     private EditText mEditNameView;
 
     private ImageButton mStopFavorite;
@@ -315,6 +317,7 @@ class ArrivalsListHeader {
         mNameContainerView = mView.findViewById(R.id.stop_name_and_info_container);
         mEditNameContainerView = mView.findViewById(R.id.edit_name_container);
         mNameView = (TextView) mView.findViewById(R.id.stop_name);
+        mDirectionView = (TextView) mView.findViewById(R.id.stop_direction);
         mEditNameView = (EditText) mView.findViewById(R.id.edit_name);
         mStopFavorite = (ImageButton) mView.findViewById(R.id.stop_favorite);
         mStopFavorite.setColorFilter(mView.getResources().getColor(R.color.header_text_color));
@@ -632,11 +635,20 @@ class ArrivalsListHeader {
     private void refreshName() {
         String name = mController.getStopName();
         String userName = mController.getUserStopName();
+        String stopDirection = mController.getStopDirection();
 
         if (!TextUtils.isEmpty(userName)) {
             mNameView.setText(userName);
         } else if (name != null) {
             mNameView.setText(name);
+        }
+
+        if (!TextUtils.isEmpty(stopDirection)) {
+            mDirectionView.setText(mContext.getString(R.string.arrival_list_stop_directions,
+                    stopDirection));
+            mDirectionView.setVisibility(View.VISIBLE);
+        } else {
+            mDirectionView.setVisibility(View.GONE);
         }
     }
 

--- a/onebusaway-android/src/main/res/layout/arrivals_list_header.xml
+++ b/onebusaway-android/src/main/res/layout/arrivals_list_header.xml
@@ -183,6 +183,19 @@
                         android:textIsSelectable="false"
                         android:layout_marginLeft="1dp"/>
 
+                <TextView
+                        android:id="@+id/stop_direction"
+                        android:textSize="17sp"
+                        android:text=" (N)"
+                        android:textColor="@color/header_text_color"
+                        android:ellipsize="none"
+                        android:singleLine="true"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="left|center_vertical"
+                        android:layout_weight=".05"
+                        android:textIsSelectable="false"/>
+
                 <ImageButton
                         android:id="@+id/stop_info_button"
                         android:background="?attr/selectableItemBackground"

--- a/onebusaway-android/src/main/res/values/donottranslate.xml
+++ b/onebusaway-android/src/main/res/values/donottranslate.xml
@@ -173,5 +173,5 @@
     <string name="ri_selected_service_trip">trip</string>
     <string name="ri_app_feedback_email">android-app@onebusaway.org</string>
 
-
+    <string name="arrival_list_stop_directions">\u0020(%1$s)</string>
 </resources>


### PR DESCRIPTION
Added `stop_direction`.

Screenshot from Nexus 6:

![device-2016-08-10-110819](https://cloud.githubusercontent.com/assets/2777974/17559197/4eb77264-5eeb-11e6-8fea-b07d9428a516.png)

Screenshots from HTC EVO 3d:

![device-2016-08-10-111523](https://cloud.githubusercontent.com/assets/2777974/17559310/d26260ba-5eeb-11e6-8440-01454b65354b.png) ![device-2016-08-10-111502](https://cloud.githubusercontent.com/assets/2777974/17559311/d263880a-5eeb-11e6-80f7-be944fa4421e.png)
