### PR TITLE
Fix #766 - Apply route filter to currently viewed alerts

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/util/test/UIUtilTest.java
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/util/test/UIUtilTest.java
@@ -53,6 +53,7 @@ import java.util.List;
 
 import static android.support.test.InstrumentationRegistry.getTargetContext;
 import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertNull;
 import static junit.framework.Assert.assertTrue;
@@ -928,7 +929,7 @@ public class UIUtilTest extends ObaTestCase {
 
         // They do appear, however, in the references list and are referenced by each arrival info
         // Make sure we build a list of all situations
-        List<ObaSituation> allSituations = UIUtils.getAllSituations(response);
+        List<ObaSituation> allSituations = UIUtils.getAllSituations(response, null);
 
         // Build a set of all IDs returned
         HashSet<String> situationIds = new HashSet<>();
@@ -971,7 +972,7 @@ public class UIUtilTest extends ObaTestCase {
 
         // They do appear, however, in the references list and are referenced by each arrival info
         // Make sure we build a list of all situations
-        allSituations = UIUtils.getAllSituations(response);
+        allSituations = UIUtils.getAllSituations(response, null);
 
         // Build a set of all IDs returned
         situationIds = new HashSet<>();
@@ -1000,5 +1001,49 @@ public class UIUtilTest extends ObaTestCase {
 
         // Make sure the stop situation object exist in list
         assertTrue(allSituations.contains(response.getSituations().get(0)));
+
+        /*
+        Test filtering routes alerts
+         */
+        response = new ObaArrivalInfoRequest.Builder(getTargetContext(), "MTS_11671").build().call();
+        assertOK(response);
+
+        List<String> routeFilters = new ArrayList<>();
+        routeFilters.add("MTS_1");
+
+        List<ObaSituation> filteredSituations = UIUtils.getAllSituations(response, routeFilters);
+
+        List<String> allIds = new ArrayList<>();
+        allSituations = UIUtils.getAllSituations(response, null);
+        for (ObaSituation situation : allSituations) {
+            allIds.add(situation.getId());
+        }
+
+        List<String> filteredIds = new ArrayList<>();
+        for (ObaSituation situation : filteredSituations) {
+            filteredIds.add(situation.getId());
+        }
+
+        // Should have two service alerts one for route 1 and one for route 11
+        assertEquals(2, allIds.size());
+        assertEquals(2, allSituations.size());
+
+        // Should contain only the alert for route 1
+        assertEquals(1, filteredIds.size());
+        assertEquals(1, filteredSituations.size());
+
+        // Should contain route 1 situation ID
+        assertTrue(filteredIds.contains("MTS_RTA:11569670"));
+
+        // route 11 situation ID should be in all IDs but not filteredIds
+        assertTrue(allIds.contains("MTS_RTA:11569666"));
+        assertFalse(filteredIds.contains("MTS_RTA:11569666"));
+
+        // Make sure filtered situation object exists
+        assertTrue(filteredSituations.contains(response.getSituation("MTS_RTA:11569670")));
+
+        // Make sure filtered out situation object is in all situations but not in filtered situations
+        assertTrue(allSituations.contains(response.getSituation("MTS_RTA:11569666")));
+        assertFalse(filteredSituations.contains(response.getSituation("MTS_RTA:11569666")));
     }
 }

--- a/onebusaway-android/src/androidTest/res/raw/arrivals_and_departures_for_stop_mts_11671_filter_route_alerts.json
+++ b/onebusaway-android/src/androidTest/res/raw/arrivals_and_departures_for_stop_mts_11671_filter_route_alerts.json
@@ -1,0 +1,579 @@
+{
+  "code": 200,
+  "currentTime": 1536288397225,
+  "data": {
+    "entry": {
+      "arrivalsAndDepartures": [
+        {
+          "arrivalEnabled": true,
+          "blockTripSequence": 11,
+          "departureEnabled": true,
+          "distanceFromStop": -473.27719098026864,
+          "frequency": null,
+          "lastUpdateTime": 1536288297000,
+          "numberOfStopsAway": -2,
+          "predicted": true,
+          "predictedArrivalInterval": null,
+          "predictedArrivalTime": 1536288300000,
+          "predictedDepartureInterval": null,
+          "predictedDepartureTime": 1536288300000,
+          "routeId": "MTS_1",
+          "routeLongName": "Fashion Valley - La Mesa",
+          "routeShortName": "1",
+          "scheduledArrivalInterval": null,
+          "scheduledArrivalTime": 1536288300000,
+          "scheduledDepartureInterval": null,
+          "scheduledDepartureTime": 1536288300000,
+          "serviceDate": 1536217200000,
+          "situationIds": [
+            "MTS_RTA:11569670"
+          ],
+          "status": "default",
+          "stopId": "MTS_11671",
+          "stopSequence": 40,
+          "tripHeadsign": "Fashion Valley",
+          "tripId": "MTS_13327700",
+          "tripStatus": {
+            "activeTripId": "MTS_13327700",
+            "blockTripSequence": 11,
+            "closestStop": "MTS_11675",
+            "closestStopTimeOffset": 23,
+            "distanceAlongTrip": 12887.684319223423,
+            "frequency": null,
+            "lastKnownDistanceAlongTrip": 0,
+            "lastKnownLocation": {
+              "lat": 32.755283,
+              "lon": -117.145927
+            },
+            "lastKnownOrientation": 0,
+            "lastLocationUpdateTime": 1536288297000,
+            "lastUpdateTime": 1536288297000,
+            "nextStop": "MTS_11675",
+            "nextStopTimeOffset": 23,
+            "orientation": 270.3022609802159,
+            "phase": "",
+            "position": {
+              "lat": 32.74957960829666,
+              "lon": -117.14632725760532
+            },
+            "predicted": true,
+            "scheduleDeviation": 0,
+            "scheduledDistanceAlongTrip": 12887.684319223423,
+            "serviceDate": 1536217200000,
+            "situationIds": [
+              "MTS_RTA:11569670"
+            ],
+            "status": "default",
+            "totalDistanceAlongTrip": 18492.8861934505,
+            "vehicleId": "MTS_2806"
+          },
+          "vehicleId": "MTS_2806"
+        },
+        {
+          "arrivalEnabled": true,
+          "blockTripSequence": 13,
+          "departureEnabled": true,
+          "distanceFromStop": 1650.8848098315357,
+          "frequency": null,
+          "lastUpdateTime": 1536288331000,
+          "numberOfStopsAway": 6,
+          "predicted": true,
+          "predictedArrivalInterval": null,
+          "predictedArrivalTime": 1536288660000,
+          "predictedDepartureInterval": null,
+          "predictedDepartureTime": 1536288660000,
+          "routeId": "MTS_11",
+          "routeLongName": "SDSU - Downtown San Diego",
+          "routeShortName": "11",
+          "scheduledArrivalInterval": null,
+          "scheduledArrivalTime": 1536288300000,
+          "scheduledDepartureInterval": null,
+          "scheduledDepartureTime": 1536288300000,
+          "serviceDate": 1536217200000,
+          "situationIds": [
+            "MTS_RTA:11569666"
+          ],
+          "status": "default",
+          "stopId": "MTS_11671",
+          "stopSequence": 23,
+          "tripHeadsign": "Downtown",
+          "tripId": "MTS_13405842",
+          "tripStatus": {
+            "activeTripId": "MTS_13405842",
+            "blockTripSequence": 13,
+            "closestStop": "MTS_11271",
+            "closestStopTimeOffset": 23,
+            "distanceAlongTrip": 8456.73840396566,
+            "frequency": null,
+            "lastKnownDistanceAlongTrip": 0,
+            "lastKnownLocation": {
+              "lat": 32.762901,
+              "lon": -117.133377
+            },
+            "lastKnownOrientation": 0,
+            "lastLocationUpdateTime": 1536288331000,
+            "lastUpdateTime": 1536288331000,
+            "nextStop": "MTS_11271",
+            "nextStopTimeOffset": 23,
+            "orientation": 180.30102584404722,
+            "phase": "",
+            "position": {
+              "lat": 32.76285682823025,
+              "lon": -117.13898669350826
+            },
+            "predicted": true,
+            "scheduleDeviation": 360,
+            "scheduledDistanceAlongTrip": 8456.73840396566,
+            "serviceDate": 1536217200000,
+            "situationIds": [
+              "MTS_RTA:11569666"
+            ],
+            "status": "default",
+            "totalDistanceAlongTrip": 16939.94079231228,
+            "vehicleId": "MTS_614"
+          },
+          "vehicleId": "MTS_614"
+        },
+        {
+          "arrivalEnabled": true,
+          "blockTripSequence": 3,
+          "departureEnabled": true,
+          "distanceFromStop": 10107.665971320457,
+          "frequency": null,
+          "lastUpdateTime": 1536288353000,
+          "numberOfStopsAway": 23,
+          "predicted": true,
+          "predictedArrivalInterval": null,
+          "predictedArrivalTime": 1536290082000,
+          "predictedDepartureInterval": null,
+          "predictedDepartureTime": 1536290082000,
+          "routeId": "MTS_11",
+          "routeLongName": "SDSU - Downtown San Diego",
+          "routeShortName": "11",
+          "scheduledArrivalInterval": null,
+          "scheduledArrivalTime": 1536290082000,
+          "scheduledDepartureInterval": null,
+          "scheduledDepartureTime": 1536290082000,
+          "serviceDate": 1536217200000,
+          "situationIds": [
+            "MTS_RTA:11569666"
+          ],
+          "status": "default",
+          "stopId": "MTS_11671",
+          "stopSequence": 23,
+          "tripHeadsign": "Downtown",
+          "tripId": "MTS_13405886",
+          "tripStatus": {
+            "activeTripId": "MTS_13405885",
+            "blockTripSequence": 2,
+            "closestStop": "MTS_99096",
+            "closestStopTimeOffset": 323,
+            "distanceAlongTrip": 15777.470891609242,
+            "frequency": null,
+            "lastKnownDistanceAlongTrip": 0,
+            "lastKnownLocation": {
+              "lat": 32.772938,
+              "lon": -117.071632
+            },
+            "lastKnownOrientation": 0,
+            "lastLocationUpdateTime": 1536288353000,
+            "lastUpdateTime": 1536288353000,
+            "nextStop": "MTS_99096",
+            "nextStopTimeOffset": 323,
+            "orientation": 48.36646069150642,
+            "phase": "",
+            "position": {
+              "lat": 32.77308969199388,
+              "lon": -117.07162227378322
+            },
+            "predicted": true,
+            "scheduleDeviation": 0,
+            "scheduledDistanceAlongTrip": 15777.470891609242,
+            "serviceDate": 1536217200000,
+            "situationIds": [
+              "MTS_RTA:11569666"
+            ],
+            "status": "default",
+            "totalDistanceAlongTrip": 15777.513649132487,
+            "vehicleId": "MTS_820"
+          },
+          "vehicleId": "MTS_820"
+        },
+        {
+          "arrivalEnabled": true,
+          "blockTripSequence": 12,
+          "departureEnabled": true,
+          "distanceFromStop": 8575.633243603981,
+          "frequency": null,
+          "lastUpdateTime": 1536288227000,
+          "numberOfStopsAway": 30,
+          "predicted": true,
+          "predictedArrivalInterval": null,
+          "predictedArrivalTime": 1536290160000,
+          "predictedDepartureInterval": null,
+          "predictedDepartureTime": 1536290160000,
+          "routeId": "MTS_1",
+          "routeLongName": "Fashion Valley - La Mesa",
+          "routeShortName": "1",
+          "scheduledArrivalInterval": null,
+          "scheduledArrivalTime": 1536290100000,
+          "scheduledDepartureInterval": null,
+          "scheduledDepartureTime": 1536290100000,
+          "serviceDate": 1536217200000,
+          "situationIds": [
+            "MTS_RTA:11569670"
+          ],
+          "status": "default",
+          "stopId": "MTS_11671",
+          "stopSequence": 40,
+          "tripHeadsign": "Fashion Valley",
+          "tripId": "MTS_13327707",
+          "tripStatus": {
+            "activeTripId": "MTS_13327707",
+            "blockTripSequence": 12,
+            "closestStop": "MTS_11044",
+            "closestStopTimeOffset": 23,
+            "distanceAlongTrip": 3838.773884639173,
+            "frequency": null,
+            "lastKnownDistanceAlongTrip": 0,
+            "lastKnownLocation": {
+              "lat": 32.76873,
+              "lon": -117.049728
+            },
+            "lastKnownOrientation": 0,
+            "lastLocationUpdateTime": 1536288227000,
+            "lastUpdateTime": 1536288227000,
+            "nextStop": "MTS_11044",
+            "nextStopTimeOffset": 23,
+            "orientation": 222.64045419996364,
+            "phase": "",
+            "position": {
+              "lat": 32.76612801864077,
+              "lon": -117.0594869335463
+            },
+            "predicted": true,
+            "scheduleDeviation": 60,
+            "scheduledDistanceAlongTrip": 3838.773884639173,
+            "serviceDate": 1536217200000,
+            "situationIds": [
+              "MTS_RTA:11569670"
+            ],
+            "status": "default",
+            "totalDistanceAlongTrip": 18492.8861934505,
+            "vehicleId": "MTS_2417"
+          },
+          "vehicleId": "MTS_2417"
+        }
+      ],
+      "nearbyStopIds": [
+        "MTS_13553",
+        "MTS_12454",
+        "MTS_13552"
+      ],
+      "situationIds": [],
+      "stopId": "MTS_11671"
+    },
+    "references": {
+      "agencies": [
+        {
+          "disclaimer": "",
+          "email": "customerfeedback@sdmts.com",
+          "fareUrl": "",
+          "id": "MTS",
+          "lang": "EN",
+          "name": "MTS",
+          "phone": "619-233-3004",
+          "privateService": false,
+          "timezone": "America/Los_Angeles",
+          "url": "http://www.sdmts.com"
+        }
+      ],
+      "routes": [
+        {
+          "agencyId": "MTS",
+          "color": "000099",
+          "description": "",
+          "id": "MTS_1",
+          "longName": "Fashion Valley - La Mesa",
+          "shortName": "1",
+          "textColor": "FFFFFF",
+          "type": 3,
+          "url": "https://www.sdmts.com/schedules-real-time?fragment=1"
+        },
+        {
+          "agencyId": "MTS",
+          "color": "000099",
+          "description": "",
+          "id": "MTS_11",
+          "longName": "SDSU - Downtown San Diego",
+          "shortName": "11",
+          "textColor": "FFFFFF",
+          "type": 3,
+          "url": "https://www.sdmts.com/schedules-real-time?fragment=11"
+        },
+        {
+          "agencyId": "MTS",
+          "color": "000099",
+          "description": "",
+          "id": "MTS_215",
+          "longName": "Mid-City Rapid",
+          "shortName": "215",
+          "textColor": "FFFFFF",
+          "type": 3,
+          "url": "https://www.sdmts.com/schedules-real-time?fragment=215"
+        }
+      ],
+      "situations": [
+        {
+          "activeWindows": [
+            {
+              "from": 1536073200,
+              "to": 1538157600
+            }
+          ],
+          "allAffects": [
+            {
+              "agencyId": "",
+              "applicationId": "",
+              "directionId": "",
+              "routeId": "MTS_1",
+              "stopId": "",
+              "tripId": ""
+            }
+          ],
+          "consequences": [
+            {
+              "condition": "no_service",
+              "conditionDetails": null
+            }
+          ],
+          "creationTime": 1536288380198,
+          "description": {
+            "lang": "en",
+            "value": "Due to road work, the eastbound bus stop on University at 8th (ID# 13391) will be closed 9/4 - 9/28, Monday - Friday from 8am -4pm. Route 1 connections can be made on University at 10th."
+          },
+          "id": "MTS_RTA:11569670",
+          "publicationWindows": [],
+          "reason": "CONSTRUCTION",
+          "severity": "",
+          "summary": {
+            "lang": "en",
+            "value": "Route 1 & 11 Stop Closed @ University & 8th"
+          },
+          "url": null
+        },
+        {
+          "activeWindows": [
+            {
+              "from": 1536073200,
+              "to": 1538157600
+            }
+          ],
+          "allAffects": [
+            {
+              "agencyId": "",
+              "applicationId": "",
+              "directionId": "",
+              "routeId": "MTS_11",
+              "stopId": "",
+              "tripId": ""
+            }
+          ],
+          "consequences": [
+            {
+              "condition": "no_service",
+              "conditionDetails": null
+            }
+          ],
+          "creationTime": 1536288380198,
+          "description": {
+            "lang": "en",
+            "value": "Due to road work, the eastbound bus stop on University at 8th (ID# 13391) will be closed 9/4 - 9/28, Monday - Friday from 8am -4pm. Route 11 connections can be made on University at 10th."
+          },
+          "id": "MTS_RTA:11569666",
+          "publicationWindows": [],
+          "reason": "CONSTRUCTION",
+          "severity": "",
+          "summary": {
+            "lang": "en",
+            "value": "Route 1 & 11 Stop Closed @ University & 8th"
+          },
+          "url": null
+        }
+      ],
+      "stops": [
+        {
+          "code": "11671",
+          "direction": "S",
+          "id": "MTS_11671",
+          "lat": 32.753833777169,
+          "locationType": 0,
+          "lon": -117.146632534228,
+          "name": "Park Bl & Howard Av",
+          "routeIds": [
+            "MTS_1",
+            "MTS_11"
+          ],
+          "wheelchairBoarding": "ACCESSIBLE"
+        },
+        {
+          "code": "11675",
+          "direction": "S",
+          "id": "MTS_11675",
+          "lat": 32.748581359718,
+          "locationType": 0,
+          "lon": -117.146482485901,
+          "name": "Park Bl & University Av",
+          "routeIds": [
+            "MTS_1",
+            "MTS_11"
+          ],
+          "wheelchairBoarding": "ACCESSIBLE"
+        },
+        {
+          "code": "11271",
+          "direction": "W",
+          "id": "MTS_11271",
+          "lat": 32.762948821329,
+          "locationType": 0,
+          "lon": -117.140272393213,
+          "name": "Adams Av & Panorama Dr (E)",
+          "routeIds": [
+            "MTS_11"
+          ],
+          "wheelchairBoarding": "UNKNOWN"
+        },
+        {
+          "code": "99096",
+          "direction": "NE",
+          "id": "MTS_99096",
+          "lat": 32.773045203141,
+          "locationType": 0,
+          "lon": -117.071553449154,
+          "name": "SDSU Transit Center",
+          "routeIds": [
+            "MTS_11"
+          ],
+          "wheelchairBoarding": "ACCESSIBLE"
+        },
+        {
+          "code": "11044",
+          "direction": "SW",
+          "id": "MTS_11044",
+          "lat": 32.765176427222,
+          "locationType": 0,
+          "lon": -117.060722289388,
+          "name": "El Cajon Bl & Art St",
+          "routeIds": [
+            "MTS_1"
+          ],
+          "wheelchairBoarding": "ACCESSIBLE"
+        },
+        {
+          "code": "13553",
+          "direction": "S",
+          "id": "MTS_13553",
+          "lat": 32.753688688176,
+          "locationType": 0,
+          "lon": -117.146401096855,
+          "name": "Park Bl & Howard Av",
+          "routeIds": [
+            "MTS_215"
+          ],
+          "wheelchairBoarding": "UNKNOWN"
+        },
+        {
+          "code": "12454",
+          "direction": "N",
+          "id": "MTS_12454",
+          "lat": 32.753894071237,
+          "locationType": 0,
+          "lon": -117.14612671249,
+          "name": "Park Bl & Howard Av",
+          "routeIds": [
+            "MTS_1",
+            "MTS_11"
+          ],
+          "wheelchairBoarding": "ACCESSIBLE"
+        },
+        {
+          "code": "13552",
+          "direction": "N",
+          "id": "MTS_13552",
+          "lat": 32.754340628328,
+          "locationType": 0,
+          "lon": -117.1463264137,
+          "name": "Park Bl & Howard Av",
+          "routeIds": [
+            "MTS_215"
+          ],
+          "wheelchairBoarding": "UNKNOWN"
+        }
+      ],
+      "trips": [
+        {
+          "blockId": "MTS_102",
+          "directionId": "1",
+          "id": "MTS_13327700",
+          "routeId": "MTS_1",
+          "routeShortName": "",
+          "serviceId": "MTS_67610-1111100-0",
+          "shapeId": "MTS_1_3_147",
+          "timeZone": "",
+          "tripHeadsign": "Fashion Valley",
+          "tripShortName": ""
+        },
+        {
+          "blockId": "MTS_101103",
+          "directionId": "1",
+          "id": "MTS_13405842",
+          "routeId": "MTS_11",
+          "routeShortName": "",
+          "serviceId": "MTS_67669-1111100-0",
+          "shapeId": "MTS_11_1_289",
+          "timeZone": "",
+          "tripHeadsign": "Downtown",
+          "tripShortName": ""
+        },
+        {
+          "blockId": "MTS_101111",
+          "directionId": "1",
+          "id": "MTS_13405886",
+          "routeId": "MTS_11",
+          "routeShortName": "",
+          "serviceId": "MTS_67669-1111100-0",
+          "shapeId": "MTS_11_1_289",
+          "timeZone": "",
+          "tripHeadsign": "Downtown",
+          "tripShortName": ""
+        },
+        {
+          "blockId": "MTS_101111",
+          "directionId": "0",
+          "id": "MTS_13405885",
+          "routeId": "MTS_11",
+          "routeShortName": "",
+          "serviceId": "MTS_67669-1111100-0",
+          "shapeId": "MTS_11_0_288",
+          "timeZone": "",
+          "tripHeadsign": "SDSU",
+          "tripShortName": ""
+        },
+        {
+          "blockId": "MTS_101",
+          "directionId": "1",
+          "id": "MTS_13327707",
+          "routeId": "MTS_1",
+          "routeShortName": "",
+          "serviceId": "MTS_67610-1111100-0",
+          "shapeId": "MTS_1_3_147",
+          "timeZone": "",
+          "tripHeadsign": "Fashion Valley",
+          "tripShortName": ""
+        }
+      ]
+    }
+  },
+  "text": "OK",
+  "version": 2
+}

--- a/onebusaway-android/src/androidTest/res/raw/urimap.json
+++ b/onebusaway-android/src/androidTest/res/raw/urimap.json
@@ -17,6 +17,7 @@
     "/api/api/where/arrivals-and-departures-for-stop/DART_4041.json": "arrivals_and_departures_for_stop_dart_4041_alerts",
     "/api/api/where/arrivals-and-departures-for-stop/MTS_11670.json": "arrivals_and_departures_for_stop_mts_11670_route_alerts",
     "/api/api/where/arrivals-and-departures-for-stop/MTS_13353.json": "arrivals_and_departures_for_stop_mts_13353_route_and_stop_alerts",
+    "/api/api/where/arrivals-and-departures-for-stop/MTS_11671.json": "arrivals_and_departures_for_stop_mts_11671_filter_route_alerts",
 
     "/api/where/current-time.json": "current_time",
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListFragment.java
@@ -150,6 +150,7 @@ public class ArrivalsListFragment extends ListFragment
 
     private ObaReferences mObaReferences;
 
+    // The list of route_ids that should have their arrival info and alerts displayed. (All if empty or null)
     private ArrayList<String> mRoutesFilter;
 
     private int mLastResponseLength = -1; // Keep copy locally, since loader overwrites

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListFragment.java
@@ -384,7 +384,7 @@ public class ArrivalsListFragment extends ListFragment
         if (loader != null) {
             ObaArrivalInfoResponse lastGood = loader.getLastGoodResponse();
             if (lastGood != null) {
-                setResponseData(lastGood.getArrivalInfo(), UIUtils.getAllSituations(lastGood),
+                setResponseData(lastGood.getArrivalInfo(), UIUtils.getAllSituations(lastGood, mRoutesFilter),
                         lastGood.getRefs());
             }
         }
@@ -456,7 +456,7 @@ public class ArrivalsListFragment extends ListFragment
                 addToDB(mStop);
             }
             info = result.getArrivalInfo();
-            situations = UIUtils.getAllSituations(result);
+            situations = UIUtils.getAllSituations(result, mRoutesFilter);
             refs = result.getRefs();
 
         } else {
@@ -471,7 +471,7 @@ public class ArrivalsListFragment extends ListFragment
                         R.string.generic_comm_error_toast,
                         Toast.LENGTH_LONG).show();
                 info = lastGood.getArrivalInfo();
