### PR TITLE
Enhance weather view settings: Use checkbox instead of dialog

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/PreferencesActivity.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/PreferencesActivity.java
@@ -111,7 +111,6 @@ public class PreferencesActivity extends PreferenceActivity
 
     ListPreference preferredUnits;
     ListPreference preferredTempUnits;
-    ListPreference showWeatherDisplayPref;
 
     ListPreference mThemePref;
 
@@ -192,9 +191,6 @@ public class PreferencesActivity extends PreferenceActivity
         preferredTempUnits = (ListPreference) findPreference(
                 getString(R.string.preference_key_preferred_temperature_units));
 
-        showWeatherDisplayPref = (ListPreference) findPreference(
-                getString(R.string.preference_key_show_weather_view));
-
         mThemePref = (ListPreference) findPreference(
                 getString(R.string.preference_key_app_theme));
         mThemePref.setOnPreferenceChangeListener(this);
@@ -250,7 +246,6 @@ public class PreferencesActivity extends PreferenceActivity
         changePreferenceSummary(getString(R.string.preference_key_region));
         changePreferenceSummary(getString(R.string.preference_key_preferred_units));
         changePreferenceSummary(getString(R.string.preference_key_preferred_temperature_units));
-        changePreferenceSummary(getString(R.string.preference_key_show_weather_view));
         changePreferenceSummary(getString(R.string.preference_key_app_theme));
         changePreferenceSummary(getString(R.string.preference_key_otp_api_url));
 
@@ -332,8 +327,6 @@ public class PreferencesActivity extends PreferenceActivity
         }else if (preferenceKey
                 .equalsIgnoreCase(getString(R.string.preference_key_preferred_temperature_units))) {
             preferredTempUnits.setSummary(preferredTempUnits.getValue());
-        }else if(preferenceKey.equalsIgnoreCase(getString(R.string.preference_key_show_weather_view))){
-            showWeatherDisplayPref.setSummary(showWeatherDisplayPref.getValue());
         }
     }
 
