### PR TITLE
Fix Issue #1426 : Replaced deprecated XML layout attributes across the app

### DIFF
--- a/onebusaway-android/src/androidTest/res/layout/main.xml
+++ b/onebusaway-android/src/androidTest/res/layout/main.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
               android:orientation="vertical"
-              android:layout_width="fill_parent"
-              android:layout_height="fill_parent"
+              android:layout_width="match_parent"
+              android:layout_height="match_parent"
         >
     <TextView
-            android:layout_width="fill_parent"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"/>
 </LinearLayout>

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/ListFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/ListFragment.java
@@ -115,7 +115,7 @@ public class ListFragment extends Fragment {
                 ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT));
 
         root.addView(pframe, new FrameLayout.LayoutParams(
-                ViewGroup.LayoutParams.FILL_PARENT, ViewGroup.LayoutParams.FILL_PARENT));
+                ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT));
 
         // ------------------------------------------------------------------
 
@@ -126,21 +126,21 @@ public class ListFragment extends Fragment {
         tv.setId(R.id.internalEmpty);
         tv.setGravity(Gravity.CENTER);
         lframe.addView(tv, new FrameLayout.LayoutParams(
-                ViewGroup.LayoutParams.FILL_PARENT, ViewGroup.LayoutParams.FILL_PARENT));
+                ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT));
 
         ListView lv = new ListView(getActivity());
         lv.setId(android.R.id.list);
         lv.setDrawSelectorOnTop(false);
         lframe.addView(lv, new FrameLayout.LayoutParams(
-                ViewGroup.LayoutParams.FILL_PARENT, ViewGroup.LayoutParams.FILL_PARENT));
+                ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT));
 
         root.addView(lframe, new FrameLayout.LayoutParams(
-                ViewGroup.LayoutParams.FILL_PARENT, ViewGroup.LayoutParams.FILL_PARENT));
+                ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT));
 
         // ------------------------------------------------------------------
 
         root.setLayoutParams(new FrameLayout.LayoutParams(
-                ViewGroup.LayoutParams.FILL_PARENT, ViewGroup.LayoutParams.FILL_PARENT));
+                ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT));
 
         return root;
     }

--- a/onebusaway-android/src/main/res/layout-v11/load_more_arrivals_button.xml
+++ b/onebusaway-android/src/main/res/layout-v11/load_more_arrivals_button.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
               android:orientation="vertical"
-              android:layout_width="fill_parent"
+              android:layout_width="match_parent"
               android:layout_height="wrap_content">
     <Button
             android:id="@+id/load_more_arrivals"
             android:text="@string/stop_info_load_more_arrivals"
-            android:layout_width="fill_parent"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:textColor="@color/stop_info_scheduled_time"
             style="?android:attr/borderlessButtonStyle"/>

--- a/onebusaway-android/src/main/res/layout/activity_feedback.xml
+++ b/onebusaway-android/src/main/res/layout/activity_feedback.xml
@@ -29,7 +29,7 @@
         android:orientation="horizontal">
 
         <LinearLayout
-            android:layout_width="fill_parent"
+            android:layout_width="match_parent"
             android:layout_height="65dp"
             android:orientation="horizontal">
 

--- a/onebusaway-android/src/main/res/layout/alert_item.xml
+++ b/onebusaway-android/src/main/res/layout/alert_item.xml
@@ -14,14 +14,14 @@
      limitations under the License.
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              android:layout_width="fill_parent"
+              android:layout_width="match_parent"
               android:layout_height="wrap_content"
               android:orientation="vertical">
     <TextView
             android:id="@android:id/text1"
             style="@style/AlertListItem"
             android:gravity="center_vertical"
-            android:layout_width="fill_parent"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:drawablePadding="8dp"/>
     <LinearLayout

--- a/onebusaway-android/src/main/res/layout/alert_list.xml
+++ b/onebusaway-android/src/main/res/layout/alert_list.xml
@@ -17,5 +17,5 @@
           android:id="@+id/arrivals_alert_list"
           android:background="@color/android:background_light"
           android:cacheColorHint="#00000000"
-          android:layout_width="fill_parent"
+          android:layout_width="match_parent"
           android:layout_height="wrap_content"/>

--- a/onebusaway-android/src/main/res/layout/arrivals_list_empty_style.xml
+++ b/onebusaway-android/src/main/res/layout/arrivals_list_empty_style.xml
@@ -25,7 +25,7 @@
 
     <androidx.cardview.widget.CardView xmlns:card_view="http://schemas.android.com/apk/res-auto"
         android:id="@+id/no_arrivals_card_view"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
         card_view:cardCornerRadius="4dp"
@@ -34,7 +34,7 @@
         <TextView
             android:id="@+id/noArrivals"
             style="@style/ListHintText"
-            android:layout_width="fill_parent"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:paddingBottom="15sp" />
     </androidx.cardview.widget.CardView>

--- a/onebusaway-android/src/main/res/layout/arrivals_list_footer_style.xml
+++ b/onebusaway-android/src/main/res/layout/arrivals_list_footer_style.xml
@@ -25,14 +25,14 @@
             xmlns:android="http://schemas.android.com/apk/res/android"
             android:id="@+id/load_arrivals_card_view"
             android:layout_gravity="center"
-            android:layout_width="fill_parent"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             card_view:cardUseCompatPadding="true"
             card_view:cardCornerRadius="4dp"
             card_view:cardBackgroundColor="@color/primary_material_light">
 
         <include
