### PR TITLE
Removed dump_syms from final APK

### DIFF
--- a/onebusaway-android/build.gradle
+++ b/onebusaway-android/build.gradle
@@ -77,7 +77,11 @@ android {
 
     packagingOptions {
         resources {
-            excludes += ['META-INF/LICENSE', 'META-INF/NOTICE']
+            excludes += ['META-INF/LICENSE', 'META-INF/NOTICE',
+                         '**/dump_syms/**',
+                         '**/linux/dump_syms.bin',
+                         '**/mac/dump_syms'
+            ]
         }
     }
 


### PR DESCRIPTION
Fix #1492 by simply removing the binaries used to convert symbols for production APKs.