### PR TITLE
Fixed #1132 - Removed text "Current location" from fragment_trip_plan…

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/TripPlanFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/TripPlanFragment.java
@@ -575,8 +575,7 @@ public class TripPlanFragment extends Fragment {
             address.setLatitude(loc.getLatitude());
             address.setLongitude(loc.getLongitude());
         }
-
-        address.setAddressLine(0, getString(R.string.tripplanner_current_location));
+        
         return address;
     }
 

--- a/onebusaway-android/src/main/res/layout/fragment_trip_plan.xml
+++ b/onebusaway-android/src/main/res/layout/fragment_trip_plan.xml
@@ -45,7 +45,6 @@
                     android:id="@+id/fromAddressTextArea"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="@string/tripplanner_current_location"
                     android:hint="@string/trip_plan_start_location_hint"
                     android:linksClickable="true"
                     android:singleLine="true"


### PR DESCRIPTION
….xml and unwanted line address.setAddressLine(0, getString(R.string.tripplanner_current_location)); at line no. 579

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `gradlew connectedObaGoogleDebugAndroidTest` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them for the initial submission of the pull request.  When addressing comments on a pull request, please push a new commit per comment when possible (reviewers will squash and merge using GitHub merge tool)