### PR TITLE
Add gradle-play-publisher for automated Play Store releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 /build/
 settings.local.json
 .kotlin/
+play-store-upload-key.json
+*.keystore

--- a/BUILD.md
+++ b/BUILD.md
@@ -50,16 +50,6 @@ Add the following to `onebusaway-android/gradle.properties`:
 
 ...where `XXXXXX` is your API key. Note that the suffix of `_oba` can be changed to configure API keys for other build flavors.
 
-### Configuration for OneSignal App ID
-
-If push arrivals notifications are active, you'll need to provide an App ID for [OneSignal](https://onesignal.com/).
-
-Add the following to `onebusaway-android/gradle.properties`:
-
-`ONESIGNAL_APP_ID=YOUR_APP_ID`
-
-...where `YOUR_APP_ID` is the unique identifier for your OneSignal application.
-
 ### Release builds
 
 To set up a release build, you need to create a `gradle.properties` file that points to a `secure.properties` file, and a `secure.properties` file that points to your keystore and alias.
@@ -80,16 +70,52 @@ key.keypassword=<your_key_password>
 Note that the paths in these files always use the Unix path separator `/`, even on Windows. If you use the Windows path separator `\` you will get the error `No value has been specified for property 'signingConfig.keyAlias'.`
 
 Before doing each release build, you'll need to:
-1. Bump `onebusaway-android/build.gradle` `versionCode` by 1 and set `versionName` to the appropriate next semantic version name. 
+1. Set `versionName` in `onebusaway-android/build.gradle` to the appropriate next semantic version name. If you are using the automated publishing workflow (see below), `versionCode` is auto-incremented. Otherwise, bump `versionCode` by 1 manually.
 2. Check `onebusaway-android/src/main/res/values/strings.xml` element `main_help_whatsnew` to make sure that the latest changes we want to highlight for the user are entered there. After update, users see this in a dialog.
 
 Then, to build all flavors run:
 
 `gradlew assembleRelease`
 
-(If you want to assemble just the Google variant, use `gradlew assembleObaGoogleRelease`
+(If you want to assemble just the Google variant, use `gradlew assembleObaGoogleRelease`)
 
 The APK files will show up in the `onebusaway-android/build/outputs/apk` folder. `obaGoogleRelease-vx.y.z.apk` is the file that's uploaded to Google Play for release.
+
+### Automated publishing with gradle-play-publisher
+
+We use [gradle-play-publisher](https://github.com/Triple-T/gradle-play-publisher) (GPP) to automate building, versioning, and uploading releases to Google Play.
+
+#### Setup
+
+1. In [Google Cloud Console](https://console.cloud.google.com/), create a service account under IAM & Admin → Service Accounts and download the JSON key file.
+2. Enable the [Google Play Android Developer API](https://console.cloud.google.com/apis/library/androidpublisher.googleapis.com) in Google Cloud Console.
+3. In [Google Play Console](https://play.google.com/console), go to Users & permissions, invite the service account email, and grant "Release manager" permissions. Note: it can take up to 36 hours for credentials to become active.
+4. Add the path to `gradle.properties`:
+   ```
+   PLAY_STORE_JSON_KEY=/path/to/service-account-key.json
+   ```
+
+#### Publishing commands
+
+| Command | Description |
+|---|---|
+| `./gradlew publishObaGoogleReleaseBundle` | Build release AAB, auto-increment `versionCode`, and upload to the open testing (beta) track |
+| `./gradlew publishObaGoogleReleaseApps` | Same as above, plus upload all Play Store metadata (listing, screenshots, etc.) |
+| `./gradlew promoteObaGoogleReleaseArtifact` | Promote the current beta release to production (e.g., alpha → beta → production) |
+
+#### Managing Play Store metadata
+
+You can download your existing Play Store listing into the repo for version control:
+
+```
+./gradlew bootstrapObaGoogleReleaseListing
+```
+
+This creates a `src/obaGoogleRelease/play/` directory with your listing text, graphics, and release notes. Edits to these files will be uploaded on the next `publishObaGoogleReleaseApps` run.
+
+#### Configuration
+
+The default configuration (in `onebusaway-android/build.gradle`) publishes App Bundles to the **beta** (open testing) track with auto-incrementing `versionCode`. To change the target track, update the `track` property in the `play {}` block to `"internal"`, `"alpha"`, or `"production"`.
 
 ### Release testing protocol
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,33 @@ OneBusAway for Android is a real-time transit information app providing bus arri
 adb shell am start -n com.joulespersecond.seattlebusbot/org.onebusaway.android.ui.HomeActivity
 ```
 
