### PR TITLE
Fixed #1171: Changed OTP Routes Color Logic

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/OTPConstants.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/OTPConstants.java
@@ -18,6 +18,8 @@ package org.onebusaway.android.directions.util;
 
 import org.onebusaway.android.BuildConfig;
 
+import android.graphics.Color;
+
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 
@@ -73,6 +75,8 @@ public class OTPConstants {
 
     // flag to indicate intent sent by or on behalf of TripPlanActivity
     public static final String INTENT_SOURCE = "org.onebusaway.android.INTENT_SOURCE";
+
+    public static final int OTP_TRANSIT_COLOR = Color.parseColor("#006500");
 
     public enum Source {ACTIVITY, NOTIFICATION}
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/DirectionsMapController.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/DirectionsMapController.java
@@ -16,6 +16,7 @@
 
 package org.onebusaway.android.map;
 
+import org.onebusaway.android.directions.util.OTPConstants;
 import org.onebusaway.android.io.elements.ObaShape;
 import org.onebusaway.android.io.elements.ObaShapeElement;
 import org.onebusaway.android.util.LocationUtils;
@@ -191,6 +192,12 @@ public class DirectionsMapController implements MapModeController {
     }
 
     private static int resolveColor(Leg leg) {
+        // Color for transit routes when planning a trip
+        if (TraverseMode.valueOf(leg.mode).isTransit()) {
+            return OTPConstants.OTP_TRANSIT_COLOR;
+        }
+
+        // Calculates color for non-trip planning situations
         if (leg.routeColor != null) {
             try {
                 return Long.decode("0xFF" + leg.routeColor).intValue();
@@ -199,10 +206,7 @@ public class DirectionsMapController implements MapModeController {
             }
         }
 
-        if (TraverseMode.valueOf(leg.mode).isTransit()) {
-            return Color.BLUE;
-        }
-
+        // Color defaults to grey which represents walking
         return Color.GRAY;
     }
 


### PR DESCRIPTION
## Resolve Color
This function gets the color for the polylines, previously, it checked if the leg was a transit route after checking the leg's route color. We want transits to always be checked first and set to a default color. This change does not affect showing routes outside of the trip planner.

## Transit Color
The color #006500 was added to OTP constants as the dedicated color for transits, this color is the same as the HUD of the trip planner.

## Screenshots
<img width="942" alt="image" src="https://github.com/OneBusAway/onebusaway-android/assets/137086062/19d07fb5-a089-432b-85e0-200269797e9f">


## Issues Affected
Closes #1171 

## Pull Request Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `gradlew connectedObaGoogleDebugAndroidTest` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them for the initial submission of the pull request.  When addressing comments on a pull request, please push a new commit per comment when possible (reviewers will squash and merge using GitHub merge tool)