### PR TITLE
Fix #803 - Initialize map layer FAB on startup, then manage visibility

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.java
@@ -1538,7 +1538,7 @@ public class HomeActivity extends AppCompatActivity
         } else {
             mLayersFab.setVisibility(View.GONE);
         }
-        mLayersFab.requestLayout();
+        mLayersFab.rebuildSpeedDialMenu();
     }
 
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.java
@@ -16,6 +16,36 @@
  */
 package org.onebusaway.android.ui;
 
+import com.google.android.gms.common.ConnectionResult;
+import com.google.android.gms.common.GoogleApiAvailability;
+import com.google.android.gms.common.api.GoogleApiClient;
+
+import com.sothree.slidinguppanel.SlidingUpPanelLayout;
+
+import org.onebusaway.android.BuildConfig;
+import org.onebusaway.android.R;
+import org.onebusaway.android.app.Application;
+import org.onebusaway.android.io.ObaAnalytics;
+import org.onebusaway.android.io.elements.ObaRegion;
+import org.onebusaway.android.io.elements.ObaRoute;
+import org.onebusaway.android.io.elements.ObaStop;
+import org.onebusaway.android.io.request.ObaArrivalInfoResponse;
+import org.onebusaway.android.map.MapModeController;
+import org.onebusaway.android.map.MapParams;
+import org.onebusaway.android.map.googlemapsv2.BaseMapFragment;
+import org.onebusaway.android.map.googlemapsv2.LayerInfo;
+import org.onebusaway.android.region.ObaRegionsTask;
+import org.onebusaway.android.report.ui.ReportActivity;
+import org.onebusaway.android.tripservice.TripService;
+import org.onebusaway.android.util.FragmentUtils;
+import org.onebusaway.android.util.LayerUtils;
+import org.onebusaway.android.util.LocationUtils;
+import org.onebusaway.android.util.PreferenceUtils;
+import org.onebusaway.android.util.RegionUtils;
+import org.onebusaway.android.util.ShowcaseViewUtils;
+import org.onebusaway.android.util.UIUtils;
+import org.opentripplanner.routing.bike_rental.BikeRentalStation;
+
 import android.app.Dialog;
 import android.content.Context;
 import android.content.DialogInterface;
@@ -54,35 +84,6 @@ import android.widget.ProgressBar;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 import android.widget.Toast;
-
-import com.google.android.gms.common.ConnectionResult;
-import com.google.android.gms.common.GoogleApiAvailability;
-import com.google.android.gms.common.api.GoogleApiClient;
-import com.sothree.slidinguppanel.SlidingUpPanelLayout;
-
-import org.onebusaway.android.BuildConfig;
-import org.onebusaway.android.R;
-import org.onebusaway.android.app.Application;
-import org.onebusaway.android.io.ObaAnalytics;
-import org.onebusaway.android.io.elements.ObaRegion;
-import org.onebusaway.android.io.elements.ObaRoute;
-import org.onebusaway.android.io.elements.ObaStop;
-import org.onebusaway.android.io.request.ObaArrivalInfoResponse;
-import org.onebusaway.android.map.MapModeController;
-import org.onebusaway.android.map.MapParams;
-import org.onebusaway.android.map.googlemapsv2.BaseMapFragment;
-import org.onebusaway.android.map.googlemapsv2.LayerInfo;
-import org.onebusaway.android.region.ObaRegionsTask;
-import org.onebusaway.android.report.ui.ReportActivity;
-import org.onebusaway.android.tripservice.TripService;
-import org.onebusaway.android.util.FragmentUtils;
-import org.onebusaway.android.util.LayerUtils;
-import org.onebusaway.android.util.LocationUtils;
-import org.onebusaway.android.util.PreferenceUtils;
-import org.onebusaway.android.util.RegionUtils;
-import org.onebusaway.android.util.ShowcaseViewUtils;
-import org.onebusaway.android.util.UIUtils;
-import org.opentripplanner.routing.bike_rental.BikeRentalStation;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -327,11 +328,11 @@ public class HomeActivity extends AppCompatActivity
 
         setupMapState(savedInstanceState);
 
+        setupLayersSpeedDial();
+
         setupMyLocationButton();
 
         setupGooglePlayServices();
-
-        setupLayersSpeedDial();
 
         UIUtils.setupActionBar(this);
 