-                android:layout_width="fill_parent"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_horizontal"
                 layout="@layout/load_more_arrivals_button"/>

--- a/onebusaway-android/src/main/res/layout/arrivals_list_header.xml
+++ b/onebusaway-android/src/main/res/layout/arrivals_list_header.xml
@@ -32,7 +32,7 @@
         <LinearLayout
                 android:id="@+id/edit_name_container"
                 android:orientation="vertical"
-                android:layout_width="fill_parent"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_centerInParent="true"
                 android:visibility="gone">
@@ -51,7 +51,7 @@
 
             <LinearLayout
                     android:orientation="horizontal"
-                    android:layout_width="fill_parent"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:paddingLeft="10dip"
                     android:paddingRight="10dip"
@@ -195,7 +195,7 @@
                         android:text="University Area Transit Center"
                         android:textColor="@color/header_text_color"
                         android:ellipsize="end"
-                        android:singleLine="true"
+                        android:maxLines="1"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_gravity="left|center_vertical"
@@ -209,7 +209,7 @@
                         android:text=" (N)"
                         android:textColor="@color/header_text_faded_color"
                         android:ellipsize="none"
-                        android:singleLine="true"
+                        android:maxLines="1"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_gravity="left|center_vertical"
@@ -254,7 +254,7 @@
                 android:textSize="18sp"
                 android:textColor="@color/header_text_color"
                 android:ellipsize="end"
-                android:singleLine="true"
+                android:maxLines="1"
                 android:layout_gravity="center"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"

--- a/onebusaway-android/src/main/res/layout/arrivals_list_header_row_template.xml
+++ b/onebusaway-android/src/main/res/layout/arrivals_list_header_row_template.xml
@@ -72,7 +72,7 @@
                 android:text="Aurora Village Via Aurora Ave."
                 android:textColor="@color/header_text_faded_color"
                 android:ellipsize="end"
-                android:singleLine="true"
+                android:maxLines="1"
                 android:textIsSelectable="false"
                 android:layout_marginLeft="8dp"
                 android:layout_toRightOf="@id/eta_route_name"

--- a/onebusaway-android/src/main/res/layout/arrivals_list_item.xml
+++ b/onebusaway-android/src/main/res/layout/arrivals_list_item.xml
@@ -23,7 +23,7 @@
 
     <androidx.cardview.widget.CardView xmlns:card_view="http://schemas.android.com/apk/res-auto"
         android:id="@+id/arrivals_card_view_eta"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
         android:foreground="?attr/selectableItemBackground"
@@ -44,7 +44,7 @@
             android:src="@drawable/ic_toggle_star" />
 
         <TableLayout
-            android:layout_width="fill_parent"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_margin="2dp"
             android:paddingTop="5dp"
@@ -84,7 +84,7 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:ellipsize="end"
-                        android:singleLine="true"
+                        android:maxLines="1"
                         tools:text="North to Univerity Area TC"
                         app:layout_constraintTop_toBottomOf="@id/reminder" />
 
@@ -150,7 +150,7 @@
                         android:contentDescription="@string/minutes_full"
                         android:ellipsize="end"
                         android:gravity="bottom"
-                        android:singleLine="true"
+                        android:maxLines="1"
                         android:text="@string/minutes_abbreviation"
                         android:textIsSelectable="false"
                         android:textSize="14sp" />

--- a/onebusaway-android/src/main/res/layout/arrivals_list_item_style_b.xml
+++ b/onebusaway-android/src/main/res/layout/arrivals_list_item_style_b.xml
@@ -28,13 +28,13 @@
             xmlns:card_view="http://schemas.android.com/apk/res-auto"
             android:id="@+id/arrivals_card_view"
             android:layout_gravity="center"
-            android:layout_width="fill_parent"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             card_view:cardUseCompatPadding="true"
             card_view:cardCornerRadius="4dp">
 
         <LinearLayout
-                android:layout_width="fill_parent"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="10dp"
                 android:layout_marginBottom="10dp"
@@ -76,7 +76,7 @@
                             style="@style/ArrivalsListItemRouteName"
                             android:textColor="@color/theme_primary"
                             android:text="5"
-                            android:singleLine="true"
+                            android:maxLines="1"
                             android:ellipsize="end"/>
 
                     <ImageButton

--- a/onebusaway-android/src/main/res/layout/donation_view.xml
+++ b/onebusaway-android/src/main/res/layout/donation_view.xml
@@ -9,7 +9,7 @@
     android:layout_alignParentTop="true"
     android:animateLayoutChanges="true"
     android:layout_alignParentEnd="true"
-    android:layout_width="fill_parent"
+    android:layout_width="match_parent"
     android:visibility="visible"
     android:background="@color/quantum_white_100"
     app:cardCornerRadius="8dp"

--- a/onebusaway-android/src/main/res/layout/eta_header_view.xml
+++ b/onebusaway-android/src/main/res/layout/eta_header_view.xml
@@ -19,7 +19,7 @@
             android:textColor="@color/header_text_color"
             android:textStyle="bold"
             android:ellipsize="end"
-            android:singleLine="true"/>
+            android:maxLines="1"/>
     <TextView
             android:id="@+id/eta_min"
             android:layout_width="wrap_content"
@@ -28,7 +28,7 @@
             android:text="min"
             android:textColor="@color/header_text_faded_color"
             android:ellipsize="end"
