### PR TITLE
Fix #895 - Insert route into recents when viewing a route's map/status from a stop

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/provider/test/ProviderTest.java
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/provider/test/ProviderTest.java
@@ -60,9 +60,9 @@ public class ProviderTest extends ProviderTestCase2<ObaProvider> {
                 new String[]{ObaContract.Stops._ID, ObaContract.Stops.DIRECTION},
                 null, null, null);
         assertNotNull(c);
-        assertTrue(c.getCount() == 1);
+        assertEquals(1, c.getCount());
         c.moveToNext();
-        assertEquals(c.getString(0), stopId);
+        assertEquals(stopId, c.getString(0));
         c.close();
 
         // Test counting
@@ -70,16 +70,16 @@ public class ProviderTest extends ProviderTestCase2<ObaProvider> {
                 new String[]{ObaContract.Stops._COUNT},
                 null, null, null);
         assertNotNull(c);
-        assertEquals(c.getCount(), 1);
+        assertEquals(1, c.getCount());
         c.moveToNext();
-        assertTrue(c.getInt(0) == 1);
+        assertEquals(1, c.getInt(0));
         c.close();
         // Get the one that we care about
         c = cr.query(uri, new String[]{ObaContract.Stops.CODE}, null, null, null);
         assertNotNull(c);
-        assertEquals(c.getCount(), 1);
+        assertEquals(1, c.getCount());
         c.moveToNext();
-        assertEquals(c.getString(0), "11060");
+        assertEquals("11060", c.getString(0));
         c.close();
 
         //
@@ -88,15 +88,15 @@ public class ProviderTest extends ProviderTestCase2<ObaProvider> {
         values = new ContentValues();
         values.put(ObaContract.Stops.USE_COUNT, 1);
         int result = cr.update(uri, values, null, null);
-        assertEquals(result, 1);
+        assertEquals(1, result);
 
         //
         // Delete
         //
         result = cr.delete(uri, null, null);
-        assertEquals(result, 1);
+        assertEquals(1, result);
         result = cr.delete(uri, null, null);
-        assertEquals(result, 0);
+        assertEquals(0, result);
     }
 
     @Test