-                situations = lastGood.getSituations();
+                situations = UIUtils.getAllSituations(lastGood, mRoutesFilter);
             } else {
                 setEmptyText(UIUtils.getStopErrorString(getActivity(), result.getCode()));
             }
@@ -1000,6 +1000,7 @@ public class ArrivalsListFragment extends ListFragment
     public void setRoutesFilter(ArrayList<String> routes) {
         mRoutesFilter = routes;
         ObaContract.StopRouteFilters.set(getActivity(), mStopId, mRoutesFilter);
+        refreshSituations(UIUtils.getAllSituations(getArrivalsLoader().getLastGoodResponse(), mRoutesFilter));
         refreshLocal();
     }
 
@@ -1321,6 +1322,7 @@ public class ArrivalsListFragment extends ListFragment
                 checks[i] = true;
             }
         }
+
         // Arguments
         Bundle args = new Bundle();
         args.putStringArray(RoutesFilterDialog.ITEMS, items);

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/UIUtils.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/UIUtils.java
@@ -1424,18 +1424,20 @@ public final class UIUtils {
 
     /**
      * Returns a list of all situations (service alerts) that are specific to the stop, routes, and
-     * agency
-     * for the provided arrivals-and-departures-for-stop response.  For route-specific alerts, this
+     * agency for the provided arrivals-and-departures-for-stop response.  For route-specific alerts, this
      * involves looping through the routes and checking the references element to see if there are
      * any route-specific alerts, and adding them to the list to be shown above the list of
-     * arrivals
-     * for a stop.  See #700.
+     * arrivals for a stop.  See #700.
      *
      * @param response response from arrivals-and-departures-for-stop API
-     * @param filter   list of routes to not retrieve service alerts for
+     * @param filter   list of route_ids to retrieve service alerts for, or null to retrieve service
+     *                 alerts for all routes. Note that this filter only affects alerts scoped to
+     *                 routes - it does not affect alerts scoped to stops or agencies
      * @return a list of all situations (service alerts) that are specific to the stop, routes, and
-     * agency (excluding those specified with filter)
-     * for the provided arrivals-and-departures-for-stop response.  See #700.
+     * agency. If a route filter list is provided, situations for all stops and agencies are included
+     * in the returned list, but only situations scoped for route_ids in the provided filter list are
+     * included in the returned list (i.e., situations specified for route_ids that aren't in the
+     * filter list are excluded).
      */
     public static List<ObaSituation> getAllSituations(final ObaArrivalInfoResponse response, List<String> filter) {
         List<ObaSituation> allSituations = new ArrayList<>();
@@ -1450,14 +1452,15 @@ public final class UIUtils {
 
         // Do the same for filtered routes
         HashSet<String> filterIds = new HashSet<>();
-        if (filter != null) {
+        if (filter != null && !filter.isEmpty()) {
             for (String routeId : filter) {
                 filterIds.add(routeId);
             }
         }
 
         // Scan through the routes, and if a route-specific situation hasn't been added yet, add it
-        // If a filter list exists and a route isn't on it, skip it's situations
+        // If a filter list exists and a route_id is not included in the filter list, don't included
+        // it's situations in the returned list.
         ObaArrivalInfo[] info = response.getArrivalInfo();
         for (ObaArrivalInfo i : info) {
             if (filterIds.isEmpty() || filterIds.contains(i.getRouteId())) {


### PR DESCRIPTION
Filters out service alerts for routes that have been filtered out from a stop's arrival list. 

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [X] Run the unit tests with `gradlew connectedObaGoogleDebugAndroidTest connectedObaAmazonDebugAndroidTest` to make sure you didn't break anything

- [X] If you have multiple commits please combine them into one commit by squashing them for the initial submission of the pull request.  When addressing comments on a pull request, please push a new commit per comment when possible (reviewers will squash and merge using GitHub merge tool)