### PR TITLE
Disable Travel Behavior Studies Feature

### DIFF
--- a/onebusaway-android/src/main/AndroidManifest.xml
+++ b/onebusaway-android/src/main/AndroidManifest.xml
@@ -39,6 +39,9 @@
     <uses-permission android:name="${applicationId}.permission.TRIP_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
+
+    <!-- Permission request for activity recognition is disabled because the related feature has been turned off.
+    See issue #1240 for more details: https://github.com/OneBusAway/onebusaway-android/issues/1240-->
     <!-- ACTIVITY_RECOGNITION API 28 and lower -->
 <!--    <uses-permission android:name="com.google.android.gms.permission.ACTIVITY_RECOGNITION" />-->
     <!-- ACTIVITY_RECOGNITION API 29 and higher -->

--- a/onebusaway-android/src/main/AndroidManifest.xml
+++ b/onebusaway-android/src/main/AndroidManifest.xml
@@ -40,9 +40,9 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
     <!-- ACTIVITY_RECOGNITION API 28 and lower -->
-    <uses-permission android:name="com.google.android.gms.permission.ACTIVITY_RECOGNITION" />
+<!--    <uses-permission android:name="com.google.android.gms.permission.ACTIVITY_RECOGNITION" />-->
     <!-- ACTIVITY_RECOGNITION API 29 and higher -->
-    <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION" />
+<!--    <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION" />-->
     <!--To enable checkBatteryOptimizations feature, also uncomment checkBatteryOptimizations() in
     the HomeActivity's onCreate() method-->
     <!--<uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS"/>-->

