### PR TITLE
feat: Support CANCELED trips

### DIFF
--- a/onebusaway-android/src/amazon/java/org/onebusaway/android/map/googlemapsv2/VehicleOverlay.java
+++ b/onebusaway-android/src/amazon/java/org/onebusaway/android/map/googlemapsv2/VehicleOverlay.java
@@ -55,6 +55,7 @@ import org.onebusaway.android.io.elements.ObaTrip;
 import org.onebusaway.android.io.elements.ObaTripDetails;
 import org.onebusaway.android.io.elements.ObaTripStatus;
 import org.onebusaway.android.io.elements.OccupancyState;
+import org.onebusaway.android.io.elements.Status;
 import org.onebusaway.android.io.request.ObaTripsForRouteResponse;
 import org.onebusaway.android.ui.TripDetailsActivity;
 import org.onebusaway.android.ui.TripDetailsListFragment;
@@ -632,9 +633,9 @@ public class VehicleOverlay implements AmazonMap.OnInfoWindowClickListener, Mark
             for (ObaTripDetails trip : trips) {
                 ObaTripStatus status = trip.getStatus();
                 if (status != null) {
-                    // Check if this vehicle is running a route we're interested in
+                    // Check if this vehicle is running a route we're interested in and isn't CANCELED
                     String activeRoute = response.getTrip(status.getActiveTripId()).getRouteId();
-                    if (routeIds.contains(activeRoute)) {
+                    if (routeIds.contains(activeRoute) && !Status.CANCELED.equals(status.getStatus())) {
                         Location l = status.getLastKnownLocation();
                         boolean isRealtime = true;
 

--- a/onebusaway-android/src/amazon/java/org/onebusaway/android/map/googlemapsv2/VehicleOverlay.java
+++ b/onebusaway-android/src/amazon/java/org/onebusaway/android/map/googlemapsv2/VehicleOverlay.java
@@ -41,6 +41,9 @@ import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.TextView;
 
+import androidx.collection.LruCache;
+import androidx.core.content.ContextCompat;
+
 import com.amazon.geo.mapsv2.AmazonMap;
 import com.amazon.geo.mapsv2.model.BitmapDescriptor;
 import com.amazon.geo.mapsv2.model.BitmapDescriptorFactory;
@@ -68,9 +71,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-
-import androidx.collection.LruCache;
-import androidx.core.content.ContextCompat;
 
 /**
  * A map overlay that shows vehicle positions on the map

--- a/onebusaway-android/src/androidTest/res/raw/arrivals_and_departures_for_stop_hart_3105_canceled.json
+++ b/onebusaway-android/src/androidTest/res/raw/arrivals_and_departures_for_stop_hart_3105_canceled.json
@@ -1,0 +1,161 @@
+{
+  "currentTime": 1381245996464,
+  "text": "OK",
+  "data": {
+    "references": {
+      "stops": [
+        {
+          "id": "Hillsborough Area Regional Transit_3105",
+          "lon": -82.416735,
+          "direction": "W",
+          "locationType": 0,
+          "name": "Alumni Dr @ Laurel Dr",
+          "wheelchairBoarding": "UNKNOWN",
+          "routeIds": [
+            "Hillsborough Area Regional Transit_5"
+          ],
+          "code": "3105",
+          "lat": 28.058141
+        },
+        {
+          "id": "Hillsborough Area Regional Transit_2981",
+          "lon": -82.422315,
+          "direction": "N",
+          "locationType": 0,
+          "name": "34th St @ North Bay St",
+          "wheelchairBoarding": "UNKNOWN",
+          "routeIds": [
+            "Hillsborough Area Regional Transit_5"
+          ],
+          "code": "2981",
+          "lat": 27.982898
+        },
+        {
+          "id": "Hillsborough Area Regional Transit_3109",
+          "lon": -82.415793,
+          "direction": "SE",
+          "locationType": 0,
+          "name": "Alumni Dr @ Leroy Collins @ Eng Bld",
+          "wheelchairBoarding": "UNKNOWN",
+          "routeIds": [
+            "Hillsborough Area Regional Transit_5"
+          ],
+          "code": "3109",
+          "lat": 28.0578
+        }
+      ],
+      "situations": [],
+      "trips": [
+        {
+          "id": "Hillsborough Area Regional Transit_909841",
+          "shapeId": "Hillsborough Area Regional Transit_32910",
+          "tripShortName": "",
+          "directionId": "0",
+          "serviceId": "Hillsborough Area Regional Transit_We",
+          "blockId": "Hillsborough Area Regional Transit_266684",
+          "routeShortName": "",
+          "tripHeadsign": "North to University Area TC",
+          "routeId": "Hillsborough Area Regional Transit_5",
+          "timeZone": ""
+        }
+      ],
+      "routes": [
+        {
+          "id": "Hillsborough Area Regional Transit_5",
+          "textColor": "FFFFFF",
+          "color": "09346D",
+          "description": "",
+          "longName": "40th Street",
+          "shortName": "5",
+          "type": 3,
+          "agencyId": "Hillsborough Area Regional Transit",
+          "url": "http://www.gohart.org/routes/hart/05.html"
+        }
+      ],
+      "agencies": [
+        {
+          "id": "Hillsborough Area Regional Transit",
+          "privateService": false,
+          "phone": "813-254-4278",
+          "timezone": "America/New_York",
+          "disclaimer": "",
+          "name": "Hillsborough Area Regional Transit",
+          "lang": "en",
+          "url": "http://www.gohart.org"
+        }
+      ]
+    },
+    "entry": {
+      "situationIds": [],
+      "stopId": "Hillsborough Area Regional Transit_3105",
+      "arrivalsAndDepartures": [
+        {
+          "serviceDate": 1381204800000,
+          "numberOfStopsAway": 36,
+          "vehicleId": "Hillsborough Area Regional Transit_2106",
+          "lastUpdateTime": 1381245991901,
+          "routeId": "Hillsborough Area Regional Transit_5",
+          "frequency": null,
+          "stopSequence": 68,
+          "scheduledDepartureInterval": null,
+          "routeShortName": "5",
+          "arrivalEnabled": true,
+          "distanceFromStop": 9900.393141158711,
+          "scheduledArrivalTime": 1381247025000,
+          "status": "CANCELED",
+          "tripId": "Hillsborough Area Regional Transit_909841",
+          "routeLongName": "40th Street",
+          "tripHeadsign": "North to University Area TC",
+          "predicted": true,
+          "predictedArrivalTime": 1381247385000,
+          "departureEnabled": true,
+          "scheduledArrivalInterval": null,
+          "predictedDepartureTime": 1381247385000,
+          "situationIds": [],
+          "stopId": "Hillsborough Area Regional Transit_3105",
+          "tripStatus": {
+            "position": {
+              "lon": -82.4224,
+              "lat": 27.982215585882088
+            },
+            "orientation": 90,
+            "closestStop": "Hillsborough Area Regional Transit_2981",
+            "activeTripId": "Hillsborough Area Regional Transit_909841",
+            "vehicleId": "Hillsborough Area Regional Transit_2106",
+            "serviceDate": 1381204800000,
+            "lastLocationUpdateTime": 0,
+            "status": "CANCELED",
+            "lastUpdateTime": 1381245991901,
+            "distanceAlongTrip": 6739.9774745284085,
+            "nextStop": "Hillsborough Area Regional Transit_2981",
+            "predicted": true,
+            "frequency": null,
+            "lastKnownOrientation": 0,
+            "totalDistanceAlongTrip": 19042.57238962139,
+            "lastKnownLocation": {
+              "lon": 27.981142044067383,
+              "lat": -82.4223403930664
+            },
+            "scheduledDistanceAlongTrip": 6739.9774745284085,
+            "situationIds": [],
+            "scheduleDeviation": 360,
+            "nextStopTimeOffset": 11,
+            "lastKnownDistanceAlongTrip": 0,
+            "closestStopTimeOffset": 11,
+            "phase": "",
+            "blockTripSequence": 5
+          },
+          "scheduledDepartureTime": 1381247025000,
+          "blockTripSequence": 5,
+          "predictedArrivalInterval": null,
+          "predictedDepartureInterval": null
+        }
+      ],
+      "nearbyStopIds": [
+        "Hillsborough Area Regional Transit_3109"
+      ]
+    }
+  },
+  "code": 200,
+  "version": 2
+}

--- a/onebusaway-android/src/androidTest/res/raw/urimap.json
+++ b/onebusaway-android/src/androidTest/res/raw/urimap.json
@@ -9,6 +9,7 @@
 
     "/api/where/arrivals-and-departures-for-stop/1_29261.json": "arrivals_and_departures_for_stop_1_29261",
     "/api/api/where/arrivals-and-departures-for-stop/Hillsborough%20Area%20Regional%20Transit_3105.json": "arrivals_and_departures_for_stop_hart_3105",
+    "/api/api/where/arrivals-and-departures-for-stop/Hillsborough%20Area%20Regional%20Transit_9999.json": "arrivals_and_departures_for_stop_hart_3105_canceled",
     "/api/where/arrivals-and-departures-for-stop/1_75403.json": "arrivals_and_departures_for_stop_1_75403",
     "/api/api/where/arrivals-and-departures-for-stop/Hillsborough%20Area%20Regional%20Transit_1622.json": "arrivals_and_departures_for_stop_hart_1622_one_past_arrival",
     "/api/api/where/arrivals-and-departures-for-stop/Hillsborough%20Area%20Regional%20Transit_6497.json": "arrivals_and_departures_for_stop_hart_6497",

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/VehicleOverlay.java
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/VehicleOverlay.java
@@ -30,6 +30,9 @@ import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.TextView;
 
+import androidx.collection.LruCache;
+import androidx.core.content.ContextCompat;
+
 import com.google.android.gms.maps.GoogleMap;
 import com.google.android.gms.maps.model.BitmapDescriptor;
 import com.google.android.gms.maps.model.BitmapDescriptorFactory;
@@ -44,6 +47,7 @@ import org.onebusaway.android.io.elements.ObaTrip;
 import org.onebusaway.android.io.elements.ObaTripDetails;
 import org.onebusaway.android.io.elements.ObaTripStatus;
 import org.onebusaway.android.io.elements.OccupancyState;
+import org.onebusaway.android.io.elements.Status;
 import org.onebusaway.android.io.request.ObaTripsForRouteResponse;
 import org.onebusaway.android.ui.TripDetailsActivity;
 import org.onebusaway.android.ui.TripDetailsListFragment;
@@ -56,9 +60,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-
-import androidx.collection.LruCache;
-import androidx.core.content.ContextCompat;
 
 /**
  * A map overlay that shows vehicle positions on the map
@@ -621,9 +622,9 @@ public class VehicleOverlay implements GoogleMap.OnInfoWindowClickListener, Mark
             for (ObaTripDetails trip : trips) {
                 ObaTripStatus status = trip.getStatus();
                 if (status != null) {
-                    // Check if this vehicle is running a route we're interested in
+                    // Check if this vehicle is running a route we're interested in and isn't CANCELED
                     String activeRoute = response.getTrip(status.getActiveTripId()).getRouteId();
-                    if (routeIds.contains(activeRoute)) {
+                    if (routeIds.contains(activeRoute) && !Status.CANCELED.equals(status.getStatus())) {
                         Location l = status.getLastKnownLocation();
                         boolean isRealtime = true;
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/io/elements/ObaTripStatus.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/io/elements/ObaTripStatus.java
@@ -135,9 +135,9 @@ public interface ObaTripStatus {
     public String getPhase();
 
     /**
-     * @return The status modifiers for the trip. Can be null.
+     * @return The status modifiers for the trip, defined by {@link Status}. Can be null.
      */
-    public String getStatus();
+    public Status getStatus();
 
     /**
      * @return The last known real-time update for the transit vehicle, or 0 if we

--- a/onebusaway-android/src/main/java/org/onebusaway/android/io/elements/ObaTripStatusElement.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/io/elements/ObaTripStatusElement.java
@@ -167,9 +167,12 @@ public final class ObaTripStatusElement implements ObaTripStatus, Serializable {
         return phase;
     }
 
+    /**
+     * @return The status modifiers for the trip, defined by {@link Status}. Can be null.
+     */
     @Override
-    public String getStatus() {
-        return status;
+    public Status getStatus() {
+        return Status.fromString(status);
     }
 
     @Override

--- a/onebusaway-android/src/main/java/org/onebusaway/android/io/elements/Status.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/io/elements/Status.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2020 Sean J. Barbeau (sjbarbeau@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.io.elements;
+
+/**
+ * The status of the trip, used in {@link ObaTripStatus}
+ * (https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md#enum-occupancystatus)
+ */
+public enum Status {
+    DEFAULT("default"),
+    CANCELED("CANCELED");
+
+    private final String status;
+
+    Status(String status) {
+        this.status = status;
+    }
+
+    public String toString() {
+        return status;
+    }
+
+    /**
+     * Converts from the string representation of status to the enumeration, or null if status isn't provided
+     *
+     * @param status the string representation of status
+     * @return the status enumeration, or null if status isn't provided
+     */
+    public static Status fromString(String status) {
+        switch (status) {
+            case "default":
+                return DEFAULT;
+            case "CANCELED":
+                return CANCELED;
+            default:
+                return null;
+        }
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/io/elements/Status.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/io/elements/Status.java
@@ -17,7 +17,6 @@ package org.onebusaway.android.io.elements;
 
 /**
  * The status of the trip, used in {@link ObaTripStatus}
- * (https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md#enum-occupancystatus)
  */
 public enum Status {
     DEFAULT("default"),

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalInfo.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalInfo.java
@@ -23,6 +23,7 @@ import org.onebusaway.android.R;
 import org.onebusaway.android.io.elements.ObaArrivalInfo;
 import org.onebusaway.android.io.elements.ObaArrivalInfo.Frequency;
 import org.onebusaway.android.io.elements.Occupancy;
+import org.onebusaway.android.io.elements.Status;
 import org.onebusaway.android.provider.ObaContract;
 import org.onebusaway.android.util.ArrivalInfoUtils;
 import org.onebusaway.android.util.UIUtils;
@@ -57,6 +58,8 @@ public final class ArrivalInfo {
     private final Occupancy mHistoricalOccupancy;
 
     private final Occupancy mPredictedOccupancy;
+
+    private final Status mStatus;
 
     /**
      * @param includeArrivalDepartureInStatusLabel true if the arrival/departure label
@@ -109,6 +112,7 @@ public final class ArrivalInfo {
 
         mHistoricalOccupancy = info.getHistoricalOccupancy();
         mPredictedOccupancy = info.getPredictedOccupancy();
+        mStatus = info.getTripStatus().getStatus();
     }
 
     /**
@@ -128,10 +132,22 @@ public final class ArrivalInfo {
 
         final Resources res = context.getResources();
 
+        // CANCELED trips
+        if (Status.CANCELED.equals(info.getTripStatus().getStatus())) {
+            if (!includeArrivalDeparture) {
+                return context.getString(R.string.stop_info_canceled);
+            }
+
+            if (mIsArrival) {
+                return context.getString(R.string.stop_info_canceled_arrival);
+            } else {
+                return context.getString(R.string.stop_info_canceled_departure);
+            }
+        }
+
+        // Frequency (exact_times=0) trips
         Frequency frequency = info.getFrequency();
-
         if (frequency != null) {
-
             int headwayAsMinutes = (int) (frequency.getHeadway() / 60);
             DateFormat formatter = DateFormat.getTimeInstance(DateFormat.SHORT);
 
@@ -151,6 +167,7 @@ public final class ArrivalInfo {
         }
 
         if (predicted != 0) {
+            // Real-time info
             long delay = predictedMins - scheduledMins;
 
             if (mEta >= 0) {
@@ -368,5 +385,14 @@ public final class ArrivalInfo {
      */
     public Occupancy getPredictedOccupancy() {
         return mPredictedOccupancy;
+    }
+
+    /**
+     * Returns the status of the trip
+     *
+     * @return the status of the trip
+     */
+    public Status getStatus() {
+        return mStatus;
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListAdapterStyleA.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListAdapterStyleA.java
@@ -17,6 +17,7 @@ package org.onebusaway.android.ui;
 
 import android.content.ContentValues;
 import android.content.Context;
+import android.graphics.Paint;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.GradientDrawable;
 import android.view.View;
@@ -29,6 +30,7 @@ import androidx.core.graphics.drawable.DrawableCompat;
 import org.onebusaway.android.R;
 import org.onebusaway.android.io.elements.ObaArrivalInfo;
 import org.onebusaway.android.io.elements.OccupancyState;
+import org.onebusaway.android.io.elements.Status;
 import org.onebusaway.android.provider.ObaContract;
 import org.onebusaway.android.util.ArrivalInfoUtils;
 import org.onebusaway.android.util.UIUtils;
@@ -83,6 +85,16 @@ public class ArrivalsListAdapterStyleA extends ArrivalsListAdapterBase<ArrivalIn
         starView.setImageResource(stopInfo.isRouteAndHeadsignFavorite() ?
                 R.drawable.focus_star_on :
                 R.drawable.focus_star_off);
+
+        // CANCELED trips
+        if (Status.CANCELED.equals(stopInfo.getStatus())) {
+            // Strike through the text fields
+            route.setPaintFlags(Paint.STRIKE_THRU_TEXT_FLAG);
+            destination.setPaintFlags(Paint.STRIKE_THRU_TEXT_FLAG);
+            time.setPaintFlags(Paint.STRIKE_THRU_TEXT_FLAG);
+            etaView.setPaintFlags(Paint.STRIKE_THRU_TEXT_FLAG);
+            minView.setPaintFlags(Paint.STRIKE_THRU_TEXT_FLAG);
+        }
 
         String shortName = arrivalInfo.getShortName();
         route.setText(shortName.trim());

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListAdapterStyleB.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListAdapterStyleB.java
@@ -21,6 +21,7 @@ package org.onebusaway.android.ui;
 import android.content.ContentValues;
 import android.content.Context;
 import android.content.res.Resources;
+import android.graphics.Paint;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.GradientDrawable;
 import android.view.LayoutInflater;
@@ -32,6 +33,9 @@ import android.widget.TableLayout;
 import android.widget.TableRow;
 import android.widget.TextView;
 
+import androidx.constraintlayout.widget.ConstraintLayout;
+import androidx.core.graphics.drawable.DrawableCompat;
+
 import com.google.firebase.analytics.FirebaseAnalytics;
 
 import org.onebusaway.android.R;
@@ -40,6 +44,7 @@ import org.onebusaway.android.io.ObaAnalytics;
 import org.onebusaway.android.io.elements.ObaArrivalInfo;
 import org.onebusaway.android.io.elements.ObaRegion;
 import org.onebusaway.android.io.elements.OccupancyState;
+import org.onebusaway.android.io.elements.Status;
 import org.onebusaway.android.provider.ObaContract;
 import org.onebusaway.android.util.ArrivalInfoUtils;
 import org.onebusaway.android.util.EmbeddedSocialUtils;
@@ -49,9 +54,6 @@ import org.onebusaway.util.comparators.AlphanumComparator;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
-
-import androidx.constraintlayout.widget.ConstraintLayout;
-import androidx.core.graphics.drawable.DrawableCompat;
 
 /**
  * Styles of arrival times used by York Region Transit
@@ -252,6 +254,12 @@ public class ArrivalsListAdapterStyleB extends ArrivalsListAdapterBase<CombinedA
             }
 
             occupancyView = (ConstraintLayout) inflater.inflate(R.layout.occupancy, null);
+
+            // CANCELED trips
+            if (Status.CANCELED.equals(stopInfo.getStatus())) {
+                // Strike through the text fields
+                scheduleView.setPaintFlags(Paint.STRIKE_THRU_TEXT_FLAG);
+            }
 
             // Occupancy
             if (stopInfo.getPredictedOccupancy() != null) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListHeader.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListHeader.java
@@ -23,6 +23,7 @@ import android.content.ContentValues;
 import android.content.Context;
 import android.content.Intent;
 import android.content.res.Resources;
+import android.graphics.Paint;
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.GradientDrawable;
 import android.location.Location;
@@ -49,6 +50,8 @@ import android.widget.RelativeLayout;
 import android.widget.TableLayout;
 import android.widget.TextView;
 
+import androidx.fragment.app.FragmentManager;
+
 import com.google.firebase.analytics.FirebaseAnalytics;
 
 import org.onebusaway.android.R;
@@ -56,6 +59,7 @@ import org.onebusaway.android.app.Application;
 import org.onebusaway.android.io.ObaAnalytics;
 import org.onebusaway.android.io.elements.ObaArrivalInfo;
 import org.onebusaway.android.io.elements.ObaRegion;
+import org.onebusaway.android.io.elements.Status;
 import org.onebusaway.android.provider.ObaContract;
 import org.onebusaway.android.util.ArrivalInfoUtils;
 import org.onebusaway.android.util.EmbeddedSocialUtils;
@@ -63,8 +67,6 @@ import org.onebusaway.android.util.UIUtils;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import androidx.fragment.app.FragmentManager;
 
 //
 // A helper class that gets most of the header interaction
@@ -721,6 +723,14 @@ class ArrivalsListHeader {
                         R.drawable.focus_star_on :
                         R.drawable.focus_star_off);
 
+                if (Status.CANCELED.equals(info1.getTripStatus().getStatus())) {
+                    // Trip is canceled - strike through text fields
+                    mEtaRouteName1.setPaintFlags(Paint.STRIKE_THRU_TEXT_FLAG);
+                    mEtaRouteDirection1.setPaintFlags(Paint.STRIKE_THRU_TEXT_FLAG);
+                    mEtaArrivalInfo1.setPaintFlags(Paint.STRIKE_THRU_TEXT_FLAG);
+                    mEtaMin1.setPaintFlags(Paint.STRIKE_THRU_TEXT_FLAG);
+                }
+
                 mEtaRouteName1.setText(info1.getShortName());
                 mEtaRouteDirection1.setText(UIUtils.formatDisplayText(info1.getHeadsign()));
                 long eta = mArrivalInfo.get(i1).getEta();
@@ -784,6 +794,15 @@ class ArrivalsListHeader {
                     mEtaRouteFavorite2.setImageResource(isFavorite2 ?
                             R.drawable.focus_star_on :
                             R.drawable.focus_star_off);
+
+                    if (Status.CANCELED.equals(info2.getTripStatus().getStatus())) {
+                        // Trip is canceled - strike through text fields
+                        mEtaRouteName2.setPaintFlags(Paint.STRIKE_THRU_TEXT_FLAG);
+                        mEtaRouteDirection2.setPaintFlags(Paint.STRIKE_THRU_TEXT_FLAG);
+                        mEtaArrivalInfo2.setPaintFlags(Paint.STRIKE_THRU_TEXT_FLAG);
+                        mEtaMin2.setPaintFlags(Paint.STRIKE_THRU_TEXT_FLAG);
+                    }
+
                     mEtaRouteName2.setText(info2.getShortName());
                     mEtaRouteDirection2.setText(UIUtils.formatDisplayText(info2.getHeadsign()));
                     eta = mArrivalInfo.get(i2).getEta();

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.java
@@ -27,6 +27,7 @@ import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.content.res.Resources;
+import android.graphics.Paint;
 import android.graphics.drawable.GradientDrawable;
 import android.location.Location;
 import android.net.Uri;
@@ -1080,6 +1081,18 @@ public class HomeActivity extends AppCompatActivity
         etaTextView = etaAndMin.findViewById(R.id.eta);
         etaTextView.setTextSize(etaTextFontSize);
         etaTextView.setText("5");
+
+        // Canceled View
+        etaAndMin = legendDialogView.findViewById(R.id.eta_view_canceled);
+        d1 = (GradientDrawable) etaAndMin.getBackground();
+        d1.setColor(resources.getColor(R.color.stop_info_scheduled_time));
+        etaAndMin.findViewById(R.id.eta_realtime_indicator).setVisibility(View.INVISIBLE);
+        etaTextView = etaAndMin.findViewById(R.id.eta);
+        etaTextView.setTextSize(etaTextFontSize);
+        etaTextView.setText("5");
+        etaTextView.setPaintFlags(Paint.STRIKE_THRU_TEXT_FLAG);
+        TextView etaMin = etaAndMin.findViewById(R.id.eta_min);
+        etaMin.setPaintFlags(Paint.STRIKE_THRU_TEXT_FLAG);
 
         builder.setView(legendDialogView);
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/TripDetailsListFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/TripDetailsListFragment.java
@@ -933,7 +933,6 @@ public class TripDetailsListFragment extends ListFragment {
                 time.setPaintFlags(Paint.STRIKE_THRU_TEXT_FLAG);
             }
 
-
             if (stopTime.getPredictedOccupancy() != null) {
                 // Predicted occupancy data
                 UIUtils.setOccupancyVisibilityAndColor(occupancyView, stopTime.getPredictedOccupancy(), OccupancyState.PREDICTED);

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/TripDetailsListFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/TripDetailsListFragment.java
@@ -28,6 +28,7 @@ import android.content.IntentSender;
 import android.content.SharedPreferences;
 import android.content.res.ColorStateList;
 import android.graphics.Color;
+import android.graphics.Paint;
 import android.graphics.PorterDuff;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.GradientDrawable;
@@ -79,6 +80,7 @@ import org.onebusaway.android.io.elements.ObaTrip;
 import org.onebusaway.android.io.elements.ObaTripSchedule;
 import org.onebusaway.android.io.elements.ObaTripStatus;
 import org.onebusaway.android.io.elements.OccupancyState;
+import org.onebusaway.android.io.elements.Status;
 import org.onebusaway.android.io.request.ObaTripDetailsRequest;
 import org.onebusaway.android.io.request.ObaTripDetailsResponse;
 import org.onebusaway.android.nav.NavigationService;
@@ -405,9 +407,16 @@ public class TripDetailsListFragment extends ListFragment {
 
         if (!status.isPredicted()) {
             // We have only schedule info, but the bus position can still be interpolated
-            vehicleDeviation.setText(context.getString(R.string.trip_details_scheduled_data));
             statusColor = R.color.stop_info_scheduled_time;
             d.setColor(getResources().getColor(statusColor));
+
+            if (Status.CANCELED.equals(status.getStatus())) {
+                // Canceled trip
+                vehicleDeviation.setText(context.getString(R.string.stop_info_canceled));
+            } else {
+                // Scheduled trip
+                vehicleDeviation.setText(context.getString(R.string.trip_details_scheduled_data));
+            }
             return;
         }
 
@@ -917,6 +926,13 @@ public class TripDetailsListFragment extends ListFragment {
                             DateUtils.FORMAT_NO_NOON |
                             DateUtils.FORMAT_NO_MIDNIGHT
             ));
+
+            if (Status.CANCELED.equals(mStatus.getStatus())) {
+                // CANCELED trip - Strike through the text fields
+                stopName.setPaintFlags(Paint.STRIKE_THRU_TEXT_FLAG);
+                time.setPaintFlags(Paint.STRIKE_THRU_TEXT_FLAG);
+            }
+
 
             if (stopTime.getPredictedOccupancy() != null) {
                 // Predicted occupancy data

--- a/onebusaway-android/src/main/res/layout/legend_dialog.xml
+++ b/onebusaway-android/src/main/res/layout/legend_dialog.xml
@@ -131,5 +131,37 @@
                     android:text="@string/main_help_legend_scheduled"/>
         </LinearLayout>
 
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="14dp"
+            android:layout_marginRight="24dp"
+            android:layout_marginTop="16dp"
+            android:layout_marginBottom="8dp">
+
+            <include
+                android:id="@+id/eta_view_canceled"
+                layout="@layout/eta_header_view"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_column="2"
+                android:layout_marginLeft="@dimen/arrival_header_text_pad_left"
+                android:layout_marginTop="3dp"
+                android:layout_marginBottom="3dp"
+                android:paddingLeft="4dp"
+                android:paddingRight="4dp"
+                android:gravity="right"
+                android:orientation="horizontal"
+                android:background="@drawable/round_corners_style_b_header_status" />
+
+            <TextView
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="16dp"
+                style="@style/legendDialogTextStyle"
+                android:layout_gravity="center_vertical"
+                android:text="@string/main_help_legend_canceled" />
+        </LinearLayout>
+
     </LinearLayout>
 </ScrollView>

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -223,6 +223,9 @@
     <string name="stop_info_scheduled_arrival">Scheduled arrival</string>
     <string name="stop_info_scheduled_departure">Scheduled departure</string>
     <string name="stop_info_scheduled">Scheduled</string>
+    <string name="stop_info_canceled_arrival">CANCELED arrival</string>
+    <string name="stop_info_canceled_departure">CANCELED departure</string>
+    <string name="stop_info_canceled">CANCELED</string>
     <string name="stop_info_time_arriving_at">Arriving at %1s</string>
     <string name="stop_info_time_departing_at">Departing at %1s</string>
     <string name="stop_info_time_arrived_at">Arrived at %1s</string>

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -125,6 +125,9 @@
     <string name="main_help_legend_scheduled">Gray means \"Scheduled arrival\" - We don\'t know
         where the bus is now, but the schedule says there is an upcoming arrival
     </string>
+    <string name="main_help_legend_canceled">Gray with strikethrough means the trip has been
+        canceled - this bus is NOT coming
+    </string>
     <string name="main_nolocation_title">Location not enabled</string>
     <string name="main_nolocation">OneBusAway would like your location, do you want to enable it
         now?
@@ -816,7 +819,8 @@
     </string>
     <string name="tutorial_arrival_header_arrival_info_text">This long! Colored background tells you
         if the bus is early (red) or late (blue). On time = green background. If we don\'t know
-        where the bus is, the scheduled time is shown (gray background).
+        where the bus is, the scheduled time is shown (gray background). Gray with strikethrough text
+        (a line through it) means the trip is canceled.
     </string>
     <string name="tutorial_arrival_header_sliding_panel_title">Slide up to show more arrivals
     </string>


### PR DESCRIPTION
TODO:
- [x] Parse and test trip status for "default" and "CANCELED"
- [x] Add CANCELED trips to arrivals list UI - Style A
- [x] Add CANCELED trips to arrivals list UI - Style B
- [x] Hide vehicle positions for CANCELED trips on the map
- [x] Add CANCELED trips to trip status UI
- [x] Add CANCELED trips to ArrivalsListHeader
- [x] Add CANCELED to Legend in Help
- [x] Test with real data - Apparently this is live in Puget Sound [trips-for-route](https://gist.github.com/barbeau/f0d2f2a94736af8156562b472eb768c4) (which we use to show vehicles on the map), but CANCELED trips are omitted entirely from the arrivals-and-departures-for-stop API, which means that the canceled trips will never be visible in the arrivals list UI.

Screenshots:

![image](https://user-images.githubusercontent.com/928045/79491263-3071df80-7fec-11ea-93da-a6723b312b00.png)

![image](https://user-images.githubusercontent.com/928045/79493169-14bc0880-7fef-11ea-871a-87516d7da927.png)

Closes https://github.com/OneBusAway/onebusaway-android/issues/1033.