### PR TITLE
feat: Support real-time occupancy for WMATA

### DIFF
--- a/onebusaway-android/src/amazon/java/org/onebusaway/android/map/googlemapsv2/VehicleOverlay.java
+++ b/onebusaway-android/src/amazon/java/org/onebusaway/android/map/googlemapsv2/VehicleOverlay.java
@@ -976,10 +976,10 @@ public class VehicleOverlay implements AmazonMap.OnInfoWindowClickListener, Mark
                 mMarkerRefreshHandler.postDelayed(mMarkerRefresh, MARKER_REFRESH_PERIOD);
             }
 
-            if (status.getRealtimeOccupancy() != null) {
+            if (status.getOccupancyStatus() != null) {
                 // Real-time occupancy data
-                UIUtils.setOccupancyVisibilityAndColor(occupancyView, status.getRealtimeOccupancy(), OccupancyState.REALTIME);
-                UIUtils.setOccupancyContentDescription(occupancyView, status.getRealtimeOccupancy(), OccupancyState.REALTIME);
+                UIUtils.setOccupancyVisibilityAndColor(occupancyView, status.getOccupancyStatus(), OccupancyState.REALTIME);
+                UIUtils.setOccupancyContentDescription(occupancyView, status.getOccupancyStatus(), OccupancyState.REALTIME);
             } else {
                 // Hide occupancy by setting null value
                 UIUtils.setOccupancyVisibilityAndColor(occupancyView, null, OccupancyState.REALTIME);

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/adapter/test/AdapterTest.java
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/adapter/test/AdapterTest.java
@@ -22,6 +22,9 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
 
+import androidx.core.widget.ImageViewCompat;
+import androidx.test.runner.AndroidJUnit4;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.onebusaway.android.R;
@@ -43,9 +46,6 @@ import org.onebusaway.android.util.UIUtils;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import androidx.core.widget.ImageViewCompat;
-import androidx.test.runner.AndroidJUnit4;
 
 import static androidx.test.InstrumentationRegistry.getTargetContext;
 import static junit.framework.Assert.assertEquals;
@@ -358,7 +358,7 @@ public class AdapterTest extends ObaTestCase {
         UIUtils.setOccupancyVisibilityAndColor(occupancy, Occupancy.FEW_SEATS_AVAILABLE, OccupancyState.HISTORICAL);
         assertEquals(View.VISIBLE, occupancy.getVisibility());
         assertEquals(View.VISIBLE, silhouette1.getVisibility());
-        assertEquals(View.INVISIBLE, silhouette2.getVisibility());
+        assertEquals(View.VISIBLE, silhouette2.getVisibility());
         assertEquals(View.INVISIBLE, silhouette3.getVisibility());
         assertEquals(backgroundColorHistorical, ((GradientDrawable) occupancy.getBackground()).getColor().getDefaultColor());
         assertEquals(silhouetteColorHistorical, ImageViewCompat.getImageTintList(silhouette1).getDefaultColor());
@@ -369,7 +369,7 @@ public class AdapterTest extends ObaTestCase {
         UIUtils.setOccupancyVisibilityAndColor(occupancy, Occupancy.FEW_SEATS_AVAILABLE, OccupancyState.PREDICTED);
         assertEquals(View.VISIBLE, occupancy.getVisibility());
         assertEquals(View.VISIBLE, silhouette1.getVisibility());
-        assertEquals(View.INVISIBLE, silhouette2.getVisibility());
+        assertEquals(View.VISIBLE, silhouette2.getVisibility());
         assertEquals(View.INVISIBLE, silhouette3.getVisibility());
         assertEquals(backgroundColorPredicted, ((GradientDrawable) occupancy.getBackground()).getColor().getDefaultColor());
         assertEquals(silhouetteColorPredicted, ImageViewCompat.getImageTintList(silhouette1).getDefaultColor());
@@ -379,7 +379,7 @@ public class AdapterTest extends ObaTestCase {
         UIUtils.setOccupancyVisibilityAndColor(occupancy, Occupancy.FEW_SEATS_AVAILABLE, OccupancyState.REALTIME);
         assertEquals(View.VISIBLE, occupancy.getVisibility());
         assertEquals(View.VISIBLE, silhouette1.getVisibility());
-        assertEquals(View.INVISIBLE, silhouette2.getVisibility());
+        assertEquals(View.VISIBLE, silhouette2.getVisibility());
         assertEquals(View.INVISIBLE, silhouette3.getVisibility());
         assertEquals(backgroundColorPredicted, ((GradientDrawable) occupancy.getBackground()).getColor().getDefaultColor());
         assertEquals(silhouetteColorPredicted, ImageViewCompat.getImageTintList(silhouette1).getDefaultColor());
@@ -517,10 +517,10 @@ public class AdapterTest extends ObaTestCase {
         assertEquals("Historically standing room", occupancy.getContentDescription());
 
         UIUtils.setOccupancyContentDescription(occupancy, Occupancy.FEW_SEATS_AVAILABLE, OccupancyState.HISTORICAL);
-        assertEquals("Historically seats available", occupancy.getContentDescription());
+        assertEquals("Historically few seats available", occupancy.getContentDescription());
 
         UIUtils.setOccupancyContentDescription(occupancy, Occupancy.MANY_SEATS_AVAILABLE, OccupancyState.HISTORICAL);
-        assertEquals("Historically seats available", occupancy.getContentDescription());
+        assertEquals("Historically many seats available", occupancy.getContentDescription());
 
         UIUtils.setOccupancyContentDescription(occupancy, Occupancy.EMPTY, OccupancyState.HISTORICAL);
         assertEquals("Historically empty", occupancy.getContentDescription());
@@ -542,10 +542,10 @@ public class AdapterTest extends ObaTestCase {
         assertEquals("Standing room", occupancy.getContentDescription());
 
         UIUtils.setOccupancyContentDescription(occupancy, Occupancy.FEW_SEATS_AVAILABLE, OccupancyState.REALTIME);
-        assertEquals("Seats available", occupancy.getContentDescription());
+        assertEquals("Few seats available", occupancy.getContentDescription());
 
         UIUtils.setOccupancyContentDescription(occupancy, Occupancy.MANY_SEATS_AVAILABLE, OccupancyState.REALTIME);
-        assertEquals("Seats available", occupancy.getContentDescription());
+        assertEquals("Many seats available", occupancy.getContentDescription());
 
         UIUtils.setOccupancyContentDescription(occupancy, Occupancy.EMPTY, OccupancyState.REALTIME);
         assertEquals("Empty", occupancy.getContentDescription());
@@ -567,10 +567,10 @@ public class AdapterTest extends ObaTestCase {
         assertEquals("Predicted standing room", occupancy.getContentDescription());
 
         UIUtils.setOccupancyContentDescription(occupancy, Occupancy.FEW_SEATS_AVAILABLE, OccupancyState.PREDICTED);
-        assertEquals("Predicted seats available", occupancy.getContentDescription());
+        assertEquals("Predicted few seats available", occupancy.getContentDescription());
 
         UIUtils.setOccupancyContentDescription(occupancy, Occupancy.MANY_SEATS_AVAILABLE, OccupancyState.PREDICTED);
-        assertEquals("Predicted seats available", occupancy.getContentDescription());
+        assertEquals("Predicted many seats available", occupancy.getContentDescription());
 
         UIUtils.setOccupancyContentDescription(occupancy, Occupancy.EMPTY, OccupancyState.PREDICTED);
         assertEquals("Predicted empty", occupancy.getContentDescription());

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/io/test/ArrivalInfoRequestTest.java
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/io/test/ArrivalInfoRequestTest.java
@@ -552,56 +552,56 @@ public class ArrivalInfoRequestTest extends ObaTestCase {
         // EMPTY
         ObaArrivalInfo info = arrivals[0];
         assertEquals(Occupancy.EMPTY, info.getHistoricalOccupancy());
-        assertEquals(Occupancy.EMPTY, info.getPredictedOccupancy());
-        assertEquals(Occupancy.EMPTY, info.getTripStatus().getRealtimeOccupancy());
+        assertEquals(Occupancy.EMPTY, info.getOccupancyStatus());
+        assertEquals(Occupancy.EMPTY, info.getTripStatus().getOccupancyStatus());
 
         // MANY_SEATS_AVAILABLE
         info = arrivals[1];
         assertEquals(Occupancy.MANY_SEATS_AVAILABLE, info.getHistoricalOccupancy());
-        assertEquals(Occupancy.MANY_SEATS_AVAILABLE, info.getPredictedOccupancy());
-        assertEquals(Occupancy.MANY_SEATS_AVAILABLE, info.getTripStatus().getRealtimeOccupancy());
+        assertEquals(Occupancy.MANY_SEATS_AVAILABLE, info.getOccupancyStatus());
+        assertEquals(Occupancy.MANY_SEATS_AVAILABLE, info.getTripStatus().getOccupancyStatus());
 
         // FEW_SEATS_AVAILABLE
         info = arrivals[2];
         assertEquals(Occupancy.FEW_SEATS_AVAILABLE, info.getHistoricalOccupancy());
-        assertEquals(Occupancy.FEW_SEATS_AVAILABLE, info.getPredictedOccupancy());
-        assertEquals(Occupancy.FEW_SEATS_AVAILABLE, info.getTripStatus().getRealtimeOccupancy());
+        assertEquals(Occupancy.FEW_SEATS_AVAILABLE, info.getOccupancyStatus());
+        assertEquals(Occupancy.FEW_SEATS_AVAILABLE, info.getTripStatus().getOccupancyStatus());
 
         // STANDING_ROOM_ONLY
         info = arrivals[3];
         assertEquals(Occupancy.STANDING_ROOM_ONLY, info.getHistoricalOccupancy());
-        assertEquals(Occupancy.STANDING_ROOM_ONLY, info.getPredictedOccupancy());
-        assertEquals(Occupancy.STANDING_ROOM_ONLY, info.getTripStatus().getRealtimeOccupancy());
+        assertEquals(Occupancy.STANDING_ROOM_ONLY, info.getOccupancyStatus());
+        assertEquals(Occupancy.STANDING_ROOM_ONLY, info.getTripStatus().getOccupancyStatus());
 
         // CRUSHED_STANDING_ROOM_ONLY
         info = arrivals[4];
         assertEquals(Occupancy.CRUSHED_STANDING_ROOM_ONLY, info.getHistoricalOccupancy());
-        assertEquals(Occupancy.CRUSHED_STANDING_ROOM_ONLY, info.getPredictedOccupancy());
-        assertEquals(Occupancy.CRUSHED_STANDING_ROOM_ONLY, info.getTripStatus().getRealtimeOccupancy());
+        assertEquals(Occupancy.CRUSHED_STANDING_ROOM_ONLY, info.getOccupancyStatus());
+        assertEquals(Occupancy.CRUSHED_STANDING_ROOM_ONLY, info.getTripStatus().getOccupancyStatus());
 
         // FULL
         info = arrivals[5];
         assertEquals(Occupancy.FULL, info.getHistoricalOccupancy());
-        assertEquals(Occupancy.FULL, info.getPredictedOccupancy());
-        assertEquals(Occupancy.FULL, info.getTripStatus().getRealtimeOccupancy());
+        assertEquals(Occupancy.FULL, info.getOccupancyStatus());
+        assertEquals(Occupancy.FULL, info.getTripStatus().getOccupancyStatus());
 
         // NOT_ACCEPTING_PASSENGERS
         info = arrivals[6];
         assertEquals(Occupancy.NOT_ACCEPTING_PASSENGERS, info.getHistoricalOccupancy());
-        assertEquals(Occupancy.NOT_ACCEPTING_PASSENGERS, info.getPredictedOccupancy());
-        assertEquals(Occupancy.NOT_ACCEPTING_PASSENGERS, info.getTripStatus().getRealtimeOccupancy());
+        assertEquals(Occupancy.NOT_ACCEPTING_PASSENGERS, info.getOccupancyStatus());
+        assertEquals(Occupancy.NOT_ACCEPTING_PASSENGERS, info.getTripStatus().getOccupancyStatus());
 
         // Empty string
         info = arrivals[7];
         assertNull(info.getHistoricalOccupancy());
-        assertNull(info.getPredictedOccupancy());
-        assertNull(info.getTripStatus().getRealtimeOccupancy());
+        assertNull(info.getOccupancyStatus());
+        assertNull(info.getTripStatus().getOccupancyStatus());
 
         // Missing field
         info = arrivals[8];
         assertNull(info.getHistoricalOccupancy());
-        assertNull(info.getPredictedOccupancy());
-        assertNull(info.getTripStatus().getRealtimeOccupancy());
+        assertNull(info.getOccupancyStatus());
+        assertNull(info.getTripStatus().getOccupancyStatus());
     }
 
     /**

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/io/test/TripsForRouteRequestTest.java
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/io/test/TripsForRouteRequestTest.java
@@ -176,38 +176,38 @@ public class TripsForRouteRequestTest extends ObaTestCase {
 
         // Occupancy - EMPTY
         ObaTripStatus status = trips[0].getStatus();
-        assertEquals(Occupancy.EMPTY, status.getRealtimeOccupancy());
+        assertEquals(Occupancy.EMPTY, status.getOccupancyStatus());
 
         // Occupancy - MANY_SEATS_AVAILABLE
         status = trips[1].getStatus();
-        assertEquals(Occupancy.MANY_SEATS_AVAILABLE, status.getRealtimeOccupancy());
+        assertEquals(Occupancy.MANY_SEATS_AVAILABLE, status.getOccupancyStatus());
 
         // Occupancy - FEW_SEATS_AVAILABLE
         status = trips[2].getStatus();
-        assertEquals(Occupancy.FEW_SEATS_AVAILABLE, status.getRealtimeOccupancy());
+        assertEquals(Occupancy.FEW_SEATS_AVAILABLE, status.getOccupancyStatus());
 
         // Occupancy - STANDING_ROOM_ONLY
         status = trips[3].getStatus();
-        assertEquals(Occupancy.STANDING_ROOM_ONLY, status.getRealtimeOccupancy());
+        assertEquals(Occupancy.STANDING_ROOM_ONLY, status.getOccupancyStatus());
 
         // Occupancy - CRUSHED_STANDING_ROOM_ONLY
         status = trips[4].getStatus();
-        assertEquals(Occupancy.CRUSHED_STANDING_ROOM_ONLY, status.getRealtimeOccupancy());
+        assertEquals(Occupancy.CRUSHED_STANDING_ROOM_ONLY, status.getOccupancyStatus());
 
         // Occupancy - FULL
         status = trips[5].getStatus();
-        assertEquals(Occupancy.FULL, status.getRealtimeOccupancy());
+        assertEquals(Occupancy.FULL, status.getOccupancyStatus());
 
         // Occupancy - NOT_ACCEPTING_PASSENGERS
         status = trips[6].getStatus();
-        assertEquals(Occupancy.NOT_ACCEPTING_PASSENGERS, status.getRealtimeOccupancy());
+        assertEquals(Occupancy.NOT_ACCEPTING_PASSENGERS, status.getOccupancyStatus());
 
         // Occupancy - Empty string
         status = trips[7].getStatus();
-        assertNull(status.getRealtimeOccupancy());
+        assertNull(status.getOccupancyStatus());
 
         // Occupancy - Missing field
         status = trips[8].getStatus();
-        assertNull(status.getRealtimeOccupancy());
+        assertNull(status.getOccupancyStatus());
     }
 }

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/util/test/UIUtilTest.java
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/util/test/UIUtilTest.java
@@ -17,6 +17,15 @@
 
 package org.onebusaway.android.util.test;
 
+import android.graphics.Color;
+import android.location.Location;
+import android.os.Bundle;
+import android.text.TextUtils;
+import android.widget.TextView;
+
+import androidx.core.util.Pair;
+import androidx.test.runner.AndroidJUnit4;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.onebusaway.android.R;
@@ -41,19 +50,10 @@ import org.onebusaway.android.util.ArrivalInfoUtils;
 import org.onebusaway.android.util.EmbeddedSocialUtils;
 import org.onebusaway.android.util.UIUtils;
 
-import android.graphics.Color;
-import android.location.Location;
-import android.os.Bundle;
-import android.text.TextUtils;
-import android.widget.TextView;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-
-import androidx.core.util.Pair;
-import androidx.test.runner.AndroidJUnit4;
 
 import static androidx.test.InstrumentationRegistry.getTargetContext;
 import static junit.framework.Assert.assertEquals;
@@ -204,8 +204,8 @@ public class UIUtilTest extends ObaTestCase {
 
         Occupancy occupancy = null;
         OccupancyState occupancyState = null;
-        if (arrivalInfo.get(0).getInfo().getPredictedOccupancy() != null) {
-            occupancy = arrivalInfo.get(0).getInfo().getPredictedOccupancy();
+        if (arrivalInfo.get(0).getInfo().getOccupancyStatus() != null) {
+            occupancy = arrivalInfo.get(0).getInfo().getOccupancyStatus();
             occupancyState = OccupancyState.PREDICTED;
         } else if (arrivalInfo.get(0).getInfo().getHistoricalOccupancy() != null) {
             occupancy = arrivalInfo.get(0).getInfo().getHistoricalOccupancy();

--- a/onebusaway-android/src/androidTest/res/raw/arrivals_and_departures_for_stop_1_10020_occupancy.json
+++ b/onebusaway-android/src/androidTest/res/raw/arrivals_and_departures_for_stop_1_10020_occupancy.json
@@ -504,8 +504,8 @@
           "departureEnabled": true,
           "scheduledArrivalInterval": null,
           "predictedDepartureTime": 1343583192000,
-          "predictedOccupancy": "empty",
-          "historicalOccupancy": "empty",
+          "occupancyStatus": "EMPTY",
+          "historicalOccupancy": "EMPTY",
           "situationIds": [
           ],
           "stopId": "1_10020",
@@ -520,7 +520,7 @@
             "vehicleId": "1_7028",
             "serviceDate": 1343545200000,
             "lastLocationUpdateTime": 0,
-            "realtimeOccupancy": "empty",
+            "occupancyStatus": "EMPTY",
             "status": "default",
             "lastUpdateTime": 1343583401000,
             "distanceAlongTrip": 4615.101547569451,
@@ -570,8 +570,8 @@
           "departureEnabled": true,
           "scheduledArrivalInterval": null,
           "predictedDepartureTime": 1343583256000,
-          "predictedOccupancy": "manySeatsAvailable",
-          "historicalOccupancy": "manySeatsAvailable",
+          "occupancyStatus": "MANY_SEATS_AVAILABLE",
+          "historicalOccupancy": "MANY_SEATS_AVAILABLE",
           "situationIds": [
           ],
           "stopId": "1_10020",
@@ -596,7 +596,7 @@
             "totalDistanceAlongTrip": 13972.111959564556,
             "lastKnownLocation": null,
             "scheduledDistanceAlongTrip": 6381.7176065370295,
-            "realtimeOccupancy": "manySeatsAvailable",
+            "occupancyStatus": "MANY_SEATS_AVAILABLE",
             "situationIds": [
             ],
             "scheduleDeviation": 287,
@@ -633,8 +633,8 @@
           "departureEnabled": true,
           "scheduledArrivalInterval": null,
           "predictedDepartureTime": 1343584769000,
-          "predictedOccupancy": "fewSeatsAvailable",
-          "historicalOccupancy": "fewSeatsAvailable",
+          "occupancyStatus": "FEW_SEATS_AVAILABLE",
+          "historicalOccupancy": "FEW_SEATS_AVAILABLE",
           "situationIds": [
           ],
           "stopId": "1_10020",
@@ -662,7 +662,7 @@
               "lat": 47.66044616699219
             },
             "scheduledDistanceAlongTrip": 11240.30192791592,
-            "realtimeOccupancy": "fewSeatsAvailable",
+            "occupancyStatus": "FEW_SEATS_AVAILABLE",
             "situationIds": [
             ],
             "scheduleDeviation": 310,
@@ -699,8 +699,8 @@
           "departureEnabled": true,
           "scheduledArrivalInterval": null,
           "predictedDepartureTime": 1343584828000,
-          "predictedOccupancy": "standingRoomOnly",
-          "historicalOccupancy": "standingRoomOnly",
+          "occupancyStatus": "STANDING_ROOM_ONLY",
+          "historicalOccupancy": "STANDING_ROOM_ONLY",
           "situationIds": [
           ],
           "stopId": "1_10020",
@@ -728,7 +728,7 @@
               "lat": 47.67125701904297
             },
             "scheduledDistanceAlongTrip": 14154.614218945204,
-            "realtimeOccupancy": "standingRoomOnly",
+            "occupancyStatus": "STANDING_ROOM_ONLY",
             "situationIds": [
             ],
             "scheduleDeviation": -71,
@@ -765,8 +765,8 @@
           "departureEnabled": true,
           "scheduledArrivalInterval": null,
           "predictedDepartureTime": 1343584828000,
-          "predictedOccupancy": "crushedStandingRoomOnly",
-          "historicalOccupancy": "crushedStandingRoomOnly",
+          "occupancyStatus": "CRUSHED_STANDING_ROOM_ONLY",
+          "historicalOccupancy": "CRUSHED_STANDING_ROOM_ONLY",
           "situationIds": [
           ],
           "stopId": "1_10020",
@@ -794,7 +794,7 @@
               "lat": 47.67125701904297
             },
             "scheduledDistanceAlongTrip": 14154.614218945204,
-            "realtimeOccupancy": "crushedStandingRoomOnly",
+            "occupancyStatus": "CRUSHED_STANDING_ROOM_ONLY",
             "situationIds": [
             ],
             "scheduleDeviation": -71,
@@ -831,8 +831,8 @@
           "departureEnabled": true,
           "scheduledArrivalInterval": null,
           "predictedDepartureTime": 1343584828000,
-          "predictedOccupancy": "full",
-          "historicalOccupancy": "full",
+          "occupancyStatus": "FULL",
+          "historicalOccupancy": "FULL",
           "situationIds": [
           ],
           "stopId": "1_10020",
@@ -860,7 +860,7 @@
               "lat": 47.67125701904297
             },
             "scheduledDistanceAlongTrip": 14154.614218945204,
-            "realtimeOccupancy": "full",
+            "occupancyStatus": "FULL",
             "situationIds": [
             ],
             "scheduleDeviation": -71,
@@ -897,8 +897,8 @@
           "departureEnabled": true,
           "scheduledArrivalInterval": null,
           "predictedDepartureTime": 1343584828000,
-          "predictedOccupancy": "notAcceptingPassengers",
-          "historicalOccupancy": "notAcceptingPassengers",
+          "occupancyStatus": "NOT_ACCEPTING_PASSENGERS",
+          "historicalOccupancy": "NOT_ACCEPTING_PASSENGERS",
           "situationIds": [
           ],
           "stopId": "1_10020",
@@ -926,7 +926,7 @@
               "lat": 47.67125701904297
             },
             "scheduledDistanceAlongTrip": 14154.614218945204,
-            "realtimeOccupancy": "notAcceptingPassengers",
+            "occupancyStatus": "NOT_ACCEPTING_PASSENGERS",
             "situationIds": [
             ],
             "scheduleDeviation": -71,
@@ -963,7 +963,7 @@
           "departureEnabled": true,
           "scheduledArrivalInterval": null,
           "predictedDepartureTime": 1343584828000,
-          "predictedOccupancy": "",
+          "occupancyStatus": "",
           "historicalOccupancy": "",
           "situationIds": [
           ],
@@ -992,7 +992,7 @@
               "lat": 47.67125701904297
             },
             "scheduledDistanceAlongTrip": 14154.614218945204,
-            "realtimeOccupancy": "",
+            "occupancyStatus": "",
             "situationIds": [
             ],
             "scheduleDeviation": -71,

--- a/onebusaway-android/src/androidTest/res/raw/trip_details_hart_1389962.json
+++ b/onebusaway-android/src/androidTest/res/raw/trip_details_hart_1389962.json
@@ -15,7 +15,7 @@
             "distanceAlongTrip": 18.00312947444871,
             "stopHeadsign": "",
             "stopId": "Hillsborough Area Regional Transit_7576",
-            "historicalOccupancy": "empty"
+            "historicalOccupancy": "EMPTY"
           },
           {
             "arrivalTime": 64346,
@@ -23,7 +23,7 @@
             "distanceAlongTrip": 854.9805970132652,
             "stopHeadsign": "",
             "stopId": "Hillsborough Area Regional Transit_6891",
-            "historicalOccupancy": "manySeatsAvailable"
+            "historicalOccupancy": "MANY_SEATS_AVAILABLE"
           },
           {
             "arrivalTime": 64385,
@@ -31,7 +31,7 @@
             "distanceAlongTrip": 1078.6900397175293,
             "stopHeadsign": "",
             "stopId": "Hillsborough Area Regional Transit_5325",
-            "historicalOccupancy": "fewSeatsAvailable"
+            "historicalOccupancy": "FEW_SEATS_AVAILABLE"
           },
           {
             "arrivalTime": 64460,
@@ -39,7 +39,7 @@
             "distanceAlongTrip": 1509.4865177310571,
             "stopHeadsign": "",
             "stopId": "Hillsborough Area Regional Transit_5763",
-            "historicalOccupancy": "standingRoomOnly"
+            "historicalOccupancy": "STANDING_ROOM_ONLY"
           },
           {
             "arrivalTime": 64523,
@@ -47,7 +47,7 @@
             "distanceAlongTrip": 1872.555307322457,
             "stopHeadsign": "",
             "stopId": "Hillsborough Area Regional Transit_5327",
-            "historicalOccupancy": "crushedStandingRoomOnly"
+            "historicalOccupancy": "CRUSHED_STANDING_ROOM_ONLY"
           },
           {
             "arrivalTime": 64628,
@@ -55,7 +55,7 @@
             "distanceAlongTrip": 2475.4296788421484,
             "stopHeadsign": "",
             "stopId": "Hillsborough Area Regional Transit_5764",
-            "historicalOccupancy": "full"
+            "historicalOccupancy": "FULL"
           },
           {
             "arrivalTime": 64680,
@@ -63,7 +63,7 @@
             "distanceAlongTrip": 2756.9267870136723,
             "stopHeadsign": "",
             "stopId": "Hillsborough Area Regional Transit_4020",
-            "historicalOccupancy": "notAcceptingPassengers"
+            "historicalOccupancy": "NOT_ACCEPTING_PASSENGERS"
           },
           {
             "arrivalTime": 64733,

--- a/onebusaway-android/src/androidTest/res/raw/trips_for_route_hart_5_occupancy.json
+++ b/onebusaway-android/src/androidTest/res/raw/trips_for_route_hart_5_occupancy.json
@@ -37,7 +37,7 @@
           "scheduledDistanceAlongTrip": 857.661738417286,
           "serviceDate": 1444017600000,
           "situationIds": [],
-          "realtimeOccupancy": "empty",
+          "occupancyStatus": "EMPTY",
           "status": "default",
           "totalDistanceAlongTrip": 23220.832205772822,
           "vehicleId": "Hillsborough Area Regional Transit_2415"
@@ -77,7 +77,7 @@
           "scheduledDistanceAlongTrip": 7767.281145230052,
           "serviceDate": 1444017600000,
           "situationIds": [],
-          "realtimeOccupancy": "manySeatsAvailable",
+          "occupancyStatus": "MANY_SEATS_AVAILABLE",
           "status": "default",
           "totalDistanceAlongTrip": 19440.69118417295,
           "vehicleId": "Hillsborough Area Regional Transit_2321"
@@ -117,7 +117,7 @@
           "scheduledDistanceAlongTrip": 7022.496607917914,
           "serviceDate": 1444017600000,
           "situationIds": [],
-          "realtimeOccupancy": "fewSeatsAvailable",
+          "occupancyStatus": "FEW_SEATS_AVAILABLE",
           "status": "default",
           "totalDistanceAlongTrip": 18710.563037074742,
           "vehicleId": "Hillsborough Area Regional Transit_2401"
@@ -157,7 +157,7 @@
           "scheduledDistanceAlongTrip": 2506.2488887140644,
           "serviceDate": 1444017600000,
           "situationIds": [],
-          "realtimeOccupancy": "standingRoomOnly",
+          "occupancyStatus": "STANDING_ROOM_ONLY",
           "status": "default",
           "totalDistanceAlongTrip": 21051.99236295506,
           "vehicleId": "Hillsborough Area Regional Transit_1501"
@@ -197,7 +197,7 @@
           "scheduledDistanceAlongTrip": 21170.487273567443,
           "serviceDate": 1444017600000,
           "situationIds": [],
-          "realtimeOccupancy": "crushedStandingRoomOnly",
+          "occupancyStatus": "CRUSHED_STANDING_ROOM_ONLY",
           "status": "default",
           "totalDistanceAlongTrip": 22769.949306527073,
           "vehicleId": "Hillsborough Area Regional Transit_2307"
@@ -237,7 +237,7 @@
           "scheduledDistanceAlongTrip": 16418.692571141262,
           "serviceDate": 1444017600000,
           "situationIds": [],
-          "realtimeOccupancy": "full",
+          "occupancyStatus": "FULL",
           "status": "default",
           "totalDistanceAlongTrip": 17334.655174006934,
           "vehicleId": "Hillsborough Area Regional Transit_2607"
@@ -277,7 +277,7 @@
           "scheduledDistanceAlongTrip": 5722.908596385503,
           "serviceDate": 1444017600000,
           "situationIds": [],
-          "realtimeOccupancy": "notAcceptingPassengers",
+          "occupancyStatus": "NOT_ACCEPTING_PASSENGERS",
           "status": "default",
           "totalDistanceAlongTrip": 13231.917317472326,
           "vehicleId": "Hillsborough Area Regional Transit_2501"
@@ -317,7 +317,7 @@
           "scheduledDistanceAlongTrip": 9601.567329244077,
           "serviceDate": 1444017600000,
           "situationIds": [],
-          "realtimeOccupancy": "",
+          "occupancyStatus": "",
           "status": "default",
           "totalDistanceAlongTrip": 16099.779813459285,
           "vehicleId": "Hillsborough Area Regional Transit_2325"

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/VehicleOverlay.java
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/VehicleOverlay.java
@@ -965,10 +965,10 @@ public class VehicleOverlay implements GoogleMap.OnInfoWindowClickListener, Mark
                 mMarkerRefreshHandler.postDelayed(mMarkerRefresh, MARKER_REFRESH_PERIOD);
             }
 
-            if (status.getRealtimeOccupancy() != null) {
+            if (status.getOccupancyStatus() != null) {
                 // Real-time occupancy data
-                UIUtils.setOccupancyVisibilityAndColor(occupancyView, status.getRealtimeOccupancy(), OccupancyState.REALTIME);
-                UIUtils.setOccupancyContentDescription(occupancyView, status.getRealtimeOccupancy(), OccupancyState.REALTIME);
+                UIUtils.setOccupancyVisibilityAndColor(occupancyView, status.getOccupancyStatus(), OccupancyState.REALTIME);
+                UIUtils.setOccupancyContentDescription(occupancyView, status.getOccupancyStatus(), OccupancyState.REALTIME);
             } else {
                 // Hide occupancy by setting null value
                 UIUtils.setOccupancyVisibilityAndColor(occupancyView, null, OccupancyState.REALTIME);

--- a/onebusaway-android/src/main/java/org/onebusaway/android/io/elements/ObaArrivalInfo.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/io/elements/ObaArrivalInfo.java
@@ -102,7 +102,7 @@ public final class ObaArrivalInfo implements Serializable{
 
     private final String historicalOccupancy;
 
-    private final String predictedOccupancy;
+    private final String occupancyStatus;
 
     ObaArrivalInfo() {
         routeId = "";
@@ -131,7 +131,7 @@ public final class ObaArrivalInfo implements Serializable{
         totalStopsInTrip = 0;
         blockTripSequence = 0;
         historicalOccupancy = "";
-        predictedOccupancy = "";
+        occupancyStatus = "";
     }
 
     /**
@@ -332,7 +332,7 @@ public final class ObaArrivalInfo implements Serializable{
     /**
      * @return the predicted occupancy of the vehicle when it arrives at this stop, or null if the occupancy is unknown
      */
-    public Occupancy getPredictedOccupancy() {
-        return Occupancy.fromString(predictedOccupancy);
+    public Occupancy getOccupancyStatus() {
+        return Occupancy.fromString(occupancyStatus);
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/io/elements/ObaTripStatus.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/io/elements/ObaTripStatus.java
@@ -176,5 +176,5 @@ public interface ObaTripStatus {
     /**
      * @return the real-time occupancy of the vehicle
      */
-    Occupancy getRealtimeOccupancy();
+    Occupancy getOccupancyStatus();
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/io/elements/ObaTripStatusElement.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/io/elements/ObaTripStatusElement.java
@@ -65,7 +65,7 @@ public final class ObaTripStatusElement implements ObaTripStatus, Serializable {
 
     private final int blockTripSequence;
 
-    private final String realtimeOccupancy;
+    private final String occupancyStatus;
 
     ObaTripStatusElement() {
         serviceDate = 0;
@@ -89,7 +89,7 @@ public final class ObaTripStatusElement implements ObaTripStatus, Serializable {
         lastLocationUpdateTime = null;
         lastKnownOrientation = null;
         blockTripSequence = 0;
-        realtimeOccupancy = "";
+        occupancyStatus = "";
     }
 
     @Override
@@ -201,10 +201,10 @@ public final class ObaTripStatusElement implements ObaTripStatus, Serializable {
     }
 
     /**
-     * @return the current realtime occupancy of this vevhicle, or null if the occupancy is unknown
+     * @return the current realtime occupancy of this vehicle, or null if the occupancy is unknown
      */
     @Override
-    public Occupancy getRealtimeOccupancy() {
-        return Occupancy.fromString(realtimeOccupancy);
+    public Occupancy getOccupancyStatus() {
+        return Occupancy.fromString(occupancyStatus);
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/io/elements/Occupancy.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/io/elements/Occupancy.java
@@ -18,15 +18,18 @@ package org.onebusaway.android.io.elements;
 /**
  * The occupancy of the vehicle, based on the OccupancyStatus element from GTFS-realtime
  * (https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md#enum-occupancystatus)
+ * <p>
+ * Also supports WMATA's extensions for occupancy of "MANY_SEATS_AVAILABLE", "FEW_SEATS_AVAILABLE",
+ * "MANY_SEATS_AVAILABLE" - #1059
  */
 public enum Occupancy {
-    EMPTY("empty"),
-    MANY_SEATS_AVAILABLE("manySeatsAvailable"),
-    FEW_SEATS_AVAILABLE("fewSeatsAvailable"),
-    STANDING_ROOM_ONLY("standingRoomOnly"),
-    CRUSHED_STANDING_ROOM_ONLY("crushedStandingRoomOnly"),
-    FULL("full"),
-    NOT_ACCEPTING_PASSENGERS("notAcceptingPassengers");
+    EMPTY("EMPTY"),
+    MANY_SEATS_AVAILABLE("MANY_SEATS_AVAILABLE"),
+    FEW_SEATS_AVAILABLE("FEW_SEATS_AVAILABLE"),
+    STANDING_ROOM_ONLY("STANDING_ROOM_ONLY"),
+    CRUSHED_STANDING_ROOM_ONLY("CRUSHED_STANDING_ROOM_ONLY"),
+    FULL("FULL"),
+    NOT_ACCEPTING_PASSENGERS("NOT_ACCEPTING_PASSENGERS");
 
     private final String mOccupancy;
 
@@ -46,19 +49,19 @@ public enum Occupancy {
      */
     public static Occupancy fromString(String occupancy) {
         switch (occupancy) {
-            case "empty":
+            case "EMPTY":
                 return EMPTY;
-            case "manySeatsAvailable":
+            case "MANY_SEATS_AVAILABLE":
                 return MANY_SEATS_AVAILABLE;
-            case "fewSeatsAvailable":
+            case "FEW_SEATS_AVAILABLE":
                 return FEW_SEATS_AVAILABLE;
-            case "standingRoomOnly":
+            case "STANDING_ROOM_ONLY":
                 return STANDING_ROOM_ONLY;
-            case "crushedStandingRoomOnly":
+            case "CRUSHED_STANDING_ROOM_ONLY":
                 return CRUSHED_STANDING_ROOM_ONLY;
-            case "full":
+            case "FULL":
                 return FULL;
-            case "notAcceptingPassengers":
+            case "NOT_ACCEPTING_PASSENGERS":
                 return NOT_ACCEPTING_PASSENGERS;
             default:
                 return null;

--- a/onebusaway-android/src/main/java/org/onebusaway/android/travelbehavior/model/ObaArrivalInfoPojo.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/travelbehavior/model/ObaArrivalInfoPojo.java
@@ -77,7 +77,7 @@ public class ObaArrivalInfoPojo {
 
     private final Occupancy historicalOccupancy;
 
-    private final Occupancy predictedOccupancy;
+    private final Occupancy occupancyStatus;
 
     public ObaArrivalInfoPojo() {
         routeId = "";
@@ -106,7 +106,7 @@ public class ObaArrivalInfoPojo {
         totalStopsInTrip = 0;
         blockTripSequence = 0;
         historicalOccupancy = null;
-        predictedOccupancy = null;
+        occupancyStatus = null;
     }
 
     public ObaArrivalInfoPojo(ObaArrivalInfo info) {
@@ -141,7 +141,7 @@ public class ObaArrivalInfoPojo {
         totalStopsInTrip = info.getTotalStopsInTrip();
         blockTripSequence = info.getBlockTripSequence();
         historicalOccupancy = info.getHistoricalOccupancy();
-        predictedOccupancy = info.getPredictedOccupancy();
+        occupancyStatus = info.getOccupancyStatus();
     }
 
     /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalInfo.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalInfo.java
@@ -111,7 +111,7 @@ public final class ArrivalInfo {
         mNotifyText = computeNotifyText(context);
 
         mHistoricalOccupancy = info.getHistoricalOccupancy();
-        mPredictedOccupancy = info.getPredictedOccupancy();
+        mPredictedOccupancy = info.getOccupancyStatus();
         if (info.getTripStatus() != null) {
             mStatus = info.getTripStatus().getStatus();
         } else {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/TripDetailsListFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/TripDetailsListFragment.java
@@ -467,10 +467,10 @@ public class TripDetailsListFragment extends ListFragment {
             }
         }
 
-        if (status.getRealtimeOccupancy() != null) {
+        if (status.getOccupancyStatus() != null) {
             // Real-time occupancy data
-            UIUtils.setOccupancyVisibilityAndColor(occupancyView, status.getRealtimeOccupancy(), OccupancyState.REALTIME);
-            UIUtils.setOccupancyContentDescription(occupancyView, status.getRealtimeOccupancy(), OccupancyState.REALTIME);
+            UIUtils.setOccupancyVisibilityAndColor(occupancyView, status.getOccupancyStatus(), OccupancyState.REALTIME);
+            UIUtils.setOccupancyContentDescription(occupancyView, status.getOccupancyStatus(), OccupancyState.REALTIME);
         } else {
             // Hide occupancy by setting null value
             UIUtils.setOccupancyVisibilityAndColor(occupancyView, null, OccupancyState.REALTIME);

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/UIUtils.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/UIUtils.java
@@ -1946,7 +1946,8 @@ public final class UIUtils {
                 // 2 icons
                 silhouette2.setVisibility(View.VISIBLE);
             case FEW_SEATS_AVAILABLE:
-                // 1 icon
+                // 2 icons
+                silhouette2.setVisibility(View.VISIBLE);
             case MANY_SEATS_AVAILABLE:
                 // 1 icon
                 silhouette1.setVisibility(View.VISIBLE);
@@ -2008,15 +2009,23 @@ public final class UIUtils {
                 }
                 break;
             case FEW_SEATS_AVAILABLE:
-                // "Standing room"
-            case MANY_SEATS_AVAILABLE:
-                // "Standing room"
+                // "Few seats available"
                 if (occupancyState == OccupancyState.HISTORICAL) {
-                    stringId = R.string.historically_seats_available;
+                    stringId = R.string.historically_few_seats_available;
                 } else if (occupancyState == OccupancyState.REALTIME) {
-                    stringId = R.string.realtime_seats_available;
+                    stringId = R.string.realtime_few_seats_available;
                 } else if (occupancyState == OccupancyState.PREDICTED) {
-                    stringId = R.string.predicted_seats_available;
+                    stringId = R.string.predicted_few_seats_available;
+                }
+                break;
+            case MANY_SEATS_AVAILABLE:
+                // "Many seats available"
+                if (occupancyState == OccupancyState.HISTORICAL) {
+                    stringId = R.string.historically_many_seats_available;
+                } else if (occupancyState == OccupancyState.REALTIME) {
+                    stringId = R.string.realtime_many_seats_available;
+                } else if (occupancyState == OccupancyState.PREDICTED) {
+                    stringId = R.string.predicted_many_seats_available;
                 }
                 break;
             case EMPTY:

--- a/onebusaway-android/src/main/res/values-es/strings.xml
+++ b/onebusaway-android/src/main/res/values-es/strings.xml
@@ -407,21 +407,21 @@
     <!-- Occupancy -->
     <string name="historically_full">Históricamente lleno</string>
     <string name="historically_standing_room">Históricamente estar de pie</string>
-    <string name="historically_seats_available">Históricamente asientos disponibles</string>
+    <string name="historically_many_seats_available">Históricamente asientos disponibles</string>
     <string name="historically_empty">Históricamente vacío</string>
     <string name="menu_title_about_historical_occupancy">Sobre la ocupación histórica</string>
     <string name="menu_title_about_occupancy">Sobre la ocupación</string>
     <string name="menu_text_about_historical_occupancy">La ocupación histórica (ícono gris) es un promedio del viaje en esta parada en los últimos 6 meses.</string>
-    <string name="menu_text_about_occupancy">La ocupación en tiempo real se muestra usando coloración verde cuando hay muchos asientos disponibles o espacio para estar disponible, y se muestra en color rojo cuando el vehículo está lleno. La ocupación histórica (ícono gris) es un promedio del viaje en esta parada en los últimos 6 meses.</string>
+    <string name="menu_text_about_occupancy">La ocupación en tiempo real se muestra usando coloración verde cuando hay muchos asientos disponibles o pocos asientos disponibles, y se muestra en color rojo cuando el vehículo está lleno. La ocupación histórica (ícono gris) es un promedio del viaje en esta parada en los últimos 6 meses.</string>
 
     <string name="realtime_full">Lleno</string>
     <string name="realtime_standing_room">Estar de pie</string>
-    <string name="realtime_seats_available">Asientos disponibles</string>
+    <string name="realtime_many_seats_available">Asientos disponibles</string>
     <string name="realtime_empty">Vacío</string>
 
     <string name="predicted_full">Lleno pronosticado</string>
     <string name="predicted_standing_room">Estar de pie pronosticado</string>
-    <string name="predicted_seats_available">Asientos disponibles pronosticado</string>
+    <string name="predicted_many_seats_available">Asientos disponibles pronosticado</string>
     <string name="predicted_empty">Vacío pronosticado</string>
 
 

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -463,21 +463,24 @@
     <!-- Occupancy -->
     <string name="historically_full">Historically full</string>
     <string name="historically_standing_room">Historically standing room</string>
-    <string name="historically_seats_available">Historically seats available</string>
+    <string name="historically_many_seats_available">Historically many seats available</string>
+    <string name="historically_few_seats_available">Historically few seats available</string>
     <string name="historically_empty">Historically empty</string>
     <string name="menu_title_about_historical_occupancy">About historical occupancy</string>
     <string name="menu_title_about_occupancy">About occupancy</string>
     <string name="menu_text_about_historical_occupancy">Historical occupancy (gray icon) is an average of trip ridership at this stop over the last 6 months.</string>
-    <string name="menu_text_about_occupancy">Real-time occupancy is shown using green coloring when there are many seats available or standing room available, and is shown in red coloring when the vehicle is full.  Historical occupancy (gray icon) is an average of trip ridership at this stop over the last 6 months.</string>
+    <string name="menu_text_about_occupancy">Real-time occupancy is shown in green when there are many seats available or few seats available, and is shown in red when the vehicle is full.  Historical occupancy (gray icon, if shown) is an average of trip ridership at this stop over the last 6 months.</string>
 
     <string name="realtime_full">Full</string>
     <string name="realtime_standing_room">Standing room</string>
-    <string name="realtime_seats_available">Seats available</string>
+    <string name="realtime_many_seats_available">Many seats available</string>
+    <string name="realtime_few_seats_available">Few seats available</string>
     <string name="realtime_empty">Empty</string>
 
     <string name="predicted_full">Predicted full</string>
     <string name="predicted_standing_room">Predicted standing room</string>
-    <string name="predicted_seats_available">Predicted seats available</string>
+    <string name="predicted_many_seats_available">Predicted many seats available</string>
+    <string name="predicted_few_seats_available">Predicted few seats available</string>
     <string name="predicted_empty">Predicted empty</string>
 
 


### PR DESCRIPTION
Live WMATA data example:

![image](https://user-images.githubusercontent.com/928045/104244666-ead62c00-5430-11eb-9653-48da345dc0d7.png)

Closes https://github.com/OneBusAway/onebusaway-android/issues/1059.

TODO:
- [x] Fix tests to account for new values/states
- [x] Confirm that historical occupancy data will use the same caps/underscore encoding instead of `camelCase` for values

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `gradlew connectedObaGoogleDebugAndroidTest connectedObaAmazonDebugAndroidTest` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them for the initial submission of the pull request.  When addressing comments on a pull request, please push a new commit per comment when possible (reviewers will squash and merge using GitHub merge tool)