### PR TITLE
FIXED : Touch Target Size Too Small in "Set a Reminder" Screen #1409

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/app/Application.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/app/Application.java
@@ -70,6 +70,7 @@ import edu.usf.cutr.open311client.models.Open311Option;
 
 import static com.google.android.gms.location.LocationServices.getFusedLocationProviderClient;
 import static org.onebusaway.android.util.UIUtils.setAppTheme;
+import java.nio.charset.StandardCharsets;
 
 public class Application extends MultiDexApplication {
 
@@ -614,7 +615,7 @@ public class Application extends MultiDexApplication {
             MessageDigest digest = null;
             try {
                 digest = MessageDigest.getInstance("SHA-1");
-                digest.update(getCustomApiUrl().getBytes());
+                digest.update(getCustomApiUrl().getBytes(StandardCharsets.UTF_8));
                 customUrl = getString(R.string.analytics_label_custom_url) +
                         ": " + getHex(digest.digest());
             } catch (Exception e) {
@@ -660,7 +661,7 @@ public class Application extends MultiDexApplication {
                     CHANNEL_DESTINATION_ALERT_ID,
                     "Destination alerts",
                     NotificationManager.IMPORTANCE_LOW);
-            channel2.setDescription("All notifications relating to Destination alerts");
+            channel3.setDescription("All notifications relating to Destination alerts");
 
             NotificationManager manager = getSystemService(NotificationManager.class);
             manager.createNotificationChannel(channel1);

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/TripInfoActivity.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/TripInfoActivity.java
@@ -352,8 +352,13 @@ public class TripInfoActivity extends AppCompatActivity {
             progressView = view.findViewById(R.id.progress);
 
             String[] reminderTimes = ReminderUtils.getReminderTimes(mDepartTime);
-            ArrayAdapter<String> adapter = new ArrayAdapter<>(getActivity(), android.R.layout.simple_spinner_item, reminderTimes);
-            adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+            ArrayAdapter<String> adapter = new ArrayAdapter<>(
+                    getActivity(),
+                    R.layout.spinner_item_reminder,           // custom layout with 24sp text
+                    R.id.text_spinner_item,                   // TextView ID from the layout
+                    reminderTimes
+            );
+            adapter.setDropDownViewResource(R.layout.spinner_dropdown_reminder); // optional, for dropdown styling
             reminder.setAdapter(adapter);
 
             //

--- a/onebusaway-android/src/main/res/layout/spinner_dropdown_reminder.xml
+++ b/onebusaway-android/src/main/res/layout/spinner_dropdown_reminder.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/text_spinner_dropdown"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:textSize="24sp"
+    android:padding="12dp"
+    android:textColor="#000000" />

--- a/onebusaway-android/src/main/res/layout/spinner_item_reminder.xml
+++ b/onebusaway-android/src/main/res/layout/spinner_item_reminder.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/text_spinner_item"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:textSize="24sp"
+    android:padding="12dp"
+    android:textColor="#000000" />

--- a/onebusaway-android/src/main/res/layout/trip_info.xml
+++ b/onebusaway-android/src/main/res/layout/trip_info.xml
@@ -98,7 +98,9 @@
                 style="@style/FormLabel"
                 android:layout_width="fill_parent"
                 android:layout_height="wrap_content"
-                android:text="@string/trip_info_reminder_header" />
+                android:text="@string/trip_info_reminder_header"
+                android:textSize="20dp"/>
+
 
             <Spinner
                 android:id="@+id/trip_info_reminder_time"

--- a/onebusaway-android/src/main/res/layout/trip_list_listitem.xml
+++ b/onebusaway-android/src/main/res/layout/trip_list_listitem.xml
@@ -15,24 +15,26 @@
      limitations under the License.
 -->
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                style="@style/ListItem"
-                android:id="@+id/stop_list_container"
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content"
-                android:orientation="horizontal">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    style="@style/ListItem"
+    android:id="@+id/stop_list_container"
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal">
+
     <ImageView
-            android:id="@+id/stop_reminder"
-            android:src="@drawable/ic_drawer_alarm"
-            android:tint="@color/navdrawer_icon_tint"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:scaleType="fitCenter"
-            android:adjustViewBounds="true"
-            android:maxHeight="25dp"
-            android:maxWidth="25dp"
-            android:layout_marginLeft="6dp"
-            android:layout_centerVertical="true"
-            android:layout_alignParentLeft="true"/>
+        android:id="@+id/stop_reminder"
+        android:src="@drawable/ic_drawer_alarm"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:scaleType="fitCenter"
+        android:adjustViewBounds="true"
+        android:maxHeight="25dp"
+        android:maxWidth="25dp"
+        android:layout_marginLeft="6dp"
+        android:layout_centerVertical="true"
+        android:layout_alignParentLeft="true"
+        app:tint="@color/navdrawer_icon_tint" />
 
     <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
                   style="@style/ListItem"

--- a/onebusaway-android/src/main/res/xml/spinner_dropdown_reminder.xml
+++ b/onebusaway-android/src/main/res/xml/spinner_dropdown_reminder.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/text_spinner_dropdown"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:textSize="48dp"
+    android:padding="12dp"
+    android:textColor="#000000" />


### PR DESCRIPTION
Fixes #1409 
FIXED : Touch Target Size Too Small in "Set a Reminder" Screen SET THE SIZE TO 48 DP FOR DROPDOWN REMINDER TIME.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `gradlew connectedObaGoogleDebugAndroidTest` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them for the initial submission of the pull request.  When addressing comments on a pull request, please push a new commit per comment when possible (reviewers will squash and merge using GitHub merge tool)