@@ -118,7 +118,7 @@ public class ProviderTest extends ProviderTestCase2<ObaProvider> {
         Uri uri = cr.insert(ObaContract.Stops.CONTENT_URI, values);
         assertNotNull(uri);
 
-        final String stopId2 = "1_1010101";
+        final String stopId2 = "1_1010101-TEST";
         values.put(ObaContract.Stops._ID, stopId2);
         uri = cr.insert(ObaContract.Stops.CONTENT_URI, values);
         assertNotNull(uri);
@@ -127,7 +127,7 @@ public class ProviderTest extends ProviderTestCase2<ObaProvider> {
                 new String[]{ObaContract.Stops._COUNT},
                 null, null, null);
         assertNotNull(c);
-        assertEquals(c.getCount(), 1);
+        assertEquals(1, c.getCount());
         c.moveToNext();
         assertTrue(c.getInt(0) == 2);
         c.close();
@@ -140,7 +140,7 @@ public class ProviderTest extends ProviderTestCase2<ObaProvider> {
                 null, null, null
         );
         assertNotNull(c);
-        assertEquals(c.getCount(), 1);
+        assertEquals(1, c.getCount());
         c.close();
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListFragment.java
@@ -874,12 +874,19 @@ public class ArrivalsListFragment extends ListFragment
 
     public void showRouteOnMap(ArrivalInfo arrivalInfo) {
         boolean handled = false;
+
+        ObaArrivalInfo info = arrivalInfo.getInfo();
+        String routeId = info.getRouteId();
+        String displayName = UIUtils.getRouteDisplayName(info);
+
+        QueryUtils.addRouteToRecents(getContext(), routeId, info.getShortName(), displayName, true);
+
         if (mListener != null) {
             handled = mListener.onShowRouteOnMapSelected(arrivalInfo);
         }
         // If the event hasn't been handled by the listener, start a new activity
         if (!handled) {
-            HomeActivity.start(getActivity(), arrivalInfo.getInfo().getRouteId());
+            HomeActivity.start(getActivity(), routeId);
         }
     }
 
@@ -1486,6 +1493,11 @@ public class ArrivalsListFragment extends ListFragment
     }
 
     private void goToTripDetails(ArrivalInfo stop) {
+        ObaArrivalInfo info = stop.getInfo();
+        String routeId = info.getRouteId();
+        String displayName = UIUtils.getRouteDisplayName(info);
+
+        QueryUtils.addRouteToRecents(getContext(), routeId, info.getShortName(), displayName, true);
         TripDetailsActivity.start(getActivity(),
                 stop.getInfo().getTripId(), stop.getInfo().getStopId(),
                 TripDetailsListFragment.SCROLL_MODE_STOP);

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/QueryUtils.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/QueryUtils.java
@@ -17,6 +17,7 @@ package org.onebusaway.android.ui;
 
 import org.onebusaway.android.R;
 import org.onebusaway.android.app.Application;
+import org.onebusaway.android.io.elements.ObaRegion;
 import org.onebusaway.android.provider.ObaContract;
 import org.onebusaway.android.util.UIUtils;
 
@@ -246,5 +247,17 @@ public final class QueryUtils {
         // Mark the combination of route and headsign as a favorite or not favorite
         ObaContract.RouteHeadsignFavorites
                 .markAsFavorite(context, routeId, headsign, stopId, favorite);
+    }
+
+    public static void addRouteToRecents(Context context, String routeId, String shortName, String routeLongName, boolean markAsUsed) {
+        ContentValues values = new ContentValues();
+        values.put(ObaContract.Routes.SHORTNAME, shortName);
+        values.put(ObaContract.Routes.LONGNAME, routeLongName);
+
+        ObaRegion currentRegion = Application.get().getCurrentRegion();
+        if (currentRegion != null) {
+            values.put(ObaContract.Routes.REGION_ID, currentRegion.getId());
+        }
+        ObaContract.Routes.insertOrUpdate(context, routeId, values, markAsUsed);
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/RouteInfoListFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/RouteInfoListFragment.java
@@ -16,7 +16,6 @@
 package org.onebusaway.android.ui;
 
 import org.onebusaway.android.R;
-import org.onebusaway.android.app.Application;
 import org.onebusaway.android.io.ObaAnalytics;
 import org.onebusaway.android.io.ObaApi;
 import org.onebusaway.android.io.elements.ObaStop;
@@ -26,11 +25,9 @@ import org.onebusaway.android.io.request.ObaRouteRequest;
 import org.onebusaway.android.io.request.ObaRouteResponse;
 import org.onebusaway.android.io.request.ObaStopsForRouteRequest;
 import org.onebusaway.android.io.request.ObaStopsForRouteResponse;
-import org.onebusaway.android.provider.ObaContract;
 import org.onebusaway.android.util.FragmentUtils;
 import org.onebusaway.android.util.UIUtils;
 
-import android.content.ContentValues;
 import android.content.Context;
 import android.net.Uri;
 import android.os.Bundle;
@@ -467,15 +464,7 @@ public class RouteInfoListFragment extends ListFragment {
             agencyText.setText(mRouteInfo.getAgency().getName());
 
             if (addToDb) {
-                ContentValues values = new ContentValues();
-                values.put(ObaContract.Routes.SHORTNAME, shortName);
-                values.put(ObaContract.Routes.LONGNAME, longName);
-                values.put(ObaContract.Routes.URL, url);
-                if (Application.get().getCurrentRegion() != null) {
-                    values.put(ObaContract.Routes.REGION_ID,
-                            Application.get().getCurrentRegion().getId());
-                }
-                ObaContract.Routes.insertOrUpdate(getActivity(), mRouteInfo.getId(), values, true);
+                QueryUtils.addRouteToRecents(getActivity(), mRouteInfo.getId(), shortName, longName, true);
             }
         } else {
             setEmptyText(UIUtils.getRouteErrorString(getActivity(), routeInfo.getCode()));

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/TripInfoActivity.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/TripInfoActivity.java
@@ -258,10 +258,7 @@ public class TripInfoActivity extends AppCompatActivity {
             mRouteName = bundle.getString(ROUTE_NAME);
             // If we get this, update it in the DB.
             if (mRouteName != null) {
-                ContentValues values = new ContentValues();
-                values.put(ObaContract.Routes.SHORTNAME, mRouteName);
-                ObaContract.Routes
-                        .insertOrUpdate(getActivity(), mRouteId, values, false);
+                QueryUtils.addRouteToRecents(getActivity(), mRouteId, mRouteName, "", false);
             }
             String name = bundle.getString(TRIP_NAME);
             if (name != null) {


### PR DESCRIPTION
* Fix order of assertEquals
* Delete row after ProviderTest.testLimit

`ProviderTest.testStops` was failing because state from `testLimit` was left over. Is `setUp()` not called per test method? Is there a better fix?

Do I need to add any tests for my code?

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [ ] Run the unit tests with `gradlew connectedObaGoogleDebugAndroidTest connectedObaAmazonDebugAndroidTest` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.

Not able to run tests through gradlew but I was able to run with Android Studio.
Output from gradlew:
```
* What went wrong:
A problem occurred configuring project ':onebusaway-android'.
> Could not generate a proxy class for class com.android.build.gradle.tasks.BuildArtifactReportTask.
```

Tested with Pixel 2XL with Pie in Puget Sound, San Diego, and Tampa regions.

In the Puget Sound region, the description for recent routes isn't correct when it is first added (e.g. **240** doesn't have its description in the screenshot below), but it gets populated when after you click it. It does seem to work for other regions though. Is this important?
![screenshot_20180812-102822](https://user-images.githubusercontent.com/1026617/44004713-c5f02aa8-9e1b-11e8-8b00-94d14b33af62.png)
