### PR TITLE
Migrate to android-fab v2.2.0 library

### DIFF
--- a/onebusaway-android/build.gradle
+++ b/onebusaway-android/build.gradle
@@ -401,7 +401,7 @@ dependencies {
     // Bottom sliding panel
     implementation 'com.sothree.slidinguppanel:library:3.3.0'
     // For floating action button speed dial
-    implementation ('uk.co.markormesher:android-fab:2.0.0')
+    implementation ('uk.co.markormesher:android-fab:2.2.0')
     // For sorting alphanumeric route names
     implementation 'org.onebusaway.util:comparators:1.0.0'
     // For tutorial (ShowcaseView) library

--- a/onebusaway-android/build.gradle
+++ b/onebusaway-android/build.gradle
@@ -401,7 +401,7 @@ dependencies {
     // Bottom sliding panel
     implementation 'com.sothree.slidinguppanel:library:3.3.0'
     // For floating action button speed dial
-    implementation ('uk.co.markormesher:android-fab:1.3.4')
+    implementation ('uk.co.markormesher:android-fab:2.0.0')
     // For sorting alphanumeric route names
     implementation 'org.onebusaway.util:comparators:1.0.0'
     // For tutorial (ShowcaseView) library

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.java
@@ -17,39 +17,6 @@
  */
 package org.onebusaway.android.ui;
 
-import com.google.android.gms.common.ConnectionResult;
-import com.google.android.gms.common.GoogleApiAvailability;
-import com.google.android.gms.common.api.GoogleApiClient;
-
-import com.microsoft.embeddedsocial.sdk.EmbeddedSocial;
-import com.microsoft.embeddedsocial.ui.fragment.ActivityFeedFragment;
-import com.microsoft.embeddedsocial.ui.fragment.PinsFragment;
-import com.microsoft.embeddedsocial.ui.fragment.PopularFeedFragment;
-import com.sothree.slidinguppanel.SlidingUpPanelLayout;
-
-import org.onebusaway.android.BuildConfig;
-import org.onebusaway.android.R;
-import org.onebusaway.android.app.Application;
-import org.onebusaway.android.io.ObaAnalytics;
-import org.onebusaway.android.io.elements.ObaRegion;
-import org.onebusaway.android.io.elements.ObaRoute;
-import org.onebusaway.android.io.elements.ObaStop;
-import org.onebusaway.android.io.request.ObaArrivalInfoResponse;
-import org.onebusaway.android.map.MapModeController;
-import org.onebusaway.android.map.MapParams;
-import org.onebusaway.android.map.googlemapsv2.BaseMapFragment;
-import org.onebusaway.android.map.googlemapsv2.LayerInfo;
-import org.onebusaway.android.region.ObaRegionsTask;
-import org.onebusaway.android.report.ui.ReportActivity;
-import org.onebusaway.android.tripservice.TripService;
-import org.onebusaway.android.util.FragmentUtils;
-import org.onebusaway.android.util.LocationUtils;
-import org.onebusaway.android.util.PreferenceUtils;
-import org.onebusaway.android.util.RegionUtils;
-import org.onebusaway.android.util.ShowcaseViewUtils;
-import org.onebusaway.android.util.UIUtils;
-import org.opentripplanner.routing.bike_rental.BikeRentalStation;
-
 import android.app.Dialog;
 import android.content.Context;
 import android.content.DialogInterface;
@@ -89,6 +56,38 @@ import android.widget.ProgressBar;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 import android.widget.Toast;
+
+import com.google.android.gms.common.ConnectionResult;
+import com.google.android.gms.common.GoogleApiAvailability;
+import com.google.android.gms.common.api.GoogleApiClient;
+import com.microsoft.embeddedsocial.sdk.EmbeddedSocial;
+import com.microsoft.embeddedsocial.ui.fragment.ActivityFeedFragment;
+import com.microsoft.embeddedsocial.ui.fragment.PinsFragment;
+import com.microsoft.embeddedsocial.ui.fragment.PopularFeedFragment;
+import com.sothree.slidinguppanel.SlidingUpPanelLayout;
+
+import org.onebusaway.android.BuildConfig;
+import org.onebusaway.android.R;
+import org.onebusaway.android.app.Application;
+import org.onebusaway.android.io.ObaAnalytics;
+import org.onebusaway.android.io.elements.ObaRegion;
+import org.onebusaway.android.io.elements.ObaRoute;
+import org.onebusaway.android.io.elements.ObaStop;
+import org.onebusaway.android.io.request.ObaArrivalInfoResponse;
+import org.onebusaway.android.map.MapModeController;
+import org.onebusaway.android.map.MapParams;
+import org.onebusaway.android.map.googlemapsv2.BaseMapFragment;
+import org.onebusaway.android.map.googlemapsv2.LayerInfo;
+import org.onebusaway.android.region.ObaRegionsTask;
+import org.onebusaway.android.report.ui.ReportActivity;
+import org.onebusaway.android.tripservice.TripService;
+import org.onebusaway.android.util.FragmentUtils;
+import org.onebusaway.android.util.LocationUtils;
+import org.onebusaway.android.util.PreferenceUtils;
+import org.onebusaway.android.util.RegionUtils;
+import org.onebusaway.android.util.ShowcaseViewUtils;
+import org.onebusaway.android.util.UIUtils;
+import org.opentripplanner.routing.bike_rental.BikeRentalStation;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -1700,7 +1699,7 @@ public class HomeActivity extends AppCompatActivity
         LAYERS_FAB_DEFAULT_BOTTOM_MARGIN = p.bottomMargin;
 
         mLayersFab.setButtonIconResource(R.drawable.ic_layers_white_24dp);
-        mLayersFab.setBackgroundColor(ContextCompat.getColor(this, R.color.theme_accent));
+        mLayersFab.setButtonBackgroundColour(ContextCompat.getColor(this, R.color.theme_accent));
 
         LayersSpeedDialAdapter adapter = new LayersSpeedDialAdapter(this);
         // Add the BaseMapFragment listener to activate the layer on the map

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.java
@@ -1700,7 +1700,7 @@ public class HomeActivity extends AppCompatActivity
         LAYERS_FAB_DEFAULT_BOTTOM_MARGIN = p.bottomMargin;
 
         mLayersFab.setButtonIconResource(R.drawable.ic_layers_white_24dp);
-        mLayersFab.setButtonBackgroundColour(ContextCompat.getColor(this, R.color.theme_accent));
+        mLayersFab.setBackgroundColor(ContextCompat.getColor(this, R.color.theme_accent));
 
         LayersSpeedDialAdapter adapter = new LayersSpeedDialAdapter(this);
         // Add the BaseMapFragment listener to activate the layer on the map
@@ -1733,7 +1733,7 @@ public class HomeActivity extends AppCompatActivity
             }
         });
         mLayersFab.setSpeedDialMenuAdapter(adapter);
