### PR TITLE
Fix #851 - Allow filtering by arrivals or departures at a stop

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/adapter/test/AdapterTest.java
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/adapter/test/AdapterTest.java
@@ -31,6 +31,7 @@ import org.onebusaway.android.io.test.ObaTestCase;
 import org.onebusaway.android.mock.MockRegion;
 import org.onebusaway.android.ui.ArrivalsListAdapterStyleA;
 import org.onebusaway.android.ui.ArrivalsListAdapterStyleB;
+import org.onebusaway.android.util.ArrivalInfoUtils.ArrivalFilter;
 
 import android.view.View;
 
@@ -75,7 +76,8 @@ public class AdapterTest extends ObaTestCase {
         final ObaArrivalInfo[] arrivals = response.getArrivalInfo();
 
         adapterA = new ArrivalsListAdapterStyleA(getTargetContext());
-        adapterA.setData(arrivals, new ArrayList<String>(), response.getCurrentTime());
+        adapterA.setData(arrivals, new ArrayList<String>(), ArrivalFilter.BOTH,
+                response.getCurrentTime());
         View v = adapterA.getView(0, null, null);
         assertNotNull(v);
     }
@@ -101,7 +103,8 @@ public class AdapterTest extends ObaTestCase {
         final ObaArrivalInfo[] arrivals = response.getArrivalInfo();
 
         adapterB = new ArrivalsListAdapterStyleB(getTargetContext());
-        adapterB.setData(arrivals, new ArrayList<String>(), response.getCurrentTime());
+        adapterB.setData(arrivals, new ArrayList<String>(), ArrivalFilter.BOTH,
+                response.getCurrentTime());
         View v = adapterB.getView(0, null, null);
         assertNotNull(v);
     }
@@ -134,7 +137,8 @@ public class AdapterTest extends ObaTestCase {
         final ObaArrivalInfo[] arrivals = response.getArrivalInfo();
 
         adapterA = new ArrivalsListAdapterStyleA(getTargetContext());
-        adapterA.setData(arrivals, new ArrayList<String>(), response.getCurrentTime());
+        adapterA.setData(arrivals, new ArrayList<String>(), ArrivalFilter.BOTH,
+                response.getCurrentTime());
         View v = adapterA.getView(0, null, null);
         assertNotNull(v);
     }