-            android:singleLine="true"
+            android:maxLines="1"
             android:textIsSelectable="false"
             android:layout_marginLeft="5dp"
             android:layout_toRightOf="@id/eta"

--- a/onebusaway-android/src/main/res/layout/fragment_arrivals_list.xml
+++ b/onebusaway-android/src/main/res/layout/fragment_arrivals_list.xml
@@ -17,8 +17,8 @@
         xmlns:android="http://schemas.android.com/apk/res/android"
         android:id="@+id/fragment_arrivals_list"
         android:orientation="vertical"
-        android:layout_width="fill_parent"
-        android:layout_height="fill_parent">
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
 
     <include layout="@layout/arrivals_list_header"/>
     <include layout="@layout/alert_list"/>
@@ -27,15 +27,15 @@
 
     <FrameLayout
             android:id="@+id/listContainer"
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent">
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
         <ListView android:id="@id/android:list"
                   style="@style/HeaderList"
-                  android:layout_width="fill_parent"
-                  android:layout_height="fill_parent"/>
+                  android:layout_width="match_parent"
+                  android:layout_height="match_parent"/>
         <TextView android:id="@+id/internalEmpty"
                   style="@style/ListHintText"
-                  android:layout_width="fill_parent"
+                  android:layout_width="match_parent"
                   android:layout_height="wrap_content"/>
 
         <include layout="@layout/refresh_loading"/>

--- a/onebusaway-android/src/main/res/layout/fragment_trip_plan.xml
+++ b/onebusaway-android/src/main/res/layout/fragment_trip_plan.xml
@@ -48,7 +48,7 @@
                     android:text="@string/tripplanner_current_location"
                     android:hint="@string/trip_plan_start_location_hint"
                     android:linksClickable="true"
-                    android:singleLine="true"
+                    android:maxLines="1"
                     android:ellipsize="end"
                     android:requiresFadingEdge="horizontal" />
             </com.google.android.material.textfield.TextInputLayout>
@@ -91,7 +91,7 @@
                     android:layout_height="wrap_content"
                     android:hint="@string/trip_plan_end_location_hint"
                     android:linksClickable="true"
-                    android:singleLine="true"
+                    android:maxLines="1"
                     android:requiresFadingEdge="horizontal" />
             </com.google.android.material.textfield.TextInputLayout>
 

--- a/onebusaway-android/src/main/res/layout/fragment_trip_plan_results.xml
+++ b/onebusaway-android/src/main/res/layout/fragment_trip_plan_results.xml
@@ -15,8 +15,8 @@
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
               android:orientation="vertical"
-              android:layout_width="fill_parent"
-              android:layout_height="fill_parent"
+              android:layout_width="match_parent"
+              android:layout_height="match_parent"
               android:weightSum="1"
               android:background="#eeeeee">
 
@@ -43,7 +43,7 @@
                     android:textAppearance="?android:attr/textAppearanceMedium"
                     android:id="@+id/option1Title"
                     android:textColor="@color/header_text_color"
-                    android:singleLine="true"
+                    android:maxLines="1"
                     android:ellipsize="end"/>
 
             <TextView
@@ -77,7 +77,7 @@
                     android:textAppearance="?android:attr/textAppearanceMedium"
                     android:id="@+id/option2Title"
                     android:textColor="@color/header_text_color"
-                    android:singleLine="true"
+                    android:maxLines="1"
                     android:ellipsize="end"/>
 
             <TextView
@@ -111,7 +111,7 @@
                     android:textAppearance="?android:attr/textAppearanceMedium"
                     android:id="@+id/option3Title"
                     android:textColor="@color/header_text_color"
-                    android:singleLine="true"
+                    android:maxLines="1"
                     android:ellipsize="end" />
 
             <TextView
@@ -166,8 +166,8 @@
                 android:id="@+id/mapFragment"/>
 
         <ExpandableListView
-                android:layout_width="fill_parent"
-                android:layout_height="fill_parent"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
                 android:background="@android:color/white"
             android:id="@+id/directionsListView"
             android:isScrollContainer="false" />

--- a/onebusaway-android/src/main/res/layout/infrastructure_issue.xml
+++ b/onebusaway-android/src/main/res/layout/infrastructure_issue.xml
@@ -87,7 +87,7 @@
                     android:layout_height="wrap_content"
                     android:text="Fixed Header"
                     android:ellipsize="end"
-                    android:singleLine="true"
+                    android:maxLines="1"
                     android:layout_margin="4dp"
                     android:id="@+id/ri_bus_stop_text"
                     android:textColor="@android:color/white"
@@ -112,7 +112,7 @@
 
             <LinearLayout
                     android:orientation="vertical"
-                    android:layout_width="fill_parent"
+                    android:layout_width="match_parent"
                     android:layout_height="match_parent">
 
                 <FrameLayout

--- a/onebusaway-android/src/main/res/layout/legend_dialog.xml
+++ b/onebusaway-android/src/main/res/layout/legend_dialog.xml
@@ -30,7 +30,7 @@
                     android:background="@drawable/round_corners_style_b_header_status"/>
 
             <TextView
-                    android:layout_width="fill_parent"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginLeft="16dp"
                     style="@style/legendDialogTextStyle"
@@ -61,7 +61,7 @@
                     android:background="@drawable/round_corners_style_b_header_status"/>
 
             <TextView
