### PR TITLE
Implemented feature: Added option to enable or disable 3D map mode

### DIFF
--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/BaseMapFragment.java
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/BaseMapFragment.java
@@ -366,6 +366,8 @@ public class BaseMapFragment extends SupportMapFragment
         uiSettings.setMyLocationButtonEnabled(false);
         // Hide Toolbar
         uiSettings.setMapToolbarEnabled(false);
+        // Check for 3D map mode settings
+        updateMap3DModeSettings();
         // Instantiate class that holds generic markers to be added by outside classes
         mSimpleMarkerOverlay = new SimpleMarkerOverlay(mMap);
 
@@ -508,7 +510,7 @@ public class BaseMapFragment extends SupportMapFragment
                 controller.notifyMapChanged();
             }
         }
-
+        updateMap3DModeSettings();
         super.onResume();
     }
 
@@ -1487,4 +1489,17 @@ public class BaseMapFragment extends SupportMapFragment
             return false;
         }
     }
+
+    /**
+     * Updates the map settings based on the current state of 3D mode preference.
+     */
+    private void updateMap3DModeSettings() {
+        if(mMap == null) return;
+
+        boolean isEnabled = Application.getPrefs().getBoolean(getString(R.string.preference_key_enable_map_3d_mode), true);
+
+        mMap.getUiSettings().setTiltGesturesEnabled(isEnabled);
+        mMap.setBuildingsEnabled(isEnabled);
+    }
+
 }

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/BaseMapFragment.java
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/BaseMapFragment.java
@@ -1500,6 +1500,15 @@ public class BaseMapFragment extends SupportMapFragment
 
         mMap.getUiSettings().setTiltGesturesEnabled(isEnabled);
         mMap.setBuildingsEnabled(isEnabled);
+
+        // Reset tilt to 0 degrees
+        mMap.moveCamera(CameraUpdateFactory.newCameraPosition(
+                new CameraPosition.Builder()
+                        .target(mMap.getCameraPosition().target)
+                        .zoom(mMap.getCameraPosition().zoom)
+                        .tilt(0)
+                        .build()
+        ));
     }
 
 }

--- a/onebusaway-android/src/main/res/values-es/strings.xml
+++ b/onebusaway-android/src/main/res/values-es/strings.xml
@@ -1098,4 +1098,6 @@
     <string name="preferences_reset_donation_timestamps_summary">Al tocar esta opción se borrarán las marcas de tiempo de \'Recuérdame más tarde\' y \'No me molestes\' asociadas con las solicitudes de donación.</string>
     <string name="preferences_show_weather_view">Mostrar vista del clima</string>
     <string name="show">Mostrar</string>
+    <string name="preferences_enable_map_3d_mode_title">Activar modo 3D del mapa</string>
+    <string name="preferences_enable_map_3d_mode_summary">Incluir edificios en 3D en el mapa</string>
 </resources>

--- a/onebusaway-android/src/main/res/values-fi/strings.xml
+++ b/onebusaway-android/src/main/res/values-fi/strings.xml
@@ -695,5 +695,7 @@
     <string name="preferences_reset_donation_timestamps_summary">Tämän vaihtoehdon napauttaminen poistaa sekä \'Muistuta minua myöhemmin\' että \'Älä vaivaudu\' aikaleimat, jotka liittyvät lahjoituspyyntöihin.</string>
     <string name="preferences_show_weather_view">Näytä säätönäkymä</string>
     <string name="show">Näytä</string>
+    <string name="preferences_enable_map_3d_mode_title">Ota käyttöön kartan 3D-tila</string>
+    <string name="preferences_enable_map_3d_mode_summary">Sisällytä 3D-rakennukset karttaan</string>
 
 </resources>

