### PR TITLE
Fixed #1196 - Loading weather image.

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.java
@@ -2014,7 +2014,7 @@ public class HomeActivity extends AppCompatActivity
         double weatherTemp = weatherResponse.getCurrent_forecast().getTemperature();
 
         if (weatherIcon != null && !weatherIcon.isEmpty()) {
-            WeatherUtils.setWeatherImage(weatherImageView, weatherIcon, this);
+            WeatherUtils.setWeatherImage(weatherImageView, weatherIcon);
         }else{
             weatherImageView.setVisibility(View.GONE);
         }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/weather/WeatherUtils.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/weather/WeatherUtils.java
@@ -1,6 +1,5 @@
 package org.onebusaway.android.ui.weather;
 
-import android.content.Context;
 import android.content.SharedPreferences;
 import android.widget.ImageView;
 import android.widget.TextView;
@@ -12,25 +11,13 @@ import java.util.Locale;
 
 public class WeatherUtils {
 
-    public static void setWeatherImage(ImageView imageView, String weatherCondition, Context context) {
-        // TODO FIXME: This is temporarily commented out because it was causing a large number
-        // of crashes in 2.13.0.
-        // See https://github.com/OneBusAway/onebusaway-android/issues/1196
-
-//        String resName = weatherCondition.replace("-", "_");
-//
-//        int resId = context.getResources().getIdentifier(resName, "drawable", context.getPackageName());
-//
-//        if (resId != 0) {
-//            // Adjusting scale for fog and wind icons.
-//            if(weatherCondition.equals("fog") || weatherCondition.equals("wind")){
-//                imageView.setScaleType(ImageView.ScaleType.CENTER);
-//            }
-//            imageView.setImageResource(resId);
-//        } else {
-//            // Default
-//            imageView.setImageResource(R.drawable.clear_day);
-//        }
+    public static void setWeatherImage(ImageView imageView, String weatherCondition) {
+        String resName = weatherCondition.replaceAll("-", "_");
+        // Adjusting scale for fog and wind icons.
+        if (weatherCondition.equals("fog") || weatherCondition.equals("wind")) {
+            imageView.setScaleType(ImageView.ScaleType.CENTER);
+        }
+        imageView.setImageResource(getWeatherDrawableRes(resName));
     }
 
     public static void setWeatherTemp(TextView weatherTempTxtView, double temp) {
@@ -48,6 +35,32 @@ public class WeatherUtils {
             temperatureText = preferredTempUnit.equals(app.getString(R.string.celsius)) ? (int) convertToCelsius(temp) + "° C" : (int) temp + "° F";
         }
         weatherTempTxtView.setText(temperatureText);
+    }
+
+
+    private static int getWeatherDrawableRes(String condition) {
+        switch (condition) {
+            case "clear_night":
+                return R.drawable.clear_night;
+            case "rain":
+                return R.drawable.rain;
+            case "snow":
+                return R.drawable.snow;
+            case "sleet":
+                return R.drawable.sleet;
+            case "wind":
+                return R.drawable.wind;
+            case "fog":
+                return R.drawable.fog;
+            case "cloudy":
+                return R.drawable.cloudy;
+            case "partly_cloudy_day":
+                return R.drawable.partly_cloudy_day;
+            case "partly_cloudy_night":
+                return R.drawable.partly_cloudy_night;
+            default:
+                return R.drawable.clear_day;
+        }
     }
 
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/weather/WeatherUtils.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/weather/WeatherUtils.java
@@ -16,6 +16,8 @@ public class WeatherUtils {
         // Adjusting scale for fog and wind icons.
         if (weatherCondition.equals("fog") || weatherCondition.equals("wind")) {
             imageView.setScaleType(ImageView.ScaleType.CENTER);
+        }else{
+            imageView.setScaleType(ImageView.ScaleType.CENTER_CROP);
         }
         imageView.setImageResource(getWeatherDrawableRes(resName));
     }

--- a/onebusaway-android/src/main/res/layout/main.xml
+++ b/onebusaway-android/src/main/res/layout/main.xml
@@ -109,7 +109,6 @@
 
                         <ImageView
                             android:id="@+id/weatherStateImageView"
-                            android:visibility="gone"
                             android:layout_width="24dp"
                             android:layout_height="24dp"
                             android:scaleType="centerCrop"


### PR DESCRIPTION
Fixes #1196.

I used a dummy keystore to generate a release version, but it crashed when I opened the app!

The app does not detect any resId when I search for weather icons in the release version.

This method is responsible for getting an image resource from the drawable using the resource name.

`int resId = context.getResources().getIdentifier(resName, "drawable", context.getPackageName());`

The method worked well with the debug version, but in the release version, it's not working. It's strange, but I think the resource names may have been parsed, and their names were changed during the release version. Therefore, I used a safer function that directly calls the path of the image from a drawable resource. I have tested it in a release version, and it's working.


- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `gradlew connectedObaGoogleDebugAndroidTest` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them for the initial submission of the pull request.  When addressing comments on a pull request, please push a new commit per comment when possible (reviewers will squash and merge using GitHub merge tool)