### PR TITLE
Fixed #1165 - Trip planner crash

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/tasks/TripRequest.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/tasks/TripRequest.java
@@ -104,7 +104,7 @@ public class TripRequest extends AsyncTask<Request, Integer, Long> {
             return;
         }
 
-        if (!mResponse.getPlan().getItinerary().isEmpty() && mResponse != null && mResponse.getPlan() != null
+        if (mResponse != null && mResponse.getPlan() != null && !mResponse.getPlan().getItinerary().isEmpty()
                 && mResponse.getPlan().getItinerary().get(0) != null) {
             mCallback.onTripRequestComplete(mResponse.getPlan(), mRequestUrl);
         } else {


### PR DESCRIPTION
Fixes #1165.

### Details

Some regions doesn't return an empty plan otherwise there is a null plan, so first we need to check if we have a non-null response then we need to check if we have a non-null plan

### Fix

Editing conditions to avoid null exception.

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `gradlew connectedObaGoogleDebugAndroidTest` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them for the initial submission of the pull request.  When addressing comments on a pull request, please push a new commit per comment when possible (reviewers will squash and merge using GitHub merge tool)