### PR TITLE
Fix #1004 - Create separate model objects for arrival-and-departure, trip-plan, and destination-reminder data

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/travelbehavior/io/task/ArrivalAndDepartureDataSaverTask.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/travelbehavior/io/task/ArrivalAndDepartureDataSaverTask.java
@@ -24,7 +24,7 @@ import org.onebusaway.android.app.Application;
 import org.onebusaway.android.io.elements.ObaArrivalInfo;
 import org.onebusaway.android.travelbehavior.constants.TravelBehaviorConstants;
 import org.onebusaway.android.travelbehavior.io.TravelBehaviorFileSaverExecutorManager;
-import org.onebusaway.android.travelbehavior.model.ArrivalAndDepartureInfo;
+import org.onebusaway.android.travelbehavior.model.ArrivalAndDepartureData;
 import org.onebusaway.android.util.PreferenceUtils;
 
 import android.Manifest;
@@ -110,8 +110,8 @@ public class ArrivalAndDepartureDataSaverTask implements Runnable {
             }
 
             File file = new File(subFolder, counter + "-" + readableDate + ".json");
-            ArrivalAndDepartureInfo.ArrivalAndDepartureData add =
-                    new ArrivalAndDepartureInfo.ArrivalAndDepartureData(mArrivalInfo, mStopId,
+            ArrivalAndDepartureData add =
+                    new ArrivalAndDepartureData(mArrivalInfo, mStopId,
                             Application.get().getCurrentRegion().getId(), mUrl, localElapsedRealtimeNanos,
                             time.getTime(), mServerTime);
             add.setLocation(location);

--- a/onebusaway-android/src/main/java/org/onebusaway/android/travelbehavior/io/task/DestinationReminderDataSaverTask.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/travelbehavior/io/task/DestinationReminderDataSaverTask.java
@@ -23,6 +23,7 @@ import org.apache.commons.io.FileUtils;
 import org.onebusaway.android.app.Application;
 import org.onebusaway.android.travelbehavior.constants.TravelBehaviorConstants;
 import org.onebusaway.android.travelbehavior.io.TravelBehaviorFileSaverExecutorManager;
+import org.onebusaway.android.travelbehavior.model.DestinationReminderData;
 import org.onebusaway.android.travelbehavior.model.DestinationReminderInfo;
 import org.onebusaway.android.util.PreferenceUtils;
 
@@ -111,10 +112,9 @@ public class DestinationReminderDataSaverTask implements Runnable {
             }
 
             File file = new File(subFolder, counter + "-" + readableDate + ".json");
-            DestinationReminderInfo.DestinationReminderData drd = new DestinationReminderInfo.
-                    DestinationReminderData(mCurrStopId ,mDestStopId, mTripId, mRouteId,
-                    Application.get().getCurrentRegion().getId(), localElapsedRealtimeNanos,
-                    time.getTime(), mServerTime, location);
+            DestinationReminderData drd = new DestinationReminderData(mCurrStopId ,mDestStopId,
+                    mTripId, mRouteId, Application.get().getCurrentRegion().getId(),
+                    localElapsedRealtimeNanos, time.getTime(), mServerTime, location);
 
             // Used Gson instead of Jackson library - Jackson had problems while deserializing
             // nested objects.  When we deserialize the object and push it to Firebase, Firebase API

--- a/onebusaway-android/src/main/java/org/onebusaway/android/travelbehavior/io/task/TripPlanDataSaverTask.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/travelbehavior/io/task/TripPlanDataSaverTask.java
@@ -23,7 +23,7 @@ import org.apache.commons.io.FileUtils;
 import org.onebusaway.android.app.Application;
 import org.onebusaway.android.travelbehavior.constants.TravelBehaviorConstants;
 import org.onebusaway.android.travelbehavior.io.TravelBehaviorFileSaverExecutorManager;
-import org.onebusaway.android.travelbehavior.model.TripPlanInfo;
+import org.onebusaway.android.travelbehavior.model.TripPlanData;
 import org.onebusaway.android.util.PreferenceUtils;
 import org.opentripplanner.api.model.TripPlan;
 
@@ -108,7 +108,7 @@ public class TripPlanDataSaverTask implements Runnable {
             }
 
             File file = new File(subFolder, counter + "-" + readableDate + ".json");
-            TripPlanInfo.TripPlanData tpd = new TripPlanInfo.TripPlanData(mTripPlan, mUrl,
+            TripPlanData tpd = new TripPlanData(mTripPlan, mUrl,
                     Application.get().getCurrentRegion().getId(), localElapsedRealtimeNanos,
                     time.getTime(), serverTime);
             tpd.setLocation(location);

--- a/onebusaway-android/src/main/java/org/onebusaway/android/travelbehavior/io/worker/ArrivalsAndDeparturesDataReaderWorker.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/travelbehavior/io/worker/ArrivalsAndDeparturesDataReaderWorker.java
@@ -21,6 +21,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.TrueFileFilter;
 import org.onebusaway.android.app.Application;
 import org.onebusaway.android.travelbehavior.constants.TravelBehaviorConstants;
+import org.onebusaway.android.travelbehavior.model.ArrivalAndDepartureData;
 import org.onebusaway.android.travelbehavior.model.ArrivalAndDepartureInfo;
 import org.onebusaway.android.travelbehavior.utils.TravelBehaviorFirebaseIOUtils;
 
@@ -66,13 +67,13 @@ public class ArrivalsAndDeparturesDataReaderWorker extends Worker {
             Collection<File> files = FileUtils.listFiles(subFolder, TrueFileFilter.INSTANCE,
                     TrueFileFilter.INSTANCE);
             if (files != null && !files.isEmpty()) {
-                List<ArrivalAndDepartureInfo.ArrivalAndDepartureData> l = new ArrayList<>();
+                List<ArrivalAndDepartureData> l = new ArrayList<>();
                 Gson gson = new Gson();
                 for (File f : files) {
                     try {
                         String jsonStr = FileUtils.readFileToString(f);
-                        ArrivalAndDepartureInfo.ArrivalAndDepartureData data =
-                                gson.fromJson(jsonStr, ArrivalAndDepartureInfo.ArrivalAndDepartureData.class);
+                        ArrivalAndDepartureData data =
+                                gson.fromJson(jsonStr, ArrivalAndDepartureData.class);
 
                         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
                             if (SystemClock.elapsedRealtimeNanos() -  data.getLocalElapsedRealtimeNanos() <

--- a/onebusaway-android/src/main/java/org/onebusaway/android/travelbehavior/io/worker/DestinationReminderReaderWorker.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/travelbehavior/io/worker/DestinationReminderReaderWorker.java
@@ -21,7 +21,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.TrueFileFilter;
 import org.onebusaway.android.app.Application;
 import org.onebusaway.android.travelbehavior.constants.TravelBehaviorConstants;
-import org.onebusaway.android.travelbehavior.model.DestinationReminderInfo;
+import org.onebusaway.android.travelbehavior.model.DestinationReminderData;
 import org.onebusaway.android.travelbehavior.utils.TravelBehaviorFirebaseIOUtils;
 
 import android.content.Context;
@@ -65,12 +65,12 @@ public class DestinationReminderReaderWorker extends Worker {
                     TrueFileFilter.INSTANCE);
             Gson gson = new Gson();
             if (files != null && !files.isEmpty()) {
-                List<DestinationReminderInfo.DestinationReminderData> l = new ArrayList<>();
+                List<DestinationReminderData> l = new ArrayList<>();
                 for (File f : files) {
                     try {
                         String jsonStr = FileUtils.readFileToString(f);
-                        DestinationReminderInfo.DestinationReminderData destinationReminderData =
-                                gson.fromJson(jsonStr, DestinationReminderInfo.DestinationReminderData.class);
+                        DestinationReminderData destinationReminderData =
+                                gson.fromJson(jsonStr, DestinationReminderData.class);
                         l.add(destinationReminderData);
                     } catch (IOException e) {
                         Log.e(TAG, e.toString());

--- a/onebusaway-android/src/main/java/org/onebusaway/android/travelbehavior/io/worker/TripPlanDataReaderWorker.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/travelbehavior/io/worker/TripPlanDataReaderWorker.java
@@ -21,7 +21,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.TrueFileFilter;
 import org.onebusaway.android.app.Application;
 import org.onebusaway.android.travelbehavior.constants.TravelBehaviorConstants;
-import org.onebusaway.android.travelbehavior.model.TripPlanInfo;
+import org.onebusaway.android.travelbehavior.model.TripPlanData;
 import org.onebusaway.android.travelbehavior.utils.TravelBehaviorFirebaseIOUtils;
 
 import android.content.Context;
@@ -67,12 +67,11 @@ public class TripPlanDataReaderWorker extends Worker {
                     TrueFileFilter.INSTANCE);
             Gson gson = new Gson();
             if (files != null && !files.isEmpty()) {
-                List<TripPlanInfo.TripPlanData> l = new ArrayList<>();
+                List<TripPlanData> l = new ArrayList<>();
                 for (File f : files) {
                     try {
                         String jsonStr = FileUtils.readFileToString(f);
-                        TripPlanInfo.TripPlanData tripPlanData = gson.fromJson(jsonStr,
-                                TripPlanInfo.TripPlanData.class);
+                        TripPlanData tripPlanData = gson.fromJson(jsonStr, TripPlanData.class);
                         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
                             if (SystemClock.elapsedRealtimeNanos() -  tripPlanData.getLocalElapsedRealtimeNanos() <
                                     TravelBehaviorConstants.MOST_RECENT_DATA_THRESHOLD_NANO) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/travelbehavior/model/ArrivalAndDepartureData.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/travelbehavior/model/ArrivalAndDepartureData.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2019 University of South Florida
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.travelbehavior.model;
+
+import org.onebusaway.android.io.elements.ObaArrivalInfo;
+
+import android.location.Location;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ArrivalAndDepartureData {
+    public TravelBehaviorInfo.LocationInfo locationInfo;
+
+    public List<ObaArrivalInfoPojo> arrivalList;
+
+    public Long localElapsedRealtimeNanos;
+
+    public Long localSystemCurrMillis;
+
+    public Long obaServerTimestamp;
+
+    public String stopId;
+
+    public Long regionId;
+
+    public String url;
+
+    public ArrivalAndDepartureData() {
+    }
+
+    public ArrivalAndDepartureData(ObaArrivalInfo[] info, String stopId, Long regionId,
+                                   String url, Long localElapsedRealtimeNanos,
+                                   Long localSystemCurrMillis, Long obaServerTimestamp) {
+        this.stopId = stopId;
+        this.regionId = regionId;
+        this.url = url;
+        this.localElapsedRealtimeNanos = localElapsedRealtimeNanos;
+        this.localSystemCurrMillis = localSystemCurrMillis;
+        this.obaServerTimestamp = obaServerTimestamp;
+
+        arrivalList = new ArrayList<>();
+        if (info != null && info.length != 0) {
+            for (ObaArrivalInfo oai: info) {
+                arrivalList.add(new ObaArrivalInfoPojo(oai));
+            }
+        }
+    }
+
+    public List<ObaArrivalInfoPojo> getArrivalList() {
+        return arrivalList;
+    }
+
+    public Long getLocalElapsedRealtimeNanos() {
+        return localElapsedRealtimeNanos;
+    }
+
+    public Long getLocalSystemCurrMillis() {
+        return localSystemCurrMillis;
+    }
+
+    public Long getObaServerTimestamp() {
+        return obaServerTimestamp;
+    }
+
+    public String getStopId() {
+        return stopId;
+    }
+
+    public Long getRegionId() {
+        return regionId;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setLocation(Location location) {
+        locationInfo = new TravelBehaviorInfo.LocationInfo(location);
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/travelbehavior/model/ArrivalAndDepartureInfo.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/travelbehavior/model/ArrivalAndDepartureInfo.java
@@ -15,87 +15,14 @@
  */
 package org.onebusaway.android.travelbehavior.model;
 
-import org.onebusaway.android.io.elements.ObaArrivalInfo;
-
-import android.location.Location;
-
-import java.util.ArrayList;
 import java.util.List;
 
 public class ArrivalAndDepartureInfo {
 
-    public static class ArrivalAndDepartureData {
-        public TravelBehaviorInfo.LocationInfo locationInfo;
+    public List<ArrivalAndDepartureData> arrivalAndDepartureData;
 
-        public List<ObaArrivalInfoPojo> arrivalList;
-
-        public Long localElapsedRealtimeNanos;
-
-        public Long localSystemCurrMillis;
-
-        public Long obaServerTimestamp;
-
-        public String stopId;
-
-        public Long regionId;
-
-        public String url;
-
-        public ArrivalAndDepartureData() {
-        }
-
-        public ArrivalAndDepartureData(ObaArrivalInfo[] info, String stopId, Long regionId,
-                                       String url, Long localElapsedRealtimeNanos,
-                                       Long localSystemCurrMillis, Long obaServerTimestamp) {
-            this.stopId = stopId;
-            this.regionId = regionId;
-            this.url = url;
-            this.localElapsedRealtimeNanos = localElapsedRealtimeNanos;
-            this.localSystemCurrMillis = localSystemCurrMillis;
-            this.obaServerTimestamp = obaServerTimestamp;
-
-            arrivalList = new ArrayList<>();
-            if (info != null && info.length != 0) {
-                for (ObaArrivalInfo oai: info) {
-                    arrivalList.add(new ObaArrivalInfoPojo(oai));
-                }
-            }
-        }
-
-        public List<ObaArrivalInfoPojo> getArrivalList() {
-            return arrivalList;
-        }
-
-        public Long getLocalElapsedRealtimeNanos() {
-            return localElapsedRealtimeNanos;
-        }
-
-        public Long getLocalSystemCurrMillis() {
-            return localSystemCurrMillis;
-        }
-
-        public Long getObaServerTimestamp() {
-            return obaServerTimestamp;
-        }
-
-        public String getStopId() {
-            return stopId;
-        }
-
-        public Long getRegionId() {
-            return regionId;
-        }
-
-        public String getUrl() {
-            return url;
-        }
-
-        public void setLocation(Location location) {
-            locationInfo = new TravelBehaviorInfo.LocationInfo(location);
-        }
+    public ArrivalAndDepartureInfo() {
     }
-
-    List<ArrivalAndDepartureData> arrivalAndDepartureData;
 
     public ArrivalAndDepartureInfo(List<ArrivalAndDepartureData> arrivalAndDepartureData) {
         this.arrivalAndDepartureData = arrivalAndDepartureData;

--- a/onebusaway-android/src/main/java/org/onebusaway/android/travelbehavior/model/DestinationReminderData.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/travelbehavior/model/DestinationReminderData.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2012-2015 Paul Watts (paulcwatts@gmail.com), University of South Florida,
+ * Benjamin Du (bendu@me.com), and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.travelbehavior.model;
+
+import android.location.Location;
+
+public class DestinationReminderData {
+    public String currStopId;
+
+    public String destStopId;
+
+    public String tripId;
+
+    public String routeId;
+
+    public Long regionId;
+
+    public Long localElapsedRealtimeNanos;
+
+    public Long localSystemCurrMillis;
+
+    public Long obaServerTimestamp;
+
+    public TravelBehaviorInfo.LocationInfo locationInfo;
+
+    public DestinationReminderData(String currStopId, String destStopId, String tripId,
+                                   String routeId, Long regionId, Long localElapsedRealtimeNanos,
+                                   Long localSystemCurrMillis, Long obaServerTimestamp,
+                                   Location location) {
+        this.currStopId = currStopId;
+        this.destStopId = destStopId;
+        this.tripId = tripId;
+        this.routeId = routeId;
+        this.regionId = regionId;
+        this.localElapsedRealtimeNanos = localElapsedRealtimeNanos;
+        this.localSystemCurrMillis = localSystemCurrMillis;
+        this.obaServerTimestamp = obaServerTimestamp;
+        this.locationInfo = new TravelBehaviorInfo.LocationInfo(location);
+    }
+
+    public Long getLocalElapsedRealtimeNanos() {
+        return localElapsedRealtimeNanos;
+    }
+
+    public Long getLocalSystemCurrMillis() {
+        return localSystemCurrMillis;
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/travelbehavior/model/DestinationReminderInfo.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/travelbehavior/model/DestinationReminderInfo.java
@@ -16,56 +16,13 @@
  */
 package org.onebusaway.android.travelbehavior.model;
 
-import android.location.Location;
-
 import java.util.List;
 
 public class DestinationReminderInfo {
-    public static class DestinationReminderData {
+    public List<DestinationReminderData> destinationReminderData;
 
-        public String currStopId;
-
-        public String destStopId;
-
-        public String tripId;
-
-        public String routeId;
-
-        public Long regionId;
-
-        public Long localElapsedRealtimeNanos;
-
-        public Long localSystemCurrMillis;
-
-        public Long obaServerTimestamp;
-
-        public TravelBehaviorInfo.LocationInfo locationInfo;
-
-        public DestinationReminderData(String currStopId, String destStopId, String tripId,
-                                       String routeId, Long regionId, Long localElapsedRealtimeNanos,
-                                       Long localSystemCurrMillis, Long obaServerTimestamp,
-                                       Location location) {
-            this.currStopId = currStopId;
-            this.destStopId = destStopId;
-            this.tripId = tripId;
-            this.routeId = routeId;
-            this.regionId = regionId;
-            this.localElapsedRealtimeNanos = localElapsedRealtimeNanos;
-            this.localSystemCurrMillis = localSystemCurrMillis;
-            this.obaServerTimestamp = obaServerTimestamp;
-            this.locationInfo = new TravelBehaviorInfo.LocationInfo(location);
-        }
-
-        public Long getLocalElapsedRealtimeNanos() {
-            return localElapsedRealtimeNanos;
-        }
-
-        public Long getLocalSystemCurrMillis() {
-            return localSystemCurrMillis;
-        }
+    public DestinationReminderInfo() {
     }
-
-    List<DestinationReminderData> destinationReminderData;
 
     public DestinationReminderInfo(List<DestinationReminderData> destinationReminderData) {
         this.destinationReminderData = destinationReminderData;

--- a/onebusaway-android/src/main/java/org/onebusaway/android/travelbehavior/model/TripPlanData.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/travelbehavior/model/TripPlanData.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2019 University of South Florida
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.travelbehavior.model;
+
+import org.opentripplanner.api.model.TripPlan;
+
+import android.location.Location;
+
+public class TripPlanData {
+    public TravelBehaviorInfo.LocationInfo locationInfo;
+
+    public TripPlan tripPlan;
+
+    public String url;
+
+    public Long regionId;
+
+    public Long localElapsedRealtimeNanos;
+
+    public Long localSystemCurrMillis;
+
+    public Long otpServerTimestamp;
+
+    public TripPlanData() {
+    }
+
+    public TripPlanData(TripPlan tripPlan, String url, Long regionId ,
+                        Long localElapsedRealtimeNanos, Long localSystemCurrMillis,
+                        Long otpServerTimestamp) {
+        this.tripPlan = tripPlan;
+        this.url = url;
+        this.regionId = regionId;
+        this.localElapsedRealtimeNanos = localElapsedRealtimeNanos;
+        this.localSystemCurrMillis = localSystemCurrMillis;
+        this.otpServerTimestamp = otpServerTimestamp;
+    }
+
+    public Long getLocalElapsedRealtimeNanos() {
+        return localElapsedRealtimeNanos;
+    }
+
+    public Long getLocalSystemCurrMillis() {
+        return localSystemCurrMillis;
+    }
+
+    public Long getOtpServerTimestamp() {
+        return otpServerTimestamp;
+    }
+
+    public void setLocation(Location location) {
+        locationInfo = new TravelBehaviorInfo.LocationInfo(location);
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/travelbehavior/model/TripPlanInfo.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/travelbehavior/model/TripPlanInfo.java
@@ -15,61 +15,13 @@
  */
 package org.onebusaway.android.travelbehavior.model;
 
-import org.opentripplanner.api.model.TripPlan;
-
-import android.location.Location;
-
 import java.util.List;
 
 public class TripPlanInfo {
+    public List<TripPlanData> tripPlanDataList;
 
-    public static class TripPlanData {
-        public TravelBehaviorInfo.LocationInfo locationInfo;
-
-        public TripPlan tripPlan;
-
-        public String url;
-
-        public Long regionId;
-
-        public Long localElapsedRealtimeNanos;
-
-        public Long localSystemCurrMillis;
-
-        public Long otpServerTimestamp;
-
-        public TripPlanData() {
-        }
-
-        public TripPlanData(TripPlan tripPlan, String url, Long regionId ,
-                            Long localElapsedRealtimeNanos, Long localSystemCurrMillis,
-                            Long otpServerTimestamp) {
-            this.tripPlan = tripPlan;
-            this.url = url;
-            this.regionId = regionId;
-            this.localElapsedRealtimeNanos = localElapsedRealtimeNanos;
-            this.localSystemCurrMillis = localSystemCurrMillis;
-            this.otpServerTimestamp = otpServerTimestamp;
-        }
-
-        public Long getLocalElapsedRealtimeNanos() {
-            return localElapsedRealtimeNanos;
-        }
-
-        public Long getLocalSystemCurrMillis() {
-            return localSystemCurrMillis;
-        }
-
-        public Long getOtpServerTimestamp() {
-            return otpServerTimestamp;
-        }
-
-        public void setLocation(Location location) {
-            locationInfo = new TravelBehaviorInfo.LocationInfo(location);
-        }
+    public TripPlanInfo() {
     }
-
-    List<TripPlanData> tripPlanDataList;
 
     public TripPlanInfo(List<TripPlanData> tripPlanDataList) {
         this.tripPlanDataList = tripPlanDataList;

--- a/onebusaway-android/src/main/java/org/onebusaway/android/travelbehavior/utils/TravelBehaviorFirebaseIOUtils.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/travelbehavior/utils/TravelBehaviorFirebaseIOUtils.java
@@ -20,10 +20,13 @@ import com.google.firebase.firestore.FieldValue;
 import com.google.firebase.firestore.FirebaseFirestore;
 
 import org.onebusaway.android.travelbehavior.constants.TravelBehaviorConstants;
+import org.onebusaway.android.travelbehavior.model.ArrivalAndDepartureData;
 import org.onebusaway.android.travelbehavior.model.ArrivalAndDepartureInfo;
+import org.onebusaway.android.travelbehavior.model.DestinationReminderData;
 import org.onebusaway.android.travelbehavior.model.DestinationReminderInfo;
 import org.onebusaway.android.travelbehavior.model.DeviceInformation;
 import org.onebusaway.android.travelbehavior.model.TravelBehaviorInfo;
+import org.onebusaway.android.travelbehavior.model.TripPlanData;
 import org.onebusaway.android.travelbehavior.model.TripPlanInfo;
 import org.onebusaway.android.util.PreferenceUtils;
 
@@ -71,7 +74,7 @@ public class TravelBehaviorFirebaseIOUtils {
                 });
     }
 
-    public static void saveArrivalsAndDepartures(List<ArrivalAndDepartureInfo.ArrivalAndDepartureData> arrivalAndDepartureList,
+    public static void saveArrivalsAndDepartures(List<ArrivalAndDepartureData> arrivalAndDepartureList,
                                                  String userId, String recordId) {
         DocumentReference document = TravelBehaviorFirebaseIOUtils.
                 getFirebaseDocReferenceByUserIdAndRecordId(userId, recordId,
@@ -89,7 +92,7 @@ public class TravelBehaviorFirebaseIOUtils {
                 });
     }
 
-    public static void saveTripPlans(List<TripPlanInfo.TripPlanData> tripPlanDataList,
+    public static void saveTripPlans(List<TripPlanData> tripPlanDataList,
                                      String userId, String recordId) {
         DocumentReference document = TravelBehaviorFirebaseIOUtils.
                 getFirebaseDocReferenceByUserIdAndRecordId(userId, recordId,
@@ -107,7 +110,7 @@ public class TravelBehaviorFirebaseIOUtils {
                 });
     }
 
-    public static void saveDestinationReminders(List<DestinationReminderInfo.DestinationReminderData> reminderData,
+    public static void saveDestinationReminders(List<DestinationReminderData> reminderData,
                                                 String userId, String recordId) {
         DocumentReference document = TravelBehaviorFirebaseIOUtils.
                 getFirebaseDocReferenceByUserIdAndRecordId(userId, recordId,


### PR DESCRIPTION
Created separate model object for  arrival-and-departure, trip-plan, and destination-reminder data. After that OBA start pushing these data to firebase:

![Screen Shot 2019-07-17 at 2 54 12 PM](https://user-images.githubusercontent.com/2777974/61414437-c1235f80-a8a2-11e9-894e-f9a434474aca.png)
