### PR TITLE
Fix #730 - Properly scale image for issue reports

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/BaseReportActivity.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/BaseReportActivity.java
@@ -50,7 +50,7 @@ public class BaseReportActivity extends AppCompatActivity {
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
-        if (resultCode == RESULT_OK && data.getBooleanExtra(CLOSE_REQUEST, false)){
+        if (resultCode == RESULT_OK && data != null && data.getBooleanExtra(CLOSE_REQUEST, false)) {
             finish();
         }
     }

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -633,6 +633,8 @@
     <string name="ri_button_gallery">Gallery</string>
     <string name="ri_address_not_found">Address not found. Please check your address.</string>
     <string name="ri_service_description_problem">Service description could not be found.</string>
+    <string name="ri_open_camera_problem">Camera couldn\'t be opened.</string>
+    <string name="ri_resize_image_problem">Image couldn\'t be resized - using full size.</string>
     <string name="ri_service_default">Choose a Problem</string>
     <string name="ri_service_stop">Stop Problem</string>
     <string name="ri_service_trip">Arrival Time Problem</string>
@@ -642,7 +644,7 @@
     <string name="ri_user_phone_hint">Phone number</string>
     <string name="ri_no_trip">No arrival times, please check back later.</string>
     <string name="ri_anonymous_checkbox">Keep it anonymous</string>
-    <string name="ri_submitting_message">Submitting your report</string>
+    <string name="ri_submitting_message">Submitting your report…</string>
     <string name="ri_unsuccessful_submit">An error occurred during submission, please try again later.</string>
 
     <!-- report issue types screen-->


### PR DESCRIPTION
* Capture full size Bitmap from camera instead of thumbnail
* Scale down full size bitmap from gallery or camera to the size of the ImageView for showing the thumbnail (avoids the OutOfMemoryError), and to the maximum resolution for use in SeeClickFix (800x600 max) before uploading to Open311 API endpoint.
* Correct for possible image rotation
* Change image name to be auto-generated from date to avoid collisions in file names