### PR TITLE
Fix #982 - Add text datatype handling to fix arrival time problem

### DIFF
--- a/onebusaway-android/build.gradle
+++ b/onebusaway-android/build.gradle
@@ -412,7 +412,7 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:2.0.0-alpha3'
     implementation 'commons-io:commons-io:2.4'
     // Open311 client library
-    implementation 'edu.usf.cutr:open311client:1.0.9'
+    implementation 'edu.usf.cutr:open311client:1.0.10'
     // JSON data binding for OBA REST API responses
     implementation 'com.fasterxml.jackson.core:jackson-core:2.9.4'
     implementation 'com.fasterxml.jackson.core:jackson-annotations:2.9.4'

--- a/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/Open311ProblemFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/Open311ProblemFragment.java
@@ -692,6 +692,7 @@ public class Open311ProblemFragment extends BaseReportFragment implements
 
             if (Boolean.valueOf(open311Attribute.getVariable())) {
                 if (Open311DataType.STRING.equals(open311Attribute.getDatatype())
+                        || Open311DataType.TEXT.equals(open311Attribute.getDatatype())
                         || Open311DataType.NUMBER.equals(open311Attribute.getDatatype())
                         || Open311DataType.DATETIME.equals(open311Attribute.getDatatype())) {
                     EditText et = (EditText) mDynamicAttributeUIMap.get(open311Attribute.getCode());
@@ -751,6 +752,7 @@ public class Open311ProblemFragment extends BaseReportFragment implements
         for (Open311Attribute open311Attribute : serviceDescription.getAttributes()) {
             if (Boolean.valueOf(open311Attribute.getVariable())) {
                 if (Open311DataType.STRING.equals(open311Attribute.getDatatype())
+                        || Open311DataType.TEXT.equals(open311Attribute.getDatatype())
                         || Open311DataType.NUMBER.equals(open311Attribute.getDatatype())
                         || Open311DataType.DATETIME.equals(open311Attribute.getDatatype())) {
                     EditText et = (EditText) mDynamicAttributeUIMap.get(open311Attribute.getCode());
@@ -848,6 +850,7 @@ public class Open311ProblemFragment extends BaseReportFragment implements
                 addDescriptionText(open311Attribute.getDescription());
             } else {
                 if (Open311DataType.STRING.equals(open311Attribute.getDatatype())
+                        || Open311DataType.TEXT.equals(open311Attribute.getDatatype())
                         || Open311DataType.NUMBER.equals(open311Attribute.getDatatype())
                         || Open311DataType.DATETIME.equals(open311Attribute.getDatatype())) {
                     createEditText(open311Attribute);


### PR DESCRIPTION
This PR handles the `text` datatype to fix arrival time problem.  Currently, OBA isn't showing an Open311 attribute if its datatype is text.  