### PR TITLE
Added option to control weather view visibility

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.java
@@ -443,6 +443,10 @@ public class HomeActivity extends AppCompatActivity
     public void onResume() {
         super.onResume();
 
+        // Check if weather view visibility is changed to hidden
+        if(isWeatherViewHiddenPref()){
+            WeatherUtils.toggleWeatherViewVisibility(false,weatherView);
+        }
         // Make sure header has sliding panel state
         if (mArrivalsListHeader != null && mSlidingPanel != null) {
             mArrivalsListHeader.setSlidingPanelCollapsed(isSlidingPanelCollapsed());
@@ -2012,7 +2016,7 @@ public class HomeActivity extends AppCompatActivity
     }
 
     private void setWeatherData() {
-        if(weatherResponse == null || mCurrentNavDrawerPosition != NAVDRAWER_ITEM_NEARBY) return;
+        if(weatherResponse == null || mCurrentNavDrawerPosition != NAVDRAWER_ITEM_NEARBY || isWeatherViewHiddenPref()) return;
         WeatherUtils.toggleWeatherViewVisibility(true,weatherView);
         TextView tempTxtView = findViewById(R.id.weatherTextView);
         ImageView weatherImageView = findViewById(R.id.weatherStateImageView);
@@ -2035,6 +2039,7 @@ public class HomeActivity extends AppCompatActivity
     }
 
     private void makeWeatherRequest(){
+        if(isWeatherViewHiddenPref()) return;
         // If weather response is null that means we need to call the weather api to get the new data
         // Adding this will avoid doing multiple requests to the weather API when updating the map in real-time
         if(weatherResponse == null){
@@ -2047,6 +2052,17 @@ public class HomeActivity extends AppCompatActivity
             setWeatherData();
         }
 
+    }
+
+
+    private boolean isWeatherViewHiddenPref(){
+        Application app = Application.get();
+        SharedPreferences sharedPreferences = Application.getPrefs();
+
+        String showOption = app.getString(R.string.show);
+        String pref = sharedPreferences.getString(app.getString(R.string.preference_key_show_weather_view), showOption);
+
+        return (!pref.equals(showOption));
     }
 
     @Override

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.java
@@ -444,7 +444,7 @@ public class HomeActivity extends AppCompatActivity
         super.onResume();
 
         // Check if weather view visibility is changed to hidden
-        if(isWeatherViewHiddenPref()){
+        if(WeatherUtils.isWeatherViewHiddenPref()){
             WeatherUtils.toggleWeatherViewVisibility(false,weatherView);
         }
         // Make sure header has sliding panel state
@@ -2016,7 +2016,7 @@ public class HomeActivity extends AppCompatActivity
     }
 
     private void setWeatherData() {
-        if(weatherResponse == null || mCurrentNavDrawerPosition != NAVDRAWER_ITEM_NEARBY || isWeatherViewHiddenPref()) return;
+        if(weatherResponse == null || mCurrentNavDrawerPosition != NAVDRAWER_ITEM_NEARBY || WeatherUtils.isWeatherViewHiddenPref()) return;
         WeatherUtils.toggleWeatherViewVisibility(true,weatherView);
         TextView tempTxtView = findViewById(R.id.weatherTextView);
         ImageView weatherImageView = findViewById(R.id.weatherStateImageView);
@@ -2039,7 +2039,7 @@ public class HomeActivity extends AppCompatActivity
     }
 
     private void makeWeatherRequest(){
-        if(isWeatherViewHiddenPref()) return;
+        if(WeatherUtils.isWeatherViewHiddenPref()) return;
         // If weather response is null that means we need to call the weather api to get the new data
         // Adding this will avoid doing multiple requests to the weather API when updating the map in real-time
         if(weatherResponse == null){
@@ -2052,17 +2052,6 @@ public class HomeActivity extends AppCompatActivity
             setWeatherData();
         }
 
-    }
-
-
-    private boolean isWeatherViewHiddenPref(){
-        Application app = Application.get();
-        SharedPreferences sharedPreferences = Application.getPrefs();
-
-        String showOption = app.getString(R.string.show);
-        String pref = sharedPreferences.getString(app.getString(R.string.preference_key_show_weather_view), showOption);
-
-        return (!pref.equals(showOption));
     }
 
     @Override

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/PreferencesActivity.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/PreferencesActivity.java
@@ -121,6 +121,7 @@ public class PreferencesActivity extends PreferenceActivity
 
     ListPreference preferredUnits;
     ListPreference preferredTempUnits;
+    ListPreference showWeatherDisplayPref;
 
     ListPreference mThemePref;
 
@@ -201,6 +202,9 @@ public class PreferencesActivity extends PreferenceActivity
         preferredTempUnits = (ListPreference) findPreference(
                 getString(R.string.preference_key_preferred_temperature_units));
 
+        showWeatherDisplayPref = (ListPreference) findPreference(
+                getString(R.string.preference_key_show_weather_view));
+
         mThemePref = (ListPreference) findPreference(
                 getString(R.string.preference_key_app_theme));
         mThemePref.setOnPreferenceChangeListener(this);
@@ -256,6 +260,7 @@ public class PreferencesActivity extends PreferenceActivity
         changePreferenceSummary(getString(R.string.preference_key_region));
         changePreferenceSummary(getString(R.string.preference_key_preferred_units));
         changePreferenceSummary(getString(R.string.preference_key_preferred_temperature_units));
+        changePreferenceSummary(getString(R.string.preference_key_show_weather_view));
         changePreferenceSummary(getString(R.string.preference_key_app_theme));
         changePreferenceSummary(getString(R.string.preference_key_otp_api_url));
 
@@ -337,6 +342,8 @@ public class PreferencesActivity extends PreferenceActivity
         }else if (preferenceKey
                 .equalsIgnoreCase(getString(R.string.preference_key_preferred_temperature_units))) {
             preferredTempUnits.setSummary(preferredTempUnits.getValue());
+        }else if(preferenceKey.equalsIgnoreCase(getString(R.string.preference_key_show_weather_view))){
+            showWeatherDisplayPref.setSummary(showWeatherDisplayPref.getValue());
         }
     }
 
