### PR TITLE
Fix restore and save backup for newer android versions

### DIFF
--- a/onebusaway-android/src/main/AndroidManifest.xml
+++ b/onebusaway-android/src/main/AndroidManifest.xml
@@ -33,8 +33,6 @@
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.VIBRATE" />
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="com.android.launcher.permission.INSTALL_SHORTCUT" />
     <uses-permission android:name="${applicationId}.permission.TRIP_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />

--- a/onebusaway-android/src/main/java/org/onebusaway/android/io/backup/Backup.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/io/backup/Backup.java
@@ -20,15 +20,19 @@ import static org.onebusaway.android.util.BackupUtilKt.uriToTempFile;
 import android.content.ContentProviderClient;
 import android.content.Context;
 import android.net.Uri;
-import android.os.Build;
-import android.os.Environment;
+import android.util.Log;
+import android.widget.Toast;
 
 import org.apache.commons.io.FileUtils;
+import org.onebusaway.android.R;
 import org.onebusaway.android.provider.ObaContract;
 import org.onebusaway.android.provider.ObaProvider;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 
 /**
  * Big note, that this is currently fairly unsafe.
@@ -42,33 +46,43 @@ import java.io.IOException;
  */
 public final class Backup {
 
-    private static final String FILE_NAME = "OneBusAway.backup";
-
-    private static final String DIRECTORY_NAME = "OBABackups";
+    public static final String FILE_NAME = "OneBusAway.backup";
 
     private static File getDB(Context context) {
         return ObaProvider.getDatabasePath(context);
     }
 
-    private static File getBackup() {
-        File backupDir = getBackupDirectory();
-        return new File(backupDir, FILE_NAME);
-    }
-
     /**
-     * Performs a backup to the SD card.
+     * Initiates a backup process, allowing the user to choose a location
+     * (such as the Documents directory) to save the backup file.
      */
-    public static String backup(Context context) throws IOException {
-        // We need two things:
-        // 1. The path to the database;
-        // 2. The path on the SD card to the backup file.
-        File backupPath = getBackup();
-        FileUtils.copyFile(getDB(context), backupPath);
-        return backupPath.getAbsolutePath();
+    public static void backup(Context context,Uri uri) throws IOException{
+        try (InputStream inputStream = new FileInputStream(getDB(context));
+             OutputStream outputStream = context.getContentResolver().openOutputStream(uri)) {
+            byte[] buffer = new byte[1024];
+            int length;
+            while ((length = inputStream.read(buffer)) > 0) {
+                if (outputStream != null) {
+                    outputStream.write(buffer, 0, length);
+                }
+            }
+            if (outputStream != null) {
+                outputStream.flush();
+            }
+            Toast.makeText(context,
+                    context.getString(R.string.preferences_db_saved),
+                    Toast.LENGTH_LONG).show();
+            Log.d("Backup", "Database backup saved successfully to: " + uri);
+        } catch (IOException e) {
+            Toast.makeText(context,
+                    context.getString(R.string.preferences_db_save_error, e.getMessage()),
+                    Toast.LENGTH_LONG).show();
+            Log.e("Backup", "Error saving database backup", e);
+        }
     }
 
     /**
-     * Performs a restore from the SD card.
+     * Restores data from the location where the user saved the backup.
      * @param uri URI to the backup file, as returned by the system UI picker. Following targeting
      *            Android 11 we can't access this directory and need to rely on the system UI picker.
      */
@@ -96,15 +110,4 @@ public final class Backup {
         }
     }
 
-    public static boolean isRestoreAvailable() {
-        return getBackup().exists();
-    }
-
-    public static File getBackupDirectory() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            return Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOCUMENTS + "/" + DIRECTORY_NAME);
-        } else {
-            return Environment.getExternalStoragePublicDirectory(DIRECTORY_NAME);
-        }
-    }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/io/backup/RestorePreference.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/io/backup/RestorePreference.java
@@ -15,15 +15,8 @@
  */
 package org.onebusaway.android.io.backup;
 
-import static org.onebusaway.android.io.backup.Backup.getBackupDirectory;
-import static org.onebusaway.android.ui.PreferencesActivity.REQUEST_CODE_RESTORE_BACKUP;
-
 import android.content.Context;
-import android.content.Intent;
-import android.os.Environment;
 import android.preference.Preference;
