### PR TITLE
Removed buildtools lib

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/travelbehavior/TravelBehaviorManager.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/travelbehavior/TravelBehaviorManager.java
@@ -31,6 +31,7 @@ import android.widget.CheckBox;
 import android.widget.EditText;
 import android.widget.Toast;
 
+import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.graphics.drawable.DrawableCompat;
 import androidx.work.Constraints;


### PR DESCRIPTION
Fix https://github.com/OneBusAway/onebusaway-android/issues/1492 by simply removing crashlytics-buildtools

- [X] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [X] Run the unit tests with `gradlew connectedObaGoogleDebugAndroidTest` to make sure you didn't break anything
