### PR TITLE
Fix donate URL

### DIFF
--- a/onebusaway-android/src/main/res/values/donottranslate.xml
+++ b/onebusaway-android/src/main/res/values/donottranslate.xml
@@ -92,7 +92,7 @@
     <string name="alerts_api_endpoint">/api/v1/regions/regionID/alerts.pb</string>
 
     <!-- Donate URL -->
-    <string name="donate_url">https://onebusaway.org/donate/</string>
+    <string name="donate_url">https://opentransitsoftwarefoundation.org/donate/</string>
 
     <!-- Powered by OBA URL -->
     <string name="powered_by_oba_url">https://onebusaway.org</string>


### PR DESCRIPTION
- [ ] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [ ] Run the unit tests with `gradlew connectedObaGoogleDebugAndroidTest` to make sure you didn't break anything

- [X] If you have multiple commits please combine them into one commit by squashing them for the initial submission of the pull request.  When addressing comments on a pull request, please push a new commit per comment when possible (reviewers will squash and merge using GitHub merge tool)


I didn't apply style or run the tests as this is a 1 line change to a string.

The old URL redirects to https://opentransitsoftwarefoundation.org/onebusaway/donate/ which 404s