@@ -627,6 +634,9 @@ public class PreferencesActivity extends PreferenceActivity
             ObaAnalytics.setShowDepartedVehicles(mFirebaseAnalytics, showDepartedBuses);
         }else if (key.equalsIgnoreCase(getString(R.string.preference_key_preferred_temperature_units))) {
             // Change the preferred temp unit description
+            changePreferenceSummary(key);
+        }else if (key.equalsIgnoreCase(getString(R.string.preference_key_show_weather_view))) {
+            // Change the preferred weather show or hide option
             changePreferenceSummary(key);
         }
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/weather/WeatherUtils.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/weather/WeatherUtils.java
@@ -40,6 +40,16 @@ public class WeatherUtils {
         weatherTempTxtView.setText(temperatureText);
     }
 
+    public static boolean isWeatherViewHiddenPref() {
+        Application app = Application.get();
+        SharedPreferences sharedPreferences = Application.getPrefs();
+
+        String showOption = app.getString(R.string.show);
+        String pref = sharedPreferences.getString(app.getString(R.string.preference_key_show_weather_view), showOption);
+
+        return (!pref.equals(showOption));
+    }
+
     public static void toggleWeatherViewVisibility(boolean shouldShow, View weatherView) {
         if (weatherView == null) {
             return;

--- a/onebusaway-android/src/main/res/values-es/strings.xml
+++ b/onebusaway-android/src/main/res/values-es/strings.xml
@@ -1096,5 +1096,6 @@
     <string name="donation_learn_more_explanation">Tenemos grandes planes para mejorar OneBusAway, pero no podemos hacerlo sin tu ayuda. Esta aplicación está actualmente desarrollada con un 100% de trabajo voluntario, y necesitamos que nos ayudes a financiar el desarrollo futuro.\n\nComo un proyecto clave de la Open Transit Software Foundation, una organización sin fines de lucro 501(c)(3), dependemos de la buena voluntad de usuarios como tú para seguir funcionando y mejorando este software.\n\nCada año, solo una pequeña fracción de nuestros usuarios dona, pero cada contribución, grande o pequeña, ayuda a asegurar que OneBusAway permanezca gratuito, actualizado y accesible para todos. Una pequeña donación, incluso solo el costo de una semana de viaje, $27.50, puede marcar la diferencia.\n\nTu contribución deducible de impuestos asegura que OneBusAway permanezca libre y accesible para todos. ¡Formemos juntos el futuro del transporte!\n\nGracias,\nEl equipo de OneBusAway</string>
     <string name="preferences_reset_donation_timestamps_title">Restablecer las marcas de tiempo de donación</string>
     <string name="preferences_reset_donation_timestamps_summary">Al tocar esta opción se borrarán las marcas de tiempo de \'Recuérdame más tarde\' y \'No me molestes\' asociadas con las solicitudes de donación.</string>
-
+    <string name="preferences_show_weather_view">Mostrar vista del clima</string>
+    <string name="show">Mostrar</string>
 </resources>

--- a/onebusaway-android/src/main/res/values-fi/strings.xml
+++ b/onebusaway-android/src/main/res/values-fi/strings.xml
@@ -693,5 +693,7 @@
     <string name="donation_learn_more_explanation">Meillä on suuria suunnitelmia OneBusAwayn parantamiseksi, mutta emme voi tehdä sitä ilman apuasi. Tämä sovellus on tällä hetkellä rakennettu 100% vapaaehtoistyöllä, ja tarvitsemme sinua auttamaan meitä rahoittamaan tulevan kehityksen.\n\nOpen Transit Software Foundationin, 501(c)(3) voittoa tavoittelemattoman järjestön, keskeisenä hankkeena me luotamme käyttäjien, kuten sinun, hyväntahtoisuuteen pysyäksemme toiminnassa ja tehdäksemme tästä ohjelmistosta paremman.\n\nJoka vuosi vain pieni osa käyttäjistämme lahjoittaa, mutta jokainen panos, suuri tai pieni, auttaa varmistamaan, että OneBusAway pysyy ilmaisena, päivitettynä ja kaikkien saavutettavissa. Pieni lahjoitus, vaikkapa vain yhden viikon työmatkakustannusten verran, 27,50 dollaria, voi tehdä suuren eron.\n\nVerovähennyskelpoinen panoksesi varmistaa, että OneBusAway pysyy vapaana ja kaikkien saavutettavissa. Muovataan yhdessä joukkoliikenteen tulevaisuutta!\n\nKiitos,\nOneBusAway-tiimi</string>
     <string name="preferences_reset_donation_timestamps_title">Nollaa Lahjoituksen Aikaleimat</string>
     <string name="preferences_reset_donation_timestamps_summary">Tämän vaihtoehdon napauttaminen poistaa sekä \'Muistuta minua myöhemmin\' että \'Älä vaivaudu\' aikaleimat, jotka liittyvät lahjoituspyyntöihin.</string>
+    <string name="preferences_show_weather_view">Näytä säätönäkymä</string>
+    <string name="show">Näytä</string>
 
 </resources>

--- a/onebusaway-android/src/main/res/values-it/strings.xml
+++ b/onebusaway-android/src/main/res/values-it/strings.xml
@@ -1007,5 +1007,7 @@
     <string name="donation_learn_more_explanation">"Abbiamo grandi piani per migliorare OneBusAway, ma non possiamo farlo senza il tuo aiuto. Questa app è attualmente sviluppata con il 100% di lavoro volontario, e abbiamo bisogno del tuo aiuto per finanziare lo sviluppo futuro.\n\nCome progetto chiave della Open Transit Software Foundation, un'organizzazione non profit 501(c)(3), ci affidiamo alla buona volontà di utenti come te per continuare a funzionare e migliorare questo software.\n\nOgni anno, solo una piccola frazione dei nostri utenti dona, ma ogni contributo, grande o piccolo, aiuta a garantire che OneBusAway rimanga gratuito, aggiornato e accessibile a tutti. Una piccola donazione, anche solo il costo di una settimana di pendolarismo, $27.50, può fare tutta la differenza.\n\nIl tuo contributo deducibile dalle tasse assicura che OneBusAway rimanga libero e accessibile per tutti. Modelliamo insieme il futuro del trasporto pubblico!\n\nGrazie,\nIl Team di OneBusAway"</string>
     <string name="preferences_reset_donation_timestamps_title">Reimposta i Timestamp delle Donazioni</string>
     <string name="preferences_reset_donation_timestamps_summary">Toccando questa opzione verranno cancellati i timestamp di \'Ricordamelo più tardi\' e \'Non disturbarmi\' associati alle richieste di donazione.</string>
+    <string name="preferences_show_weather_view">Mostra vista meteo</string>
+    <string name="show">Mostra</string>
 
 </resources>

--- a/onebusaway-android/src/main/res/values-pl/strings.xml
+++ b/onebusaway-android/src/main/res/values-pl/strings.xml
@@ -713,5 +713,7 @@
     <string name="donation_learn_more_explanation">Mamy wielkie plany na ulepszenie OneBusAway, ale nie możemy tego zrobić bez Twojej pomocy. Ta aplikacja jest obecnie tworzona w 100% dzięki pracy wolontariuszy, i potrzebujemy Ciebie, abyś pomógł nam sfinansować przyszły rozwój.\n\nJako kluczowy projekt Open Transit Software Foundation, organizacji non-profit 501(c)(3), polegamy na dobrej woli użytkowników takich jak Ty, aby kontynuować działanie i ulepszanie tego oprogramowania.\n\nCo roku tylko mała część naszych użytkowników dokonuje darowizn, ale każdy wkład, duży czy mały, pomaga zapewnić, że OneBusAway pozostanie darmowe, aktualne i dostępne dla wszystkich. Mała darowizna, nawet tylko koszt tygodniowego dojazdu do pracy, 27,50 dolarów, może zrobić różnicę.\n\nTwoja darowizna odliczalna od podatku zapewnia, że OneBusAway pozostanie darmowe i dostępne dla każdego. Kształtujmy razem przyszłość transportu publicznego!\n\nDziękujemy,\nZespół OneBusAway</string>
     <string name="preferences_reset_donation_timestamps_title">Zresetuj Znaczniki Czasu Dotacji</string>
     <string name="preferences_reset_donation_timestamps_summary">Dotknięcie tej opcji spowoduje wyczyszczenie znaczników czasu \'Przypomnij mi później\' i \'Nie przeszkadzaj mi\' związanych z prośbami o darowizny.</string>
+    <string name="preferences_show_weather_view">Pokaż widok pogody</string>
+    <string name="show">Pokaż</string>
 
 </resources>

--- a/onebusaway-android/src/main/res/values/arrays.xml
+++ b/onebusaway-android/src/main/res/values/arrays.xml
@@ -101,6 +101,10 @@
         <item>@string/fahrenheit</item>
         <item>@string/celsius</item>
     </string-array>
+    <string-array name="preferred_weather_view_option">
+        <item>@string/show</item>
+        <item>@string/hide</item>
+    </string-array>
     <string-array name="app_theme_options">
         <item>@string/preferences_app_theme_option_system_default</item>
         <item>@string/preferences_app_theme_option_light</item>

--- a/onebusaway-android/src/main/res/values/donottranslate.xml
+++ b/onebusaway-android/src/main/res/values/donottranslate.xml
@@ -35,6 +35,7 @@
     <string name="preferences_key_about">preference_about</string>
     <string name="preference_key_preferred_units">preference_preferred_units</string>
     <string name="preference_key_preferred_temperature_units">preference_preferred_temperature_units</string>
+    <string name="preference_key_show_weather_view">preference_key_show_weather_view</string>
     <string name="preference_key_app_theme">preference_app_theme</string>
     <string name="preference_key_arrival_info_style">preference_arrival_info_style</string>
     <string name="preference_key_show_negative_arrivals">preference_show_negative_arrivals</string>

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -1245,5 +1245,7 @@
     <string name="donation_learn_more_explanation">We have big plans to improve OneBusAway, but we can\'t do it without your help. This app is currently built with 100% volunteer labor, and we need you to help us fund future development.\n\nAs a key project of the Open Transit Software Foundation, a 501(c)(3) non-profit, we rely on the goodwill of users like you to keep running and making this software better.\n\nEvery year, only a small fraction of our users donate, but every contribution, big or small, helps ensure that OneBusAway remains free, updated, and accessible to everyone. A small donation, even just the cost of one week of commuting, $27.50, can make all the difference.\n\nYour tax-deductible contribution ensures that OneBusAway remains free and accessible for everyone. Let\'s shape the future of transit together!\n\nThank you,\nThe OneBusAway Team</string>
     <string name="preferences_reset_donation_timestamps_title">Reset Donation Timestamps</string>
     <string name="preferences_reset_donation_timestamps_summary">Tapping this option will clear both the \'Remind Me Later\' and \'Don\'t Bother Me\' timestamps associated with donation requests.</string>
+    <string name="preferences_show_weather_view">Show weather view</string>
+    <string name="show">Show</string>
 
 </resources>

--- a/onebusaway-android/src/main/res/xml/preferences.xml
+++ b/onebusaway-android/src/main/res/xml/preferences.xml
@@ -64,6 +64,7 @@
             android:title="@string/preferences_show_header_arrivals_title" />
         <ListPreference
             android:defaultValue="@string/preferences_preferred_units_option_automatic"
+            android:negativeButtonText="@string/close"
             android:entries="@array/preferred_units_options"
             android:entryValues="@array/preferred_units_options"
             android:key="@string/preference_key_preferred_units"
@@ -71,13 +72,23 @@
 
         <ListPreference
             android:defaultValue="@string/preferences_preferred_units_option_automatic"
+            android:negativeButtonText="@string/close"
             android:entries="@array/preferred_temp_unit_options"
             android:entryValues="@array/preferred_temp_unit_options"
             android:key="@string/preference_key_preferred_temperature_units"
             android:title="@string/preferred_temperature_unit" />
 
         <ListPreference
+            android:defaultValue="@string/show"
+            android:negativeButtonText="@string/close"
+            android:entries="@array/preferred_weather_view_option"
+            android:entryValues="@array/preferred_weather_view_option"
+            android:key="@string/preference_key_show_weather_view"
+            android:title="@string/preferences_show_weather_view" />
+
+        <ListPreference
                 android:defaultValue="@string/preferences_app_theme_option_system_default"
+                android:negativeButtonText="@string/close"
                 android:entries="@array/app_theme_options"
                 android:entryValues="@array/app_theme_options"
                 android:key="@string/preference_key_app_theme"


### PR DESCRIPTION
Fixes #1215.

## Keychanges

1. Added option to allow control weather view visibility by default weather view is shown
2. Changed preferences dialog negative button from `cancel` to `close`

## Video

[Video](https://github.com/OneBusAway/onebusaway-android/assets/29693819/9c67e78b-b999-4880-88ed-f542639aaac7)



- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `gradlew connectedObaGoogleDebugAndroidTest` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them for the initial submission of the pull request.  When addressing comments on a pull request, please push a new commit per comment when possible (reviewers will squash and merge using GitHub merge tool)