@@ -167,7 +171,8 @@ public class AdapterTest extends ObaTestCase {
         final ObaArrivalInfo[] arrivals = response.getArrivalInfo();
 
         adapterB = new ArrivalsListAdapterStyleB(getTargetContext());
-        adapterB.setData(arrivals, new ArrayList<String>(), response.getCurrentTime());
+        adapterB.setData(arrivals, new ArrayList<String>(), ArrivalFilter.BOTH,
+                response.getCurrentTime());
         if (!adapterB.isEmpty()) {
             View v = adapterB.getView(0, null, null);
             assertNotNull(v);

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/util/test/UIUtilTest.java
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/util/test/UIUtilTest.java
@@ -873,61 +873,91 @@ public class UIUtilTest extends ObaTestCase {
     public void testGetNoArrivalsMessage() {
         String result;
 
-        // Arrivals only or both arrivals and departures
-        boolean onlyDepartures = false;
+        // Test for both arrivals and departures
+        ArrivalFilter arrivalFilter = ArrivalFilter.BOTH;
 
         // Less than an hour
-        result = UIUtils.getNoArrivalsMessage(getTargetContext(), 35, false, false, onlyDepartures);
+        result = UIUtils.getNoArrivalsMessage(getTargetContext(), 35, false, false, arrivalFilter);
         assertEquals("No arrivals in the next 35 min.", result);
 
-        result = UIUtils.getNoArrivalsMessage(getTargetContext(), 35, true, false, onlyDepartures);
+        result = UIUtils.getNoArrivalsMessage(getTargetContext(), 35, true, false, arrivalFilter);
         assertEquals("No additional arrivals in the next 35 min.", result);
 
-        result = UIUtils.getNoArrivalsMessage(getTargetContext(), 35, false, true, onlyDepartures);
+        result = UIUtils.getNoArrivalsMessage(getTargetContext(), 35, false, true, arrivalFilter);
         assertEquals("35+ min", result);
 
-        result = UIUtils.getNoArrivalsMessage(getTargetContext(), 35, true, true, onlyDepartures);
+        result = UIUtils.getNoArrivalsMessage(getTargetContext(), 35, true, true, arrivalFilter);
         assertEquals("35+ min", result);
 
         // More than an hour
-        result = UIUtils.getNoArrivalsMessage(getTargetContext(), 75, false, false, onlyDepartures);
+        result = UIUtils.getNoArrivalsMessage(getTargetContext(), 75, false, false, arrivalFilter);
         assertEquals("No arrivals in the next 1 hour and 15 min.", result);
 
-        result = UIUtils.getNoArrivalsMessage(getTargetContext(), 75, true, false, onlyDepartures);
+        result = UIUtils.getNoArrivalsMessage(getTargetContext(), 75, true, false, arrivalFilter);
         assertEquals("No additional arrivals in the next 1 hr and 15 min.", result);
 
-        result = UIUtils.getNoArrivalsMessage(getTargetContext(), 75, false, true, onlyDepartures);
+        result = UIUtils.getNoArrivalsMessage(getTargetContext(), 75, false, true, arrivalFilter);
         assertEquals("1h 15+ min", result);
 
-        result = UIUtils.getNoArrivalsMessage(getTargetContext(), 75, true, true, onlyDepartures);
+        result = UIUtils.getNoArrivalsMessage(getTargetContext(), 75, true, true, arrivalFilter);
         assertEquals("1h 15+ min", result);
 
-        onlyDepartures = true;
+        // Test for only arrivals
+        arrivalFilter = ArrivalFilter.ONLY_ARRIVALS;
 
         // Less than an hour
-        result = UIUtils.getNoArrivalsMessage(getTargetContext(), 35, false, false, onlyDepartures);
-        assertEquals("No departures in the next 35 min.", result);
+        result = UIUtils.getNoArrivalsMessage(getTargetContext(), 35, false, false, arrivalFilter);
+        assertEquals("No arrivals in the next 35 min.", result);
 
-        result = UIUtils.getNoArrivalsMessage(getTargetContext(), 35, true, false, onlyDepartures);
-        assertEquals("No additional departures in the next 35 min.", result);
+        result = UIUtils.getNoArrivalsMessage(getTargetContext(), 35, true, false, arrivalFilter);
+        assertEquals("No additional arrivals in the next 35 min.", result);
 
-        result = UIUtils.getNoArrivalsMessage(getTargetContext(), 35, false, true, onlyDepartures);
+        result = UIUtils.getNoArrivalsMessage(getTargetContext(), 35, false, true, arrivalFilter);
         assertEquals("35+ min", result);
 
-        result = UIUtils.getNoArrivalsMessage(getTargetContext(), 35, true, true, onlyDepartures);
+        result = UIUtils.getNoArrivalsMessage(getTargetContext(), 35, true, true, arrivalFilter);
         assertEquals("35+ min", result);
 
         // More than an hour
-        result = UIUtils.getNoArrivalsMessage(getTargetContext(), 75, false, false, onlyDepartures);
-        assertEquals("No departures in the next 1 hour and 15 min.", result);
+        result = UIUtils.getNoArrivalsMessage(getTargetContext(), 75, false, false, arrivalFilter);
+        assertEquals("No arrivals in the next 1 hour and 15 min.", result);
 
-        result = UIUtils.getNoArrivalsMessage(getTargetContext(), 75, true, false, onlyDepartures);
-        assertEquals("No additional departures in the next 1 hr and 15 min.", result);
+        result = UIUtils.getNoArrivalsMessage(getTargetContext(), 75, true, false, arrivalFilter);
+        assertEquals("No additional arrivals in the next 1 hr and 15 min.", result);
 
-        result = UIUtils.getNoArrivalsMessage(getTargetContext(), 75, false, true, onlyDepartures);
+        result = UIUtils.getNoArrivalsMessage(getTargetContext(), 75, false, true, arrivalFilter);
         assertEquals("1h 15+ min", result);
 
-        result = UIUtils.getNoArrivalsMessage(getTargetContext(), 75, true, true, onlyDepartures);
+        result = UIUtils.getNoArrivalsMessage(getTargetContext(), 75, true, true, arrivalFilter);
+        assertEquals("1h 15+ min", result);
+
+        // Test for only departures
+        arrivalFilter = ArrivalFilter.ONLY_DEPARTURES;
+
+        // Less than an hour
+        result = UIUtils.getNoArrivalsMessage(getTargetContext(), 35, false, false, arrivalFilter);
+        assertEquals("No departures in the next 35 min.", result);
+
+        result = UIUtils.getNoArrivalsMessage(getTargetContext(), 35, true, false, arrivalFilter);
+        assertEquals("No additional departures in the next 35 min.", result);
+
+        result = UIUtils.getNoArrivalsMessage(getTargetContext(), 35, false, true, arrivalFilter);
+        assertEquals("35+ min", result);
+
+        result = UIUtils.getNoArrivalsMessage(getTargetContext(), 35, true, true, arrivalFilter);
+        assertEquals("35+ min", result);
+
+        // More than an hour
+        result = UIUtils.getNoArrivalsMessage(getTargetContext(), 75, false, false, arrivalFilter);
+        assertEquals("No departures in the next 1 hour and 15 min.", result);
+
+        result = UIUtils.getNoArrivalsMessage(getTargetContext(), 75, true, false, arrivalFilter);
+        assertEquals("No additional departures in the next 1 hr and 15 min.", result);
+
+        result = UIUtils.getNoArrivalsMessage(getTargetContext(), 75, false, true, arrivalFilter);
+        assertEquals("1h 15+ min", result);
+
+        result = UIUtils.getNoArrivalsMessage(getTargetContext(), 75, true, true, arrivalFilter);
         assertEquals("1h 15+ min", result);
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/provider/ObaContract.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/provider/ObaContract.java
@@ -106,6 +106,14 @@ public final class ObaContract {
          * </P>
          */
         public static final String REGION_ID = "region_id";
+
+        /**
+         * Whether the selected stop should show arrivals, departures or both.
+         * <P>
+         * Type: INTEGER
+         * </P>
+         */
+        public static final String ARRIVAL_FILTER = "arrival_filter";
     }
 
     protected interface RoutesColumns {
@@ -166,25 +174,6 @@ public final class ObaContract {
 
     protected interface StopRouteFilterColumns extends StopRouteKeyColumns {
         // No additional columns
-    }
-
-    protected interface StopArrivalFilterColumns {
-        /**
-         * The referenced Stop ID. This may or may not represent a key in the
-         * Stops table.
-         * <P>
-         * Type: TEXT
-         * </P>
-         */
-        public static final String STOP_ID = "stop_id";
-
-        /**
-         * Whether the selected stop should show arrivals, departures or both.
-         * <P>
-         * Type: INTEGER
-         * </P>
-         */
-        public static final String ARRIVAL_FILTER = "arrival_filter";
     }
 
     protected interface TripsColumns extends StopRouteKeyColumns {
@@ -646,6 +635,33 @@ public final class ObaContract {
             values.putNull(ObaContract.Stops.ACCESS_TIME);
             return cr.update(uri, values, null, null) > 0;
         }
+
+        public static int getArrivalFilter(Context context, Uri uri) {
+            ContentResolver cr = context.getContentResolver();
+            Cursor c = cr.query(uri, new String[]{ARRIVAL_FILTER}, null, null, null);
+
+            int result = 0;
+            if (c != null && c.moveToNext()) {
+                result = c.getInt(0);
+            }
+
+            if (c != null) {
+                c.close();
+            }
+
+            return result;
+        }
+
+        public static void setArrivalFilter(Context context, Uri uri, int filterOption) {
+            if (context == null) {
+                return;
+            }
+
+            ContentResolver cr = context.getContentResolver();
+            ContentValues values = new ContentValues();
+            values.put(ARRIVAL_FILTER, filterOption);
+            cr.update(uri, values, null, null);
+        }
     }
 
     public static class Routes implements BaseColumns, RoutesColumns,
@@ -746,51 +762,6 @@ public final class ObaContract {
             }
             // If we get this far, assume its not
             return false;
-        }
-    }
-
-    public static class StopArrivalFilter implements StopArrivalFilterColumns {
-        private StopArrivalFilter() {
-            // Cannot be instantiated
-        }
-
-        public static final String PATH = "stop_arrival_filter";
-
-        public static final Uri CONTENT_URI = Uri.withAppendedPath(AUTHORITY_URI, PATH);
-        public static final String CONTENT_DIR_TYPE = "vnd.android.dit" +
-                BuildConfig.DATABASE_AUTHORITY + ".stoparrivalfilter";
-
-        private static final String FILTER_WHERE = STOP_ID + "=?";
-
-        public static int get(Context context, String stopId) {
-            final String[] selection = {ARRIVAL_FILTER};
-            final String[] selectionArgs = {stopId};
-            ContentResolver cr = context.getContentResolver();
-            Cursor c = cr.query(CONTENT_URI, selection, FILTER_WHERE, selectionArgs, null);
-
-            int result = 0;
-            if (c != null && c.moveToNext()) {
-                result = c.getInt(0);
-            }
-            c.close();
-
-            return result;
-        }
-
-        public static void set(Context context, String stopId, int filterOption) {
-            if (context == null) {
-                return;
-            }
-
-            final String[] selectionArgs = {stopId};
-            ContentResolver cr = context.getContentResolver();
-
-            cr.delete(CONTENT_URI, FILTER_WHERE, selectionArgs);
-
-            ContentValues values = new ContentValues();
-            values.put(ARRIVAL_FILTER, filterOption);
-            values.put(STOP_ID, stopId);
-            cr.insert(CONTENT_URI, values);
         }
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/provider/ObaContract.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/provider/ObaContract.java
@@ -168,6 +168,25 @@ public final class ObaContract {
         // No additional columns
     }
 
+    protected interface StopArrivalFilterColumns {
+        /**
+         * The referenced Stop ID. This may or may not represent a key in the
+         * Stops table.
+         * <P>
+         * Type: TEXT
+         * </P>
+         */
+        public static final String STOP_ID = "stop_id";
+
+        /**
+         * Whether the selected stop should show arrivals, departures or both.
+         * <P>
+         * Type: INTEGER
+         * </P>
+         */
+        public static final String ARRIVAL_FILTER = "arrival_filter";
+    }
+
     protected interface TripsColumns extends StopRouteKeyColumns {
 
         /**
@@ -727,6 +746,51 @@ public final class ObaContract {
             }
             // If we get this far, assume its not
             return false;
+        }
+    }
+
+    public static class StopArrivalFilter implements StopArrivalFilterColumns {
+        private StopArrivalFilter() {
+            // Cannot be instantiated
+        }
+
+        public static final String PATH = "stop_arrival_filter";
+
+        public static final Uri CONTENT_URI = Uri.withAppendedPath(AUTHORITY_URI, PATH);
+        public static final String CONTENT_DIR_TYPE = "vnd.android.dit" +
+                BuildConfig.DATABASE_AUTHORITY + ".stoparrivalfilter";
+
+        private static final String FILTER_WHERE = STOP_ID + "=?";
+
+        public static int get(Context context, String stopId) {
+            final String[] selection = {ARRIVAL_FILTER};
+            final String[] selectionArgs = {stopId};
+            ContentResolver cr = context.getContentResolver();
+            Cursor c = cr.query(CONTENT_URI, selection, FILTER_WHERE, selectionArgs, null);
+
+            int result = 0;
+            if (c != null && c.moveToNext()) {
+                result = c.getInt(0);
+            }
+            c.close();
+
+            return result;
+        }
+
+        public static void set(Context context, String stopId, int filterOption) {
+            if (context == null) {
+                return;
+            }
+
+            final String[] selectionArgs = {stopId};
+            ContentResolver cr = context.getContentResolver();
+
+            cr.delete(CONTENT_URI, FILTER_WHERE, selectionArgs);
+
+            ContentValues values = new ContentValues();
+            values.put(ARRIVAL_FILTER, filterOption);
+            values.put(STOP_ID, stopId);
+            cr.insert(CONTENT_URI, values);
         }
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/provider/ObaContract.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/provider/ObaContract.java
@@ -24,6 +24,7 @@ import org.onebusaway.android.app.Application;
 import org.onebusaway.android.io.ObaAnalytics;
 import org.onebusaway.android.io.elements.ObaRegion;
 import org.onebusaway.android.io.elements.ObaRegionElement;
+import org.onebusaway.android.util.ArrivalInfoUtils.ArrivalFilter;
 
 import android.content.ContentResolver;
 import android.content.ContentUris;
@@ -636,7 +637,7 @@ public final class ObaContract {
             return cr.update(uri, values, null, null) > 0;
         }
 
-        public static int getArrivalFilter(Context context, Uri uri) {
+        public static ArrivalFilter getArrivalFilter(Context context, Uri uri) {
             ContentResolver cr = context.getContentResolver();
             Cursor c = cr.query(uri, new String[]{ARRIVAL_FILTER}, null, null, null);
 
@@ -649,13 +650,15 @@ public final class ObaContract {
                 c.close();
             }
 
-            return result;
+            return ArrivalFilter.fromInt(result);
         }
 
-        public static void setArrivalFilter(Context context, Uri uri, int filterOption) {
+        public static void setArrivalFilter(Context context, Uri uri, ArrivalFilter arrivalFilter) {
             if (context == null) {
                 return;
             }
+
+            int filterOption = ArrivalFilter.toInt(arrivalFilter);
 
             ContentResolver cr = context.getContentResolver();
             ContentValues values = new ContentValues();

--- a/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/SimpleArrivalListFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/SimpleArrivalListFragment.java
@@ -181,7 +181,7 @@ public class SimpleArrivalListFragment extends Fragment
         contentLayout.removeAllViews();
 
         ArrayList<ArrivalInfo> arrivalInfos = ArrivalInfoUtils.convertObaArrivalInfo(getActivity(),
-                info, new ArrayList<String>(), currentTime, false);
+                info, ArrivalInfoUtils.ArrivalFilter.BOTH, new ArrayList<String>(), currentTime, false);
 
         for (ArrivalInfo stopInfo : arrivalInfos) {
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListAdapterBase.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListAdapterBase.java
@@ -17,6 +17,7 @@ package org.onebusaway.android.ui;
 
 import org.onebusaway.android.io.elements.ObaArrivalInfo;
 import org.onebusaway.android.util.ArrayAdapter;
+import org.onebusaway.android.util.ArrivalInfoUtils;
 
 import android.content.ContentQueryMap;
 import android.content.Context;
@@ -41,5 +42,6 @@ public abstract class ArrivalsListAdapterBase<T> extends ArrayAdapter<T> {
         notifyDataSetChanged();
     }
 
-    abstract public void setData(ObaArrivalInfo[] arrivals, ArrayList<String> routesFilter, long currentTime);
+    abstract public void setData(ObaArrivalInfo[] arrivals, ArrayList<String> routesFilter,
+                                 ArrivalInfoUtils.ArrivalFilter arrivalFilter, long currentTime);
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListAdapterStyleA.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListAdapterStyleA.java
@@ -46,15 +46,16 @@ public class ArrivalsListAdapterStyleA extends ArrivalsListAdapterBase<ArrivalIn
     /**
      * Sets the data to be used with the adapter
      *
-     * @param routesFilter routeIds to filter for
-     * @param currentTime  current time in milliseconds
+     * @param routesFilter  routeIds to filter for
+     * @param arrivalFilter whether to include arrivals, departures, or both
+     * @param currentTime   current time in milliseconds
      */
     public void setData(ObaArrivalInfo[] arrivals, ArrayList<String> routesFilter,
-            long currentTime) {
+                        ArrivalInfoUtils.ArrivalFilter arrivalFilter, long currentTime) {
         if (arrivals != null) {
             ArrayList<ArrivalInfo> list =
                     ArrivalInfoUtils.convertObaArrivalInfo(getContext(),
-                            arrivals, routesFilter, currentTime, false);
+                            arrivals, arrivalFilter, routesFilter, currentTime, false);
             setData(list);
         } else {
             setData(null);

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListAdapterStyleB.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListAdapterStyleB.java
@@ -71,15 +71,16 @@ public class ArrivalsListAdapterStyleB extends ArrivalsListAdapterBase<CombinedA
     /**
      * Sets the data to be used with the adapter
      *
-     * @param routesFilter routeIds to filter for
-     * @param currentTime  current time in milliseconds
+     * @param routesFilter  routeIds to filter for
+     * @param arrivalFilter whether to include arrivals, departures, or both
+     * @param currentTime   current time in milliseconds
      */
     public void setData(ObaArrivalInfo[] arrivals, ArrayList<String> routesFilter,
-            long currentTime) {
+                        ArrivalInfoUtils.ArrivalFilter arrivalFilter, long currentTime) {
         if (arrivals != null) {
             ArrayList<ArrivalInfo> list =
                     ArrivalInfoUtils.convertObaArrivalInfo(getContext(),
-                            arrivals, routesFilter, currentTime, true);
+                            arrivals, arrivalFilter, routesFilter, currentTime, true);
 
             // Sort list by route and headsign, in that order
             Collections.sort(list, new Comparator<ArrivalInfo>() {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListFragment.java
@@ -318,8 +318,7 @@ public class ArrivalsListFragment extends ListFragment
         setStopId();
         setUserInfo();
 
-        int arrivalFilter = ObaContract.Stops.getArrivalFilter(getActivity(), mStopUri);
-        mArrivalFilter = ArrivalFilter.fromInt(arrivalFilter);
+        mArrivalFilter = ObaContract.Stops.getArrivalFilter(getActivity(), mStopUri);
 
         setupHeader(savedInstanceState);
 
@@ -1357,7 +1356,7 @@ public class ArrivalsListFragment extends ListFragment
 
     private void showArrivalFilterDialog() {
         Bundle args = new Bundle();
-        args.putInt(ArrivalFilterDialog.SELECTION, mArrivalFilter.toInt());
+        args.putInt(ArrivalFilterDialog.SELECTION, ArrivalFilter.toInt(mArrivalFilter));
         ArrivalFilterDialog frag = new ArrivalFilterDialog();
         frag.setArguments(args);
         frag.show(getActivity().getSupportFragmentManager(), ".ArrivalFilterDialog");
@@ -1512,7 +1511,7 @@ public class ArrivalsListFragment extends ListFragment
 
         mArrivalFilter = newFilter;
 
-        ObaContract.Stops.setArrivalFilter(getActivity(), mStopUri, selection);
+        ObaContract.Stops.setArrivalFilter(getActivity(), mStopUri, ArrivalFilter.fromInt(selection));
         refreshSituations(UIUtils.getAllSituations(getArrivalsLoader().getLastGoodResponse(), mRoutesFilter));
         refreshLocal();
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListFragment.java
@@ -1011,6 +1011,13 @@ public class ArrivalsListFragment extends ListFragment
     }
 
     @Override
+    public void setArrivalFilter(ArrivalFilter filter) {
+        mArrivalFilter = filter;
+        ObaContract.Stops.setArrivalFilter(getActivity(), mStopUri, filter);
+        refreshLocal();
+    }
+
+    @Override
     public void setRoutesFilter(ArrayList<String> routes) {
         mRoutesFilter = routes;
         ObaContract.StopRouteFilters.set(getActivity(), mStopId, mRoutesFilter);
@@ -1441,7 +1448,7 @@ public class ArrivalsListFragment extends ListFragment
             }
 
             AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
-            return builder.setTitle(R.string.stop_info_filter_title)
+            return builder.setTitle(R.string.stop_info_route_filter_title)
                     .setMultiChoiceItems(items, mChecks, this)
                     .setPositiveButton(R.string.stop_info_save, this)
                     .setNegativeButton(R.string.stop_info_cancel, null)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListFragment.java
@@ -318,7 +318,7 @@ public class ArrivalsListFragment extends ListFragment
         setStopId();
         setUserInfo();
 
-        int arrivalFilter = ObaContract.StopArrivalFilter.get(getActivity(), mStopId);
+        int arrivalFilter = ObaContract.Stops.getArrivalFilter(getActivity(), mStopUri);
         mArrivalFilter = ArrivalFilter.fromInt(arrivalFilter);
 
         setupHeader(savedInstanceState);
@@ -346,8 +346,7 @@ public class ArrivalsListFragment extends ListFragment
         // Set initial minutesAfter value in the empty list view
         setEmptyText(
                 UIUtils.getNoArrivalsMessage(getActivity(), getArrivalsLoader().getMinutesAfter(),
-                        false, false,
-                        mArrivalFilter == ArrivalFilter.ONLY_DEPARTURES)
+                        false, false, mArrivalFilter)
         );
 
         if (mHeader != null) {
@@ -518,8 +517,7 @@ public class ArrivalsListFragment extends ListFragment
                 // No additional arrivals were included in the response, show a toast
                 Toast.makeText(getActivity(),
                         UIUtils.getNoArrivalsMessage(getActivity(),
-                                getArrivalsLoader().getMinutesAfter(), true, false,
-                                mArrivalFilter == ArrivalFilter.ONLY_DEPARTURES),
+                                getArrivalsLoader().getMinutesAfter(), true, false, mArrivalFilter),
                         Toast.LENGTH_LONG
                 ).show();
                 mLoadedMoreArrivals = false;  // Only show the toast once
@@ -582,8 +580,7 @@ public class ArrivalsListFragment extends ListFragment
             }
             // Reset the empty text just in case there is no data.
             setEmptyText(UIUtils.getNoArrivalsMessage(Application.get().getApplicationContext(),
-                    minutesAfter, false, false,
-                    mArrivalFilter == ArrivalFilter.ONLY_DEPARTURES));
+                    minutesAfter, false, false, mArrivalFilter));
             mAdapter.setData(info, mRoutesFilter, mArrivalFilter, System.currentTimeMillis());
         }
 
@@ -1007,6 +1004,11 @@ public class ArrivalsListFragment extends ListFragment
         } else {
             return null;
         }
+    }
+
+    @Override
+    public ArrivalFilter getArrivalFilter() {
+        return mArrivalFilter;
     }
 
     @Override
@@ -1510,15 +1512,14 @@ public class ArrivalsListFragment extends ListFragment
 
         mArrivalFilter = newFilter;
 
-        ObaContract.StopArrivalFilter.set(getActivity(), mStopId, selection);
+        ObaContract.Stops.setArrivalFilter(getActivity(), mStopUri, selection);
         refreshSituations(UIUtils.getAllSituations(getArrivalsLoader().getLastGoodResponse(), mRoutesFilter));
         refreshLocal();
 
         // Update empty text to reflect arrival filter choice (e.g. no more departures vs arrivals)
         if (mArrivalFilter == ArrivalFilter.ONLY_DEPARTURES || switchedFromOnlyDepartures) {
             setEmptyText(UIUtils.getNoArrivalsMessage(Application.get().getApplicationContext(),
-                    getArrivalsLoader().getMinutesAfter(), false, false,
-                    mArrivalFilter == ArrivalFilter.ONLY_DEPARTURES));
+                    getArrivalsLoader().getMinutesAfter(), false, false, mArrivalFilter));
         }
 
         // Update "load more" button to say arrivals/departures based on filter settings

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListHeader.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListHeader.java
@@ -24,6 +24,7 @@ import org.onebusaway.android.io.elements.ObaArrivalInfo;
 import org.onebusaway.android.io.elements.ObaRegion;
 import org.onebusaway.android.provider.ObaContract;
 import org.onebusaway.android.util.ArrivalInfoUtils;
+import org.onebusaway.android.util.ArrivalInfoUtils.ArrivalFilter;
 import org.onebusaway.android.util.EmbeddedSocialUtils;
 import org.onebusaway.android.util.UIUtils;
 
@@ -837,16 +838,21 @@ class ArrivalsListHeader {
                 }
             } else {
                 // Show abbreviated "no upcoming arrivals" message (e.g., "35+ min")
+
+                ArrivalFilter filter = ArrivalFilter
+                        .fromInt(ObaContract.StopArrivalFilter.get(mContext, mController.getStopId()));
+                boolean onlyDepartures = filter == ArrivalFilter.ONLY_DEPARTURES;
+
                 int minAfter = mController.getMinutesAfter();
                 if (minAfter != -1) {
                     mNoArrivals
                             .setText(
-                                    UIUtils.getNoArrivalsMessage(mContext, minAfter, false, false));
+                                    UIUtils.getNoArrivalsMessage(mContext, minAfter, false, false, onlyDepartures));
                 } else {
                     minAfter = 35;  // Assume 35 minutes, because that's the API default
                     mNoArrivals
                             .setText(
-                                    UIUtils.getNoArrivalsMessage(mContext, minAfter, false, false));
+                                    UIUtils.getNoArrivalsMessage(mContext, minAfter, false, false, onlyDepartures));
                 }
                 mNumHeaderArrivals = 0;
             }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListHeader.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListHeader.java
