### PR TITLE
Fix #1012 - Trip status text being clipped when using larger font sizes

### DIFF
--- a/onebusaway-android/src/main/res/layout/trip_details_listitem.xml
+++ b/onebusaway-android/src/main/res/layout/trip_details_listitem.xml
@@ -17,7 +17,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="fill_parent"
-    android:layout_height="@dimen/trip_details_transit_line_height"
+    android:layout_height="wrap_content"
     android:orientation="horizontal">
 
     <include
@@ -64,7 +64,9 @@
     <LinearLayout
         android:id="@+id/transit_line"
         android:layout_width="wrap_content"
-        android:layout_height="match_parent"
+        android:layout_height="0dp"
+        android:layout_alignTop="@+id/stop_details"
+        android:layout_alignBottom="@+id/stop_details"
         android:weightSum="1"
         android:layout_alignParentLeft="true"
         android:layout_marginLeft="30dp"
@@ -95,6 +97,7 @@
     </LinearLayout>
 
     <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/stop_details"
         style="@style/ListItem"
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"

--- a/onebusaway-android/src/main/res/values/dimens.xml
+++ b/onebusaway-android/src/main/res/values/dimens.xml
@@ -64,7 +64,6 @@
 
     <!-- Trip details - transit stop and line -->
     <dimen name="trip_details_transit_line_width">3dp</dimen>
-    <dimen name="trip_details_transit_line_height">65dp</dimen>
     <dimen name="trip_details_transit_stop_width">13dp</dimen>
     <dimen name="trip_details_transit_stop_width_focused">16dp</dimen>
     <dimen name="trip_details_transit_bus_icon">18dp</dimen>


### PR DESCRIPTION
When using larger font sizes, the arrival time is clipped and not readable because the items are of a fixed size. This changes it so that the item size is based on the size of the text content, the line on the left is then also sized based on the height of that content. This is to fix Issue #1012 

Currently this is how it looks at the largest font size:

![Screenshot_1569198114](https://user-images.githubusercontent.com/8473011/65396872-eaa7ae00-dd5f-11e9-8984-1c4114751fdd.png)


With this PR, it should now look like this:


![Screenshot_1569198041](https://user-images.githubusercontent.com/8473011/65396888-19258900-dd60-11e9-98b1-de11e5259da5.png)


And at the smallest font size it looks like this:


![Screenshot_1569198908](https://user-images.githubusercontent.com/8473011/65396906-47a36400-dd60-11e9-8f02-4791fae5f432.png)
