### PR TITLE
WIP - Fix #896 - Use new OTP API v1.x format exclusively

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/app/Application.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/app/Application.java
@@ -304,7 +304,6 @@ public class Application extends MultiDexApplication {
             setCustomApiUrl(null);
             if (regionChanged && region.getOtpBaseUrl() != null) {
                 setCustomOtpApiUrl(null);
-                setUseOldOtpApiUrlVersion(false);
             }
         } else {
             //User must have just entered a custom API URL via Preferences, so clear the region info
@@ -387,24 +386,6 @@ public class Application extends MultiDexApplication {
      */
     public void setCustomOtpApiUrl(String url) {
         PreferenceUtils.saveString(getString(R.string.preference_key_otp_api_url), url);
-    }
-
-    /**
-     * @return true if the OTP url version is old, or false  if it has not been set
-     */
-    public boolean getUseOldOtpApiUrlVersion() {
-        SharedPreferences preferences = getPrefs();
-        return preferences.getBoolean(getString(R.string.preference_key_otp_api_url_version), false);
-    }
-
-    /**
-     * Sets the OTP Api url version
-     *
-     * @param useOldOtpApiUrlVersion indicates that if otp url structure belongs to older version
-     */
-    public void setUseOldOtpApiUrlVersion(boolean useOldOtpApiUrlVersion) {
-        PreferenceUtils.saveBoolean(getString(R.string.preference_key_otp_api_url_version),
-                useOldOtpApiUrlVersion);
     }
 
     private static final String HEXES = "0123456789abcdef";

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/PreferencesActivity.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/PreferencesActivity.java
@@ -278,7 +278,6 @@ public class PreferencesActivity extends PreferenceActivity
                 mCustomOtpApiUrlPref.setSummary(
                         getString(R.string.preferences_otp_api_servername_summary));
             }
-            Application.get().setUseOldOtpApiUrlVersion(false);
         }
     }
 

--- a/onebusaway-android/src/main/res/values/donottranslate.xml
+++ b/onebusaway-android/src/main/res/values/donottranslate.xml
@@ -25,7 +25,6 @@
     <string name="preference_key_region">preference_region</string>
     <string name="preference_key_oba_api_url">preferences_oba_api_url</string>
     <string name="preference_key_otp_api_url">preferences_otp_api_url</string>
-    <string name="preference_key_otp_api_url_version">preferences_otp_api_url_structure</string>
     <string name="preference_key_last_region_update">preference_last_region_update</string>
     <string name="preference_key_auto_select_region">preference_auto_select_region</string>
     <string name="preference_key_experimental_regions">preference_experimental_regions</string>


### PR DESCRIPTION
* This removes the format for the OTP API pre v1.0

TODO:
* This fails with a HTTP 404 for Sound Transit's OTP server.  Need to follow up with Sound Transit and see if it's a server whitelist issue or something else.