### PR TITLE
Fix #946 - Don't show multiple notifications for reminders

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/tripservice/BootstrapService.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/tripservice/BootstrapService.java
@@ -28,6 +28,6 @@ public class BootstrapService extends BroadcastReceiver {
      */
     @Override
     public void onReceive(Context context, Intent intent) {
-        TripService.scheduleAll(context);
+        TripService.scheduleAll(context, true);
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/tripservice/CancelNotifyTask.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/tripservice/CancelNotifyTask.java
@@ -53,7 +53,7 @@ public final class CancelNotifyTask implements Runnable {
             values.put(ObaContract.TripAlerts.STATE, ObaContract.TripAlerts.STATE_CANCELLED);
             cr.update(mUri, values, null, null);
 
-            TripService.scheduleAll(mContext);
+            TripService.scheduleAll(mContext, true);
         } finally {
             mTaskContext.taskComplete();
         }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/tripservice/PollerTask.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/tripservice/PollerTask.java
@@ -105,7 +105,7 @@ public final class PollerTask implements Runnable {
             values.put(ObaContract.TripAlerts.STATE, ObaContract.TripAlerts.STATE_CANCELLED);
             mCR.update(alertUri, values, null, null);
 
-            TripService.scheduleAll(mContext);
+            TripService.scheduleAll(mContext, true);
             return;
         }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/tripservice/TripService.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/tripservice/TripService.java
@@ -26,6 +26,7 @@ import android.content.Intent;
 import android.net.Uri;
 import android.os.Binder;
 import android.os.Build;
+import android.os.Bundle;
 import android.os.IBinder;
 import android.os.Parcel;
 import android.os.RemoteException;
@@ -91,6 +92,8 @@ public class TripService extends Service {
 
     private static final String NOTIFY_TITLE = ".notifyTitle";
 
+    private static final String START_FOREGROUND = ".startForeground";
+
     public static final int FOREGROUND_NOTIFICATION_ID = 1800001;
 
     private ExecutorService mThreadPool;
@@ -119,25 +122,25 @@ public class TripService extends Service {
         }
     }
 
-    //
-    // This is the old onStart method that will be called on the pre-2.0
-    // platform. On 2.0 or later we override onStartCommand so this
-    // method will not be called.
-    //
-    @Override
-    public void onStart(Intent intent, int startId) {
-        handleCommand(intent, startId);
-    }
-
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            //create notification regarding foreground
+        // Check if we should start the service in the foreground
+        boolean startInForeground = false;
+        Bundle bundle = intent.getExtras();
+        if (bundle != null) {
+            startInForeground = bundle.getBoolean(START_FOREGROUND);
+        }
+        String action = intent.getAction();
+
+        // ACTION_NOTIFY should never run in the foreground to avoid multiple notifications (#946)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
+                && startInForeground
+                && !ACTION_NOTIFY.equals(action)) {
+            // Create notification for running service in the foreground
             Intent notificationIntent = new Intent(this, TripService.class);
             PendingIntent pendingIntent = PendingIntent.getActivity(this, 0,
                     notificationIntent, 0);
 
-            String action = intent.getAction();
             String foregroundNotifyTitle = Application.get().getResources()
                     .getString(R.string.foreground_all_intent_title);
             String foregroundNotifyText = "";
@@ -148,11 +151,7 @@ public class TripService extends Service {
             } else if (ACTION_POLL.equals(action)) {
                 foregroundNotifyText = Application.get().getResources()
                         .getString(R.string.foreground_action_poll_text);
-            } else if (ACTION_NOTIFY.equals(action)) {
-                foregroundNotifyText = Application.get().getResources()
-                        .getString(R.string.foreground_action_notify_text);
-            }
-            else {
+            } else if (ACTION_CANCEL.equals(action)) {
                 foregroundNotifyText = Application.get().getResources()
                         .getString(R.string.foreground_action_cancel_text);
             }
@@ -222,11 +221,9 @@ public class TripService extends Service {
         if (ACTION_SCHEDULE.equals(action)) {
             mThreadPool.submit(new SchedulerTask(this, taskContext, uri));
             return START_REDELIVER_INTENT;
-
         } else if (ACTION_POLL.equals(action)) {
             mThreadPool.submit(new PollerTask(this, taskContext, uri));
             return START_NOT_STICKY;
-
         } else if (ACTION_NOTIFY.equals(action)) {
             // Create the notification
             String notifyTitle = intent.getStringExtra(NOTIFY_TITLE);
@@ -234,11 +231,9 @@ public class TripService extends Service {
 
             mThreadPool.submit(new NotifierTask(this, taskContext, uri, notifyTitle, notifyText));
             return START_REDELIVER_INTENT;
-
         } else if (ACTION_CANCEL.equals(action)) {
             mThreadPool.submit(new CancelNotifyTask(this, taskContext, uri));
             return START_NOT_STICKY;
-
         } else {
             Log.e(TAG, "Unknown action: " + action);
             //stopSelfResult(startId);
@@ -264,11 +259,20 @@ public class TripService extends Service {
     //
     // Trip helpers
     //
-    public static void scheduleAll(Context context) {
+
+    /**
+     * Starts the service to schedule all pending reminders
+     *
+     * @param context
+     * @param startForeground true if the service should be started in the foreground, false if it should not.  This parameter doesn't have any effect on Android versions less than 8.0.
+     */
+    public static void scheduleAll(Context context, boolean startForeground) {
         final Intent intent = new Intent(context, TripService.class);
         intent.setAction(TripService.ACTION_SCHEDULE);
         intent.setData(ObaContract.Trips.CONTENT_URI);
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        intent.putExtra(TripService.START_FOREGROUND, startForeground);
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && startForeground) {
             context.startForegroundService(intent);
         } else {
             context.startService(intent);

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.java
@@ -17,41 +17,6 @@
  */
 package org.onebusaway.android.ui;
 
-import com.google.android.gms.common.ConnectionResult;
-import com.google.android.gms.common.GoogleApiAvailability;
-import com.google.android.gms.common.api.GoogleApiClient;
-import com.google.android.material.floatingactionbutton.FloatingActionButton;
-
-import com.microsoft.embeddedsocial.sdk.EmbeddedSocial;
-import com.microsoft.embeddedsocial.ui.fragment.ActivityFeedFragment;
-import com.microsoft.embeddedsocial.ui.fragment.MyProfileFragment;
-import com.microsoft.embeddedsocial.ui.fragment.PinsFragment;
-import com.sothree.slidinguppanel.SlidingUpPanelLayout;
-
-import org.onebusaway.android.BuildConfig;
-import org.onebusaway.android.R;
-import org.onebusaway.android.app.Application;
-import org.onebusaway.android.io.ObaAnalytics;
-import org.onebusaway.android.io.elements.ObaRegion;
-import org.onebusaway.android.io.elements.ObaRoute;
-import org.onebusaway.android.io.elements.ObaStop;
-import org.onebusaway.android.io.request.ObaArrivalInfoResponse;
-import org.onebusaway.android.map.MapModeController;
-import org.onebusaway.android.map.MapParams;
-import org.onebusaway.android.map.googlemapsv2.BaseMapFragment;
-import org.onebusaway.android.map.googlemapsv2.LayerInfo;
-import org.onebusaway.android.region.ObaRegionsTask;
-import org.onebusaway.android.report.ui.ReportActivity;
-import org.onebusaway.android.tripservice.TripService;
-import org.onebusaway.android.util.FragmentUtils;
-import org.onebusaway.android.util.LocationUtils;
-import org.onebusaway.android.util.PermissionUtils;
-import org.onebusaway.android.util.PreferenceUtils;
-import org.onebusaway.android.util.RegionUtils;
-import org.onebusaway.android.util.ShowcaseViewUtils;
-import org.onebusaway.android.util.UIUtils;
-import org.opentripplanner.routing.bike_rental.BikeRentalStation;
-
 import android.app.Dialog;
 import android.content.Context;
 import android.content.DialogInterface;
@@ -86,6 +51,40 @@ import android.widget.ProgressBar;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 import android.widget.Toast;
+
+import com.google.android.gms.common.ConnectionResult;
+import com.google.android.gms.common.GoogleApiAvailability;
+import com.google.android.gms.common.api.GoogleApiClient;
+import com.google.android.material.floatingactionbutton.FloatingActionButton;
+import com.microsoft.embeddedsocial.sdk.EmbeddedSocial;
+import com.microsoft.embeddedsocial.ui.fragment.ActivityFeedFragment;
+import com.microsoft.embeddedsocial.ui.fragment.MyProfileFragment;
+import com.microsoft.embeddedsocial.ui.fragment.PinsFragment;
+import com.sothree.slidinguppanel.SlidingUpPanelLayout;
+
+import org.onebusaway.android.BuildConfig;
+import org.onebusaway.android.R;
+import org.onebusaway.android.app.Application;
+import org.onebusaway.android.io.ObaAnalytics;
+import org.onebusaway.android.io.elements.ObaRegion;
+import org.onebusaway.android.io.elements.ObaRoute;
+import org.onebusaway.android.io.elements.ObaStop;
+import org.onebusaway.android.io.request.ObaArrivalInfoResponse;
+import org.onebusaway.android.map.MapModeController;
+import org.onebusaway.android.map.MapParams;
+import org.onebusaway.android.map.googlemapsv2.BaseMapFragment;
+import org.onebusaway.android.map.googlemapsv2.LayerInfo;
+import org.onebusaway.android.region.ObaRegionsTask;
+import org.onebusaway.android.report.ui.ReportActivity;
+import org.onebusaway.android.tripservice.TripService;
+import org.onebusaway.android.util.FragmentUtils;
+import org.onebusaway.android.util.LocationUtils;
+import org.onebusaway.android.util.PermissionUtils;
+import org.onebusaway.android.util.PreferenceUtils;
+import org.onebusaway.android.util.RegionUtils;
+import org.onebusaway.android.util.ShowcaseViewUtils;
+import org.onebusaway.android.util.UIUtils;
+import org.opentripplanner.routing.bike_rental.BikeRentalStation;
 
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
@@ -1117,7 +1116,7 @@ public class HomeActivity extends AppCompatActivity
             // Updates will remove the alarms. This should put them back.
             // (Unfortunately I can't find a way to reschedule them without
             // having the app run again).
-            TripService.scheduleAll(this);
+            TripService.scheduleAll(this, true);
             PreferenceUtils.saveInt(WHATS_NEW_VER, appInfo.versionCode);
             return true;
         }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/MyRemindersFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/MyRemindersFragment.java
@@ -16,13 +16,6 @@
  */
 package org.onebusaway.android.ui;
 
-import org.onebusaway.android.R;
-import org.onebusaway.android.io.ObaAnalytics;
-import org.onebusaway.android.provider.ObaContract;
-import org.onebusaway.android.tripservice.TripService;
-import org.onebusaway.android.util.PreferenceUtils;
-import org.onebusaway.android.util.UIUtils;
-
 import android.app.AlertDialog;
 import android.content.ContentResolver;
 import android.content.DialogInterface;
@@ -39,6 +32,13 @@ import android.view.View;
 import android.widget.AdapterView;
 import android.widget.ListView;
 import android.widget.TextView;
+
+import org.onebusaway.android.R;
+import org.onebusaway.android.io.ObaAnalytics;
+import org.onebusaway.android.provider.ObaContract;
+import org.onebusaway.android.tripservice.TripService;
+import org.onebusaway.android.util.PreferenceUtils;
+import org.onebusaway.android.util.UIUtils;
 
 import androidx.cursoradapter.widget.SimpleCursorAdapter;
 import androidx.loader.app.LoaderManager;
@@ -299,7 +299,7 @@ public final class MyRemindersFragment extends ListFragment
         // TODO: Confirmation dialog?
         ContentResolver cr = getActivity().getContentResolver();
         cr.delete(ObaContract.Trips.buildUri(ids[0], ids[1]), null, null);
-        TripService.scheduleAll(getActivity());
+        TripService.scheduleAll(getActivity(), true);
 
         getLoaderManager().getLoader(0).onContentChanged();
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/TripInfoActivity.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/TripInfoActivity.java
@@ -15,13 +15,6 @@
  */
 package org.onebusaway.android.ui;
 
-import org.onebusaway.android.R;
-import org.onebusaway.android.io.ObaAnalytics;
-import org.onebusaway.android.provider.ObaContract;
-import org.onebusaway.android.tripservice.TripService;
-import org.onebusaway.android.util.FragmentUtils;
-import org.onebusaway.android.util.UIUtils;
-
 import android.app.AlertDialog;
 import android.app.Dialog;
 import android.content.ContentResolver;
@@ -46,6 +39,13 @@ import android.widget.Button;
 import android.widget.Spinner;
 import android.widget.TextView;
 import android.widget.Toast;
+
+import org.onebusaway.android.R;
+import org.onebusaway.android.io.ObaAnalytics;
+import org.onebusaway.android.provider.ObaContract;
+import org.onebusaway.android.tripservice.TripService;
+import org.onebusaway.android.util.FragmentUtils;
+import org.onebusaway.android.util.UIUtils;
 
 import java.util.List;
 
@@ -452,7 +452,7 @@ public class TripInfoActivity extends AppCompatActivity {
             if (c != null) {
                 c.close();
             }
-            TripService.scheduleAll(getActivity());
+            TripService.scheduleAll(getActivity(), true);
 
             Toast.makeText(getActivity(), R.string.trip_info_saved, Toast.LENGTH_SHORT)
                     .show();
@@ -536,7 +536,7 @@ public class TripInfoActivity extends AppCompatActivity {
                                     public void onClick(DialogInterface dialog, int which) {
                                         ContentResolver cr = getActivity().getContentResolver();
                                         cr.delete(tripUri, null, null);
-                                        TripService.scheduleAll(getActivity());
+                                        TripService.scheduleAll(getActivity(), true);
                                         getActivity().finish();
                                     }
                                 }

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -109,7 +109,7 @@
     <string name="main_help_whatsnew_title">What\'s New?</string>
     <string name="main_help_whatsnew">&#8226;\u0020
         <b>Improved reminder reliability</b>
-        - Various changes to make reminders alert you at the right time.  You may notice extra \"sticky\" notifications when reminders trigger that help with reliability.\n&#8226;\u0020
+        - Various changes to make reminders alert you at the right time.\n&#8226;\u0020
         <b>Improved notification management (Android 8.0 Oreo and up)</b>
         - Manage notification sounds using the Android system menu under \"Apps\".\n&#8226;\u0020
         <b>Improved trip status icon</b>


### PR DESCRIPTION
Fixes https://github.com/OneBusAway/onebusaway-android/issues/946.

* Allows various application components to explicitly specify whether or not the TripService should run in the foreground
* Never run in the foreground for ACTION_NOTIFY to avoid the "sticky" notification that shows while the service is running
* Always run in the foreground on device reboot
* Run in foreground for most other situations, even as a result of UI interactions.  We could potentially scale this back if it's not found to be necessary.
* Remove deprecated onStart() method, which dates back to Android 2.0 (TBT)
* Some code cleanup
* Update What's New text to remove reference to "sticky" notifications

@paulnabanita1 Could you please review and test?  New expected behavior is that we shouldn't see the foreground service notification when the reminder notifications trigger.