### PR TITLE
Fixed #1180 -  Dark mode for trip time picker

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/TripPlanFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/TripPlanFragment.java
@@ -18,6 +18,7 @@ package org.onebusaway.android.ui;
 import android.app.DatePickerDialog;
 import android.app.Dialog;
 import android.app.TimePickerDialog;
+import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.res.TypedArray;
@@ -25,6 +26,7 @@ import android.location.Location;
 import android.os.Bundle;
 import android.text.TextUtils;
 import android.util.Log;
+import android.view.ContextThemeWrapper;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -177,6 +179,8 @@ public class TripPlanFragment extends Fragment {
             }
         };
 
+        Context context = new ContextThemeWrapper(getActivity(), R.style.MyTimePickerDialogTheme);
+
         final DatePickerDialog.OnDateSetListener dateCallback = new DatePickerDialog.OnDateSetListener() {
 
             @Override
@@ -196,7 +200,7 @@ public class TripPlanFragment extends Fragment {
             @Override
             public boolean onTouch(View view, MotionEvent motionEvent) {
                 if (motionEvent.getAction() == MotionEvent.ACTION_UP) {
-                    new DatePickerDialog(view.getContext(), dateCallback, mMyCalendar
+                    new DatePickerDialog(context, dateCallback, mMyCalendar
                             .get(Calendar.YEAR), mMyCalendar.get(Calendar.MONTH),
                             mMyCalendar.get(Calendar.DAY_OF_MONTH)).show();
                 }
@@ -209,7 +213,7 @@ public class TripPlanFragment extends Fragment {
             @Override
             public boolean onTouch(View view, MotionEvent motionEvent) {
                 if (motionEvent.getAction() == MotionEvent.ACTION_UP) {
-                    new TimePickerDialog(view.getContext(), timeCallback,
+                    new TimePickerDialog(context, timeCallback,
                             mMyCalendar.get(Calendar.HOUR_OF_DAY),
                             mMyCalendar.get(Calendar.MINUTE), false).show();
                 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/TripPlanFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/TripPlanFragment.java
@@ -179,7 +179,7 @@ public class TripPlanFragment extends Fragment {
             }
         };
 
-        Context context = new ContextThemeWrapper(getActivity(), R.style.MyTimePickerDialogTheme);
+        Context context = new ContextThemeWrapper(getActivity(), R.style.dayNightTimePickerDialogTheme);
 
         final DatePickerDialog.OnDateSetListener dateCallback = new DatePickerDialog.OnDateSetListener() {
 

--- a/onebusaway-android/src/main/res/values/themes.xml
+++ b/onebusaway-android/src/main/res/values/themes.xml
@@ -29,7 +29,7 @@
     </style>
 
     <!-- Custom TimePickerDialog theme for dark mode -->
-    <style name="MyTimePickerDialogTheme" parent="Theme.MaterialComponents.DayNight.Dialog">
+    <style name="dayNightTimePickerDialogTheme" parent="Theme.MaterialComponents.DayNight.Dialog">
         <item name="colorPrimary">@color/theme_primary</item>
         <item name="colorPrimaryDark">@color/theme_primary_dark</item>
         <item name="colorAccent">@color/theme_accent</item>

--- a/onebusaway-android/src/main/res/values/themes.xml
+++ b/onebusaway-android/src/main/res/values/themes.xml
@@ -25,5 +25,14 @@
         <item name="autoCompleteTextViewStyle">@style/cursorColor</item>
         <!-- Allows us to force Dark Theme throughout the app -->
         <item name="android:forceDarkAllowed">true</item>
+
     </style>
+
+    <!-- Custom TimePickerDialog theme for dark mode -->
+    <style name="MyTimePickerDialogTheme" parent="Theme.MaterialComponents.DayNight.Dialog">
+        <item name="colorPrimary">@color/theme_primary</item>
+        <item name="colorPrimaryDark">@color/theme_primary_dark</item>
+        <item name="colorAccent">@color/theme_accent</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
Fixes #1180 

Added a custom theme for the dialog to support dark mode.

<table>
  <tr>
    <td>
      <img src="https://github.com/OneBusAway/onebusaway-android/assets/29693819/a4810d83-61ee-4e72-b63c-7cfea2366b03" alt="Screenshot_1710712612" style="width: 100%; max-width: 300px;"/>
    </td>
    <td>
      <img src="https://github.com/OneBusAway/onebusaway-android/assets/29693819/e34ef783-3b83-4b46-9637-97a975fd96c6" alt="Screenshot_1710712600" style="width: 100%; max-width: 300px;"/>
    </td>
  </tr>
</table>





- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `gradlew connectedObaGoogleDebugAndroidTest` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them for the initial submission of the pull request.  When addressing comments on a pull request, please push a new commit per comment when possible (reviewers will squash and merge using GitHub merge tool)