@@ -91,6 +91,8 @@ class ArrivalsListHeader {
 
         ArrayList<String> getRoutesFilter();
 
+        ArrivalFilter getArrivalFilter();
+
         void setRoutesFilter(ArrayList<String> filter);
 
         int getNumRoutes();
@@ -838,21 +840,18 @@ class ArrivalsListHeader {
                 }
             } else {
                 // Show abbreviated "no upcoming arrivals" message (e.g., "35+ min")
-
-                ArrivalFilter filter = ArrivalFilter
-                        .fromInt(ObaContract.StopArrivalFilter.get(mContext, mController.getStopId()));
-                boolean onlyDepartures = filter == ArrivalFilter.ONLY_DEPARTURES;
+                ArrivalFilter arrivalFilter = mController.getArrivalFilter();
 
                 int minAfter = mController.getMinutesAfter();
                 if (minAfter != -1) {
                     mNoArrivals
                             .setText(
-                                    UIUtils.getNoArrivalsMessage(mContext, minAfter, false, false, onlyDepartures));
+                                    UIUtils.getNoArrivalsMessage(mContext, minAfter, false, false, arrivalFilter));
                 } else {
                     minAfter = 35;  // Assume 35 minutes, because that's the API default
                     mNoArrivals
                             .setText(
-                                    UIUtils.getNoArrivalsMessage(mContext, minAfter, false, false, onlyDepartures));
+                                    UIUtils.getNoArrivalsMessage(mContext, minAfter, false, false, arrivalFilter));
                 }
                 mNumHeaderArrivals = 0;
             }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/ArrivalInfoUtils.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/ArrivalInfoUtils.java
