### PR TITLE
Bug : Infinite loader seen while setting the reminder

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/TripInfoActivity.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/TripInfoActivity.java
@@ -540,6 +540,7 @@ public class TripInfoActivity extends AppCompatActivity {
                     Log.d(TAG, "Reminder set successfully");
                 } else {
                     Log.d(TAG, "Response or url is null");
+                    handleReminderFailure();
                 }
             });
         }


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.
Not applicable as no UI changes have been done. 

- [x] Run the unit tests with `gradlew connectedObaGoogleDebugAndroidTest` to make sure you didn't break anything
Not Needed as no new functionality has been added. 

- [x] If you have multiple commits please combine them into one commit by squashing them for the initial submission of the pull request.  When addressing comments on a pull request, please push a new commit per comment when possible (reviewers will squash and merge using GitHub merge tool)
It is under one commit only. 


**Category :**  Bug 

**Issue** : An infinite loader is seen while setting a reminder. 

**Image**

![Screenshot_20241209-172424](https://github.com/user-attachments/assets/8c929139-89e6-49ab-8cdb-e90b835375e5)


**RCA :**  The bug is caused when we receive null as a response from the API [https://onebusaway.co/api/v1/regions/11/alarms](https://onebusaway.co/api/v1/regions/11/alarms) while setting the reminder. There is only a log statement to handle it causing the infinite loader to run. 


**Resolution:**
The failure was handled using the existing function in the Activity.