@@ -1474,14 +1475,61 @@ public class HomeActivity extends AppCompatActivity
     }
 
     private void setupLayersSpeedDial() {
-
         mLayersFab = (uk.co.markormesher.android_fab.FloatingActionButton) findViewById(R.id.layersSpeedDial);
 
         ViewGroup.MarginLayoutParams p = (ViewGroup.MarginLayoutParams) mLayersFab
                 .getLayoutParams();
-
         LAYERS_FAB_DEFAULT_BOTTOM_MARGIN = p.bottomMargin;
 
+        mLayersFab.setIcon(R.drawable.ic_layers_white_24dp);
+        mLayersFab.setBackgroundColour(ContextCompat.getColor(this, R.color.theme_accent));
+
+        LayersSpeedDialAdapter adapter = new LayersSpeedDialAdapter(this);
+        // Add the BaseMapFragment listener to activate the layer on the map
+        adapter.addLayerActivationListener(mMapFragment);
+
+        // Add another listener to rebuild the menu options after selection. This other listener
+        // was added here because the call to rebuildSpeedDialMenu exists on the FAB and we have a
+        // reference to it only in the main activity.
+        adapter.addLayerActivationListener(new LayersSpeedDialAdapter.LayerActivationListener() {
+            @Override
+            public void onActivateLayer(LayerInfo layer) {
+                Handler h = new Handler(getMainLooper());
+                h.postDelayed(new Runnable() {
+                    @Override
+                    public void run() {
+                        mLayersFab.rebuildSpeedDialMenu();
+                    }
+                }, 100);
+            }
+
+            @Override
+            public void onDeactivateLayer(LayerInfo layer) {
+                Handler h = new Handler(getMainLooper());
+                h.postDelayed(new Runnable() {
+                    @Override
+                    public void run() {
+                        mLayersFab.rebuildSpeedDialMenu();
+                    }
+                }, 100);
+            }
+        });
+        mLayersFab.setMenuAdapter(adapter);
+        mLayersFab.setOnSpeedDialOpenListener(
+                new uk.co.markormesher.android_fab.FloatingActionButton.OnSpeedDialOpenListener() {
+                    @Override
+                    public void onOpen(uk.co.markormesher.android_fab.FloatingActionButton v) {
+                        mLayersFab.setIcon(R.drawable.ic_add_white_24dp);
+                    }
+                });
+        mLayersFab.setOnSpeedDialCloseListener(
+                new uk.co.markormesher.android_fab.FloatingActionButton.OnSpeedDialCloseListener() {
+                    @Override
+                    public void onClose(uk.co.markormesher.android_fab.FloatingActionButton v) {
+                        mLayersFab.setIcon(R.drawable.ic_layers_white_24dp);
+                    }
+                });
+        mLayersFab.setContentCoverEnabled(false);
     }
 
     /**
@@ -1489,61 +1537,13 @@ public class HomeActivity extends AppCompatActivity
      * is updated
      */
     private void updateLayersFab() {
-        if (Application.isBikeshareEnabled()) {
-            if (mCurrentNavDrawerPosition == NAVDRAWER_ITEM_NEARBY) {
-                mLayersFab.setVisibility(View.VISIBLE);
-
-                mLayersFab.setIcon(R.drawable.ic_layers_white_24dp);
-                mLayersFab.setBackgroundColour(ContextCompat.getColor(this, R.color.theme_accent));
-
-                LayersSpeedDialAdapter adapter = new LayersSpeedDialAdapter(this);
-                // Add the BaseMapFragment listener to activate the layer on the map
-                adapter.addLayerActivationListener(mMapFragment);
-
-                // Add another listener to rebuild the menu options after selection. This other listener
-                // was added here because the call to rebuildSpeedDialMenu exists on the FAB and we have a
-                // reference to it only in the main activity.
-                adapter.addLayerActivationListener(new LayersSpeedDialAdapter.LayerActivationListener() {
-                    @Override
-                    public void onActivateLayer(LayerInfo layer) {
-                        Handler h = new Handler(getMainLooper());
-                        h.postDelayed(new Runnable() {
-                            @Override
-                            public void run() {
-                                mLayersFab.rebuildSpeedDialMenu();
-                            }
-                        }, 100);
-                    }
-
-                    @Override
-                    public void onDeactivateLayer(LayerInfo layer) {
-                        Handler h = new Handler(getMainLooper());
-                        h.postDelayed(new Runnable() {
-                            @Override
-                            public void run() {
-                                mLayersFab.rebuildSpeedDialMenu();
-                            }
-                        }, 100);
-                    }
-                });
-                mLayersFab.setMenuAdapter(adapter);
-                mLayersFab.setOnSpeedDialOpenListener(new uk.co.markormesher.android_fab.FloatingActionButton.OnSpeedDialOpenListener() {
-                    @Override
-                    public void onOpen(uk.co.markormesher.android_fab.FloatingActionButton v) {
-                        mLayersFab.setIcon(R.drawable.ic_add_white_24dp);
-                    }
-                });
-                mLayersFab.setOnSpeedDialCloseListener(new uk.co.markormesher.android_fab.FloatingActionButton.OnSpeedDialCloseListener() {
-                    @Override
-                    public void onClose(uk.co.markormesher.android_fab.FloatingActionButton v) {
-                        mLayersFab.setIcon(R.drawable.ic_layers_white_24dp);
-                    }
-                });
-                mLayersFab.setContentCoverEnabled(false);
-            }
+        if (Application.isBikeshareEnabled()
+                && mCurrentNavDrawerPosition == NAVDRAWER_ITEM_NEARBY) {
+            mLayersFab.setVisibility(View.VISIBLE);
         } else {
             mLayersFab.setVisibility(View.GONE);
         }
+        mLayersFab.requestLayout();
     }
 
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.java
@@ -901,21 +901,17 @@ public class HomeActivity extends AppCompatActivity
                     getString(R.string.analytics_action_button_press),
                     getString(R.string.analytics_label_button_press_map_icon));
         } else {
-            hideBusStopFragment();
+            // No stop is in focus (e.g., user tapped on the map), so hide the panel
+            // and clear the currently focused stopId
+            mFocusedStopId = null;
+            moveFabsLocation();
+            mSlidingPanel.setPanelState(SlidingUpPanelLayout.PanelState.HIDDEN);
+            if (mArrivalsListFragment != null) {
+                FragmentManager fm = getSupportFragmentManager();
+                fm.beginTransaction().remove(mArrivalsListFragment).commit();
+            }
+            mShowArrivalsMenu = false;
         }
