### PR TITLE
Modified feedback activity to sync feedback request message

### DIFF
--- a/onebusaway-android/src/main/res/layout/activity_feedback.xml
+++ b/onebusaway-android/src/main/res/layout/activity_feedback.xml
@@ -17,7 +17,7 @@
             style="@style/MaterialLayoutTextView"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/feedback_msg"
+            android:text="@string/feedback_notify_dialog_msg"
             android:textAppearance="?android:attr/textAppearanceMedium"
             android:textColor="@android:color/black"
             android:textSize="14sp" />

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -318,7 +318,6 @@
     <string name="feedback_action_reply_yes">Yes</string>
 
     <!-- Destination reminder feedback Activity -->
-    <string name="feedback_msg">Were you notified at the right time to exit at your stop?</string>
     <string name="feedback_freeText">Write your feedback</string>
     <string name="feedback_checkbox_text">Include system log (your choice will be saved for future trips)</string>
     <string name="feedback_log_guide">Your feedback will be sent to OneBusAway. If you check \"Include system logs\"


### PR DESCRIPTION
During beta testing of destination reminders feature, it was found that the feedback request message was different in the notification from the one displayed in the feedback activity screen. This PR modifies the relevant files to sync the messages.
Feedback notification received after completion of a trip:
![notify](https://user-images.githubusercontent.com/42182508/56678648-36f7a080-6691-11e9-8017-9fb030ef56d2.JPG)
Screenshots of feedback activity before and after the modifications:
![fix_feedback_msg](https://user-images.githubusercontent.com/42182508/56678659-3c54eb00-6691-11e9-9081-29ba453f30d2.JPG)


Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [ ] Run the unit tests with `gradlew connectedObaGoogleDebugAndroidTest connectedObaAmazonDebugAndroidTest` to make sure you didn't break anything

- [ ] If you have multiple commits please combine them into one commit by squashing them for the initial submission of the pull request.  When addressing comments on a pull request, please push a new commit per comment when possible (reviewers will squash and merge using GitHub merge tool)