### PR TITLE
Add time info to travel behavior activity

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/travelbehavior/model/TravelBehaviorInfo.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/travelbehavior/model/TravelBehaviorInfo.java
@@ -28,25 +28,31 @@ public class TravelBehaviorInfo {
         public String detectedActivity;
         public String detectedActivityType;
         public Integer confidenceLevel;
-        public Long transitEventElapsedRealtimeNanos;
+        public Long eventElapsedRealtimeNanos;
         public Long systemClockElapsedRealtimeNanos;
         public Long systemClockCurrentTimeMillis;
         public Long numberOfNanosInThePastWhenEventHappened;
+        public Long eventTimeMillis;
 
         public TravelBehaviorActivity() {
         }
 
         public TravelBehaviorActivity(String detectedActivity, String detectedActivityType,
-                                      Long transitEventElapsedRealtimeNanos) {
+                                      Long eventElapsedRealtimeNanos) {
             this.detectedActivity = detectedActivity;
             this.detectedActivityType = detectedActivityType;
-            this.transitEventElapsedRealtimeNanos = transitEventElapsedRealtimeNanos;
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-                systemClockElapsedRealtimeNanos = SystemClock.elapsedRealtimeNanos();
-            }
+            // When the transition event happened, in nanos since boot
+            this.eventElapsedRealtimeNanos = eventElapsedRealtimeNanos;
+            // Current time, in milliseconds since epoch (normal clock time)
             systemClockCurrentTimeMillis = System.currentTimeMillis();
-            numberOfNanosInThePastWhenEventHappened = TimeUnit.MILLISECONDS.
-                    toNanos(systemClockCurrentTimeMillis) - transitEventElapsedRealtimeNanos;
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+                // Current time, in nanos since boot
+                systemClockElapsedRealtimeNanos = SystemClock.elapsedRealtimeNanos();
+                // Number of nanos in the past from current time when the event happened
+                numberOfNanosInThePastWhenEventHappened = systemClockElapsedRealtimeNanos - eventElapsedRealtimeNanos;
+                // When the transition event happened, in milliseconds since epoch (normal clock time)
+                eventTimeMillis = systemClockCurrentTimeMillis - TimeUnit.NANOSECONDS.toMillis(numberOfNanosInThePastWhenEventHappened);
+            }
         }
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/travelbehavior/model/TravelBehaviorInfo.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/travelbehavior/model/TravelBehaviorInfo.java
@@ -17,8 +17,10 @@ package org.onebusaway.android.travelbehavior.model;
 
 import android.location.Location;
 import android.os.Build;
