### PR TITLE
Fix #765 - Allow sorting reminders by departure time

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/MyRemindersFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/MyRemindersFragment.java
@@ -20,9 +20,12 @@ import org.onebusaway.android.R;
 import org.onebusaway.android.io.ObaAnalytics;
 import org.onebusaway.android.provider.ObaContract;
 import org.onebusaway.android.tripservice.TripService;
+import org.onebusaway.android.util.PreferenceUtils;
 import org.onebusaway.android.util.UIUtils;
 
+import android.app.AlertDialog;
 import android.content.ContentResolver;
+import android.content.DialogInterface;
 import android.database.ContentObserver;
 import android.database.Cursor;
 import android.os.Bundle;
@@ -31,7 +34,11 @@ import android.support.v4.app.LoaderManager;
 import android.support.v4.content.CursorLoader;
 import android.support.v4.content.Loader;
 import android.support.v4.widget.SimpleCursorAdapter;
+import android.util.Log;
 import android.view.ContextMenu;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.ListView;
@@ -91,6 +98,8 @@ public final class MyRemindersFragment extends ListFragment
     public void onActivityCreated(Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
 
+        setHasOptionsMenu(true);
+        setReminderOrder();
         // Set empty text
         setEmptyText(getString(R.string.trip_list_notrips));
         registerForContextMenu(getListView());
@@ -129,6 +138,21 @@ public final class MyRemindersFragment extends ListFragment
         super.onDestroy();
     }
 
+    private int mCurrentSortOrder;
+    private static String sortBy;
+
+    private void setReminderOrder() {
+        mCurrentSortOrder = PreferenceUtils.getReminderSortOrderFromPreferences();
+        switch (mCurrentSortOrder) {
+            case 0: //sort by name
+                sortBy = ObaContract.Trips.NAME + " asc";
+                break;
+            case 1:
+                sortBy = ObaContract.Trips.DEPARTURE + " asc";
+                break;
+        }
+    }
+
     @Override
     public Loader<Cursor> onCreateLoader(int id, Bundle args) {
         return new CursorLoader(getActivity(),
@@ -136,7 +160,7 @@ public final class MyRemindersFragment extends ListFragment
                 PROJECTION,
                 null,
                 null,
-                ObaContract.Trips.NAME + " asc");
+                sortBy);
     }
 
     @Override
