### PR TITLE
Fix: Apply edge-to-edge window insets to report/feedback activities

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/BaseReportActivity.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/BaseReportActivity.java
@@ -16,10 +16,12 @@
 package org.onebusaway.android.report.ui;
 
 import org.onebusaway.android.R;
+import org.onebusaway.android.util.UIUtils;
 
 import android.annotation.SuppressLint;
 import android.content.Intent;
 import android.graphics.Color;
+import android.os.Bundle;
 import android.view.Gravity;
 import android.view.View;
 import android.widget.FrameLayout;
@@ -39,6 +41,12 @@ import androidx.fragment.app.FragmentTransaction;
  * Created by Cagri Cetin
  */
 public class BaseReportActivity extends AppCompatActivity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        UIUtils.setupActionBar(this);
+    }
 
     public static final String CLOSE_REQUEST = "BaseReportActivityClose";
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/AboutActivity.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/AboutActivity.java
@@ -29,6 +29,7 @@ import com.google.android.material.appbar.CollapsingToolbarLayout;
 import com.google.android.material.textview.MaterialTextView;
 
 import org.onebusaway.android.R;
+import org.onebusaway.android.util.UIUtils;
 
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
@@ -49,6 +50,7 @@ public class AboutActivity extends AppCompatActivity {
         setContentView(R.layout.activity_about);
         Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
+        UIUtils.setupActionBar(this);
         CollapsingToolbarLayout toolBarLayout = (CollapsingToolbarLayout) findViewById(
                 R.id.toolbar_layout);
         toolBarLayout.setTitle(getTitle());

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/DonationLearnMoreActivity.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/DonationLearnMoreActivity.java
@@ -6,8 +6,10 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.widget.Button;
 import android.widget.TextView;
+
 import org.onebusaway.android.R;
 import org.onebusaway.android.app.Application;
+import org.onebusaway.android.util.UIUtils;
 
 public class DonationLearnMoreActivity extends AppCompatActivity {
 
@@ -15,6 +17,7 @@ public class DonationLearnMoreActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_donation_learn_more);
+        UIUtils.setupActionBar(this);
 
         // Update explanation text with app name for white-label support
         TextView explanationView = findViewById(R.id.textView5);

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/FeedbackActivity.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/FeedbackActivity.java
@@ -21,6 +21,7 @@ import org.onebusaway.android.io.ObaAnalytics;
 import org.onebusaway.android.nav.NavigationService;
 import org.onebusaway.android.nav.NavigationUploadWorker;
 import org.onebusaway.android.util.PreferenceUtils;
+import org.onebusaway.android.util.UIUtils;
 
 import java.io.File;
 import java.io.IOException;
@@ -56,6 +57,7 @@ public class FeedbackActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_feedback);
+        UIUtils.setupActionBar(this);
         setTitle(getResources().getString(R.string.feedback_label));
 
         Intent intent = this.getIntent();


### PR DESCRIPTION
 (Fix: #1474), attempt to speed the process up

- [X] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [X] Run the unit tests with `gradlew connectedObaGoogleDebugAndroidTest` to make sure you didn't break anything