### PR TITLE
Fix #1007 - Call save-device-info method at application launch

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/travelbehavior/TravelBehaviorManager.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/travelbehavior/TravelBehaviorManager.java
@@ -35,6 +35,7 @@ import org.onebusaway.android.travelbehavior.io.task.DestinationReminderDataSave
 import org.onebusaway.android.travelbehavior.io.task.TripPlanDataSaverTask;
 import org.onebusaway.android.travelbehavior.io.worker.OptOutTravelBehaviorParticipantWorker;
 import org.onebusaway.android.travelbehavior.io.worker.RegisterTravelBehaviorParticipantWorker;
+import org.onebusaway.android.travelbehavior.io.worker.UpdateDeviceInfoWorker;
 import org.onebusaway.android.travelbehavior.receiver.TransitionBroadcastReceiver;
 import org.onebusaway.android.travelbehavior.utils.TravelBehaviorFirebaseIOUtils;
 import org.onebusaway.android.travelbehavior.utils.TravelBehaviorUtils;
@@ -316,6 +317,21 @@ public class TravelBehaviorManager {
                         "Travel behavior activity-transition-update failed set up: ");
             }
         });
+
+        saveDeviceInformation();
+    }
+
+    private void saveDeviceInformation() {
+        String uid = PreferenceUtils.getString(TravelBehaviorConstants.USER_ID);
+        Data myData = new Data.Builder()
+                .putString(TravelBehaviorConstants.USER_ID, uid)
+                .build();
+
+        OneTimeWorkRequest workRequest = new OneTimeWorkRequest.Builder(
+                UpdateDeviceInfoWorker.class)
+                .setInputData(myData)
+                .build();
+        WorkManager.getInstance().enqueue(workRequest);
     }
 
     public void stopCollectingData() {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/travelbehavior/io/worker/UpdateDeviceInfoWorker.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/travelbehavior/io/worker/UpdateDeviceInfoWorker.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2019 University of South Florida
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.travelbehavior.io.worker;
+
+import com.google.android.gms.common.GoogleApiAvailability;
+
+import org.onebusaway.android.app.Application;
+import org.onebusaway.android.travelbehavior.constants.TravelBehaviorConstants;
+import org.onebusaway.android.travelbehavior.model.DeviceInformation;
+import org.onebusaway.android.travelbehavior.utils.TravelBehaviorFirebaseIOUtils;
+import org.onebusaway.android.util.PreferenceUtils;
+
+import android.content.Context;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import android.os.Build;
+import android.view.accessibility.AccessibilityManager;
+
+import androidx.annotation.NonNull;
+import androidx.work.Worker;
+import androidx.work.WorkerParameters;
+
+import static android.content.Context.ACCESSIBILITY_SERVICE;
+
+public class UpdateDeviceInfoWorker extends Worker {
+
+    private static final String TAG = "TripPlanReadWorker";
+
+    public UpdateDeviceInfoWorker(@NonNull Context context, @NonNull WorkerParameters workerParams) {
+        super(context, workerParams);
+    }
+
+    @NonNull
+    @Override
+    public Result doWork() {
+        saveDeviceInformation();
+        return Result.success();
+    }
+
+    private void saveDeviceInformation() {
+        PackageManager pm = getApplicationContext().getPackageManager();
+        PackageInfo appInfoOba;
+        PackageInfo appInfoGps;
+        String obaVersion = "";
+        String googlePlayServicesAppVersion = "";
+        try {
+            appInfoOba = pm.getPackageInfo(getApplicationContext().getPackageName(),
+                    PackageManager.GET_META_DATA);
+            obaVersion = appInfoOba.versionName;
+        } catch (PackageManager.NameNotFoundException e) {
+            // Leave version as empty string
+        }
+        try {
+            appInfoGps = pm.getPackageInfo(GoogleApiAvailability.GOOGLE_PLAY_SERVICES_PACKAGE, 0);
+            googlePlayServicesAppVersion = appInfoGps.versionName;
+        } catch (PackageManager.NameNotFoundException e) {
+            // Leave version as empty string
+        }
+
+        AccessibilityManager am = (AccessibilityManager) getApplicationContext().getSystemService(ACCESSIBILITY_SERVICE);
+        Boolean isTalkBackEnabled = am.isTouchExplorationEnabled();
+
+        DeviceInformation di = new DeviceInformation(obaVersion, Build.MODEL, Build.VERSION.RELEASE,
+                Build.VERSION.SDK_INT, googlePlayServicesAppVersion,
+                GoogleApiAvailability.GOOGLE_PLAY_SERVICES_VERSION_CODE,
+                Application.get().getCurrentRegion().getId(), isTalkBackEnabled);
+
+        int hashCode = di.hashCode();
+        int mostRecentDeviceHash = PreferenceUtils.getInt(TravelBehaviorConstants.DEVICE_INFO_HASH,
+                -1);
+
+        String uid = getInputData().getString(TravelBehaviorConstants.USER_ID);
+
+        // Update if the device info is changed
+        if (hashCode != mostRecentDeviceHash && uid != null) {
+
+            String recordId = Long.toString(System.currentTimeMillis());
+            TravelBehaviorFirebaseIOUtils.saveDeviceInfo(di, uid, recordId, hashCode);
+        }
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/travelbehavior/model/DeviceInformation.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/travelbehavior/model/DeviceInformation.java
@@ -35,6 +35,8 @@ public class DeviceInformation {
 
     public Boolean isTalkBackEnabled;
 
+    public String timestamp;
+
     public DeviceInformation(String appVersion, String deviceModel, String sdkVersion,
                              Integer sdkVersionInt, String googlePlayServicesApp,
                              Integer googlePlayServicesLib, Long regionId, Boolean isTalkBackEnabled) {
@@ -46,6 +48,10 @@ public class DeviceInformation {
         this.googlePlayServicesLib = googlePlayServicesLib;
         this.regionId = regionId;
         this.isTalkBackEnabled = isTalkBackEnabled;
+    }
+
+    public void setTimestamp(String timestamp) {
+        this.timestamp = timestamp;
     }
 
     @Override

--- a/onebusaway-android/src/main/java/org/onebusaway/android/travelbehavior/receiver/TransitionBroadcastReceiver.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/travelbehavior/receiver/TransitionBroadcastReceiver.java
@@ -115,8 +115,6 @@ public class TransitionBroadcastReceiver extends BroadcastReceiver {
         requestActivityRecognition();
 
         requestLocationUpdates();
-
-        saveDeviceInformation();
     }
 
     private void saveTravelBehavior(TravelBehaviorInfo tbi) {
@@ -226,44 +224,6 @@ public class TransitionBroadcastReceiver extends BroadcastReceiver {
             PendingIntent pi = PendingIntent.getBroadcast(mContext, reqCode++, intent, PendingIntent.FLAG_ONE_SHOT);
             lm.requestLocationUpdates(provider, 0, 0, pi);
             PreferenceUtils.saveInt(TravelBehaviorConstants.LOCATION_REQUEST_CODE, reqCode);
-        }
-    }
-
-    private void saveDeviceInformation() {
-        PackageManager pm = mContext.getPackageManager();
-        PackageInfo appInfoOba;
-        PackageInfo appInfoGps;
-        String obaVersion = "";
-        String googlePlayServicesAppVersion = "";
-        try {
-            appInfoOba = pm.getPackageInfo(mContext.getPackageName(),
-                    PackageManager.GET_META_DATA);
-            obaVersion = appInfoOba.versionName;
-        } catch (PackageManager.NameNotFoundException e) {
-            // Leave version as empty string
-        }
-        try {
-            appInfoGps = pm.getPackageInfo(GoogleApiAvailability.GOOGLE_PLAY_SERVICES_PACKAGE, 0);
-            googlePlayServicesAppVersion = appInfoGps.versionName;
-        } catch (PackageManager.NameNotFoundException e) {
-            // Leave version as empty string
-        }
-
-        AccessibilityManager am = (AccessibilityManager) mContext.getSystemService(ACCESSIBILITY_SERVICE);
-        Boolean isTalkBackEnabled = am.isTouchExplorationEnabled();
-
-        DeviceInformation di = new DeviceInformation(obaVersion, Build.MODEL, Build.VERSION.RELEASE,
-                Build.VERSION.SDK_INT, googlePlayServicesAppVersion,
-                GoogleApiAvailability.GOOGLE_PLAY_SERVICES_VERSION_CODE,
-                Application.get().getCurrentRegion().getId(), isTalkBackEnabled);
-
-        int hashCode = di.hashCode();
-        int mostRecentDeviceHash = PreferenceUtils.getInt(TravelBehaviorConstants.DEVICE_INFO_HASH,
-                -1);
-
-        // Update if the device info is changed
-        if (hashCode != mostRecentDeviceHash) {
-            TravelBehaviorFirebaseIOUtils.saveDeviceInfo(di, mUid, mRecordId, hashCode);
         }
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/travelbehavior/utils/TravelBehaviorFirebaseIOUtils.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/travelbehavior/utils/TravelBehaviorFirebaseIOUtils.java
@@ -130,6 +130,8 @@ public class TravelBehaviorFirebaseIOUtils {
 
     public static void saveDeviceInfo(DeviceInformation deviceInformation, String userId,
                                       String recordId, int hashCode) {
+        deviceInformation.setTimestamp(recordId);
+
         DocumentReference document = TravelBehaviorFirebaseIOUtils.
                 getFirebaseDocReferenceByUserIdAndRecordId(userId, recordId,
                         TravelBehaviorConstants.FIREBASE_DEVICE_INFO_FOLDER);


### PR DESCRIPTION
Calling the `saveDeviceInfo` method in the app launch.  Previously, we were calling this method on every transition event and it was causing duplicate ~device-information` records on Firebase.  Now, we only call once when the app is started.  The new data looks like this on Firebase:

![Screen Shot 2019-07-18 at 3 21 10 PM](https://user-images.githubusercontent.com/2777974/61496002-b2ef4500-a96f-11e9-9993-88734df04884.png)