+## Automated Publishing (gradle-play-publisher)
+
+Uses [gradle-play-publisher](https://github.com/Triple-T/gradle-play-publisher) to auto-increment `versionCode`, build, and upload to Google Play.
+
+### Setup
+1. In [Google Cloud Console](https://console.cloud.google.com/), create a service account (IAM & Admin → Service Accounts) and download the JSON key
+2. Enable the Google Play Android Developer API in Google Cloud Console
+3. In [Google Play Console](https://play.google.com/console), invite the service account email under Users & permissions and grant "Release manager" permissions
+4. Add to `gradle.properties`: `PLAY_STORE_JSON_KEY=/path/to/service-account-key.json`
+
+### Commands
+```bash
+# Build AAB, auto-increment versionCode, upload to open testing (beta) track
+./gradlew publishObaGoogleReleaseBundle
+
+# Same as above + upload all Play Store metadata
+./gradlew publishObaGoogleReleaseApps
+
+# Promote beta release to production
+./gradlew promoteObaGoogleReleaseArtifact
+
+# Download existing Play Store listing metadata into repo
+./gradlew bootstrapObaGoogleReleaseListing
+```
+
+Configuration is in the `play {}` block of `onebusaway-android/build.gradle`. Default: App Bundles to the **beta** (open testing) track with auto-incrementing `versionCode`.
+
 ## Build Variants
 
 The project uses two flavor dimensions:

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ buildscript {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin:2.3.4"
         classpath 'com.google.firebase:firebase-crashlytics-gradle:3.0.6'
+        classpath 'com.github.triplet.gradle:play-publisher:4.0.0'
     }
 }
 

--- a/onebusaway-android/build.gradle
+++ b/onebusaway-android/build.gradle
@@ -19,6 +19,7 @@ import org.apache.tools.ant.filters.ConcatFilter
 
 apply plugin: 'com.android.application'
 apply plugin: 'com.google.devtools.ksp'
+apply plugin: 'com.github.triplet.play'
 
 repositories {
     maven {
@@ -40,7 +41,7 @@ android {
         minSdkVersion 21
         targetSdkVersion 36
         versionCode 153
-        versionName "2.14.9"
+        versionName "26.1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
@@ -286,6 +287,21 @@ dependencies {
 
 apply plugin:'com.google.gms.google-services'
 apply plugin: 'com.google.firebase.crashlytics'
+
+play {
+    // Path to the Google Play service account JSON key file.
+    // Set via gradle.properties: PLAY_STORE_JSON_KEY=/path/to/service-account-key.json
+    if (project.hasProperty('PLAY_STORE_JSON_KEY')) {
+        serviceAccountCredentials = file(project.property('PLAY_STORE_JSON_KEY'))
+    }
+
+    // Auto-increment versionCode based on the highest code currently on the Play Store
+    resolutionStrategy = com.github.triplet.gradle.androidpublisher.ResolutionStrategy.AUTO
+
+    // Upload to the open testing (beta) track, matching the existing release workflow
+    defaultToAppBundles = true
+    track = "beta"
+}
 
 /**
  * Validates that strings with %1$s placeholders in the base English strings.xml


### PR DESCRIPTION
Set up gradle-play-publisher (GPP) 4.0.0 to automate versionCode incrementing, AAB building, and uploading to Google Play. Publishes to the open testing (beta) track by default, matching the existing release workflow. Document setup and commands in BUILD.md and CLAUDE.md.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `gradlew connectedObaGoogleDebugAndroidTest` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them for the initial submission of the pull request.  When addressing comments on a pull request, please push a new commit per comment when possible (reviewers will squash and merge using GitHub merge tool)