-        mLayersFab.setOnSpeedMenuDialOpenListener(
+        mLayersFab.setOnSpeedDialMenuOpenListener(
                 new SpeedDialMenuOpenListener() {
                     @Override
                     public void onOpen(uk.co.markormesher.android_fab.FloatingActionButton v) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.java
@@ -96,6 +96,9 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 
+import uk.co.markormesher.android_fab.SpeedDialMenuCloseListener;
+import uk.co.markormesher.android_fab.SpeedDialMenuOpenListener;
+
 import static org.onebusaway.android.ui.NavigationDrawerFragment.NAVDRAWER_ITEM_ACTIVITY_FEED;
 import static org.onebusaway.android.ui.NavigationDrawerFragment.NAVDRAWER_ITEM_HELP;
 import static org.onebusaway.android.ui.NavigationDrawerFragment.NAVDRAWER_ITEM_MY_REMINDERS;
@@ -1690,14 +1693,14 @@ public class HomeActivity extends AppCompatActivity
     }
 
     private void setupLayersSpeedDial() {
-        mLayersFab = (uk.co.markormesher.android_fab.FloatingActionButton) findViewById(R.id.layersSpeedDial);
+        mLayersFab = findViewById(R.id.layersSpeedDial);
 
         ViewGroup.MarginLayoutParams p = (ViewGroup.MarginLayoutParams) mLayersFab
                 .getLayoutParams();
         LAYERS_FAB_DEFAULT_BOTTOM_MARGIN = p.bottomMargin;
 
-        mLayersFab.setIcon(R.drawable.ic_layers_white_24dp);
-        mLayersFab.setBackgroundColour(ContextCompat.getColor(this, R.color.theme_accent));
+        mLayersFab.setButtonIconResource(R.drawable.ic_layers_white_24dp);
+        mLayersFab.setButtonBackgroundColour(ContextCompat.getColor(this, R.color.theme_accent));
 
         LayersSpeedDialAdapter adapter = new LayersSpeedDialAdapter(this);
         // Add the BaseMapFragment listener to activate the layer on the map
@@ -1729,19 +1732,19 @@ public class HomeActivity extends AppCompatActivity
                 }, 100);
             }
         });
