### PR TITLE
Fix background shading in arrival list

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListFragment.java
@@ -1136,7 +1136,7 @@ public class ArrivalsListFragment extends ListFragment
         listParam.leftMargin = UIUtils.dpToPixels(getActivity(), 5);
         listParam.rightMargin = UIUtils.dpToPixels(getActivity(), 5);
         // Set the listview background to give the cards more contrast
-        getListView().setBackgroundColor(
+        getListView().getRootView().setBackgroundColor(
                 getResources().getColor(R.color.stop_info_arrival_list_background));
         // Update the layout parameters
         getListView().setLayoutParams(listParam);

--- a/onebusaway-android/src/main/res/layout/arrivals_list_empty_style.xml
+++ b/onebusaway-android/src/main/res/layout/arrivals_list_empty_style.xml
@@ -13,33 +13,35 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<LinearLayout
-        xmlns:android="http://schemas.android.com/apk/res/android"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:paddingBottom="2dp"
-        android:paddingTop="3dp"
-        android:paddingLeft="5dp"
-        android:paddingRight="5dp"
-        android:orientation="vertical">
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@color/stop_info_arrival_list_background"
+    android:orientation="vertical"
+    android:paddingLeft="5dp"
+    android:paddingTop="3dp"
+    android:paddingRight="5dp"
+    android:paddingBottom="2dp">
 
-    <androidx.cardview.widget.CardView
-            xmlns:card_view="http://schemas.android.com/apk/res-auto"
-            android:id="@+id/no_arrivals_card_view"
-            android:layout_gravity="center"
+    <androidx.cardview.widget.CardView xmlns:card_view="http://schemas.android.com/apk/res-auto"
+        android:id="@+id/no_arrivals_card_view"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        card_view:cardCornerRadius="4dp"
+        card_view:cardUseCompatPadding="true">
+
+        <TextView
+            android:id="@+id/noArrivals"
+            style="@style/ListHintText"
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"
-            card_view:cardUseCompatPadding="true"
-            card_view:cardCornerRadius="4dp">
-
-        <TextView android:id="@+id/noArrivals"
-                  style="@style/ListHintText"
-                  android:paddingBottom="15sp"
-                  android:layout_width="fill_parent"
-                  android:layout_height="wrap_content"/>
+            android:paddingBottom="15sp" />
     </androidx.cardview.widget.CardView>
-    <include layout="@layout/arrivals_list_footer_style"
-             android:layout_width="match_parent"
-             android:layout_height="wrap_content"/>
+
+    <include
+        layout="@layout/arrivals_list_footer_style"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
 </LinearLayout>
 


### PR DESCRIPTION
Fix for #451 regarding inconsistent background shading behind cards.

Changes:
arrivals_list_empty_style.xml: arrival_list_background background color was added to arrivals_list_empty_style.xml to add the background color properly when the arrival list is empty.
ArrivalsListFragment.java: Apply background color to root view of list view, this sets the arrival_list_background color properly to the entire area.

Screenshots:
Arrival List when empty before fix:
![image](https://github.com/OneBusAway/onebusaway-android/assets/53415491/df6abd81-a87c-4d46-92a3-dcee0671a5a4)
Arrival List when empty after fix:
![image](https://github.com/OneBusAway/onebusaway-android/assets/53415491/a46b85a0-9a6a-4a79-aa46-cd2a17acac70)
Arrival List with content before fix:
![image](https://github.com/OneBusAway/onebusaway-android/assets/53415491/22772cc8-c0f7-4fa0-b18a-b7fee92d1d63)
Arrival List with content after fix:
![image](https://github.com/OneBusAway/onebusaway-android/assets/53415491/34e66ce1-960e-4d23-bd44-39638bdb73a3)

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the AndroidStyle.xml style template to your code in Android Studio.
- [x] Run the unit tests with gradlew connectedObaGoogleDebugAndroidTest connectedObaAmazonDebugAndroidTest to make sure you didn't break anything
- [x] If you have multiple commits please combine them into one commit by squashing them for the initial submission of the pull request. When addressing comments on a pull request, please push a new commit per comment when possible (reviewers will squash and merge using GitHub merge tool)