### PR TITLE
Fix #907 - Fail oba release build if Embedded Social API key is missing

### DIFF
--- a/onebusaway-android/build.gradle
+++ b/onebusaway-android/build.gradle
@@ -238,6 +238,14 @@ android {
             }
     }
 
+    variantFilter { variant ->
+        def names = variant.flavors*.name
+        // Make sure that OBA release builds always have an Embedded Social API key (#907)
+        if (names.contains("oba") && variant.buildType.name == "release" && getEmbeddedSocialApiKey(variant.flavors.get(0).name) == "") {
+            throw new InvalidUserDataException("gradle.properties must contain an EmbeddedSocialApiKey_oba API key for oba release builds")
+        }
+    }
+
     // http://stackoverflow.com/questions/20673625/gradle-0-7-0-duplicate-files-during-packaging-of-apk
     packagingOptions {
         exclude 'META-INF/LICENSE'

--- a/onebusaway-android/build.gradle
+++ b/onebusaway-android/build.gradle
@@ -238,14 +238,6 @@ android {
             }
     }
 
-    variantFilter { variant ->
-        def names = variant.flavors*.name
-        // Make sure that OBA release builds always have an Embedded Social API key (#907)
-        if (names.contains("oba") && variant.buildType.name == "release" && getEmbeddedSocialApiKey(variant.flavors.get(0).name) == "") {
-            throw new InvalidUserDataException("gradle.properties must contain an EmbeddedSocialApiKey_oba API key for oba release builds")
-        }
-    }
-
     // http://stackoverflow.com/questions/20673625/gradle-0-7-0-duplicate-files-during-packaging-of-apk
     packagingOptions {
         exclude 'META-INF/LICENSE'
@@ -391,9 +383,16 @@ task askForPasswords << {
 }
 
 tasks.whenTaskAdded { theTask ->
-    if (theTask.name.matches("\\bpackage\\w+Release\\b")) {
+   if (theTask.name.matches("\\bpackage\\w+Release\\b")) {
         theTask.dependsOn "askForPasswords"
-    }
+   }
+   // Make sure that OBA release builds always have an Embedded Social API key (#907)
+   def runningTask = project.gradle.startParameter.taskNames
+
+   if ((runningTask.toString().toLowerCase().matches("(.*)oba(.*)release(.*)") || runningTask.toString().toLowerCase().contains("assemblerelease") )  && !project.hasProperty('EmbeddedSocialApiKey_oba')) {
+        throw new InvalidUserDataException("gradle.properties must contain an EmbeddedSocialApiKey_oba API key for oba release builds")
+   }
+
 }
 
 // Exclude all classes from dependencies that conflict with Android platform classes (#849)


### PR DESCRIPTION
#### This PR does the following

When ES key name in `gradle.properties` is **invalid** (for example, `EmbeddedSocialApiKey_bad=xxxxxxxxxxxxxxxxxx`):
* all debug builds (including running from Android Studio) succeed (Example commands - `gradlew assembleObaGoogleDebug`, `gradlew assembleAgencyXGoogleDebug`)
* all non-oba flavor release builds, such as `gradlew assembleAgencyXGoogleRelease  -D org.gradle.daemon=false` and `gradlew assembleAgencyYGoogleRelease  -D org.gradle.daemon=false`, succeed
* `gradlew assembleObaGoogleRelease  -D org.gradle.daemon=false` fails  (this is the important part that fixes #907)

When ES key name in `gradle.properties` is **valid** (for example, `EmbeddedSocialApiKey_oba=xxxxxxxxxxxxxxxxxx`):
* All clean and builds succeed (debug and release) (Example commands - `gradlew assembleObaGoogleDebug`, `gradlew assembleObaGoogleRelease  -D org.gradle.daemon=false`, `gradlew assembleAgencyXGoogleDebug`, `gradlew assembleAgencyXGoogleRelease  -D org.gradle.daemon=false`

####  TODO:
- [x] Currently `gradlew clean` fails when the oba flavor key name is invalid (i.e., , `EmbeddedSocialApiKey_bad=xxxxxxxxxxxxxxxxxx` or `EmbeddedSocialApiKey_xxx` is missing) presumably because it's cleaning release builds too.  We need to fix so we can clean the project for debug builds without the ES key.