-        mLayersFab.setMenuAdapter(adapter);
-        mLayersFab.setOnSpeedDialOpenListener(
-                new uk.co.markormesher.android_fab.FloatingActionButton.OnSpeedDialOpenListener() {
+        mLayersFab.setSpeedDialMenuAdapter(adapter);
+        mLayersFab.setOnSpeedMenuDialOpenListener(
+                new SpeedDialMenuOpenListener() {
                     @Override
                     public void onOpen(uk.co.markormesher.android_fab.FloatingActionButton v) {
-                        mLayersFab.setIcon(R.drawable.ic_add_white_24dp);
+                        mLayersFab.setButtonIconResource(R.drawable.ic_add_white_24dp);
                     }
                 });
-        mLayersFab.setOnSpeedDialCloseListener(
-                new uk.co.markormesher.android_fab.FloatingActionButton.OnSpeedDialCloseListener() {
+        mLayersFab.setOnSpeedDialMenuCloseListener(
+                new SpeedDialMenuCloseListener() {
                     @Override
                     public void onClose(uk.co.markormesher.android_fab.FloatingActionButton v) {
-                        mLayersFab.setIcon(R.drawable.ic_layers_white_24dp);
+                        mLayersFab.setButtonIconResource(R.drawable.ic_layers_white_24dp);
                     }
                 });
         mLayersFab.setContentCoverEnabled(false);

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/LayersSpeedDialAdapter.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/LayersSpeedDialAdapter.java
@@ -21,15 +21,13 @@ import org.onebusaway.android.util.LayerUtils;
 
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.graphics.Color;
-import android.os.Build;
 import android.preference.PreferenceManager;
-import android.widget.TextView;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import uk.co.markormesher.android_fab.SpeedDialMenuAdapter;
+import uk.co.markormesher.android_fab.SpeedDialMenuItem;
 
 /**
  * Control the display of the available layers options in a speed dial when the layers Floating
@@ -73,44 +71,53 @@ public class LayersSpeedDialAdapter extends SpeedDialMenuAdapter {
     }
 
     @Override
-    protected int getCount() {
+    public int getCount() {
         return 1;
     }
 
+    /**
+     * Gets the menu item to display at the specified position in the range 0 to `getCount() - 1`.
+     * See `SpeedDialMenuItem` for more details.
+     * Note: positions start at zero closest to the FAB and increase for items further away.
+     * @return the menu item to display at the specified position
+     */
     @SuppressWarnings("deprecation")
     @Override
-    protected MenuItem getViews(Context context, int position) {
+    public SpeedDialMenuItem getMenuItem(Context context, int position) {
         // Refresh active layer info
         activatedLayers[0] = LayerUtils.isBikeshareLayerVisible();
 
         LayerInfo layer = layers[position];
-        MenuItem menuItem = new MenuItem();
-
-        menuItem.iconDrawableId = layer.getIconDrawableId();
 
         // Adding a view so the color of the text match the color of the speed dial disc
-        TextView label = new TextView(context);
-        label.setText(layer.getLayerlabel());
-        label.setTextColor(Color.WHITE);
-        int labelDrawableId;
-        if (activatedLayers[position]) {
-            labelDrawableId = layer.getLabelBackgroundDrawableId();
-        } else {
-            labelDrawableId = R.drawable.speed_dial_disabled_item_label;
-        }
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
-            label.setBackground(context.getResources().getDrawable(labelDrawableId));
-        } else {
-            label.setBackgroundDrawable(context.getResources().getDrawable(labelDrawableId));
-        }
+        // FIX ME - Doesn't seem like the below commented code is possible any more with v2 of android-fab library
+//        TextView label = new TextView(context);
+//        label.setText(layer.getLayerlabel());
+//        label.setTextColor(Color.WHITE);
+//        int labelDrawableId;
+//        if (activatedLayers[position]) {
+//            labelDrawableId = layer.getLabelBackgroundDrawableId();
+//        } else {
+//            labelDrawableId = R.drawable.speed_dial_disabled_item_label;
+//        }
+//        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+//            label.setBackground(context.getResources().getDrawable(labelDrawableId));
+//        } else {
+//            label.setBackgroundDrawable(context.getResources().getDrawable(labelDrawableId));
+//        }
 
-        menuItem.labelView = label;
-
+        // Just set the icon and label text for now, until we can fix the above
+        SpeedDialMenuItem menuItem = new SpeedDialMenuItem(context, layer.getIconDrawableId(), layer.getLayerlabel());
         return menuItem;
     }
 
+    /**
+     * Handler for click events on menu items.
+     * The position passed corresponds to positions passed to `getMenuItem()`.
+     * @return `true` to close the menu after the click; `false` to leave it open
+     */
     @Override
-    protected boolean onMenuItemClick(int position) {
+    public boolean onMenuItemClick(int position) {
         if (position < activatedLayers.length) {
             if (activatedLayers[position]) {
                 for (LayerActivationListener listener : layerActivationListeners) {
@@ -145,7 +152,7 @@ public class LayersSpeedDialAdapter extends SpeedDialMenuAdapter {
 
     @SuppressWarnings("deprecation")
     @Override
-    protected int getBackgroundColour(int position) {
+    public int getBackgroundColour(int position) {
         // Refresh active layer info
         activatedLayers[0] = LayerUtils.isBikeshareLayerVisible();
 
@@ -156,8 +163,8 @@ public class LayersSpeedDialAdapter extends SpeedDialMenuAdapter {
     }
 
     @Override
-    protected boolean rotateFab() {
-        return true;
+    public float fabRotationDegrees() {
+        return 45.0f;
     }
 
     /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/LayersSpeedDialAdapter.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/LayersSpeedDialAdapter.java
@@ -15,13 +15,17 @@
  */
 package org.onebusaway.android.ui;
 
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.graphics.Color;
+import android.os.Build;
+import android.preference.PreferenceManager;
+import android.widget.TextView;
+
+import org.jetbrains.annotations.NotNull;
 import org.onebusaway.android.R;
 import org.onebusaway.android.map.googlemapsv2.LayerInfo;
 import org.onebusaway.android.util.LayerUtils;
-
-import android.content.Context;
-import android.content.SharedPreferences;
-import android.preference.PreferenceManager;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -89,26 +93,40 @@ public class LayersSpeedDialAdapter extends SpeedDialMenuAdapter {
 
         LayerInfo layer = layers[position];
 
-        // Adding a view so the color of the text match the color of the speed dial disc
-        // FIX ME - Doesn't seem like the below commented code is possible any more with v2 of android-fab library
-//        TextView label = new TextView(context);
-//        label.setText(layer.getLayerlabel());
-//        label.setTextColor(Color.WHITE);
-//        int labelDrawableId;
-//        if (activatedLayers[position]) {
-//            labelDrawableId = layer.getLabelBackgroundDrawableId();
-//        } else {
-//            labelDrawableId = R.drawable.speed_dial_disabled_item_label;
-//        }
-//        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
-//            label.setBackground(context.getResources().getDrawable(labelDrawableId));
-//        } else {
-//            label.setBackgroundDrawable(context.getResources().getDrawable(labelDrawableId));
-//        }
-
         // Just set the icon and label text for now, until we can fix the above
         SpeedDialMenuItem menuItem = new SpeedDialMenuItem(context, layer.getIconDrawableId(), layer.getLayerlabel());
         return menuItem;
+    }
+
+    /**
+     * Apply formatting to the `TextView` used for the label of the menu item at the given position.
+     * Note: positions start at zero closest to the FAB and increase for items further away.
+     *
+     * @param context
+     * @param position
+     * @param label
+     */
+    @Override
+    public void onPrepareItemLabel(@NotNull Context context, int position, @NotNull TextView label) {
+        // Refresh active layer info
+        activatedLayers[0] = LayerUtils.isBikeshareLayerVisible();
+
+        LayerInfo layer = layers[position];
+
+        // Set a solid background for the speed dial item label so you can see the text over the map
+        label.setText(layer.getLayerlabel());
+        label.setTextColor(Color.WHITE);
+        int labelDrawableId;
+        if (activatedLayers[position]) {
+            labelDrawableId = layer.getLabelBackgroundDrawableId();
+        } else {
+            labelDrawableId = R.drawable.speed_dial_disabled_item_label;
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+            label.setBackground(context.getResources().getDrawable(labelDrawableId));
+        } else {
+            label.setBackgroundDrawable(context.getResources().getDrawable(labelDrawableId));
+        }
     }
 
     /**


### PR DESCRIPTION
Prep for https://github.com/OneBusAway/onebusaway-android/pull/806.

TODO:
- [x] It doesn't seem like we can control the background view of the menu item labels any more - I filed an issue at https://github.com/markormesher/android-fab/issues/24. **EDIT** Fixed in android-fab v2.2.0.
- [x] There is strange behavior with the visibility of the menu item when the menu item is tapped on.  The menu item disappears when you tap on it, until you collapse and re-open the speed dial.  I filed an issue at https://github.com/markormesher/android-fab/issues/25. **EDIT** Fixed in android-fab v2.2.0.