### PR TITLE
Fix #987: Toggle route filter from bus options menu

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/util/test/UIUtilTest.java
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/util/test/UIUtilTest.java
@@ -200,6 +200,7 @@ public class UIUtilTest extends ObaTestCase {
         boolean hasUrl = !TextUtils.isEmpty(url);
         boolean isReminderVisible = false;  // We don't have views here, so just fake it
         boolean isRouteFavorite = false;  // We'll fake this too, for our purposes
+        boolean hasRouteFilter = false;
 
         Occupancy occupancy = null;
         OccupancyState occupancyState = null;
@@ -214,7 +215,7 @@ public class UIUtilTest extends ObaTestCase {
         // HART has route schedule URLs in test data, so below options should allow the user to set
         // a reminder and view the route schedule
         List<String> options = UIUtils
-                .buildTripOptions(getTargetContext(), isRouteFavorite, hasUrl, isReminderVisible, occupancy, occupancyState);
+                .buildTripOptions(getTargetContext(), isRouteFavorite, hasUrl, isReminderVisible, hasRouteFilter, occupancy, occupancyState);
 
         if (!EmbeddedSocialUtils.isSocialEnabled()) {
             // Developer hasn't configured ES SDK key (or we're on Travis), so it doesn't include that menu item.
@@ -234,11 +235,34 @@ public class UIUtilTest extends ObaTestCase {
             assertEquals(options.get(7), "Join discussion");
         }
 
+        // "Show only this route" should toggle to "Show all routes" when hasRouteFilter is true
+        hasRouteFilter = true;
+        options = UIUtils
+                .buildTripOptions(getTargetContext(), isRouteFavorite, hasUrl, isReminderVisible, hasRouteFilter, occupancy, occupancyState);
+        if (!EmbeddedSocialUtils.isSocialEnabled()) {
+            // Developer hasn't configured ES SDK key (or we're on Travis), so it doesn't include that menu item.
+            assertEquals(7, options.size());
+        } else {
+            assertEquals(8, options.size());
+        }
+        assertEquals(options.get(0), "Add star to route");
+        assertEquals(options.get(1), "Show route on map");
+        assertEquals(options.get(2), "Show trip status");
+        assertEquals(options.get(3), "Set a reminder");
+        assertEquals(options.get(4), "Show all routes");
+        assertEquals(options.get(5), "Show route schedule");
+        assertEquals(options.get(6), "Report arrival time problem");
+        if (EmbeddedSocialUtils.isSocialEnabled()) {
+            assertEquals(options.get(7), "Join discussion");
+        }
+        // "Reset hasRouteFilter to false to remaining tests
+        hasRouteFilter = false;
+
         isReminderVisible = true;
 
         // Now we should see route schedules and *edit* the reminder
         options = UIUtils
-                .buildTripOptions(getTargetContext(), isRouteFavorite, hasUrl, isReminderVisible, occupancy, occupancyState);
+                .buildTripOptions(getTargetContext(), isRouteFavorite, hasUrl, isReminderVisible, hasRouteFilter, occupancy, occupancyState);
         if (!EmbeddedSocialUtils.isSocialEnabled()) {
             // Developer hasn't configured ES SDK key (or we're on Travis), so it doesn't include that menu item.
             assertEquals(7, options.size());
@@ -282,7 +306,7 @@ public class UIUtilTest extends ObaTestCase {
         // PSTA does not have route schedule URLs in test data, so below options should allow the
         // user to set a reminder but NOT view the route schedule
         options = UIUtils
-                .buildTripOptions(getTargetContext(), isRouteFavorite, hasUrl2, isReminderVisible, occupancy, occupancyState);
+                .buildTripOptions(getTargetContext(), isRouteFavorite, hasUrl2, isReminderVisible, hasRouteFilter, occupancy, occupancyState);
         if (!EmbeddedSocialUtils.isSocialEnabled()) {
             // Developer hasn't configured ES SDK key (or we're on Travis), so it doesn't include that menu item.
             assertEquals(6, options.size());
@@ -303,7 +327,7 @@ public class UIUtilTest extends ObaTestCase {
 
         // Now we should see *edit* the reminder, and still no route schedule
         options = UIUtils
-                .buildTripOptions(getTargetContext(), isRouteFavorite, hasUrl2, isReminderVisible, occupancy, occupancyState);
+                .buildTripOptions(getTargetContext(), isRouteFavorite, hasUrl2, isReminderVisible, hasRouteFilter, occupancy, occupancyState);
         if (!EmbeddedSocialUtils.isSocialEnabled()) {
             // Developer hasn't configured ES SDK key (or we're on Travis), so it doesn't include that menu item.
             assertEquals(6, options.size());
@@ -329,7 +353,7 @@ public class UIUtilTest extends ObaTestCase {
         // HART has route schedule URLs in test data, so below options should allow the user to set
         // a reminder and view the route schedule
         options = UIUtils
-                .buildTripOptions(getTargetContext(), isRouteFavorite, hasUrl, isReminderVisible, occupancy, occupancyState);
+                .buildTripOptions(getTargetContext(), isRouteFavorite, hasUrl, isReminderVisible, hasRouteFilter, occupancy, occupancyState);
         if (!EmbeddedSocialUtils.isSocialEnabled()) {
             // Developer hasn't configured ES SDK key (or we're on Travis), so it doesn't include that menu item.
             assertEquals(7, options.size());
@@ -351,7 +375,7 @@ public class UIUtilTest extends ObaTestCase {
 
         // Now we should see route schedules and *edit* the reminder
         options = UIUtils
-                .buildTripOptions(getTargetContext(), isRouteFavorite, hasUrl, isReminderVisible, occupancy, occupancyState);
+                .buildTripOptions(getTargetContext(), isRouteFavorite, hasUrl, isReminderVisible, hasRouteFilter, occupancy, occupancyState);
         if (!EmbeddedSocialUtils.isSocialEnabled()) {
             // Developer hasn't configured ES SDK key (or we're on Travis), so it doesn't include that menu item.
             assertEquals(7, options.size());
@@ -375,7 +399,7 @@ public class UIUtilTest extends ObaTestCase {
         // PSTA does not have route schedule URLs in test data, so below options should allow the
         // user to set a reminder but NOT view the route schedule
         options = UIUtils
-                .buildTripOptions(getTargetContext(), isRouteFavorite, hasUrl2, isReminderVisible, occupancy, occupancyState);
+                .buildTripOptions(getTargetContext(), isRouteFavorite, hasUrl2, isReminderVisible, hasRouteFilter, occupancy, occupancyState);
         if (!EmbeddedSocialUtils.isSocialEnabled()) {
             // Developer hasn't configured ES SDK key (or we're on Travis), so it doesn't include that menu item.
             assertEquals(6, options.size());
@@ -396,7 +420,7 @@ public class UIUtilTest extends ObaTestCase {
 
         // Now we should see *edit* the reminder, and still no route schedule
         options = UIUtils
-                .buildTripOptions(getTargetContext(), isRouteFavorite, hasUrl2, isReminderVisible, occupancy, occupancyState);
+                .buildTripOptions(getTargetContext(), isRouteFavorite, hasUrl2, isReminderVisible, hasRouteFilter, occupancy, occupancyState);
         if (!EmbeddedSocialUtils.isSocialEnabled()) {
             // Developer hasn't configured ES SDK key (or we're on Travis), so it doesn't include that menu item.
             assertEquals(6, options.size());
@@ -421,7 +445,7 @@ public class UIUtilTest extends ObaTestCase {
         occupancy = Occupancy.EMPTY;
         occupancyState = OccupancyState.HISTORICAL;
         options = UIUtils
-                .buildTripOptions(getTargetContext(), isRouteFavorite, hasUrl2, isReminderVisible, occupancy, occupancyState);
+                .buildTripOptions(getTargetContext(), isRouteFavorite, hasUrl2, isReminderVisible, hasRouteFilter, occupancy, occupancyState);
         if (!EmbeddedSocialUtils.isSocialEnabled()) {
             // Developer hasn't configured ES SDK key (or we're on Travis), so it doesn't include that menu item.
             assertEquals(7, options.size());
@@ -445,7 +469,7 @@ public class UIUtilTest extends ObaTestCase {
         occupancy = Occupancy.EMPTY;
         occupancyState = OccupancyState.PREDICTED;
         options = UIUtils
-                .buildTripOptions(getTargetContext(), isRouteFavorite, hasUrl2, isReminderVisible, occupancy, occupancyState);
+                .buildTripOptions(getTargetContext(), isRouteFavorite, hasUrl2, isReminderVisible, hasRouteFilter, occupancy, occupancyState);
         if (!EmbeddedSocialUtils.isSocialEnabled()) {
             // Developer hasn't configured ES SDK key (or we're on Travis), so it doesn't include that menu item.
             assertEquals(7, options.size());
@@ -469,7 +493,7 @@ public class UIUtilTest extends ObaTestCase {
         occupancy = Occupancy.EMPTY;
         occupancyState = OccupancyState.REALTIME;
         options = UIUtils
-                .buildTripOptions(getTargetContext(), isRouteFavorite, hasUrl2, isReminderVisible, occupancy, occupancyState);
+                .buildTripOptions(getTargetContext(), isRouteFavorite, hasUrl2, isReminderVisible, hasRouteFilter, occupancy, occupancyState);
         if (!EmbeddedSocialUtils.isSocialEnabled()) {
             // Developer hasn't configured ES SDK key (or we're on Travis), so it doesn't include that menu item.
             assertEquals(7, options.size());

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListFragment.java
@@ -728,6 +728,8 @@ public class ArrivalsListFragment extends ListFragment
         // Check route favorite, for whether we show "Add star" or "Remove star"
         final boolean isRouteFavorite = ObaContract.RouteHeadsignFavorites.isFavorite(routeId,
                 arrivalInfo.getInfo().getHeadsign(), arrivalInfo.getInfo().getStopId());
+        // Check to see if there is a route filter, for whether we show "Show all routes" or "Show only this route"
+        boolean hasRouteFilter = !mRoutesFilter.isEmpty();
 
         final Occupancy occupancy;
         final OccupancyState occupancyState;
@@ -743,7 +745,7 @@ public class ArrivalsListFragment extends ListFragment
         }
 
         List<String> items = UIUtils
-                .buildTripOptions(getActivity(), isRouteFavorite, hasUrl, isReminderVisible, occupancy, occupancyState);
+                .buildTripOptions(getActivity(), isRouteFavorite, hasUrl, isReminderVisible, hasRouteFilter, occupancy, occupancyState);
         List<Integer> icons = UIUtils.buildTripOptionsIcons(isRouteFavorite, hasUrl, occupancy);
 
         ListAdapter adapter = new ArrayAdapterWithIcon(getActivity(), items, icons);
@@ -775,6 +777,10 @@ public class ArrivalsListFragment extends ListFragment
                 } else if (which == 4) {
                     ArrayList<String> routes = new ArrayList<String>(1);
                     routes.add(arrivalInfo.getInfo().getRouteId());
+                    // toggle route filter - if user selection equals existing route filter, clear it
+                    if (routes.equals(mRoutesFilter) || mRoutesFilter.size() > routes.size()) {
+                        routes.clear();
+                    }
                     setRoutesFilter(routes);
                     if (mHeader != null) {
                         mHeader.refresh();

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/UIUtils.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/UIUtils.java
@@ -1250,7 +1250,7 @@ public final class UIUtils {
      * that trip
      */
     public static List<String> buildTripOptions(Context c, boolean isRouteFavorite, boolean hasUrl,
-                                                boolean isReminderVisible, Occupancy occupancy, OccupancyState occupancyState) {
+                                                boolean isReminderVisible, boolean hasRouteFilter, Occupancy occupancy, OccupancyState occupancyState) {
         ArrayList<String> list = new ArrayList<>();
         if (!isRouteFavorite) {
             list.add(c.getString(R.string.bus_options_menu_add_star));
@@ -1267,7 +1267,11 @@ public final class UIUtils {
             list.add(c.getString(R.string.bus_options_menu_edit_reminder));
         }
 
-        list.add(c.getString(R.string.bus_options_menu_show_only_this_route));
+        if (!hasRouteFilter) {
+            list.add(c.getString(R.string.bus_options_menu_show_only_this_route));
+        } else {
+            list.add(c.getString(R.string.bus_options_menu_show_all_routes));
+        }
 
         if (hasUrl) {
             list.add(c.getString(R.string.bus_options_menu_show_route_schedule));

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -144,6 +144,7 @@
     <string name="bus_options_menu_set_reminder">Set a reminder</string>
     <string name="bus_options_menu_edit_reminder">Edit this reminder</string>
     <string name="bus_options_menu_show_only_this_route">Show only this route</string>
+    <string name="bus_options_menu_show_all_routes">"Show all routes"</string>
     <string name="bus_options_menu_show_route_schedule">Show route schedule</string>
     <string name="bus_options_menu_report_trip_problem">Report arrival time problem</string>
 


### PR DESCRIPTION
Note - Hello!  This is my first contribution to OneBusAway.  I did run the unit tests, and testBuildTripOptions() in UIUtilTest does fail, but it also fails on the untouched code on the master branch of my forked repo.  I did  add an additional parameter to buildTripOptions(), so that parameter will need to be added in the test files when buildTripOptions() is called.  But, I'm hesitant to edit the tests as a newcomer to the code base, especially since that test fails without the code that I added.  Very excited to have had the opportunity to learn from the project and am open to any feedback to make this a helpful contribution!
  
Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `gradlew connectedObaGoogleDebugAndroidTest connectedObaAmazonDebugAndroidTest` to make sure you didn't break anything

- [X] If you have multiple commits please combine them into one commit by squashing them for the initial submission of the pull request.  When addressing comments on a pull request, please push a new commit per comment when possible (reviewers will squash and merge using GitHub merge tool)