@@ -108,13 +108,7 @@ public class ArrivalInfoUtils {
      * Type for arrival filtering options (only arrivals, only departures, or both)
      */
     public enum ArrivalFilter {
-        BOTH(0), ONLY_ARRIVALS(1), ONLY_DEPARTURES(2);
-
-        private int value;
-
-        ArrivalFilter(int value) {
-            this.value = value;
-        }
+        BOTH, ONLY_ARRIVALS, ONLY_DEPARTURES;
 
         public static ArrivalFilter fromInt(int value) {
             switch (value) {
@@ -125,11 +119,21 @@ public class ArrivalInfoUtils {
                 case 2:
                     return ArrivalFilter.ONLY_DEPARTURES;
             }
+
             return ArrivalFilter.BOTH;
         }
 
-        public int toInt() {
-            return this.value;
+        public static int toInt(ArrivalFilter arrivalFilter) {
+            switch(arrivalFilter) {
+                case BOTH:
+                    return 0;
+                case ONLY_ARRIVALS:
+                    return 1;
+                case ONLY_DEPARTURES:
+                    return 2;
+            }
+
+            return 0;
         }
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/UIUtils.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/UIUtils.java
@@ -909,15 +909,15 @@ public final class UIUtils {
      *                           it should not
      * @param shortFormat        true if the format should be abbreviated, false if it should be
      *                           long
-     * @param onlyDepartures     true if the user has filtered out all arrivals
+     * @param arrivalFilter      the user's current setting for showing arrivals, departures or both
      * @return a user-readable string saying the number of minutes in which no arrivals are coming,
      * or the number of hours and minutes if minutes > 60
      */
     public static String getNoArrivalsMessage(Context context, int minutes,
-            boolean additionalArrivals, boolean shortFormat, boolean onlyDepartures) {
+            boolean additionalArrivals, boolean shortFormat, ArrivalInfoUtils.ArrivalFilter arrivalFilter) {
 
         String type;
-        if (onlyDepartures) {
+        if (arrivalFilter == ArrivalInfoUtils.ArrivalFilter.ONLY_DEPARTURES) {
             type = context.getString(R.string.stop_info_type_departure);
         } else {
             type = context.getString(R.string.stop_info_type_arrival);

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/UIUtils.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/UIUtils.java
@@ -909,11 +909,20 @@ public final class UIUtils {
      *                           it should not
      * @param shortFormat        true if the format should be abbreviated, false if it should be
      *                           long
+     * @param onlyDepartures     true if the user has filtered out all arrivals
      * @return a user-readable string saying the number of minutes in which no arrivals are coming,
      * or the number of hours and minutes if minutes > 60
      */
     public static String getNoArrivalsMessage(Context context, int minutes,
-            boolean additionalArrivals, boolean shortFormat) {
+            boolean additionalArrivals, boolean shortFormat, boolean onlyDepartures) {
+
+        String type;
+        if (onlyDepartures) {
+            type = context.getString(R.string.stop_info_type_departure);
+        } else {
+            type = context.getString(R.string.stop_info_type_arrival);
+        }
+
         if (minutes <= MINUTES_IN_HOUR) {
             // Return just minutes
             if (additionalArrivals) {
@@ -925,7 +934,7 @@ public final class UIUtils {
                 } else {
                     // Long version
                     return context
-                            .getString(R.string.stop_info_no_additional_data_minutes, minutes);
+                            .getString(R.string.stop_info_no_additional_data_minutes, type, minutes);
                 }
             } else {
                 if (shortFormat) {
@@ -934,7 +943,7 @@ public final class UIUtils {
                             .getString(R.string.stop_info_nodata_minutes_short_format, minutes);
                 } else {
                     // Long version
-                    return context.getString(R.string.stop_info_nodata_minutes, minutes);
+                    return context.getString(R.string.stop_info_nodata_minutes, type, minutes);
                 }
             }
         } else {
@@ -950,7 +959,7 @@ public final class UIUtils {
                     // Long version
                     return context.getResources()
                             .getQuantityString(R.plurals.stop_info_no_additional_data_hours_minutes,
-                                    minutes / 60, minutes % 60, minutes / 60);
+                                    minutes / 60, type, minutes % 60, minutes / 60);
                 }
             } else {
                 if (shortFormat) {
@@ -965,7 +974,7 @@ public final class UIUtils {
                     return context.getResources()
                             .getQuantityString(R.plurals.stop_info_nodata_hours_minutes,
                                     minutes / 60,
-                                    minutes % 60, minutes / 60);
+                                    type, minutes % 60, minutes / 60);
                 }
             }
         }

--- a/onebusaway-android/src/main/res/layout/arrivals_list_header.xml
+++ b/onebusaway-android/src/main/res/layout/arrivals_list_header.xml
@@ -27,7 +27,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="@dimen/arrival_header_height_two_arrivals"
                     android:layout_alignParentTop="true"
-                    android:layout_above="@+id/filter_group"
+                    android:layout_above="@+id/filters"
                     android:orientation="vertical">
 
         <LinearLayout
@@ -292,39 +292,79 @@
                 android:visibility="gone"/>
     </RelativeLayout>
 
-    <!-- Filter by route -->
     <LinearLayout
-            android:id="@+id/filter_group"
-            style="@style/Header3Text"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_alignParentBottom="true"
-            android:gravity="center_vertical"
-            android:orientation="horizontal"
-            android:background="@color/theme_primary_dark"
-            android:visibility="gone">
-
-        <TextView
-                android:id="@+id/filter_text"
+        android:id="@+id/filters"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true"
+        android:orientation="vertical">
+        <!-- Filter by route -->
+        <LinearLayout
+                android:id="@+id/route_filter_group"
                 style="@style/Header3Text"
-                android:layout_width="wrap_content"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:layout_marginTop="5dp"
-                android:layout_marginBottom="5dp"
-                android:gravity="center_vertical|right"/>
-
-        <TextView
-                android:id="@+id/show_all"
-                android:text="@string/stop_info_filter_showall"
-                style="@style/Header3Text"
-                android:layout_width="wrap_content"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:layout_marginLeft="2dp"
                 android:gravity="center_vertical"
-                android:bufferType="spannable"
-                android:linksClickable="true"
-                android:textColorLink="@color/theme_accent"/>
+                android:orientation="horizontal"
+                android:background="@color/theme_primary_dark"
+                android:visibility="gone">
+
+            <TextView
+                    android:id="@+id/route_filter_text"
+                    style="@style/Header3Text"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:layout_marginTop="5dp"
+                    android:layout_marginBottom="5dp"
+                    android:gravity="center_vertical|right"/>
+
+            <TextView
+                    android:id="@+id/show_all"
+                    android:text="@string/stop_info_filter_showall"
+                    style="@style/Header3Text"
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent"
+                    android:layout_weight="1"
+                    android:layout_marginLeft="2dp"
+                    android:gravity="center_vertical"
+                    android:bufferType="spannable"
+                    android:linksClickable="true"
+                    android:textColorLink="@color/theme_accent"/>
+        </LinearLayout>
+        <!-- Filter by arrival type -->
+        <LinearLayout
+                android:id="@+id/arrival_filter_group"
+                style="@style/Header3Text"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_vertical"
+                android:orientation="horizontal"
+                android:background="@color/theme_primary_dark"
+                android:visibility="gone">
+
+            <TextView
+                    android:id="@+id/arrival_filter_text"
+                    style="@style/Header3Text"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:layout_marginTop="5dp"
+                    android:layout_marginBottom="5dp"
+                    android:gravity="center_vertical|right"/>
+
+            <TextView
+                    android:id="@+id/arrival_show_all"
+                    android:text="@string/stop_info_filter_showall"
+                    style="@style/Header3Text"
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent"
+                    android:layout_weight="1"
+                    android:layout_marginLeft="2dp"
+                    android:gravity="center_vertical"
+                    android:bufferType="spannable"
+                    android:linksClickable="true"
+                    android:textColorLink="@color/theme_accent"/>
+        </LinearLayout>
     </LinearLayout>
 </RelativeLayout>

--- a/onebusaway-android/src/main/res/menu-v14/arrivals_list.xml
+++ b/onebusaway-android/src/main/res/menu-v14/arrivals_list.xml
@@ -36,6 +36,8 @@
         <item android:id="@+id/filter"
               android:title="@string/stop_info_option_filter"
               android:icon="@drawable/ic_menu_trip"/>
+        <item android:id="@+id/arrival_filter"
+              android:title="Filter arrivals/departures" />
         <item android:id="@+id/edit_name"
               android:title="@string/stop_info_option_editname"
               android:icon="@drawable/android:ic_menu_edit"/>

--- a/onebusaway-android/src/main/res/menu/arrivals_list.xml
+++ b/onebusaway-android/src/main/res/menu/arrivals_list.xml
@@ -33,6 +33,8 @@
         <item android:id="@+id/filter"
               android:title="@string/stop_info_option_filter"
               android:icon="@drawable/ic_menu_trip"/>
+        <item android:id="@+id/arrival_filter"
+              android:title="Filter arrivals/departures" />
         <item android:id="@+id/edit_name"
               android:title="@string/stop_info_option_editname"
               android:icon="@drawable/android:ic_menu_edit"/>

--- a/onebusaway-android/src/main/res/values-es/strings.xml
+++ b/onebusaway-android/src/main/res/values-es/strings.xml
@@ -273,8 +273,8 @@
     </plurals>
     <string name="stop_info_load_more_arrivals">Cargar más llegadas</string>
     <string name="stop_info_item_options_title">Opciones de bus</string>
-    <string name="stop_info_filter_title">Mostrar sólo estas rutas</string>
-    <string name="stop_info_filter_header">Mostrando %1$d de %2$d rutas</string>
+    <string name="stop_info_route_filter_title">Mostrar sólo estas rutas</string>
+    <string name="stop_info_route_filter_header">Mostrando %1$d de %2$d rutas</string>
     <string name="stop_info_filter_showall">(mostrar todas)</string>
     <string name="stop_info_save">Guardar</string>
     <string name="stop_info_cancel">Cancelar</string>

--- a/onebusaway-android/src/main/res/values-fi/strings.xml
+++ b/onebusaway-android/src/main/res/values-fi/strings.xml
@@ -252,8 +252,8 @@
     </plurals>
     <string name="stop_info_load_more_arrivals">Näytä lisää saapuvia</string>
     <string name="stop_info_item_options_title">Toiminnot</string>
-    <string name="stop_info_filter_title">Näytä ainoastaan nämä reitit</string>
-    <string name="stop_info_filter_header">Näyttää %1$d / %2$d reiteistä</string>
+    <string name="stop_info_route_filter_title">Näytä ainoastaan nämä reitit</string>
+    <string name="stop_info_route_filter_header">Näyttää %1$d / %2$d reiteistä</string>
     <string name="stop_info_filter_showall">(näytä kaikki)</string>
     <string name="stop_info_save">Tallenna</string>
     <string name="stop_info_cancel">Peruuta</string>

--- a/onebusaway-android/src/main/res/values/dimens.xml
+++ b/onebusaway-android/src/main/res/values/dimens.xml
@@ -49,7 +49,7 @@
     <dimen name="arrival_header_height_no_arrivals">50dp</dimen>
     <dimen name="arrival_header_height_one_arrival">106dp</dimen>
     <dimen name="arrival_header_height_two_arrivals">146dp</dimen>
-    <dimen name="arrival_header_height_offset_filter_routes">25dp</dimen>
+    <dimen name="arrival_header_height_offset_filter">25dp</dimen>
     <dimen name="arrival_header_height_edit_name">100dp</dimen>
     <dimen name="arrival_header_left_margin">10dp</dimen>
     <dimen name="arrival_header_bottom_margin">8dp</dimen>

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -237,14 +237,16 @@
     <string name="stop_info_option_removestar">Remove star from stop</string>
     <string name="stop_info_option_report_problem">Report stop problem</string>
     <string name="stop_info_option_night_light">Night light</string>
-    <string name="stop_info_nodata_minutes">No arrivals in the next %1$d min.</string>
+    <string name="stop_info_type_arrival">arrivals</string>
+    <string name="stop_info_type_departure">departures</string>
+    <string name="stop_info_nodata_minutes">No %1$s in the next %2$d min.</string>
     <string name="stop_info_nodata_minutes_short_format">%1$d+ min</string>
     <plurals name="stop_info_nodata_hours_minutes">
-        <item quantity="one">No arrivals in the next 1 hour and %1$d min.</item>
+        <item quantity="one">No %1$s in the next 1 hour and %2$d min.</item>
         <!-- Entire element below should be on a single line if XML is reformatted - see #99 -->
-        <item quantity="other">No arrivals in the next
-            <xliff:g id="count">%2$d</xliff:g>
-            hours and %1$d min.
+        <item quantity="other">No %1$s in the next
+            <xliff:g id="count">%3$d</xliff:g>
+            hours and %2$d min.
         </item>
     </plurals>
     <plurals name="stop_info_nodata_hours_minutes_short_format">
@@ -253,16 +255,16 @@
         <item quantity="other"><xliff:g id="count">%2$d</xliff:g>h %1$d+ min
         </item>
     </plurals>
-    <string name="stop_info_no_additional_data_minutes">No additional arrivals in the next %1$d
+    <string name="stop_info_no_additional_data_minutes">No additional %1$s in the next %2$d
         min.
     </string>
     <string name="stop_info_no_additional_data_minutes_short_format">%1$d+ min</string>
     <plurals name="stop_info_no_additional_data_hours_minutes">
-        <item quantity="one">No additional arrivals in the next 1 hr and %1$d min.</item>
+        <item quantity="one">No additional %1$s in the next 1 hr and %2$d min.</item>
         <!-- Entire element below should be on a single line if XML is reformatted - see #99 -->
-        <item quantity="other">No additional arrivals in the next
-            <xliff:g id="count">%2$d</xliff:g>
-            hrs and %1$d min.
+        <item quantity="other">No additional %1$s in the next
+            <xliff:g id="count">%3$d</xliff:g>
+            hrs and %2$d min.
         </item>
     </plurals>
     <plurals name="stop_info_no_additional_data_hours_minutes_short_format">
@@ -272,10 +274,15 @@
         </item>
     </plurals>
     <string name="stop_info_load_more_arrivals">Load more arrivals</string>
+    <string name="stop_info_load_more_departures">Load more departures</string>
     <string name="stop_info_item_options_title">Bus options</string>
     <string name="stop_info_filter_title">Show only these routes</string>
     <string name="stop_info_filter_header">Showing %1$d of %2$d routes</string>
     <string name="stop_info_filter_showall">(show all)</string>
+    <string name="stop_info_arrival_filter_title">Show</string>
+    <string name="stop_info_arrival_filter_both">Both</string>
+    <string name="stop_info_arrival_filter_arrivals">Arrivals only</string>
+    <string name="stop_info_arrival_filter_departures">Departures only</string>
     <string name="stop_info_save">Save</string>
     <string name="stop_info_cancel">Cancel</string>
     <string name="stop_info_clear">Clear</string>

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -276,9 +276,11 @@
     <string name="stop_info_load_more_arrivals">Load more arrivals</string>
     <string name="stop_info_load_more_departures">Load more departures</string>
     <string name="stop_info_item_options_title">Bus options</string>
-    <string name="stop_info_filter_title">Show only these routes</string>
-    <string name="stop_info_filter_header">Showing %1$d of %2$d routes</string>
+    <string name="stop_info_route_filter_title">Show only these routes</string>
+    <string name="stop_info_route_filter_header">Showing %1$d of %2$d routes</string>
     <string name="stop_info_filter_showall">(show all)</string>
+    <string name="stop_info_arrivals_hidden">Arrivals are hidden</string>
+    <string name="stop_info_departures_hidden">Departures are hidden</string>
     <string name="stop_info_arrival_filter_title">Show</string>
     <string name="stop_info_arrival_filter_both">Both</string>
     <string name="stop_info_arrival_filter_arrivals">Arrivals only</string>


### PR DESCRIPTION
- Adds option to filter arrivals/departures from stop arrivals. Fixes #851. 
- Saves user preferences for stops (I made a new table for this, but wasn't sure of the best option between that and editing the stops table...)
- Changes 'load more arrivals' and 'no arrivals' messages to say departures when a stop is set to show only departures. This could help indicate to a user that they have 'only departures' on rather than there being no arrivals. 

I think I'm mostly done with this, but want to make sure I'm on the right track.


- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `gradlew connectedObaGoogleDebugAndroidTest connectedObaAmazonDebugAndroidTest` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them for the initial submission of the pull request.  When addressing comments on a pull request, please push a new commit per comment when possible (reviewers will squash and merge using GitHub merge tool)