### PR TITLE
Fix: Add bounds check to getItinerary and NPE-safe action checks in RealtimeService

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/directions/realtime/RealtimeServiceTest.java
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/directions/realtime/RealtimeServiceTest.java
@@ -119,6 +119,14 @@ public class RealtimeServiceTest {
         bundle.putInt(OTPConstants.SELECTED_ITINERARY, 0);
 
         assertEquals("getItinerary should return the selected itinerary", it, mService.getItinerary(bundle));
+
+        // Test with out of bounds index (positive)
+        bundle.putInt(OTPConstants.SELECTED_ITINERARY, 1);
+        assertNull("getItinerary should return null for out of bounds index", mService.getItinerary(bundle));
+
+        // Test with out of bounds index (negative)
+        bundle.putInt(OTPConstants.SELECTED_ITINERARY, -1);
+        assertNull("getItinerary should return null for negative index", mService.getItinerary(bundle));
     }
 
     @Test
@@ -130,5 +138,13 @@ public class RealtimeServiceTest {
             fail("onHandleIntent should not throw NPE on empty bundle: " + e.getMessage());
         }
         // Other exceptions propagate naturally and fail the test visibly
+
+        // Test with null action
+        Intent nullActionIntent = new Intent();
+        try {
+            mService.onHandleIntent(nullActionIntent);
+        } catch (NullPointerException e) {
+            fail("onHandleIntent should not throw NPE on null action: " + e.getMessage());
+        }
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/realtime/RealtimeService.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/realtime/RealtimeService.java
@@ -87,7 +87,7 @@ public class RealtimeService extends IntentService {
             bundle = new Bundle();
         }
 
-        if (intent.getAction().equals(OTPConstants.INTENT_START_CHECKS)) {
+        if (OTPConstants.INTENT_START_CHECKS.equals(intent.getAction())) {
             disableListenForTripUpdates();
             if (!rescheduleRealtimeUpdates(bundle)) {
                 Itinerary itinerary = getItinerary(bundle);
@@ -97,7 +97,7 @@ public class RealtimeService extends IntentService {
                     Log.w(TAG, "Cannot start realtime updates - no itinerary in bundle");
                 }
             }
-        } else if (intent.getAction().equals(OTPConstants.INTENT_CHECK_TRIP_TIME)) {
+        } else if (OTPConstants.INTENT_CHECK_TRIP_TIME.equals(intent.getAction())) {
             checkForItineraryChange(bundle);
         }
 
@@ -329,6 +329,9 @@ public class RealtimeService extends IntentService {
             return null;
         }
         int i = bundle.getInt(OTPConstants.SELECTED_ITINERARY);
+        if (i < 0 || i >= itineraries.size()) {
+            return null;
+        }
         return itineraries.get(i);
     }
 


### PR DESCRIPTION
## Description
This PR addresses follow-up suggestions from the review of the previous real-time service fix in `RealtimeService.java`. The goal is to further improve safety and prevent possible crashes when handling unexpected or malformed data.

## Changes
- **Range Check in `getItinerary`**: Added a check to make sure the selected itinerary index is within the valid range before accessing the list.
- **Safe Action Check**: Updated `onHandleIntent` to safely compare the intent action so the app doesn’t crash if the action is missing.
- **Tests Added**: Added tests in `RealtimeServiceTest.java` to confirm:
  - `getItinerary` returns `null` when the index is out of range.
  - `onHandleIntent` handles `null` actions safely.

### Checklist

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `gradlew connectedObaGoogleDebugAndroidTest` to make sure you didn't break anything.