### PR TITLE
feat: Add timestamp to the activity-transitions document

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/travelbehavior/model/TravelBehaviorInfo.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/travelbehavior/model/TravelBehaviorInfo.java
@@ -121,6 +121,10 @@ public class TravelBehaviorInfo {
 
     public Boolean isIgnoringBatteryOptimizations;
 
+    // For Firebase to be able to query TravelBehaviorInfo by time, we need a timestamp here,
+    // even if it is duplicate data as in List<TravelBehaviorActivity>.
+    public Long firstActivityEventTimeMillis;
+
     public TravelBehaviorInfo() {
     }
 
@@ -128,5 +132,8 @@ public class TravelBehaviorInfo {
                               Boolean isIgnoringBatteryOptimizations) {
         this.activities = activities;
         this.isIgnoringBatteryOptimizations = isIgnoringBatteryOptimizations;
+        if (activities != null && !activities.isEmpty()) {
+            firstActivityEventTimeMillis = activities.get(0).eventTimeMillis;
+        }
     }
 }


### PR DESCRIPTION
For opt-in travel behavior contributions - In order to activate a filter by activity start time on the trevel-behavior-analysis tool, it is necessary to at least have access to the activity start time as a field on the document.

Closes #1062 

@welozano Could you please take a look at this?

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `gradlew connectedObaGoogleDebugAndroidTest connectedObaAmazonDebugAndroidTest` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them for the initial submission of the pull request.  When addressing comments on a pull request, please push a new commit per comment when possible (reviewers will squash and merge using GitHub merge tool)