### PR TITLE
Fix dark mode support for alert dialog on Android 15

### DIFF
--- a/onebusaway-android/src/main/res/values/themes.xml
+++ b/onebusaway-android/src/main/res/values/themes.xml
@@ -29,7 +29,7 @@
         <item name="alertDialogTheme">@style/customAlertDialogTheme</item>
 
     </style>
-K
+
     <!-- Custom TimePickerDialog theme for dark mode -->
     <style name="dayNightTimePickerDialogTheme" parent="Theme.MaterialComponents.DayNight.Dialog">
         <item name="colorPrimary">@color/theme_primary</item>

--- a/onebusaway-android/src/main/res/values/themes.xml
+++ b/onebusaway-android/src/main/res/values/themes.xml
@@ -25,14 +25,29 @@
         <item name="autoCompleteTextViewStyle">@style/cursorColor</item>
         <!-- Allows us to force Dark Theme throughout the app -->
         <item name="android:forceDarkAllowed">true</item>
+        <!-- Allows us to force AlertDialog Theme across the app -->
+        <item name="alertDialogTheme">@style/customAlertDialogTheme</item>
 
     </style>
-
+K
     <!-- Custom TimePickerDialog theme for dark mode -->
     <style name="dayNightTimePickerDialogTheme" parent="Theme.MaterialComponents.DayNight.Dialog">
         <item name="colorPrimary">@color/theme_primary</item>
         <item name="colorPrimaryDark">@color/theme_primary_dark</item>
         <item name="colorAccent">@color/theme_accent</item>
     </style>
+
+    <!-- Custom Theme For Alert Dialog -->
+    <style name="customAlertDialogTheme" parent="Theme.AppCompat.Light.Dialog.Alert">
+        <item name="android:background">@android:color/white</item>
+        <item name="buttonBarPositiveButtonStyle">@style/customAlertDialogButton</item>
+        <item name="buttonBarNegativeButtonStyle">@style/customAlertDialogButton</item>
+        <item name="buttonBarNeutralButtonStyle">@style/customAlertDialogButton</item>
+    </style>
+
+    <style name="customAlertDialogButton" parent="Widget.AppCompat.Button.ButtonBar.AlertDialog">
+        <item name="android:textColor">@color/theme_primary</item>
+    </style>
+
 
 </resources>


### PR DESCRIPTION
Fixes #1247.

## **Summary**

Alert dialogs were not functioning correctly on Android 15 when invoked from any `Fragment`, as noted in [ticket #1247](#1247). The issue did not affect alert dialogs called from activities, where they continued to work as expected.

## **Fix**

A custom alert dialog implementation was added across the application. The solution has been tested on Android 7, 11, 12, 13, 14, and 15, using Google Pixel 8 Pro and Ximote Note 8 Pro devices.

## **Screenshot**

<div align="center">

<table>
  <tr>
    <td>
      <strong>Before:</strong><br>
      <img src="https://github.com/user-attachments/assets/d0dbcb36-73d9-48c9-8d58-236919cf3825" width="300" />
    </td>
    <td>
      <strong>After:</strong><br>
      <img src="https://github.com/user-attachments/assets/7ba0940c-832f-4263-aed6-735d79632f9f" width="300" />
    </td>
  </tr>
</table>

</div>

## **TODO**
- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `gradlew connectedObaGoogleDebugAndroidTest` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them for the initial submission of the pull request.  When addressing comments on a pull request, please push a new commit per comment when possible (reviewers will squash and merge using GitHub merge tool)