### PR TITLE
Refactor TripDetailsActivity launch to use Builder pattern

### DIFF
--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/VehicleOverlay.java
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/VehicleOverlay.java
@@ -530,11 +530,16 @@ public class VehicleOverlay implements GoogleMap.OnInfoWindowClickListener, Mark
             ObaTripStatus status = mMarkerData.getStatusFromMarker(marker);
             if (status != null) {
                 if (mController != null && mController.getFocusedStopId() != null) {
-                    TripDetailsActivity.start(mActivity, status.getActiveTripId(),
-                            mController.getFocusedStopId(), TripDetailsListFragment.SCROLL_MODE_VEHICLE);
+                    new TripDetailsActivity.Builder(mActivity, status.getActiveTripId())
+                            .setStopId(mController.getFocusedStopId())
+                            .setScrollMode(TripDetailsListFragment.SCROLL_MODE_VEHICLE)
+                            .setUpMode("back")
+                            .start();
                 } else {
-                    TripDetailsActivity.start(mActivity, status.getActiveTripId(),
-                            TripDetailsListFragment.SCROLL_MODE_VEHICLE);
+                    new TripDetailsActivity.Builder(mActivity, status.getActiveTripId())
+                            .setScrollMode(TripDetailsListFragment.SCROLL_MODE_VEHICLE)
+                            .setUpMode("back")
+                            .start();
                 }
             }
         }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListFragment.java
@@ -1467,9 +1467,11 @@ public class ArrivalsListFragment extends ListFragment implements LoaderManager.
         // Save to recent routes
         DBUtil.addRouteToDB(getActivity(),stop);
 
-        TripDetailsActivity.start(getActivity(),
-                stop.getInfo().getTripId(), stop.getInfo().getStopId(),
-                TripDetailsListFragment.SCROLL_MODE_STOP);
+        new TripDetailsActivity.Builder(getActivity(), stop.getInfo().getTripId())
+                .setStopId(stop.getInfo().getStopId())
+                .setScrollMode(TripDetailsListFragment.SCROLL_MODE_STOP)
+                .setUpMode(NavHelp.UP_MODE_BACK)
+                .start();
     }
 
     private void goToRoute(ArrivalInfo stop) {


### PR DESCRIPTION
# Fix: Preserve stop selection state when navigating back from trip details

## Summary
This PR fixes a UX issue where the selected stop would lose its selection state when navigating back from the "Show trip status" screen, affecting both arrival list navigation and vehicle info bubble navigation.

## Problem Description
When users followed these flows, the selected stop would become unselected upon returning to the map:

1. **Arrival List Flow**: Select stop → View arrivals → "Show trip status" → Back button → Stop selection lost
2. **Vehicle Bubble Flow**: Select stop → "Show vehicles on map" → Click vehicle info bubble → Back button → Stop selection lost

The root cause was that `TripDetailsActivity` was being launched without proper up navigation mode, causing the back button to recreate `HomeActivity` instead of returning to the existing instance, which lost the preserved stop selection state.

## Solution
Replace static `TripDetailsActivity.start()` calls with the Builder pattern and set `UP_MODE_BACK` to ensure proper back navigation:

### Changes Made

**1. ArrivalsListFragment.java** 
- Updated `goToTripDetails()` method to use Builder pattern
- Added `.setUpMode(NavHelp.UP_MODE_BACK)` for proper navigation

**2. VehicleOverlay.java**
- Updated `onInfoWindowClick()` method to use Builder pattern
- Added `.setUpMode("back")` for both with/without focused stop scenarios

## Technical Details
- Uses `TripDetailsActivity.Builder` instead of static `start()` methods
- Sets up mode to "back" which makes `NavHelp.goUp()` call `activity.finish()` instead of recreating HomeActivity
- Preserves the activity stack and state restoration flow
- No functional changes to trip details display or behavior