-                    android:layout_width="fill_parent"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginLeft="16dp"
                     style="@style/legendDialogTextStyle"
@@ -92,7 +92,7 @@
                     android:background="@drawable/round_corners_style_b_header_status"/>
 
             <TextView
-                    android:layout_width="fill_parent"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginLeft="16dp"
                     style="@style/legendDialogTextStyle"
@@ -123,7 +123,7 @@
                     android:background="@drawable/round_corners_style_b_header_status"/>
 
             <TextView
-                    android:layout_width="fill_parent"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginLeft="16dp"
                     style="@style/legendDialogTextStyle"
@@ -155,7 +155,7 @@
                 android:background="@drawable/round_corners_style_b_header_status" />
 
             <TextView
-                android:layout_width="fill_parent"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginLeft="16dp"
                 style="@style/legendDialogTextStyle"

--- a/onebusaway-android/src/main/res/layout/list_direction_item.xml
+++ b/onebusaway-android/src/main/res/layout/list_direction_item.xml
@@ -16,14 +16,14 @@
 <RelativeLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:orientation="vertical"
-    android:layout_width="fill_parent"
-    android:layout_height="fill_parent"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
     android:padding="10dp">
 
     <ImageView
         android:id="@+id/imgIcon"
         android:layout_width="20dp"
-        android:layout_height="fill_parent"
+        android:layout_height="match_parent"
         android:layout_centerVertical="true"
         android:layout_marginRight="15dp"
         android:layout_marginTop="5dp"
@@ -32,7 +32,7 @@
     <TextView
         android:id="@+id/noIconText"
         android:layout_width="20dp"
-        android:layout_height="fill_parent"
+        android:layout_height="match_parent"
         android:layout_centerVertical="true"
         android:layout_marginRight="15dp"
         android:visibility="gone"
@@ -42,8 +42,8 @@
 
     <TextView
         android:id="@+id/directionText"
-        android:layout_width="fill_parent"
-        android:layout_height="fill_parent"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
         android:layout_toRightOf="@id/imgIcon"
         android:textSize="14sp"
         android:textColor="#000000"

--- a/onebusaway-android/src/main/res/layout/list_item_entry.xml
+++ b/onebusaway-android/src/main/res/layout/list_item_entry.xml
@@ -14,7 +14,7 @@
      limitations under the License.
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              android:layout_width="fill_parent"
+              android:layout_width="match_parent"
               android:layout_height="wrap_content"
               android:minHeight="48dp"
               android:gravity="center_vertical"
@@ -30,7 +30,7 @@
         <TextView android:id="@+id/list_item_entry_title"
                   android:layout_width="wrap_content"
                   android:layout_height="wrap_content"
-                  android:singleLine="true"
+                  android:maxLines="1"
                   android:ellipsize="marquee"
                   android:fadingEdge="horizontal"
                   android:textSize="15sp"

--- a/onebusaway-android/src/main/res/layout/list_item_section.xml
+++ b/onebusaway-android/src/main/res/layout/list_item_section.xml
@@ -15,7 +15,7 @@
 -->
 <LinearLayout
         xmlns:android="http://schemas.android.com/apk/res/android"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="@color/navdrawer_text_color_selected"
         android:orientation="vertical">

--- a/onebusaway-android/src/main/res/layout/list_subdirection_item.xml
+++ b/onebusaway-android/src/main/res/layout/list_subdirection_item.xml
@@ -15,15 +15,15 @@
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
               android:orientation="horizontal"
-              android:layout_width="fill_parent"
-              android:layout_height="fill_parent"
+              android:layout_width="match_parent"
+              android:layout_height="match_parent"
               android:paddingLeft="10dp"
               android:paddingRight="10dp">
 
     <ImageView
             android:id="@+id/imgIcon"
             android:layout_width="16dp"
-            android:layout_height="fill_parent"
+            android:layout_height="match_parent"
             android:gravity="center_vertical"
             android:layout_alignParentTop="true"
             android:layout_alignParentBottom="true"
@@ -32,8 +32,8 @@
 
     <TextView
             android:id="@+id/directionText"
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
             android:gravity="center_vertical"
             android:layout_alignParentTop="true"
             android:layout_alignParentBottom="true"

--- a/onebusaway-android/src/main/res/layout/load_more_arrivals_button.xml
+++ b/onebusaway-android/src/main/res/layout/load_more_arrivals_button.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
               android:orientation="vertical"
-              android:layout_width="fill_parent"
+              android:layout_width="match_parent"
               android:layout_height="wrap_content">
     <Button
             android:id="@+id/load_more_arrivals"
             android:text="@string/stop_info_load_more_arrivals"
-            android:layout_width="fill_parent"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             style="@style/LoadMoreArrivals"/>
 </LinearLayout>

--- a/onebusaway-android/src/main/res/layout/loading.xml
+++ b/onebusaway-android/src/main/res/layout/loading.xml
@@ -16,8 +16,8 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
               android:id="@+id/loading"
               android:orientation="horizontal"
-              android:layout_width="fill_parent"
-              android:layout_height="fill_parent"
+              android:layout_width="match_parent"
+              android:layout_height="match_parent"
               android:gravity="center"
               android:visibility="gone">
     <ProgressBar android:id="@+id/progress_small"

--- a/onebusaway-android/src/main/res/layout/main.xml
+++ b/onebusaway-android/src/main/res/layout/main.xml
@@ -23,8 +23,8 @@
     <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
                     android:id="@+id/mainlayout"
                     android:orientation="vertical"
