### PR TITLE
Revert "Changed back button behavior from returning to Home page to previous page in Report page"

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/InfrastructureIssueActivity.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/InfrastructureIssueActivity.java
@@ -730,7 +730,7 @@ public class InfrastructureIssueActivity extends BaseReportActivity implements
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
             case android.R.id.home:
-                onBackPressed();
+                finishActivityWithResult();
                 return true;
             default:
                 return super.onOptionsItemSelected(item);


### PR DESCRIPTION
Reverts OneBusAway/onebusaway-android#1507

^ This PR introduced a weird UX.

# Current behavior (after PR #1507)

On the "Stop Problem" screen, pressing the home button in the nav bar at the top doesn't actually always return the user to the home page. Instead, if a problem is selected, it clears the selected problem and remains on the "Stop Problem" screen. 

https://github.com/user-attachments/assets/2be3800a-7091-44c7-97e5-160479fb779f

^ This video first shows the back button behavior, then shows the home button behavior. 

# Updated behavior (this PR)

The home button always goes home instead of clearing the selected problem. The back button behavior is unchanged.

https://github.com/user-attachments/assets/c3900058-65ed-44ba-bb36-c87c1e9f5e8e