### PR TITLE
Fix #609 - Add custom reminder sound and vibration

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/tripservice/NotifierTask.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/tripservice/NotifierTask.java
@@ -66,8 +66,6 @@ public final class NotifierTask implements Runnable {
 
     private String mNotifyTitle;
 
-    private SharedPreferences mSettings;
-
     public NotifierTask(Context context,
                         TaskContext taskContext,
                         Uri uri,
@@ -79,8 +77,6 @@ public final class NotifierTask implements Runnable {
         mUri = uri;
         mNotifyTitle = notifyTitle;
         mNotifyText = notifyText;
-
-        mSettings = Application.getPrefs();
     }
 
     @Override
@@ -150,12 +146,14 @@ public final class NotifierTask implements Runnable {
                 .setContentTitle(notifyTitle)
                 .setContentText(notifyText);
 
-        boolean vibratePreference = mSettings.getBoolean("preference_vibrate_allowed", true);
+        SharedPreferences appPrefs = Application.getPrefs();
+
+        boolean vibratePreference = appPrefs.getBoolean("preference_vibrate_allowed", true);
         if (vibratePreference) {
             notifyBuilder.setDefaults(Notification.DEFAULT_VIBRATE);
         }
 
-        String soundPreference = mSettings.getString("preference_notification_sound", "");
+        String soundPreference = appPrefs.getString("preference_notification_sound", "");
         if (soundPreference.isEmpty()) {
             notifyBuilder.setSound(Settings.System.DEFAULT_NOTIFICATION_URI);
         } else {

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -620,6 +620,12 @@
     <string name="minutes_abbreviation">min</string>
     <string name="minutes_full">minutes</string>
 
+    <string name="preferences_preferred_vibration_title">Vibrate</string>
+    <string name="preferences_preferred_vibration_summary">Let OneBusAway notifications vibrate</string>
+
+    <string name="preferences_preferred_sound_title">Reminder sound</string>
+    <string name="preferences_preferred_sound_summary">Select the OneBusAway notification tone</string>
+
     <!-- Navigation Drawer -->
     <string name="navigation_drawer_open">Open navigation drawer</string>
     <string name="navigation_drawer_close">Close navigation drawer</string>

--- a/onebusaway-android/src/main/res/xml/preferences.xml
+++ b/onebusaway-android/src/main/res/xml/preferences.xml
@@ -59,6 +59,18 @@
     <PreferenceCategory
             android:key="@string/preference_key_notifications"
             android:title="@string/preferences_category_notifications">
+        <RingtonePreference
+                android:showDefault="true"
+                android:showSilent="true"
+                android:key="preference_notification_sound"
+                android:title="@string/preferences_preferred_sound_title"
+                android:summary="@string/preferences_preferred_sound_summary"
+                android:ringtoneType="notification" />
+        <CheckBoxPreference
+            android:key="preference_vibrate_allowed"
+            android:title="@string/preferences_preferred_vibration_title"
+            android:summary="@string/preferences_preferred_vibration_summary"
+            android:defaultValue="true"/>
         <CheckBoxPreference
             android:key="@string/preference_key_trip_plan_notifications"
             android:title="@string/preferences_trip_plan_notifications_title"


### PR DESCRIPTION
Per user request, add settings to toggle vibration and customize notification sounds. This PR also removes old commented-out code that demo'd the (at the time, new) android notification builder. 

User has additional settings under Notifications:
![notifications](https://user-images.githubusercontent.com/6608362/30531110-e569bb88-9c00-11e7-808f-8b4f47747ff0.PNG)

Tapping on reminder sound brings up the standard Android sound picker:

![reminder_sound](https://user-images.githubusercontent.com/6608362/30531109-e5691d72-9c00-11e7-90a9-3d2e48bfbdde.PNG)

Notifications sent from OneBusAway adhere to these user preferences.


_________________________________________________

- [X] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [X] Run the unit tests with `gradlew connectedObaGoogleDebugAndroidTest connectedObaAmazonDebugAndroidTest` to make sure you didn't break anything

- [X] If you have multiple commits please combine them into one commit by squashing them.