### PR TITLE
Use app name as default reminder name if none set

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/tripservice/NotifierTask.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/tripservice/NotifierTask.java
@@ -31,6 +31,7 @@ import android.database.Cursor;
 import android.net.Uri;
 import android.provider.Settings;
 import android.support.v4.app.NotificationCompat;
+import android.text.TextUtils;
 
 /**
  * A task (thread) that is responsible for generating a Notification to remind the user of an
@@ -75,7 +76,7 @@ public final class NotifierTask implements Runnable {
         mTaskContext = taskContext;
         mCR = mContext.getContentResolver();
         mUri = uri;
-        mNotifyTitle = notifyTitle;
+        mNotifyTitle = TextUtils.isEmpty(notifyTitle) ? mContext.getString(R.string.app_name) : notifyTitle;
         mNotifyText = notifyText;
     }
 


### PR DESCRIPTION
This fixes Pebble watch notifications which apparently need a non-empty title to provide a minute-by-minute bus reminder notification.

Pebble notifications broke as a side effect of PR #769.  I'm just bringing back using app name as a default title instead of using an empty string.