### PR TITLE
Fix #848 - Speed up builds for Android Gradle Plugin v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,14 @@ In order to support certain features in OneBusAway, we need to request various p
 
 ## Troubleshooting
 
+### Building the project takes forever (like, 4 minutes) - what's up?
+
+In your `gradle.properties` file in the root of the project, add:
+
+`org.gradle.jvmargs=-Xmx2048m`
+
+This must be at least 2 Gb to take advantage of Dex In Process.  See [this post](https://medium.com/google-developers/faster-android-studio-builds-with-dex-in-process-5988ed8aa37e) for more info.
+
 ### When running the project, I get a NullPointerException in `BaseMapFragment`, related to `mMap`
 
 You're most likely trying to run the `obaAmazon` build variant on an Google Android device, or the `obaGoogle` build flavor on an Amazon device.

--- a/onebusaway-android/build.gradle
+++ b/onebusaway-android/build.gradle
@@ -358,11 +358,11 @@ tasks.whenTaskAdded { theTask ->
 
 dependencies {
     // Google Play Services Analytics (we need this on Amazon flavor too)
-    implementation('com.google.android.gms:play-services-analytics:9.4.0') {
+    implementation('com.google.android.gms:play-services-analytics:11.8.0') {
         exclude module: 'play-services-ads' // See #342
     }
     // Google Play Services Location (we need this on Amazon flavor too)
-    implementation 'com.google.android.gms:play-services-location:9.4.0'
+    implementation 'com.google.android.gms:play-services-location:11.8.0'
     // Support libraries
     implementation "com.android.support:cardview-v7:27.0.2"
     implementation "com.android.support:design:27.0.2"
@@ -386,13 +386,20 @@ dependencies {
     // POJOs used for full data-binding via Jackson
     implementation 'edu.usf.cutr.opentripplanner.android:opentripplanner-pojos:1.0.0-SNAPSHOT'
     // Google Play Services Maps (only for Google flavor)
-    googleImplementation 'com.google.android.gms:play-services-maps:9.4.0'
+    googleImplementation 'com.google.android.gms:play-services-maps:11.8.0'
     // Google Play Services Places is required by ProprietaryMapHelpV2 (only for Google flavor)
-    googleImplementation 'com.google.android.gms:play-services-places:9.4.0'
+    googleImplementation 'com.google.android.gms:play-services-places:11.8.0'
     // Amazon Maps (only for Amazon flavor)
     amazonImplementation 'com.amazon.android:amazon-maps-api:2.0'
-    // Embedded Social
+    // Embedded Social SDK
     implementation('com.acrowntest.test:sdk:0.0.42:release@aar') {
         transitive = true;
     }
+    // Needed to eliminate conflict with OpenID dependency within the EmbeddedSocial SDK (#843)
+    implementation "com.android.support:customtabs:27.0.2"
+    // Needed to eliminate conflict with EmbeddedSocial SDK Google Play Services & Firebase libraries (#843)
+    implementation "com.google.android.gms:play-services-auth:11.8.0"
+    implementation "com.google.android.gms:play-services-gcm:11.8.0"
+    implementation "com.google.firebase:firebase-core:11.8.0"
+    implementation "com.google.firebase:firebase-analytics:11.8.0"
 }

--- a/onebusaway-android/build.gradle
+++ b/onebusaway-android/build.gradle
@@ -416,6 +416,8 @@ dependencies {
     implementation('com.acrowntest.test:sdk:0.0.42:release@aar') {
         transitive = true;
     }
+    // Required to support multidex for minSdkVersion <= 20
+    implementation 'com.android.support:multidex:1.0.1'
 }
 
 // Dependencies not directly used in this project, but used by dependencies that we are using

--- a/onebusaway-android/build.gradle
+++ b/onebusaway-android/build.gradle
@@ -44,7 +44,7 @@ ext {
     compileSdkVersion = 27
     // supportLibVersion must have the same major version number as compileSdkVersion
     supportLibVersion = "27.0.2"
-    playServicesVersion = "11.6.2"
+    playServicesVersion = "11.8.0"
 }
 
 android {

--- a/onebusaway-android/build.gradle
+++ b/onebusaway-android/build.gradle
@@ -259,11 +259,6 @@ android {
     }
 
     buildTypes {
-        debug {
-            minifyEnabled true
-            useProguard false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-project.txt'
-        }
         release {
             signingConfig signingConfigs.release
             minifyEnabled true
@@ -272,9 +267,11 @@ android {
         }
         // Append the version name to the end of aligned APKs
         android.applicationVariants.all { variant ->
-            variant.outputs.all { output ->
-                def file = output.outputFile
-                outputFileName = "${variant.name}-v${variant.versionName}.apk"
+            if (variant.buildType.name == "release") {
+                variant.outputs.all { output ->
+                    def file = output.outputFile
+                    outputFileName = "${variant.name}-v${variant.versionName}.apk"
+                }
             }
         }
     }

--- a/onebusaway-android/build.gradle
+++ b/onebusaway-android/build.gradle
@@ -39,8 +39,16 @@ repositories {
     }
 }
 
+// Custom properties for OBA
+ext {
+    compileSdkVersion = 27
+    // supportLibVersion must have the same major version number as compileSdkVersion
+    supportLibVersion = "27.0.2"
+    playServicesVersion = "11.8.0"
+}
+
 android {
-    compileSdkVersion 27
+    compileSdkVersion this.ext.compileSdkVersion
     buildToolsVersion "26.0.2"
 
     defaultConfig {
@@ -259,6 +267,11 @@ android {
     }
 
     buildTypes {
+        debug {
+            minifyEnabled true
+            useProguard false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-project.txt'
+        }
         release {
             signingConfig signingConfigs.release
             minifyEnabled true
@@ -358,14 +371,21 @@ tasks.whenTaskAdded { theTask ->
 
 dependencies {
     // Google Play Services Analytics (we need this on Amazon flavor too)
-    implementation('com.google.android.gms:play-services-analytics:11.8.0') {
+    implementation("com.google.android.gms:play-services-analytics:${this.ext.playServicesVersion}") {
         exclude module: 'play-services-ads' // See #342
+        force = true
     }
     // Google Play Services Location (we need this on Amazon flavor too)
-    implementation 'com.google.android.gms:play-services-location:11.8.0'
+    implementation("com.google.android.gms:play-services-location:${this.ext.playServicesVersion}") {
+        force = true
+    }
     // Support libraries
-    implementation "com.android.support:cardview-v7:27.0.2"
-    implementation "com.android.support:design:27.0.2"
+    implementation ("com.android.support:cardview-v7:${this.ext.supportLibVersion}") {
+        force = true
+    }
+    implementation ("com.android.support:design:${this.ext.supportLibVersion}") {
+        force = true
+    }
     implementation 'commons-io:commons-io:2.4'
     // Open311 client library
     implementation 'edu.usf.cutr:open311client:1.0.9'
@@ -376,9 +396,7 @@ dependencies {
     // Bottom sliding panel
     implementation 'com.sothree.slidinguppanel:library:3.3.0'
     // For floating action button speed dial
-    implementation ('uk.co.markormesher:android-fab:1.3.4') {
-        exclude group: 'com.android.support'
-    }
+    implementation ('uk.co.markormesher:android-fab:1.3.4')
     // For sorting alphanumeric route names
     implementation 'org.onebusaway.util:comparators:1.0.0'
     // For tutorial (ShowcaseView) library
@@ -386,20 +404,28 @@ dependencies {
     // POJOs used for full data-binding via Jackson
     implementation 'edu.usf.cutr.opentripplanner.android:opentripplanner-pojos:1.0.0-SNAPSHOT'
     // Google Play Services Maps (only for Google flavor)
-    googleImplementation 'com.google.android.gms:play-services-maps:11.8.0'
+    googleImplementation ("com.google.android.gms:play-services-maps:${this.ext.playServicesVersion}") {
+        force = true
+    }
     // Google Play Services Places is required by ProprietaryMapHelpV2 (only for Google flavor)
-    googleImplementation 'com.google.android.gms:play-services-places:11.8.0'
+    googleImplementation ("com.google.android.gms:play-services-places:${this.ext.playServicesVersion}") {
+        force = true
+    }
     // Amazon Maps (only for Amazon flavor)
     amazonImplementation 'com.amazon.android:amazon-maps-api:2.0'
     // Embedded Social SDK
     implementation('com.acrowntest.test:sdk:0.0.42:release@aar') {
         transitive = true;
     }
+}
+
+// Dependencies not directly used in this project, but used by dependencies that we are using
+configurations.all {
     // Needed to eliminate conflict with OpenID dependency within the EmbeddedSocial SDK (#843)
-    implementation "com.android.support:customtabs:27.0.2"
-    // Needed to eliminate conflict with EmbeddedSocial SDK Google Play Services & Firebase libraries (#843)
-    implementation "com.google.android.gms:play-services-auth:11.8.0"
-    implementation "com.google.android.gms:play-services-gcm:11.8.0"
-    implementation "com.google.firebase:firebase-core:11.8.0"
-    implementation "com.google.firebase:firebase-analytics:11.8.0"
+    resolutionStrategy.force "com.android.support:customtabs:${this.ext.supportLibVersion}"
+    // Needed to eliminate conflict with EmbeddedSocial SDK Google Play Services & Firebase libraries
+    resolutionStrategy.force "com.google.android.gms:play-services-auth:${this.ext.playServicesVersion}"
+    resolutionStrategy.force "com.google.android.gms:play-services-gcm:${this.ext.playServicesVersion}"
+    resolutionStrategy.force "com.google.firebase:firebase-core:${this.ext.playServicesVersion}"
+    resolutionStrategy.force "com.google.firebase:firebase-analytics:${this.ext.playServicesVersion}"
 }

--- a/onebusaway-android/build.gradle
+++ b/onebusaway-android/build.gradle
@@ -48,6 +48,9 @@ ext {
 }
 
 android {
+    dexOptions {
+        preDexLibraries true
+    }
     compileSdkVersion this.ext.compileSdkVersion
     buildToolsVersion "26.0.2"
 
@@ -57,6 +60,7 @@ android {
         versionCode 87
         versionName "2.3.2"
 
+        multiDexEnabled true
         vectorDrawables.useSupportLibrary = true
     }
 
@@ -267,11 +271,6 @@ android {
     }
 
     buildTypes {
-        debug {
-            minifyEnabled true
-            useProguard false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-project.txt'
-        }
         release {
             signingConfig signingConfigs.release
             minifyEnabled true

--- a/onebusaway-android/build.gradle
+++ b/onebusaway-android/build.gradle
@@ -44,7 +44,7 @@ ext {
     compileSdkVersion = 27
     // supportLibVersion must have the same major version number as compileSdkVersion
     supportLibVersion = "27.0.2"
-    playServicesVersion = "11.8.0"
+    playServicesVersion = "11.6.2"
 }
 
 android {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/app/Application.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/app/Application.java
@@ -47,6 +47,7 @@ import android.hardware.GeomagneticField;
 import android.location.Location;
 import android.location.LocationManager;
 import android.preference.PreferenceManager;
+import android.support.multidex.MultiDexApplication;
 import android.telephony.TelephonyManager;
 import android.text.TextUtils;
 import android.util.Log;
@@ -62,7 +63,7 @@ import edu.usf.cutr.open311client.models.Open311Option;
 
 import static com.google.android.gms.location.LocationServices.FusedLocationApi;
 
-public class Application extends android.app.Application {
+public class Application extends MultiDexApplication {
 
     public static final String APP_UID = "app_uid";
 


### PR DESCRIPTION
* Add org.gradle.jvmargs=-Xmx2048m to gradle.properties (no code change as it's a local config, but I added to README and my personal workspace)
* Only append version names to release builds (to prevent changes to output files causing full builds on each build)
* Update to latest support and Play Services versions
* Filter out conflicting dependencies of dependencies using "force" config. This cleaning splits out our dependencies vs. dependencies used by our dependencies, while making sure they are all referencing the same version numbers defined in the "ext" block
* Use multidex instead of minify for debug builds - significantly speeds up builds by around 1 minute, reducing clean build times from ~2 min 15 sec to ~1 min 14 sec.