### PR TITLE
Zoom and center map on stop marker click

### DIFF
--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/StopOverlay.java
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/StopOverlay.java
@@ -22,6 +22,7 @@ import com.google.android.gms.maps.model.BitmapDescriptorFactory;
 import com.google.android.gms.maps.model.LatLng;
 import com.google.android.gms.maps.model.Marker;
 import com.google.android.gms.maps.model.MarkerOptions;
+import com.google.android.gms.maps.CameraUpdateFactory;
 
 import org.onebusaway.android.BuildConfig;
 import org.onebusaway.android.R;
@@ -155,6 +156,23 @@ public class StopOverlay implements MarkerListeners {
         }
 
         doFocusChange(stop);
+
+        float currentZoom = mMap.getCameraPosition().zoom;
+
+        if (currentZoom < BaseMapFragment.CAMERA_DEFAULT_ZOOM) {
+            mMap.animateCamera(
+                    CameraUpdateFactory.newLatLngZoom(
+                            marker.getPosition(),
+                            BaseMapFragment.CAMERA_DEFAULT_ZOOM
+                    )
+            );
+        } else {
+            mMap.animateCamera(
+                    CameraUpdateFactory.newLatLng(
+                            marker.getPosition()
+                    )
+            );
+        }
 
         return true;
     }


### PR DESCRIPTION
### Summary
Improve map usability by automatically centering and zooming the map when a stop marker is selected.

### Change
When a stop marker is tapped, the map animates the camera to the marker’s location with an appropriate zoom level.

### Testing
- Android Emulator
- Manual testing of marker interactions

Fixes #1343

