### PR TITLE
Fixed #1140 - Support for dark mode when removing POI.

### DIFF
--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/BaseMapFragment.java
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/BaseMapFragment.java
@@ -338,6 +338,10 @@ public class BaseMapFragment extends SupportMapFragment
                 )
         ) {
             mMap.setMapStyle(MapStyleOptions.loadRawResourceStyle(getContext(), R.raw.dark_map));
+        }else{
+            // it's a light mode just remove POI
+            String removePOIStyle = "[{\"featureType\":\"poi\",\"elementType\":\"all\",\"stylers\":[{\"visibility\":\"off\"}]}]";
+            mMap.setMapStyle(new MapStyleOptions(removePOIStyle));
         }
 
         initMap(mLastSavedInstanceState);
@@ -379,9 +383,7 @@ public class BaseMapFragment extends SupportMapFragment
             initMapState(args);
         }
 
-        // Remove All POI from the map
-        String removePOIStyle = "[{\"featureType\":\"poi\",\"elementType\":\"all\",\"stylers\":[{\"visibility\":\"off\"}]}]";
-        mMap.setMapStyle(new MapStyleOptions(removePOIStyle));
+
     }
 
     private void initMapState(Bundle args) {

--- a/onebusaway-android/src/main/res/raw/dark_map.json
+++ b/onebusaway-android/src/main/res/raw/dark_map.json
@@ -1,5 +1,14 @@
 [
   {
+    "featureType": "poi",
+    "elementType": "all",
+    "stylers": [
+      {
+        "visibility": "off"
+      }
+    ]
+  },
+  {
     "featureType": "all",
     "elementType": "geometry",
     "stylers": [


### PR DESCRIPTION
Fixes #1140 

There was a conflict between setting a style for removing POI and the dark mode, now it's fixed by doing a configuration for map dark mode files.


<table>
  <tr>
    <td><img src="https://github.com/OneBusAway/onebusaway-android/assets/29693819/5d1ea51c-9b1a-4546-83cc-ccaf5e334d70" alt="Screenshot_1709738307"></td>
    <td><img src="https://github.com/OneBusAway/onebusaway-android/assets/29693819/7c2a36fb-0506-4f77-ad39-0be955591656" alt="Screenshot_1709738238"></td>
  </tr>
</table>



- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `gradlew connectedObaGoogleDebugAndroidTest` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them for the initial submission of the pull request.  When addressing comments on a pull request, please push a new commit per comment when possible (reviewers will squash and merge using GitHub merge tool)