### PR TITLE
Change default geocoder from Google Places SDK to Pelias API for trip planning

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -40,6 +40,16 @@ also mention how you would build/run the **amazon** flavor for the **oba** brand
 1. To build and push the app to the device, run `gradlew installObaGoogleDebug` from the command line at the root of the project (or `gradlew installObaAmazonDebug` for Amazon build flavor)
 1. To start the app, run `adb shell am start -n com.joulespersecond.seattlebusbot/org.onebusaway.android.ui.HomeActivity` (alternately, you can manually start the app)
 
+### Configuration Pelias API key for geocoding
+
+If trip planning is active, you'll need to provide an API key for [geocode.earth](https://geocode.earth/).
+
+Add the following to `onebusaway-android/gradle.properties`:
+
+`Pelias_oba=XXXXXX`
+
+...where `XXXXXX` is your API key. Note that the suffix of `_oba` can be changed to configure API keys for other build flavors.
+
 ### Release builds
 
 To build a release build, you need to create a `gradle.properties` file that points to a `secure.properties` file, and a `secure.properties` file that points to your keystore and alias.

--- a/REBRANDING.md
+++ b/REBRANDING.md
@@ -87,6 +87,16 @@ No matter which default is defined, users can change the sorting style by using 
 
 `USE_FIXED_REGION` - Valid values are `true` and `false` - If true, then the app will be fixed to the region information provided for this brand dimension in the `build.gradle`.  If false, then the app will function with the normal multi-region process, and work across various regions defined in the Regions API.  This value is false for the original OneBusAway brand so it supports multi-region.
 
+**Configuration Pelias API key for geocoding**
+
+If trip planning is active, you'll need to provide an API key for [geocode.earth](https://geocode.earth/).
+
+Add the following to `onebusaway-android/gradle.properties`:
+
+`Pelias_oba=XXXXXX`
+
+...where `XXXXXX` is your API key. Note that the suffix of `_oba` can be changed to configure API keys for other build flavors.
+
 ## Examples
 
 Here's an example of how configuration options are set up for the sample agency "Agency X" in `build.gradle`:

--- a/onebusaway-android/build.gradle
+++ b/onebusaway-android/build.gradle
@@ -102,6 +102,7 @@ android {
             buildConfigField "boolean", "USE_FIXED_REGION", "false" // Supports multi-region
             buildConfigField "String", "EMBEDDED_SOCIAL_API_KEY", "\"" + getEmbeddedSocialKey("ApiKey", name) + "\""
             buildConfigField "String", "EMBEDDED_SOCIAL_TELEMETRY_KEY", "\"" + getEmbeddedSocialKey("TelemetryKey", name) + "\""
+            buildConfigField "String", "PELIAS_API_KEY", "\"" + getPeliasKey(name) + "\""
             // Below fields need to be defined so flavor builds, but will not be used by app
             buildConfigField "String", "FIXED_REGION_NAME", "null"
             buildConfigField "String", "FIXED_REGION_OBA_BASE_URL", "null"
@@ -149,6 +150,7 @@ android {
             buildConfigField "boolean", "USE_FIXED_REGION", "false" // Supports multi-region
             buildConfigField "String", "EMBEDDED_SOCIAL_API_KEY", "\"" + getEmbeddedSocialKey("ApiKey", name) + "\""
             buildConfigField "String", "EMBEDDED_SOCIAL_TELEMETRY_KEY", "\"" + getEmbeddedSocialKey("TelemetryKey", name) + "\""
+            buildConfigField "String", "PELIAS_API_KEY", "\"" + getPeliasKey(name) + "\""
             // Below fields need to be defined so flavor builds, but will not be used by app
             buildConfigField "String", "FIXED_REGION_NAME", "null"
             buildConfigField "String", "FIXED_REGION_OBA_BASE_URL", "null"
@@ -187,6 +189,7 @@ android {
             buildConfigField "boolean", "USE_FIXED_REGION", "true" // Does not support multi-region
             buildConfigField "String", "EMBEDDED_SOCIAL_API_KEY", "\"" + getEmbeddedSocialKey("ApiKey", name) + "\""
             buildConfigField "String", "EMBEDDED_SOCIAL_TELEMETRY_KEY", "\"" + getEmbeddedSocialKey("TelemetryKey", name) + "\""
+            buildConfigField "String", "PELIAS_API_KEY", "\"" + getPeliasKey(name) + "\""
             // Fixed region info that the app will use
             buildConfigField "String", "FIXED_REGION_NAME", "\"Agency Y\""
             buildConfigField "String", "FIXED_REGION_OBA_BASE_URL",
@@ -229,6 +232,7 @@ android {
             buildConfigField "boolean", "USE_FIXED_REGION", "true" // Does not support multi-region
             buildConfigField "String", "EMBEDDED_SOCIAL_API_KEY", "\"" + getEmbeddedSocialKey("ApiKey", name) + "\""
             buildConfigField "String", "EMBEDDED_SOCIAL_TELEMETRY_KEY", "\"" + getEmbeddedSocialKey("TelemetryKey", name) + "\""
+            buildConfigField "String", "PELIAS_API_KEY", "\"" + getPeliasKey(name) + "\""
             // Fixed region info that the app will use
             buildConfigField "String", "FIXED_REGION_NAME", "\"YORK\""
             buildConfigField "String", "FIXED_REGION_OBA_BASE_URL",
@@ -361,6 +365,19 @@ android {
  */
 def getEmbeddedSocialKey(keyType, productFlavor) {
     def keyName = "EmbeddedSocial" + keyType + "_" + productFlavor
+    if (project.hasProperty(keyName)) {
+        return project.property(keyName)
+    } else {
+        return ""
+    }
+}
+/**
+ * Gets the Pelias geocoding API key for the given product flavor
+ * @param productFlavor the product flavor being built
+ * @return the Pelias geocoding API key for the given product flavor
+ */
+def getPeliasKey(productFlavor) {
+    def keyName = "Pelias" + "_" + productFlavor
     if (project.hasProperty(keyName)) {
         return project.property(keyName)
     } else {

--- a/onebusaway-android/build.gradle
+++ b/onebusaway-android/build.gradle
@@ -442,10 +442,10 @@ dependencies {
     implementation 'com.github.amlcurran.showcaseview:library:5.4.3'
     // POJOs used for full data-binding via Jackson
     implementation 'edu.usf.cutr.opentripplanner.android:opentripplanner-pojos:1.0.0-SNAPSHOT'
+    // Pelias for point-of-interest search and geocoding for trip planning origin and destination
+    implementation 'edu.usf.cutr:pelias-client-library:1.0.3'
     // Google Play Services Maps (only for Google flavor)
     googleImplementation 'com.google.android.gms:play-services-maps:16.1.0'
-    // Google Play Services Places is required by ProprietaryMapHelpV2 (only for Google flavor)
-    googleImplementation 'com.google.android.libraries.places:places-compat:1.1.0'
     // Amazon Maps (only for Amazon flavor)
     amazonImplementation 'com.amazon.android:amazon-maps-api:2.0'
     // Embedded Social SDK

--- a/onebusaway-android/build.gradle
+++ b/onebusaway-android/build.gradle
@@ -105,6 +105,7 @@ android {
             buildConfigField "boolean", "USE_FIXED_REGION", "false" // Supports multi-region
             buildConfigField "String", "EMBEDDED_SOCIAL_API_KEY", "\"" + getEmbeddedSocialKey("ApiKey", name) + "\""
             buildConfigField "String", "EMBEDDED_SOCIAL_TELEMETRY_KEY", "\"" + getEmbeddedSocialKey("TelemetryKey", name) + "\""
+            buildConfigField "boolean", "USE_PELIAS_GEOCODING", "true"
             buildConfigField "String", "PELIAS_API_KEY", "\"" + getPeliasKey(name) + "\""
             // Below fields need to be defined so flavor builds, but will not be used by app
             buildConfigField "String", "FIXED_REGION_NAME", "null"
@@ -153,6 +154,7 @@ android {
             buildConfigField "boolean", "USE_FIXED_REGION", "false" // Supports multi-region
             buildConfigField "String", "EMBEDDED_SOCIAL_API_KEY", "\"" + getEmbeddedSocialKey("ApiKey", name) + "\""
             buildConfigField "String", "EMBEDDED_SOCIAL_TELEMETRY_KEY", "\"" + getEmbeddedSocialKey("TelemetryKey", name) + "\""
+            buildConfigField "boolean", "USE_PELIAS_GEOCODING", "true"
             buildConfigField "String", "PELIAS_API_KEY", "\"" + getPeliasKey(name) + "\""
             // Below fields need to be defined so flavor builds, but will not be used by app
             buildConfigField "String", "FIXED_REGION_NAME", "null"
@@ -192,6 +194,7 @@ android {
             buildConfigField "boolean", "USE_FIXED_REGION", "true" // Does not support multi-region
             buildConfigField "String", "EMBEDDED_SOCIAL_API_KEY", "\"" + getEmbeddedSocialKey("ApiKey", name) + "\""
             buildConfigField "String", "EMBEDDED_SOCIAL_TELEMETRY_KEY", "\"" + getEmbeddedSocialKey("TelemetryKey", name) + "\""
+            buildConfigField "boolean", "USE_PELIAS_GEOCODING", "true"
             buildConfigField "String", "PELIAS_API_KEY", "\"" + getPeliasKey(name) + "\""
             // Fixed region info that the app will use
             buildConfigField "String", "FIXED_REGION_NAME", "\"Agency Y\""
@@ -235,6 +238,7 @@ android {
             buildConfigField "boolean", "USE_FIXED_REGION", "true" // Does not support multi-region
             buildConfigField "String", "EMBEDDED_SOCIAL_API_KEY", "\"" + getEmbeddedSocialKey("ApiKey", name) + "\""
             buildConfigField "String", "EMBEDDED_SOCIAL_TELEMETRY_KEY", "\"" + getEmbeddedSocialKey("TelemetryKey", name) + "\""
+            buildConfigField "boolean", "USE_PELIAS_GEOCODING", "false"
             buildConfigField "String", "PELIAS_API_KEY", "\"" + getPeliasKey(name) + "\""
             // Fixed region info that the app will use
             buildConfigField "String", "FIXED_REGION_NAME", "\"YORK\""
@@ -479,6 +483,8 @@ dependencies {
     implementation 'edu.usf.cutr:pelias-client-library:1.0.3'
     // Google Play Services Maps (only for Google flavor)
     googleImplementation 'com.google.android.gms:play-services-maps:16.1.0'
+    // Google Play Services Places is required by ProprietaryMapHelpV2 (only for Google flavor)
+    googleImplementation 'com.google.android.libraries.places:places-compat:1.1.0'
     // Amazon Maps (only for Amazon flavor)
     amazonImplementation 'com.amazon.android:amazon-maps-api:2.0'
     // Embedded Social SDK

--- a/onebusaway-android/proguard-project.txt
+++ b/onebusaway-android/proguard-project.txt
@@ -38,6 +38,13 @@
 # Keep all OpenTripPlanner POJO classes
 -keep class org.opentripplanner.** { *; }
 
+# Keep all Pelias POJO classes for geocoding
+-keep class edu.usf.cutr.pelias.** { *; }
+
+# Keep all class members for GeoJSON Feature class and deserializers for geocoding
+-keepclassmembers class org.geojson.Feature** { *; }
+-keepclassmembers class org.geojson.jackson.LngLatAltDeserializer** { *; }
+
 # SearchView
 -keep class android.support.v7.widget.SearchView { *; }
 

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/ProprietaryMapHelpV2.java
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/ProprietaryMapHelpV2.java
@@ -15,17 +15,9 @@
  */
 package org.onebusaway.android.map.googlemapsv2;
 
-import com.google.android.gms.common.GooglePlayServicesNotAvailableException;
-import com.google.android.gms.common.GooglePlayServicesRepairableException;
-import com.google.android.gms.maps.model.LatLng;
-import com.google.android.gms.maps.model.LatLngBounds;
 import com.google.android.gms.maps.model.Marker;
-import com.google.android.libraries.places.compat.Place;
-import com.google.android.libraries.places.compat.ui.PlaceAutocomplete;
 
 import org.onebusaway.android.R;
-import org.onebusaway.android.directions.util.CustomAddress;
-import org.onebusaway.android.io.elements.ObaRegion;
 
 import android.app.AlertDialog;
 import android.content.Context;
@@ -35,9 +27,6 @@ import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.net.Uri;
-import android.view.View;
-
-import androidx.fragment.app.Fragment;
 
 /**
  * Helper methods specific to Google Maps API v2
@@ -98,79 +87,6 @@ public class ProprietaryMapHelpV2 {
         );
         AlertDialog dialog = builder.create();
         dialog.show();
-    }
-
-    /**
-     * Decode the result of an Intent to Google Places Autocomplete into a CustomAddress.
-     * Here because of LatLng, Place which are specific to Google Places API.
-     */
-    public static CustomAddress getCustomAddressFromPlacesIntent(Context context, Intent intent) {
-        Place place = PlaceAutocomplete.getPlace(context, intent);
-
-        CustomAddress address = new CustomAddress();
-
-        String placeName = place.getName().toString();
-        address.setAddressLine(0, placeName);
-
-        String addressString = place.getAddress().toString();
-        String[] tokens = addressString.split(PLACES_ADDRESS_SEPARATOR);
-
-        // Posible that first line of address is place name.
-        int start = placeName.equals(tokens[0]) ? 1 : 0;
-
-        int j = 1; // address line index
-        for (int i = start; i < tokens.length; i++) {
-            address.setAddressLine(j++, tokens[i]);
-        }
-
-        LatLng loc = place.getLatLng();
-
-        address.setLatitude(loc.latitude);
-        address.setLongitude(loc.longitude);
-
-        return address;
-    }
-
-    /**
-     * Helper class to start Google Places Autocomplete when a field is clicked.
-     * Does not check that Google API is available.
-     * Here because of the use of LatLngBounds. Decode result with
-     * getCustomAddressFromPlacesIntent.
-     */
-    public static class StartPlacesAutocompleteOnClick implements View.OnClickListener {
-
-        int mRequestCode;
-        Fragment mFragment;
-        ObaRegion mRegion;
-
-        public StartPlacesAutocompleteOnClick(int requestCode, Fragment fragment, ObaRegion region) {
-            mRequestCode = requestCode;
-            mFragment = fragment;
-            mRegion = region;
-        }
-
-        @Override
-        public void onClick(View v) {
-            Intent intent = null;
-            PlaceAutocomplete.IntentBuilder builder =
-                    new PlaceAutocomplete.IntentBuilder(PlaceAutocomplete.MODE_OVERLAY);
-
-            if (mRegion != null) {
-                // Bias search results to region bounds
-                LatLngBounds bounds = MapHelpV2.getRegionBounds(mRegion);
-                builder.setBoundsBias(bounds);
-            }
-
-            try {
-                intent = builder.build(mFragment.getActivity());
-            } catch (GooglePlayServicesRepairableException e) {
-                e.printStackTrace();
-            } catch (GooglePlayServicesNotAvailableException e) {
-                e.printStackTrace();
-            }
-
-            mFragment.startActivityForResult(intent, mRequestCode);
-        }
     }
 
     /**

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/ProprietaryMapHelpV2.java
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/ProprietaryMapHelpV2.java
@@ -15,10 +15,6 @@
  */
 package org.onebusaway.android.map.googlemapsv2;
 
-import com.google.android.gms.maps.model.Marker;
-
-import org.onebusaway.android.R;
-
 import android.app.AlertDialog;
 import android.content.Context;
 import android.content.DialogInterface;
@@ -27,6 +23,21 @@ import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.net.Uri;
+import android.view.View;
+
+import androidx.fragment.app.Fragment;
+
+import com.google.android.gms.common.GooglePlayServicesNotAvailableException;
+import com.google.android.gms.common.GooglePlayServicesRepairableException;
+import com.google.android.gms.maps.model.LatLng;
+import com.google.android.gms.maps.model.LatLngBounds;
+import com.google.android.gms.maps.model.Marker;
+import com.google.android.libraries.places.compat.Place;
+import com.google.android.libraries.places.compat.ui.PlaceAutocomplete;
+
+import org.onebusaway.android.R;
+import org.onebusaway.android.directions.util.CustomAddress;
+import org.onebusaway.android.io.elements.ObaRegion;
 
 /**
  * Helper methods specific to Google Maps API v2
@@ -87,6 +98,79 @@ public class ProprietaryMapHelpV2 {
         );
         AlertDialog dialog = builder.create();
         dialog.show();
+    }
+
+    /**
+     * Decode the result of an Intent to Google Places Autocomplete into a CustomAddress.
+     * Here because of LatLng, Place which are specific to Google Places API.
+     */
+    public static CustomAddress getCustomAddressFromPlacesIntent(Context context, Intent intent) {
+        Place place = PlaceAutocomplete.getPlace(context, intent);
+
+        CustomAddress address = new CustomAddress();
+
+        String placeName = place.getName().toString();
+        address.setAddressLine(0, placeName);
+
+        String addressString = place.getAddress().toString();
+        String[] tokens = addressString.split(PLACES_ADDRESS_SEPARATOR);
+
+        // Posible that first line of address is place name.
+        int start = placeName.equals(tokens[0]) ? 1 : 0;
+
+        int j = 1; // address line index
+        for (int i = start; i < tokens.length; i++) {
+            address.setAddressLine(j++, tokens[i]);
+        }
+
+        LatLng loc = place.getLatLng();
+
+        address.setLatitude(loc.latitude);
+        address.setLongitude(loc.longitude);
+
+        return address;
+    }
+
+    /**
+     * Helper class to start Google Places Autocomplete when a field is clicked.
+     * Does not check that Google API is available.
+     * Here because of the use of LatLngBounds. Decode result with
+     * getCustomAddressFromPlacesIntent.
+     */
+    public static class StartPlacesAutocompleteOnClick implements View.OnClickListener {
+
+        int mRequestCode;
+        Fragment mFragment;
+        ObaRegion mRegion;
+
+        public StartPlacesAutocompleteOnClick(int requestCode, Fragment fragment, ObaRegion region) {
+            mRequestCode = requestCode;
+            mFragment = fragment;
+            mRegion = region;
+        }
+
+        @Override
+        public void onClick(View v) {
+            Intent intent = null;
+            PlaceAutocomplete.IntentBuilder builder =
+                    new PlaceAutocomplete.IntentBuilder(PlaceAutocomplete.MODE_OVERLAY);
+
+            if (mRegion != null) {
+                // Bias search results to region bounds
+                LatLngBounds bounds = MapHelpV2.getRegionBounds(mRegion);
+                builder.setBoundsBias(bounds);
+            }
+
+            try {
+                intent = builder.build(mFragment.getActivity());
+            } catch (GooglePlayServicesRepairableException e) {
+                e.printStackTrace();
+            } catch (GooglePlayServicesNotAvailableException e) {
+                e.printStackTrace();
+            }
+
+            mFragment.startActivityForResult(intent, mRequestCode);
+        }
     }
 
     /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/CustomAddress.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/CustomAddress.java
@@ -17,6 +17,7 @@
 package org.onebusaway.android.directions.util;
 
 import org.geojson.Feature;
+import org.geojson.Point;
 
 import android.location.Address;
 import android.os.Parcel;
@@ -83,18 +84,20 @@ public class CustomAddress extends Address {
         super.setFeatureName((String) address.getProperties().get("label"));
 //        super.setAdminArea(address.getAdminArea());
 //        super.setSubAdminArea(address.getSubAdminArea());
-        super.setLocality((String) address.getProperties().get("locality"));
+//        super.setLocality((String) address.getProperties().get("locality"));
 //        super.setSubLocality(address.getSubLocality());
 //        super.setThoroughfare(address.getThoroughfare());
 //        super.setSubThoroughfare(address.getSubThoroughfare());
         super.setPostalCode((String) address.getProperties().get("postalcode"));
 //        super.setCountryCode(address.getCountryCode());
         super.setCountryName((String) address.getProperties().get("country"));
-//        super.setLatitude(address.getLatitude());
-//        super.setLongitude(address.getLongitude());
 //        super.setPhone(address.getPhone());
 //        super.setUrl(address.getUrl());
 //        super.setExtras(address.getExtras());
+
+        Point p = (Point) address.getGeometry();
+        super.setLatitude(p.getCoordinates().getLatitude());
+        super.setLongitude(p.getCoordinates().getLongitude());
     }
 
     @Override

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/CustomAddress.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/CustomAddress.java
@@ -16,6 +16,8 @@
 
 package org.onebusaway.android.directions.util;
 
+import org.geojson.Feature;
+
 import android.location.Address;
 import android.os.Parcel;
 import android.os.Parcelable;
@@ -41,6 +43,10 @@ public class CustomAddress extends Address {
         super(Locale.getDefault());
     }
 
+    /**
+     * Creates a CustomAddress out of a Android Address from the Android platform Geocoder API
+     * @param address
+     */
     public CustomAddress(Address address) {
         super(address.getLocale());
         for (int i = 0; i <= address.getMaxAddressLineIndex(); i++) {
@@ -61,6 +67,34 @@ public class CustomAddress extends Address {
         super.setPhone(address.getPhone());
         super.setUrl(address.getUrl());
         super.setExtras(address.getExtras());
+    }
+
+    /**
+     * Creates a CustomAddress out of a GeoJSON Feature (e.g., from Pelias Autocomplete API)
+     * @param address
+     */
+    public CustomAddress(Feature address) {
+        super(Locale.getDefault());
+
+        // TODO - see if we need to fill out more fields
+        // For example response with fields see https://github.com/CUTR-at-USF/pelias-client-library/blob/master/src/test/resources/autocomplete-with-focus.json
+        // and https://github.com/CUTR-at-USF/pelias-client-library/blob/master/src/test/java/edu/usf/cutr/pelias/AutocompleteTest.java#L42
+        super.setAddressLine(0, (String) address.getProperties().get("name"));
+        super.setFeatureName((String) address.getProperties().get("label"));
+//        super.setAdminArea(address.getAdminArea());
+//        super.setSubAdminArea(address.getSubAdminArea());
+        super.setLocality((String) address.getProperties().get("locality"));
+//        super.setSubLocality(address.getSubLocality());
+//        super.setThoroughfare(address.getThoroughfare());
+//        super.setSubThoroughfare(address.getSubThoroughfare());
+        super.setPostalCode((String) address.getProperties().get("postalcode"));
+//        super.setCountryCode(address.getCountryCode());
+        super.setCountryName((String) address.getProperties().get("country"));
+//        super.setLatitude(address.getLatitude());
+//        super.setLongitude(address.getLongitude());
+//        super.setPhone(address.getPhone());
+//        super.setUrl(address.getUrl());
+//        super.setExtras(address.getExtras());
     }
 
     @Override

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/PlacesAutoCompleteAdapter.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/PlacesAutoCompleteAdapter.java
@@ -21,6 +21,7 @@ import org.onebusaway.android.io.elements.ObaRegion;
 import org.onebusaway.android.util.LocationUtils;
 
 import android.content.Context;
+import android.util.Log;
 import android.widget.ArrayAdapter;
 import android.widget.Filter;
 import android.widget.Filterable;
@@ -64,9 +65,11 @@ public class PlacesAutoCompleteAdapter extends ArrayAdapter<CustomAddress> imple
                 FilterResults filterResults = new FilterResults();
                 if (constraint != null) {
                     // Retrieve the autocomplete results.
-                        mResultList = LocationUtils.processGeocoding(mContext, mRegion,
-                                constraint.toString());
+//                    mResultList = LocationUtils.processGeocoding(mContext, mRegion,
+//                                constraint.toString());
+                    mResultList = LocationUtils.processPeliasGeocoding(mContext, mRegion, constraint.toString());
                     if (mResultList != null){
+                        Log.d("Geocode", "Num of results: " + mResultList.size());
                         // Assign the data to the FilterResults
                         filterResults.values = mResultList;
                         filterResults.count = mResultList.size();

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/PlacesAutoCompleteAdapter.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/PlacesAutoCompleteAdapter.java
@@ -17,14 +17,15 @@
 
 package org.onebusaway.android.directions.util;
 
-import org.onebusaway.android.io.elements.ObaRegion;
-import org.onebusaway.android.util.LocationUtils;
-
 import android.content.Context;
 import android.util.Log;
 import android.widget.ArrayAdapter;
 import android.widget.Filter;
 import android.widget.Filterable;
+
+import org.onebusaway.android.BuildConfig;
+import org.onebusaway.android.io.elements.ObaRegion;
+import org.onebusaway.android.util.LocationUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -64,10 +65,13 @@ public class PlacesAutoCompleteAdapter extends ArrayAdapter<CustomAddress> imple
             protected Filter.FilterResults performFiltering(CharSequence constraint) {
                 FilterResults filterResults = new FilterResults();
                 if (constraint != null) {
-                    // Retrieve the autocomplete results.
-//                    mResultList = LocationUtils.processGeocoding(mContext, mRegion,
-//                                constraint.toString());
-                    mResultList = LocationUtils.processPeliasGeocoding(mContext, mRegion, constraint.toString());
+                    // Retrieve the autocomplete results
+                    if (BuildConfig.USE_PELIAS_GEOCODING) {
+                        mResultList = LocationUtils.processPeliasGeocoding(mContext, mRegion, constraint.toString());
+                    } else {
+                        // Use Google Places SDK
+                        mResultList = LocationUtils.processGooglePlacesGeocoding(mContext, mRegion, constraint.toString());
+                    }
                     if (mResultList != null){
                         Log.d("Geocode", "Num of results: " + mResultList.size());
                         // Assign the data to the FilterResults

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.java
@@ -17,44 +17,6 @@
  */
 package org.onebusaway.android.ui;
 
-import com.google.android.gms.common.ConnectionResult;
-import com.google.android.gms.common.GoogleApiAvailability;
-import com.google.android.gms.common.api.GoogleApiClient;
-import com.google.android.material.floatingactionbutton.FloatingActionButton;
-import com.google.firebase.analytics.FirebaseAnalytics;
-
-import com.microsoft.embeddedsocial.sdk.EmbeddedSocial;
-import com.microsoft.embeddedsocial.ui.fragment.ActivityFeedFragment;
-import com.microsoft.embeddedsocial.ui.fragment.MyProfileFragment;
-import com.microsoft.embeddedsocial.ui.fragment.PinsFragment;
-import com.sothree.slidinguppanel.SlidingUpPanelLayout;
-
-import org.onebusaway.android.BuildConfig;
-import org.onebusaway.android.R;
-import org.onebusaway.android.app.Application;
-import org.onebusaway.android.io.ObaAnalytics;
-import org.onebusaway.android.io.elements.ObaRegion;
-import org.onebusaway.android.io.elements.ObaRoute;
-import org.onebusaway.android.io.elements.ObaStop;
-import org.onebusaway.android.io.request.ObaArrivalInfoResponse;
-import org.onebusaway.android.map.MapModeController;
-import org.onebusaway.android.map.MapParams;
-import org.onebusaway.android.map.googlemapsv2.BaseMapFragment;
-import org.onebusaway.android.map.googlemapsv2.LayerInfo;
-import org.onebusaway.android.region.ObaRegionsTask;
-import org.onebusaway.android.report.ui.ReportActivity;
-import org.onebusaway.android.travelbehavior.TravelBehaviorManager;
-import org.onebusaway.android.travelbehavior.utils.TravelBehaviorUtils;
-import org.onebusaway.android.tripservice.TripService;
-import org.onebusaway.android.util.FragmentUtils;
-import org.onebusaway.android.util.LocationUtils;
-import org.onebusaway.android.util.PermissionUtils;
-import org.onebusaway.android.util.PreferenceUtils;
-import org.onebusaway.android.util.RegionUtils;
-import org.onebusaway.android.util.ShowcaseViewUtils;
-import org.onebusaway.android.util.UIUtils;
-import org.opentripplanner.routing.bike_rental.BikeRentalStation;
-
 import android.Manifest;
 import android.app.Dialog;
 import android.content.Context;
@@ -91,18 +53,55 @@ import android.widget.RelativeLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.content.ContextCompat;
+import androidx.fragment.app.FragmentManager;
+
+import com.google.android.gms.common.ConnectionResult;
+import com.google.android.gms.common.GoogleApiAvailability;
+import com.google.android.gms.common.api.GoogleApiClient;
+import com.google.android.material.floatingactionbutton.FloatingActionButton;
+import com.google.firebase.analytics.FirebaseAnalytics;
+import com.microsoft.embeddedsocial.sdk.EmbeddedSocial;
+import com.microsoft.embeddedsocial.ui.fragment.ActivityFeedFragment;
+import com.microsoft.embeddedsocial.ui.fragment.MyProfileFragment;
+import com.microsoft.embeddedsocial.ui.fragment.PinsFragment;
+import com.sothree.slidinguppanel.SlidingUpPanelLayout;
+
+import org.onebusaway.android.BuildConfig;
+import org.onebusaway.android.R;
+import org.onebusaway.android.app.Application;
+import org.onebusaway.android.io.ObaAnalytics;
+import org.onebusaway.android.io.elements.ObaRegion;
+import org.onebusaway.android.io.elements.ObaRoute;
+import org.onebusaway.android.io.elements.ObaStop;
+import org.onebusaway.android.io.request.ObaArrivalInfoResponse;
+import org.onebusaway.android.map.MapModeController;
+import org.onebusaway.android.map.MapParams;
+import org.onebusaway.android.map.googlemapsv2.BaseMapFragment;
+import org.onebusaway.android.map.googlemapsv2.LayerInfo;
+import org.onebusaway.android.region.ObaRegionsTask;
+import org.onebusaway.android.report.ui.ReportActivity;
+import org.onebusaway.android.travelbehavior.TravelBehaviorManager;
+import org.onebusaway.android.travelbehavior.utils.TravelBehaviorUtils;
+import org.onebusaway.android.tripservice.TripService;
+import org.onebusaway.android.util.FragmentUtils;
+import org.onebusaway.android.util.LocationUtils;
+import org.onebusaway.android.util.PermissionUtils;
+import org.onebusaway.android.util.PreferenceUtils;
+import org.onebusaway.android.util.RegionUtils;
+import org.onebusaway.android.util.ShowcaseViewUtils;
+import org.onebusaway.android.util.UIUtils;
+import org.opentripplanner.routing.bike_rental.BikeRentalStation;
+
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
-
-import androidx.annotation.NonNull;
-import androidx.appcompat.app.AlertDialog;
-import androidx.appcompat.app.AppCompatActivity;
-import androidx.core.content.ContextCompat;
-import androidx.fragment.app.FragmentManager;
 
 import static org.onebusaway.android.ui.NavigationDrawerFragment.NAVDRAWER_ITEM_ACTIVITY_FEED;
 import static org.onebusaway.android.ui.NavigationDrawerFragment.NAVDRAWER_ITEM_HELP;
@@ -513,14 +512,10 @@ public class HomeActivity extends AppCompatActivity
                 }
                 break;
             case NAVDRAWER_ITEM_PLAN_TRIP:
-//                Intent planTrip = new Intent(HomeActivity.this, TripPlanActivity.class);
-//                startActivity(planTrip);
-//                ObaAnalytics.reportUiEvent(mFirebaseAnalytics,
-//                        getString(R.string.analytics_label_button_press_trip_plan),
-//                        null);
-                UIUtils.showNoTripPlannerDialog(this);
+                Intent planTrip = new Intent(HomeActivity.this, TripPlanActivity.class);
+                startActivity(planTrip);
                 ObaAnalytics.reportUiEvent(mFirebaseAnalytics,
-                        getString(R.string.analytics_label_button_press_google_cost_increase),
+                        getString(R.string.analytics_label_button_press_trip_plan),
                         null);
                 break;
             case NAVDRAWER_ITEM_PAY_FARE:

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/TripPlanActivity.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/TripPlanActivity.java
@@ -17,8 +17,24 @@
  */
 package org.onebusaway.android.ui;
 
-import com.google.firebase.analytics.FirebaseAnalytics;
+import android.app.AlertDialog;
+import android.app.ProgressDialog;
+import android.content.DialogInterface;
+import android.content.Intent;
+import android.location.Location;
+import android.os.Bundle;
+import android.text.TextUtils;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.ViewTreeObserver;
+import android.widget.ListView;
+import android.widget.Toast;
 
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.fragment.app.Fragment;
+
+import com.google.firebase.analytics.FirebaseAnalytics;
 import com.sothree.slidinguppanel.ScrollableViewHelper;
 import com.sothree.slidinguppanel.SlidingUpPanelLayout;
 
@@ -35,24 +51,7 @@ import org.opentripplanner.api.model.Itinerary;
 import org.opentripplanner.api.model.TripPlan;
 import org.opentripplanner.api.ws.Message;
 
-import android.app.AlertDialog;
-import android.app.ProgressDialog;
-import android.content.DialogInterface;
-import android.content.Intent;
-import android.location.Location;
-import android.os.Bundle;
-import android.text.TextUtils;
-import android.view.MenuItem;
-import android.view.View;
-import android.view.ViewGroup;
-import android.view.ViewTreeObserver;
-import android.widget.ListView;
-import android.widget.Toast;
-
 import java.util.ArrayList;
-
-import androidx.appcompat.app.AppCompatActivity;
-import androidx.fragment.app.Fragment;
 
 
 public class TripPlanActivity extends AppCompatActivity implements TripRequest.Callback,
@@ -158,7 +157,7 @@ public class TripPlanActivity extends AppCompatActivity implements TripRequest.C
             fragment.setArguments(bundle);
             fragment.setListener(this);
             getSupportFragmentManager().beginTransaction()
-                    .add(R.id.trip_plan_fragment_container, fragment).commit();
+                    .add(R.id.trip_plan_fragment_container, fragment, TripPlanFragment.TAG).commit();
         }
 
         mPanel = (SlidingUpPanelLayout) findViewById(R.id.trip_plan_sliding_layout);

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/TripPlanFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/TripPlanFragment.java
@@ -287,6 +287,7 @@ public class TripPlanFragment extends Fragment {
         if (mBuilder.ready() && mListener != null) {
             mFromAddressTextArea.dismissDropDown();
             mToAddressTextArea.dismissDropDown();
+            UIUtils.closeKeyboard(getContext(), mFromAddressTextArea);
             mListener.onTripRequestReady();
         }
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/TripPlanFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/TripPlanFragment.java
@@ -284,6 +284,8 @@ public class TripPlanFragment extends Fragment {
 
     private void checkRequestAndSubmit() {
         if (mBuilder.ready() && mListener != null) {
+            mFromAddressTextArea.dismissDropDown();
+            mToAddressTextArea.dismissDropDown();
             mListener.onTripRequestReady();
         }
     }
@@ -352,6 +354,9 @@ public class TripPlanFragment extends Fragment {
                 // do nothing
             }
         });
+
+        mFromAddressTextArea.dismissDropDown();
+        mToAddressTextArea.dismissDropDown();
     }
 
     @Override
@@ -568,6 +573,7 @@ public class TripPlanFragment extends Fragment {
 
             checkRequestAndSubmit();
         });
+        tv.dismissDropDown();
     }
 
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/TripPlanFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/TripPlanFragment.java
@@ -562,6 +562,13 @@ public class TripPlanFragment extends Fragment {
         return address;
     }
 
+    /**
+     * Receives a geocoding result from the Google Places SDK
+     *
+     * @param requestCode
+     * @param resultCode
+     * @param intent
+     */
     @Override
     public void onActivityResult(int requestCode, int resultCode, Intent intent) {
         if (resultCode != -1) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/TripPlanFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/TripPlanFragment.java
@@ -15,24 +15,6 @@
  */
 package org.onebusaway.android.ui;
 
-import com.google.android.gms.common.ConnectionResult;
-import com.google.android.gms.common.GooglePlayServicesUtil;
-import com.google.android.gms.common.api.GoogleApiClient;
-import com.google.firebase.analytics.FirebaseAnalytics;
-
-import org.onebusaway.android.R;
-import org.onebusaway.android.app.Application;
-import org.onebusaway.android.directions.util.ConversionUtils;
-import org.onebusaway.android.directions.util.CustomAddress;
-import org.onebusaway.android.directions.util.OTPConstants;
-import org.onebusaway.android.directions.util.PlacesAutoCompleteAdapter;
-import org.onebusaway.android.directions.util.TripRequestBuilder;
-import org.onebusaway.android.io.ObaAnalytics;
-import org.onebusaway.android.io.elements.ObaRegion;
-import org.onebusaway.android.util.LocationUtils;
-import org.onebusaway.android.util.PreferenceUtils;
-import org.onebusaway.android.util.UIUtils;
-
 import android.app.DatePickerDialog;
 import android.app.Dialog;
 import android.app.TimePickerDialog;
@@ -60,15 +42,33 @@ import android.widget.TextView;
 import android.widget.TimePicker;
 import android.widget.Toast;
 
+import androidx.appcompat.app.AlertDialog;
+import androidx.fragment.app.Fragment;
+
+import com.google.android.gms.common.ConnectionResult;
+import com.google.android.gms.common.GooglePlayServicesUtil;
+import com.google.android.gms.common.api.GoogleApiClient;
+import com.google.firebase.analytics.FirebaseAnalytics;
+
+import org.onebusaway.android.R;
+import org.onebusaway.android.app.Application;
+import org.onebusaway.android.directions.util.ConversionUtils;
+import org.onebusaway.android.directions.util.CustomAddress;
+import org.onebusaway.android.directions.util.OTPConstants;
+import org.onebusaway.android.directions.util.PlacesAutoCompleteAdapter;
+import org.onebusaway.android.directions.util.TripRequestBuilder;
+import org.onebusaway.android.io.ObaAnalytics;
+import org.onebusaway.android.io.elements.ObaRegion;
+import org.onebusaway.android.util.LocationUtils;
+import org.onebusaway.android.util.PreferenceUtils;
+import org.onebusaway.android.util.UIUtils;
+
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
-
-import androidx.appcompat.app.AlertDialog;
-import androidx.fragment.app.Fragment;
 
 
 public class TripPlanFragment extends Fragment {
@@ -83,6 +83,8 @@ public class TripPlanFragment extends Fragment {
          */
         void onTripRequestReady();
     }
+
+    public static final String TAG = "TripPlanFragment";
 
     private static final int USE_FROM_ADDRESS = 1;
     private static final int USE_TO_ADDRESS = 2;
@@ -101,7 +103,6 @@ public class TripPlanFragment extends Fragment {
     Calendar mMyCalendar;
 
     protected GoogleApiClient mGoogleApiClient;
-    private static final String TAG = "TripPlanFragment";
 
     private CustomAddress mFromAddress, mToAddress;
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/BuildFlavorUtils.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/BuildFlavorUtils.java
@@ -15,11 +15,12 @@
  */
 package org.onebusaway.android.util;
 
-import org.onebusaway.android.R;
-import org.onebusaway.android.app.Application;
-
 import android.content.SharedPreferences;
 import android.content.res.Resources;
+
+import org.onebusaway.android.BuildConfig;
+import org.onebusaway.android.R;
+import org.onebusaway.android.app.Application;
 
 /**
  * Constants and utilities used in the build.gradle build flavors to define certain features per
@@ -92,5 +93,15 @@ public class BuildFlavorUtils {
         }
         // Return style A by default
         return ARRIVAL_INFO_STYLE_A;
+    }
+
+    /**
+     * Returns true if the Pelias API key is non-empty, false if it is not
+     *
+     * @return true if the Pelias API key is non-empty, false if it is not
+     */
+    public static boolean isPeliasApiKeyDefined() {
+        String peliasKey = BuildConfig.PELIAS_API_KEY;
+        return peliasKey != null && peliasKey.length() != 0;
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/LocationUtils.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/LocationUtils.java
@@ -15,15 +15,6 @@
  */
 package org.onebusaway.android.util;
 
-import com.google.android.gms.common.ConnectionResult;
-import com.google.android.gms.common.api.GoogleApiClient;
-import com.google.android.gms.location.LocationServices;
-
-import org.onebusaway.android.R;
-import org.onebusaway.android.app.Application;
-import org.onebusaway.android.directions.util.CustomAddress;
-import org.onebusaway.android.io.elements.ObaRegion;
-
 import android.content.Context;
 import android.location.Address;
 import android.location.Geocoder;
@@ -35,6 +26,16 @@ import android.os.SystemClock;
 import android.provider.Settings;
 import android.text.TextUtils;
 import android.util.Log;
+
+import com.google.android.gms.common.ConnectionResult;
+import com.google.android.gms.common.api.GoogleApiClient;
+import com.google.android.gms.location.LocationServices;
+
+import org.onebusaway.android.BuildConfig;
+import org.onebusaway.android.R;
+import org.onebusaway.android.app.Application;
+import org.onebusaway.android.directions.util.CustomAddress;
+import org.onebusaway.android.io.elements.ObaRegion;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -455,10 +456,9 @@ public class LocationUtils {
 
         List<CustomAddress> addresses = new ArrayList<>();
         try {
-            // FIXME - Replace with Pelias key
-            String apiKey = "YourKeyHere";
+            String apiKey = BuildConfig.PELIAS_API_KEY;
             PeliasRequest.Builder requestBuilder = new AutocompleteRequest.Builder(apiKey, address)
-                    .setApiEndpoint("https://api.geocode.earth/v1/autocomplete");  // FIXME - Replace with Pelias endpoint
+                    .setApiEndpoint(Application.get().getString(R.string.pelias_api_url));
 
             if (region != null) {
                 double[] regionSpan = new double[4];

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/LocationUtils.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/LocationUtils.java
@@ -292,8 +292,8 @@ public class LocationUtils {
         }
     }
 
-    public static List<CustomAddress> processGeocoding(Context context, ObaRegion region,
-                                                            String... reqs) {
+    public static List<CustomAddress> processGooglePlacesGeocoding(Context context, ObaRegion region,
+                                                                   String... reqs) {
         return processGeocoding(context, region, false, reqs);
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/LocationUtils.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/LocationUtils.java
@@ -458,7 +458,7 @@ public class LocationUtils {
             // FIXME - Replace with Pelias key
             String apiKey = "YourKeyHere";
             PeliasRequest.Builder requestBuilder = new AutocompleteRequest.Builder(apiKey, address)
-                    .setApiEndpoint("YourEndpointHere");  // FIXME - Replace with Pelias endpoint
+                    .setApiEndpoint("https://api.geocode.earth/v1/autocomplete");  // FIXME - Replace with Pelias endpoint
 
             if (region != null) {
                 double[] regionSpan = new double[4];

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/LocationUtils.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/LocationUtils.java
@@ -42,6 +42,10 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import edu.usf.cutr.pelias.AutocompleteRequest;
+import edu.usf.cutr.pelias.PeliasRequest;
+import edu.usf.cutr.pelias.PeliasResponse;
+
 /**
  * Utilities to help obtain and process location data
  *
@@ -358,6 +362,123 @@ public class LocationUtils {
             e.printStackTrace();
         }
 
+
+        addresses = filterAddressesBBox(region, addresses);
+
+        boolean resultsCloseEnough = true;
+
+        if (geocodingForMarker && latLngSet) {
+            float results[] = new float[1];
+            resultsCloseEnough = false;
+
+            for (CustomAddress addressToCheck : addresses) {
+                Location.distanceBetween(latitude, longitude,
+                        addressToCheck.getLatitude(), addressToCheck.getLongitude(), results);
+                if (results[0] < GEOCODING_MAX_ERROR) {
+                    resultsCloseEnough = true;
+                    break;
+                }
+            }
+        }
+
+        if ((addresses == null) || addresses.isEmpty() || !resultsCloseEnough) {
+            if (addresses == null) {
+                addresses = new ArrayList<CustomAddress>();
+            }
+            Log.e(TAG, "Geocoder did not find enough addresses: " + addresses);
+        }
+
+        addresses = filterAddressesBBox(region, addresses);
+
+        if (geocodingForMarker && latLngSet && addresses != null && !addresses.isEmpty()) {
+            float results[] = new float[1];
+            float minDistanceToOriginalLatLon = Float.MAX_VALUE;
+            CustomAddress closestAddress = addresses.get(0);
+
+            for (CustomAddress addressToCheck : addresses) {
+                Location.distanceBetween(latitude, longitude,
+                        addressToCheck.getLatitude(), addressToCheck.getLongitude(), results);
+                if (results[0] < minDistanceToOriginalLatLon) {
+                    closestAddress = addressToCheck;
+                    minDistanceToOriginalLatLon = results[0];
+                }
+            }
+            addressesReturn.add(closestAddress);
+        } else {
+            addressesReturn.addAll(addresses);
+        }
+
+        return addressesReturn;
+    }
+
+    public static List<CustomAddress> processPeliasGeocoding(Context context, ObaRegion region,
+            String... reqs) {
+        return processPeliasGeocoding(context, region, false, reqs);
+    }
+
+    public static List<CustomAddress> processPeliasGeocoding(Context context, ObaRegion region, boolean geocodingForMarker, String... reqs) {
+        ArrayList<CustomAddress> addressesReturn = new ArrayList<CustomAddress>();
+
+        String address = reqs[0];
+
+        if (address == null || address.equalsIgnoreCase("")) {
+            return null;
+        }
+
+        double latitude = 0, longitude = 0;
+        boolean latLngSet = false;
+
+        try {
+            if (reqs.length >= 3) {
+                latitude = Double.parseDouble(reqs[1]);
+                longitude = Double.parseDouble(reqs[2]);
+                latLngSet = true;
+            }
+        } catch (Exception e) {
+            Log.e(TAG, "Geocoding without reference latitude/longitude");
+        }
+
+        if (address.equalsIgnoreCase(context.getString(R.string.tripplanner_current_location))) {
+            if (latLngSet) {
+                CustomAddress addressReturn = new CustomAddress(context.getResources().getConfiguration().locale);
+                addressReturn.setLatitude(latitude);
+                addressReturn.setLongitude(longitude);
+                addressReturn.setAddressLine(addressReturn.getMaxAddressLineIndex() + 1,
+                        context.getString(R.string.tripplanner_current_location));
+
+                addressesReturn.add(addressReturn);
+
+                return addressesReturn;
+            }
+            return null;
+        }
+
+        List<CustomAddress> addresses = new ArrayList<>();
+        try {
+            // FIXME - Replace with Pelias key
+            String apiKey = "YourKeyHere";
+            PeliasRequest.Builder requestBuilder = new AutocompleteRequest.Builder(apiKey, address)
+                    .setApiEndpoint("YourEndpointHere");  // FIXME - Replace with Pelias endpoint
+
+            if (region != null) {
+                double[] regionSpan = new double[4];
+                RegionUtils.getRegionSpan(region, regionSpan);
+                double minLat = regionSpan[2] - (regionSpan[0] / 2);
+                double minLon = regionSpan[3] - (regionSpan[1] / 2);
+                double maxLat = regionSpan[2] + (regionSpan[0] / 2);
+                double maxLon = regionSpan[3] + (regionSpan[1] / 2);
+
+                requestBuilder.setBoundaryRect(minLat, minLon, maxLat, maxLon);
+            }
+
+            // Call the Pelias API
+            PeliasResponse response = requestBuilder.build().call();
+            for (org.geojson.Feature feature : response.getFeatures()) {
+                addresses.add(new CustomAddress(feature));
+            }
+        } catch (IOException e) {
+            Log.e(TAG, e.toString());
+        }
 
         addresses = filterAddressesBBox(region, addresses);
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/UIUtils.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/UIUtils.java
@@ -17,29 +17,6 @@
 
 package org.onebusaway.android.util;
 
-import com.google.android.gms.common.GoogleApiAvailability;
-import com.google.firebase.analytics.FirebaseAnalytics;
-
-import org.onebusaway.android.R;
-import org.onebusaway.android.app.Application;
-import org.onebusaway.android.io.ObaAnalytics;
-import org.onebusaway.android.io.ObaApi;
-import org.onebusaway.android.io.elements.ObaArrivalInfo;
-import org.onebusaway.android.io.elements.ObaRegion;
-import org.onebusaway.android.io.elements.ObaRoute;
-import org.onebusaway.android.io.elements.ObaSituation;
-import org.onebusaway.android.io.elements.ObaStop;
-import org.onebusaway.android.io.elements.Occupancy;
-import org.onebusaway.android.io.elements.OccupancyState;
-import org.onebusaway.android.io.request.ObaArrivalInfoResponse;
-import org.onebusaway.android.map.MapParams;
-import org.onebusaway.android.provider.ObaContract;
-import org.onebusaway.android.ui.ArrivalsListActivity;
-import org.onebusaway.android.ui.HomeActivity;
-import org.onebusaway.android.ui.RouteInfoActivity;
-import org.onebusaway.android.view.RealtimeIndicatorView;
-import org.onebusaway.util.comparators.AlphanumComparator;
-
 import android.animation.Animator;
 import android.animation.AnimatorListenerAdapter;
 import android.annotation.TargetApi;
@@ -94,18 +71,6 @@ import android.widget.ImageView;
 import android.widget.TextView;
 import android.widget.Toast;
 
-import java.io.File;
-import java.io.IOException;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-
 import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.ActionBar;
@@ -122,6 +87,41 @@ import androidx.core.util.Pair;
 import androidx.core.view.MenuItemCompat;
 import androidx.core.widget.ImageViewCompat;
 import androidx.fragment.app.Fragment;
+
+import com.google.android.gms.common.GoogleApiAvailability;
+import com.google.firebase.analytics.FirebaseAnalytics;
+
+import org.onebusaway.android.R;
+import org.onebusaway.android.app.Application;
+import org.onebusaway.android.io.ObaAnalytics;
+import org.onebusaway.android.io.ObaApi;
+import org.onebusaway.android.io.elements.ObaArrivalInfo;
+import org.onebusaway.android.io.elements.ObaRegion;
+import org.onebusaway.android.io.elements.ObaRoute;
+import org.onebusaway.android.io.elements.ObaSituation;
+import org.onebusaway.android.io.elements.ObaStop;
+import org.onebusaway.android.io.elements.Occupancy;
+import org.onebusaway.android.io.elements.OccupancyState;
+import org.onebusaway.android.io.request.ObaArrivalInfoResponse;
+import org.onebusaway.android.map.MapParams;
+import org.onebusaway.android.provider.ObaContract;
+import org.onebusaway.android.ui.ArrivalsListActivity;
+import org.onebusaway.android.ui.HomeActivity;
+import org.onebusaway.android.ui.RouteInfoActivity;
+import org.onebusaway.android.view.RealtimeIndicatorView;
+import org.onebusaway.util.comparators.AlphanumComparator;
+
+import java.io.File;
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static org.onebusaway.android.util.PermissionUtils.LOCATION_PERMISSIONS;
 import static org.onebusaway.android.util.PermissionUtils.LOCATION_PERMISSION_REQUEST;
@@ -1858,31 +1858,6 @@ public final class UIUtils {
                         }
                 )
                 .setNegativeButton(R.string.no_thanks,
-                        (dialog, which) -> {
-                            // No-op
-                        }
-                );
-        builder.create().show();
-    }
-
-    /**
-     * Shows the dialog to explain why the trip planning isn't available.  If this provided activity
-     * can't manage dialogs then this method is a no-op.
-     *
-     * NOTE - this dialog can't be managed under the old dialog framework as the method
-     * ActivityCompat.shouldShowRequestPermissionRationale() always returns false.
-     */
-    public static void showNoTripPlannerDialog(@NonNull Activity activity) {
-        if (!canManageDialog(activity)) {
-            return;
-        }
-        TextView textView = (TextView) activity.getLayoutInflater().inflate(R.layout.whats_new_dialog, null);
-        textView.setText(R.string.no_trip_planner_message);
-        AlertDialog.Builder builder = new AlertDialog.Builder(activity)
-                .setTitle(R.string.no_trip_planner_title)
-                .setView(textView)
-                .setCancelable(false)
-                .setPositiveButton(R.string.ok,
                         (dialog, which) -> {
                             // No-op
                         }

--- a/onebusaway-android/src/main/res/layout/fragment_trip_plan.xml
+++ b/onebusaway-android/src/main/res/layout/fragment_trip_plan.xml
@@ -30,8 +30,7 @@
                     android:text="@string/trip_plan_from"
                     android:textColor="@color/trip_plan_label"
                     android:id="@+id/trip_plan_from"
-                    android:layout_gravity="center_vertical"
-            />
+                android:layout_gravity="center_vertical" />
 
             <AutoCompleteTextView
                     android:layout_width="0dip"
@@ -46,9 +45,7 @@
                     android:ellipsize="end"
                     android:requiresFadingEdge="horizontal"
                     android:layout_marginLeft="4dp"
-                    android:layout_gravity="center_vertical"
-            />
-
+                android:layout_gravity="center_vertical" />
 
             <ImageButton
                     android:layout_width="wrap_content"
@@ -58,9 +55,7 @@
                     android:background="#00000000"
                     android:src="@drawable/ic_my_location"
                     android:tint="@color/material_gray"
-                    android:layout_gravity="center_vertical"
-            />
-
+                android:layout_gravity="center_vertical" />
         </TableRow>
 
         <TableRow android:layout_width="wrap_content">
@@ -96,11 +91,8 @@
                     android:background="#00000000"
                     android:src="@drawable/ic_my_location"
                     android:tint="@color/material_gray"
-                    android:layout_gravity="center_vertical"
-            />
-
+                android:layout_gravity="center_vertical" />
         </TableRow>
-
     </TableLayout>
 
     <LinearLayout

--- a/onebusaway-android/src/main/res/layout/fragment_trip_plan_results.xml
+++ b/onebusaway-android/src/main/res/layout/fragment_trip_plan_results.xml
@@ -169,7 +169,8 @@
                 android:layout_width="fill_parent"
                 android:layout_height="fill_parent"
                 android:background="@android:color/white"
-                android:id="@+id/directionsListView"/>
+            android:id="@+id/directionsListView"
+            android:isScrollContainer="false" />
 
     </FrameLayout>
 

--- a/onebusaway-android/src/main/res/values/donottranslate.xml
+++ b/onebusaway-android/src/main/res/values/donottranslate.xml
@@ -92,6 +92,9 @@
     <!-- Google Play Store Listing prefix -->
     <string name="google_play_listing_prefix">https://play.google.com/store/apps/details?id=%1s</string>
 
+    <!-- Pelias API URL for geocoding -->
+    <string name="pelias_api_url">https://api.geocode.earth/v1/autocomplete</string>
+
     <!-- Oba Analytics Messages -->
     <string name="analytics_problem">report_problem</string>
     <string name="analytics_accessibility">accessibility</string>

--- a/onebusaway-android/src/main/res/values/donottranslate.xml
+++ b/onebusaway-android/src/main/res/values/donottranslate.xml
@@ -132,7 +132,6 @@
     <string name="analytics_label_button_press_nearby">nearby</string>
     <string name="analytics_label_button_press_reminders">my_reminders</string>
     <string name="analytics_label_button_press_trip_plan">trip_plan</string>
-    <string name="analytics_label_button_press_google_cost_increase">google_cost_increase</string>
     <string name="analytics_label_button_press_settings">settings</string>
     <string name="analytics_label_button_press_help">help</string>
     <string name="analytics_label_button_press_feedback">send_feedback</string>

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -110,8 +110,6 @@
     <string name="main_help_whatsnew">&#8226;\u0020
         <b>Help us improve transit</b>
         - Optionally participate in research to improve multimodal transportation.\n&#8226;\u0020
-        <b>Trip planner turned off (again)</b>
-        - Google ultimately rejected our non-profit\'s request for credits because OneBusAway \“recreates Google Products or Services.\" More at http://bit.ly/oba-trip-plan \n&#8226;\u0020
         <b>Bug fixes</b>
         - See http://bit.ly/oba-android-releases
     </string>
@@ -950,7 +948,10 @@
     <string name="tripplanner_report_trip_problem">Report Trip Plan Problem</string>
 
     <string name="no_trip_planner_title">Google cost increase</string>
-    <string name="no_trip_planner_message">Google ultimately rejected our non-profit\'s request for credits because OneBusAway \"recreates Google Products or Services.\" We can\'t afford the new ~$1,000 per month fee for the Places API, so we\'ve had to shut down the trip planner while we investigate alternate services. More details at http://bit.ly/oba-trip-plan</string>
+    <string name="no_trip_planner_message">Google is now charging OneBusAway for all trip plans (about $1,000 per month)!
+        OBA is an open source project and can\’t pay for these costs. We\'ve created a non-profit and applied to Google for Nonprofits, but are still waiting for approval.
+        In the mean-time, we\'ve had to shut down the trip planner. If you\'d like to express your support for OneBusAway to Google for Nonprofits,
+        please reach out to them on Twitter at https://twitter.com/googlenonprofit?s=17!</string>
 
     <!-- Instructions generation -->
 


### PR DESCRIPTION
~~*Please do not merge*~~

This is a work-in-progress pull request that includes an early version of using the Pelias Geocoding API instead of the Places SDK for geocoding for trip origin and destinations.

Instructions for configuring a Pelias API key are in https://github.com/OneBusAway/onebusaway-android/pull/1018/commits/ffca5dcf88e8c25baa7cb67319da0aa33da1aabc.

To test:
1. Tap "Plan a trip" in the navigation drawer
1. Tap origin or destination field
1. Enter origin or destination

TODO:
- [X] Add pelias client dependency
- [X] Integrate pelias client into existing UI dropdown list
- [x] Move pelias endpoint to `do_not_translate.xml`
- [x] Move pelias key into `gradle.properties`
- [x] Fix UI bugs after planning a trip and entering another origin/destination
- [x] Fix release builds - Proguard config to enable pelias library?
- [x] Allow Google Places API as an option instead of Pelias, configurable via build flavor (e.g., for York)