-                    android:layout_width="fill_parent"
-                    android:layout_height="fill_parent">
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent">
 
         <com.sothree.slidinguppanel.SlidingUpPanelLayout
                 xmlns:sothree="http://schemas.android.com/apk/res-auto"
@@ -160,7 +160,7 @@
                 <!-- ROUTE MODE HEADER -->
                 <include android:id="@+id/route_info"
                          layout="@layout/route_info_head"
-                         android:layout_width="fill_parent"
+                         android:layout_width="match_parent"
                          android:layout_height="wrap_content"
                          android:layout_alignParentTop="true"
                          android:layout_alignParentLeft="true"

--- a/onebusaway-android/src/main/res/layout/material_list_item.xml
+++ b/onebusaway-android/src/main/res/layout/material_list_item.xml
@@ -63,7 +63,7 @@
 
             <TextView
                     android:id="@+id/rtl_desc"
-                    android:layout_width="fill_parent"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_below="@id/rtl_title"
                     style="@style/Line2Text"

--- a/onebusaway-android/src/main/res/layout/my_search_route_list.xml
+++ b/onebusaway-android/src/main/res/layout/my_search_route_list.xml
@@ -15,20 +15,20 @@
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
               android:orientation="vertical"
-              android:layout_width="fill_parent"
-              android:layout_height="fill_parent"
+              android:layout_width="match_parent"
+              android:layout_height="match_parent"
               android:gravity="top">
 
     <org.onebusaway.android.view.SearchViewV1
             android:id="@+id/search"
-            android:layout_width="fill_parent"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"/>
 
     <ListView android:id="@id/android:list"
-              android:layout_width="fill_parent"
-              android:layout_height="fill_parent"/>
+              android:layout_width="match_parent"
+              android:layout_height="match_parent"/>
     <TextView android:id="@id/android:empty"
               style="@style/ListHintText"
-              android:layout_width="fill_parent"
+              android:layout_width="match_parent"
               android:layout_height="wrap_content"/>
 </LinearLayout>

--- a/onebusaway-android/src/main/res/layout/my_search_stop_list.xml
+++ b/onebusaway-android/src/main/res/layout/my_search_stop_list.xml
@@ -15,21 +15,21 @@
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
               android:orientation="vertical"
-              android:layout_width="fill_parent"
-              android:layout_height="fill_parent">
+              android:layout_width="match_parent"
+              android:layout_height="match_parent">
 
     <org.onebusaway.android.view.SearchViewV1
             android:id="@+id/search"
-            android:layout_width="fill_parent"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"/>
 
     <ListView android:id="@id/android:list"
-              android:layout_width="fill_parent"
-              android:layout_height="fill_parent"/>
+              android:layout_width="match_parent"
+              android:layout_height="match_parent"/>
     <TextView android:id="@id/android:empty"
               style="@style/ListHintText"
               android:bufferType="spannable"
               android:linksClickable="true"
-              android:layout_width="fill_parent"
+              android:layout_width="match_parent"
               android:layout_height="wrap_content"/>
 </LinearLayout>

--- a/onebusaway-android/src/main/res/layout/night_light.xml
+++ b/onebusaway-android/src/main/res/layout/night_light.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
               android:orientation="vertical"
-              android:layout_width="fill_parent"
-              android:layout_height="fill_parent">
+              android:layout_width="match_parent"
+              android:layout_height="match_parent">
     <View
             android:id="@+id/screen"
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
             android:onClick="toggleLight"/>
 </LinearLayout>

--- a/onebusaway-android/src/main/res/layout/occupancy_dialog.xml
+++ b/onebusaway-android/src/main/res/layout/occupancy_dialog.xml
@@ -22,7 +22,7 @@
 
             <TextView
                 android:id="@+id/realtime_occupancy_description"
-                android:layout_width="fill_parent"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="13dp"
                 android:layout_marginBottom="10dp"
@@ -39,7 +39,7 @@
 
             <TextView
                 android:id="@+id/historial_occupancy_description"
-                android:layout_width="fill_parent"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="13dp"
                 android:layout_marginBottom="10dp"

--- a/onebusaway-android/src/main/res/layout/refresh_loading.xml
+++ b/onebusaway-android/src/main/res/layout/refresh_loading.xml
@@ -16,8 +16,8 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
               android:id="@+id/refresh_loading"
               android:orientation="horizontal"
-              android:layout_width="fill_parent"
-              android:layout_height="fill_parent"
+              android:layout_width="match_parent"
+              android:layout_height="match_parent"
               android:gravity="center|top"
               android:layout_marginTop="20dp"
               android:visibility="gone">

--- a/onebusaway-android/src/main/res/layout/report_issue_customer_service.xml
+++ b/onebusaway-android/src/main/res/layout/report_issue_customer_service.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
         xmlns:android="http://schemas.android.com/apk/res/android"
-        android:layout_width="fill_parent"
-        android:layout_height="fill_parent"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
         android:minWidth="350dp"
         android:orientation="vertical">
 

--- a/onebusaway-android/src/main/res/layout/report_issue_customer_service_item.xml
+++ b/onebusaway-android/src/main/res/layout/report_issue_customer_service_item.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                android:layout_width="fill_parent"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="horizontal"
                 android:padding="5dip">

