### PR TITLE
Fix showing multiple alerts and ObaGoogle release version generation

### DIFF
--- a/onebusaway-android/build.gradle
+++ b/onebusaway-android/build.gradle
@@ -395,6 +395,7 @@ dependencies {
     implementation "androidx.room:room-ktx:2.6.1"
     // GTFS Realtime bindings for parsing GTFS-realtime data
     implementation group: 'org.mobilitydata', name: 'gtfs-realtime-bindings', version: '0.0.8'
+    implementation 'com.google.api.grpc:proto-google-common-protos:2.9.0'
 }
 
 apply plugin:'com.google.gms.google-services'

--- a/onebusaway-android/src/main/java/org/onebusaway/android/widealerts/GtfsAlerts.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/widealerts/GtfsAlerts.java
@@ -65,15 +65,16 @@ public class GtfsAlerts {
                 continue;
             }
             GtfsRealtime.Alert alert = entity.getAlert();
-            GtfsAlertsHelper.markAlertAsRead(Application.get().getApplicationContext() ,entity);
-
             String id = entity.getId();
             String title = GtfsAlertsHelper.getAlertTitle(alert);
             String description = GtfsAlertsHelper.getAlertDescription(alert);
             String url = GtfsAlertsHelper.getAlertUrl(alert);
 
             Log.d(TAG, "Alert: " + id + " - " + title + " - " + description + " - " + url);
+            GtfsAlertsHelper.markAlertAsRead(Application.get().getApplicationContext(), entity);
             callback.onAlert(title, description, url);
+            // Only trigger the callback for one alert.
+            break;
         }
     }
 


### PR DESCRIPTION
## Key Changes

-  Fix showing multiple alerts at the same time 
-  Fix error during generating `ObaGoogle-Release` cause of missing classes related to `firestore` when we excluded the `protobuf` lib that firestore depends on it to prevent clashes with `GTFS-real-time parsing library`

## TODO

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `gradlew connectedObaGoogleDebugAndroidTest` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them for the initial submission of the pull request.  When addressing comments on a pull request, please push a new commit per comment when possible (reviewers will squash and merge using GitHub merge tool)