--- a/onebusaway-android/src/main/res/values-it/strings.xml
+++ b/onebusaway-android/src/main/res/values-it/strings.xml
@@ -1009,5 +1009,7 @@
     <string name="preferences_reset_donation_timestamps_summary">Toccando questa opzione verranno cancellati i timestamp di \'Ricordamelo più tardi\' e \'Non disturbarmi\' associati alle richieste di donazione.</string>
     <string name="preferences_show_weather_view">Mostra vista meteo</string>
     <string name="show">Mostra</string>
+    <string name="preferences_enable_map_3d_mode_title">Abilita la modalità 3D della mappa</string>
+    <string name="preferences_enable_map_3d_mode_summary">Includi edifici in 3D nella mappa</string>
 
 </resources>

--- a/onebusaway-android/src/main/res/values-pl/strings.xml
+++ b/onebusaway-android/src/main/res/values-pl/strings.xml
@@ -715,5 +715,7 @@
     <string name="preferences_reset_donation_timestamps_summary">Dotknięcie tej opcji spowoduje wyczyszczenie znaczników czasu \'Przypomnij mi później\' i \'Nie przeszkadzaj mi\' związanych z prośbami o darowizny.</string>
     <string name="preferences_show_weather_view">Pokaż widok pogody</string>
     <string name="show">Pokaż</string>
+    <string name="preferences_enable_map_3d_mode_title">Włącz tryb 3D mapy</string>
+    <string name="preferences_enable_map_3d_mode_summary">Uwzględnij budynki 3D na mapie</string>
 
 </resources>

--- a/onebusaway-android/src/main/res/values/donottranslate.xml
+++ b/onebusaway-android/src/main/res/values/donottranslate.xml
@@ -40,6 +40,7 @@
     <string name="preference_key_arrival_info_style">preference_arrival_info_style</string>
     <string name="preference_key_show_negative_arrivals">preference_show_negative_arrivals</string>
     <string name="preference_key_show_zoom_controls">preference_show_zoom_controls</string>
+    <string name="preference_key_enable_map_3d_mode">preference_enable_map_3d_view</string>
     <string name="preference_key_hide_alerts">preference_hide_alerts</string>
     <string name="preference_key_default_stop_sort">preference_default_stop_sort</string>
     <string name="preference_key_default_reminder_time">preference_default_reminder_time</string>

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -1247,5 +1247,6 @@
     <string name="preferences_reset_donation_timestamps_summary">Tapping this option will clear both the \'Remind Me Later\' and \'Don\'t Bother Me\' timestamps associated with donation requests.</string>
     <string name="preferences_show_weather_view">Show weather view</string>
     <string name="show">Show</string>
-
+    <string name="preferences_enable_map_3d_mode_title">Enable map 3D mode</string>
+    <string name="preferences_enable_map_3d_mode_summary">Include 3D buildings in the map</string>
 </resources>

--- a/onebusaway-android/src/main/res/xml/preferences.xml
+++ b/onebusaway-android/src/main/res/xml/preferences.xml
@@ -49,6 +49,12 @@
 
         <CheckBoxPreference
             android:defaultValue="true"
+            android:key="@string/preference_key_enable_map_3d_mode"
+            android:summary="@string/preferences_enable_map_3d_mode_summary"
+            android:title="@string/preferences_enable_map_3d_mode_title" />
+
+        <CheckBoxPreference
+            android:defaultValue="true"
             android:key="@string/preference_key_show_tutorial_screens"
             android:summary="@string/preferences_show_tutorial_screens_summary"
             android:title="@string/preferences_show_tutorial_screens_title" />


### PR DESCRIPTION
Fixes #1216.

## Key changes

- Added option to control enable/disable 3d map mode, this will also hide 3d buildings

## Video

https://github.com/OneBusAway/onebusaway-android/assets/29693819/bbdf8175-0fb7-4688-aa84-8ae0dd5962d5


## TODO
- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `gradlew connectedObaGoogleDebugAndroidTest` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them for the initial submission of the pull request.  When addressing comments on a pull request, please push a new commit per comment when possible (reviewers will squash and merge using GitHub merge tool)