### PR TITLE
Fixed #629 - Vehicle marker arrow overlap

### DIFF
--- a/onebusaway-android/src/main/res/layout/vehicle_info_window.xml
+++ b/onebusaway-android/src/main/res/layout/vehicle_info_window.xml
@@ -23,10 +23,12 @@
         style="@style/StopInfoDestination"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        app:layout_constraintStart_toStartOf="parent"
-        tools:text="5 - North to Univerity Area TC"
         android:ellipsize="end"
-        android:singleLine="true" />
+        android:singleLine="true"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="5 - North to Univerity Area TC" />
 
     <include
         android:id="@+id/status"
@@ -52,23 +54,26 @@
     <TextView
         android:id="@+id/last_updated"
         style="@style/StopInfoTime"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/trip_more_info"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/status"
+        app:layout_constraintVertical_bias="0.0"
         tools:text="Updated 3 min ago" />
 
     <ImageView
         android:id="@+id/trip_more_info"
         android:layout_width="28dp"
         android:layout_height="28dp"
-        app:layout_constraintEnd_toEndOf="@+id/route_and_destination"
-        app:layout_constraintBottom_toBottomOf="@id/last_updated"
-        android:translationY="4dp"
-        android:translationX="9dp"
-        android:src="@drawable/ic_navigation_chevron_right"
-        android:maxHeight="24dp"
+        android:adjustViewBounds="true"
         android:maxWidth="24dp"
+        android:maxHeight="24dp"
         android:scaleType="fitCenter"
-        android:adjustViewBounds="true" />
+        android:src="@drawable/ic_navigation_chevron_right"
+
+        app:layout_constraintBottom_toBottomOf="@id/last_updated"
+        app:layout_constraintEnd_toEndOf="@+id/route_and_destination"
+        app:layout_constraintTop_toTopOf="@+id/last_updated" />
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Fixes #629 

Here is the example before and after.

| Before | After | After | After |
|--------|-------|-------|-------|
| ![before](https://github.com/OneBusAway/onebusaway-android/assets/29693819/c2026707-2ef6-448a-872a-78741b0c9cab) | ![afterf](https://github.com/OneBusAway/onebusaway-android/assets/29693819/87ed5e9e-a337-4d07-9104-9283cb57e836) | ![after1](https://github.com/OneBusAway/onebusaway-android/assets/29693819/dacf9593-c33d-4499-9cf8-7ac3e5f4ee34) | ![after2](https://github.com/OneBusAway/onebusaway-android/assets/29693819/d0e8006e-5fd3-4557-9775-67ef7a95cc85) |

Updating time will take a new line and will not overlap with the arrow.


- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `gradlew connectedObaGoogleDebugAndroidTest` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them for the initial submission of the pull request.  When addressing comments on a pull request, please push a new commit per comment when possible (reviewers will squash and merge using GitHub merge tool)