### PR TITLE
Fix #496 - Correctly reflect arrival/departure information in reminder text

### DIFF
--- a/onebusaway-android/src/amazon/java/org/onebusaway/android/map/googlemapsv2/VehicleOverlay.java
+++ b/onebusaway-android/src/amazon/java/org/onebusaway/android/map/googlemapsv2/VehicleOverlay.java
@@ -41,6 +41,7 @@ import org.onebusaway.android.io.elements.ObaTripStatus;
 import org.onebusaway.android.io.request.ObaTripsForRouteResponse;
 import org.onebusaway.android.ui.ArrivalInfo;
 import org.onebusaway.android.ui.TripDetailsActivity;
+import org.onebusaway.android.util.ArrivalInfoUtils;
 import org.onebusaway.android.ui.TripDetailsListFragment;
 import org.onebusaway.android.util.MathUtils;
 import org.onebusaway.android.util.UIUtils;
@@ -740,7 +741,7 @@ public class VehicleOverlay implements AmazonMap.OnInfoWindowClickListener {
 
             if (isRealtime) {
                 long deviationMin = TimeUnit.SECONDS.toMinutes(status.getScheduleDeviation());
-                colorResource = ArrivalInfo.computeColorFromDeviation(deviationMin);
+                colorResource = ArrivalInfoUtils.computeColorFromDeviation(deviationMin);
             } else {
                 colorResource = R.color.stop_info_scheduled_time;
             }
@@ -868,9 +869,9 @@ public class VehicleOverlay implements AmazonMap.OnInfoWindowClickListener {
 
             if (isRealtime) {
                 long deviationMin = TimeUnit.SECONDS.toMinutes(status.getScheduleDeviation());
-                String statusString = ArrivalInfo.computeArrivalLabelFromDelay(r, deviationMin);
+                String statusString = ArrivalInfoUtils.computeArrivalLabelFromDelay(r, deviationMin);
                 statusView.setText(statusString);
-                statusColor = ArrivalInfo.computeColorFromDeviation(deviationMin);
+                statusColor = ArrivalInfoUtils.computeColorFromDeviation(deviationMin);
                 d.setColor(r.getColor(statusColor));
                 statusView.setPadding(pSides, pTopBottom, pSides, pTopBottom);
             } else {

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/util/test/UIUtilTest.java
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/util/test/UIUtilTest.java
@@ -16,6 +16,7 @@ import org.onebusaway.android.mock.MockObaStop;
 import org.onebusaway.android.mock.MockRegion;
 import org.onebusaway.android.provider.ObaContract;
 import org.onebusaway.android.ui.ArrivalInfo;
+import org.onebusaway.android.util.ArrivalInfoUtils;
 import org.onebusaway.android.util.UIUtils;
 
 import android.graphics.Color;
@@ -135,7 +136,7 @@ public class UIUtilTest extends ObaTestCase {
 
         ObaArrivalInfo[] arrivals = response.getArrivalInfo();
         assertNotNull(arrivals);
-        ArrayList<ArrivalInfo> arrivalInfo = ArrivalInfo.convertObaArrivalInfo(getContext(),
+        ArrayList<ArrivalInfo> arrivalInfo = ArrivalInfoUtils.convertObaArrivalInfo(getContext(),
                 arrivals, null, response.getCurrentTime(), true);
 
         ObaRoute route = response.getRoute(arrivalInfo.get(0).getInfo().getRouteId());
@@ -184,7 +185,7 @@ public class UIUtilTest extends ObaTestCase {
 
         arrivals = response2.getArrivalInfo();
         assertNotNull(arrivals);
-        arrivalInfo = ArrivalInfo.convertObaArrivalInfo(getContext(),
+        arrivalInfo = ArrivalInfoUtils.convertObaArrivalInfo(getContext(),
                 arrivals, null, response2.getCurrentTime(), true);
 
         route = response2.getRoute(arrivalInfo.get(0).getInfo().getRouteId());
@@ -443,17 +444,17 @@ public class UIUtilTest extends ObaTestCase {
         // Get the response
         ObaArrivalInfo[] arrivals = response.getArrivalInfo();
         assertNotNull(arrivals);
-        ArrayList<ArrivalInfo> arrivalInfo = ArrivalInfo.convertObaArrivalInfo(getContext(),
+        ArrayList<ArrivalInfo> arrivalInfo = ArrivalInfoUtils.convertObaArrivalInfo(getContext(),
                 arrivals, null, response.getCurrentTime(), true);
 
         // Now confirm that we have the correct number of elements, and values for ETAs for the test
         validateUatcArrivalInfo(arrivalInfo);
 
         // First non-negative arrival should be "0", in index 5
-        int firstNonNegativeArrivalIndex = ArrivalInfo.findFirstNonNegativeArrival(arrivalInfo);
+        int firstNonNegativeArrivalIndex = ArrivalInfoUtils.findFirstNonNegativeArrival(arrivalInfo);
         assertEquals(5, firstNonNegativeArrivalIndex);
 
-        ArrayList<Integer> preferredArrivalIndexes = ArrivalInfo
+        ArrayList<Integer> preferredArrivalIndexes = ArrivalInfoUtils
                 .findPreferredArrivalIndexes(arrivalInfo);
 
         // Indexes 11 and 13 should hold the favorites
@@ -473,9 +474,9 @@ public class UIUtilTest extends ObaTestCase {
                 false);
 
         // Process the response again (resetting the included favorite info)
-        arrivalInfo = ArrivalInfo.convertObaArrivalInfo(getContext(),
+        arrivalInfo = ArrivalInfoUtils.convertObaArrivalInfo(getContext(),
                 arrivals, null, response.getCurrentTime(), true);
-        preferredArrivalIndexes = ArrivalInfo.findPreferredArrivalIndexes(arrivalInfo);
+        preferredArrivalIndexes = ArrivalInfoUtils.findPreferredArrivalIndexes(arrivalInfo);
 
         // Now the first two non-negative arrival times should be returned - indexes 5 and 6
         assertEquals(5, preferredArrivalIndexes.get(0).intValue());
@@ -511,7 +512,7 @@ public class UIUtilTest extends ObaTestCase {
          * Labels *with* arrive/depart included, and time labels
          */
         boolean includeArriveDepartLabels = true;
-        ArrayList<ArrivalInfo> arrivalInfo = ArrivalInfo.convertObaArrivalInfo(
+        ArrayList<ArrivalInfo> arrivalInfo = ArrivalInfoUtils.convertObaArrivalInfo(
                 getContext(),
                 arrivals, null, response.getCurrentTime(), includeArriveDepartLabels);
 
@@ -615,7 +616,7 @@ public class UIUtilTest extends ObaTestCase {
          * Status labels *without* arrive/depart included
          */
         includeArriveDepartLabels = false;
-        arrivalInfo = ArrivalInfo.convertObaArrivalInfo(getContext(), arrivals, null,
+        arrivalInfo = ArrivalInfoUtils.convertObaArrivalInfo(getContext(), arrivals, null,
                 response.getCurrentTime(), includeArriveDepartLabels);
 
         // Now confirm that we have the correct number of elements, and values for ETAs for the test
@@ -654,6 +655,75 @@ public class UIUtilTest extends ObaTestCase {
         assertEquals("On time", arrivalInfo.get(29).getStatusText());
         assertEquals("9 min delay", arrivalInfo.get(30).getStatusText());
         assertEquals("On time", arrivalInfo.get(31).getStatusText());
+
+        /**
+         * Test notification texts
+         */
+
+        assertEquals("Route " + UIUtils.getRouteDisplayName(arrivalInfo.get(0).getInfo())
+                + " has arrived.", arrivalInfo.get(0).getNotifyText());
+        assertEquals("Route " + UIUtils.getRouteDisplayName(arrivalInfo.get(1).getInfo())
+                + " has departed.", arrivalInfo.get(1).getNotifyText());
+        assertEquals("Route " + UIUtils.getRouteDisplayName(arrivalInfo.get(2).getInfo())
+                + " has departed.", arrivalInfo.get(2).getNotifyText());
+        assertEquals("Route " + UIUtils.getRouteDisplayName(arrivalInfo.get(3).getInfo())
+                + " has arrived.", arrivalInfo.get(3).getNotifyText());
+        assertEquals("Route " + UIUtils.getRouteDisplayName(arrivalInfo.get(4).getInfo())
+                + " has departed.", arrivalInfo.get(4).getNotifyText());
+        assertEquals("Route " + UIUtils.getRouteDisplayName(arrivalInfo.get(5).getInfo())
+                + " is departing now!", arrivalInfo.get(5).getNotifyText());
+        assertEquals("Route " + UIUtils.getRouteDisplayName(arrivalInfo.get(6).getInfo())
+                + " is arriving now!", arrivalInfo.get(6).getNotifyText());
+        assertEquals("Route " + UIUtils.getRouteDisplayName(arrivalInfo.get(7).getInfo())
+                + " is arriving in 3 min!", arrivalInfo.get(7).getNotifyText());
+        assertEquals("Route " + UIUtils.getRouteDisplayName(arrivalInfo.get(8).getInfo())
+                + " is departing in 5 min!", arrivalInfo.get(8).getNotifyText());
+        assertEquals("Route " + UIUtils.getRouteDisplayName(arrivalInfo.get(9).getInfo())
+                + " is departing in 5 min!", arrivalInfo.get(9).getNotifyText());
+        assertEquals("Route " + UIUtils.getRouteDisplayName(arrivalInfo.get(10).getInfo())
+                + " is arriving in 6 min!", arrivalInfo.get(10).getNotifyText());
+        assertEquals("Route " + UIUtils.getRouteDisplayName(arrivalInfo.get(11).getInfo())
+                + " is arriving in 7 min!", arrivalInfo.get(11).getNotifyText());
+        assertEquals("Route " + UIUtils.getRouteDisplayName(arrivalInfo.get(12).getInfo())
+                + " is arriving in 10 min!", arrivalInfo.get(12).getNotifyText());
+        assertEquals("Route " + UIUtils.getRouteDisplayName(arrivalInfo.get(13).getInfo())
+                + " is departing in 14 min!", arrivalInfo.get(13).getNotifyText());
+        assertEquals("Route " + UIUtils.getRouteDisplayName(arrivalInfo.get(14).getInfo())
+                + " is arriving in 17 min!", arrivalInfo.get(14).getNotifyText());
+        assertEquals("Route " + UIUtils.getRouteDisplayName(arrivalInfo.get(15).getInfo())
+                + " is arriving in 20 min!", arrivalInfo.get(15).getNotifyText());
+        assertEquals("Route " + UIUtils.getRouteDisplayName(arrivalInfo.get(16).getInfo())
+                + " is departing in 20 min!", arrivalInfo.get(16).getNotifyText());
+        assertEquals("Route " + UIUtils.getRouteDisplayName(arrivalInfo.get(17).getInfo())
+                + " is arriving in 23 min!", arrivalInfo.get(17).getNotifyText());
+        assertEquals("Route " + UIUtils.getRouteDisplayName(arrivalInfo.get(18).getInfo())
+                + " is departing in 25 min!", arrivalInfo.get(18).getNotifyText());
+        assertEquals("Route " + UIUtils.getRouteDisplayName(arrivalInfo.get(19).getInfo())
+                + " is arriving in 26 min!", arrivalInfo.get(19).getNotifyText());
+        assertEquals("Route " + UIUtils.getRouteDisplayName(arrivalInfo.get(20).getInfo())
+                + " is departing in 27 min!", arrivalInfo.get(20).getNotifyText());
+        assertEquals("Route " + UIUtils.getRouteDisplayName(arrivalInfo.get(21).getInfo())
+                + " is arriving in 28 min!", arrivalInfo.get(21).getNotifyText());
+        assertEquals("Route " + UIUtils.getRouteDisplayName(arrivalInfo.get(22).getInfo())
+                + " is arriving in 30 min!", arrivalInfo.get(22).getNotifyText());
+        assertEquals("Route " + UIUtils.getRouteDisplayName(arrivalInfo.get(23).getInfo())
+                + " is departing in 30 min!", arrivalInfo.get(23).getNotifyText());
+        assertEquals("Route " + UIUtils.getRouteDisplayName(arrivalInfo.get(24).getInfo())
+                + " is arriving in 32 min!", arrivalInfo.get(24).getNotifyText());
+        assertEquals("Route " + UIUtils.getRouteDisplayName(arrivalInfo.get(25).getInfo())
+                + " is arriving in 32 min!", arrivalInfo.get(25).getNotifyText());
+        assertEquals("Route " + UIUtils.getRouteDisplayName(arrivalInfo.get(26).getInfo())
+                + " is arriving in 34 min!", arrivalInfo.get(26).getNotifyText());
+        assertEquals("Route " + UIUtils.getRouteDisplayName(arrivalInfo.get(27).getInfo())
+                + " is arriving in 34 min!", arrivalInfo.get(27).getNotifyText());
+        assertEquals("Route " + UIUtils.getRouteDisplayName(arrivalInfo.get(28).getInfo())
+                + " is departing in 35 min!", arrivalInfo.get(28).getNotifyText());
+        assertEquals("Route " + UIUtils.getRouteDisplayName(arrivalInfo.get(29).getInfo())
+                + " is departing in 35 min!", arrivalInfo.get(29).getNotifyText());
+        assertEquals("Route " + UIUtils.getRouteDisplayName(arrivalInfo.get(30).getInfo())
+                + " is arriving in 35 min!", arrivalInfo.get(30).getNotifyText());
+        assertEquals("Route " + UIUtils.getRouteDisplayName(arrivalInfo.get(31).getInfo())
+                + " is departing in 35 min!", arrivalInfo.get(31).getNotifyText());
     }
 
     public void testMaybeShrinkRouteName() {

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/VehicleOverlay.java
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/VehicleOverlay.java
@@ -30,6 +30,7 @@ import org.onebusaway.android.io.elements.ObaTripStatus;
 import org.onebusaway.android.io.request.ObaTripsForRouteResponse;
 import org.onebusaway.android.ui.ArrivalInfo;
 import org.onebusaway.android.ui.TripDetailsActivity;
+import org.onebusaway.android.util.ArrivalInfoUtils;
 import org.onebusaway.android.ui.TripDetailsListFragment;
 import org.onebusaway.android.util.MathUtils;
 import org.onebusaway.android.util.UIUtils;
@@ -729,7 +730,7 @@ public class VehicleOverlay implements GoogleMap.OnInfoWindowClickListener {
 
             if (isRealtime) {
                 long deviationMin = TimeUnit.SECONDS.toMinutes(status.getScheduleDeviation());
-                colorResource = ArrivalInfo.computeColorFromDeviation(deviationMin);
+                colorResource = ArrivalInfoUtils.computeColorFromDeviation(deviationMin);
             } else {
                 colorResource = R.color.stop_info_scheduled_time;
             }
@@ -857,9 +858,9 @@ public class VehicleOverlay implements GoogleMap.OnInfoWindowClickListener {
 
             if (isRealtime) {
                 long deviationMin = TimeUnit.SECONDS.toMinutes(status.getScheduleDeviation());
-                String statusString = ArrivalInfo.computeArrivalLabelFromDelay(r, deviationMin);
+                String statusString = ArrivalInfoUtils.computeArrivalLabelFromDelay(r, deviationMin);
                 statusView.setText(statusString);
-                statusColor = ArrivalInfo.computeColorFromDeviation(deviationMin);
+                statusColor = ArrivalInfoUtils.computeColorFromDeviation(deviationMin);
                 d.setColor(r.getColor(statusColor));
                 statusView.setPadding(pSides, pTopBottom, pSides, pTopBottom);
             } else {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/ConversionUtils.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/ConversionUtils.java
@@ -17,7 +17,7 @@
 package org.onebusaway.android.directions.util;
 
 import org.onebusaway.android.R;
-import org.onebusaway.android.ui.ArrivalInfo;
+import org.onebusaway.android.util.ArrivalInfoUtils;
 import org.onebusaway.android.util.PreferenceUtils;
 import org.opentripplanner.api.model.Itinerary;
 import org.opentripplanner.api.model.Leg;
@@ -360,7 +360,7 @@ public class ConversionUtils {
         timezone = noDeviceTimezoneNote;
 
         int color = applicationContext.getResources().getColor(
-                ArrivalInfo.computeColorFromDeviation(
+                ArrivalInfoUtils.computeColorFromDeviation(
                         calNewTime.getTimeInMillis() - calOldTime.getTimeInMillis()));
 
         newTimeString = new SpannableString(timeFormat.format(calNewTime.getTime()) + " ");

--- a/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/SimpleArrivalListFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/SimpleArrivalListFragment.java
@@ -27,6 +27,7 @@ import org.onebusaway.android.map.MapParams;
 import org.onebusaway.android.provider.ObaContract;
 import org.onebusaway.android.ui.ArrivalInfo;
 import org.onebusaway.android.ui.ArrivalsListLoader;
+import org.onebusaway.android.util.ArrivalInfoUtils;
 import org.onebusaway.android.util.FragmentUtils;
 import org.onebusaway.android.util.UIUtils;
 
@@ -177,7 +178,7 @@ public class SimpleArrivalListFragment extends Fragment
                 findViewById(R.id.simple_arrival_content);
         contentLayout.removeAllViews();
 
-        ArrayList<ArrivalInfo> arrivalInfos = ArrivalInfo.convertObaArrivalInfo(getActivity(),
+        ArrayList<ArrivalInfo> arrivalInfos = ArrivalInfoUtils.convertObaArrivalInfo(getActivity(),
                 info, new ArrayList<String>(), currentTime, false);
 
         for (ArrivalInfo stopInfo : arrivalInfos) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/tripservice/TripService.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/tripservice/TripService.java
@@ -84,6 +84,8 @@ public class TripService extends Service {
 
     private static final String EXTRA_TIMEDIFF = ".timeDiff";
 
+    private static final String IS_ARRIVING = ".isArriving";
+
     private ExecutorService mThreadPool;
 
     private NotificationManager mNM;
@@ -182,8 +184,9 @@ public class TripService extends Service {
         } else if (ACTION_NOTIFY.equals(action)) {
             // Create the notification
             long timeDiff = intent.getLongExtra(EXTRA_TIMEDIFF, 0);
-            mThreadPool.submit(new NotifierTask(this,
-                    taskContext, uri, timeDiff));
+            boolean isArriving = intent.getBooleanExtra(IS_ARRIVING, false);
+
+            mThreadPool.submit(new NotifierTask(this, taskContext, uri, timeDiff, isArriving));
             return START_REDELIVER_INTENT;
 
         } else if (ACTION_CANCEL.equals(action)) {
@@ -233,11 +236,12 @@ public class TripService extends Service {
         alarm.set(AlarmManager.RTC_WAKEUP, triggerTime, alarmIntent);
     }
 
-    public static void notifyTrip(Context context, Uri alertUri, long diffTime) {
+    public static void notifyTrip(Context context, Uri alertUri, long diffTime, boolean isArriving) {
         final Intent intent = new Intent(context, TripService.class);
         intent.setAction(ACTION_NOTIFY);
         intent.setData(alertUri);
         intent.putExtra(EXTRA_TIMEDIFF, diffTime);
+        intent.putExtra(IS_ARRIVING, isArriving);
         context.startService(intent);
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/tripservice/TripService.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/tripservice/TripService.java
@@ -82,9 +82,7 @@ public class TripService extends Service {
     public static final String ACTION_CANCEL =
             BuildConfig.APPLICATION_ID + ".action.CANCEL";
 
-    private static final String EXTRA_TIMEDIFF = ".timeDiff";
-
-    private static final String IS_ARRIVING = ".isArriving";
+    private static final String NOTIFY_TEXT = ".notifyText";
 
     private ExecutorService mThreadPool;
 
@@ -183,10 +181,9 @@ public class TripService extends Service {
 
         } else if (ACTION_NOTIFY.equals(action)) {
             // Create the notification
-            long timeDiff = intent.getLongExtra(EXTRA_TIMEDIFF, 0);
-            boolean isArriving = intent.getBooleanExtra(IS_ARRIVING, false);
+            String notifyText = intent.getStringExtra(NOTIFY_TEXT);
 
-            mThreadPool.submit(new NotifierTask(this, taskContext, uri, timeDiff, isArriving));
+            mThreadPool.submit(new NotifierTask(this, taskContext, uri, notifyText));
             return START_REDELIVER_INTENT;
 
         } else if (ACTION_CANCEL.equals(action)) {
@@ -236,12 +233,11 @@ public class TripService extends Service {
         alarm.set(AlarmManager.RTC_WAKEUP, triggerTime, alarmIntent);
     }
 
-    public static void notifyTrip(Context context, Uri alertUri, long diffTime, boolean isArriving) {
+    public static void notifyTrip(Context context, Uri alertUri, String notifyText) {
         final Intent intent = new Intent(context, TripService.class);
         intent.setAction(ACTION_NOTIFY);
         intent.setData(alertUri);
-        intent.putExtra(EXTRA_TIMEDIFF, diffTime);
-        intent.putExtra(IS_ARRIVING, isArriving);
+        intent.putExtra(NOTIFY_TEXT, notifyText);
         context.startService(intent);
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalInfo.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalInfo.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2010 Paul Watts (paulcwatts@gmail.com)
+ * Copyright (C) 2010-2016 Paul Watts (paulcwatts@gmail.com)
+ * University of South Florida (sjbarbeau@gmail.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,170 +17,19 @@
 package org.onebusaway.android.ui;
 
 import org.onebusaway.android.R;
-import org.onebusaway.android.app.Application;
 import org.onebusaway.android.io.elements.ObaArrivalInfo;
 import org.onebusaway.android.io.elements.ObaArrivalInfo.Frequency;
 import org.onebusaway.android.provider.ObaContract;
+import org.onebusaway.android.util.ArrivalInfoUtils;
 import org.onebusaway.android.util.UIUtils;
 
 import android.content.Context;
 import android.content.res.Resources;
 
 import java.text.DateFormat;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.Date;
 
 public final class ArrivalInfo {
-
-    final static class InfoComparator implements Comparator<ArrivalInfo> {
-
-        public int compare(ArrivalInfo lhs, ArrivalInfo rhs) {
-            return (int) (lhs.mEta - rhs.mEta);
-        }
-    }
-
-    /**
-     * Converts the ObaArrivalInfo array received from the server to an ArrayList for the adapter
-     * @param context
-     * @param arrivalInfo
-     * @param filter routeIds to filter for
-     * @param ms current time in milliseconds
-     * @param includeArrivalDepartureInStatusLabel true if the arrival/departure label should be
-     *                                             included in the status label, false if it should
-     *                                             not
-     * @return ArrayList of arrival info to be used with the adapter
-     */
-    public static final ArrayList<ArrivalInfo> convertObaArrivalInfo(Context context,
-            ObaArrivalInfo[] arrivalInfo,
-            ArrayList<String> filter, long ms,
-            boolean includeArrivalDepartureInStatusLabel) {
-        final int len = arrivalInfo.length;
-        ArrayList<ArrivalInfo> result = new ArrayList<ArrivalInfo>(len);
-        if (filter != null && filter.size() > 0) {
-            // Only add routes that haven't been filtered out
-            for (int i = 0; i < len; ++i) {
-                ObaArrivalInfo arrival = arrivalInfo[i];
-                if (filter.contains(arrival.getRouteId())) {
-                    ArrivalInfo info = new ArrivalInfo(context, arrival, ms,
-                            includeArrivalDepartureInStatusLabel);
-                    if (shouldAddEta(info)) {
-                        result.add(info);
-                    }
-                }
-            }
-        } else {
-            // Add arrivals for all routes
-            for (int i = 0; i < len; ++i) {
-                ArrivalInfo info = new ArrivalInfo(context, arrivalInfo[i], ms,
-                        includeArrivalDepartureInStatusLabel);
-                if (shouldAddEta(info)) {
-                    result.add(info);
-                }
-            }
-        }
-
-        // Sort by ETA
-        Collections.sort(result, new InfoComparator());
-        return result;
-    }
-
-    /**
-     * Returns true if this ETA should be added based on the user preference for adding negative
-     * arrival times, and false if it should not
-     *
-     * @param info info that includes the ETA to be evaluated
-     * @return true if this ETA should be added based on the user preference for adding negative
-     * arrival times, and false if it should not
-     */
-    private static boolean shouldAddEta(ArrivalInfo info) {
-        boolean showNegativeArrivals = Application.getPrefs()
-                .getBoolean(Application.get().getResources()
-                        .getString(R.string.preference_key_show_negative_arrivals), true);
-        if (info.getEta() >= 0) {
-            // Always add positive ETAs
-            return true;
-        } else {
-            // Only add negative ETAs based on setting
-            if (showNegativeArrivals) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /**
-     * Returns the index in the provided infoList for the first non-negative arrival ETA in the
-     * list, or -1 if no non-negative ETAs exist in the list
-     *
-     * @param infoList list to search for non-negative arrival times, ordered by relative ETA from
-     *                 negative infinity to positive infinity
-     * @return the index in the provided infoList for the first non-negative arrival ETA in the
-     * list, or -1 if no non-negative ETAs exist in the list
-     */
-    public static int findFirstNonNegativeArrival(ArrayList<ArrivalInfo> infoList) {
-        for (int i = 0; i < infoList.size(); i++) {
-            ArrivalInfo info = infoList.get(i);
-            if (info.getEta() >= 0) {
-                return i;
-            }
-        }
-        // We didn't find any non-negative ETAs
-        return -1;
-    }
-
-    /**
-     * Returns the indexes in the provided infoList for the preferred route/headsign combinations
-     * to be prioritized for displayed in the header, or null if no non-negative ETAs exist in the
-     * list.  If no route/headsign combinations are favorited, the indexes returned may simply be
-     * the indexes of the first (and second, if it exists) non-negative arrival times.
-     *
-     * @param infoList list to search for non-negative arrival times, ordered by relative ETA from
-     *                 negative infinity to positive infinity
-     * @return the indexes in the provided infoList for the preferred route/headsign combinations
-     * to be prioritized for displayed in the header, or null if no non-negative ETAs exist in the
-     * list
-     */
-    public static ArrayList<Integer> findPreferredArrivalIndexes(ArrayList<ArrivalInfo> infoList) {
-        // Start by getting the index of the first non-negative arrival time
-        int firstIndex = findFirstNonNegativeArrival(infoList);
-        if (firstIndex == -1) {
-            return null;
-        }
-        // Find any favorites
-        ArrayList<Integer> preferredIndexes = new ArrayList<>();
-        for (int i = firstIndex; i < infoList.size(); i++) {
-            ArrivalInfo info = infoList.get(i);
-            if (info.isRouteAndHeadsignFavorite()) {
-                preferredIndexes.add(i);
-            }
-        }
-
-        // If we have at least two favorites, that's enough to fill the header - return them
-        if (preferredIndexes.size() >= 2) {
-            return preferredIndexes;
-        }
-
-        // If we have one favorite, and the index is different from the firstIndex, then add the firstIndex and return
-        if (preferredIndexes.size() == 1 && preferredIndexes.get(0) != firstIndex) {
-            preferredIndexes.add(firstIndex);
-        }
-
-        // If we have no preferred indexes (i.e., starred route/headsigns) at this point, then add the firstIndex
-        if (preferredIndexes.size() == 0) {
-            preferredIndexes.add(firstIndex);
-
-            // If there is another non-negative arrival time, then add it too
-            int secondIndex = firstIndex + 1;
-            if (secondIndex < infoList.size()) {
-                preferredIndexes.add(secondIndex);
-            }
-        }
-
-        return preferredIndexes;
-    }
-
 
     private final ObaArrivalInfo mInfo;
 
@@ -190,6 +40,8 @@ public final class ArrivalInfo {
     private final String mStatusText;
 
     private final String mTimeText;
+
+    private final String mNotifyText;
 
     private final int mColor;
 
@@ -208,7 +60,7 @@ public final class ArrivalInfo {
      *                                             should not
      */
     public ArrivalInfo(Context context, ObaArrivalInfo info, long now,
-            boolean includeArrivalDepartureInStatusLabel) {
+                       boolean includeArrivalDepartureInStatusLabel) {
         mInfo = info;
         // First, all times have to have to be converted to 'minutes'
         final long nowMins = now / ms_in_mins;
@@ -238,7 +90,7 @@ public final class ArrivalInfo {
             mDisplayTime = scheduled;
         }
 
-        mColor = computeColor(scheduledMins, predictedMins);
+        mColor = ArrivalInfoUtils.computeColor(scheduledMins, predictedMins);
 
         mStatusText = computeStatusLabel(context, info, now, predicted,
                 scheduledMins, predictedMins, includeArrivalDepartureInStatusLabel);
@@ -247,73 +99,20 @@ public final class ArrivalInfo {
         // Check if the user has marked this routeId/headsign/stopId as a favorite
         mIsRouteAndHeadsignFavorite = ObaContract.RouteHeadsignFavorites
                 .isFavorite(info.getRouteId(), info.getHeadsign(), info.getStopId());
+
+        mNotifyText = computeNotifyText(context);
     }
 
     /**
-     * Returns the status color to be used, depending on whether the vehicle is running early,
-     * late,
-     * ontime,
-     * or if we don't have real-time info (i.e., scheduled)
-     *
-     * @param scheduled the scheduled time, in minutes past unix epoch
-     * @param predicted the predicted time, in minutes past unix epoch
-     * @return the status color to be used, depending on whether the vehicle is running early, late,
-     * ontime,
-     * or if we don't have real-time info (i.e., scheduled)
-     */
-    public static int computeColor(final long scheduled, final long predicted) {
-        if (predicted != 0) {
-            return computeColorFromDeviation(predicted - scheduled);
-        } else {
-            // Use scheduled color
-            return R.color.stop_info_scheduled_time;
-        }
-    }
-
-    /**
-     * Returns the status color to be used, depending on whether the vehicle is running early,
-     * late,
-     * ontime,
-     * or if we don't have real-time info (i.e., scheduled)
-     *
-     * @param delay the deviation from the scheduled time, in minutes - positive means bus is running late,
-     *              negative means early
-     * @return the status color to be used, depending on whether the vehicle is running early, late,
-     * ontime,
-     * or if we don't have real-time info (i.e., scheduled)
-     */
-    public static int computeColorFromDeviation(final long delay) {
-        // Bus is arriving
-        if (delay > 0) {
-            // Arriving delayed
-            return R.color.stop_info_delayed;
-        } else if (delay < 0) {
-            // Arriving early
-            return R.color.stop_info_early;
-        } else {
-            // Arriving on time
-            return R.color.stop_info_ontime;
-        }
-    }
-
-    /**
-     *
-     * @param context
-     * @param info
-     * @param now
-     * @param predicted
-     * @param scheduledMins
-     * @param predictedMins
      * @param includeArrivalDeparture true if the arrival/departure label should be included, false
      *                                if it should not
-     * @return
      */
     private String computeStatusLabel(Context context,
-            ObaArrivalInfo info,
-            final long now,
-            final long predicted,
-            final long scheduledMins,
-            final long predictedMins, boolean includeArrivalDeparture) {
+                                      ObaArrivalInfo info,
+                                      final long now,
+                                      final long predicted,
+                                      final long scheduledMins,
+                                      final long predictedMins, boolean includeArrivalDeparture) {
         if (context == null) {
             // The Activity has been destroyed, so just return an empty string to avoid an NPE
             return "";
@@ -348,7 +147,7 @@ public final class ArrivalInfo {
 
             if (mEta >= 0) {
                 // Bus hasn't yet arrived/departed
-                return computeArrivalLabelFromDelay(res, delay);
+                return ArrivalInfoUtils.computeArrivalLabelFromDelay(res, delay);
             } else {
                 /**
                  * Arrival/departure time has passed
@@ -450,31 +249,37 @@ public final class ArrivalInfo {
         }
     }
 
-    /**
-     * Computes the arrival status label from the delay (i.e., schedule deviation), where positive
-     * means the bus is running late and negative means the bus is running ahead of schedule
-     *
-     * @param delay schedule deviation, in minutes, for this vehicle where positive
-     *              means the bus is running late and negative means the bus is running ahead of
-     *              schedule
-     * @return the arrival status label based on the deviation
-     */
-    public static String computeArrivalLabelFromDelay(Resources res, long delay) {
-        if (delay > 0) {
-            // Arriving delayed
-            return res.getQuantityString(
-                    R.plurals.stop_info_arrive_delayed, (int) delay,
-                    delay);
-        } else if (delay < 0) {
-            // Arriving early
-            delay = -delay;
-            return res
-                    .getQuantityString(
-                            R.plurals.stop_info_arrive_early,
-                            (int) delay, delay);
+    private String computeNotifyText(Context context) {
+        if (context == null) {
+            // The Activity has been destroyed, so just return an empty string to avoid an NPE
+            return "";
+        }
+
+        final String routeDisplayName = UIUtils.getRouteDisplayName(mInfo);
+
+        if (mEta == 0) {
+            // Bus is arriving now
+            if (mIsArrival) {
+                return context.getString(R.string.trip_stat_lessthanone_arriving, routeDisplayName);
+            } else {
+                return context.getString(R.string.trip_stat_lessthanone_departing, routeDisplayName);
+            }
+        } else if (mEta > 0) {
+            // Bus hasn't yet arrived
+            if (mIsArrival) {
+                return context.getString(R.string.trip_stat_arriving, routeDisplayName,
+                        (int) (mEta));
+            } else {
+                return context.getString(R.string.trip_stat_departing, routeDisplayName,
+                        (int) (mEta));
+            }
         } else {
-            // Arriving on time
-            return res.getString(R.string.stop_info_ontime);
+            // Bus arrived or departed
+            if (mIsArrival) {
+                return context.getString(R.string.trip_stat_gone_arrived, routeDisplayName);
+            } else {
+                return context.getString(R.string.trip_stat_gone_departed, routeDisplayName);
+            }
         }
     }
 
@@ -498,6 +303,10 @@ public final class ArrivalInfo {
         return mTimeText;
     }
 
+    public final String getNotifyText() {
+        return mNotifyText;
+    }
+
     /**
      * Returns true if this arrival info is for an arrival time, false if it is for a departure
      * time
@@ -516,8 +325,11 @@ public final class ArrivalInfo {
     }
 
     /**
-     * Returns true if there is real-time arrival info available for this trip, false if there is not
-     * @return true if there is real-time arrival info available for this trip, false if there is not
+     * Returns true if there is real-time arrival info available for this trip, false if there is
+     * not
+     *
+     * @return true if there is real-time arrival info available for this trip, false if there is
+     * not
      */
     public final boolean getPredicted() {
         return mPredicted;

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListAdapterStyleA.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListAdapterStyleA.java
@@ -18,6 +18,7 @@ package org.onebusaway.android.ui;
 import org.onebusaway.android.R;
 import org.onebusaway.android.io.elements.ObaArrivalInfo;
 import org.onebusaway.android.provider.ObaContract;
+import org.onebusaway.android.util.ArrivalInfoUtils;
 import org.onebusaway.android.util.UIUtils;
 
 import android.content.ContentValues;
@@ -51,7 +52,7 @@ public class ArrivalsListAdapterStyleA extends ArrivalsListAdapterBase<ArrivalIn
             long currentTime) {
         if (arrivals != null) {
             ArrayList<ArrivalInfo> list =
-                    ArrivalInfo.convertObaArrivalInfo(getContext(),
+                    ArrivalInfoUtils.convertObaArrivalInfo(getContext(),
                             arrivals, routesFilter, currentTime, false);
             setData(list);
         } else {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListAdapterStyleB.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListAdapterStyleB.java
@@ -20,6 +20,8 @@ package org.onebusaway.android.ui;
 import org.onebusaway.android.R;
 import org.onebusaway.android.io.elements.ObaArrivalInfo;
 import org.onebusaway.android.provider.ObaContract;
+import org.onebusaway.android.util.ArrivalInfoUtils;
+import org.onebusaway.android.util.MyTextUtils;
 import org.onebusaway.android.util.UIUtils;
 import org.onebusaway.util.comparators.AlphanumComparator;
 
@@ -70,7 +72,7 @@ public class ArrivalsListAdapterStyleB extends ArrivalsListAdapterBase<CombinedA
             long currentTime) {
         if (arrivals != null) {
             ArrayList<ArrivalInfo> list =
-                    ArrivalInfo.convertObaArrivalInfo(getContext(),
+                    ArrivalInfoUtils.convertObaArrivalInfo(getContext(),
                             arrivals, routesFilter, currentTime, true);
 
             // Sort list by route and headsign, in that order

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListFragment.java
@@ -30,6 +30,7 @@ import org.onebusaway.android.map.MapParams;
 import org.onebusaway.android.provider.ObaContract;
 import org.onebusaway.android.report.ui.InfrastructureIssueActivity;
 import org.onebusaway.android.util.ArrayAdapterWithIcon;
+import org.onebusaway.android.util.ArrivalInfoUtils;
 import org.onebusaway.android.util.BuildFlavorUtils;
 import org.onebusaway.android.util.FragmentUtils;
 import org.onebusaway.android.util.LocationUtils;
@@ -838,7 +839,7 @@ public class ArrivalsListFragment extends ListFragment
         ArrayList<ArrivalInfo> list = null;
 
         if (mArrivalInfo != null) {
-            list = ArrivalInfo.convertObaArrivalInfo(getActivity(), mArrivalInfo, mRoutesFilter,
+            list = ArrivalInfoUtils.convertObaArrivalInfo(getActivity(), mArrivalInfo, mRoutesFilter,
                     System.currentTimeMillis(), true);
         }
         return list;

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListHeader.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListHeader.java
@@ -22,6 +22,7 @@ import org.onebusaway.android.io.ObaAnalytics;
 import org.onebusaway.android.io.elements.ObaArrivalInfo;
 import org.onebusaway.android.io.elements.ObaRegion;
 import org.onebusaway.android.provider.ObaContract;
+import org.onebusaway.android.util.ArrivalInfoUtils;
 import org.onebusaway.android.util.UIUtils;
 
 import android.annotation.TargetApi;
@@ -662,7 +663,7 @@ class ArrivalsListHeader {
 
         if (mArrivalInfo != null && !mInNameEdit) {
             // Get the indexes for arrival times that should be featured in the header
-            ArrayList<Integer> etaIndexes = ArrivalInfo.findPreferredArrivalIndexes(mArrivalInfo);
+            ArrayList<Integer> etaIndexes = ArrivalInfoUtils.findPreferredArrivalIndexes(mArrivalInfo);
             if (etaIndexes != null) {
                 // We have a non-negative ETA for at least one bus - fill the first arrival row
                 final int i1 = etaIndexes.get(0);

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/TripDetailsListFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/TripDetailsListFragment.java
@@ -26,6 +26,7 @@ import org.onebusaway.android.io.elements.ObaTripSchedule;
 import org.onebusaway.android.io.elements.ObaTripStatus;
 import org.onebusaway.android.io.request.ObaTripDetailsRequest;
 import org.onebusaway.android.io.request.ObaTripDetailsResponse;
+import org.onebusaway.android.util.ArrivalInfoUtils;
 import org.onebusaway.android.util.UIUtils;
 
 import android.content.Context;
@@ -324,7 +325,7 @@ public class TripDetailsListFragment extends ListFragment {
                         DateUtils.FORMAT_NO_MIDNIGHT
         );
 
-        statusColor = ArrivalInfo.computeColorFromDeviation(deviationMin);
+        statusColor = ArrivalInfoUtils.computeColorFromDeviation(deviationMin);
         if (statusColor != R.color.stop_info_ontime) {
             // Show early/late/scheduled color
             d.setColor(getResources().getColor(statusColor));
@@ -580,7 +581,7 @@ public class TripDetailsListFragment extends ListFragment {
                 deviation = mStatus.getScheduleDeviation();
                 long deviationMin = TimeUnit.SECONDS.toMinutes(mStatus.getScheduleDeviation());
                 if (mStatus.isPredicted()) {
-                    statusColor = ArrivalInfo.computeColorFromDeviation(deviationMin);
+                    statusColor = ArrivalInfoUtils.computeColorFromDeviation(deviationMin);
                 } else {
                     statusColor = R.color.stop_info_scheduled_time;
                 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/ArrivalInfoUtils.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/ArrivalInfoUtils.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright (C) 2016 University of South Florida (sjbarbeau@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.onebusaway.android.util;
+
+import org.onebusaway.android.R;
+import org.onebusaway.android.app.Application;
+import org.onebusaway.android.io.elements.ObaArrivalInfo;
+import org.onebusaway.android.ui.ArrivalInfo;
+
+import android.content.Context;
+import android.content.res.Resources;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+
+public class ArrivalInfoUtils {
+
+    final static class InfoComparator implements Comparator<ArrivalInfo> {
+
+        public int compare(ArrivalInfo lhs, ArrivalInfo rhs) {
+            return (int) (lhs.getEta() - rhs.getEta());
+        }
+    }
+
+    /**
+     * Converts the ObaArrivalInfo array received from the server to an ArrayList for the adapter
+     * @param context
+     * @param arrivalInfo
+     * @param filter routeIds to filter for
+     * @param ms current time in milliseconds
+     * @param includeArrivalDepartureInStatusLabel true if the arrival/departure label should be
+     *                                             included in the status label, false if it should
+     *                                             not
+     * @return ArrayList of arrival info to be used with the adapter
+     */
+    public static final ArrayList<ArrivalInfo> convertObaArrivalInfo(Context context,
+                                                                     ObaArrivalInfo[] arrivalInfo,
+                                                                     ArrayList<String> filter, long ms,
+                                                                     boolean includeArrivalDepartureInStatusLabel) {
+        final int len = arrivalInfo.length;
+        ArrayList<ArrivalInfo> result = new ArrayList<ArrivalInfo>(len);
+        if (filter != null && filter.size() > 0) {
+            // Only add routes that haven't been filtered out
+            for (int i = 0; i < len; ++i) {
+                ObaArrivalInfo arrival = arrivalInfo[i];
+                if (filter.contains(arrival.getRouteId())) {
+                    ArrivalInfo info = new ArrivalInfo(context, arrival, ms,
+                            includeArrivalDepartureInStatusLabel);
+                    if (shouldAddEta(info)) {
+                        result.add(info);
+                    }
+                }
+            }
+        } else {
+            // Add arrivals for all routes
+            for (int i = 0; i < len; ++i) {
+                ArrivalInfo info = new ArrivalInfo(context, arrivalInfo[i], ms,
+                        includeArrivalDepartureInStatusLabel);
+                if (shouldAddEta(info)) {
+                    result.add(info);
+                }
+            }
+        }
+
+        // Sort by ETA
+        Collections.sort(result, new InfoComparator());
+        return result;
+    }
+
+    /**
+     * Returns true if this ETA should be added based on the user preference for adding negative
+     * arrival times, and false if it should not
+     *
+     * @param info info that includes the ETA to be evaluated
+     * @return true if this ETA should be added based on the user preference for adding negative
+     * arrival times, and false if it should not
+     */
+    private static boolean shouldAddEta(ArrivalInfo info) {
+        boolean showNegativeArrivals = Application.getPrefs()
+                .getBoolean(Application.get().getResources()
+                        .getString(R.string.preference_key_show_negative_arrivals), true);
+        if (info.getEta() >= 0) {
+            // Always add positive ETAs
+            return true;
+        } else {
+            // Only add negative ETAs based on setting
+            if (showNegativeArrivals) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Returns the index in the provided infoList for the first non-negative arrival ETA in the
+     * list, or -1 if no non-negative ETAs exist in the list
+     *
+     * @param infoList list to search for non-negative arrival times, ordered by relative ETA from
+     *                 negative infinity to positive infinity
+     * @return the index in the provided infoList for the first non-negative arrival ETA in the
+     * list, or -1 if no non-negative ETAs exist in the list
+     */
+    public static int findFirstNonNegativeArrival(ArrayList<ArrivalInfo> infoList) {
+        for (int i = 0; i < infoList.size(); i++) {
+            ArrivalInfo info = infoList.get(i);
+            if (info.getEta() >= 0) {
+                return i;
+            }
+        }
+        // We didn't find any non-negative ETAs
+        return -1;
+    }
+
+    /**
+     * Returns the indexes in the provided infoList for the preferred route/headsign combinations
+     * to be prioritized for displayed in the header, or null if no non-negative ETAs exist in the
+     * list.  If no route/headsign combinations are favorited, the indexes returned may simply be
+     * the indexes of the first (and second, if it exists) non-negative arrival times.
+     *
+     * @param infoList list to search for non-negative arrival times, ordered by relative ETA from
+     *                 negative infinity to positive infinity
+     * @return the indexes in the provided infoList for the preferred route/headsign combinations
+     * to be prioritized for displayed in the header, or null if no non-negative ETAs exist in the
+     * list
+     */
+    public static ArrayList<Integer> findPreferredArrivalIndexes(ArrayList<ArrivalInfo> infoList) {
+        // Start by getting the index of the first non-negative arrival time
+        int firstIndex = findFirstNonNegativeArrival(infoList);
+        if (firstIndex == -1) {
+            return null;
+        }
+        // Find any favorites
+        ArrayList<Integer> preferredIndexes = new ArrayList<>();
+        for (int i = firstIndex; i < infoList.size(); i++) {
+            ArrivalInfo info = infoList.get(i);
+            if (info.isRouteAndHeadsignFavorite()) {
+                preferredIndexes.add(i);
+            }
+        }
+
+        // If we have at least two favorites, that's enough to fill the header - return them
+        if (preferredIndexes.size() >= 2) {
+            return preferredIndexes;
+        }
+
+        // If we have one favorite, and the index is different from the firstIndex, then add the firstIndex and return
+        if (preferredIndexes.size() == 1 && preferredIndexes.get(0) != firstIndex) {
+            preferredIndexes.add(firstIndex);
+        }
+
+        // If we have no preferred indexes (i.e., starred route/headsigns) at this point, then add the firstIndex
+        if (preferredIndexes.size() == 0) {
+            preferredIndexes.add(firstIndex);
+
+            // If there is another non-negative arrival time, then add it too
+            int secondIndex = firstIndex + 1;
+            if (secondIndex < infoList.size()) {
+                preferredIndexes.add(secondIndex);
+            }
+        }
+
+        return preferredIndexes;
+    }
+
+    /**
+     * Returns the status color to be used, depending on whether the vehicle is running early,
+     * late,
+     * ontime,
+     * or if we don't have real-time info (i.e., scheduled)
+     *
+     * @param scheduled the scheduled time, in minutes past unix epoch
+     * @param predicted the predicted time, in minutes past unix epoch
+     * @return the status color to be used, depending on whether the vehicle is running early, late,
+     * ontime,
+     * or if we don't have real-time info (i.e., scheduled)
+     */
+    public static int computeColor(final long scheduled, final long predicted) {
+        if (predicted != 0) {
+            return computeColorFromDeviation(predicted - scheduled);
+        } else {
+            // Use scheduled color
+            return R.color.stop_info_scheduled_time;
+        }
+    }
+
+    /**
+     * Returns the status color to be used, depending on whether the vehicle is running early,
+     * late,
+     * ontime,
+     * or if we don't have real-time info (i.e., scheduled)
+     *
+     * @param delay the deviation from the scheduled time, in minutes - positive means bus is
+     *              running late,
+     *              negative means early
+     * @return the status color to be used, depending on whether the vehicle is running early, late,
+     * ontime,
+     * or if we don't have real-time info (i.e., scheduled)
+     */
+    public static int computeColorFromDeviation(final long delay) {
+        // Bus is arriving
+        if (delay > 0) {
+            // Arriving delayed
+            return R.color.stop_info_delayed;
+        } else if (delay < 0) {
+            // Arriving early
+            return R.color.stop_info_early;
+        } else {
+            // Arriving on time
+            return R.color.stop_info_ontime;
+        }
+    }
+
+    /**
+     * Computes the arrival status label from the delay (i.e., schedule deviation), where positive
+     * means the bus is running late and negative means the bus is running ahead of schedule
+     *
+     * @param delay schedule deviation, in minutes, for this vehicle where positive
+     *              means the bus is running late and negative means the bus is running ahead of
+     *              schedule
+     * @return the arrival status label based on the deviation
+     */
+    public static String computeArrivalLabelFromDelay(Resources res, long delay) {
+        if (delay > 0) {
+            // Arriving delayed
+            return res.getQuantityString(
+                    R.plurals.stop_info_arrive_delayed, (int) delay,
+                    delay);
+        } else if (delay < 0) {
+            // Arriving early
+            delay = -delay;
+            return res
+                    .getQuantityString(
+                            R.plurals.stop_info_arrive_early,
+                            (int) delay, delay);
+        } else {
+            // Arriving on time
+            return res.getString(R.string.stop_info_ontime);
+        }
+    }
+}

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -418,10 +418,12 @@
     <string name="trip_list_context_showroute">Show route</string>
 
     <!--  Trip notifications -->
-    <string name="trip_stat_gone">Route %s has departed.</string>
-    <string name="trip_stat_lessthanone">Route %s is less than a minute away!</string>
-    <string name="trip_stat_one">Route %s is 1 minute away!</string>
-    <string name="trip_stat">Route %1$s is %2$d minutes away!</string>
+    <string name="trip_stat_gone_arrived">Route %s has arrived.</string>
+    <string name="trip_stat_gone_departed">Route %s has departed.</string>
+    <string name="trip_stat_lessthanone_arriving">Route %s is arriving now!</string>
+    <string name="trip_stat_lessthanone_departing">Route %s is departing now!</string>
+    <string name="trip_stat_arriving">Route %1$s is arriving in %2$d min!</string>
+    <string name="trip_stat_departing">Route %1$s is departing in %2$d min!</string>
 
     <!-- Report problem -->
     <string name="report_problem_comment_hint">Problem description (optional)</string>


### PR DESCRIPTION
Add arrival and departure information to reminder notification text:

![device-2016-05-16-222541](https://cloud.githubusercontent.com/assets/2777974/15309544/c64e0db6-1bb5-11e6-9d78-bb83ace78192.png)

PR #499 was closed without being merged. Therefore, I am opening a new PR.

cc'd @barbeau 
