### PR TITLE
Fix #1124 - Added localhost correct IP for the emulator.

### DIFF
--- a/onebusaway-android/src/main/res/xml/network_security_config.xml
+++ b/onebusaway-android/src/main/res/xml/network_security_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
     <domain-config cleartextTrafficPermitted="true">
-        <domain includeSubdomains="true">localhost</domain>
+        <domain includeSubdomains="true">10.0.2.2</domain>
     </domain-config>
 </network-security-config>


### PR DESCRIPTION
Fixed #1124 

After running the local server using docker in my machine, I started to monitor the API calls, I found that it's incorrect to use `127.0.0.1 or localhost` because the Android emulator runs in a VM therefore here 127.0.0.1 or localhost will be an emulator's loopback address.

So it's correct to use `http://10.0.2.2:8080/` as a base URL for connecting to a local host.


Ref : 

- https://developer.android.com/studio/run/emulator-networking
- https://stackoverflow.com/a/5495789

Successful calling in Android emulator.

![image](https://github.com/OneBusAway/onebusaway-android/assets/29693819/b860a69f-4d97-42b9-aa77-d72ca53843f8)


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `gradlew connectedObaGoogleDebugAndroidTest` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them for the initial submission of the pull request.  When addressing comments on a pull request, please push a new commit per comment when possible (reviewers will squash and merge using GitHub merge tool)