### PR TITLE
Allow use of a non-HTTPS localhost OBA server

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/PreferencesActivity.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/PreferencesActivity.java
@@ -619,14 +619,24 @@ public class PreferencesActivity extends PreferenceActivity
      * @return true if the provided apiUrl could be a valid URL, false if it could not
      */
     private boolean validateUrl(String apiUrl) {
-        try {
-            // URI.parse() doesn't tell us if the scheme is missing, so use URL() instead (#126)
-            URL url = new URL(apiUrl);
-        } catch (MalformedURLException e) {
+        if (!apiUrl.startsWith("http")) {
             // Assume HTTPS scheme if none is provided
             apiUrl = getString(R.string.https_prefix) + apiUrl;
         }
-        return Patterns.WEB_URL.matcher(apiUrl).matches();
+
+        URL url = null;
+        try {
+            // URI.parse() doesn't tell us if the scheme is missing, so use URL() instead (#126)
+            url = new URL(apiUrl);
+        } catch (MalformedURLException e) {
+            return false;
+        }
+
+        if (url.getHost().equals("localhost")) {
+            return true;
+        } else {
+            return Patterns.WEB_URL.matcher(apiUrl).matches();
+        }
     }
 
     /**

--- a/onebusaway-android/src/main/res/xml/network_security_config.xml
+++ b/onebusaway-android/src/main/res/xml/network_security_config.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <!-- See https://github.com/OneBusAway/onebusaway-multiregion-support/issues/14 for TODO list
-    of regions still working to transition to HTTPS. Exceptions for these regions are below. -->
     <domain-config cleartextTrafficPermitted="true">
-        <!-- San Diego OTP server -->
-        <domain includeSubdomains="true">realtime.sdmts.com</domain>
+        <domain includeSubdomains="true">localhost</domain>
     </domain-config>
 </network-security-config>


### PR DESCRIPTION
I want to be able to use a locally-hosted OBA server with the OBA Android app, just like I can with the OBA iOS app. Previously, this was prevented by two issues: 1. the regex check for determining if a server was valid, and 2. the network security config policy.

This commit alters both, first by allowing valid localhost URLs and second by modifying the network security config policy.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `gradlew connectedObaGoogleDebugAndroidTest` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them for the initial submission of the pull request.  When addressing comments on a pull request, please push a new commit per comment when possible (reviewers will squash and merge using GitHub merge tool)