### PR TITLE
Fix EditText overlap with icons in Report Problem screens

### DIFF
--- a/onebusaway-android/src/main/res/layout/report_issue_text_item.xml
+++ b/onebusaway-android/src/main/res/layout/report_issue_text_item.xml
@@ -16,7 +16,8 @@
 
         <com.google.android.material.textfield.TextInputLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content">
+            android:layout_height="wrap_content"
+            style="@style/MaterialItem">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/riti_editText"


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `gradlew connectedObaGoogleDebugAndroidTest` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them for the initial submission of the pull request.  When addressing comments on a pull request, please push a new commit per comment when possible (reviewers will squash and merge using GitHub merge tool)

<hr>

Fixes: #1374 

<hr>

**Screenshots:**

| <img src="https://github.com/user-attachments/assets/368dd50b-ea79-4040-b251-4c1c0718042a" width="400"> | <img src="https://github.com/user-attachments/assets/daaf7945-e2ee-4b92-87c3-9411640d7632" width="400"> |
| --- | --- |

