### PR TITLE
Make the dark mode override 'stick' (#1104)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/app/Application.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/app/Application.java
@@ -61,6 +61,7 @@ import edu.usf.cutr.open311client.Open311Manager;
 import edu.usf.cutr.open311client.models.Open311Option;
 
 import static com.google.android.gms.location.LocationServices.getFusedLocationProviderClient;
+import static org.onebusaway.android.util.UIUtils.setAppTheme;
 
 public class Application extends MultiDexApplication {
 
@@ -436,6 +437,7 @@ public class Application extends MultiDexApplication {
         }
 
         checkArrivalStylePreferenceDefault();
+        checkDarkMode();
 
         // Get the current app version.
         PackageManager pm = getPackageManager();
@@ -478,6 +480,15 @@ public class Application extends MultiDexApplication {
                     Log.d(TAG, "Using arrival info style B (Cards) as default preference");
                     break;
             }
+        }
+    }
+
+    private void checkDarkMode() {
+        String appThemePrefKey = getResources()
+                .getString(R.string.preference_key_app_theme);
+        String appThemePref = mPrefs.getString(appThemePrefKey, null);
+        if (appThemePref != null) {
+            setAppTheme(appThemePref);
         }
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/PreferencesActivity.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/PreferencesActivity.java
@@ -20,6 +20,7 @@ package org.onebusaway.android.ui;
 import static org.onebusaway.android.util.PermissionUtils.RESTORE_BACKUP_PERMISSION_REQUEST;
 import static org.onebusaway.android.util.PermissionUtils.SAVE_BACKUP_PERMISSION_REQUEST;
 import static org.onebusaway.android.util.PermissionUtils.STORAGE_PERMISSIONS;
+import static org.onebusaway.android.util.UIUtils.setAppTheme;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
@@ -664,18 +665,6 @@ public class PreferencesActivity extends PreferenceActivity
 
             // Since the current region was updated as a result of enabling/disabling experimental servers, go home
             NavHelp.goHome(this, false);
-        }
-    }
-
-    private void setAppTheme(String themeValue) {
-        if (themeValue.equalsIgnoreCase(Application.get().getString(R.string.preferences_app_theme_option_system_default))) {
-            AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM);
-        }
-        if (themeValue.equalsIgnoreCase(Application.get().getString(R.string.preferences_app_theme_option_dark))) {
-            AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES);
-        }
-        if (themeValue.equalsIgnoreCase(Application.get().getString(R.string.preferences_app_theme_option_light))) {
-            AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO);
         }
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/RouteFavoriteDialogFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/RouteFavoriteDialogFragment.java
@@ -28,6 +28,7 @@ import android.os.Bundle;
 import android.util.Log;
 
 import androidx.fragment.app.DialogFragment;
+import androidx.loader.app.LoaderManager;
 
 /**
  * Asks the user if they was to save a route/headsign favorite for all stops, or just this stop
@@ -210,7 +211,8 @@ public class RouteFavoriteDialogFragment extends DialogFragment {
                                     // Saved the favorite for just this stop
                                     QueryUtils.setFavoriteRouteAndHeadsign(getActivity(),
                                             routeUri, headsign, stopId, values, favorite);
-                                    getLoaderManager().initLoader(ROUTE_INFO_LOADER, null,
+                                    LoaderManager.getInstance(getActivity()).restartLoader(
+                                            ROUTE_INFO_LOADER, null,
                                             new QueryUtils.RouteLoaderCallback(getActivity(),
                                                     routeId));
                                     mCallback.onSelectionComplete(true);
@@ -221,7 +223,8 @@ public class RouteFavoriteDialogFragment extends DialogFragment {
                                             routeUri, headsign, null, values, favorite);
                                     // Request the full details of the starred route, so that
                                     // the long name can be displayed later
-                                    getLoaderManager().initLoader(ROUTE_INFO_LOADER, null,
+                                    LoaderManager.getInstance(getActivity()).restartLoader(
+                                            ROUTE_INFO_LOADER, null,
                                             new QueryUtils.RouteLoaderCallback(getActivity(),
                                                     routeId));
                                     mCallback.onSelectionComplete(true);

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/UIUtils.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/UIUtils.java
@@ -76,6 +76,7 @@ import androidx.annotation.NonNull;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.app.AppCompatDelegate;
 import androidx.appcompat.widget.SearchView;
 import androidx.core.content.ContextCompat;
 import androidx.core.content.pm.ShortcutInfoCompat;
@@ -2009,5 +2010,17 @@ public final class UIUtils {
         intent.setAction(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS);
         intent.setData(Uri.parse("package:" + activity.getPackageName()));
         activity.startActivity(intent);
+    }
+
+    public static void setAppTheme(String themeValue) {
+        if (themeValue.equalsIgnoreCase(Application.get().getString(R.string.preferences_app_theme_option_system_default))) {
+            AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM);
+        }
+        if (themeValue.equalsIgnoreCase(Application.get().getString(R.string.preferences_app_theme_option_dark))) {
+            AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES);
+        }
+        if (themeValue.equalsIgnoreCase(Application.get().getString(R.string.preferences_app_theme_option_light))) {
+            AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO);
+        }
     }
 }


### PR DESCRIPTION
This fix ensures that the map remembers the user's selection of either light or dark mode, even when the app stops and starts.