### PR TITLE
Changed target SDK version to 26 to fix Android Pie bus stop detection.

### DIFF
--- a/onebusaway-android/build.gradle
+++ b/onebusaway-android/build.gradle
@@ -50,7 +50,7 @@ android {
 
     defaultConfig {
         minSdkVersion 15
-        targetSdkVersion 28
+        targetSdkVersion 26
         versionCode 98
         versionName "2.4.1"
 


### PR DESCRIPTION
This is a workaround for https://github.com/OneBusAway/onebusaway-android/issues/950 until it's implemented.