### PR TITLE
Fix #769 - Add custom reminder notification names

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -11,3 +11,4 @@ We'd like to thank the following developers who have contributed to OneBusAway A
 * Mike Karabushin
 * Aziz Batihk
 * Charles Bond
+* Bridgette Eichelberger (bridgette@outlook.com)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/tripservice/NotifierTask.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/tripservice/NotifierTask.java
@@ -16,6 +16,10 @@
  */
 package org.onebusaway.android.tripservice;
 
+import org.onebusaway.android.R;
+import org.onebusaway.android.provider.ObaContract;
+import org.onebusaway.android.ui.ArrivalsListActivity;
+
 import android.app.Notification;
 import android.app.PendingIntent;
 import android.content.ContentResolver;
@@ -24,10 +28,6 @@ import android.content.Intent;
 import android.database.Cursor;
 import android.net.Uri;
 import android.support.v4.app.NotificationCompat;
-
-import org.onebusaway.android.R;
-import org.onebusaway.android.provider.ObaContract;
-import org.onebusaway.android.ui.ArrivalsListActivity;
 
 /**
  * A task (thread) that is responsible for generating a Notification to remind the user of an
@@ -61,14 +61,18 @@ public final class NotifierTask implements Runnable {
 
     private String mNotifyText;
 
+    private String mNotifyTitle;
+
     public NotifierTask(Context context,
                         TaskContext taskContext,
                         Uri uri,
+                        String notifyTitle,
                         String notifyText) {
         mContext = context;
         mTaskContext = taskContext;
         mCR = mContext.getContentResolver();
         mUri = uri;
+        mNotifyTitle = notifyTitle;
         mNotifyText = notifyText;
     }
 
@@ -111,7 +115,7 @@ public final class NotifierTask implements Runnable {
                 new ArrivalsListActivity.Builder(mContext, stopId).getIntent(),
                 PendingIntent.FLAG_UPDATE_CURRENT);
 
-        Notification notification = createNotification(mNotifyText,
+        Notification notification = createNotification(mNotifyTitle, mNotifyText,
                 pendingContentIntent, pendingDeleteIntent);
 
         mTaskContext.setNotification(id, notification);
@@ -132,13 +136,15 @@ public final class NotifierTask implements Runnable {
      * Create a notification and populate it with our latest data.  This method replaces
      * an implementation using Notification.setLatestEventInfo((), which was deprecated (see #290).
      *
+     * @param notifyTitle   notification title
+     * @param notifyText    notification text
      * @param contentIntent intent to fire on click
      * @param deleteIntent  intent to remove/delete
      */
