### PR TITLE
Fix the notification channel description typo in createNotificationChannels(). Channel3's description is set on channel2. ALSO, Used UTF-8 charset when converting the custom API URL to bytes in reportAnalytics() to avoid charset issues.

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/app/Application.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/app/Application.java
@@ -70,6 +70,7 @@ import edu.usf.cutr.open311client.models.Open311Option;
 
 import static com.google.android.gms.location.LocationServices.getFusedLocationProviderClient;
 import static org.onebusaway.android.util.UIUtils.setAppTheme;
+import java.nio.charset.StandardCharsets;
 
 public class Application extends MultiDexApplication {
 
@@ -614,7 +615,7 @@ public class Application extends MultiDexApplication {
             MessageDigest digest = null;
             try {
                 digest = MessageDigest.getInstance("SHA-1");
-                digest.update(getCustomApiUrl().getBytes());
+                digest.update(getCustomApiUrl().getBytes(StandardCharsets.UTF_8));
                 customUrl = getString(R.string.analytics_label_custom_url) +
                         ": " + getHex(digest.digest());
             } catch (Exception e) {
@@ -660,7 +661,7 @@ public class Application extends MultiDexApplication {
                     CHANNEL_DESTINATION_ALERT_ID,
                     "Destination alerts",
                     NotificationManager.IMPORTANCE_LOW);
-            channel2.setDescription("All notifications relating to Destination alerts");
+            channel3.setDescription("All notifications relating to Destination alerts");
 
             NotificationManager manager = getSystemService(NotificationManager.class);
             manager.createNotificationChannel(channel1);


### PR DESCRIPTION
1)In the method createNotificationChannels() the original code accidentally set the description for the destination alerts channel (channel3) on channel2. This fix ensures the description is properly assigned to channel3, making the notification channel's purpose clear to users in their device settings.

2)In the reportAnalytics() method, there's a call to digest.update(getCustomApiUrl().getBytes()). Using getBytes() without specifying a charset can lead to inconsistent behavior on different devices. It's better to use StandardCharsets.UTF_8.

Fixes #1407 

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `gradlew connectedObaGoogleDebugAndroidTest` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them for the initial submission of the pull request.  When addressing comments on a pull request, please push a new commit per comment when possible (reviewers will squash and merge using GitHub merge tool)