### PR TITLE
Fixed #1121 - Correct Spacing

### DIFF
--- a/onebusaway-android/src/main/res/layout/main.xml
+++ b/onebusaway-android/src/main/res/layout/main.xml
@@ -94,7 +94,7 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_gravity="bottom|end"
-                        android:layout_marginBottom="72dp"
+                        android:layout_marginBottom="80dp"
                         android:layout_alignParentBottom="true"
                         android:layout_alignParentRight="true"
                         android:drawable="@drawable/ic_layers_white_24dp"/>


### PR DESCRIPTION
Fixed #1121

- Increasing the margin between the two buttons
- Refactor: Instead of using left and right it's better to use start and end for RTL support.

I have tested different scenarios for the two buttons like opening the arrivals list / using locations that don't have bike-sharing options


Screenshots:

<table>
  <tr>
    <td><img src="https://github.com/OneBusAway/onebusaway-android/assets/29693819/986936f2-6802-4b26-8c93-0b0a535b7e60" alt="correct2" style="width:100%;"></td>
    <td><img src="https://github.com/OneBusAway/onebusaway-android/assets/29693819/3981e83f-b6ae-4a01-90ea-44f1259ef26e" alt="correct1" style="width:100%;"></td>
    <td><img src="https://github.com/OneBusAway/onebusaway-android/assets/29693819/a932aa95-a217-4daf-b834-2508f0c1c032" alt="Screenshot_1708878024" style="width:100%;"></td>
  </tr>
</table>



Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `gradlew connectedObaGoogleDebugAndroidTest` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them for the initial submission of the pull request.  When addressing comments on a pull request, please push a new commit per comment when possible (reviewers will squash and merge using GitHub merge tool)