### PR TITLE
Fix PendingIntent FLAG_MUTABLE crash on API 34+

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/realtime/RealtimeService.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/realtime/RealtimeService.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2016 Cambridge Systematics, Inc.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -151,7 +151,7 @@ public class RealtimeService extends IntentService {
 
                 int flags;
                 if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
-                    flags = PendingIntent.FLAG_CANCEL_CURRENT | PendingIntent.FLAG_MUTABLE;
+                    flags = PendingIntent.FLAG_CANCEL_CURRENT | PendingIntent.FLAG_IMMUTABLE;
                 } else {
                     flags = PendingIntent.FLAG_CANCEL_CURRENT;
                 }
@@ -258,7 +258,7 @@ public class RealtimeService extends IntentService {
         openIntent.setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
         int flags;
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
-            flags = PendingIntent.FLAG_CANCEL_CURRENT | PendingIntent.FLAG_MUTABLE;
+            flags = PendingIntent.FLAG_CANCEL_CURRENT | PendingIntent.FLAG_IMMUTABLE;
         } else {
             flags = PendingIntent.FLAG_CANCEL_CURRENT;
         }
@@ -313,7 +313,7 @@ public class RealtimeService extends IntentService {
         }
         int flags;
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
-            flags = PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_MUTABLE;
+            flags = PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE;
         } else {
             flags = PendingIntent.FLAG_UPDATE_CURRENT;
         }
