### PR TITLE
Task 705 allowing starring route from route header on map view

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.java
@@ -37,6 +37,7 @@ import android.os.Handler;
 import android.text.TextUtils;
 import android.util.Log;
 import android.view.View;
+import android.widget.ImageButton;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
@@ -282,6 +283,10 @@ public class RouteMapController implements MapModeController {
         // Prevents completely hiding vehicle markers at top of route
         private int VEHICLE_MARKER_PADDING;
 
+        private ImageButton mHeaderRouteStar;
+
+        private boolean mFavorite = false;
+
         RoutePopup() {
             mActivity = mFragment.getActivity();
             float paddingDp =
@@ -295,7 +300,16 @@ public class RouteMapController implements MapModeController {
             mRouteLongName = (TextView) mView.findViewById(R.id.long_name);
             mAgencyName = (TextView) mView.findViewById(R.id.agency);
             mProgressBar = (ProgressBar) mView.findViewById(R.id.route_info_loading_spinner);
-
+            mHeaderRouteStar = mView.findViewById(R.id.header_route_star);
+            mHeaderRouteStar.setColorFilter(mView.getResources().getColor(R.color.header_text_color));
+            mHeaderRouteStar.setOnClickListener(new View.OnClickListener() {
+                public void onClick(View v) {
+                    mHeaderRouteStar.setImageResource(!mFavorite ?
+                            R.drawable.focus_star_on :
+                            R.drawable.focus_star_off);
+                    mFavorite = !mFavorite;
+                }
+            });
             // Make sure the cancel button is shown
             View cancel = mView.findViewById(R.id.cancel_route_mode);
             cancel.setVisibility(View.VISIBLE);

--- a/onebusaway-android/src/main/res/layout/route_info_head.xml
+++ b/onebusaway-android/src/main/res/layout/route_info_head.xml
@@ -18,6 +18,15 @@
                 android:elevation="3dp"
                 android:layout_height="wrap_content"
                 style="@style/HeaderItem">
+    <ImageButton
+            android:id="@+id/header_route_star"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:src="@drawable/ic_toggle_star_outline"
+            android:layout_alignParentStart="true"
+            android:layout_centerVertical="true"
+            android:layout_marginStart="8dp"
+            android:background="?attr/selectableItemBackground"/>
     <ProgressBar
             android:id="@+id/route_info_loading_spinner"
             style="?android:progressBarStyleLarge"
@@ -46,7 +55,8 @@
                     android:singleLine="true"
                     android:maxLength="6"
                     android:maxLines="1"
-                    android:ellipsize="end">
+                    android:ellipsize="end"
+                    android:layout_marginStart="30dp">
             </TextView>
             <LinearLayout
                     android:orientation="vertical"


### PR DESCRIPTION
Implemented partial functionality of the star next to the route header. The star is clickable and the image changes correspondingly, but there is no connection to whether the route is a favorited route or not.
![Screenshot 2024-04-25 at 11 48 37 PM](https://github.com/OneBusAway/onebusaway-android/assets/123328784/4aa2128e-6bf6-4760-a4fa-4b8635da5003)
![Screenshot 2024-04-25 at 11 48 46 PM](https://github.com/OneBusAway/onebusaway-android/assets/123328784/d2800362-2420-4fde-a170-a07658a34116)
