### PR TITLE
Upgraded outdated com.android.support dependencies (Fix: #1463)

### DIFF
--- a/onebusaway-android/build.gradle
+++ b/onebusaway-android/build.gradle
@@ -354,7 +354,6 @@ dependencies {
     implementation 'androidx.activity:activity-ktx:1.9.3'
     implementation 'androidx.fragment:fragment-ktx:1.8.4'
     implementation 'androidx.cardview:cardview:1.0.0'
-    implementation 'androidx.lifecycle:lifecycle-common:2.9.2'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'commons-io:commons-io:2.4'
     implementation 'org.apache.commons:commons-lang3:3.0'


### PR DESCRIPTION
First 2 dependencies as stated in (#1463)

- [X] Apply the `AndroidStyle.xml` style template to your code in Android Studio.
- [X] Run the unit tests with `gradlew connectedObaGoogleDebugAndroidTest` to make sure you didn't break anything
