### PR TITLE
Enhancement: Added directions to polylines when routing

### DIFF
--- a/onebusaway-android/build.gradle
+++ b/onebusaway-android/build.gradle
@@ -348,7 +348,7 @@ dependencies {
     // Pelias for point-of-interest search and geocoding for trip planning origin and destination
     implementation 'edu.usf.cutr:pelias-client-library:1.1.0'
     // Google Play Services Maps (only for Google flavor)
-    googleImplementation 'com.google.android.gms:play-services-maps:18.0.2'
+    googleImplementation 'com.google.android.gms:play-services-maps:18.2.0'
     // Google Play Services Places is required by ProprietaryMapHelpV2 (only for Google flavor)
     googleImplementation 'com.google.android.libraries.places:places-compat:1.1.0'
     // Autocomplete text views with clear button for trip planning

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/BaseMapFragment.java
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/BaseMapFragment.java
@@ -53,6 +53,7 @@ import com.google.android.gms.maps.LocationSource;
 import com.google.android.gms.maps.OnMapReadyCallback;
 import com.google.android.gms.maps.SupportMapFragment;
 import com.google.android.gms.maps.UiSettings;
+import com.google.android.gms.maps.model.BitmapDescriptorFactory;
 import com.google.android.gms.maps.model.CameraPosition;
 import com.google.android.gms.maps.model.LatLng;
 import com.google.android.gms.maps.model.LatLngBounds;
@@ -60,6 +61,10 @@ import com.google.android.gms.maps.model.MapStyleOptions;
 import com.google.android.gms.maps.model.Marker;
 import com.google.android.gms.maps.model.Polyline;
 import com.google.android.gms.maps.model.PolylineOptions;
+import com.google.android.gms.maps.model.StampStyle;
+import com.google.android.gms.maps.model.StrokeStyle;
+import com.google.android.gms.maps.model.StyleSpan;
+import com.google.android.gms.maps.model.TextureStyle;
 import com.google.android.gms.maps.model.VisibleRegion;
 import com.google.firebase.analytics.FirebaseAnalytics;
 
@@ -1038,12 +1043,18 @@ public class BaseMapFragment extends SupportMapFragment
                 mLineOverlay.clear();
             }
             PolylineOptions lineOptions;
+            StampStyle polylineArrow = TextureStyle.newBuilder(
+                BitmapDescriptorFactory.fromResource(R.drawable.ic_navigation_expand_more)
+            ).build();
+            StyleSpan polylineArrowSpan = new StyleSpan(
+                StrokeStyle.colorBuilder(lineOverlayColor).stamp(polylineArrow).build()
+            );
 
             int totalPoints = 0;
 
             for (ObaShape s : shapes) {
                 lineOptions = new PolylineOptions();
-                lineOptions.color(lineOverlayColor);
+                lineOptions.addSpan(polylineArrowSpan);
 
                 for (Location l : s.getPoints()) {
                     lineOptions.add(MapHelpV2.makeLatLng(l));


### PR DESCRIPTION
Upgraded gms:play-services-maps to 18.2.0 allows for arrows to be built into polylines which was previously not possible; this makes the directions of the routes easier to differentiate.

Fixes #910

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `gradlew connectedObaGoogleDebugAndroidTest` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them for the initial submission of the pull request.  When addressing comments on a pull request, please push a new commit per comment when possible (reviewers will squash and merge using GitHub merge tool)