--- a/onebusaway-android/src/main/res/layout/report_issue_single_value_list_item.xml
+++ b/onebusaway-android/src/main/res/layout/report_issue_single_value_list_item.xml
@@ -51,8 +51,8 @@
                     android:layout_alignParentEnd="true"/>
 
             <RadioGroup
-                    android:layout_width="fill_parent"
-                    android:layout_height="fill_parent"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
                     android:layout_centerVertical="true"
                     android:layout_below="@+id/risvli_textView"
                     android:id="@+id/risvli_radioGroup"

--- a/onebusaway-android/src/main/res/layout/report_stop_problem.xml
+++ b/onebusaway-android/src/main/res/layout/report_stop_problem.xml
@@ -13,14 +13,14 @@
      limitations under the License.
 -->
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
             android:background="@color/material_background"
             android:configChanges="keyboardHidden|orientation|screenSize">
 
     <LinearLayout
             android:orientation="vertical"
-            android:layout_width="fill_parent"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content">
 
         <FrameLayout

--- a/onebusaway-android/src/main/res/layout/report_trip_problem.xml
+++ b/onebusaway-android/src/main/res/layout/report_trip_problem.xml
@@ -14,14 +14,14 @@
      limitations under the License.
 -->
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
             android:background="@color/material_background"
             android:configChanges="keyboardHidden|orientation|screenSize">
 
     <LinearLayout
             android:orientation="vertical"
-            android:layout_width="fill_parent"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content">
 
         <FrameLayout
@@ -99,7 +99,7 @@
             <CheckBox
                     android:id="@+id/report_problem_onvehicle"
                     android:text="@string/report_problem_onvehicle_bus"
-                    android:layout_width="fill_parent"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     style="@style/MaterialItem">
             </CheckBox>

--- a/onebusaway-android/src/main/res/layout/route_info.xml
+++ b/onebusaway-android/src/main/res/layout/route_info.xml
@@ -15,24 +15,24 @@
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
               android:orientation="vertical"
-              android:layout_width="fill_parent"
-              android:layout_height="fill_parent">
+              android:layout_width="match_parent"
+              android:layout_height="match_parent">
 
     <include layout="@layout/route_info_head"/>
     <include layout="@layout/loading"/>
 
     <FrameLayout
             android:id="@+id/listContainer"
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent">
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
         <ExpandableListView android:id="@id/android:list"
                             style="@style/HeaderList"
-                            android:layout_width="fill_parent"
-                            android:layout_height="fill_parent"/>
+                            android:layout_width="match_parent"
+                            android:layout_height="match_parent"/>
 
         <TextView android:id="@+id/internalEmpty"
                   style="@style/ListHintText"
-                  android:layout_width="fill_parent"
+                  android:layout_width="match_parent"
                   android:layout_height="wrap_content"/>
     </FrameLayout>
 </LinearLayout>

--- a/onebusaway-android/src/main/res/layout/route_info_head.xml
+++ b/onebusaway-android/src/main/res/layout/route_info_head.xml
@@ -14,7 +14,7 @@
      limitations under the License.
 -->
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                android:layout_width="fill_parent"
+                android:layout_width="match_parent"
                 android:elevation="3dp"
                 android:layout_height="wrap_content"
                 style="@style/HeaderItem">
@@ -31,7 +31,7 @@
             android:layout_alignParentLeft="true"
             android:layout_centerVertical="true"/>
     <TableLayout
-            android:layout_width="fill_parent"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_alignParentLeft="true"
             android:layout_centerVertical="true"
@@ -40,12 +40,11 @@
             <TextView
                     android:id="@+id/short_name"
                     style="@style/RouteInfoShortName"
-                    android:layout_width="fill_parent"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_column="0"
-                    android:singleLine="true"
-                    android:maxLength="6"
                     android:maxLines="1"
+                    android:maxLength="6"
                     android:ellipsize="end">
             </TextView>
             <LinearLayout
@@ -56,13 +55,13 @@
                 <TextView
                         android:id="@+id/long_name"
                         style="@style/RouteInfoLongName"
-                        android:layout_width="fill_parent"
+                        android:layout_width="match_parent"
                         android:layout_height="wrap_content">
                 </TextView>
                 <TextView
                         android:id="@+id/agency"
                         style="@style/RouteInfoAgency"
-                        android:layout_width="fill_parent"
+                        android:layout_width="match_parent"
                         android:layout_height="wrap_content">
                 </TextView>
             </LinearLayout>

--- a/onebusaway-android/src/main/res/layout/route_info_listitem.xml
+++ b/onebusaway-android/src/main/res/layout/route_info_listitem.xml
@@ -15,7 +15,7 @@
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
               style="@style/ListItem"
-              android:layout_width="fill_parent"
+              android:layout_width="match_parent"
               android:layout_height="wrap_content"
               android:orientation="vertical">
     <TextView

--- a/onebusaway-android/src/main/res/layout/route_list_item.xml
+++ b/onebusaway-android/src/main/res/layout/route_list_item.xml
@@ -18,7 +18,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     style="@style/ListItem"
-    android:layout_width="fill_parent"
+    android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="horizontal">
     <TextView

--- a/onebusaway-android/src/main/res/layout/search_box.xml
+++ b/onebusaway-android/src/main/res/layout/search_box.xml
@@ -14,7 +14,7 @@
      limitations under the License.
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              android:layout_width="fill_parent"
+              android:layout_width="match_parent"
               android:layout_height="wrap_content"
               style="@style/FindSearchBox">
 
