### PR TITLE
fix: Show dialog before location permissions prompt on initial startup

### DIFF
--- a/onebusaway-android/src/amazon/java/org/onebusaway/android/map/googlemapsv2/BaseMapFragment.java
+++ b/onebusaway-android/src/amazon/java/org/onebusaway/android/map/googlemapsv2/BaseMapFragment.java
@@ -47,6 +47,10 @@ import android.view.ViewGroup;
 import android.widget.CheckBox;
 import android.widget.Toast;
 
+import androidx.appcompat.app.AlertDialog;
+import androidx.core.graphics.drawable.DrawableCompat;
+import androidx.fragment.app.DialogFragment;
+
 import com.google.android.gms.common.api.GoogleApiClient;
 import com.amazon.geo.mapsv2.CameraUpdateFactory;
 import com.amazon.geo.mapsv2.AmazonMap;
@@ -96,10 +100,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-
-import androidx.appcompat.app.AlertDialog;
-import androidx.core.graphics.drawable.DrawableCompat;
-import androidx.fragment.app.DialogFragment;
 
 import static org.onebusaway.android.util.PermissionUtils.LOCATION_PERMISSIONS;
 import static org.onebusaway.android.util.PermissionUtils.LOCATION_PERMISSION_REQUEST;
@@ -199,6 +199,8 @@ public class BaseMapFragment extends SupportMapFragment
     private boolean mUserDeniedPermission = false;
 
     private FirebaseAnalytics mFirebaseAnalytics;
+
+    private AlertDialog locationPermissionDialog;
 
     @Override
     public void onActivateLayer(LayerInfo layer) {
@@ -1380,12 +1382,17 @@ public class BaseMapFragment extends SupportMapFragment
         if (!canManageDialog(getActivity())) {
             return;
         }
+        if (locationPermissionDialog != null &&
+            locationPermissionDialog.isShowing()) {
+            return;
+        }
         AlertDialog.Builder builder = new AlertDialog.Builder(getActivity())
                 .setTitle(R.string.location_permissions_title)
                 .setMessage(R.string.location_permissions_message)
                 .setCancelable(false)
                 .setPositiveButton(R.string.ok,
                         (dialog, which) -> {
+                            PreferenceUtils.setUserDeniedLocationPermissions(false);
                             // Request permissions from the user
                             requestPermissions(LOCATION_PERMISSIONS, LOCATION_PERMISSION_REQUEST);
                         }
@@ -1399,7 +1406,8 @@ public class BaseMapFragment extends SupportMapFragment
                             }
                         }
                 );
