### PR TITLE
Fix: Updated textSize from dp to sp for accessibility

### DIFF
--- a/onebusaway-android/src/main/res/layout/activity_donation_learn_more.xml
+++ b/onebusaway-android/src/main/res/layout/activity_donation_learn_more.xml
@@ -25,7 +25,7 @@
                 android:id="@+id/textView5"
                 android:layout_marginHorizontal="@dimen/dialog_margin"
                 android:layout_marginVertical="@dimen/dialog_margin"
-                android:textSize="16sp" />
+                android:textSize="18sp" />
 
         <Button
                 android:textSize="24sp"

--- a/onebusaway-android/src/main/res/layout/activity_feedback.xml
+++ b/onebusaway-android/src/main/res/layout/activity_feedback.xml
@@ -20,7 +20,7 @@
             android:text="@string/feedback_msg"
             android:textAppearance="?android:attr/textAppearanceMedium"
             android:textColor="@android:color/black"
-            android:textSize="14sp" />
+            android:textSize="16sp" />
     </FrameLayout>
     <FrameLayout
         style="@style/MaterialLayout"


### PR DESCRIPTION
fix #1339  Replaced all android:textSize="XXdp" instances with XXsp across layout XML files.

Verified that UI remains visually consistent while becoming more accessible.