-import android.preference.PreferenceActivity;
-import android.provider.DocumentsContract;
 import android.util.AttributeSet;
 
 public class RestorePreference extends Preference {
@@ -50,20 +43,11 @@ public class RestorePreference extends Preference {
 
     @Override
     public boolean isEnabled() {
-        // This is only enabled if the SD card is attached.
-        final String state = Environment.getExternalStorageState();
-        // Also, this is only enabled if there's a backup file
-        return (Environment.MEDIA_MOUNTED_READ_ONLY.equals(state) ||
-                Environment.MEDIA_MOUNTED.equals(state)) &&
-                Backup.isRestoreAvailable();
+        return true;
     }
 
     @Override
     protected void onClick() {
-        Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
-        intent.setType("*/*");
-        intent.putExtra(DocumentsContract.EXTRA_INITIAL_URI, getBackupDirectory().toURI());
-        ((PreferenceActivity) getContext()).startActivityForResult(intent, REQUEST_CODE_RESTORE_BACKUP);
         super.onClick();
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/io/backup/SavePreference.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/io/backup/SavePreference.java
@@ -15,10 +15,7 @@
  */
 package org.onebusaway.android.io.backup;
 
-import org.onebusaway.android.util.BackupUtils;
-
 import android.content.Context;
-import android.os.Environment;
 import android.preference.Preference;
 import android.util.AttributeSet;
 
@@ -46,13 +43,11 @@ public class SavePreference extends Preference {
 
     @Override
     public boolean isEnabled() {
-        // This is only enabled if the SD card is attached.
-        return Environment.MEDIA_MOUNTED
-                .equals(Environment.getExternalStorageState());
+        return true;
     }
 
     @Override
     protected void onClick() {
-        BackupUtils.save(getContext());
+        super.onClick();
     }
 }

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -675,7 +675,8 @@
     <string name="preferences_save_title">Save to storage</string>
     <string name="preferences_save_summary">Saves your starred and recent stops and routes</string>
     <string name="preferences_restore_title">Restore from storage</string>
-    <string name="preferences_restore_summary">Restores from previous save. After selecting this option you\'ll be asked to pick a file. Please select \"db.backup\" or \"OneBusAway.backup\", which will be in a folder \"OBABackups\", likely on your SD card or under your \"Documents\" folder.</string>
+    <string name="preferences_restore_summary">Restores from a previous backup. After selecting this option, you\'ll be asked to pick a file. Please select the backup file (e.g., "db.backup" or "OneBusAway.backup"), which may be in your "Documents" folder or any location where you saved the backup.
+</string>
 
     <string name="preferences_db_saved">Saved successfully!</string>
     <string name="preferences_db_save_error">Unable to save: %1$s</string>


### PR DESCRIPTION
Fixes #1212 

# Details

Starting with Android 10, users reported issues with backup and restore functionality, especially on Android 13, where they were unable to create or restore backups. This was due to changes in how external storage permissions are handled. More details can be found in the [Android documentation](https://developer.android.com/training/data-storage/shared/media#storage-permission).

To address this, I integrated the updated APIs that support saving and restoring local backups, ensuring compatibility from Android 5 (Lollipop) through the latest versions of Android.

# How old backup/restore works

- Previously, backups were only saved in a folder named OBABackups under the Android Documents directory. Users were unable to select a specific location to save backups. Additionally, the restore functionality was disabled until the app could verify whether the backup folder existed. This approach had limitations, such as when a user wanted to transfer a backup to a different phone and restore it without creating a new backup.
- Users encountered unexpected errors when attempting to update an existing backup, making it possible to back up only once.
- The functionality was completely broken on Android 13 and above.
- The application used read and write external storage permissions, which may be a concern for users regarding privacy and security.
- Backup was disabled if you don't have SD card

# New Changes 

- Users can now take backup to any folder of their choice by default we will navigate the user to `Documents directory`
- Users can restore backups from any location at any time.
- Functionality has been tested and works perfectly on Android 7 (Nougat), Android 10, Android 11, Android 13, and Android 14.
- Removed read and write external storage permissions to address privacy and security concerns.
- Completely rely on the Android UI file picker to ensure compatibility without requiring additional permissions.
- Save in local storage or external storage

# Main Changes

- Removed requesting storage permissions
- Changed logic of the backup functionality 
# Video

https://github.com/user-attachments/assets/6faf68c4-82b1-44e2-a77a-71e624d3db1f



# TODO  
- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `gradlew connectedObaGoogleDebugAndroidTest` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them for the initial submission of the pull request.  When addressing comments on a pull request, please push a new commit per comment when possible (reviewers will squash and merge using GitHub merge tool)