@@ -345,7 +345,7 @@ public class RealtimeService extends IntentService {
         String name = bundle.getString(OTPConstants.NOTIFICATION_TARGET);
         try {
             return Class.forName(name);
-        } catch(ClassNotFoundException e) {
+        } catch (ClassNotFoundException e) {
             Log.e(TAG, "unable to find class for name " + name);
         }
         return null;


### PR DESCRIPTION
I tried running the tests without making any changes and they failed. This PR has the fix.

## Problem

Android 14 (API 34) introduced a security restriction that disallows creating a `PendingIntent` with `FLAG_MUTABLE` when using an implicit intent (no explicit component target). All three `PendingIntent`s in `RealtimeService` used `FLAG_MUTABLE` which causes an `IllegalArgumentException` crash on API 34+ devices.

See https://developer.android.com/about/versions/14/behavior-changes-14#safer-intents

> If an app creates a mutable pending intent with an intent that doesn't specify a component or package, the system throws an exception.

This leads to the error:

```
Targeting U+ (version 34 and above) disallows creating or retrieving a PendingIntent with FLAG_MUTABLE,
an implicit Intent within and without FLAG_NO_CREATE and FLAG_ALLOW_UNSAFE_IMPLICIT_INTENT for security
reasons. To retrieve an already existing PendingIntent, use FLAG_NO_CREATE, however, to create a new 
PendingIntent with an implicit Intent use FLAG_IMMUTABLE.
```

This was originally flagged in [#1488](https://github.com/OneBusAway/onebusaway-android/pull/1488) where the author correctly changed one site to `FLAG_IMMUTABLE` but the review asked for it to be reverted to maintain consistency with the rest of the file. This PR fixes all three sites consistently.

## Fix

Replace `FLAG_MUTABLE` with `FLAG_IMMUTABLE` in all three `PendingIntent` creation sites in `RealtimeService`. None of these intents need to be modified after creation, so `FLAG_IMMUTABLE` is the correct flag.

## Testing

The existing `testOnHandleIntentWithEmptyBundleDoesNotCrash` test in `RealtimeServiceTest` reproduces the crash and passes after this fix when run on an API 34+ device. Note that CI runs on API 33, so this failure would not have been caught automatically.

### Before this change:

```
$ ./gradlew connectedObaGoogleDebugAndroidTest
WARNING: A restricted method in java.lang.System has been called
WARNING: java.lang.System::load has been called by net.rubygrapefruit.platform.internal.NativeLibraryLoader in an unnamed module (file:/Users/rob/.gradle/wrapper/dists/gradle-9.1.0-all/7wzd0jkjit61aq2p43wpjgij9/gradle-9.1.0/lib/native-platform-0.22-milestone-28.jar)
WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in this module
WARNING: Restricted methods will be blocked in a future release unless native access is enabled

Configuration on demand is an incubating feature.
Calculating task graph as configuration cache cannot be reused because file 'onebusaway-android/build.gradle' has changed.

> Configure project :onebusaway-android
WARNING: The option setting 'android.r8.proguardAndroidTxt.disallowed=false' is deprecated.
The current default is 'true'.
It will be removed in version 10.0 of the Android Gradle plugin.
WARNING: The option setting 'android.enableJetifier=true' is deprecated.
The current default is 'false'.
It will be removed in version 10.0 of the Android Gradle plugin.

> Task :onebusaway-android:compileObaGoogleDebugAndroidTestJavaWithJavac
Java compiler version 25 has deprecated support for compiling with source/target version 8.
Try one of the following options:
    1. [Recommended] Use Java toolchain with a lower language version
    2. Set a higher source/target version
    3. Use a lower version of the JDK running the build (if you're not using Java toolchain)
For more details on how to configure these settings, see https://developer.android.com/build/jdks.
To suppress this warning, set android.javaCompile.suppressSourceTargetDeprecationWarning=true in gradle.properties.
warning: [options] source value 8 is obsolete and will be removed in a future release
warning: [options] target value 8 is obsolete and will be removed in a future release
warning: [options] To suppress warnings about obsolete options, use -Xlint:-options.
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
3 warnings
Starting 218 tests on SM-S921U1 - 16

org.onebusaway.android.directions.realtime.RealtimeServiceTest > testOnHandleIntentWithEmptyBundleDoesNotCrash[SM-S921U1 - 16] FAILED 
        java.lang.IllegalArgumentException: com.joulespersecond.seattlebusbot: Targeting U+ (version 34 and above) disallows creating or retrieving a PendingIntent with FLAG_MUTABLE, an implicit Intent within and without FLAG_NO_CREATE and FLAG_ALLOW_UNSAFE_IMPLICIT_INTENT for security reasons. To retrieve an already existing PendingIntent, use FLAG_NO_CREATE, however, to create a new PendingIntent with an implicit Intent use FLAG_IMMUTABLE.
        at android.os.Parcel.createExceptionOrNull(Parcel.java:3358)
SM-S921U1 - 16 Tests 154/218 completed. (0 skipped) (1 failed)
SM-S921U1 - 16 Tests 163/218 completed. (0 skipped) (1 failed)
SM-S921U1 - 16 Tests 182/218 completed. (0 skipped) (1 failed)
Tests on SM-S921U1 - 16 failed: There was 1 failure(s).
Finished 218 tests on SM-S921U1 - 16

> Task :onebusaway-android:connectedObaGoogleDebugAndroidTest FAILED

[Incubating] Problems report is available at: file:///Users/rob/Documents/GitHub/onebusaway-android/build/reports/problems/problems-report.html

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':onebusaway-android:connectedObaGoogleDebugAndroidTest'.
> There were failing tests. See the report at: file:///Users/rob/Documents/GitHub/onebusaway-android/onebusaway-android/build/reports/androidTests/connected/debug/flavors/obaGoogle/index.html

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to generate a Build Scan (Powered by Develocity).
> Get more help at https://help.gradle.org.

Deprecated Gradle features were used in this build, making it incompatible with Gradle 10.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/9.1.0/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD FAILED in 58s
69 actionable tasks: 14 executed, 55 up-to-date
Configuration cache entry stored.
```

### After this change:

```
$ ./gradlew assembleObaGoogleDebug            
WARNING: A restricted method in java.lang.System has been called
WARNING: java.lang.System::load has been called by net.rubygrapefruit.platform.internal.NativeLibraryLoader in an unnamed module (file:/Users/rob/.gradle/wrapper/dists/gradle-9.1.0-all/7wzd0jkjit61aq2p43wpjgij9/gradle-9.1.0/lib/native-platform-0.22-milestone-28.jar)
WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in this module
WARNING: Restricted methods will be blocked in a future release unless native access is enabled

Configuration on demand is an incubating feature.
Reusing configuration cache.

> Task :onebusaway-android:compileObaGoogleDebugJavaWithJavac
Java compiler version 25 has deprecated support for compiling with source/target version 8.
Try one of the following options:
    1. [Recommended] Use Java toolchain with a lower language version
    2. Set a higher source/target version
    3. Use a lower version of the JDK running the build (if you're not using Java toolchain)
For more details on how to configure these settings, see https://developer.android.com/build/jdks.
To suppress this warning, set android.javaCompile.suppressSourceTargetDeprecationWarning=true in gradle.properties.
warning: [options] source value 8 is obsolete and will be removed in a future release
warning: [options] target value 8 is obsolete and will be removed in a future release
warning: [options] To suppress warnings about obsolete options, use -Xlint:-options.
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
3 warnings

[Incubating] Problems report is available at: file:///Users/rob/Documents/GitHub/onebusaway-android/build/reports/problems/problems-report.html

BUILD SUCCESSFUL in 2s
38 actionable tasks: 6 executed, 32 up-to-date
Configuration cache entry reused.
```

- [X] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [X] Run the unit tests with `gradlew connectedObaGoogleDebugAndroidTest` to make sure you didn't break anything

- [X] If you have multiple commits please combine them into one commit by squashing them for the initial submission of the pull request.  When addressing comments on a pull request, please push a new commit per comment when possible (reviewers will squash and merge using GitHub merge tool)