### PR TITLE
Fixed #1163 - Restoring backup crash.

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/PreferencesActivity.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/PreferencesActivity.java
@@ -402,7 +402,9 @@ public class PreferencesActivity extends PreferenceActivity
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
         if (requestCode == REQUEST_CODE_RESTORE_BACKUP) {
-            BackupUtils.restore(this, data.getData());
+            if(data != null){
+                BackupUtils.restore(this, data.getData());
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #1163.

### Details

The issue was about the `onActivityResult` method. The `onActivityResult` method is a callback method in an Android Activity class that gets called automatically when another activity launched by the current activity exits, delivering a result back to it. This method is used to handle the result returned by the child activity. so the method was responsible for getting the data from the `File picker activity` about our `backup-file`, when we go back and do not select any file we get a `null expection`.


### Fix

Added validation for null data that returns.

### Video

[Screencast from 03-11-2024 01:44:48 PM.webm](https://github.com/OneBusAway/onebusaway-android/assets/29693819/245ae03c-8fd8-4935-bc9c-dd71ac6c875c)



- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `gradlew connectedObaGoogleDebugAndroidTest` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them for the initial submission of the pull request.  When addressing comments on a pull request, please push a new commit per comment when possible (reviewers will squash and merge using GitHub merge tool)