### PR TITLE
Fix: Update target API level to meet Google Play requirements

### DIFF
--- a/onebusaway-android/build.gradle
+++ b/onebusaway-android/build.gradle
@@ -35,11 +35,11 @@ repositories {
 }
 
 android {
-    compileSdk 34
+    compileSdk 36
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 34
+        targetSdkVersion 36
         versionCode 151
         versionName "2.14.7"
 

--- a/onebusaway-android/src/main/res/values-v35/themes.xml
+++ b/onebusaway-android/src/main/res/values-v35/themes.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="Theme.OneBusAway" parent="Theme.AppCompat.Light.DarkActionBar">
+        <!--   App branding color for the app bar -->
+        <item name="colorPrimary">@color/theme_primary</item>
+        <!--   Darker variant for the status bar and contextual app bars -->
+        <item name="colorPrimaryDark">@color/theme_primary_dark</item>
+        <!--   Theme UI controls like checkboxes and text fields -->
+        <item name="colorAccent">@color/theme_accent</item>
+        <!-- Change the default cursor color so its visible in the action bar -->
+        <item name="autoCompleteTextViewStyle">@style/cursorColor</item>
+        <!-- Allows us to force Dark Theme throughout the app -->
+        <item name="android:forceDarkAllowed">true</item>
+        <!-- Allows us to force AlertDialog Theme across the app -->
+        <item name="alertDialogTheme">@style/customAlertDialogTheme</item>
+
+        <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
+    </style>
+</resources>


### PR DESCRIPTION
About #1443 

## Key Changes 

Starting with Android 15, edge-to-edge mode is forcibly enabled, causing app content to overlap with the status bar on newer Android versions.

Fixed by adding ` <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>` to app theme targeting the android version 15>= 

## Refrences 

- https://developer.android.com/codelabs/edge-to-edge
- https://stackoverflow.com/questions/79095037/android-15-edge-to-edge-mode-hide-a-top-view

## Testing 

I have tested the changes with Android 15, 16, 11, and 8, 7 

Used Google pixel and Samsung 


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `gradlew connectedObaGoogleDebugAndroidTest` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them for the initial submission of the pull request.  When addressing comments on a pull request, please push a new commit per comment when possible (reviewers will squash and merge using GitHub merge tool)