+import android.os.SystemClock;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 public class TravelBehaviorInfo {
 
@@ -26,13 +28,25 @@ public class TravelBehaviorInfo {
         public String detectedActivity;
         public String detectedActivityType;
         public Integer confidenceLevel;
+        public Long transitEventElapsedRealtimeNanos;
+        public Long systemClockElapsedRealtimeNanos;
+        public Long systemClockCurrentTimeMillis;
+        public Long numberOfNanosInThePastWhenEventHappened;
 
         public TravelBehaviorActivity() {
         }
 
-        public TravelBehaviorActivity(String detectedActivity, String detectedActivityType) {
+        public TravelBehaviorActivity(String detectedActivity, String detectedActivityType,
+                                      Long transitEventElapsedRealtimeNanos) {
             this.detectedActivity = detectedActivity;
             this.detectedActivityType = detectedActivityType;
+            this.transitEventElapsedRealtimeNanos = transitEventElapsedRealtimeNanos;
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+                systemClockElapsedRealtimeNanos = SystemClock.elapsedRealtimeNanos();
+            }
+            systemClockCurrentTimeMillis = System.currentTimeMillis();
+            numberOfNanosInThePastWhenEventHappened = TimeUnit.MILLISECONDS.
+                    toNanos(systemClockCurrentTimeMillis) - transitEventElapsedRealtimeNanos;
         }
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/travelbehavior/receiver/RecognitionBroadcastReceiver.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/travelbehavior/receiver/RecognitionBroadcastReceiver.java
@@ -15,6 +15,11 @@
  */
 package org.onebusaway.android.travelbehavior.receiver;
 
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.util.Log;
+
 import com.google.android.gms.location.ActivityRecognitionResult;
 import com.google.android.gms.location.DetectedActivity;
 import com.google.firebase.firestore.DocumentReference;
@@ -24,11 +29,6 @@ import org.onebusaway.android.travelbehavior.model.TravelBehaviorInfo;
 import org.onebusaway.android.travelbehavior.utils.TravelBehaviorFirebaseIOUtils;
 import org.onebusaway.android.travelbehavior.utils.TravelBehaviorUtils;
 import org.onebusaway.android.util.PreferenceUtils;
-
-import android.content.BroadcastReceiver;
-import android.content.Context;
-import android.content.Intent;
-import android.util.Log;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -95,10 +95,11 @@ public class RecognitionBroadcastReceiver extends BroadcastReceiver {
             updateMap.put("detectedActivity", tba.detectedActivity);
             updateMap.put("detectedActivityType", tba.detectedActivityType);
             updateMap.put("confidenceLevel", tba.confidenceLevel);
-            updateMap.put("transitEventElapsedRealtimeNanos", tba.transitEventElapsedRealtimeNanos);
+            updateMap.put("eventElapsedRealtimeNanos", tba.eventElapsedRealtimeNanos);
             updateMap.put("systemClockElapsedRealtimeNanos", tba.systemClockElapsedRealtimeNanos);
             updateMap.put("systemClockCurrentTimeMillis", tba.systemClockCurrentTimeMillis);
             updateMap.put("numberOfNanosInThePastWhenEventHappened", tba.numberOfNanosInThePastWhenEventHappened);
+            updateMap.put("eventTimeMillis", tba.eventTimeMillis);
             list.add(updateMap);
         }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/travelbehavior/receiver/RecognitionBroadcastReceiver.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/travelbehavior/receiver/RecognitionBroadcastReceiver.java
@@ -95,6 +95,10 @@ public class RecognitionBroadcastReceiver extends BroadcastReceiver {
             updateMap.put("detectedActivity", tba.detectedActivity);
             updateMap.put("detectedActivityType", tba.detectedActivityType);
             updateMap.put("confidenceLevel", tba.confidenceLevel);
+            updateMap.put("transitEventElapsedRealtimeNanos", tba.transitEventElapsedRealtimeNanos);
+            updateMap.put("systemClockElapsedRealtimeNanos", tba.systemClockElapsedRealtimeNanos);
+            updateMap.put("systemClockCurrentTimeMillis", tba.systemClockCurrentTimeMillis);
+            updateMap.put("numberOfNanosInThePastWhenEventHappened", tba.numberOfNanosInThePastWhenEventHappened);
             list.add(updateMap);
         }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/travelbehavior/receiver/TransitionBroadcastReceiver.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/travelbehavior/receiver/TransitionBroadcastReceiver.java
@@ -88,7 +88,8 @@ public class TransitionBroadcastReceiver extends BroadcastReceiver {
                     sb.append(TravelBehaviorUtils.toTransitionType(event.getTransitionType())).append("\n");
                     mActivityList.add(new TravelBehaviorInfo.TravelBehaviorActivity(
                             TravelBehaviorUtils.toActivityString(event.getActivityType()),
-                            TravelBehaviorUtils.toTransitionType(event.getTransitionType())));
+                            TravelBehaviorUtils.toTransitionType(event.getTransitionType()),
+                            event.getElapsedRealTimeNanos()));
                 }
 
                 Log.d(TAG, "Detected activity transition: " + sb.toString());


### PR DESCRIPTION
Timestamps are added to transition events.  For each transition event we collect the following timestamps:
(A) -> `TransitEvent.elapsedRealtimeNanos() `,
(B) -> `SystemClock.elapsedRealtimeNanos()`,
(C) -> `System.currentTimeMillis()`, and
(D) -> (C) - (A)  = number of nanoseconds in the past when the event happened.

The data looks like the following in Firebase:

![Screen Shot 2019-07-14 at 2 02 19 PM](https://user-images.githubusercontent.com/2777974/61189308-760a1200-a640-11e9-812d-819d72269272.png)