@@ -28,7 +28,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:inputType="text"
-            android:singleLine="true"
+            android:maxLines="1"
             android:imeOptions="actionSearch"/>
 
     </com.google.android.material.textfield.TextInputLayout>

--- a/onebusaway-android/src/main/res/layout/simple_list_item_2_checked.xml
+++ b/onebusaway-android/src/main/res/layout/simple_list_item_2_checked.xml
@@ -17,7 +17,7 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
                 android:paddingTop="2dip"
                 android:paddingBottom="2dip"
-                android:layout_width="fill_parent"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:minHeight="?android:attr/listPreferredItemHeight"
                 android:mode="twoLine"

--- a/onebusaway-android/src/main/res/layout/situation.xml
+++ b/onebusaway-android/src/main/res/layout/situation.xml
@@ -32,25 +32,25 @@
                 android:id="@+id/alert_title"
                 style="@style/HeaderText"
                 android:background="@color/theme_primary"
-                android:layout_width="fill_parent"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginLeft="10dp"
                 android:layout_marginRight="10dp"/>
     </LinearLayout>
     <ScrollView
             android:id="@+id/alert_scrollview"
-            android:layout_width="fill_parent"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_below="@+id/situation_header"
             android:background="@color/listview_background">
         <LinearLayout
                 xmlns:android="http://schemas.android.com/apk/res/android"
                 android:orientation="vertical"
-                android:layout_width="fill_parent"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content">
             <TextView
                     android:id="@+id/alert_description"
-                    android:layout_width="fill_parent"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginLeft="10dp"
                     android:layout_marginRight="10dp"

--- a/onebusaway-android/src/main/res/layout/stop_list_item.xml
+++ b/onebusaway-android/src/main/res/layout/stop_list_item.xml
@@ -19,7 +19,7 @@
                 style="@style/ListItem"
                 android:id="@+id/stop_list_container"
                 android:layout_height="wrap_content"
-                android:layout_width="fill_parent"
+                android:layout_width="match_parent"
                 android:minHeight="77dp"
                 android:orientation="horizontal">
     <ImageView
@@ -42,7 +42,7 @@
                   android:layout_marginLeft="@dimen/keyline_2"
                   android:layout_alignParentLeft="true"
                   android:layout_centerVertical="true"
-                  android:layout_width="fill_parent"
+                  android:layout_width="match_parent"
                   android:layout_height="wrap_content"
                   android:orientation="vertical">
         <TextView

--- a/onebusaway-android/src/main/res/layout/tab_trip_results_view.xml
+++ b/onebusaway-android/src/main/res/layout/tab_trip_results_view.xml
@@ -30,7 +30,7 @@
             android:gravity="center"
             android:layout_gravity="center"
             android:ellipsize="end"
-            android:singleLine="true"
+            android:maxLines="1"
             android:textSize="@dimen/trip_results_tab_text_size"
             android:textColor="@color/body_text_1"
             android:textAllCaps="true"

--- a/onebusaway-android/src/main/res/layout/trip_details.xml
+++ b/onebusaway-android/src/main/res/layout/trip_details.xml
@@ -16,24 +16,24 @@
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
               android:orientation="vertical"
-              android:layout_width="fill_parent"
-              android:layout_height="fill_parent">
+              android:layout_width="match_parent"
+              android:layout_height="match_parent">
 
     <include layout="@layout/trip_details_head"/>
     <include layout="@layout/loading"/>
 
     <FrameLayout
             android:id="@+id/listContainer"
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent">
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
         <ListView android:id="@id/android:list"
                   style="@style/HeaderList"
-                  android:layout_width="fill_parent"
-                  android:layout_height="fill_parent"/>
+                  android:layout_width="match_parent"
+                  android:layout_height="match_parent"/>
 
         <TextView android:id="@+id/internalEmpty"
                   style="@style/ListHintText"
-                  android:layout_width="fill_parent"
+                  android:layout_width="match_parent"
                   android:layout_height="wrap_content"/>
     </FrameLayout>
 </LinearLayout>

--- a/onebusaway-android/src/main/res/layout/trip_details_head.xml
+++ b/onebusaway-android/src/main/res/layout/trip_details_head.xml
@@ -16,7 +16,7 @@
 <TableLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     style="@style/HeaderItem"
-    android:layout_width="fill_parent"
+    android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical">
 
@@ -28,7 +28,7 @@
             android:layout_marginLeft="6dp"
             android:layout_marginStart="6dp"
             android:layout_gravity="center_vertical"
-            android:layout_width="fill_parent"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_column="0"
             android:maxLength="6"
@@ -48,7 +48,7 @@
             <TextView
                 android:id="@+id/long_name"
                 style="@style/RouteInfoLongName"
-                android:layout_width="fill_parent"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 tools:text="South to Netpark" />
 
@@ -62,14 +62,14 @@
             <TextView
                 android:id="@+id/vehicle"
                 style="@style/TripDetailsVehicle"
-                android:layout_width="fill_parent"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 tools:text="Vehicle: Hillsborough Area Regional Transit_1720" />
 
             <TextView
                 android:id="@+id/trip_short_name"
                 style="@style/TripDetailsVehicle"
-                android:layout_width="fill_parent"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 tools:text="via Stadium" />
 
@@ -87,7 +87,7 @@
                 <TextView
                     android:id="@+id/status"
                     style="@style/TripDetailsStatus"