--- a/onebusaway-android/src/main/java/org/onebusaway/android/travelbehavior/TravelBehaviorManager.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/travelbehavior/TravelBehaviorManager.java
@@ -77,6 +77,11 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * This feature has been disabled due to issues related to ticket #1240.
+ * See: https://github.com/OneBusAway/onebusaway-android/issues/1240
+ */
+
 public class TravelBehaviorManager {
 
     private static final String TAG = "TravelBehaviorManager";
@@ -94,366 +99,366 @@ public class TravelBehaviorManager {
     }
 
     public void registerTravelBehaviorParticipant() {
-        registerTravelBehaviorParticipant(false);
+        //registerTravelBehaviorParticipant(false);
     }
 
     public void registerTravelBehaviorParticipant(boolean forceStart) {
         // Do not register if enrolling is no more allowed;
-        if (!TravelBehaviorUtils.allowEnrollMoreParticipantsInStudy()) {
-            return;
-        }
-
-        boolean isUserOptOut = PreferenceUtils.getBoolean(TravelBehaviorConstants.USER_OPT_OUT,
-                false);
-        if (forceStart) isUserOptOut = false;
+//        if (!TravelBehaviorUtils.allowEnrollMoreParticipantsInStudy()) {
+//            return;
+//        }
+//
+//        boolean isUserOptOut = PreferenceUtils.getBoolean(TravelBehaviorConstants.USER_OPT_OUT,
+//                false);
+//        if (forceStart) isUserOptOut = false;
         // If user opt out or Global switch is off then do nothing
-        if (!TravelBehaviorUtils.isTravelBehaviorActiveInRegion() || isUserOptOut) {
-            stopCollectingData();
-            return;
-        }
+//        if (!TravelBehaviorUtils.isTravelBehaviorActiveInRegion() || isUserOptOut) {
+//            stopCollectingData();
+//            return;
+//        }
 
-        boolean isUserOptIn = PreferenceUtils.getBoolean(TravelBehaviorConstants.USER_OPT_IN,
-                false);
+//        boolean isUserOptIn = PreferenceUtils.getBoolean(TravelBehaviorConstants.USER_OPT_IN,
+//                false);
 
         // If the user not opt in yet
-        if (!isUserOptIn) {
-            showParticipationDialog();
-        }
+//        if (!isUserOptIn) {
+//            showParticipationDialog();
+//        }
     }
 
-    private void showParticipationDialog() {
-        View v = LayoutInflater.from(mActivityContext).inflate(R.layout.research_participation_dialog, null);
-        CheckBox neverShowDialog = v.findViewById(R.id.research_never_ask_again);
-
-        new AlertDialog.Builder(mActivityContext)
-                .setView(v)
-                .setTitle(R.string.travel_behavior_opt_in_title)
-                .setIcon(createIcon())
-                .setCancelable(false)
-                .setPositiveButton(R.string.travel_behavior_dialog_learn_more,
-                        (dialog, which) -> showAgeDialog())
-                .setNegativeButton(R.string.travel_behavior_dialog_not_now,
-                        (dialog, which) -> {
-                            // If the user has chosen not to see the dialog again opt them out of the study, otherwise do nothing so they are prompted again later
-                            if (neverShowDialog.isChecked()) {
-                                optOutUser();
-                                ObaAnalytics.reportUiEvent(mFirebaseAnalytics,
-                                        mApplicationContext.getString(R.string.analytics_label_button_travel_behavior_opt_out_at_first_dialog),
-                                        null);
-                            } else {
-                                ObaAnalytics.reportUiEvent(mFirebaseAnalytics,
-                                        mApplicationContext.getString(R.string.analytics_label_button_travel_behavior_enroll_not_now),
-                                        null);
-                            }
-                        })
-                .create().show();
-    }
-
-    private void showAgeDialog() {
-        new AlertDialog.Builder(mActivityContext)
-                .setMessage(R.string.travel_behavior_age_message)
-                .setTitle(R.string.travel_behavior_opt_in_title)
-                .setIcon(createIcon())
-                .setCancelable(false)
-                .setPositiveButton(R.string.travel_behavior_dialog_yes,
-                        (dialog, which) -> {
-                            showInformedConsent();
-                            dialog.dismiss();
-                            ObaAnalytics.reportUiEvent(mFirebaseAnalytics,
-                                    mApplicationContext.getString(R.string.analytics_label_button_travel_behavior_opt_in_over_18),
-                                    null);
-                        })
-                .setNegativeButton(R.string.travel_behavior_dialog_no,
-                        (dialog, which) -> {
-                            Toast.makeText(mApplicationContext,
-                                    R.string.travel_behavior_age_invalid_message, Toast.LENGTH_LONG).show();
-                            optOutUser();
-                            dialog.dismiss();
-                            ObaAnalytics.reportUiEvent(mFirebaseAnalytics,
-                                    mApplicationContext.getString(R.string.analytics_label_button_travel_behavior_opt_out_under_18),
-                                    null);
-                        })
-                .create().show();
-    }
-
-    private void showInformedConsent() {
-        String consentHtml = getHtmlConsentDocument();
-        new AlertDialog.Builder(mActivityContext)
-                .setMessage(Html.fromHtml(consentHtml))
-                .setTitle(R.string.travel_behavior_opt_in_title)
-                .setIcon(createIcon())
-                .setCancelable(false)
-                .setPositiveButton(R.string.travel_behavior_dialog_consent_agree,
-                        (dialog, which) -> {
-                            showEmailDialog();
-                            ObaAnalytics.reportUiEvent(mFirebaseAnalytics,
-                                    mApplicationContext.getString(R.string.analytics_label_button_travel_behavior_opt_in_informed_consent),
-                                    null);
-                        })
-                .setNegativeButton(R.string.travel_behavior_dialog_consent_disagree,
-                        (dialog, which) -> {
-                            optOutUser();
-                            ObaAnalytics.reportUiEvent(mFirebaseAnalytics,
-                                    mApplicationContext.getString(R.string.analytics_label_button_travel_behavior_opt_out_informed_consent),
-                                    null);
-                        })
-                .create().show();
-    }
-
-    private String getHtmlConsentDocument() {
-        InputStream inputStream = mApplicationContext.getResources().
-                openRawResource(R.raw.travel_behavior_informed_consent);
-        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-
-        byte[] buf = new byte[1024];
-        int len;
-        try {
-            while ((len = inputStream.read(buf)) != -1) {
-                outputStream.write(buf, 0, len);
-            }
-            outputStream.close();
-            inputStream.close();
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-        return outputStream.toString();
-    }
-
-    private void showEmailDialog() {
-        showEmailDialog(null);
-    }
-
-    private void showEmailDialog(String email) {
-        LayoutInflater inflater = ((AppCompatActivity) mActivityContext).getLayoutInflater();
-        final View editTextView = inflater.inflate(R.layout.travel_behavior_email_dialog, null);
-        EditText emailEditText = editTextView.findViewById(R.id.tb_email_edittext);
-        EditText emailEditTextConfirm = editTextView.findViewById(R.id.tb_email_edittext_confirm);
-
-        if (email != null) {
-            emailEditText.setText(email);
-        }
-
-        new AlertDialog.Builder(mActivityContext)
-                .setTitle(R.string.travel_behavior_opt_in_title)
-                .setMessage(R.string.travel_behavior_email_message)
-                .setIcon(createIcon())
-                .setCancelable(false)
-                .setView(editTextView)
-                .setPositiveButton(R.string.travel_behavior_dialog_email_save,
-                        (dialog, which) -> {
-                            String currentEmail = emailEditText.getText().toString();
-                            String currentEmailConfirm = emailEditTextConfirm.getText().toString();
-                            if (!TextUtils.isEmpty(currentEmail) &&
-                                    Patterns.EMAIL_ADDRESS.matcher(currentEmail).matches() &&
-                                    currentEmail.equalsIgnoreCase(currentEmailConfirm)) {
-                                registerUser(currentEmail);
-                                checkPermissions();
-                            } else {
-                                Toast.makeText(mApplicationContext, R.string.travel_behavior_email_invalid,
-                                        Toast.LENGTH_LONG).show();
-                                // Android automatically dismisses the dialog.
-                                // Show the dialog again if the email is invalid
-                                showEmailDialog(currentEmail);
-                            }
-                        })
-                .create().show();
-    }
-
-    private void checkPermissions() {
-        if (!PermissionUtils.hasGrantedAllPermissions(mApplicationContext, TravelBehaviorConstants.PERMISSIONS)) {
-            HomeActivity homeActivity = (HomeActivity) mActivityContext;
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                // When targeting Android 11 and up, BACKGROUND_LOCATION and ACTIVITY_RECOGNITION_PERMISSION must be requested independently of all other permissions
-                // Request activity permission here, and then background location the subsequent callback set up in HomeActivity
-                homeActivity.requestPhysicalActivityPermission();
-            }
-        }
-    }
-
-    private void registerUser(String email) {
-        Data myData = new Data.Builder()
-                .putString(TravelBehaviorConstants.USER_EMAIL, email)
-                .build();
-
-        Constraints constraints = new Constraints.Builder()
-                .setRequiredNetworkType(NetworkType.CONNECTED)
-                .build();
-
-        OneTimeWorkRequest workRequest = new OneTimeWorkRequest.
-                Builder(RegisterTravelBehaviorParticipantWorker.class)
-                .setInputData(myData)
-                .setConstraints(constraints)
-                .build();
-
-        WorkManager workManager = WorkManager.getInstance();
-        workManager.enqueue(workRequest);
-        ListenableFuture<WorkInfo> listenableFuture = workManager.
-                getWorkInfoById(workRequest.getId());
-        Futures.addCallback(listenableFuture, new FutureCallback<WorkInfo>() {
-            @Override
-            public void onSuccess(@NullableDecl WorkInfo result) {
-                AppCompatActivity activity = (AppCompatActivity) mActivityContext;
-                activity.runOnUiThread(() -> Toast.makeText(mApplicationContext, R.string.travel_behavior_enroll_success,
-                        Toast.LENGTH_LONG).show());
-            }
-
-            @Override
-            public void onFailure(Throwable t) {
-                AppCompatActivity activity = (AppCompatActivity) mActivityContext;
-                activity.runOnUiThread(() -> Toast.makeText(mApplicationContext, R.string.travel_behavior_enroll_fail,
-                        Toast.LENGTH_LONG).show());
-            }
-        }, TravelBehaviorFileSaverExecutorManager.getInstance().getThreadPoolExecutor());
-    }
+//    private void showParticipationDialog() {
+//        View v = LayoutInflater.from(mActivityContext).inflate(R.layout.research_participation_dialog, null);
+//        CheckBox neverShowDialog = v.findViewById(R.id.research_never_ask_again);
+//
+//        new AlertDialog.Builder(mActivityContext)
+//                .setView(v)
+//                .setTitle(R.string.travel_behavior_opt_in_title)
+//                .setIcon(createIcon())
+//                .setCancelable(false)
+//                .setPositiveButton(R.string.travel_behavior_dialog_learn_more,
+//                        (dialog, which) -> showAgeDialog())
+//                .setNegativeButton(R.string.travel_behavior_dialog_not_now,
+//                        (dialog, which) -> {
+//                            // If the user has chosen not to see the dialog again opt them out of the study, otherwise do nothing so they are prompted again later
+//                            if (neverShowDialog.isChecked()) {
+//                                optOutUser();
+//                                ObaAnalytics.reportUiEvent(mFirebaseAnalytics,
+//                                        mApplicationContext.getString(R.string.analytics_label_button_travel_behavior_opt_out_at_first_dialog),
+//                                        null);
+//                            } else {
+//                                ObaAnalytics.reportUiEvent(mFirebaseAnalytics,
+//                                        mApplicationContext.getString(R.string.analytics_label_button_travel_behavior_enroll_not_now),
+//                                        null);
+//                            }
+//                        })
+//                .create().show();
+//    }
+//
+//    private void showAgeDialog() {
+//        new AlertDialog.Builder(mActivityContext)
+//                .setMessage(R.string.travel_behavior_age_message)
+//                .setTitle(R.string.travel_behavior_opt_in_title)
+//                .setIcon(createIcon())
+//                .setCancelable(false)
+//                .setPositiveButton(R.string.travel_behavior_dialog_yes,
+//                        (dialog, which) -> {
+//                            showInformedConsent();
+//                            dialog.dismiss();
+//                            ObaAnalytics.reportUiEvent(mFirebaseAnalytics,
+//                                    mApplicationContext.getString(R.string.analytics_label_button_travel_behavior_opt_in_over_18),
+//                                    null);
+//                        })
+//                .setNegativeButton(R.string.travel_behavior_dialog_no,
+//                        (dialog, which) -> {
+//                            Toast.makeText(mApplicationContext,
+//                                    R.string.travel_behavior_age_invalid_message, Toast.LENGTH_LONG).show();
+//                            optOutUser();
+//                            dialog.dismiss();
+//                            ObaAnalytics.reportUiEvent(mFirebaseAnalytics,
+//                                    mApplicationContext.getString(R.string.analytics_label_button_travel_behavior_opt_out_under_18),
+//                                    null);
+//                        })
+//                .create().show();
+//    }
+//
+//    private void showInformedConsent() {
+//        String consentHtml = getHtmlConsentDocument();
+//        new AlertDialog.Builder(mActivityContext)
+//                .setMessage(Html.fromHtml(consentHtml))
+//                .setTitle(R.string.travel_behavior_opt_in_title)
+//                .setIcon(createIcon())
+//                .setCancelable(false)
+//                .setPositiveButton(R.string.travel_behavior_dialog_consent_agree,
+//                        (dialog, which) -> {
+//                            showEmailDialog();
+//                            ObaAnalytics.reportUiEvent(mFirebaseAnalytics,
+//                                    mApplicationContext.getString(R.string.analytics_label_button_travel_behavior_opt_in_informed_consent),
+//                                    null);
+//                        })
+//                .setNegativeButton(R.string.travel_behavior_dialog_consent_disagree,
+//                        (dialog, which) -> {
+//                            optOutUser();
+//                            ObaAnalytics.reportUiEvent(mFirebaseAnalytics,
+//                                    mApplicationContext.getString(R.string.analytics_label_button_travel_behavior_opt_out_informed_consent),
+//                                    null);
+//                        })
+//                .create().show();
+//    }
+//
+//    private String getHtmlConsentDocument() {
+//        InputStream inputStream = mApplicationContext.getResources().
+//                openRawResource(R.raw.travel_behavior_informed_consent);
+//        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+//
+//        byte[] buf = new byte[1024];
+//        int len;
+//        try {
+//            while ((len = inputStream.read(buf)) != -1) {
+//                outputStream.write(buf, 0, len);
+//            }
+//            outputStream.close();
+//            inputStream.close();
+//        } catch (IOException e) {
+//            e.printStackTrace();
+//        }
+//        return outputStream.toString();
+//    }
+//
+//    private void showEmailDialog() {
+//        showEmailDialog(null);
+//    }
+//
+//    private void showEmailDialog(String email) {
+//        LayoutInflater inflater = ((AppCompatActivity) mActivityContext).getLayoutInflater();
+//        final View editTextView = inflater.inflate(R.layout.travel_behavior_email_dialog, null);
+//        EditText emailEditText = editTextView.findViewById(R.id.tb_email_edittext);
+//        EditText emailEditTextConfirm = editTextView.findViewById(R.id.tb_email_edittext_confirm);
+//
+//        if (email != null) {
+//            emailEditText.setText(email);
+//        }
+//
+//        new AlertDialog.Builder(mActivityContext)
+//                .setTitle(R.string.travel_behavior_opt_in_title)
+//                .setMessage(R.string.travel_behavior_email_message)
+//                .setIcon(createIcon())
+//                .setCancelable(false)
+//                .setView(editTextView)
+//                .setPositiveButton(R.string.travel_behavior_dialog_email_save,
+//                        (dialog, which) -> {
+//                            String currentEmail = emailEditText.getText().toString();
+//                            String currentEmailConfirm = emailEditTextConfirm.getText().toString();
+//                            if (!TextUtils.isEmpty(currentEmail) &&
+//                                    Patterns.EMAIL_ADDRESS.matcher(currentEmail).matches() &&
+//                                    currentEmail.equalsIgnoreCase(currentEmailConfirm)) {
+//                                registerUser(currentEmail);
+//                                checkPermissions();
+//                            } else {
+//                                Toast.makeText(mApplicationContext, R.string.travel_behavior_email_invalid,
+//                                        Toast.LENGTH_LONG).show();
+//                                // Android automatically dismisses the dialog.
+//                                // Show the dialog again if the email is invalid
+//                                showEmailDialog(currentEmail);
+//                            }
+//                        })
+//                .create().show();
+//    }
+//
+//    private void checkPermissions() {
+//        if (!PermissionUtils.hasGrantedAllPermissions(mApplicationContext, TravelBehaviorConstants.PERMISSIONS)) {
+//            HomeActivity homeActivity = (HomeActivity) mActivityContext;
+//            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+//                // When targeting Android 11 and up, BACKGROUND_LOCATION and ACTIVITY_RECOGNITION_PERMISSION must be requested independently of all other permissions
+//                // Request activity permission here, and then background location the subsequent callback set up in HomeActivity
+//                homeActivity.requestPhysicalActivityPermission();
+//            }
+//        }
+//    }
+//
+//    private void registerUser(String email) {
+//        Data myData = new Data.Builder()
+//                .putString(TravelBehaviorConstants.USER_EMAIL, email)
+//                .build();
+//
+//        Constraints constraints = new Constraints.Builder()
+//                .setRequiredNetworkType(NetworkType.CONNECTED)
+//                .build();
+//
+//        OneTimeWorkRequest workRequest = new OneTimeWorkRequest.
+//                Builder(RegisterTravelBehaviorParticipantWorker.class)
+//                .setInputData(myData)
+//                .setConstraints(constraints)
+//                .build();
+//
+//        WorkManager workManager = WorkManager.getInstance();
+//        workManager.enqueue(workRequest);
+//        ListenableFuture<WorkInfo> listenableFuture = workManager.
+//                getWorkInfoById(workRequest.getId());
+//        Futures.addCallback(listenableFuture, new FutureCallback<WorkInfo>() {
+//            @Override
+//            public void onSuccess(@NullableDecl WorkInfo result) {
+//                AppCompatActivity activity = (AppCompatActivity) mActivityContext;
+//                activity.runOnUiThread(() -> Toast.makeText(mApplicationContext, R.string.travel_behavior_enroll_success,
+//                        Toast.LENGTH_LONG).show());
+//            }
+//
+//            @Override
+//            public void onFailure(Throwable t) {
+//                AppCompatActivity activity = (AppCompatActivity) mActivityContext;
+//                activity.runOnUiThread(() -> Toast.makeText(mApplicationContext, R.string.travel_behavior_enroll_fail,
+//                        Toast.LENGTH_LONG).show());
+//            }
+//        }, TravelBehaviorFileSaverExecutorManager.getInstance().getThreadPoolExecutor());
+//    }
 
     public static void startCollectingData(Context applicationContext) {
-        if (TravelBehaviorUtils.isUserParticipatingInStudy()) {
-            new TravelBehaviorManager(null, applicationContext).startCollectingData();
-        }
+//        if (TravelBehaviorUtils.isUserParticipatingInStudy()) {
+//            new TravelBehaviorManager(null, applicationContext).startCollectingData();
+//        }
     }
 
-    private void startCollectingData() {
-        int[] activities = {DetectedActivity.IN_VEHICLE,
-                DetectedActivity.ON_BICYCLE, DetectedActivity.WALKING,
-                DetectedActivity.STILL, DetectedActivity.RUNNING};
+//    private void startCollectingData() {
+//        int[] activities = {DetectedActivity.IN_VEHICLE,
+//                DetectedActivity.ON_BICYCLE, DetectedActivity.WALKING,
+//                DetectedActivity.STILL, DetectedActivity.RUNNING};
+//
+//        List<ActivityTransition> transitions = new ArrayList<>();
+//
+//        for (int activity : activities) {
+//            transitions.add(new ActivityTransition.Builder()
+//                    .setActivityType(activity)
+//                    .setActivityTransition(ActivityTransition.ACTIVITY_TRANSITION_ENTER)
+//                    .build());
+//
+//            transitions.add(new ActivityTransition.Builder()
+//                    .setActivityType(activity)
+//                    .setActivityTransition(ActivityTransition.ACTIVITY_TRANSITION_EXIT)
+//                    .build());
+//        }
+//
+//        ActivityTransitionRequest atr = new ActivityTransitionRequest(transitions);
+//        Intent intent = new Intent(mApplicationContext, TransitionBroadcastReceiver.class);
+//        // If pending intent is already created do not create a new one
+//
+////        PendingIntent pi = PendingIntent.getBroadcast(mApplicationContext, 100, intent,
+////                PendingIntent.FLAG_NO_CREATE);
+//
+//        // The above method returns null if the pending intent is not active
+//        // it returns the pending intent object if the pending intent is alive
+//        // --> The idea is here that if the pending intent is alive (i.e., pi object is not null)
+//        // then do not create a new object
+//        // However, every time the above method is called, the application stops receiving
+//        // activity transitions
+//        // TODO: figure out the problem described above
+//
+//        int flags;
+//        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
+//            flags = PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_MUTABLE;
+//        } else {
+//            flags = PendingIntent.FLAG_UPDATE_CURRENT;
+//        }
+//        PendingIntent pi = PendingIntent.getBroadcast(mApplicationContext, 100,
+//                intent, flags);
+//        Task<Void> task = ActivityRecognition.getClient(mApplicationContext)
+//                .requestActivityTransitionUpdates(atr, pi);
+//        task.addOnCompleteListener(task1 -> {
+//            if (task1.isSuccessful()) {
+//                Log.d(TAG, "Travel behavior activity-transition-update set up");
+//            } else {
+//
+//                TravelBehaviorFirebaseIOUtils.logErrorMessage(task1.getException(),
+//                        "Travel behavior activity-transition-update failed set up: ");
+//            }
+//        });
+//
+//        saveDeviceInformation();
+//    }
 
-        List<ActivityTransition> transitions = new ArrayList<>();
-
-        for (int activity : activities) {
-            transitions.add(new ActivityTransition.Builder()
-                    .setActivityType(activity)
-                    .setActivityTransition(ActivityTransition.ACTIVITY_TRANSITION_ENTER)
-                    .build());
-
-            transitions.add(new ActivityTransition.Builder()
-                    .setActivityType(activity)
-                    .setActivityTransition(ActivityTransition.ACTIVITY_TRANSITION_EXIT)
-                    .build());
-        }
-
-        ActivityTransitionRequest atr = new ActivityTransitionRequest(transitions);
-        Intent intent = new Intent(mApplicationContext, TransitionBroadcastReceiver.class);
-        // If pending intent is already created do not create a new one
-
-//        PendingIntent pi = PendingIntent.getBroadcast(mApplicationContext, 100, intent,
-//                PendingIntent.FLAG_NO_CREATE);
-
-        // The above method returns null if the pending intent is not active
-        // it returns the pending intent object if the pending intent is alive
-        // --> The idea is here that if the pending intent is alive (i.e., pi object is not null)
-        // then do not create a new object
-        // However, every time the above method is called, the application stops receiving
-        // activity transitions
-        // TODO: figure out the problem described above
-
-        int flags;
-        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
-            flags = PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_MUTABLE;
-        } else {
-            flags = PendingIntent.FLAG_UPDATE_CURRENT;
-        }
-        PendingIntent pi = PendingIntent.getBroadcast(mApplicationContext, 100,
-                intent, flags);
-        Task<Void> task = ActivityRecognition.getClient(mApplicationContext)
-                .requestActivityTransitionUpdates(atr, pi);
-        task.addOnCompleteListener(task1 -> {
-            if (task1.isSuccessful()) {
-                Log.d(TAG, "Travel behavior activity-transition-update set up");
-            } else {
-
-                TravelBehaviorFirebaseIOUtils.logErrorMessage(task1.getException(),
-                        "Travel behavior activity-transition-update failed set up: ");
-            }
-        });
-
-        saveDeviceInformation();
-    }
-
-    private void saveDeviceInformation() {
-        String uid = PreferenceUtils.getString(TravelBehaviorConstants.USER_ID);
-        Data myData = new Data.Builder()
-                .putString(TravelBehaviorConstants.USER_ID, uid)
-                .build();
-
-        OneTimeWorkRequest workRequest = new OneTimeWorkRequest.Builder(
-                UpdateDeviceInfoWorker.class)
-                .setInputData(myData)
-                .build();
-        WorkManager.getInstance().enqueue(workRequest);
-    }
+//    private void saveDeviceInformation() {
+//        String uid = PreferenceUtils.getString(TravelBehaviorConstants.USER_ID);
+//        Data myData = new Data.Builder()
+//                .putString(TravelBehaviorConstants.USER_ID, uid)
+//                .build();
+//
+//        OneTimeWorkRequest workRequest = new OneTimeWorkRequest.Builder(
+//                UpdateDeviceInfoWorker.class)
+//                .setInputData(myData)
+//                .build();
+//        WorkManager.getInstance().enqueue(workRequest);
+//    }
 
     public void stopCollectingData() {
-        Intent intent = new Intent(mApplicationContext, TransitionBroadcastReceiver.class);
-        int flags;
-        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
-            flags = PendingIntent.FLAG_NO_CREATE | PendingIntent.FLAG_MUTABLE;
-        } else {
-            flags = PendingIntent.FLAG_NO_CREATE;
-        }
-        PendingIntent pi = PendingIntent.getBroadcast(mApplicationContext, 100, intent,
-                flags);
-        if (pi != null) {
-            ActivityRecognition.getClient(mApplicationContext).removeActivityUpdates(pi);
-            pi.cancel();
-        }
+//        Intent intent = new Intent(mApplicationContext, TransitionBroadcastReceiver.class);
+//        int flags;
+//        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
+//            flags = PendingIntent.FLAG_NO_CREATE | PendingIntent.FLAG_MUTABLE;
+//        } else {
+//            flags = PendingIntent.FLAG_NO_CREATE;
+//        }
+//        PendingIntent pi = PendingIntent.getBroadcast(mApplicationContext, 100, intent,
+//                flags);
+//        if (pi != null) {
+//            ActivityRecognition.getClient(mApplicationContext).removeActivityUpdates(pi);
+//            pi.cancel();
+//        }
     }
 