-    }
-
-    private void hideBusStopFragment() {
-        // No stop is in focus (e.g., user tapped on the map), so hide the panel
-        // and clear the currently focused stopId
-        mFocusedStopId = null;
-        moveFabsLocation();
-        mSlidingPanel.setPanelState(SlidingUpPanelLayout.PanelState.HIDDEN);
-        if (mArrivalsListFragment != null) {
-            FragmentManager fm = getSupportFragmentManager();
-            fm.beginTransaction().remove(mArrivalsListFragment).commit();
-        }
-        mShowArrivalsMenu = false;
     }
 
     /**
@@ -937,7 +933,6 @@ public class HomeActivity extends AppCompatActivity
             mBikeRentalStationId = null;
         } else {
             mBikeRentalStationId = bikeRentalStation.id;
-            //hideBusStopFragment();
         }
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/LayersSpeedDialAdapter.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/LayersSpeedDialAdapter.java
@@ -15,17 +15,17 @@
  */
 package org.onebusaway.android.ui;
 
+import org.onebusaway.android.R;
+import org.onebusaway.android.map.googlemapsv2.BaseMapFragment;
+import org.onebusaway.android.map.googlemapsv2.LayerInfo;
+import org.onebusaway.android.util.LayerUtils;
+
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.graphics.Color;
 import android.os.Build;
 import android.preference.PreferenceManager;
 import android.widget.TextView;
-
-import org.onebusaway.android.R;
-import org.onebusaway.android.map.googlemapsv2.BaseMapFragment;
-import org.onebusaway.android.map.googlemapsv2.LayerInfo;
-import org.onebusaway.android.util.LayerUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -75,9 +75,7 @@ public class LayersSpeedDialAdapter extends SpeedDialMenuAdapter {
 
     private void setupActivated() {
         activatedLayers = new Boolean[1];
-
-        boolean isBikeLayerActivated = LayerUtils.isBikeshareLayerVisible();
-        activatedLayers[0] = isBikeLayerActivated;
+        activatedLayers[0] = LayerUtils.isBikeshareLayerVisible();
     }
 
     @Override
@@ -88,6 +86,8 @@ public class LayersSpeedDialAdapter extends SpeedDialMenuAdapter {
     @SuppressWarnings("deprecation")
     @Override
     protected MenuItem getViews(Context context, int position) {
+        // Refresh active layer info
+        activatedLayers[0] = LayerUtils.isBikeshareLayerVisible();
 
         LayerInfo layer = layers[position];
         MenuItem menuItem = new MenuItem();
@@ -148,6 +148,9 @@ public class LayersSpeedDialAdapter extends SpeedDialMenuAdapter {
     @SuppressWarnings("deprecation")
     @Override
     protected int getBackgroundColour(int position) {
+        // Refresh active layer info
+        activatedLayers[0] = LayerUtils.isBikeshareLayerVisible();
+
         int activatedColor = layers[position].getLayerColor();
         int deactivatedColor = context.getResources().getColor(R.color.layer_disabled);
         return activatedLayers[position] ?


### PR DESCRIPTION
* This moves the initialization of the map layer FAB into the setup method called from HomeActivity.onCreate(), so it's initialized no matter what the initial visiblity state should be.  Then, based on the region availability of bikeshare and which fragment is currently visible (e.g., Starred Stops or My reminders), the visiblity is toggled.  This treats the map layer FAB similarly to how the My Location FAB is treated.

@carvalhorr Could you please review to make sure I didn't miss anything?  My primary concern is to make sure we're not triggering bikeshare API calls even when the other non-map fragments are visible and the map isn't.  From my testing it seems like this solution wouldn't have that side-effect, but I'd like you to have a look just to make sure.