### PR TITLE
Fixed #1179 - Supported adding custom region using deep-links

### DIFF
--- a/onebusaway-android/src/main/AndroidManifest.xml
+++ b/onebusaway-android/src/main/AndroidManifest.xml
@@ -15,7 +15,8 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:tools="http://schemas.android.com/tools"
+    xmlns:android="http://schemas.android.com/apk/res/android">
 
     <permission
             android:name="${applicationId}.permission.TRIP_SERVICE"
@@ -203,7 +204,19 @@
         <!-- ActionBarCompat library doesn't have an ActionBarPreferenceActivity, so define parent here-->
         <activity
             android:name="org.onebusaway.android.ui.PreferencesActivity"
-            android:parentActivityName="org.onebusaway.android.ui.HomeActivity">
+            android:parentActivityName="org.onebusaway.android.ui.HomeActivity"
+            android:exported="true"
+            tools:ignore="ExportedPreferenceActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:host="add-region"
+                    android:scheme="onebusaway" />
+            </intent-filter>
             <meta-data
                     android:name="android.support.PARENT_ACTIVITY"
                     android:value="org.onebusaway.android.ui.HomeActivity"/>

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/PreferencesActivity.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/PreferencesActivity.java
@@ -685,23 +685,25 @@ public class PreferencesActivity extends PreferenceActivity
     /**
      * The function will process deep links used for adding custom regions
      */
-    void onAddCustomRegion(){
+    void onAddCustomRegion() {
         Uri deepLink = getIntent().getData();
-        if (deepLink != null) {
-            String obaCustomUrl = deepLink.getQueryParameter("oba-url");
-            String otpCustomURl = deepLink.getQueryParameter("otp-url");
-
-            // onPreferenceChange is responsible for checking changes if it's valid
-            if(obaCustomUrl != null && onPreferenceChange(mCustomApiUrlPref,obaCustomUrl)){
-                Application.get().setCustomApiUrl(obaCustomUrl);
-            }
-
-            if(otpCustomURl != null && onPreferenceChange(mCustomOtpApiUrlPref,otpCustomURl)){
-                Application.get().setCustomOtpApiUrl(otpCustomURl);
-            }
-            Intent i = new Intent(this,HomeActivity.class);
-            startActivity(i);
-            finish();
+        if(deepLink == null){
+            return;
         }
+        String obaCustomUrl = deepLink.getQueryParameter("oba-url");
+        String otpCustomURl = deepLink.getQueryParameter("otp-url");
+
+        // onPreferenceChange is responsible for checking changes if it's valid
+        if (obaCustomUrl != null && onPreferenceChange(mCustomApiUrlPref, obaCustomUrl)) {
+            Application.get().setCustomApiUrl(obaCustomUrl);
+        }
+
+        if (otpCustomURl != null && onPreferenceChange(mCustomOtpApiUrlPref, otpCustomURl)) {
+            Application.get().setCustomOtpApiUrl(otpCustomURl);
+        }
+        Intent i = new Intent(this, HomeActivity.class);
+        startActivity(i);
+        finish();
+
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/PreferencesActivity.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/PreferencesActivity.java
@@ -236,6 +236,8 @@ public class PreferencesActivity extends PreferenceActivity
         if (showCheckRegionDialog) {
             showCheckRegionDialog();
         }
+
+        onAddCustomRegion();
     }
 
     @Override
@@ -526,7 +528,7 @@ public class PreferencesActivity extends PreferenceActivity
         boolean currentValue = settings
                 .getBoolean(getString(R.string.preference_key_auto_select_region), true);
 
-        //If the use has selected to auto-select region, and the previous state of the setting was false, 
+        //If the use has selected to auto-select region, and the previous state of the setting was false,
         //then run the auto-select by going to HomeFragment
         if ((currentValue && !mAutoSelectInitialValue)) {
             Log.d(TAG,
@@ -677,6 +679,29 @@ public class PreferencesActivity extends PreferenceActivity
 
             // Since the current region was updated as a result of enabling/disabling experimental servers, go home
             NavHelp.goHome(this, false);
+        }
+    }
+
+    /**
+     * The function will process deep links used for adding custom regions
+     */
+    void onAddCustomRegion(){
+        Uri deepLink = getIntent().getData();
+        if (deepLink != null) {
+            String obaCustomUrl = deepLink.getQueryParameter("oba-url");
+            String otpCustomURl = deepLink.getQueryParameter("otp-url");
+
+            // onPreferenceChange is responsible for checking changes if it's valid
+            if(obaCustomUrl != null && onPreferenceChange(mCustomApiUrlPref,obaCustomUrl)){
+                Application.get().setCustomApiUrl(obaCustomUrl);
+            }
+
+            if(otpCustomURl != null && onPreferenceChange(mCustomOtpApiUrlPref,otpCustomURl)){
+                Application.get().setCustomOtpApiUrl(otpCustomURl);
+            }
+            Intent i = new Intent(this,HomeActivity.class);
+            startActivity(i);
+            finish();
         }
     }
 }


### PR DESCRIPTION
Added #1179  - deep-link support for adding custom region

## Details

- Validation for adding a `oba-url`
- Validation for adding a `otp-url`

if `oba-url` is empty we don't do anything. Same as `otp-url`

Field `name` is not required for Android.

### Video showing adding a valid `oba-url` and `otp-url`

[valid-link.webm](https://github.com/OneBusAway/onebusaway-android/assets/29693819/e96a8988-38f1-4ee8-b0f3-90a01a1ac972)

### Video showing adding a invalid `oba-url` and `otp-url`
[invalid-link.webm](https://github.com/OneBusAway/onebusaway-android/assets/29693819/a5bed2e7-ec93-498d-9dd4-7ed56be207e4)



## Checks 
- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `gradlew connectedObaGoogleDebugAndroidTest` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them for the initial submission of the pull request.  When addressing comments on a pull request, please push a new commit per comment when possible (reviewers will squash and merge using GitHub merge tool)