-        builder.create().show();
+        locationPermissionDialog = builder.create();
+        locationPermissionDialog.show();
     }
 
     /**

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/BaseMapFragment.java
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/BaseMapFragment.java
@@ -189,6 +189,8 @@ public class BaseMapFragment extends SupportMapFragment
 
     private FirebaseAnalytics mFirebaseAnalytics;
 
+    private AlertDialog locationPermissionDialog;
+
     @Override
     public void onActivateLayer(LayerInfo layer) {
         switch (layer.getLayerlabel()) {
@@ -1369,6 +1371,9 @@ public class BaseMapFragment extends SupportMapFragment
         if (!canManageDialog(getActivity())) {
             return;
         }
+        if (locationPermissionDialog != null && locationPermissionDialog.isShowing()) {
+            return;
+        }
         AlertDialog.Builder builder = new AlertDialog.Builder(getActivity())
                 .setTitle(R.string.location_permissions_title)
                 .setMessage(R.string.location_permissions_message)
@@ -1389,7 +1394,8 @@ public class BaseMapFragment extends SupportMapFragment
                             }
                         }
                 );
-        builder.create().show();
+        locationPermissionDialog = builder.create();
+        locationPermissionDialog.show();
     }
 
     /**

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/BaseMapFragment.java
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/BaseMapFragment.java
@@ -25,7 +25,6 @@ import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
 import android.graphics.drawable.Drawable;
 import android.location.Location;
-import android.net.Uri;
 import android.os.Bundle;
 import android.os.Handler;
 import android.provider.Settings;
@@ -36,6 +35,10 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.CheckBox;
 import android.widget.Toast;
+
+import androidx.appcompat.app.AlertDialog;
+import androidx.core.graphics.drawable.DrawableCompat;
+import androidx.fragment.app.DialogFragment;
 
 import com.google.android.gms.common.api.GoogleApiClient;
 import com.google.android.gms.maps.CameraUpdateFactory;
@@ -87,12 +90,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import androidx.appcompat.app.AlertDialog;
-import androidx.core.graphics.drawable.DrawableCompat;
-import androidx.fragment.app.DialogFragment;
-
 import static org.onebusaway.android.util.PermissionUtils.LOCATION_PERMISSIONS;
 import static org.onebusaway.android.util.PermissionUtils.LOCATION_PERMISSION_REQUEST;
+import static org.onebusaway.android.util.UIUtils.canManageDialog;
 
 /**
  * The MapFragment class is split into two basic modes:
@@ -120,8 +120,6 @@ public class BaseMapFragment extends SupportMapFragment
     public static final String TAG = "BaseMapFragment";
 
     private static final int REQUEST_NO_LOCATION = 41;
-
-    private static final String USER_DENIED_PERMISSION = ".UserDeniedPermission";
 
     //
     // Location Services and Maps API v2 constants
@@ -279,9 +277,7 @@ public class BaseMapFragment extends SupportMapFragment
 
         mFirebaseAnalytics = FirebaseAnalytics.getInstance(getActivity());
 
-        if (savedInstanceState != null) {
-            savedInstanceState.getBoolean(USER_DENIED_PERMISSION, false);
-        }
+        mUserDeniedPermission = PreferenceUtils.userDeniedLocationPermission();
 
         mLocationHelper = new LocationHelper(getActivity());
 
@@ -329,12 +325,10 @@ public class BaseMapFragment extends SupportMapFragment
 
     private void initMap(Bundle savedInstanceState) {
         UiSettings uiSettings = mMap.getUiSettings();
+        mUserDeniedPermission = PreferenceUtils.userDeniedLocationPermission();
 
         if (!mUserDeniedPermission) {
             requestPermissionAndInit(getActivity());
-        } else {
-            // Explain permission to user
-            UIUtils.showLocationPermissionDialog(this);
         }
 
         // Set location source
@@ -392,8 +386,8 @@ public class BaseMapFragment extends SupportMapFragment
             // Make sure location helper is registered
             mLocationHelper.registerListener(this);
         } else {
-            // Request permissions from the user
-            requestPermissions(LOCATION_PERMISSIONS, LOCATION_PERMISSION_REQUEST);
+            // Explain permission to user
+            showLocationPermissionDialog();
         }
     }
 
@@ -473,6 +467,7 @@ public class BaseMapFragment extends SupportMapFragment
 
     @Override
     public void onResume() {
+        mUserDeniedPermission = PreferenceUtils.userDeniedLocationPermission();
         if (mLocationHelper != null) {
             mLocationHelper.onResume();
         }
@@ -507,7 +502,6 @@ public class BaseMapFragment extends SupportMapFragment
         outState.putInt(MapParams.MAP_PADDING_TOP, mMapPaddingTop);
         outState.putInt(MapParams.MAP_PADDING_RIGHT, mMapPaddingRight);
         outState.putInt(MapParams.MAP_PADDING_BOTTOM, mMapPaddingBottom);
-        outState.putBoolean(USER_DENIED_PERMISSION, mUserDeniedPermission);
     }
 
     @Override
@@ -724,7 +718,7 @@ public class BaseMapFragment extends SupportMapFragment
         String serverName = Application.get().getCustomApiUrl();
         if (mWarnOutOfRange && (Application.get().getCurrentRegion() != null || !TextUtils
                 .isEmpty(serverName))) {
-            if (mRunning && UIUtils.canManageDialog(getActivity())) {
+            if (mRunning && canManageDialog(getActivity())) {
                 showDialog(MapDialogFragment.OUTOFRANGE_DIALOG);
             }
         }
@@ -826,15 +820,16 @@ public class BaseMapFragment extends SupportMapFragment
 
         Location lastLocation = Application.getLastKnownLocation(getActivity(), apiClient);
         if (lastLocation == null) {
-            String text;
             if (!PermissionUtils.hasGrantedPermissions(Application.get(), LOCATION_PERMISSIONS)) {
-                text = getResources().getString(R.string.no_location_permission);
+                if (!PreferenceUtils.userDeniedLocationPermission()) {
+                    requestPermissionAndInit(getActivity());
+                }
             } else {
-                text = getResources().getString(R.string.main_waiting_for_location);
+                Toast.makeText(getActivity(),
+                        getResources().getString(R.string.main_waiting_for_location),
+                        Toast.LENGTH_SHORT).show();
+
             }
-            Toast.makeText(getActivity(),
-                    text,
-                    Toast.LENGTH_SHORT).show();
             return false;
         }
 
@@ -925,7 +920,7 @@ public class BaseMapFragment extends SupportMapFragment
             // If we don't even have a response object, something went really wrong
             code = ObaApi.OBA_INTERNAL_ERROR;
         }
-        if (UIUtils.canManageDialog(context)) {
+        if (canManageDialog(context)) {
             Toast.makeText(context,
                     context.getString(UIUtils.getMapErrorString(context, code)),
                     Toast.LENGTH_LONG).show();
@@ -1361,6 +1356,40 @@ public class BaseMapFragment extends SupportMapFragment
                     );
             return builder.create();
         }
+    }
+
+    /**
+     * Shows the dialog to explain why location permissions are needed.  If this provided activity
+     * can't manage dialogs then this method is a no-op.
+     * <p>
+     * NOTE - this dialog can't be managed under the old dialog framework as the method
+     * ActivityCompat.shouldShowRequestPermissionRationale() always returns false.
+     */
+    public void showLocationPermissionDialog() {
+        if (!canManageDialog(getActivity())) {
+            return;
+        }
+        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity())
+                .setTitle(R.string.location_permissions_title)
+                .setMessage(R.string.location_permissions_message)
+                .setCancelable(false)
+                .setPositiveButton(R.string.ok,
+                        (dialog, which) -> {
+                            PreferenceUtils.setUserDeniedLocationPermissions(false);
+                            // Request permissions from the user
+                            requestPermissions(LOCATION_PERMISSIONS, LOCATION_PERMISSION_REQUEST);
+                        }
+                )
+                .setNegativeButton(R.string.no_thanks,
+                        (dialog, which) -> {
+                            if (mOnLocationPermissionResultListener != null) {
+                                mUserDeniedPermission = true;
+                                PreferenceUtils.setUserDeniedLocationPermissions(true);
+                                mOnLocationPermissionResultListener.onLocationPermissionResult(PackageManager.PERMISSION_DENIED);
+                            }
+                        }
+                );
+        builder.create().show();
     }
 
     /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.java
