### PR TITLE
Fixed #895 - Allow saving for routes into the DB

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListFragment.java
@@ -829,6 +829,8 @@ public class ArrivalsListFragment extends ListFragment
         if (mListener != null) {
             handled = mListener.onShowRouteOnMapSelected(arrivalInfo);
         }
+        // Save to recent routes
+        DBUtil.addRouteToDB(getActivity(),arrivalInfo);
         // If the event hasn't been handled by the listener, start a new activity
         if (!handled) {
             HomeActivity.start(getActivity(), arrivalInfo.getInfo().getRouteId());
@@ -1429,6 +1431,10 @@ public class ArrivalsListFragment extends ListFragment
     }
 
     private void goToTripDetails(ArrivalInfo stop) {
+
+        // Save to recent routes
+        DBUtil.addRouteToDB(getActivity(),stop);
+
         TripDetailsActivity.start(getActivity(),
                 stop.getInfo().getTripId(), stop.getInfo().getStopId(),
                 TripDetailsListFragment.SCROLL_MODE_STOP);

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/SearchResultsFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/SearchResultsFragment.java
@@ -44,6 +44,7 @@ import org.onebusaway.android.io.request.ObaRoutesForLocationResponse;
 import org.onebusaway.android.io.request.ObaStopsForLocationRequest;
 import org.onebusaway.android.io.request.ObaStopsForLocationResponse;
 import org.onebusaway.android.util.ArrayAdapter;
+import org.onebusaway.android.util.DBUtil;
 import org.onebusaway.android.util.LocationUtils;
 import org.onebusaway.android.util.UIUtils;
 
@@ -196,6 +197,7 @@ public class SearchResultsFragment extends ListFragment
 
         builder.setItems(R.array.search_route_options, new DialogInterface.OnClickListener() {
             public void onClick(DialogInterface dialog, int which) {
+                DBUtil.addRouteToDB(getActivity(),route);
                 switch (which) {
                     case 0:
                         // Show on list
@@ -205,6 +207,7 @@ public class SearchResultsFragment extends ListFragment
                         // Show on map
                         HomeActivity.start(getActivity(), routeId);
                         break;
+
                 }
             }
         });

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/DBUtil.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/DBUtil.java
@@ -1,10 +1,15 @@
 package org.onebusaway.android.util;
 
 import org.onebusaway.android.app.Application;
+import org.onebusaway.android.io.elements.ObaRoute;
 import org.onebusaway.android.io.elements.ObaStop;
 import org.onebusaway.android.provider.ObaContract;
+import org.onebusaway.android.ui.ArrivalInfo;
 
 import android.content.ContentValues;
+import android.content.Context;
+
+import com.squareup.okhttp.Route;
 
 /**
  * Created by azizmb9494 on 2/20/16.
@@ -24,5 +29,31 @@ public class DBUtil {
             values.put(ObaContract.Stops.REGION_ID, Application.get().getCurrentRegion().getId());
         }
         ObaContract.Stops.insertOrUpdate(stop.getId(), values, true);
+    }
+
+    public static void addRouteToDB(Context ctx, ArrivalInfo arrivalInfo){
+        ContentValues routeValues = new ContentValues();
+
+        routeValues.put(ObaContract.Routes.SHORTNAME, arrivalInfo.getInfo().getShortName());
+        routeValues.put(ObaContract.Routes.LONGNAME, arrivalInfo.getInfo().getRouteLongName());
+
+        if (Application.get().getCurrentRegion() != null) {
+            routeValues.put(ObaContract.Routes.REGION_ID,
+                    Application.get().getCurrentRegion().getId());
+        }
+        ObaContract.Routes.insertOrUpdate(ctx, arrivalInfo.getInfo().getRouteId(), routeValues, true);
+    }
+
+    public static void addRouteToDB(Context ctx, ObaRoute route){
+        ContentValues routeValues = new ContentValues();
+
+        routeValues.put(ObaContract.Routes.SHORTNAME, route.getShortName());
+        routeValues.put(ObaContract.Routes.LONGNAME, route.getLongName());
+
+        if (Application.get().getCurrentRegion() != null) {
+            routeValues.put(ObaContract.Routes.REGION_ID,
+                    Application.get().getCurrentRegion().getId());
+        }
+        ObaContract.Routes.insertOrUpdate(ctx, route.getId(), routeValues, true);
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/DBUtil.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/DBUtil.java
@@ -8,8 +8,7 @@ import org.onebusaway.android.ui.ArrivalInfo;
 
 import android.content.ContentValues;
 import android.content.Context;
-
-import com.squareup.okhttp.Route;
+import android.text.TextUtils;
 
 /**
  * Created by azizmb9494 on 2/20/16.
@@ -34,8 +33,15 @@ public class DBUtil {
     public static void addRouteToDB(Context ctx, ArrivalInfo arrivalInfo){
         ContentValues routeValues = new ContentValues();
 
-        routeValues.put(ObaContract.Routes.SHORTNAME, arrivalInfo.getInfo().getShortName());
-        routeValues.put(ObaContract.Routes.LONGNAME, arrivalInfo.getInfo().getRouteLongName());
+        String shortName = arrivalInfo.getInfo().getShortName();
+        String longName = arrivalInfo.getInfo().getRouteLongName();
+
+        if (TextUtils.isEmpty(longName)) {
+            longName = UIUtils.formatDisplayText(arrivalInfo.getInfo().getHeadsign());
+        }
+
+        routeValues.put(ObaContract.Routes.SHORTNAME, shortName);
+        routeValues.put(ObaContract.Routes.LONGNAME, longName);
 
         if (Application.get().getCurrentRegion() != null) {
             routeValues.put(ObaContract.Routes.REGION_ID,
@@ -47,8 +53,18 @@ public class DBUtil {
     public static void addRouteToDB(Context ctx, ObaRoute route){
         ContentValues routeValues = new ContentValues();
 
-        routeValues.put(ObaContract.Routes.SHORTNAME, route.getShortName());
-        routeValues.put(ObaContract.Routes.LONGNAME, route.getLongName());
+        String shortName = route.getShortName();
+        String longName = route.getLongName();
+
+        if (TextUtils.isEmpty(shortName)) {
+            shortName = longName;
+        }
+        if (TextUtils.isEmpty(longName) || shortName.equals(longName)) {
+            longName = route.getDescription();
+        }
+        routeValues.put(ObaContract.Routes.SHORTNAME, shortName);
+        routeValues.put(ObaContract.Routes.LONGNAME, longName);
+        routeValues.put(ObaContract.Routes.URL, route.getUrl());
 
         if (Application.get().getCurrentRegion() != null) {
             routeValues.put(ObaContract.Routes.REGION_ID,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/DBUtil.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/DBUtil.java
@@ -31,6 +31,8 @@ public class DBUtil {
     }
 
     public static void addRouteToDB(Context ctx, ArrivalInfo arrivalInfo){
+        if (Application.get().getCurrentRegion() == null) return;
+
         ContentValues routeValues = new ContentValues();
 
         String shortName = arrivalInfo.getInfo().getShortName();
@@ -42,15 +44,14 @@ public class DBUtil {
 
         routeValues.put(ObaContract.Routes.SHORTNAME, shortName);
         routeValues.put(ObaContract.Routes.LONGNAME, longName);
+        routeValues.put(ObaContract.Routes.REGION_ID, Application.get().getCurrentRegion().getId());
 
-        if (Application.get().getCurrentRegion() != null) {
-            routeValues.put(ObaContract.Routes.REGION_ID,
-                    Application.get().getCurrentRegion().getId());
-        }
         ObaContract.Routes.insertOrUpdate(ctx, arrivalInfo.getInfo().getRouteId(), routeValues, true);
     }
 
     public static void addRouteToDB(Context ctx, ObaRoute route){
+        if (Application.get().getCurrentRegion() == null) return;
+
         ContentValues routeValues = new ContentValues();
 
         String shortName = route.getShortName();
@@ -62,14 +63,12 @@ public class DBUtil {
         if (TextUtils.isEmpty(longName) || shortName.equals(longName)) {
             longName = route.getDescription();
         }
+
         routeValues.put(ObaContract.Routes.SHORTNAME, shortName);
         routeValues.put(ObaContract.Routes.LONGNAME, longName);
         routeValues.put(ObaContract.Routes.URL, route.getUrl());
+        routeValues.put(ObaContract.Routes.REGION_ID, Application.get().getCurrentRegion().getId());
 
-        if (Application.get().getCurrentRegion() != null) {
-            routeValues.put(ObaContract.Routes.REGION_ID,
-                    Application.get().getCurrentRegion().getId());
-        }
         ObaContract.Routes.insertOrUpdate(ctx, route.getId(), routeValues, true);
     }
 }


### PR DESCRIPTION
Fixes #895 

### Details

After a couple of hours investigating the issue and the DB and trying to debug the saving into the DB, I found that class `ObaContract` is responsible for the CRUD operations and after reviewing the class code I found that an inner class called `Routes` that was having a function called `InsertOrUpdate` and sure the class responsible for managing `CRUD` operations of recent routes and I found that this method isn't used when showing a route on the map / showing trip statues / searching for a route and of course, saving will not work in this case.

### Fix
I wrote two functions in the `DBUtil` class that will work to save the route when showing it showing trip statues / or clicking on the route in search results. and called this function when all of these operations are used and now it's working perfectly.


### Video showing trying different test cases

[Screencast from 03-09-2024 01:47:30 PM.webm](https://github.com/OneBusAway/onebusaway-android/assets/29693819/e55d8d84-08c8-4dc5-b6ca-1e3c5bd78128)



- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `gradlew connectedObaGoogleDebugAndroidTest` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them for the initial submission of the pull request.  When addressing comments on a pull request, please push a new commit per comment when possible (reviewers will squash and merge using GitHub merge tool)