-    private Notification createNotification(String notifyText,
+    private Notification createNotification(String notifyTitle,
+                                            String notifyText,
                                             PendingIntent contentIntent,
                                             PendingIntent deleteIntent) {
-        final String title = mContext.getString(R.string.app_name);
         return new NotificationCompat.Builder(mContext)
                 .setSmallIcon(R.drawable.ic_stat_notification)
                 .setDefaults(Notification.DEFAULT_ALL)
@@ -147,7 +153,7 @@ public final class NotifierTask implements Runnable {
                 //.setVibrate(VIBRATE_PATTERN)
                 .setContentIntent(contentIntent)
                 .setDeleteIntent(deleteIntent)
-                .setContentTitle(title)
+                .setContentTitle(notifyTitle)
                 .setContentText(notifyText)
                 .build();
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/tripservice/PollerTask.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/tripservice/PollerTask.java
@@ -16,12 +16,6 @@
  */
 package org.onebusaway.android.tripservice;
 
-import android.content.ContentResolver;
-import android.content.ContentValues;
-import android.content.Context;
-import android.database.Cursor;
-import android.net.Uri;
-
 import org.onebusaway.android.io.ObaApi;
 import org.onebusaway.android.io.elements.ObaArrivalInfo;
 import org.onebusaway.android.io.request.ObaArrivalInfoRequest;
@@ -29,6 +23,12 @@ import org.onebusaway.android.io.request.ObaArrivalInfoResponse;
 import org.onebusaway.android.provider.ObaContract;
 import org.onebusaway.android.ui.ArrivalInfo;
 import org.onebusaway.android.util.UIUtils;
+
+import android.content.ContentResolver;
+import android.content.ContentValues;
+import android.content.Context;
+import android.database.Cursor;
+import android.net.Uri;
 
 /**
  * A task (thread) that is responsible for polling the server to determine if a Notification to
@@ -137,9 +137,14 @@ public final class PollerTask implements Runnable {
                 // Bus is within the reminder interval (or it possibly has left!)
                 // Send off a notification.
                 //Log.d(TAG, "Notify for trip: " + alertUri);
-                TripService.notifyTrip(mContext, mUri, arrivalInfo.getNotifyText());
+                TripService.notifyTrip(mContext, mUri, getReminderName(tripId, stopId), arrivalInfo.getNotifyText());
             }
         }
+    }
+
+    private String getReminderName(String tripId, String stopId) {
+        final Uri uri = ObaContract.Trips.buildUri(tripId, stopId);
+        return UIUtils.stringForQuery(mContext, uri, ObaContract.Trips.NAME);
     }
 
     private long getReminderMin(String tripId, String stopId) {
@@ -151,7 +156,6 @@ public final class PollerTask implements Runnable {
      * Checks arrivals from given ObaArrivalInfoResponse
      *
      * @param response arrival information
-     * @param tripId
      * @return ArrivalInfo, or return null if the arrival can't be found.
      */
     private ArrivalInfo checkArrivals(ObaArrivalInfoResponse response, String tripId) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/tripservice/PollerTask.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/tripservice/PollerTask.java
@@ -156,6 +156,7 @@ public final class PollerTask implements Runnable {
      * Checks arrivals from given ObaArrivalInfoResponse
      *
      * @param response arrival information
+     * @param tripId trip id 
      * @return ArrivalInfo, or return null if the arrival can't be found.
      */
     private ArrivalInfo checkArrivals(ObaArrivalInfoResponse response, String tripId) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/tripservice/SchedulerTask.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/tripservice/SchedulerTask.java
@@ -143,9 +143,9 @@ public final class SchedulerTask implements Runnable {
     }
 
     private boolean scheduleAlert(Uri uri,
-            String tripId,
-            String stopId,
-            long triggerTime) {
+                                  String tripId,
+                                  String stopId,
+                                  long triggerTime) {
 
         Time tmp = new Time();
         tmp.set(triggerTime);

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -778,7 +778,8 @@
         "* Cagri Cetin\n"
         "* Mike Karabushin\n"
         "* Aziz Batihk\n"
-        "* Charles Bond\n\n"
+        "* Charles Bond\n"
+        "* Bridgette Eichelberger\n\n"
 
         "Want to contribute to this app? Check it out on Github at
         https://github.com/OneBusAway/onebusaway-android.\n\n"


### PR DESCRIPTION
#769 Replace app name in notification title with user-inputted notification name. Small style fixes to changed files.

__________________

**Existing**

Existing reminder notification; title is app name.

![existing](https://user-images.githubusercontent.com/6608362/28809457-62777b0e-7638-11e7-8d92-f24482bf0b4a.PNG)

_______________________________________________

**Proposed**

User sets reminder name as before... 
![proposed-1](https://user-images.githubusercontent.com/6608362/28809458-627789fa-7638-11e7-9c70-de4ca1c9dc5d.PNG)

... which is the new notification title.
![proposed-2](https://user-images.githubusercontent.com/6608362/28809456-6272a886-7638-11e7-91bf-f8d68f89693d.PNG)


___________________________________________


- [X] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [X] Run the unit tests with `gradlew connectedObaGoogleDebugAndroidTest connectedObaAmazonDebugAndroidTest` to make sure you didn't break anything

- [X] If you have multiple commits please combine them into one commit by squashing them.