@@ -1350,6 +1350,7 @@ public class HomeActivity extends AppCompatActivity
             if (mMapFragment != null) {
                 // Reset the preference to ask user to enable location
                 PreferenceUtils.saveBoolean(getString(R.string.preference_key_never_show_location_dialog), false);
+                PreferenceUtils.setUserDeniedLocationPermissions(false);
 
                 mMapFragment.setMyLocation(true, true);
                 ObaAnalytics.reportUiEvent(mFirebaseAnalytics,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/PreferenceUtils.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/PreferenceUtils.java
@@ -203,6 +203,26 @@ public class PreferenceUtils {
     }
 
     /**
+     * Returns true if the user has previously indicated that they don't want to be prompted to provide
+     * location permissions. Note that this means they haven't actually be prompted with the
+     * system permission dialog.
+     */
+    public static boolean userDeniedLocationPermission() {
+        Resources r = Application.get().getResources();
+        return getBoolean(r.getString(R.string.preferences_key_user_denied_location_permissions), false);
+    }
+
+    /**
+     * Set value to true if the user has previously indicated that they don't want to be prompted to provide
+     * location permissions, or false if they have indicated that they want to be prompted with
+     * the system permission dialog.
+     */
+    public static void setUserDeniedLocationPermissions(boolean value) {
+        Resources r = Application.get().getResources();
+        saveBoolean(r.getString(R.string.preferences_key_user_denied_location_permissions), value);
+    }
+
+    /**
      * Returns true if preferred units are metric, false if Imperial. If set to Automatic,
      * assume Imperial if the default locale is the US, metric otherwise.
      *

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/UIUtils.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/UIUtils.java
@@ -123,9 +123,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import static org.onebusaway.android.util.PermissionUtils.LOCATION_PERMISSIONS;
-import static org.onebusaway.android.util.PermissionUtils.LOCATION_PERMISSION_REQUEST;
-
 /**
  * A class containing utility methods related to the user interface
  */
@@ -1856,35 +1853,6 @@ public final class UIUtils {
                     Application.get().getString(R.string.analytics_label_button_bike_share),
                     Application.get().getString(R.string.analytics_label_download_app));
         }
-    }
-
-    /**
-     * Shows the dialog to explain why location permissions are needed.  If this provided activity
-     * can't manage dialogs then this method is a no-op.
-     * <p>
-     * NOTE - this dialog can't be managed under the old dialog framework as the method
-     * ActivityCompat.shouldShowRequestPermissionRationale() always returns false.
-     */
-    public static void showLocationPermissionDialog(@NonNull Fragment fragment) {
-        if (!canManageDialog(fragment.getActivity())) {
-            return;
-        }
-        AlertDialog.Builder builder = new AlertDialog.Builder(fragment.getActivity())
-                .setTitle(R.string.location_permissions_title)
-                .setMessage(R.string.location_permissions_message)
-                .setCancelable(false)
-                .setPositiveButton(R.string.ok,
-                        (dialog, which) -> {
-                            // Request permissions from the user
-                            fragment.requestPermissions(LOCATION_PERMISSIONS, LOCATION_PERMISSION_REQUEST);
-                        }
-                )
-                .setNegativeButton(R.string.no_thanks,
-                        (dialog, which) -> {
-                            // No-op
-                        }
-                );
-        builder.create().show();
     }
 
     /**

--- a/onebusaway-android/src/main/res/values/donottranslate.xml
+++ b/onebusaway-android/src/main/res/values/donottranslate.xml
@@ -64,6 +64,7 @@
     <string name="preferences_key_user_share_destination_logs">preferences_user_share_logs</string>
     <string name="preference_key_never_show_destination_reminder_beta_dialog">preference_never_show_destination_reminder_beta_dialog</string>
     <string name="preferences_key_travel_behavior">preference_travel_behavior</string>
+    <string name="preferences_key_user_denied_location_permissions">preferences_key_user_denied_location_permissions</string>
 
     <!-- Regions API URL -->
     <string name="regions_api_url">https://regions.onebusaway.org/regions-v3.json</string>

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -845,10 +845,13 @@
     </string>
 
     <!-- Permissions -->
-    <string name="location_permissions_title">Real-time location needs permission</string>
-    <string name="location_permissions_message">To show your real-time position on the map
-        you\'ll need to grant location permissions. If you select \"Never ask again\" you will need
-        to reinstall the app or enable permissions via system settings to see your real-time location.
+    <string name="location_permissions_title">Location permissions</string>
+    <string name="location_permissions_message">We recommend allowing location use while the app is
+        running to show your real-time position on the map and automatically select your OneBusAway
+        region for your local transit agency. This location data is not collected by OneBusAway.
+
+        \n\nAlternately, you can manually select your region if you choose not to allow
+        location permissions.
     </string>
     <string name="no_thanks">No thanks</string>
 


### PR DESCRIPTION
On initial startup, the user is now shown a dialog explaining foreground location use before being shown the system permission prompt:

![image](https://user-images.githubusercontent.com/928045/115933710-69ddf600-a45d-11eb-8012-2719107af5e1.png)

Additional improvements include:
* The "No thanks" option for prompting location was previously broken (we kept prompting the user for location permissions), so this fixes that too.
* It also allows the user to initially deny the prompt, and then the user taps on the "my location" button, they will be prompted with the dialog again (previously we just shows an info Toast telling the user to go change the permission in system settings).

Closes #1067

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `gradlew connectedObaGoogleDebugAndroidTest connectedObaAmazonDebugAndroidTest` to make sure you didn't break anything

- [ ] If you have multiple commits please combine them into one commit by squashing them for the initial submission of the pull request.  When addressing comments on a pull request, please push a new commit per comment when possible (reviewers will squash and merge using GitHub merge tool)