-                    android:layout_width="fill_parent"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     tools:text="13 min 0 sec late (Last update: 6:37 PM)" />
 

--- a/onebusaway-android/src/main/res/layout/trip_details_listitem.xml
+++ b/onebusaway-android/src/main/res/layout/trip_details_listitem.xml
@@ -16,7 +16,7 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:layout_width="fill_parent"
+    android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="horizontal">
 
@@ -99,7 +99,7 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/stop_details"
         style="@style/ListItem"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_alignParentLeft="true"
         android:layout_marginLeft="50dp"
@@ -111,7 +111,7 @@
             style="@style/Line1Text"
             tools:text="Marion Transit Center"
             android:ellipsize="end"
-            android:singleLine="true"
+            android:maxLines="1"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content" />
 

--- a/onebusaway-android/src/main/res/layout/trip_info.xml
+++ b/onebusaway-android/src/main/res/layout/trip_info.xml
@@ -14,8 +14,8 @@
 -->
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:layout_width="fill_parent"
-    android:layout_height="fill_parent">
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
 
     <include
         android:id="@+id/progress"
@@ -41,7 +41,7 @@
 
         <LinearLayout
             style="@style/HeaderItem"
-            android:layout_width="fill_parent"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical"
             android:paddingBottom="16dp">
@@ -89,20 +89,20 @@
         </LinearLayout>
 
         <LinearLayout
-            android:layout_width="fill_parent"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical"
             android:padding="4dp">
 
             <TextView
                 style="@style/FormLabel"
-                android:layout_width="fill_parent"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="@string/trip_info_reminder_header" />
 
             <Spinner
                 android:id="@+id/trip_info_reminder_time"
-                android:layout_width="fill_parent"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content" />
 
             <com.google.android.material.textfield.TextInputLayout
@@ -113,7 +113,7 @@
 
                 <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/name"
-                    android:layout_width="fill_parent"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content" />
 
             </com.google.android.material.textfield.TextInputLayout>

--- a/onebusaway-android/src/main/res/layout/trip_list_listitem.xml
+++ b/onebusaway-android/src/main/res/layout/trip_list_listitem.xml
@@ -17,7 +17,7 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
                 style="@style/ListItem"
                 android:id="@+id/stop_list_container"
-                android:layout_width="fill_parent"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="horizontal">
     <ImageView
@@ -39,18 +39,18 @@
                   android:layout_marginLeft="@dimen/keyline_2"
                   android:layout_alignParentLeft="true"
                   android:layout_centerVertical="true"
-                  android:layout_width="fill_parent"
+                  android:layout_width="match_parent"
                   android:layout_height="wrap_content"
                   android:orientation="vertical">
         <TextView
                 android:id="@+id/name"
                 style="@style/Line1Text"
-                android:layout_width="fill_parent"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content">
         </TextView>
         <LinearLayout
                 android:orientation="horizontal"
-                android:layout_width="fill_parent"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content">
             <TextView
                     style="@style/Line2Text"
@@ -78,7 +78,7 @@
         <TextView
                 android:id="@+id/departure_time"
                 style="@style/Line2Text"
-                android:layout_width="fill_parent"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content">
         </TextView>
     </LinearLayout>

--- a/onebusaway-android/src/main/res/layout/trip_plan_advanced_settings_dialog.xml
+++ b/onebusaway-android/src/main/res/layout/trip_plan_advanced_settings_dialog.xml
@@ -15,8 +15,8 @@
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
               android:orientation="vertical"
-              android:layout_width="fill_parent"
-              android:layout_height="fill_parent"
+              android:layout_width="match_parent"
+              android:layout_height="match_parent"
               android:paddingLeft="@dimen/dialog_margin"
               android:paddingRight="@dimen/dialog_margin"
               android:paddingTop="@dimen/dialog_margin">
@@ -39,7 +39,7 @@
     </LinearLayout>
 
     <LinearLayout
-            android:layout_width="fill_parent"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="horizontal">
 

--- a/onebusaway-android/src/main/res/layout/tutorial_item.xml
+++ b/onebusaway-android/src/main/res/layout/tutorial_item.xml
@@ -6,16 +6,16 @@
 
 
     <ImageView
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
             android:id="@+id/ti_imageView"
             android:layout_margin="16dp"
             android:layout_gravity="center"
             android:layout_weight="1"/>
 
     <TextView
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
             android:textAppearance="?android:attr/textAppearanceMedium"
             android:id="@+id/ti_textView"
             android:layout_below="@+id/ti_imageView"

--- a/onebusaway-android/src/main/res/layout/vehicle_info_window.xml
+++ b/onebusaway-android/src/main/res/layout/vehicle_info_window.xml
@@ -24,7 +24,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:ellipsize="end"
-        android:singleLine="true"
+        android:maxLines="1"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [ ] Run the unit tests with `gradlew connectedObaGoogleDebugAndroidTest` to make sure you didn't break anything

- [ ] If you have multiple commits please combine them into one commit by squashing them for the initial submission of the pull request.  When addressing comments on a pull request, please push a new commit per comment when possible (reviewers will squash and merge using GitHub merge tool)

Fixes : #1426 
This PR addresses the use of deprecated XML layout attributes throughout the codebase:  
- Replaces deprecated _fill_parent_ with _match_parent_
- Replaces deprecated _android:singleLine="true"_ with _android:maxLines="1"_
