### PR TITLE
WIP - Fix #871 - Fix Logo Padding in left hand mode

### DIFF
--- a/onebusaway-android/src/amazon/java/org/onebusaway/android/map/googlemapsv2/BaseMapFragment.java
+++ b/onebusaway-android/src/amazon/java/org/onebusaway/android/map/googlemapsv2/BaseMapFragment.java
@@ -121,6 +121,13 @@ public class BaseMapFragment extends SupportMapFragment
         StopOverlay.OnFocusChangedListener, OnMapReadyCallback,
         VehicleOverlay.Controller, LayersSpeedDialAdapter.LayerActivationListener {
 
+
+    public interface OnAdjustPaddingListener {
+        void setPadding(boolean leftHandMode);
+    }
+
+    OnAdjustPaddingListener mAdjustPaddingCallback;
+
     public static final String TAG = "BaseMapFragment";
 
     private static final int REQUEST_NO_LOCATION = 41;
@@ -185,6 +192,18 @@ public class BaseMapFragment extends SupportMapFragment
     LocationHelper mLocationHelper;
 
     Bundle mLastSavedInstanceState;
+
+    @Override
+    public void onAttach(Activity activity) {
+        super.onAttach(activity);
+
+        try {
+            mAdjustPaddingCallback = (OnAdjustPaddingListener) activity;
+        } catch (ClassCastException e) {
+            throw new ClassCastException(activity.toString()
+                    + " must implement OnAdjustPaddingListener");
+        }
+    }
 
     @Override
     public void onActivateLayer(LayerInfo layer) {
@@ -302,7 +321,12 @@ public class BaseMapFragment extends SupportMapFragment
 
     @Override
     public void onMapReady(com.amazon.geo.mapsv2.AmazonMap map) {
+
+        SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(getContext());
+        boolean leftHandMode = preferences.getBoolean(getString(R.string.preference_key_left_hand_mode), false);
+
         mMap = map;
+        mAdjustPaddingCallback.setPadding(leftHandMode);
 
         MapClickListeners mapClickListeners = new MapClickListeners();
 
@@ -355,8 +379,7 @@ public class BaseMapFragment extends SupportMapFragment
 
         mMapPaddingBottom = args
                 .getInt(MapParams.MAP_PADDING_BOTTOM, MapParams.DEFAULT_MAP_PADDING);
-        setPadding(mMapPaddingLeft, mMapPaddingTop, mMapPaddingRight, mMapPaddingBottom);
-
+        
         String mode = args.getString(MapParams.MODE);
         if (mode == null) {
             mode = MapParams.MODE_STOP;

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/BaseMapFragment.java
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/BaseMapFragment.java
@@ -110,6 +110,13 @@ public class BaseMapFragment extends SupportMapFragment
         StopOverlay.OnFocusChangedListener, OnMapReadyCallback,
         VehicleOverlay.Controller, LayersSpeedDialAdapter.LayerActivationListener {
 
+
+    public interface OnAdjustPaddingListener {
+        void setPadding(boolean leftHandMode);
+    }
+
+    OnAdjustPaddingListener mAdjustPaddingCallback;
+
     public static final String TAG = "BaseMapFragment";
 
     private static final int REQUEST_NO_LOCATION = 41;
@@ -174,6 +181,18 @@ public class BaseMapFragment extends SupportMapFragment
     LocationHelper mLocationHelper;
 
     Bundle mLastSavedInstanceState;
+
+    @Override
+    public void onAttach(Activity activity) {
+        super.onAttach(activity);
+
+        try {
+            mAdjustPaddingCallback = (OnAdjustPaddingListener) activity;
+        } catch (ClassCastException e) {
+            throw new ClassCastException(activity.toString()
+                    + " must implement OnAdjustPaddingListener");
+        }
+    }
 
     @Override
     public void onActivateLayer(LayerInfo layer) {
@@ -291,7 +310,12 @@ public class BaseMapFragment extends SupportMapFragment
 
     @Override
     public void onMapReady(com.google.android.gms.maps.GoogleMap map) {
+
+        SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(getContext());
+        boolean leftHandMode = preferences.getBoolean(getString(R.string.preference_key_left_hand_mode), false);
+
         mMap = map;
+        mAdjustPaddingCallback.setPadding(leftHandMode);
 
         MapClickListeners mapClickListeners = new MapClickListeners();
 
@@ -344,8 +368,7 @@ public class BaseMapFragment extends SupportMapFragment
 
         mMapPaddingBottom = args
                 .getInt(MapParams.MAP_PADDING_BOTTOM, MapParams.DEFAULT_MAP_PADDING);
-        setPadding(mMapPaddingLeft, mMapPaddingTop, mMapPaddingRight, mMapPaddingBottom);
-
+        
         String mode = args.getString(MapParams.MODE);
         if (mode == null) {
             mode = MapParams.MODE_STOP;

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapParams.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapParams.java
@@ -63,4 +63,6 @@ public class MapParams {
     public static final int DEFAULT_ZOOM = 18;
 
     public static final int DEFAULT_MAP_PADDING = 0;
+
+    public static final int MAP_PADDING_LEFT_HAND_MODE = 875;
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.java
@@ -125,7 +125,7 @@ public class HomeActivity extends AppCompatActivity
         implements BaseMapFragment.OnFocusChangedListener,
         BaseMapFragment.OnProgressBarChangedListener,
         ArrivalsListFragment.Listener, NavigationDrawerCallbacks,
-        ObaRegionsTask.Callback {
+        ObaRegionsTask.Callback, BaseMapFragment.OnAdjustPaddingListener {
 
     interface SlidingPanelController {
 
@@ -419,7 +419,6 @@ public class HomeActivity extends AppCompatActivity
         checkDisplayZoomControls();
 
         checkLeftHandMode();
-
 
         updateLayersFab();
         mFabMyLocation.requestLayout();
@@ -1633,8 +1632,28 @@ public class HomeActivity extends AppCompatActivity
 
         setFABLocation(leftHandMode);
 
+        setLogoPadding(leftHandMode);
     }
 
+    @Override
+    public void setPadding(boolean leftHandMode) {
+        setLogoPadding(leftHandMode);
+    }
+
+    private void setLogoPadding(boolean leftHandMode) {
+        int topPadding = MapParams.DEFAULT_MAP_PADDING;
+        int bottomPadding = MapParams.DEFAULT_MAP_PADDING;
+        int rightPadding = MapParams.DEFAULT_MAP_PADDING;
+        int leftPadding;
+
+        if(leftHandMode) {
+            leftPadding = MapParams.MAP_PADDING_LEFT_HAND_MODE;
+        } else {
+            leftPadding = MapParams.DEFAULT_MAP_PADDING;
+        }
+
+        mMapFragment.setPadding(leftPadding, topPadding, rightPadding, bottomPadding);
+    }
 
     private void setFABLocation(boolean leftHandMode) {
         if (mFabMyLocation != null) {


### PR DESCRIPTION
Fixed issue [(#871)](https://github.com/OneBusAway/onebusaway-android/issues/871) by adjusting logo padding when left hand mode is enabled. 

The fix required that HomeActivity implement a callback to listen for the the `onMapReady` call in the BaseMapFragment since the `checkLeftHandMode` in HomeActivity executed before the map was ready, leading to some issues where padding wasn't set properly when app is first opened. 

Let me know what you think. 

<img src="https://user-images.githubusercontent.com/19160743/39091739-9b02ad70-45b0-11e8-8fe8-5267b4baef83.png" width="218" height="384">

<img src="https://user-images.githubusercontent.com/19160743/39091741-a502698c-45b0-11e8-8f24-1e593b4610e5.png" width="218" height="384">