@@ -573,9 +566,6 @@ public class PreferencesActivity extends PreferenceActivity
             ObaAnalytics.setShowDepartedVehicles(mFirebaseAnalytics, showDepartedBuses);
         }else if (key.equalsIgnoreCase(getString(R.string.preference_key_preferred_temperature_units))) {
             // Change the preferred temp unit description
-            changePreferenceSummary(key);
-        }else if (key.equalsIgnoreCase(getString(R.string.preference_key_show_weather_view))) {
-            // Change the preferred weather show or hide option
             changePreferenceSummary(key);
         }
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/weather/WeatherUtils.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/weather/WeatherUtils.java
@@ -42,12 +42,8 @@ public class WeatherUtils {
 
     public static boolean isWeatherViewHiddenPref() {
         Application app = Application.get();
-        SharedPreferences sharedPreferences = Application.getPrefs();
-
-        String showOption = app.getString(R.string.show);
-        String pref = sharedPreferences.getString(app.getString(R.string.preference_key_show_weather_view), showOption);
-
-        return (!pref.equals(showOption));
+        boolean isWeatherViewEnabled = Application.getPrefs().getBoolean(app.getString(R.string.preference_key_display_weather_view), true);
+        return (!isWeatherViewEnabled);
     }
 
     public static void toggleWeatherViewVisibility(boolean shouldShow, View weatherView) {

--- a/onebusaway-android/src/main/res/values-es/strings.xml
+++ b/onebusaway-android/src/main/res/values-es/strings.xml
@@ -1118,4 +1118,5 @@
     <string name="remind_me_latter">Recordármelo más tarde</string>
     <string name="survey_dismiss_dialog_skip_this_survey">Omitir esta encuesta</string>
     <string name="dismiss_survey_dialog_body">Tu opinión ayuda a mejorar los servicios de tránsito y las experiencias en la aplicación.</string>
+    <string name="preferences_show_weather_view_on_map">Mostrar la vista del clima en el mapa</string>
 </resources>

--- a/onebusaway-android/src/main/res/values-fi/strings.xml
+++ b/onebusaway-android/src/main/res/values-fi/strings.xml
@@ -715,4 +715,5 @@
     <string name="remind_me_latter">Muistuta myöhemmin</string>
     <string name="survey_dismiss_dialog_skip_this_survey">Ohita tämä kysely</string>
     <string name="dismiss_survey_dialog_body">Palautteesi auttaa parantamaan liikennepalveluja ja sovelluskokemuksia.</string>
+    <string name="preferences_show_weather_view_on_map">Näytä säätiedot kartalla</string>
 </resources>

--- a/onebusaway-android/src/main/res/values-it/strings.xml
+++ b/onebusaway-android/src/main/res/values-it/strings.xml
@@ -1029,4 +1029,5 @@
     <string name="remind_me_latter">Ricordamelo più tardi</string>
     <string name="survey_dismiss_dialog_skip_this_survey">Salta questo sondaggio</string>
     <string name="dismiss_survey_dialog_body">Il tuo feedback aiuta a migliorare i servizi di trasporto e le esperienze con l\'app.</string>
+    <string name="preferences_show_weather_view_on_map">Mostra la vista del meteo sulla mappa</string>
 </resources>

--- a/onebusaway-android/src/main/res/values-pl/strings.xml
+++ b/onebusaway-android/src/main/res/values-pl/strings.xml
@@ -735,4 +735,5 @@
     <string name="remind_me_later">Przypomnij mi później</string>
     <string name="survey_dismiss_dialog_skip_this_survey">Pomiń tę ankietę</string>
     <string name="dismiss_survey_dialog_body">Twoja opinia pomoże w poprawie usług transportowych i doświadczeń z aplikacją.</string>
+    <string name="preferences_show_weather_view_on_map">Wyświetl widok pogody na mapie</string>
 </resources>

--- a/onebusaway-android/src/main/res/values/arrays.xml
+++ b/onebusaway-android/src/main/res/values/arrays.xml
@@ -101,10 +101,6 @@
         <item>@string/fahrenheit</item>
         <item>@string/celsius</item>
     </string-array>
-    <string-array name="preferred_weather_view_option">
-        <item>@string/show</item>
-        <item>@string/hide</item>
-    </string-array>
     <string-array name="app_theme_options">
         <item>@string/preferences_app_theme_option_system_default</item>
         <item>@string/preferences_app_theme_option_light</item>

--- a/onebusaway-android/src/main/res/values/donottranslate.xml
+++ b/onebusaway-android/src/main/res/values/donottranslate.xml
@@ -35,7 +35,7 @@
     <string name="preferences_key_about">preference_about</string>
     <string name="preference_key_preferred_units">preference_preferred_units</string>
     <string name="preference_key_preferred_temperature_units">preference_preferred_temperature_units</string>
-    <string name="preference_key_show_weather_view">preference_key_show_weather_view</string>
+    <string name="preference_key_display_weather_view">preference_key_display_weather_view</string>
     <string name="preference_key_app_theme">preference_app_theme</string>
     <string name="preference_key_arrival_info_style">preference_arrival_info_style</string>
     <string name="preference_key_show_negative_arrivals">preference_show_negative_arrivals</string>

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -1267,4 +1267,5 @@
     <string name="remind_me_latter">Remind Me Later</string>
     <string name="survey_dismiss_dialog_skip_this_survey">Skip This Survey</string>
     <string name="dismiss_survey_dialog_body">Your feedback helps improve transit services and app experiences.</string>
+    <string name="preferences_show_weather_view_on_map">Display the weather view on the map</string>
 </resources>

--- a/onebusaway-android/src/main/res/xml/preferences.xml
+++ b/onebusaway-android/src/main/res/xml/preferences.xml
@@ -54,6 +54,12 @@
             android:title="@string/preferences_enable_map_3d_mode_title" />
 
         <CheckBoxPreference
+                android:defaultValue="true"
+                android:key="@string/preference_key_display_weather_view"
+                android:summary="@string/preferences_show_weather_view_on_map"
+                android:title="@string/preferences_show_weather_view" />
+
+        <CheckBoxPreference
             android:defaultValue="true"
             android:key="@string/preference_key_show_available_studies"
             android:summary="@string/preferences_show_available_studies_body"
@@ -89,14 +95,6 @@
             android:entryValues="@array/preferred_temp_unit_options"
             android:key="@string/preference_key_preferred_temperature_units"
             android:title="@string/preferred_temperature_unit" />
-
-        <ListPreference
-            android:defaultValue="@string/show"
-            android:negativeButtonText="@string/close"
-            android:entries="@array/preferred_weather_view_option"
-            android:entryValues="@array/preferred_weather_view_option"
-            android:key="@string/preference_key_show_weather_view"
-            android:title="@string/preferences_show_weather_view" />
 
         <ListPreference
                 android:defaultValue="@string/preferences_app_theme_option_system_default"


### PR DESCRIPTION
Improved the weather view setting: Instead of showing a dialog to select show/hide, I added a checkbox that enables or disables the weather feature to make the overall settings interface more user-friendly.

# Screenshot

![image](https://github.com/user-attachments/assets/e2c805de-2ab3-4e9e-a946-d70782a61e47)


# TODO
- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `gradlew connectedObaGoogleDebugAndroidTest` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them for the initial submission of the pull request.  When addressing comments on a pull request, please push a new commit per comment when possible (reviewers will squash and merge using GitHub merge tool)