### PR TITLE
Disable access background location

### DIFF
--- a/onebusaway-android/src/main/AndroidManifest.xml
+++ b/onebusaway-android/src/main/AndroidManifest.xml
@@ -29,7 +29,6 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
-    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.VIBRATE" />
@@ -38,10 +37,11 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
 
-    <!-- Permission request for activity recognition is disabled because the related feature has been turned off.
+    <!-- Permission request for activity recognition and background location is disabled because the related feature has been turned off.
     See issue #1240 for more details: https://github.com/OneBusAway/onebusaway-android/issues/1240-->
     <!-- ACTIVITY_RECOGNITION API 28 and lower -->
 <!--    <uses-permission android:name="com.google.android.gms.permission.ACTIVITY_RECOGNITION" />-->
+<!--    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />-->
     <!-- ACTIVITY_RECOGNITION API 29 and higher -->
 <!--    <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION" />-->
     <!--To enable checkBatteryOptimizations feature, also uncomment checkBatteryOptimizations() in


### PR DESCRIPTION
Fixes #1092 

We were using background location for travel behavior studies... but currently, the feature is disabled 

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `gradlew connectedObaGoogleDebugAndroidTest` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them for the initial submission of the pull request.  When addressing comments on a pull request, please push a new commit per comment when possible (reviewers will squash and merge using GitHub merge tool)