### PR TITLE
Add Transit Center View for user-created stop groups

### DIFF
--- a/onebusaway-android/src/main/AndroidManifest.xml
+++ b/onebusaway-android/src/main/AndroidManifest.xml
@@ -280,6 +280,13 @@
                 android:value="org.onebusaway.android.ui.HomeActivity"/>
         </activity>
         <activity
+            android:name="org.onebusaway.android.ui.TransitCenterDetailActivity"
+            android:parentActivityName="org.onebusaway.android.ui.HomeActivity">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="org.onebusaway.android.ui.HomeActivity"/>
+        </activity>
+        <activity
             android:name="org.onebusaway.android.ui.TripPlanActivity"
             android:label="@string/title_activity_trip_plan"
             android:parentActivityName="org.onebusaway.android.ui.HomeActivity">

--- a/onebusaway-android/src/main/java/org/onebusaway/android/provider/ObaContract.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/provider/ObaContract.java
@@ -149,6 +149,44 @@ public final class ObaContract {
         public static final String REGION_ID = "region_id";
     }
 
+    protected interface TransitCenterColumns {
+
+        /**
+         * The user-chosen name of the transit center.
+         * <P>
+         * Type: TEXT
+         * </P>
+         */
+        String NAME = "name";
+
+        /**
+         * The region ID for filtering.
+         * <P>
+         * Type: INTEGER
+         * </P>
+         */
+        String REGION_ID = "region_id";
+    }
+
+    protected interface TransitCenterStopColumns {
+
+        /**
+         * The transit center ID.
+         * <P>
+         * Type: INTEGER
+         * </P>
+         */
+        String TRANSIT_CENTER_ID = "transit_center_id";
+
+        /**
+         * The stop ID.
+         * <P>
+         * Type: TEXT
+         * </P>
+         */
+        String STOP_ID = "stop_id";
+    }
+
     protected interface StopRouteKeyColumns {
 
         /**
@@ -1974,6 +2012,106 @@ public final class ObaContract {
                 }
             }
             return null;
+        }
+    }
+
+    public static class TransitCenters implements BaseColumns, TransitCenterColumns {
+
+        // Cannot be instantiated
+        private TransitCenters() {
+        }
+
+        /** The URI path portion for this table */
+        public static final String PATH = "transit_centers";
+
+        /** The content:// style URI for this table */
+        public static final Uri CONTENT_URI = Uri.withAppendedPath(
+                AUTHORITY_URI, PATH);
+
+        public static final String CONTENT_TYPE
+                = "vnd.android.cursor.item/" + BuildConfig.DATABASE_AUTHORITY + ".transitcenter";
+
+        public static final String CONTENT_DIR_TYPE
+                = "vnd.android.dir/" + BuildConfig.DATABASE_AUTHORITY + ".transitcenter";
+
+        public static Uri buildUri(long id) {
+            return ContentUris.withAppendedId(CONTENT_URI, id);
+        }
+
+        public static Uri insert(Context context, String name, long regionId) {
+            ContentResolver cr = context.getContentResolver();
+            ContentValues values = new ContentValues();
+            values.put(NAME, name);
+            values.put(REGION_ID, regionId);
+            return cr.insert(CONTENT_URI, values);
+        }
+
+        public static void delete(Context context, long id) {
+            ContentResolver cr = context.getContentResolver();
+            cr.delete(buildUri(id), null, null);
+            // Also delete associated stops
+            cr.delete(TransitCenterStops.CONTENT_URI,
+                    TransitCenterStops.TRANSIT_CENTER_ID + "=?",
+                    new String[]{String.valueOf(id)});
+        }
+
+        public static void rename(Context context, long id, String newName) {
+            ContentResolver cr = context.getContentResolver();
+            ContentValues values = new ContentValues();
+            values.put(NAME, newName);
+            cr.update(buildUri(id), values, null, null);
+        }
+    }
+
+    public static class TransitCenterStops implements TransitCenterStopColumns {
+
+        // Cannot be instantiated
+        private TransitCenterStops() {
+        }
+
+        /** The URI path portion for this table */
+        public static final String PATH = "transit_center_stops";
+
+        /** The content:// style URI for this table */
+        public static final Uri CONTENT_URI = Uri.withAppendedPath(
+                AUTHORITY_URI, PATH);
+
+        public static final String CONTENT_DIR_TYPE
+                = "vnd.android.dir/" + BuildConfig.DATABASE_AUTHORITY + ".transitcenterstop";
+
+        public static void addStop(Context context, long transitCenterId, String stopId) {
+            ContentResolver cr = context.getContentResolver();
+            ContentValues values = new ContentValues();
+            values.put(TRANSIT_CENTER_ID, transitCenterId);
+            values.put(STOP_ID, stopId);
+            cr.insert(CONTENT_URI, values);
+        }
+
+        public static void removeStop(Context context, long transitCenterId, String stopId) {
+            ContentResolver cr = context.getContentResolver();
+            cr.delete(CONTENT_URI,
+                    TRANSIT_CENTER_ID + "=? AND " + STOP_ID + "=?",
+                    new String[]{String.valueOf(transitCenterId), stopId});
+        }
+
+        public static ArrayList<String> getStopIds(Context context, long transitCenterId) {
+            ContentResolver cr = context.getContentResolver();
+            Cursor c = cr.query(CONTENT_URI,
+                    new String[]{STOP_ID},
+                    TRANSIT_CENTER_ID + "=?",
+                    new String[]{String.valueOf(transitCenterId)},
+                    null);
+            ArrayList<String> result = new ArrayList<String>();
+            if (c != null) {
+                try {
+                    while (c.moveToNext()) {
+                        result.add(c.getString(0));
+                    }
+                } finally {
+                    c.close();
+                }
+            }
+            return result;
         }
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/provider/ObaProvider.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/provider/ObaProvider.java
@@ -49,7 +49,7 @@ public class ObaProvider extends ContentProvider {
 
     private class OpenHelper extends SQLiteOpenHelper {
 
-        private static final int DATABASE_VERSION = 33;
+        private static final int DATABASE_VERSION = 34;
 
         public OpenHelper(Context context) {
             super(context, DATABASE_NAME, null, DATABASE_VERSION);
@@ -322,6 +322,23 @@ public class ObaProvider extends ContentProvider {
             if (oldVersion == 32){
                 db.execSQL("ALTER TABLE " + ObaContract.Regions.PATH +
                         " ADD COLUMN " + ObaContract.Regions.PLAUSIBLE_ANALYTICS_SERVER_URL + " VARCHAR DEFAULT NULL");
+                ++oldVersion;
+            }
+            if (oldVersion == 33) {
+                db.execSQL(
+                        "CREATE TABLE " +
+                                ObaContract.TransitCenters.PATH + " (" +
+                                ObaContract.TransitCenters._ID + " INTEGER PRIMARY KEY AUTOINCREMENT, " +
+                                ObaContract.TransitCenters.NAME + " VARCHAR NOT NULL, " +
+                                ObaContract.TransitCenters.REGION_ID + " INTEGER" +
+                                ");");
+                db.execSQL(
+                        "CREATE TABLE " +
+                                ObaContract.TransitCenterStops.PATH + " (" +
+                                ObaContract.TransitCenterStops.TRANSIT_CENTER_ID + " INTEGER NOT NULL, " +
+                                ObaContract.TransitCenterStops.STOP_ID + " VARCHAR NOT NULL" +
+                                ");");
+                ++oldVersion;
             }
         }
 
@@ -393,6 +410,8 @@ public class ObaProvider extends ContentProvider {
             db.execSQL("DROP TABLE IF EXISTS " + ObaContract.RegionOpen311Servers.PATH);
             db.execSQL("DROP TABLE IF EXISTS " + ObaContract.RouteHeadsignFavorites.PATH);
             db.execSQL("DROP TABLE IF EXISTS " + ObaContract.NavStops.PATH);
+            db.execSQL("DROP TABLE IF EXISTS " + ObaContract.TransitCenters.PATH);
+            db.execSQL("DROP TABLE IF EXISTS " + ObaContract.TransitCenterStops.PATH);
         }
     }
 
@@ -434,6 +453,12 @@ public class ObaProvider extends ContentProvider {
 
     private static final int NAV_STOPS = 19;
 
+    private static final int TRANSIT_CENTERS = 20;
+
+    private static final int TRANSIT_CENTERS_ID = 21;
+
+    private static final int TRANSIT_CENTER_STOPS = 22;
+
     private static final UriMatcher sUriMatcher;
 
     private static final HashMap<String, String> sStopsProjectionMap;
@@ -451,6 +476,8 @@ public class ObaProvider extends ContentProvider {
     private static final HashMap<String, String> sRegionBoundsProjectionMap;
 
     private static final HashMap<String, String> sRegionOpen311ProjectionMap;
+
+    private static final HashMap<String, String> sTransitCentersProjectionMap;
 
     // Insert helpers are useful.
     private DatabaseUtils.InsertHelper mStopsInserter;
@@ -474,6 +501,10 @@ public class ObaProvider extends ContentProvider {
     private DatabaseUtils.InsertHelper mRouteHeadsignFavoritesInserter;
 
     private DatabaseUtils.InsertHelper mNavStopsInserter;
+
+    private DatabaseUtils.InsertHelper mTransitCentersInserter;
+
+    private DatabaseUtils.InsertHelper mTransitCenterStopsInserter;
 
     static {
         sUriMatcher = new UriMatcher(UriMatcher.NO_MATCH);
@@ -502,6 +533,12 @@ public class ObaProvider extends ContentProvider {
         sUriMatcher.addURI(ObaContract.AUTHORITY, ObaContract.RouteHeadsignFavorites.PATH,
                 ROUTE_HEADSIGN_FAVORITES);
         sUriMatcher.addURI(ObaContract.AUTHORITY, ObaContract.NavStops.PATH, NAV_STOPS);
+        sUriMatcher.addURI(ObaContract.AUTHORITY, ObaContract.TransitCenters.PATH,
+                TRANSIT_CENTERS);
+        sUriMatcher.addURI(ObaContract.AUTHORITY, ObaContract.TransitCenters.PATH + "/#",
+                TRANSIT_CENTERS_ID);
+        sUriMatcher.addURI(ObaContract.AUTHORITY, ObaContract.TransitCenterStops.PATH,
+                TRANSIT_CENTER_STOPS);
 
         sStopsProjectionMap = new HashMap<String, String>();
         sStopsProjectionMap.put(ObaContract.Stops._ID, ObaContract.Stops._ID);
@@ -635,6 +672,14 @@ public class ObaProvider extends ContentProvider {
                 .put(ObaContract.Regions.SIDECAR_BASE_URL, ObaContract.Regions.SIDECAR_BASE_URL);
         sRegionsProjectionMap
                 .put(ObaContract.Regions.PLAUSIBLE_ANALYTICS_SERVER_URL, ObaContract.Regions.PLAUSIBLE_ANALYTICS_SERVER_URL);
+
+        sTransitCentersProjectionMap = new HashMap<String, String>();
+        sTransitCentersProjectionMap.put(ObaContract.TransitCenters._ID,
+                ObaContract.TransitCenters._ID);
+        sTransitCentersProjectionMap.put(ObaContract.TransitCenters.NAME,
+                ObaContract.TransitCenters.NAME);
+        sTransitCentersProjectionMap.put(ObaContract.TransitCenters.REGION_ID,
+                ObaContract.TransitCenters.REGION_ID);
     }
 
     private SQLiteDatabase mDb;
@@ -693,6 +738,12 @@ public class ObaProvider extends ContentProvider {
                 return ObaContract.RouteHeadsignFavorites.CONTENT_DIR_TYPE;
             case NAV_STOPS:
                 return ObaContract.NavStops.CONTENT_DIR_TYPE;
+            case TRANSIT_CENTERS:
+                return ObaContract.TransitCenters.CONTENT_DIR_TYPE;
+            case TRANSIT_CENTERS_ID:
+                return ObaContract.TransitCenters.CONTENT_TYPE;
+            case TRANSIT_CENTER_STOPS:
+                return ObaContract.TransitCenterStops.CONTENT_DIR_TYPE;
             default:
                 throw new IllegalArgumentException("Unknown URI: " + uri);
         }
@@ -850,6 +901,17 @@ public class ObaProvider extends ContentProvider {
                 result = ContentUris.withAppendedId(ObaContract.NavStops.CONTENT_URI, longId);
                 return result;
 
+            case TRANSIT_CENTERS:
+                longId = mTransitCentersInserter.insert(values);
+                result = ContentUris.withAppendedId(ObaContract.TransitCenters.CONTENT_URI, longId);
+                return result;
+
+            case TRANSIT_CENTER_STOPS:
+                longId = mTransitCenterStopsInserter.insert(values);
+                result = ContentUris.withAppendedId(ObaContract.TransitCenterStops.CONTENT_URI,
+                        longId);
+                return result;
+
             // What would these mean, anyway??
             case STOPS_ID:
             case ROUTES_ID:
@@ -1004,6 +1066,27 @@ public class ObaProvider extends ContentProvider {
                 qb.setTables(ObaContract.NavStops.PATH);
                 return qb.query(mDb, projection, selection, selectionArgs,
                         null, null, sortOrder, limit);
+
+            case TRANSIT_CENTERS:
+                qb.setTables(ObaContract.TransitCenters.PATH);
+                qb.setProjectionMap(sTransitCentersProjectionMap);
+                return qb.query(mDb, projection, selection, selectionArgs,
+                        null, null, sortOrder, limit);
+
+            case TRANSIT_CENTERS_ID:
+                qb.setTables(ObaContract.TransitCenters.PATH);
+                qb.setProjectionMap(sTransitCentersProjectionMap);
+                qb.appendWhere(ObaContract.TransitCenters._ID);
+                qb.appendWhere("=");
+                qb.appendWhere(String.valueOf(ContentUris.parseId(uri)));
+                return qb.query(mDb, projection, selection, selectionArgs,
+                        null, null, sortOrder, limit);
+
+            case TRANSIT_CENTER_STOPS:
+                qb.setTables(ObaContract.TransitCenterStops.PATH);
+                return qb.query(mDb, projection, selection, selectionArgs,
+                        null, null, sortOrder, limit);
+
             default:
                 throw new IllegalArgumentException("Unknown URI: " + uri);
         }
@@ -1080,6 +1163,18 @@ public class ObaProvider extends ContentProvider {
                 return db.update(ObaContract.NavStops.PATH, values,
                         where(ObaContract.NavStops._ID, uri), selectionArgs);
 
+            case TRANSIT_CENTERS:
+                return db.update(ObaContract.TransitCenters.PATH, values, selection,
+                        selectionArgs);
+
+            case TRANSIT_CENTERS_ID:
+                return db.update(ObaContract.TransitCenters.PATH, values,
+                        whereLong(ObaContract.TransitCenters._ID, uri), selectionArgs);
+
+            case TRANSIT_CENTER_STOPS:
+                return db.update(ObaContract.TransitCenterStops.PATH, values, selection,
+                        selectionArgs);
+
             default:
                 throw new IllegalArgumentException("Unknown URI: " + uri);
         }
@@ -1153,6 +1248,16 @@ public class ObaProvider extends ContentProvider {
             case NAV_STOPS:
                 return db.delete(ObaContract.NavStops.PATH, selection, selectionArgs);
 
+            case TRANSIT_CENTERS:
+                return db.delete(ObaContract.TransitCenters.PATH, selection, selectionArgs);
+
+            case TRANSIT_CENTERS_ID:
+                return db.delete(ObaContract.TransitCenters.PATH,
+                        whereLong(ObaContract.TransitCenters._ID, uri), selectionArgs);
+
+            case TRANSIT_CENTER_STOPS:
+                return db.delete(ObaContract.TransitCenterStops.PATH, selection, selectionArgs);
+
             default:
                 throw new IllegalArgumentException("Unknown URI: " + uri);
         }
@@ -1209,6 +1314,10 @@ public class ObaProvider extends ContentProvider {
             mRouteHeadsignFavoritesInserter = new DatabaseUtils.InsertHelper(mDb,
                     ObaContract.RouteHeadsignFavorites.PATH);
             mNavStopsInserter = new DatabaseUtils.InsertHelper(mDb, ObaContract.NavStops.PATH);
+            mTransitCentersInserter = new DatabaseUtils.InsertHelper(mDb,
+                    ObaContract.TransitCenters.PATH);
+            mTransitCenterStopsInserter = new DatabaseUtils.InsertHelper(mDb,
+                    ObaContract.TransitCenterStops.PATH);
         }
         return mDb;
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/AddStopToTransitCenterDialog.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/AddStopToTransitCenterDialog.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui;
+
+import android.app.Dialog;
+import android.database.Cursor;
+import android.os.Bundle;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
+import androidx.fragment.app.DialogFragment;
+
+import org.onebusaway.android.R;
+import org.onebusaway.android.app.Application;
+import org.onebusaway.android.provider.ObaContract;
+
+import java.util.ArrayList;
+
+public class AddStopToTransitCenterDialog extends DialogFragment {
+
+    private static final String ARG_TRANSIT_CENTER_ID = "transit_center_id";
+
+    private long mTransitCenterId;
+    private ArrayList<String> mStopIds = new ArrayList<>();
+    private ArrayList<String> mStopNames = new ArrayList<>();
+    private ArrayList<String> mExistingStopIds;
+    private OnStopsAddedListener mListener;
+
+    public interface OnStopsAddedListener {
+        void onStopsAdded();
+    }
+
+    public static AddStopToTransitCenterDialog newInstance(long transitCenterId) {
+        AddStopToTransitCenterDialog dialog = new AddStopToTransitCenterDialog();
+        Bundle args = new Bundle();
+        args.putLong(ARG_TRANSIT_CENTER_ID, transitCenterId);
+        dialog.setArguments(args);
+        return dialog;
+    }
+
+    public void setOnStopsAddedListener(OnStopsAddedListener listener) {
+        mListener = listener;
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        if (getArguments() != null) {
+            mTransitCenterId = getArguments().getLong(ARG_TRANSIT_CENTER_ID, -1);
+        }
+        mExistingStopIds = ObaContract.TransitCenterStops.getStopIds(
+                requireActivity(), mTransitCenterId);
+    }
+
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        // Query starred stops synchronously for the dialog
+        String selection = ObaContract.Stops.FAVORITE + "=1";
+        if (Application.get().getCurrentRegion() != null) {
+            selection += " AND " + QueryUtils.getRegionWhere(ObaContract.Stops.REGION_ID,
+                    Application.get().getCurrentRegion().getId());
+        }
+
+        Cursor c = requireActivity().getContentResolver().query(
+                ObaContract.Stops.CONTENT_URI,
+                new String[]{ObaContract.Stops._ID, ObaContract.Stops.UI_NAME},
+                selection, null,
+                ObaContract.Stops.UI_NAME + " ASC");
+
+        mStopIds.clear();
+        mStopNames.clear();
+        boolean[] checkedItems = null;
+
+        if (c != null) {
+            try {
+                checkedItems = new boolean[c.getCount()];
+                while (c.moveToNext()) {
+                    String stopId = c.getString(0);
+                    String stopName = c.getString(1);
+                    mStopIds.add(stopId);
+                    mStopNames.add(stopName);
+                    checkedItems[c.getPosition()] = mExistingStopIds.contains(stopId);
+                }
+            } finally {
+                c.close();
+            }
+        }
+
+        String[] names = mStopNames.toArray(new String[0]);
+        final boolean[] selected = checkedItems != null ? checkedItems : new boolean[0];
+
+        AlertDialog.Builder builder = new AlertDialog.Builder(requireActivity());
+        builder.setTitle(R.string.transit_center_add_stops);
+        builder.setMultiChoiceItems(names, selected, (dialog, which, isChecked) -> {
+            selected[which] = isChecked;
+        });
+        builder.setPositiveButton(android.R.string.ok, (dialog, which) -> {
+            for (int i = 0; i < mStopIds.size(); i++) {
+                String stopId = mStopIds.get(i);
+                boolean wasExisting = mExistingStopIds.contains(stopId);
+                if (selected[i] && !wasExisting) {
+                    ObaContract.TransitCenterStops.addStop(
+                            requireActivity(), mTransitCenterId, stopId);
+                } else if (!selected[i] && wasExisting) {
+                    ObaContract.TransitCenterStops.removeStop(
+                            requireActivity(), mTransitCenterId, stopId);
+                }
+            }
+            if (mListener != null) {
+                mListener.onStopsAdded();
+            }
+        });
+        builder.setNegativeButton(android.R.string.cancel, null);
+
+        return builder.create();
+    }
+
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.java
@@ -138,6 +138,7 @@ import static org.onebusaway.android.ui.NavigationDrawerFragment.NAVDRAWER_ITEM_
 import static org.onebusaway.android.ui.NavigationDrawerFragment.NAVDRAWER_ITEM_SIGN_IN;
 import static org.onebusaway.android.ui.NavigationDrawerFragment.NAVDRAWER_ITEM_STARRED_ROUTES;
 import static org.onebusaway.android.ui.NavigationDrawerFragment.NAVDRAWER_ITEM_STARRED_STOPS;
+import static org.onebusaway.android.ui.NavigationDrawerFragment.NAVDRAWER_ITEM_TRANSIT_CENTERS;
 import static org.onebusaway.android.ui.NavigationDrawerFragment.NavigationDrawerCallbacks;
 import static org.onebusaway.android.util.PermissionUtils.LOCATION_PERMISSIONS;
 import static uk.co.markormesher.android_fab.FloatingActionButton.POSITION_BOTTOM;
@@ -246,6 +247,8 @@ public class HomeActivity extends AppCompatActivity
     BaseMapFragment mMapFragment;
 
     MyRemindersFragment mMyRemindersFragment;
+
+    TransitCentersFragment mMyTransitCentersFragment;
 
     /**
      * Control which menu options are shown per fragment menu groups
@@ -557,6 +560,12 @@ public class HomeActivity extends AppCompatActivity
                             null);
                 }
                 break;
+            case NAVDRAWER_ITEM_TRANSIT_CENTERS:
+                if (mCurrentNavDrawerPosition != NAVDRAWER_ITEM_TRANSIT_CENTERS) {
+                    showTransitCentersFragment();
+                    mCurrentNavDrawerPosition = item;
+                }
+                break;
             case NAVDRAWER_ITEM_MY_REMINDERS:
                 if (mCurrentNavDrawerPosition != NAVDRAWER_ITEM_MY_REMINDERS) {
                     showMyRemindersFragment();
@@ -638,6 +647,7 @@ public class HomeActivity extends AppCompatActivity
         hideStarredRoutesFragment();
         hideStarredStopsFragment();
         hideReminderFragment();
+        hideTransitCentersFragment();
         mShowStarredStopsMenu = false;
         /**
          * Show fragment (we use show instead of replace to keep the map state)
@@ -696,6 +706,7 @@ public class HomeActivity extends AppCompatActivity
         hideMapFragment();
         hideReminderFragment();
         hideStarredRoutesFragment();
+        hideTransitCentersFragment();
         hideSlidingPanel();
         mShowArrivalsMenu = false;
         showZoomControls(false);
@@ -732,6 +743,7 @@ public class HomeActivity extends AppCompatActivity
         hideReminderFragment();
         hideSlidingPanel();
         hideStarredStopsFragment();
+        hideTransitCentersFragment();
         mShowArrivalsMenu = false;
         showZoomControls(false);
 
@@ -766,6 +778,7 @@ public class HomeActivity extends AppCompatActivity
         hideStarredRoutesFragment();
         hideStarredStopsFragment();
         hideMapFragment();
+        hideTransitCentersFragment();
         hideSlidingPanel();
         mShowArrivalsMenu = false;
         mShowStarredStopsMenu = false;
@@ -822,6 +835,43 @@ public class HomeActivity extends AppCompatActivity
                 .findFragmentByTag(MyRemindersFragment.TAG);
         if (mMyRemindersFragment != null && !mMyRemindersFragment.isHidden()) {
             fm.beginTransaction().hide(mMyRemindersFragment).commit();
+        }
+    }
+
+    private void showTransitCentersFragment() {
+        FragmentManager fm = getSupportFragmentManager();
+        hideFloatingActionButtons();
+        hideMapProgressBar();
+        hideMapFragment();
+        hideStarredStopsFragment();
+        hideStarredRoutesFragment();
+        hideReminderFragment();
+        hideSlidingPanel();
+        mShowArrivalsMenu = false;
+        mShowStarredStopsMenu = false;
+        showZoomControls(false);
+
+        if (mMyTransitCentersFragment == null) {
+            mMyTransitCentersFragment = (TransitCentersFragment) fm
+                    .findFragmentByTag(TransitCentersFragment.TAG);
+
+            if (mMyTransitCentersFragment == null) {
+                Log.d(TAG, "Creating new TransitCentersFragment");
+                mMyTransitCentersFragment = new TransitCentersFragment();
+                fm.beginTransaction().add(R.id.main_fragment_container,
+                        mMyTransitCentersFragment, TransitCentersFragment.TAG).commit();
+            }
+        }
+        fm.beginTransaction().show(mMyTransitCentersFragment).commit();
+        setTitle(R.string.navdrawer_item_transit_centers);
+    }
+
+    private void hideTransitCentersFragment() {
+        FragmentManager fm = getSupportFragmentManager();
+        mMyTransitCentersFragment = (TransitCentersFragment) fm
+                .findFragmentByTag(TransitCentersFragment.TAG);
+        if (mMyTransitCentersFragment != null && !mMyTransitCentersFragment.isHidden()) {
+            fm.beginTransaction().hide(mMyTransitCentersFragment).commit();
         }
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/NavigationDrawerFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/NavigationDrawerFragment.java
@@ -102,6 +102,8 @@ public class NavigationDrawerFragment extends Fragment {
 
     protected static final int NAVDRAWER_ITEM_PAY_FARE = 13;
 
+    protected static final int NAVDRAWER_ITEM_TRANSIT_CENTERS = 14;
+
     protected static final int NAVDRAWER_ITEM_INVALID = -1;
 
     protected static final int NAVDRAWER_ITEM_SEPARATOR = -2;
@@ -124,7 +126,8 @@ public class NavigationDrawerFragment extends Fragment {
             0, // My profile
             0, // Sign in
             R.string.navdrawer_item_open_source,
-            R.string.navdrawer_item_pay_fare
+            R.string.navdrawer_item_pay_fare,
+            R.string.navdrawer_item_transit_centers
     };
 
     // icons for navdrawer items (indices must correspond to above array)
@@ -142,7 +145,8 @@ public class NavigationDrawerFragment extends Fragment {
             0, // My profile
             0, // Sign in
             R.drawable.ic_drawer_github, // Open-source
-            R.drawable.ic_payment // Pay my fare
+            R.drawable.ic_payment, // Pay my fare
+            R.drawable.ic_drawer_maps_place // Transit centers
     };
 
     // Secondary navdrawer item icons that appear align to right of list item layout
@@ -160,7 +164,8 @@ public class NavigationDrawerFragment extends Fragment {
             0, // My profile
             0, // Sign in
             R.drawable.ic_drawer_link, // Open-source
-            R.drawable.ic_drawer_link // Pay my fare
+            R.drawable.ic_drawer_link, // Pay my fare
+            0 // Transit centers
     };
 
     // list of navdrawer items that were actually added to the navdrawer, in order
@@ -433,6 +438,7 @@ public class NavigationDrawerFragment extends Fragment {
         mNavDrawerItems.add(NAVDRAWER_ITEM_NEARBY);
         mNavDrawerItems.add(NAVDRAWER_ITEM_STARRED_STOPS);
         mNavDrawerItems.add(NAVDRAWER_ITEM_STARRED_ROUTES);
+        mNavDrawerItems.add(NAVDRAWER_ITEM_TRANSIT_CENTERS);
 
         // Add reminders if they should be shown
         if(ReminderUtils.shouldShowReminders()){

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/TransitCenterDetailActivity.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/TransitCenterDetailActivity.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui;
+
+import android.os.Bundle;
+import android.view.MenuItem;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.fragment.app.FragmentManager;
+
+import org.onebusaway.android.util.UIUtils;
+
+public class TransitCenterDetailActivity extends AppCompatActivity {
+
+    public static final String EXTRA_TRANSIT_CENTER_ID = "transit_center_id";
+    public static final String EXTRA_TRANSIT_CENTER_NAME = "transit_center_name";
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        UIUtils.setupActionBar(this);
+
+        long transitCenterId = getIntent().getLongExtra(EXTRA_TRANSIT_CENTER_ID, -1);
+        String name = getIntent().getStringExtra(EXTRA_TRANSIT_CENTER_NAME);
+
+        if (getSupportActionBar() != null) {
+            getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+            if (name != null) {
+                getSupportActionBar().setTitle(name);
+            }
+        }
+
+        if (savedInstanceState == null) {
+            TransitCenterDetailFragment fragment = TransitCenterDetailFragment.newInstance(
+                    transitCenterId, name);
+            FragmentManager fm = getSupportFragmentManager();
+            fm.beginTransaction()
+                    .add(android.R.id.content, fragment, TransitCenterDetailFragment.TAG)
+                    .commit();
+        }
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (item.getItemId() == android.R.id.home) {
+            finish();
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/TransitCenterDetailFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/TransitCenterDetailFragment.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui;
+
+import android.database.Cursor;
+import android.os.Bundle;
+import android.view.ContextMenu;
+import android.view.ContextMenu.ContextMenuInfo;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
+import android.view.View;
+import android.widget.AdapterView.AdapterContextMenuInfo;
+import android.widget.ListView;
+import android.widget.TextView;
+
+import androidx.cursoradapter.widget.SimpleCursorAdapter;
+import androidx.loader.app.LoaderManager;
+import androidx.loader.content.CursorLoader;
+import androidx.loader.content.Loader;
+
+import org.onebusaway.android.R;
+import org.onebusaway.android.provider.ObaContract;
+import org.onebusaway.android.util.UIUtils;
+
+import java.util.ArrayList;
+
+public class TransitCenterDetailFragment extends ListFragment
+        implements LoaderManager.LoaderCallbacks<Cursor>, QueryUtils.StopList.Columns {
+
+    public static final String TAG = "TransitCenterDetailFragment";
+
+    private static final String ARG_TRANSIT_CENTER_ID = "transit_center_id";
+    private static final String ARG_TRANSIT_CENTER_NAME = "transit_center_name";
+
+    private static final int CONTEXT_MENU_REMOVE_STOP = 20;
+
+    private long mTransitCenterId;
+    private boolean mStarredOnly = false;
+    private SimpleCursorAdapter mAdapter;
+
+    public static TransitCenterDetailFragment newInstance(long transitCenterId, String name) {
+        TransitCenterDetailFragment fragment = new TransitCenterDetailFragment();
+        Bundle args = new Bundle();
+        args.putLong(ARG_TRANSIT_CENTER_ID, transitCenterId);
+        args.putString(ARG_TRANSIT_CENTER_NAME, name);
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+    @Override
+    public void onActivityCreated(Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+        setHasOptionsMenu(true);
+
+        Bundle args = getArguments();
+        if (args != null) {
+            mTransitCenterId = args.getLong(ARG_TRANSIT_CENTER_ID, -1);
+        }
+
+        setEmptyText(getString(R.string.transit_center_empty));
+        registerForContextMenu(getListView());
+
+        mAdapter = QueryUtils.StopList.newAdapter(getActivity());
+        setListAdapter(mAdapter);
+
+        getLoaderManager().initLoader(0, null, this);
+    }
+
+    @Override
+    public Loader<Cursor> onCreateLoader(int id, Bundle args) {
+        ArrayList<String> stopIds =
+                ObaContract.TransitCenterStops.getStopIds(getActivity(), mTransitCenterId);
+        if (stopIds.isEmpty()) {
+            // Return a loader that will produce an empty cursor
+            return new CursorLoader(getActivity(),
+                    ObaContract.Stops.CONTENT_URI,
+                    PROJECTION,
+                    ObaContract.Stops._ID + "='__NONE__'",
+                    null, null);
+        }
+
+        StringBuilder sb = new StringBuilder();
+        sb.append(ObaContract.Stops._ID);
+        sb.append(" IN (");
+        for (int i = 0; i < stopIds.size(); i++) {
+            if (i > 0) {
+                sb.append(",");
+            }
+            sb.append("'");
+            sb.append(stopIds.get(i).replace("'", "''"));
+            sb.append("'");
+        }
+        sb.append(")");
+
+        if (mStarredOnly) {
+            sb.append(" AND ");
+            sb.append(ObaContract.Stops.FAVORITE);
+            sb.append("=1");
+        }
+
+        return new CursorLoader(getActivity(),
+                ObaContract.Stops.CONTENT_URI,
+                PROJECTION,
+                sb.toString(),
+                null,
+                ObaContract.Stops.UI_NAME + " ASC");
+    }
+
+    @Override
+    public void onLoadFinished(Loader<Cursor> loader, Cursor data) {
+        mAdapter.swapCursor(data);
+    }
+
+    @Override
+    public void onLoaderReset(Loader<Cursor> loader) {
+        mAdapter.swapCursor(null);
+    }
+
+    @Override
+    public void onListItemClick(ListView l, View v, int position, long id) {
+        SimpleCursorAdapter cursorAdapter = (SimpleCursorAdapter) l.getAdapter();
+        Cursor c = cursorAdapter.getCursor();
+        c.moveToPosition(position - l.getHeaderViewsCount());
+        String stopId = c.getString(COL_ID);
+        String stopName = c.getString(COL_NAME);
+        String stopDir = c.getString(COL_DIRECTION);
+
+        ArrivalsListActivity.Builder b = new ArrivalsListActivity.Builder(getActivity(), stopId);
+        b.setStopName(stopName);
+        b.setStopDirection(stopDir);
+        b.setUpMode(NavHelp.UP_MODE_BACK);
+        b.start();
+    }
+
+    @Override
+    public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
+        inflater.inflate(R.menu.transit_center_detail_options, menu);
+    }
+
+    @Override
+    public void onPrepareOptionsMenu(Menu menu) {
+        MenuItem toggleItem = menu.findItem(R.id.toggle_starred);
+        if (toggleItem != null) {
+            toggleItem.setTitle(mStarredOnly ?
+                    R.string.transit_center_all_stops :
+                    R.string.transit_center_starred_only);
+        }
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        int itemId = item.getItemId();
+        if (itemId == R.id.add_stops) {
+            AddStopToTransitCenterDialog dialog =
+                    AddStopToTransitCenterDialog.newInstance(mTransitCenterId);
+            dialog.setOnStopsAddedListener(() -> {
+                getLoaderManager().restartLoader(0, null, TransitCenterDetailFragment.this);
+            });
+            dialog.show(getActivity().getSupportFragmentManager(), "add_stops");
+            return true;
+        } else if (itemId == R.id.toggle_starred) {
+            mStarredOnly = !mStarredOnly;
+            getActivity().invalidateOptionsMenu();
+            getLoaderManager().restartLoader(0, null, this);
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public void onCreateContextMenu(ContextMenu menu, View v, ContextMenuInfo menuInfo) {
+        super.onCreateContextMenu(menu, v, menuInfo);
+        AdapterContextMenuInfo info = (AdapterContextMenuInfo) menuInfo;
+        final TextView text = (TextView) info.targetView.findViewById(R.id.stop_name);
+        if (text != null) {
+            menu.setHeaderTitle(UIUtils.formatDisplayText(text.getText().toString()));
+        }
+        menu.add(0, CONTEXT_MENU_REMOVE_STOP, 0, R.string.transit_center_remove_stop);
+    }
+
+    @Override
+    public boolean onContextItemSelected(MenuItem item) {
+        if (item.getItemId() == CONTEXT_MENU_REMOVE_STOP) {
+            AdapterContextMenuInfo info = (AdapterContextMenuInfo) item.getMenuInfo();
+            String stopId = QueryUtils.StopList.getId(getListView(), info.position);
+            ObaContract.TransitCenterStops.removeStop(getActivity(), mTransitCenterId, stopId);
+            getLoaderManager().restartLoader(0, null, this);
+            return true;
+        }
+        return super.onContextItemSelected(item);
+    }
+
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/TransitCentersFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/TransitCentersFragment.java
@@ -1,0 +1,271 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui;
+
+import android.content.ContentResolver;
+import android.content.Intent;
+import android.database.ContentObserver;
+import android.database.Cursor;
+import android.os.Bundle;
+import android.os.Handler;
+import android.text.TextUtils;
+import android.view.ContextMenu;
+import android.view.ContextMenu.ContextMenuInfo;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
+import android.view.View;
+import android.widget.AdapterView.AdapterContextMenuInfo;
+import android.widget.EditText;
+import android.widget.ListView;
+import android.widget.TextView;
+
+import androidx.appcompat.app.AlertDialog;
+import androidx.cursoradapter.widget.SimpleCursorAdapter;
+import androidx.loader.app.LoaderManager;
+import androidx.loader.content.CursorLoader;
+import androidx.loader.content.Loader;
+
+import org.onebusaway.android.R;
+import org.onebusaway.android.app.Application;
+import org.onebusaway.android.provider.ObaContract;
+
+import java.util.ArrayList;
+
+public class TransitCentersFragment extends ListFragment
+        implements LoaderManager.LoaderCallbacks<Cursor> {
+
+    public static final String TAG = "TransitCentersFragment";
+
+    private static final int CONTEXT_MENU_RENAME = 1;
+    private static final int CONTEXT_MENU_DELETE = 2;
+
+    private SimpleCursorAdapter mAdapter;
+    private ContentObserver mObserver;
+    private static final Handler mHandler = new Handler();
+
+    @Override
+    public void onActivityCreated(Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+        setHasOptionsMenu(true);
+        setEmptyText(getString(R.string.transit_center_empty));
+        registerForContextMenu(getListView());
+
+        String[] from = {ObaContract.TransitCenters.NAME};
+        int[] to = {R.id.transit_center_name};
+        mAdapter = new SimpleCursorAdapter(getActivity(),
+                R.layout.transit_center_list_item, null, from, to, 0);
+        setListAdapter(mAdapter);
+
+        ContentResolver cr = getActivity().getContentResolver();
+        mObserver = new ContentObserver(mHandler) {
+            @Override
+            public void onChange(boolean selfChange) {
+                if (isAdded()) {
+                    getLoaderManager().restartLoader(0, null, TransitCentersFragment.this);
+                }
+            }
+        };
+        cr.registerContentObserver(ObaContract.TransitCenters.CONTENT_URI, true, mObserver);
+
+        getLoaderManager().initLoader(0, null, this);
+    }
+
+    @Override
+    public void onDestroy() {
+        if (mObserver != null && getActivity() != null) {
+            ContentResolver cr = getActivity().getContentResolver();
+            cr.unregisterContentObserver(mObserver);
+            mObserver = null;
+        }
+        super.onDestroy();
+    }
+
+    @Override
+    public Loader<Cursor> onCreateLoader(int id, Bundle args) {
+        String selection = null;
+        if (Application.get().getCurrentRegion() != null) {
+            long regionId = Application.get().getCurrentRegion().getId();
+            selection = "(" + ObaContract.TransitCenters.REGION_ID + "=" + regionId +
+                    " OR " + ObaContract.TransitCenters.REGION_ID + " IS NULL)";
+        }
+        return new CursorLoader(getActivity(),
+                ObaContract.TransitCenters.CONTENT_URI,
+                new String[]{
+                        ObaContract.TransitCenters._ID,
+                        ObaContract.TransitCenters.NAME
+                },
+                selection, null,
+                ObaContract.TransitCenters.NAME + " ASC");
+    }
+
+    @Override
+    public void onLoadFinished(Loader<Cursor> loader, Cursor data) {
+        mAdapter.swapCursor(data);
+        updateStopCounts();
+    }
+
+    @Override
+    public void onLoaderReset(Loader<Cursor> loader) {
+        mAdapter.swapCursor(null);
+    }
+
+    @Override
+    public void onListItemClick(ListView l, View v, int position, long id) {
+        Cursor c = (Cursor) mAdapter.getItem(position);
+        if (c == null) {
+            return;
+        }
+        long transitCenterId = c.getLong(0);
+        String name = c.getString(1);
+
+        Intent intent = new Intent(getActivity(), TransitCenterDetailActivity.class);
+        intent.putExtra(TransitCenterDetailActivity.EXTRA_TRANSIT_CENTER_ID, transitCenterId);
+        intent.putExtra(TransitCenterDetailActivity.EXTRA_TRANSIT_CENTER_NAME, name);
+        startActivity(intent);
+    }
+
+    @Override
+    public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
+        inflater.inflate(R.menu.transit_centers_options, menu);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (item.getItemId() == R.id.add_transit_center) {
+            showAddDialog();
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public void onCreateContextMenu(ContextMenu menu, View v, ContextMenuInfo menuInfo) {
+        super.onCreateContextMenu(menu, v, menuInfo);
+        AdapterContextMenuInfo info = (AdapterContextMenuInfo) menuInfo;
+        Cursor c = (Cursor) mAdapter.getItem(info.position);
+        if (c != null) {
+            menu.setHeaderTitle(c.getString(1));
+        }
+        menu.add(0, CONTEXT_MENU_RENAME, 0, R.string.transit_center_rename);
+        menu.add(0, CONTEXT_MENU_DELETE, 0, R.string.transit_center_delete);
+    }
+
+    @Override
+    public boolean onContextItemSelected(MenuItem item) {
+        AdapterContextMenuInfo info = (AdapterContextMenuInfo) item.getMenuInfo();
+        Cursor c = (Cursor) mAdapter.getItem(info.position);
+        if (c == null) {
+            return super.onContextItemSelected(item);
+        }
+        final long transitCenterId = c.getLong(0);
+        final String name = c.getString(1);
+
+        switch (item.getItemId()) {
+            case CONTEXT_MENU_RENAME:
+                showRenameDialog(transitCenterId, name);
+                return true;
+            case CONTEXT_MENU_DELETE:
+                showDeleteConfirmation(transitCenterId);
+                return true;
+            default:
+                return super.onContextItemSelected(item);
+        }
+    }
+
+    private void showAddDialog() {
+        final EditText input = new EditText(getActivity());
+        input.setHint(R.string.transit_center_name_hint);
+        input.setSingleLine();
+
+        new AlertDialog.Builder(getActivity())
+                .setTitle(R.string.transit_center_add)
+                .setView(input)
+                .setPositiveButton(android.R.string.ok, (dialog, which) -> {
+                    String name = input.getText().toString().trim();
+                    if (!TextUtils.isEmpty(name)) {
+                        long regionId = 0;
+                        if (Application.get().getCurrentRegion() != null) {
+                            regionId = Application.get().getCurrentRegion().getId();
+                        }
+                        ObaContract.TransitCenters.insert(getActivity(), name, regionId);
+                    }
+                })
+                .setNegativeButton(android.R.string.cancel, null)
+                .show();
+    }
+
+    private void showRenameDialog(final long transitCenterId, String currentName) {
+        final EditText input = new EditText(getActivity());
+        input.setText(currentName);
+        input.setSingleLine();
+        input.setSelection(currentName.length());
+
+        new AlertDialog.Builder(getActivity())
+                .setTitle(R.string.transit_center_rename)
+                .setView(input)
+                .setPositiveButton(android.R.string.ok, (dialog, which) -> {
+                    String newName = input.getText().toString().trim();
+                    if (!TextUtils.isEmpty(newName)) {
+                        ObaContract.TransitCenters.rename(getActivity(), transitCenterId, newName);
+                    }
+                })
+                .setNegativeButton(android.R.string.cancel, null)
+                .show();
+    }
+
+    private void showDeleteConfirmation(final long transitCenterId) {
+        new AlertDialog.Builder(getActivity())
+                .setMessage(R.string.transit_center_delete_confirm)
+                .setPositiveButton(android.R.string.ok, (dialog, which) -> {
+                    ObaContract.TransitCenters.delete(getActivity(), transitCenterId);
+                })
+                .setNegativeButton(android.R.string.cancel, null)
+                .show();
+    }
+
+    private void updateStopCounts() {
+        ListView listView = getListView();
+        if (listView == null) {
+            return;
+        }
+        // Post to update views after adapter has bound data
+        listView.post(() -> {
+            if (!isAdded() || mAdapter.getCursor() == null) {
+                return;
+            }
+            Cursor cursor = mAdapter.getCursor();
+            for (int i = 0; i < listView.getChildCount(); i++) {
+                View child = listView.getChildAt(i);
+                int position = listView.getFirstVisiblePosition() + i;
+                if (position >= cursor.getCount()) {
+                    break;
+                }
+                cursor.moveToPosition(position);
+                long tcId = cursor.getLong(0);
+                ArrayList<String> stopIds =
+                        ObaContract.TransitCenterStops.getStopIds(getActivity(), tcId);
+                TextView countView = child.findViewById(R.id.transit_center_stop_count);
+                if (countView != null) {
+                    countView.setText(getResources().getQuantityString(
+                            R.plurals.transit_center_stop_count,
+                            stopIds.size(), stopIds.size()));
+                }
+            }
+        });
+    }
+
+}

--- a/onebusaway-android/src/main/res/layout/transit_center_list_item.xml
+++ b/onebusaway-android/src/main/res/layout/transit_center_list_item.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (C) 2026 Open Transit Software Foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    style="@style/ListItem"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:minHeight="77dp"
+    android:orientation="vertical"
+    android:paddingLeft="@dimen/keyline_2"
+    android:paddingRight="@dimen/keyline_2"
+    android:gravity="center_vertical">
+
+    <TextView
+        android:id="@+id/transit_center_name"
+        style="@style/Line1Text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:ellipsize="end"
+        android:maxLines="1" />
+
+    <TextView
+        android:id="@+id/transit_center_stop_count"
+        style="@style/Line2Text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content" />
+
+</LinearLayout>

--- a/onebusaway-android/src/main/res/menu/transit_center_detail_options.xml
+++ b/onebusaway-android/src/main/res/menu/transit_center_detail_options.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (C) 2026 Open Transit Software Foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/add_stops"
+        android:title="@string/transit_center_add_stops"
+        app:showAsAction="ifRoom" />
+
+    <item
+        android:id="@+id/toggle_starred"
+        android:title="@string/transit_center_starred_only"
+        app:showAsAction="never" />
+
+</menu>

--- a/onebusaway-android/src/main/res/menu/transit_centers_options.xml
+++ b/onebusaway-android/src/main/res/menu/transit_centers_options.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (C) 2026 Open Transit Software Foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/add_transit_center"
+        android:title="@string/transit_center_add"
+        app:showAsAction="ifRoom" />
+
+</menu>

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -30,6 +30,23 @@
     <string name="navdrawer_item_open_source">Visit us on GitHub</string>
     <string name="navdrawer_item_plan_trip">Plan a trip (beta)</string>
     <string name="navdrawer_item_pay_fare">Pay my fare</string>
+    <string name="navdrawer_item_transit_centers">Transit centers</string>
+
+    <!-- Transit Centers -->
+    <string name="transit_center_add">Add transit center</string>
+    <string name="transit_center_name_hint">Transit center name</string>
+    <string name="transit_center_rename">Rename</string>
+    <string name="transit_center_delete">Delete</string>
+    <string name="transit_center_delete_confirm">Delete this transit center?</string>
+    <string name="transit_center_empty">No transit centers</string>
+    <string name="transit_center_add_stops">Add stops</string>
+    <string name="transit_center_remove_stop">Remove from transit center</string>
+    <string name="transit_center_starred_only">Starred only</string>
+    <string name="transit_center_all_stops">All stops</string>
+    <plurals name="transit_center_stop_count">
+        <item quantity="one">%d stop</item>
+        <item quantity="other">%d stops</item>
+    </plurals>
 
     <!-- Permissions -->
     <string name="trip_service_perm_label">start the trip service</string>


### PR DESCRIPTION

Closes #1221

### Problem

Users who transfer at transit hubs (e.g., Bellevue Transit Center) have to star individual stops and scroll through a flat list to compare arrival times. There is no way to group related stops together.

### Solution

Adds a "Transit centers" feature that lets users create named groups of stops, accessible from the navigation drawer. Users can:

- Create, rename, and delete transit center groups
- Add starred stops to a group via a multi-choice picker
- View all stops in a group with a single tap
- Toggle between "all stops" and "starred only" within a group
- Remove individual stops via long-press context menu

Tapping a stop opens the existing `ArrivalsListActivity` — no new arrivals UI needed.

### Demo

 <p align="center">
  <video src="https://github.com/user-attachments/assets/7945b56d-1e18-4200-b100-647174720fd7" width="350" />
  </p>


### Implementation

**Database (v33 → v34):**
- `transit_centers` table — stores group name + region ID
- `transit_center_stops` join table — maps groups to stop IDs
- Cascading `++oldVersion` migration so all upgrade paths work

**UI:**
- `TransitCentersFragment` — CursorLoader + ContentObserver list of groups
- `TransitCenterDetailFragment` — two-step query (get stop IDs, then query Stops with IN clause)
- `AddStopToTransitCenterDialog` — multi-choice picker for starred stops
- `TransitCenterDetailActivity` — hosts detail fragment, uses `UIUtils.setupActionBar()` + `android.R.id.content` pattern

**Navigation:**
- New `NAVDRAWER_ITEM_TRANSIT_CENTERS` in drawer (between Starred Routes and My Reminders)
- Show/hide fragment pattern in `HomeActivity` matching existing nav items

### New files (7)

| File | Purpose |
|------|---------|
| `TransitCentersFragment.java` | List of transit center groups |
| `TransitCenterDetailActivity.java` | Hosts detail fragment |
| `TransitCenterDetailFragment.java` | Stops within a group |
| `AddStopToTransitCenterDialog.java` | Starred stop picker |
| `transit_center_list_item.xml` | Group list item layout |
| `transit_centers_options.xml` | "Add" menu |
| `transit_center_detail_options.xml` | "Add stops" + "Toggle starred" menu |

### Modified files (6)

| File | Change |
|------|--------|
| `ObaContract.java` | TransitCenters + TransitCenterStops classes |
| `ObaProvider.java` | DB v34 migration, URI matching, CRUD |
| `NavigationDrawerFragment.java` | New nav drawer item |
| `HomeActivity.java` | Show/hide transit centers fragment |
| `AndroidManifest.xml` | Register detail activity |
| `strings.xml` | 14 new string resources (including plurals) |

### Test plan

- Open nav drawer → "Transit centers" → empty state shows "No transit centers"
- Tap add → enter name → group appears in list with "0 stops"
- Tap group → "Add stops" → pick starred stops → stops appear in detail view
- Toggle "Starred only" → filters correctly
- Tap a stop → ArrivalsListActivity opens
- Long-press stop → "Remove from transit center" → stop removed
- Long-press group in list → rename works, delete works
- Switch regions → groups from other regions not shown



