### PR TITLE
Feat #21: set default reminder time to previous selection

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/TripInfoActivity.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/TripInfoActivity.java
@@ -44,6 +44,7 @@ import org.onebusaway.android.R;
 import org.onebusaway.android.provider.ObaContract;
 import org.onebusaway.android.tripservice.TripService;
 import org.onebusaway.android.util.FragmentUtils;
+import org.onebusaway.android.util.PreferenceUtils;
 import org.onebusaway.android.util.UIUtils;
 
 import java.util.List;
@@ -270,7 +271,7 @@ public class TripInfoActivity extends AppCompatActivity {
         private boolean initFromCursor(Cursor cursor) {
             if (cursor == null || cursor.getCount() < 1) {
                 // Reminder defaults to 10 in the UI
-                mReminderTime = 10;
+                mReminderTime = PreferenceUtils.getInt(getString(R.string.preference_key_default_reminder_time), 10);
                 return false;
             }
             cursor.moveToFirst();
@@ -446,6 +447,8 @@ public class TripInfoActivity extends AppCompatActivity {
                 c.close();
             }
             TripService.scheduleAll(getActivity(), true);
+
+            PreferenceUtils.saveInt(getString(R.string.preference_key_default_reminder_time), reminder);
 
             Toast.makeText(getActivity(), R.string.trip_info_saved, Toast.LENGTH_SHORT)
                     .show();

--- a/onebusaway-android/src/main/res/values/donottranslate.xml
+++ b/onebusaway-android/src/main/res/values/donottranslate.xml
@@ -38,6 +38,7 @@
     <string name="preference_key_show_negative_arrivals">preference_show_negative_arrivals</string>
     <string name="preference_key_show_zoom_controls">preference_show_zoom_controls</string>
     <string name="preference_key_default_stop_sort">preference_default_stop_sort</string>
+    <string name="preference_key_default_reminder_time">preference_default_reminder_time</string>
     <string name="preference_key_default_reminder_sort">preference_default_reminder_sort</string>
     <string name="preference_key_tutorial">preference_key_tutorial</string>
     <string name="preference_key_show_header_arrivals">preference_key_show_header_arrivals</string>


### PR DESCRIPTION
Address issue #21. Sets the default reminder time to the previous selection.

To accomplish this, I used a new preference that is set when a departure reminder is saved.

Closes #21.