### PR TITLE
Add Starred Routes list (#354)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/MyRouteListFragmentBase.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/MyRouteListFragmentBase.java
@@ -65,7 +65,7 @@ abstract class MyRouteListFragmentBase extends MyListFragmentBase
             activity.setResult(Activity.RESULT_OK, shortcut.getIntent());
             activity.finish();
         } else {
-            RouteInfoActivity.start(getActivity(), routeId);
+            HomeActivity.start(getActivity(), routeId);
         }
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/MyStarredRoutesFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/MyStarredRoutesFragment.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright (C) 2012-2015 Paul Watts (paulcwatts@gmail.com), University of South Florida
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Modifications copyright (C) 2023 Millan Philipose, University of Washington.
+ * This file is adapted from MyStarredStopsFragment, to display starred routes rather than stops.
+ */
+package org.onebusaway.android.ui;
+
+import com.google.firebase.analytics.FirebaseAnalytics;
+
+import org.onebusaway.android.R;
+import org.onebusaway.android.app.Application;
+import org.onebusaway.android.io.ObaAnalytics;
+import org.onebusaway.android.provider.ObaContract;
+import org.onebusaway.android.util.PreferenceUtils;
+import org.onebusaway.android.util.ShowcaseViewUtils;
+
+import android.content.DialogInterface;
+import android.database.Cursor;
+import android.net.Uri;
+import android.os.Bundle;
+import android.util.Log;
+import android.view.ContextMenu;
+import android.view.ContextMenu.ContextMenuInfo;
+import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.AdapterView.AdapterContextMenuInfo;
+
+import androidx.appcompat.app.AlertDialog;
+import androidx.loader.content.CursorLoader;
+import androidx.loader.content.Loader;
+
+public class MyStarredRoutesFragment extends MyRouteListFragmentBase {
+
+    public static final String TAG = "MyStarredRoutesFragment";
+    public static final String TAB_NAME = "starred_rts";
+
+    private static String sortBy;
+
+    private FirebaseAnalytics mFirebaseAnalytics;
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+            Bundle savedInstanceState) {
+        mFirebaseAnalytics = FirebaseAnalytics.getInstance(getContext());
+        return super.onCreateView(inflater, container, savedInstanceState);
+    }
+
+    @Override
+    public Loader<Cursor> onCreateLoader(int id, Bundle args) {
+        // Set the sort by clause, in case its the first execution and none is set.
+        // We use the same sorting preference (name vs most recent) as is used for sorting routes.
+        final int currentRouteOrder = PreferenceUtils.getStopSortOrderFromPreferences();
+        setSortByClause(currentRouteOrder);
+
+        return new CursorLoader(getActivity(),
+                ObaContract.Routes.CONTENT_URI,
+                PROJECTION,
+                ObaContract.Routes.FAVORITE + "=1" +
+                        (Application.get().getCurrentRegion() == null ? "" : " AND " +
+                                QueryUtils.getRegionWhere(ObaContract.Routes.REGION_ID,
+                                        Application.get().getCurrentRegion().getId())),
+                null, sortBy);
+    }
+
+    @Override
+    public void onActivityCreated(Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+        setHasOptionsMenu(true);
+    }
+
+    @Override
+    public void onCreateContextMenu(ContextMenu menu, View v,
+                                    ContextMenuInfo menuInfo) {
+        super.onCreateContextMenu(menu, v, menuInfo);
+        menu.add(0, CONTEXT_MENU_DELETE, 0, R.string.my_context_remove_star);
+    }
+
+    @Override
+    public boolean onContextItemSelected(MenuItem item) {
+        AdapterContextMenuInfo info = (AdapterContextMenuInfo) item.getMenuInfo();
+        switch (item.getItemId()) {
+            case CONTEXT_MENU_DELETE:
+                final String id = QueryUtils.RouteList.getId(getListView(), info.position);
+                final Uri uri = Uri.withAppendedPath(ObaContract.Routes.CONTENT_URI, id);
+                ObaContract.Routes.markAsFavorite(getActivity(), uri, false);
+                ObaContract.RouteHeadsignFavorites.markAsFavorite(getActivity(), id, null, null, false);
+                return true;
+            default:
+                return super.onContextItemSelected(item);
+        }
+    }
+
+    @Override
+    public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
+        inflater.inflate(R.menu.my_starred_route_options, menu);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        final int id = item.getItemId();
+        if (id == R.id.clear_starred) {
+            new ClearDialog()
+                    .show(getActivity().getSupportFragmentManager(), "confirm_clear_starred_routes");
+            return true;
+        } else if (id == R.id.sort_stops) {
+            ShowcaseViewUtils.doNotShowTutorial(ShowcaseViewUtils.TUTORIAL_STARRED_STOPS_SORT);
+            showSortByDialog();
+        }
+        return false;
+    }
+
+    private void showSortByDialog() {
+        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+        builder.setTitle(R.string.menu_option_sort_by);
+
+        final int currentRouteOrder = PreferenceUtils.getStopSortOrderFromPreferences();
+
+        builder.setSingleChoiceItems(R.array.sort_stops, currentRouteOrder,
+                new DialogInterface.OnClickListener() {
+                    public void onClick(DialogInterface dialog, int index) {
+                        // If the user picked a different option, change the sort order
+                        if (currentRouteOrder != index) {
+                            setSortByClause(index);
+
+                            // Restart the loader with the new sorting
+                            getLoaderManager().restartLoader(0, null, MyStarredRoutesFragment.this);
+                        }
+                        dialog.dismiss();
+                    }
+                });
+        AlertDialog dialog = builder.create();
+        dialog.setOwnerActivity(getActivity());
+        dialog.show();
+    }
+
+    /**
+     * Sets the "sort by" string for ordering the routes, based on the given index of
+     * R.array.sort_stops.  It also saves the sort by order to preferences.
+     *
+     * @param index the index of R.array.sort_stops that should be set
+     */
+    private void setSortByClause(int index) {
+        switch (index) {
+            case 0:
+                // Sort by name
+                Log.d(TAG, "Sort by name");
+                sortBy = "length(" + ObaContract.Routes.SHORTNAME + "), "
+                        + ObaContract.Routes.SHORTNAME + " asc";
+                ObaAnalytics.reportUiEvent(mFirebaseAnalytics,
+                        getString(R.string.analytics_label_sort_by_name_stops),
+                        null);
+                break;
+            case 1:
+                // Sort by frequently used
+                Log.d(TAG, "Sort by frequently used");
+                sortBy = ObaContract.Routes.USE_COUNT + " desc";
+                ObaAnalytics.reportUiEvent(mFirebaseAnalytics,
+                        getString(R.string.analytics_label_sort_by_mfu_stops),
+                        null);
+                break;
+        }
+        // Set the sort option to preferences
+        final String[] sortOptions = getResources().getStringArray(R.array.sort_stops);
+        PreferenceUtils.saveString(getResources()
+                        .getString(R.string.preference_key_default_stop_sort),
+                sortOptions[index]);
+    }
+
+    @Override
+    protected int getEmptyText() {
+        return R.string.my_no_starred_routes;
+    }
+
+    public static class ClearDialog extends ClearConfirmDialog {
+
+        @Override
+        protected void doClear() {
+            ObaContract.Routes.markAsFavorite(getActivity(), ObaContract.Routes.CONTENT_URI, false);
+            ObaContract.RouteHeadsignFavorites.clearAllFavorites(getActivity());
+            ObaAnalytics.reportUiEvent(FirebaseAnalytics.getInstance(getContext()),
+                    getString(R.string.analytics_label_edit_field_bookmark_delete),
+                    null);
+        }
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/NavigationDrawerFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/NavigationDrawerFragment.java
@@ -71,17 +71,20 @@ public class NavigationDrawerFragment extends Fragment {
 
     protected static final int NAVDRAWER_ITEM_STARRED_STOPS = 1;
 
-    protected static final int NAVDRAWER_ITEM_MY_REMINDERS = 2;
+    protected static final int NAVDRAWER_ITEM_STARRED_ROUTES = 2;
 
-    protected static final int NAVDRAWER_ITEM_SETTINGS = 3;
+    protected static final int NAVDRAWER_ITEM_MY_REMINDERS = 3;
 
-    protected static final int NAVDRAWER_ITEM_HELP = 4;
+    protected static final int NAVDRAWER_ITEM_SETTINGS = 4;
 
-    protected static final int NAVDRAWER_ITEM_SEND_FEEDBACK = 5;
+    protected static final int NAVDRAWER_ITEM_HELP = 5;
 
-    protected static final int NAVDRAWER_ITEM_PLAN_TRIP = 6;
+    protected static final int NAVDRAWER_ITEM_SEND_FEEDBACK = 6;
 
-    //protected static final int NAVDRAWER_ITEM_POPULAR = 7;
+    protected static final int NAVDRAWER_ITEM_PLAN_TRIP = 7;
+
+
+
     @Deprecated
     protected static final int NAVDRAWER_ITEM_PINS = 8;
 
@@ -109,12 +112,12 @@ public class NavigationDrawerFragment extends Fragment {
     private static final int[] NAVDRAWER_TITLE_RES_ID = new int[]{
             R.string.navdrawer_item_nearby,
             R.string.navdrawer_item_starred_stops,
+            R.string.navdrawer_item_starred_routes,
             R.string.navdrawer_item_my_reminders,
             R.string.navdrawer_item_settings,
             R.string.navdrawer_item_help,
             R.string.navdrawer_item_send_feedback,
             R.string.navdrawer_item_plan_trip,
-            0, // Popular discussions
             0, // Pinned discussions
             0, // Social activity feed
             0, // My profile
@@ -126,13 +129,13 @@ public class NavigationDrawerFragment extends Fragment {
     // icons for navdrawer items (indices must correspond to above array)
     private static final int[] NAVDRAWER_ICON_RES_ID = new int[]{
             R.drawable.ic_drawer_maps_place,  // Nearby
-            R.drawable.ic_drawer_star, // Starred Stops
+            R.drawable.ic_stop_flag_triangle, // Starred Stops
+            R.drawable.ic_bus, // Starred Routes
             R.drawable.ic_drawer_alarm, // My reminders
             0, // Settings
             0, // Help
             0, // Send feedback
             R.drawable.ic_maps_directions, // Plan a trip
-            0, // Popular discussions
             0, // Pinned discussions
             0, // Social activity feed
             0, // My profile
@@ -145,12 +148,12 @@ public class NavigationDrawerFragment extends Fragment {
     private static final int[] NAVDRAWER_ICON_SECONDARY_RES_ID = new int[]{
             0,  // Nearby
             0, // Starred Stops
+            0, // Starred Routes
             0, // My reminders
             0, // Settings
             0, // Help
             0, // Send feedback
             0, // Plan a trip
-            0, // Popular discussions
             0, // Pinned discussions
             0, // Social activity feed
             0, // My profile
@@ -418,6 +421,7 @@ public class NavigationDrawerFragment extends Fragment {
 
         mNavDrawerItems.add(NAVDRAWER_ITEM_NEARBY);
         mNavDrawerItems.add(NAVDRAWER_ITEM_STARRED_STOPS);
+        mNavDrawerItems.add(NAVDRAWER_ITEM_STARRED_ROUTES);
         mNavDrawerItems.add(NAVDRAWER_ITEM_MY_REMINDERS);
 
         if (currentRegion != null) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/RouteFavoriteDialogFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/RouteFavoriteDialogFragment.java
@@ -48,6 +48,8 @@ public class RouteFavoriteDialogFragment extends DialogFragment {
 
     private static final String KEY_FAVORITE = "favorite";
 
+    private static final int ROUTE_INFO_LOADER = 0;
+
     // Selections need to match strings.xml "route_favorite_options"
     private static final int SELECTION_THIS_STOP = 0;
 
@@ -71,6 +73,7 @@ public class RouteFavoriteDialogFragment extends DialogFragment {
          */
         void onSelectionComplete(boolean savedFavorite);
     }
+
 
     /**
      * Builder used to create a new RouteFavoriteDialogFragment
@@ -207,12 +210,20 @@ public class RouteFavoriteDialogFragment extends DialogFragment {
                                     // Saved the favorite for just this stop
                                     QueryUtils.setFavoriteRouteAndHeadsign(getActivity(),
                                             routeUri, headsign, stopId, values, favorite);
+                                    getLoaderManager().initLoader(ROUTE_INFO_LOADER, null,
+                                            new QueryUtils.RouteLoaderCallback(getActivity(),
+                                                    routeId));
                                     mCallback.onSelectionComplete(true);
                                 } else {
                                     Log.d(TAG, "All stops");
                                     // Saved the favorite for all stops by passing null as stopId
                                     QueryUtils.setFavoriteRouteAndHeadsign(getActivity(),
                                             routeUri, headsign, null, values, favorite);
+                                    // Request the full details of the starred route, so that
+                                    // the long name can be displayed later
+                                    getLoaderManager().initLoader(ROUTE_INFO_LOADER, null,
+                                            new QueryUtils.RouteLoaderCallback(getActivity(),
+                                                    routeId));
                                     mCallback.onSelectionComplete(true);
                                 }
                             }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/RouteInfoListFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/RouteInfoListFragment.java
@@ -15,6 +15,19 @@
  */
 package org.onebusaway.android.ui;
 
+import org.onebusaway.android.R;
+import org.onebusaway.android.app.Application;
+import org.onebusaway.android.io.ObaApi;
+import org.onebusaway.android.io.elements.ObaStop;
+import org.onebusaway.android.io.elements.ObaStopGroup;
+import org.onebusaway.android.io.elements.ObaStopGrouping;
+import org.onebusaway.android.io.request.ObaRouteResponse;
+import org.onebusaway.android.io.request.ObaStopsForRouteRequest;
+import org.onebusaway.android.io.request.ObaStopsForRouteResponse;
+import org.onebusaway.android.provider.ObaContract;
+import org.onebusaway.android.util.FragmentUtils;
+import org.onebusaway.android.util.UIUtils;
+
 import android.content.ContentValues;
 import android.content.Context;
 import android.net.Uri;
@@ -32,20 +45,6 @@ import android.view.ViewGroup;
 import android.widget.ExpandableListView;
 import android.widget.SimpleExpandableListAdapter;
 import android.widget.TextView;
-
-import org.onebusaway.android.R;
-import org.onebusaway.android.app.Application;
-import org.onebusaway.android.io.ObaApi;
-import org.onebusaway.android.io.elements.ObaStop;
-import org.onebusaway.android.io.elements.ObaStopGroup;
-import org.onebusaway.android.io.elements.ObaStopGrouping;
-import org.onebusaway.android.io.request.ObaRouteRequest;
-import org.onebusaway.android.io.request.ObaRouteResponse;
-import org.onebusaway.android.io.request.ObaStopsForRouteRequest;
-import org.onebusaway.android.io.request.ObaStopsForRouteResponse;
-import org.onebusaway.android.provider.ObaContract;
-import org.onebusaway.android.util.FragmentUtils;
-import org.onebusaway.android.util.UIUtils;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -98,7 +97,6 @@ public class RouteInfoListFragment extends ListFragment {
             return;
         }
         mRouteId = uri.getLastPathSegment();
-
         getLoaderManager().initLoader(ROUTE_INFO_LOADER, null, mRouteCallback);
         getLoaderManager().initLoader(ROUTE_STOPS_LOADER, null, mStopsCallback);
     }
@@ -228,7 +226,7 @@ public class RouteInfoListFragment extends ListFragment {
 
         @Override
         public Loader<ObaRouteResponse> onCreateLoader(int id, Bundle args) {
-            return new RouteInfoLoader(getActivity(), mRouteId);
+            return new QueryUtils.RouteInfoLoader(getActivity(), mRouteId);
         }
 
         @Override
@@ -268,25 +266,6 @@ public class RouteInfoListFragment extends ListFragment {
     //
     // Loader
     //
-    private final static class RouteInfoLoader extends AsyncTaskLoader<ObaRouteResponse> {
-
-        private final String mRouteId;
-
-        RouteInfoLoader(Context context, String routeId) {
-            super(context);
-            mRouteId = routeId;
-        }
-
-        @Override
-        public void onStartLoading() {
-            forceLoad();
-        }
-
-        @Override
-        public ObaRouteResponse loadInBackground() {
-            return ObaRouteRequest.newRequest(getContext(), mRouteId).call();
-        }
-    }
 
     private final static class StopsForRouteLoader extends AsyncTaskLoader<StopsForRouteInfo> {
 

--- a/onebusaway-android/src/main/res/layout/route_list_item.xml
+++ b/onebusaway-android/src/main/res/layout/route_list_item.xml
@@ -12,22 +12,32 @@
      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
      See the License for the specific language governing permissions and
      limitations under the License.
+
+     Modifications copyright (C) 2023 Millan Philipose (millan.j.philipose@gmail.com)
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              style="@style/ListItem"
-              android:layout_width="fill_parent"
-              android:layout_height="wrap_content"
-              android:orientation="vertical">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    style="@style/ListItem"
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal">
     <TextView
             android:id="@+id/short_name"
-            style="@style/Line1Text"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content">
+            android:gravity="center"
+            style="@style/StopInfoRoute"
+            app:autoSizeTextType="uniform"
+            app:autoSizeMaxTextSize="36sp"
+            android:layout_width="70sp"
+            android:layout_height="60sp"
+            android:paddingStart="0sp"
+            android:paddingEnd="10sp">
     </TextView>
     <TextView
             android:id="@+id/long_name"
-            style="@style/Line2Text"
+            android:gravity="center_vertical"
+            style="@style/Line1Text"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content">
+            android:layout_height="match_parent"
+            android:paddingEnd="10sp">
     </TextView>
 </LinearLayout>

--- a/onebusaway-android/src/main/res/menu/my_starred_route_options.xml
+++ b/onebusaway-android/src/main/res/menu/my_starred_route_options.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2010 Paul Watts (paulcwatts@gmail.com)
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+
+     Modifications copyright (C) 2023 Millan Philipose (millan.j.philipose)
+     Adapted from my_starred_stop_options.xml to work for the starred stops view.
+-->
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:onebusaway="http://schemas.android.com/apk/res-auto">
+    <group
+        android:id="@+id/starred_route_menu_group">
+        <item android:id="@+id/sort_stops"
+            android:title="@string/menu_option_sort_by"
+            android:icon="@drawable/ic_action_content_sort"
+            onebusaway:showAsAction="ifRoom"/>
+        <item android:id="@+id/clear_starred"
+            android:title="@string/my_option_clear_starred_routes"
+            android:icon="@drawable/android:ic_menu_close_clear_cancel"/>
+    </group>
+</menu>

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -23,6 +23,7 @@
     <!-- Navigation Drawer -->
     <string name="navdrawer_item_nearby">Nearby</string>
     <string name="navdrawer_item_starred_stops">Starred stops</string>
+    <string name="navdrawer_item_starred_routes">Starred routes</string>
     <string name="navdrawer_item_my_reminders">My reminders</string>
     <string name="navdrawer_item_settings">Settings</string>
     <string name="navdrawer_item_help">Help</string>
@@ -370,6 +371,9 @@
     <string name="my_no_recent_stops">You have no recent stops.</string>
     <string name="my_no_starred_stops">You have no starred stops.\n\nYou can add a star to a stop on
         the arrivals screen by tapping on the star next to the stop name.
+    </string>
+    <string name="my_no_starred_routes">You have no starred routes.\n\nYou can add a star to a route
+        on the arrivals screen by tapping on the star next to the route number.
     </string>
     <string name="my_no_recent_routes">You have no recent routes.</string>
     <!-- <string name="my_no_starred_routes">You have no starred routes.</string>-->
@@ -1201,4 +1205,5 @@
     <string name="travel_behavior_dialog_opt_out_title">Opt out of study?</string>
     <string name="travel_behavior_dialog_opt_out_message">If you opt out of the research study, we won\'t receive any more information about your travel behavior to help improve public transit.</string>
     <string name="cancel">Cancel</string>
+    <string name="my_option_clear_starred_routes">Remove all starred routes</string>
 </resources>


### PR DESCRIPTION
I added a new tab below Starred Stops called Starred Routes.

![Screenshot from 2023-11-30 21-16-17](https://github.com/OneBusAway/onebusaway-android/assets/5483104/2d985517-b133-4177-b79a-006cba25f001)

It takes you to a list of routes which are starred at at least one stop.

![Screenshot from 2023-12-01 20-54-47](https://github.com/OneBusAway/onebusaway-android/assets/5483104/bbb583b5-1008-43f6-bc94-ea78d22c1ae1)

A long press on a route shows a popup menu with various options, including an option to remove all stars from that route.

![Screenshot from 2023-11-30 21-18-50](https://github.com/OneBusAway/onebusaway-android/assets/5483104/4682e505-f6b3-4157-9d14-9ec9dccd07ff)

There is also a button in the top right menu to remove all stars from all routes.

![Screenshot from 2023-12-01 21-24-00](https://github.com/OneBusAway/onebusaway-android/assets/5483104/38446ff6-147c-4ff4-b656-7b8315cea3f6)

When the user taps one of the starred routes, it shows the map view for that route. 

![Screenshot from 2023-12-01 21-17-20](https://github.com/OneBusAway/onebusaway-android/assets/5483104/c0047010-e67e-4e48-9a14-45593e67ea14)

This is better than the old method of showing a text-based list of stops because the map is much more readable and it provides useful information about the actual location of buses. Most users I have spoken to do not know that the route-specific map view exists, and they say that it is useful when I show it to them. I modified the "recent routes" list to have similar behavior.

I made one change to existing code, factoring out the classes RouteInfoLoader and RouteInfoLoaderCallback from RouteInfoListFragment into QueryUtils. This is because I need to load the long name of a route when it is starred by the user, to make sure that the Starred Routes page is fully populated.