### PR TITLE
Added firebase crashlytics

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ buildscript {
         classpath 'com.android.tools.build:gradle:8.2.2'
         classpath 'com.google.gms:google-services:4.3.15'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.9.9'
     }
 }
 

--- a/onebusaway-android/build.gradle
+++ b/onebusaway-android/build.gradle
@@ -328,6 +328,7 @@ dependencies {
     implementation 'com.google.firebase:firebase-storage:20.3.0'
     // Firebase crashlytics
     implementation 'com.google.firebase:firebase-crashlytics-buildtools:2.9.9'
+    implementation 'com.google.firebase:firebase-crashlytics:18.6.4'
     // Google Play Services Location
     implementation 'com.google.android.gms:play-services-location:19.0.1'
     // Support libraries
@@ -382,3 +383,4 @@ dependencies {
 }
 
 apply plugin:'com.google.gms.google-services'
+apply plugin: 'com.google.firebase.crashlytics'


### PR DESCRIPTION
Integrated Firebase Crashlytics to track better and monitor app crashes. As part of the setup, you'll notice a test crash in the Firebase crashlytics dashboard, which is a demonstration. 

This addition will significantly enhance our ability to manage and improve the stability of our releases and monitor them.

## TODO
- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `gradlew connectedObaGoogleDebugAndroidTest` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them for the initial submission of the pull request.  When addressing comments on a pull request, please push a new commit per comment when possible (reviewers will squash and merge using GitHub merge tool)