@@ -169,8 +193,8 @@ public final class MyRemindersFragment extends ListFragment
 
         simpleAdapter.setViewBinder(new SimpleCursorAdapter.ViewBinder() {
             public boolean setViewValue(View view,
-                    Cursor cursor,
-                    int columnIndex) {
+                                        Cursor cursor,
+                                        int columnIndex) {
                 if (columnIndex == COL_NAME) {
                     TextView text = (TextView) view;
                     String name = cursor.getString(columnIndex);
@@ -230,8 +254,8 @@ public final class MyRemindersFragment extends ListFragment
 
     @Override
     public void onCreateContextMenu(ContextMenu menu,
-            View v,
-            ContextMenu.ContextMenuInfo menuInfo) {
+                                    View v,
+                                    ContextMenu.ContextMenuInfo menuInfo) {
         super.onCreateContextMenu(menu, v, menuInfo);
         AdapterView.AdapterContextMenuInfo info = (AdapterView.AdapterContextMenuInfo) menuInfo;
         final TextView text = (TextView) info.targetView.findViewById(R.id.name);
@@ -300,5 +324,70 @@ public final class MyRemindersFragment extends ListFragment
                 c.getString(COL_ROUTE_ID)
         };
         return result;
+    }
+
+    @Override
+    public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
+        menu.add(R.string.menu_option_sort_by).setIcon(R.drawable.ic_action_content_sort).setShowAsAction(MenuItem.SHOW_AS_ACTION_IF_ROOM);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        final CharSequence menuId = item.getTitle();
+        if (menuId.equals(getResources().getString(R.string.menu_option_sort_by))) {
+            showSortByDialog();
+        }
+        return false;
+    }
+
+    private void showSortByDialog() {
+        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+        builder.setTitle(R.string.menu_option_sort_by);
+        mCurrentSortOrder = PreferenceUtils.getReminderSortOrderFromPreferences();
+        builder.setSingleChoiceItems(R.array.sort_reminders, mCurrentSortOrder,
+                new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        //if selected option is different, change option
+
+                        if (mCurrentSortOrder != which) {
+                            setSortByClause(which);
+
+                            //restart with new order
+                            getLoaderManager().restartLoader(0, null, MyRemindersFragment.this);
+                        }
+                        dialog.dismiss();
+                    }
+                });
+        AlertDialog dialog = builder.create();
+        dialog.setOwnerActivity(getActivity());
+        dialog.show();
+    }
+
+    /**
+     * Sets the sortBy string for the loader and save it to preference
+     *
+     * @param index the index of R.array.sort_reminder that should be set
+     */
+    private void setSortByClause(int index) {
+        switch (index) {
+            case 0:
+                Log.d(TAG, "setSortByClause: sort by name");
+                sortBy = ObaContract.Trips.NAME + " asc";
+                ObaAnalytics.reportEventWithCategory(ObaAnalytics.ObaEventCategory.UI_ACTION.toString(),
+                        getActivity().getString(R.string.analytics_action_button_press),
+                        getActivity().getString(R.string.analytics_label_sort_by_name_reminder));
+                break;
+            case 1:
+                Log.d(TAG, "setSortByClause: sort by time");
+                sortBy = ObaContract.Trips.DEPARTURE + " asc";
+                ObaAnalytics.reportEventWithCategory(ObaAnalytics.ObaEventCategory.UI_ACTION.toString(),
+                        getActivity().getString(R.string.analytics_action_button_press),
+                        getActivity().getString(R.string.analytics_label_sort_by_departure_time_reminder));
+                break;
+        }
+        final String[] sortOptions = getResources().getStringArray(R.array.sort_reminders);
+        PreferenceUtils.saveString(getString(R.string.preference_key_default_reminder_sort)
+                , sortOptions[index]);
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/PreferenceUtils.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/PreferenceUtils.java
@@ -165,6 +165,25 @@ public class PreferenceUtils {
     }
 
     /**
+     * Returns current reminder sort order from the SharedPreferences
+     *
+     * @return the currently selected reminder sort order as the index in R.array.sort_stops
+     */
+    public static int getReminderSortOrderFromPreferences(){
+        Resources resources = Application.get().getResources();
+        SharedPreferences preferences = Application.getPrefs();
+        String[] sortOptions = resources.getStringArray(R.array.sort_reminders);
+        String sortPref = preferences.getString(resources.getString(
+                R.string.preference_key_default_reminder_sort), sortOptions[0]);
+        if (sortPref.equalsIgnoreCase(sortOptions[0])){
+            return 0;
+        } else if (sortPref.equalsIgnoreCase(sortOptions[1])){
+            return 1;
+        }
+        return 0;  //Default to the first option
+    }
+
+    /**
      * Saves provided MapView center location and zoom level to preferences
      *
      * @param lat  latitude of map center

--- a/onebusaway-android/src/main/res/values/arrays.xml
+++ b/onebusaway-android/src/main/res/values/arrays.xml
@@ -38,6 +38,10 @@
         <item>Name</item>
         <item>Most frequently used</item>
     </string-array>
+    <string-array name="sort_reminders">
+        <item>Name</item>
+        <item>Time</item>
+    </string-array>
     <string-array name="sort_arrivals">
         <item>Estimated arrival</item>
         <item>Route</item>

--- a/onebusaway-android/src/main/res/values/donottranslate.xml
+++ b/onebusaway-android/src/main/res/values/donottranslate.xml
@@ -36,6 +36,7 @@
     <string name="preference_key_arrival_info_style">preference_arrival_info_style</string>
     <string name="preference_key_show_negative_arrivals">preference_show_negative_arrivals</string>
     <string name="preference_key_default_stop_sort">preference_default_stop_sort</string>
+    <string name="preference_key_default_reminder_sort">preference_default_reminder_sort</string>
     <string name="preference_key_tutorial">preference_key_tutorial</string>
     <string name="preference_key_show_header_arrivals">preference_key_show_header_arrivals</string>
     <string name="preference_key_tutorial_counter">preference_key_tutorial_counter</string>
@@ -97,6 +98,12 @@
     </string>
     <string name="analytics_label_sort_by_mfu_stops">Clicked sort by most frequently used from
         MyStarredStopsFragment
+    </string>
+    <string name="analytics_label_sort_by_name_reminder">Clicked sort by name from
+        MyRemindersFragment
+    </string>
+    <string name="analytics_label_sort_by_departure_time_reminder">Clicked sort by departure time from
+        MyRemindersFragment
     </string>
     <string name="analytics_label_show_arrivals_in_header">Clicked show arrivals in header
     </string>


### PR DESCRIPTION
I worked on this (#765 ) issue. I tried to use a similar style as sorting starred stops.
----------------

**before**
It was only sorted by the name of a reminder.

**proposed**
It allows users to switch between "sort by name" and "sort by time"

let me know if there are things that need to be changed. Thank you!

-----------------

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `gradlew connectedObaGoogleDebugAndroidTest connectedObaAmazonDebugAndroidTest` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.