-    private Drawable createIcon() {
-        Drawable icon = mApplicationContext.getResources().getDrawable(R.drawable.ic_light_bulb);
-        DrawableCompat.setTint(icon, mApplicationContext.getResources().getColor(R.color.theme_primary));
-        return icon;
-    }
+//    private Drawable createIcon() {
+//        Drawable icon = mApplicationContext.getResources().getDrawable(R.drawable.ic_light_bulb);
+//        DrawableCompat.setTint(icon, mApplicationContext.getResources().getColor(R.color.theme_primary));
+//        return icon;
+//    }
 
     public static void optOutUser() {
-        PreferenceUtils.saveBoolean(TravelBehaviorConstants.USER_OPT_OUT, true);
-        PreferenceUtils.saveBoolean(TravelBehaviorConstants.USER_OPT_IN, false);
+//        PreferenceUtils.saveBoolean(TravelBehaviorConstants.USER_OPT_OUT, true);
+//        PreferenceUtils.saveBoolean(TravelBehaviorConstants.USER_OPT_IN, false);
     }
 
     public static void optOutUserOnServer() {
-        String uid = PreferenceUtils.getString(TravelBehaviorConstants.USER_ID);
-        Data myData = new Data.Builder()
-                .putString(TravelBehaviorConstants.USER_ID, uid)
-                .build();
-
-        OneTimeWorkRequest workRequest = new OneTimeWorkRequest.Builder(
-                OptOutTravelBehaviorParticipantWorker.class)
-                .setInputData(myData)
-                .build();
-        WorkManager.getInstance().enqueue(workRequest);
+//        String uid = PreferenceUtils.getString(TravelBehaviorConstants.USER_ID);
+//        Data myData = new Data.Builder()
+//                .putString(TravelBehaviorConstants.USER_ID, uid)
+//                .build();
+//
+//        OneTimeWorkRequest workRequest = new OneTimeWorkRequest.Builder(
+//                OptOutTravelBehaviorParticipantWorker.class)
+//                .setInputData(myData)
+//                .build();
+//        WorkManager.getInstance().enqueue(workRequest);
     }
 
     public static void optInUser(String uid) {
-        PreferenceUtils.saveString(TravelBehaviorConstants.USER_ID, uid);
-        PreferenceUtils.saveBoolean(TravelBehaviorConstants.USER_OPT_IN, true);
-        PreferenceUtils.saveBoolean(TravelBehaviorConstants.USER_OPT_OUT, false);
+//        PreferenceUtils.saveString(TravelBehaviorConstants.USER_ID, uid);
+//        PreferenceUtils.saveBoolean(TravelBehaviorConstants.USER_OPT_IN, true);
+//        PreferenceUtils.saveBoolean(TravelBehaviorConstants.USER_OPT_OUT, false);
     }
 
     public static void saveDestinationReminders(String currStopId, String destStopId, String tripId,
                                                 String routeId, Long serverTime) {
-        if (TravelBehaviorUtils.isUserParticipatingInStudy()) {
-            DestinationReminderDataSaverTask saverTask = new DestinationReminderDataSaverTask(currStopId,
-                    destStopId, tripId, routeId, serverTime, Application.get().getApplicationContext());
-            TravelBehaviorFileSaverExecutorManager manager = TravelBehaviorFileSaverExecutorManager.getInstance();
-            manager.runTask(saverTask);
-        }
+//        if (TravelBehaviorUtils.isUserParticipatingInStudy()) {
+//            DestinationReminderDataSaverTask saverTask = new DestinationReminderDataSaverTask(currStopId,
+//                    destStopId, tripId, routeId, serverTime, Application.get().getApplicationContext());
+//            TravelBehaviorFileSaverExecutorManager manager = TravelBehaviorFileSaverExecutorManager.getInstance();
+//            manager.runTask(saverTask);
+//        }
     }
 
     public static void saveArrivalInfo(ObaArrivalInfo[] info, String url, long serverTime, String stopId) {
-        if (TravelBehaviorUtils.isUserParticipatingInStudy()) {
-            ArrivalAndDepartureDataSaverTask saverTask = new ArrivalAndDepartureDataSaverTask(info,
-                    serverTime, url, stopId, Application.get().getApplicationContext());
-            TravelBehaviorFileSaverExecutorManager manager = TravelBehaviorFileSaverExecutorManager.getInstance();
-            manager.runTask(saverTask);
-        }
+//        if (TravelBehaviorUtils.isUserParticipatingInStudy()) {
+//            ArrivalAndDepartureDataSaverTask saverTask = new ArrivalAndDepartureDataSaverTask(info,
+//                    serverTime, url, stopId, Application.get().getApplicationContext());
+//            TravelBehaviorFileSaverExecutorManager manager = TravelBehaviorFileSaverExecutorManager.getInstance();
+//            manager.runTask(saverTask);
+//        }
     }
 
     public static void saveTripPlan(TripPlan tripPlan, String url, Context applicationContext) {
-        if (TravelBehaviorUtils.isUserParticipatingInStudy()) {
-            TripPlanDataSaverTask dataSaverTask = new TripPlanDataSaverTask(tripPlan, url,
-                    applicationContext);
-            TravelBehaviorFileSaverExecutorManager executorManager =
-                    TravelBehaviorFileSaverExecutorManager.getInstance();
-            executorManager.runTask(dataSaverTask);
-        }
+//        if (TravelBehaviorUtils.isUserParticipatingInStudy()) {
+//            TripPlanDataSaverTask dataSaverTask = new TripPlanDataSaverTask(tripPlan, url,
+//                    applicationContext);
+//            TravelBehaviorFileSaverExecutorManager executorManager =
+//                    TravelBehaviorFileSaverExecutorManager.getInstance();
+//            executorManager.runTask(dataSaverTask);
+//        }
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/travelbehavior/TravelBehaviorManager.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/travelbehavior/TravelBehaviorManager.java
@@ -93,9 +93,9 @@ public class TravelBehaviorManager {
     private FirebaseAnalytics mFirebaseAnalytics;
 
     public TravelBehaviorManager(Context activityContext, Context applicationContext) {
-        mActivityContext = activityContext;
-        mApplicationContext = applicationContext;
-        mFirebaseAnalytics = FirebaseAnalytics.getInstance(activityContext);
+//        mActivityContext = activityContext;
+//        mApplicationContext = applicationContext;
+//        mFirebaseAnalytics = FirebaseAnalytics.getInstance(activityContext);
     }
 
     public void registerTravelBehaviorParticipant() {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.java
@@ -280,7 +280,7 @@ public class HomeActivity extends AppCompatActivity
 
     private FirebaseAnalytics mFirebaseAnalytics;
 
-    private ActivityResultLauncher<String> travelBehaviorPermissionsLauncher;
+    //private ActivityResultLauncher<String> travelBehaviorPermissionsLauncher;
 
     private ObaWeatherResponse weatherResponse;
 
@@ -405,7 +405,7 @@ public class HomeActivity extends AppCompatActivity
 
         setupGooglePlayServices();
 
-        setupPermissions(this);
+        //setupPermissions(this);
 
         UIUtils.setupActionBar(this);
 
@@ -1931,15 +1931,15 @@ public class HomeActivity extends AppCompatActivity
      * @param activity
      */
     private void setupPermissions(AppCompatActivity activity) {
-        travelBehaviorPermissionsLauncher =
-                registerForActivityResult(new ActivityResultContracts.RequestPermission(), isGranted -> {
-                    if (isGranted) {
-                        // User opt-ed into study and granted physical activity tracking - now request background location permissions (when targeting Android 11 we can't request both simultaneously)
-                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                            activity.requestPermissions(TravelBehaviorConstants.BACKGROUND_LOCATION_PERMISSION, BACKGROUND_LOCATION_PERMISSION_REQUEST);
-                        }
-                    }
-                });
+//        travelBehaviorPermissionsLauncher =
+//                registerForActivityResult(new ActivityResultContracts.RequestPermission(), isGranted -> {
+//                    if (isGranted) {
+//                        // User opt-ed into study and granted physical activity tracking - now request background location permissions (when targeting Android 11 we can't request both simultaneously)
+//                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+//                            activity.requestPermissions(TravelBehaviorConstants.BACKGROUND_LOCATION_PERMISSION, BACKGROUND_LOCATION_PERMISSION_REQUEST);
+//                        }
+//                    }
+//                });
     }
 
     /**
@@ -1948,9 +1948,9 @@ public class HomeActivity extends AppCompatActivity
      * activity permissions. This method should only be called after the user opts into the travel behavior study.
      */
     public void requestPhysicalActivityPermission() {
-        if (travelBehaviorPermissionsLauncher != null){
-            travelBehaviorPermissionsLauncher.launch(Manifest.permission.ACTIVITY_RECOGNITION);
-        }
+//        if (travelBehaviorPermissionsLauncher != null){
+//            travelBehaviorPermissionsLauncher.launch(Manifest.permission.ACTIVITY_RECOGNITION);
+//        }
     }
 
     /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/PreferencesActivity.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/PreferencesActivity.java
@@ -158,18 +158,18 @@ public class PreferencesActivity extends PreferenceActivity
         mAnalyticsPref = findPreference(getString(R.string.preferences_key_analytics));
         mAnalyticsPref.setOnPreferenceChangeListener(this);
 
-        mTravelBehaviorPref = (CheckBoxPreference) findPreference(getString(R.string.preferences_key_travel_behavior));
-        mTravelBehaviorPref.setOnPreferenceChangeListener(this);
+//        mTravelBehaviorPref = (CheckBoxPreference) findPreference(getString(R.string.preferences_key_travel_behavior));
+//        mTravelBehaviorPref.setOnPreferenceChangeListener(this);
 
-        if (!TravelBehaviorUtils.isTravelBehaviorActiveInRegion() ||
-                (!TravelBehaviorUtils.allowEnrollMoreParticipantsInStudy() &&
-                        !TravelBehaviorUtils.isUserParticipatingInStudy())) {
-            PreferenceCategory aboutCategory = (PreferenceCategory)
-                    findPreference(getString(R.string.preferences_category_about));
-            aboutCategory.removePreference(mTravelBehaviorPref);
-        } else {
-            mTravelBehaviorPref.setChecked(TravelBehaviorUtils.isUserParticipatingInStudy());
-        }
+//        if (!TravelBehaviorUtils.isTravelBehaviorActiveInRegion() ||
+//                (!TravelBehaviorUtils.allowEnrollMoreParticipantsInStudy() &&
+//                        !TravelBehaviorUtils.isUserParticipatingInStudy())) {
+//            PreferenceCategory aboutCategory = (PreferenceCategory)
+//                    findPreference(getString(R.string.preferences_category_about));
+//            aboutCategory.removePreference(mTravelBehaviorPref);
+//        } else {
+//            mTravelBehaviorPref.setChecked(TravelBehaviorUtils.isUserParticipatingInStudy());
+//        }
 
         pushFirebaseData = findPreference(getString(R.string.preference_key_push_firebase_data));
         pushFirebaseData.setOnPreferenceClickListener(this);
@@ -492,14 +492,14 @@ public class PreferencesActivity extends PreferenceActivity
             //Report if the analytics turns off, just before shared preference changed
             ObaAnalytics.setSendAnonymousData(mFirebaseAnalytics, isAnalyticsActive);
         } else if (preference.equals(mTravelBehaviorPref) && newValue instanceof Boolean) {
-            Boolean activateTravelBehaviorCollection = (Boolean) newValue;
-            if (activateTravelBehaviorCollection) {
-                new TravelBehaviorManager(this, getApplicationContext()).
-                        registerTravelBehaviorParticipant(true);
-            } else {
-                showOptOutDialog();
-                return false;
-            }
+//            Boolean activateTravelBehaviorCollection = (Boolean) newValue;
+//            if (activateTravelBehaviorCollection) {
+//                new TravelBehaviorManager(this, getApplicationContext()).
+//                        registerTravelBehaviorParticipant(true);
+//            } else {
+//                showOptOutDialog();
+//                return false;
+//            }
         } else if (preference.equals(mLeftHandMode) && newValue instanceof Boolean) {
             Boolean isLeftHandEnabled = (Boolean) newValue;
             //Report if left handed mode is turned on, just before shared preference changed
@@ -515,31 +515,32 @@ public class PreferencesActivity extends PreferenceActivity
 
     /**
      * Shows the dialog to explain user is choosing to opt out of travel behavior research study
+     * Currently disabled see ticket https://github.com/OneBusAway/onebusaway-android/issues/1240
      */
-    private void showOptOutDialog() {
-        androidx.appcompat.app.AlertDialog.Builder builder = new androidx.appcompat.app.AlertDialog.Builder(this)
-                .setTitle(R.string.travel_behavior_dialog_opt_out_title)
-                .setMessage(R.string.travel_behavior_dialog_opt_out_message)
-                .setCancelable(false)
-                .setPositiveButton(R.string.ok,
-                        (dialog, which) -> {
-                            // Remove user from study
-                            new TravelBehaviorManager(this, getApplicationContext()).
-                                    stopCollectingData();
-                            TravelBehaviorManager.optOutUser();
-                            TravelBehaviorManager.optOutUserOnServer();
-                            // Change preference
-                            mTravelBehaviorPref.setChecked(false);
-                            PreferenceUtils.saveBoolean(getString(R.string.preferences_key_travel_behavior), false);
-                        }
-                )
-                .setNegativeButton(R.string.cancel,
-                        (dialog, which) -> {
-                            // No-op
-                        }
-                );
-        builder.create().show();
-    }
+//    private void showOptOutDialog() {
+//        androidx.appcompat.app.AlertDialog.Builder builder = new androidx.appcompat.app.AlertDialog.Builder(this)
+//                .setTitle(R.string.travel_behavior_dialog_opt_out_title)
+//                .setMessage(R.string.travel_behavior_dialog_opt_out_message)
+//                .setCancelable(false)
+//                .setPositiveButton(R.string.ok,
+//                        (dialog, which) -> {
+//                            // Remove user from study
+//                            new TravelBehaviorManager(this, getApplicationContext()).
+//                                    stopCollectingData();
+//                            TravelBehaviorManager.optOutUser();
+//                            TravelBehaviorManager.optOutUserOnServer();
+//                            // Change preference
+//                            mTravelBehaviorPref.setChecked(false);
+//                            PreferenceUtils.saveBoolean(getString(R.string.preferences_key_travel_behavior), false);
+//                        }
+//                )
+//                .setNegativeButton(R.string.cancel,
+//                        (dialog, which) -> {
+//                            // No-op
+//                        }
+//                );
+//        builder.create().show();
+//    }
 
     @Override
     protected void onDestroy() {

--- a/onebusaway-android/src/main/res/xml/preferences.xml
+++ b/onebusaway-android/src/main/res/xml/preferences.xml
@@ -179,6 +179,8 @@
             android:key="@string/preferences_key_analytics"
             android:summary="@string/preferences_analytics_summary"
             android:title="@string/preferences_analytics_title" />
+
+<!--         Disabled due to issues related to ticket #1240 ,see: https://github.com/OneBusAway/onebusaway-android/issues/1240-->
 <!--        <CheckBoxPreference-->
 <!--            android:defaultValue="false"-->
 <!--            android:key="@string/preferences_key_travel_behavior"-->

--- a/onebusaway-android/src/main/res/xml/preferences.xml
+++ b/onebusaway-android/src/main/res/xml/preferences.xml
@@ -179,11 +179,11 @@
             android:key="@string/preferences_key_analytics"
             android:summary="@string/preferences_analytics_summary"
             android:title="@string/preferences_analytics_title" />
-        <CheckBoxPreference
-            android:defaultValue="false"
-            android:key="@string/preferences_key_travel_behavior"
-            android:summary="@string/preferences_travel_behavior_summary"
-            android:title="@string/preferences_travel_behavior_title" />
+<!--        <CheckBoxPreference-->
+<!--            android:defaultValue="false"-->
+<!--            android:key="@string/preferences_key_travel_behavior"-->
+<!--            android:summary="@string/preferences_travel_behavior_summary"-->
+<!--            android:title="@string/preferences_travel_behavior_title" />-->
         <Preference
             android:key="@string/preference_key_tutorial"
             android:summary="@string/preferences_tutorial_summary"


### PR DESCRIPTION
Fixes: #1240 

## Key Changes

### Disabled Travel Behavior Functionality (No longer using `ACTIVITY_RECOGNITION`)

- **Commented Out Public Functions in `TravelBehaviourManager`**  
  To make restoring the feature easier in the future, public functions have been commented instead of fully removing them. This avoids the need to edit multiple parts of the code.

- **Removed `ACTIVITY_RECOGNITION` Permission from `AndroidManifest.xml`**  
  Since the travel behavior functionality is no longer in use, the related permission has been removed from the manifest file.

- **Removed Preferences Related to the Travel Behavior Study**  
  Cleaned up preferences and configurations that were associated with the travel behavior study feature.


- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `gradlew connectedObaGoogleDebugAndroidTest` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them for the initial submission of the pull 