### PR TITLE
Add home screen widget (#1075)

### DIFF
--- a/onebusaway-android/src/main/AndroidManifest.xml
+++ b/onebusaway-android/src/main/AndroidManifest.xml
@@ -47,7 +47,9 @@
     <!--To enable checkBatteryOptimizations feature, also uncomment checkBatteryOptimizations() in
     the HomeActivity's onCreate() method-->
     <!--<uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS"/>-->
-    <!-- For reminders - SCHEDULE_EXACT_ALARM is required when targeting Android 12 or higher-->
+    <!-- Exact alarms for widget refresh timers. USE_EXACT_ALARM (API 33+) is auto-granted;
+         SCHEDULE_EXACT_ALARM (API 31-32) requires user approval but is needed for reminders too. -->
+    <uses-permission android:name="android.permission.USE_EXACT_ALARM" android:minSdkVersion="33"/>
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM"/>
     <!-- For notifications, POST_NOTIFICATIONS is required when targeting Android 12 or higher-->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
@@ -289,6 +291,14 @@
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value="org.onebusaway.android.ui.HomeActivity"/>
         </activity>
+        <activity
+            android:name=".ui.widget.StopTimesWidgetConfigActivity"
+            android:exported="true"
+            android:theme="@style/WidgetConfigDialogTheme"/>
+        <activity
+            android:name=".ui.widget.StopPickerActivity"
+            android:exported="false"
+            android:label="@string/widget_config_select_a_stop" />
 
 
         <!-- Provider is defined in build.gradle flavors -->
@@ -334,6 +344,17 @@
         </receiver>
         <receiver
             android:enabled="true" android:name=".travelbehavior.receiver.LocationBroadcastReceiver">
+        </receiver>
+        <receiver
+            android:name=".ui.widget.StopTimesWidget"
+            android:label="@string/widget_label"
+            android:exported="false" >
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/stop_times_widget_info" />
         </receiver>
 
         <meta-data

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/ArrivalsListFragment.java
@@ -81,6 +81,7 @@ import org.onebusaway.android.report.ui.InfrastructureIssueActivity;
 import org.onebusaway.android.travelbehavior.TravelBehaviorManager;
 import org.onebusaway.android.ui.survey.SurveyManager;
 import org.onebusaway.android.io.request.survey.model.StudyResponse;
+import org.onebusaway.android.ui.widget.StopTimesWidgetConfigActivity;
 import org.onebusaway.android.util.ArrayAdapterWithIcon;
 import org.onebusaway.android.util.ArrivalInfoUtils;
 import org.onebusaway.android.util.BuildFlavorUtils;
@@ -656,6 +657,8 @@ public class ArrivalsListFragment extends ListFragment implements LoaderManager.
             }
         } else if (id == R.id.show_stop_details) {
             showStopDetailsDialog();
+        } else if (id == R.id.add_stop_widget) {
+            initWidgetConfig();
         } else if (id == R.id.report_stop_problem) {
             if (mStop != null) {
                 Intent intent = makeIntent(getActivity(), mStop.getId(), mStop.getName(),
@@ -1327,6 +1330,16 @@ public class ArrivalsListFragment extends ListFragment implements LoaderManager.
                 PlausibleAnalytics.REPORT_ARRIVALS_EVENT_URL,
                 getActivity().getString(R.string.analytics_label_button_press_stop_details),
                 null);
+    }
+
+    private void initWidgetConfig() {
+        final Context context = getContext();
+        final String stopName = mStop != null ? mStop.getName() : "";
+        final Intent intent = new Intent(context, StopTimesWidgetConfigActivity.class);
+
+        intent.putExtra(StopTimesWidgetConfigActivity.EXTRA_STOP_ID, getStopId());
+        intent.putExtra(StopTimesWidgetConfigActivity.EXTRA_STOP_NAME, stopName);
+        startActivity(intent);
     }
 
     /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/widget/StopPickerActivity.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/widget/StopPickerActivity.java
@@ -1,0 +1,324 @@
+/*
+ * Copyright (C) 2025 Rob Godfrey (rob_godfrey@outlook.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.widget;
+
+import org.onebusaway.android.R;
+import org.onebusaway.android.provider.ObaContract;
+import org.onebusaway.android.util.UIUtils;
+
+import android.content.Context;
+import android.content.Intent;
+import android.database.Cursor;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.BaseAdapter;
+import android.widget.ImageView;
+import android.widget.ListView;
+import android.widget.TextView;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.content.ContextCompat;
+import androidx.loader.app.LoaderManager;
+import androidx.loader.content.CursorLoader;
+import androidx.loader.content.Loader;
+
+/**
+ * Activity that lets the user pick a transit stop for the Stop Times widget.
+ * <p>
+ * Shows two sections loaded from the local OBA database: starred stops and
+ * recent stops (capped at 20). When the user taps a stop, the activity returns
+ * RESULT_OK with {@link #EXTRA_STOP_ID} and {@link #EXTRA_STOP_NAME} in the
+ * result Intent.
+ */
+public class StopPickerActivity extends AppCompatActivity implements LoaderManager.LoaderCallbacks<Cursor> {
+
+    public static final String EXTRA_STOP_ID = "stop_id";
+    public static final String EXTRA_STOP_NAME = "stop_name";
+
+    private static final int LOADER_STARRED = 0;
+    private static final int LOADER_RECENT = 1;
+
+    // Columns from ObaContract.Stops
+    private static final int COL_ID = 0;
+    private static final int COL_NAME = 1;
+    private static final int COL_DIRECTION = 2;
+    private static final int COL_FAVORITE = 3;
+    private static final String[] STOP_PROJECTION = {
+            ObaContract.Stops._ID,
+            ObaContract.Stops.UI_NAME,
+            ObaContract.Stops.DIRECTION,
+            ObaContract.Stops.FAVORITE,
+    };
+
+    private StopPickerAdapter mAdapter;
+    private Cursor mStarredCursor;
+    private Cursor mRecentCursor;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_stop_picker);
+
+        final ListView listView = findViewById(R.id.stop_list);
+
+        mAdapter = new StopPickerAdapter(this);
+        listView.setAdapter(mAdapter);
+
+        listView.setOnItemClickListener((parent, view, position, id) -> {
+            final StopPickerAdapter.StopItem stopItem = mAdapter.getStop(position);
+            if (stopItem == null) { // header row
+                return;
+            }
+            final Intent result = new Intent();
+            result.putExtra(EXTRA_STOP_ID, stopItem.stopId);
+            result.putExtra(EXTRA_STOP_NAME, stopItem.stopName);
+            setResult(RESULT_OK, result);
+            finish();
+        });
+
+        LoaderManager.getInstance(this).initLoader(LOADER_STARRED, null, this);
+        LoaderManager.getInstance(this).initLoader(LOADER_RECENT, null, this);
+    }
+
+    /// Builds a CursorLoader for either the starred or recent stops section.
+    @NonNull
+    @Override
+    public Loader<Cursor> onCreateLoader(int id, @Nullable Bundle args) {
+        final String whereClause;
+        final String orderByClause;
+        final android.net.Uri uri;
+
+        if (id == LOADER_STARRED) {
+            whereClause = String.format("%s = 1", ObaContract.Stops.FAVORITE);
+            orderByClause = String.format("%s ASC", ObaContract.Stops.UI_NAME);
+            uri = ObaContract.Stops.CONTENT_URI;
+        } else {
+            whereClause = String.format("%s IS NOT NULL", ObaContract.Stops.ACCESS_TIME);
+            orderByClause = String.format("%s DESC", ObaContract.Stops.ACCESS_TIME);
+            uri = ObaContract.Stops.CONTENT_URI.buildUpon().appendQueryParameter("limit", "20").build();
+        }
+
+        return new CursorLoader(this, uri, STOP_PROJECTION, whereClause, null, orderByClause);
+    }
+
+    @Override
+    public void onLoadFinished(@NonNull Loader<Cursor> loader, Cursor data) {
+        if (loader.getId() == LOADER_STARRED) {
+            mStarredCursor = data;
+        } else {
+            mRecentCursor = data;
+        }
+        mAdapter.setData(mStarredCursor, mRecentCursor);
+    }
+
+    @Override
+    public void onLoaderReset(@NonNull Loader<Cursor> loader) {
+        if (loader.getId() == LOADER_STARRED) {
+            mStarredCursor = null;
+        } else {
+            mRecentCursor = null;
+        }
+        mAdapter.setData(mStarredCursor, mRecentCursor);
+    }
+
+    /**
+     * Adapter for the stop list. Supports three view types:
+     * <p>
+     * - HEADER: section header
+     * <p>
+     * - STOP: stop row
+     * <p>
+     * - EMPTY: empty row for when there are no starred/recent stops
+     */
+    private static class StopPickerAdapter extends BaseAdapter {
+
+        enum RowType {HEADER, STOP, EMPTY}
+
+        /// A single row in the list. Either a section header or a stop.
+        static class ListItem {
+            final RowType rowType;
+            final String label;
+            final StopItem stop;
+
+            ListItem(String label, RowType rowType) {
+                this.rowType = rowType;
+                this.label = label;
+                this.stop = null;
+            }
+
+            ListItem(StopItem stop) {
+                this.rowType = RowType.STOP;
+                this.label = null;
+                this.stop = stop;
+            }
+        }
+
+        static class StopItem {
+            final String stopId;
+            final String stopName;
+            final String direction;
+            final boolean isFavorite;
+
+            StopItem(String stopId, String stopName, String direction, boolean isFavorite) {
+                this.stopId = stopId;
+                this.stopName = stopName;
+                this.direction = direction;
+                this.isFavorite = isFavorite;
+            }
+        }
+
+        private final Context mContext;
+        private final String sectionHeaderStarred;
+        private final String listItemNoStarred;
+        private final String sectionHeaderRecent;
+        private final String listItemNoRecents;
+        private final List<ListItem> mItems = new ArrayList<>();
+
+        StopPickerAdapter(Context context) {
+            mContext = context;
+            sectionHeaderStarred = context.getString(R.string.my_starred_title);
+            listItemNoStarred = context.getString(R.string.my_no_starred_stops);
+            sectionHeaderRecent = context.getString(R.string.my_recent_title);
+            listItemNoRecents = context.getString(R.string.my_no_recent_stops);
+        }
+
+        void setData(@Nullable Cursor starred, @Nullable Cursor recent) {
+            mItems.clear();
+
+            mItems.add(new ListItem(sectionHeaderStarred, RowType.HEADER));
+            if (starred != null && starred.getCount() > 0 && starred.moveToFirst()) {
+                do {
+                    mItems.add(new ListItem(cursorToStop(starred)));
+                } while (starred.moveToNext());
+            } else {
+                mItems.add(new ListItem(listItemNoStarred, RowType.EMPTY));
+            }
+
+            mItems.add(new ListItem(sectionHeaderRecent, RowType.HEADER));
+            if (recent != null && recent.getCount() > 0 && recent.moveToFirst()) {
+                do {
+                    mItems.add(new ListItem(cursorToStop(recent)));
+                } while (recent.moveToNext());
+            } else {
+                mItems.add(new ListItem(listItemNoRecents, RowType.EMPTY));
+            }
+
+            notifyDataSetChanged();
+        }
+
+        private StopItem cursorToStop(Cursor c) {
+            return new StopItem(
+                    c.getString(COL_ID),
+                    c.getString(COL_NAME),
+                    c.getString(COL_DIRECTION),
+                    c.getInt(COL_FAVORITE) == 1
+            );
+        }
+
+        @Nullable
+        StopItem getStop(int position) {
+            if (position < 0 || position >= mItems.size()) {
+                return null;
+            }
+            final ListItem item = mItems.get(position);
+            return item.rowType == RowType.STOP ? item.stop : null;
+        }
+
+        @Override
+        public int getViewTypeCount() {
+            return RowType.values().length;
+        }
+
+        @Override
+        public int getItemViewType(int position) {
+            return mItems.get(position).rowType.ordinal();
+        }
+
+        @Override
+        public boolean isEnabled(int position) {
+            return mItems.get(position).rowType == RowType.STOP;
+        }
+
+        @Override
+        public int getCount() {
+            return mItems.size();
+        }
+
+        @Override
+        public Object getItem(int position) {
+            return mItems.get(position);
+        }
+
+        @Override
+        public long getItemId(int position) {
+            return position;
+        }
+
+        @Override
+        public View getView(int position, View convertView, ViewGroup parent) {
+            final ListItem item = mItems.get(position);
+            switch (item.rowType) {
+                case HEADER:
+                    return bindHeader(convertView, parent, item.label);
+                case EMPTY:
+                    return bindEmpty(convertView, parent, item.label);
+                default:
+                    return bindStop(convertView, parent, item.stop);
+            }
+        }
+
+        private View bindHeader(View convertView, ViewGroup parent, String label) {
+            convertView = inflate(convertView, parent, R.layout.list_item_section);
+            ((TextView) convertView.findViewById(R.id.list_item_section_text)).setText(label);
+            return convertView;
+        }
+
+        private View bindEmpty(View convertView, ViewGroup parent, String label) {
+            convertView = inflate(convertView, parent, R.layout.list_item_empty_section);
+            ((TextView) convertView.findViewById(R.id.list_item_empty_text)).setText(label);
+            return convertView;
+        }
+
+        private View bindStop(View convertView, ViewGroup parent, StopItem stop) {
+            convertView = inflate(convertView, parent, R.layout.stop_list_item);
+            ((TextView) convertView.findViewById(R.id.stop_name)).setText(stop.stopName);
+            UIUtils.setStopDirection(convertView.findViewById(R.id.direction), stop.direction, true);
+
+            final ImageView favoriteIcon = convertView.findViewById(R.id.stop_favorite);
+            favoriteIcon.setVisibility(stop.isFavorite ? View.VISIBLE : View.GONE);
+            if (stop.isFavorite) {
+                favoriteIcon.setColorFilter(ContextCompat.getColor(mContext, R.color.navdrawer_icon_tint));
+            }
+            return convertView;
+        }
+
+        private View inflate(View convertView, ViewGroup parent, int layoutRes) {
+            if (convertView != null && Integer.valueOf(layoutRes).equals(convertView.getTag())) {
+                return convertView;
+            }
+            final View view = LayoutInflater.from(mContext).inflate(layoutRes, parent, false);
+            view.setTag(layoutRes);
+            return view;
+        }
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/widget/StopTimesWidget.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/widget/StopTimesWidget.java
@@ -1,0 +1,501 @@
+/*
+ * Copyright (C) 2025 Rob Godfrey (rob_godfrey@outlook.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.widget;
+
+import org.onebusaway.android.R;
+import org.onebusaway.android.ui.ArrivalsListActivity;
+
+import android.app.AlarmManager;
+import android.app.PendingIntent;
+import android.os.Build;
+import android.util.Log;
+import android.appwidget.AppWidgetManager;
+import android.appwidget.AppWidgetProvider;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.os.SystemClock;
+import android.view.View;
+import android.widget.RemoteViews;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * AppWidgetProvider for the Stop Times widget. Each widget instance is identified by an
+ * appWidgetId assigned by the system. Config and arrival data for each instance are stored
+ * in {@link WidgetPrefs}.
+ */
+public class StopTimesWidget extends AppWidgetProvider {
+
+    public static final String ACTION_REFRESH_WIDGET = "org.onebusaway.android.ui.ACTION_REFRESH_WIDGET";
+    public static final String ACTION_UPDATE_RELATIVE_TIMES = "org.onebusaway.android.ui.ACTION_UPDATE_WIDGET_RELATIVE_TIMES";
+    public static final String ACTION_APPLY_PENDING_CONFIG = "org.onebusaway.android.ui.ACTION_APPLY_PENDING_WIDGET_CONFIG";
+
+    public static final String EXTRA_STOP_ID = "stop_id";
+    public static final String EXTRA_STOP_NAME = "stop_name";
+    public static final String EXTRA_WIDGET_NAME = "widget_name";
+    public static final String EXTRA_ROUTE_IDS = "route_ids";
+    public static final String EXTRA_ROUTE_NAMES = "route_names";
+
+    private static final String TAG = "StopTimesWidget";
+
+    private static final int WIDGET_CELL_SIZE_2 = 110;
+    private static final int WIDGET_CELL_SIZE_3 = 250;
+    private static final int WIDGET_CELL_SIZE_4 = 300;
+
+    private static final int[] WIDGET_ROW_IDS = {
+            R.id.widget_route_1_row,
+            R.id.widget_route_2_row,
+            R.id.widget_route_3_row
+    };
+
+    private static final int[] WIDGET_ROUTE_TITLE_IDS = {
+            R.id.widget_route_1_title,
+            R.id.widget_route_2_title,
+            R.id.widget_route_3_title
+    };
+
+    private static final int[][] WIDGET_ETA_IDS = {
+            {R.id.widget_route_1_eta_1, R.id.widget_route_1_eta_2, R.id.widget_route_1_eta_3},
+            {R.id.widget_route_2_eta_1, R.id.widget_route_2_eta_2, R.id.widget_route_2_eta_3},
+            {R.id.widget_route_3_eta_1, R.id.widget_route_3_eta_2, R.id.widget_route_3_eta_3}
+    };
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        final String action = intent.getAction();
+        super.onReceive(context, intent);
+        final int widgetId = intent.getIntExtra(
+                AppWidgetManager.EXTRA_APPWIDGET_ID,
+                AppWidgetManager.INVALID_APPWIDGET_ID
+        );
+
+        if (ACTION_REFRESH_WIDGET.equals(action)) {
+            // refresh widget (triggered every five mins or by refresh button)
+            scheduleNextRefresh(context, widgetId);
+            final AppWidgetManager mgr = AppWidgetManager.getInstance(context);
+            refreshWidget(context, mgr, widgetId);
+
+        } else if (ACTION_UPDATE_RELATIVE_TIMES.equals(action)) {
+            // update widget labels (triggered every minute); always reschedule even if the
+            // screen is off so the chain continues when the screen comes back on
+            scheduleNextRelativeTimesUpdate(context, widgetId);
+            updateArrivalsFromCache(context, widgetId);
+
+        } else if (ACTION_APPLY_PENDING_CONFIG.equals(action)) {
+            if (widgetId == AppWidgetManager.INVALID_APPWIDGET_ID) return;
+            // callback after requestPinAppWidget succeeds
+            final String stopId = intent.getStringExtra(EXTRA_STOP_ID);
+            final String stopName = intent.getStringExtra(EXTRA_STOP_NAME);
+            final String widgetName = intent.getStringExtra(EXTRA_WIDGET_NAME);
+            final ArrayList<String> routeIdList = intent.getStringArrayListExtra(EXTRA_ROUTE_IDS);
+            final ArrayList<String> routeNameList = intent.getStringArrayListExtra(EXTRA_ROUTE_NAMES);
+            final Map<String, String> routeShortNames = new HashMap<>();
+            if (routeIdList != null && routeNameList != null) {
+                for (int i = 0; i < routeIdList.size(); i++) {
+                    routeShortNames.put(routeIdList.get(i),
+                            i < routeNameList.size() ? routeNameList.get(i) : routeIdList.get(i));
+                }
+            }
+            final WidgetConfig config = new WidgetConfig(stopId, stopName, widgetName, routeShortNames);
+            final AppWidgetManager mgr = AppWidgetManager.getInstance(context);
+
+            WidgetPrefs.saveConfig(context, widgetId, config);
+            scheduleRepeatingRefreshBroadcasts(context, widgetId);
+            refreshWidget(context, mgr, widgetId);
+        }
+    }
+
+    @Override
+    public void onUpdate(final Context context, final AppWidgetManager appWidgetManager, final int[] appWidgetIds) {
+        Log.d(TAG, "onUpdate widgetIds=" + java.util.Arrays.toString(appWidgetIds));
+        for (final int appWidgetId : appWidgetIds) {
+            scheduleRepeatingRefreshBroadcasts(context, appWidgetId);
+            updateArrivalsFromCache(context, appWidgetId);
+
+            final WidgetConfig config = WidgetPrefs.loadConfig(context, appWidgetId);
+            Log.d(TAG, "onUpdate id=" + appWidgetId + " hasConfig=" + (config != null));
+            if (config == null) {
+                // Widget was placed with no config: On some devices, requestPinAppWidget
+                // places the widget without re-launching the configure activity or firing the
+                // callback, leaving the pending config unclaimed. Apply it here so the widget
+                // is immediately usable without requiring the user to configure it again.
+                final WidgetConfig pending = WidgetPrefs.loadAndClearPendingPinConfig(context);
+                if (pending != null) {
+                    WidgetPrefs.saveConfig(context, appWidgetId, pending);
+                    refreshWidget(context, appWidgetManager, appWidgetId);
+                } else {
+                    continue;
+                }
+            }
+
+            final WidgetArrivalSnapshot snapshot = WidgetPrefs.loadSnapshot(context, appWidgetId);
+            final boolean isStale = snapshot == null ||
+                    System.currentTimeMillis() - snapshot.getFetchedAtMs() > TimeUnit.MINUTES.toMillis(5);
+            if (isStale) {
+                WidgetArrivalWorker.enqueue(context, appWidgetId);
+            }
+        }
+    }
+
+    @Override
+    public void onDeleted(Context context, int[] appWidgetIds) {
+        Log.d(TAG, "onDeleted widgetIds=" + java.util.Arrays.toString(appWidgetIds));
+        final AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
+
+        for (final int appWidgetId : appWidgetIds) {
+            final Intent relativeTimesIntent = new Intent(context, StopTimesWidget.class);
+            relativeTimesIntent.setAction(ACTION_UPDATE_RELATIVE_TIMES);
+            alarmManager.cancel(PendingIntent.getBroadcast(
+                    context,
+                    requestCode(appWidgetId, ACTION_UPDATE_RELATIVE_TIMES),
+                    relativeTimesIntent,
+                    PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE));
+
+            final Intent apiRefreshIntent = new Intent(context, StopTimesWidget.class);
+            apiRefreshIntent.setAction(ACTION_REFRESH_WIDGET);
+            apiRefreshIntent.putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId);
+            alarmManager.cancel(PendingIntent.getBroadcast(
+                    context,
+                    requestCode(appWidgetId, ACTION_REFRESH_WIDGET),
+                    apiRefreshIntent,
+                    PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE));
+
+            WidgetPrefs.delete(context, appWidgetId);
+        }
+    }
+
+    @Override
+    public void onAppWidgetOptionsChanged(Context context,
+                                          AppWidgetManager appWidgetManager,
+                                          int appWidgetId,
+                                          Bundle newOptions) {
+        updateArrivalsFromCache(context, appWidgetId);
+    }
+
+    /**
+     * Triggers a full widget refresh for a single instance. Shows the loading state and
+     * enqueues {@link WidgetArrivalWorker} to fetch arrivals from the OBA API in the
+     * background. Once the worker finishes, it calls {@link #updateArrivalsFromCache}
+     * to populate the rows.
+     */
+    static void refreshWidget(Context context, AppWidgetManager appWidgetManager, int appWidgetId) {
+        Log.d(TAG, "refreshWidget id=" + appWidgetId);
+        applyLoadingState(context, appWidgetManager, appWidgetId);
+
+        final WidgetConfig widgetConfig = WidgetPrefs.loadConfig(context, appWidgetId);
+        if (widgetConfig != null) {
+            WidgetArrivalWorker.enqueue(context, appWidgetId);
+        }
+    }
+
+    // Switches the widget UI to the "loading" state for a single widget
+    private static void applyLoadingState(Context context, AppWidgetManager appWidgetManager, int appWidgetId) {
+        Log.d(TAG, "applyLoadingState id=" + appWidgetId + " calling updateAppWidget");
+        final RemoteViews views = new RemoteViews(context.getPackageName(), R.layout.stop_times_widget);
+
+        final WidgetConfig widgetConfig = WidgetPrefs.loadConfig(context, appWidgetId);
+        if (widgetConfig == null) {
+            views.setTextViewText(R.id.stop_times_widget_title, context.getString(R.string.widget_not_configured));
+        } else {
+            views.setTextViewText(R.id.stop_times_widget_title, widgetConfig.getWidgetName());
+            bindStopIntent(context, views, appWidgetId, widgetConfig.getStopId());
+            views.setViewVisibility(R.id.widget_loading_spinner, View.VISIBLE);
+            for (final int rowId : WIDGET_ROW_IDS) {
+                views.setViewVisibility(rowId, View.GONE);
+            }
+        }
+
+        bindRefreshIntent(context, views, appWidgetId);
+
+        appWidgetManager.updateAppWidget(appWidgetId, views);
+    }
+
+    // Tapping the widget body opens the arrivals list for the configured stop
+    private static void bindStopIntent(Context context, RemoteViews views, int appWidgetId, String stopId) {
+        final Intent intent = new ArrivalsListActivity.Builder(context, stopId).getIntent();
+        intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        final PendingIntent pendingIntent = PendingIntent.getActivity(
+                context,
+                appWidgetId,
+                intent,
+                PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE
+        );
+        views.setOnClickPendingIntent(R.id.widget_root, pendingIntent);
+    }
+
+    // Tapping the refresh button triggers an immediate API fetch
+    private static void bindRefreshIntent(Context context, RemoteViews views, int appWidgetId) {
+        final Intent refreshIntent = new Intent(context, StopTimesWidget.class);
+        refreshIntent.setAction(ACTION_REFRESH_WIDGET);
+        refreshIntent.putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId);
+
+        final PendingIntent refreshPendingIntent = PendingIntent.getBroadcast(
+                context,
+                (appWidgetId * 3) + 2,
+                refreshIntent,
+                PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE
+        );
+
+        views.setOnClickPendingIntent(R.id.refresh_header, refreshPendingIntent);
+    }
+
+    // Shows or hides route rows and ETA columns based on the current widget dimensions
+    private static void applySizeVisibility(final Context context, final RemoteViews views, final int minWidthDp, final int minHeightDp) {
+        // Hide ETA columns as the widget gets narrower
+        if (minWidthDp <= WIDGET_CELL_SIZE_4) {
+            for (final int[] rowEtas : WIDGET_ETA_IDS) {
+                views.setViewVisibility(rowEtas[2], View.GONE);
+            }
+        }
+        if (minWidthDp <= WIDGET_CELL_SIZE_3) {
+            for (final int[] rowEtas : WIDGET_ETA_IDS) {
+                views.setViewVisibility(rowEtas[1], View.GONE);
+            }
+        }
+
+        final int headerHorizontalPaddingPx = dpToPx(context, 18);
+
+        // At minimum height, hide bottom rows, remove the spacer, and tighten padding
+        if (minHeightDp <= WIDGET_CELL_SIZE_2) {
+            final int headerVerticalPaddingPx = dpToPx(context, 6);
+            views.setViewVisibility(R.id.widget_route_2_row, View.GONE);
+            views.setViewVisibility(R.id.widget_route_3_row, View.GONE);
+            views.setViewVisibility(R.id.header_spacer, View.GONE);
+            views.setViewPadding(R.id.stop_times_widget_header, headerHorizontalPaddingPx, headerVerticalPaddingPx, headerHorizontalPaddingPx, headerVerticalPaddingPx);
+            views.setViewPadding(R.id.widget_updated_at, 0, 0, 0, dpToPx(context, 5));
+        } else {
+            final int headerVerticalPaddingPx = dpToPx(context, 8);
+            views.setViewVisibility(R.id.header_spacer, View.VISIBLE);
+            views.setViewPadding(R.id.stop_times_widget_header, headerHorizontalPaddingPx, headerVerticalPaddingPx, headerHorizontalPaddingPx, headerVerticalPaddingPx);
+            views.setViewPadding(R.id.widget_updated_at, 0, 0, 0, dpToPx(context, 10));
+        }
+    }
+
+    private static int dpToPx(Context context, int dp) {
+        return (int) (dp * context.getResources().getDisplayMetrics().density);
+    }
+
+    // Schedules both alarms for a widget. Called once on placement/reboot via onUpdate.
+    // Both alarms reschedule themselves on each fire via onReceive.
+    static void scheduleRepeatingRefreshBroadcasts(Context context, int appWidgetId) {
+        scheduleNextRelativeTimesUpdate(context, appWidgetId);
+        scheduleNextRefresh(context, appWidgetId);
+    }
+
+    // Schedules the next per-minute label update
+    static void scheduleNextRelativeTimesUpdate(Context context, int appWidgetId) {
+        scheduleExactAlarm(context, appWidgetId, ACTION_UPDATE_RELATIVE_TIMES, TimeUnit.MINUTES.toMillis(1));
+    }
+
+    // Schedules the next 5-minute data refresh
+    static void scheduleNextRefresh(Context context, int appWidgetId) {
+        scheduleExactAlarm(context, appWidgetId, ACTION_REFRESH_WIDGET, TimeUnit.MINUTES.toMillis(5));
+    }
+
+    // Schedules an exact alarm for the given action. The data refresh uses ELAPSED_REALTIME_WAKEUP
+    // so it runs even with the screen off; the relative-times update uses ELAPSED_REALTIME since
+    // the labels are only visible when the screen is on. On API 31+ falls back to setWindow if
+    // the SCHEDULE_EXACT_ALARM permission has not been granted by the user.
+    private static void scheduleExactAlarm(Context context, int appWidgetId, String action, long delayMs) {
+        final AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
+        final Intent intent = new Intent(context, StopTimesWidget.class);
+        intent.setAction(action);
+        intent.putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId);
+
+        final PendingIntent pendingIntent = PendingIntent.getBroadcast(
+                context,
+                requestCode(appWidgetId, action),
+                intent,
+                PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+
+        final long triggerAt = SystemClock.elapsedRealtime() + delayMs;
+        final int alarmType = ACTION_UPDATE_RELATIVE_TIMES.equals(action)
+                ? AlarmManager.ELAPSED_REALTIME
+                : AlarmManager.ELAPSED_REALTIME_WAKEUP;
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && !alarmManager.canScheduleExactAlarms()) {
+            alarmManager.setWindow(alarmType, triggerAt, TimeUnit.SECONDS.toMillis(30), pendingIntent);
+        } else {
+            alarmManager.setExact(alarmType, triggerAt, pendingIntent);
+        }
+    }
+
+    // Returns a unique PendingIntent request code for the given widget ID and action.
+    // Index 0 = REFRESH alarm, 1 = RELATIVE_TIMES alarm, 2 = refresh button (see bindRefreshIntent).
+    private static int requestCode(int widgetId, String action) {
+        final int numSlots = 3;
+        final int actionIndex;
+        switch (action) {
+            case ACTION_REFRESH_WIDGET:
+                actionIndex = 0;
+                break;
+            case ACTION_UPDATE_RELATIVE_TIMES:
+                actionIndex = 1;
+                break;
+            default:
+                throw new IllegalArgumentException("Unknown action: " + action);
+        }
+        return (widgetId * numSlots) + actionIndex;
+    }
+
+    /**
+     * Populates the widget's arrival rows from the last cached {@link WidgetArrivalSnapshot}.
+     * Called by {@link WidgetArrivalWorker} after a successful API fetch, and by the per-minute
+     * alarm to reformat ETA labels without hitting the network.
+     */
+    static void updateArrivalsFromCache(Context context, int widgetId) {
+        Log.d(TAG, "updateArrivalsFromCache id=" + widgetId);
+        final RemoteViews views = new RemoteViews(context.getPackageName(), R.layout.stop_times_widget);
+        final WidgetArrivalSnapshot arrivalSnapshot = WidgetPrefs.loadSnapshot(context, widgetId);
+        final WidgetConfig config = WidgetPrefs.loadConfig(context, widgetId);
+        final AppWidgetManager mgr = AppWidgetManager.getInstance(context);
+
+        if (config != null) {
+            views.setTextViewText(R.id.stop_times_widget_title, config.getWidgetName());
+        }
+
+        if (arrivalSnapshot == null) {
+            views.setViewVisibility(R.id.widget_loading_spinner, View.GONE);
+            mgr.updateAppWidget(widgetId, views);
+            return;
+        }
+
+        // If cached data is too old, trigger a full refresh instead of displaying stale times
+        final long snapshotAgeMs = System.currentTimeMillis() - arrivalSnapshot.getFetchedAtMs();
+        if (snapshotAgeMs > TimeUnit.MINUTES.toMillis(10)) {
+            refreshWidget(context, mgr, widgetId);
+            return;
+        }
+
+        final Bundle options = mgr.getAppWidgetOptions(widgetId);
+        final int minWidthDp = options.getInt(AppWidgetManager.OPTION_APPWIDGET_MIN_WIDTH);
+        final int minHeightDp = options.getInt(AppWidgetManager.OPTION_APPWIDGET_MIN_HEIGHT);
+
+        bindRouteRows(context, views, arrivalSnapshot.getRoutes());
+        bindUpdatedAtLabel(context, views, arrivalSnapshot.getFetchedAtMs());
+
+        views.setViewVisibility(R.id.widget_loading_spinner, View.GONE);
+        applySizeVisibility(context, views, minWidthDp, minHeightDp);
+
+        if (config != null) {
+            bindStopIntent(context, views, widgetId, config.getStopId());
+        }
+        bindRefreshIntent(context, views, widgetId);
+
+        mgr.updateAppWidget(widgetId, views);
+    }
+
+    private static void bindRouteRows(Context context,
+                                      RemoteViews views,
+                                      List<WidgetArrivalSnapshot.Route> routes) {
+        for (int rowIndex = 0; rowIndex < WIDGET_ROUTE_TITLE_IDS.length; rowIndex++) {
+            if (rowIndex >= routes.size()) {
+                views.setViewVisibility(WIDGET_ROW_IDS[rowIndex], View.GONE);
+                continue;
+            }
+
+            views.setViewVisibility(WIDGET_ROW_IDS[rowIndex], View.VISIBLE);
+
+            final WidgetArrivalSnapshot.Route route = routes.get(rowIndex);
+            views.setTextViewText(WIDGET_ROUTE_TITLE_IDS[rowIndex], route.getShortName());
+            views.setViewVisibility(WIDGET_ROUTE_TITLE_IDS[rowIndex], View.VISIBLE);
+
+            final List<WidgetArrivalSnapshot.Arrival> validArrivals = new ArrayList<>();
+            for (final WidgetArrivalSnapshot.Arrival arrival : route.getArrivals()) {
+                boolean isStale = arrival.getBestArrivalTimeMs() < System.currentTimeMillis() - TimeUnit.MINUTES.toMillis(2);
+                if (!isStale) {
+                    validArrivals.add(arrival);
+                }
+            }
+
+            bindEtaPills(context, views, WIDGET_ETA_IDS[rowIndex], validArrivals);
+        }
+    }
+
+    private static void bindEtaPills(Context context,
+                                     RemoteViews views,
+                                     int[] etaViewIds,
+                                     List<WidgetArrivalSnapshot.Arrival> validArrivals) {
+        if (validArrivals.isEmpty()) {
+            // No upcoming arrivals — show N/A in the first pill and hide the rest
+            views.setTextViewText(etaViewIds[0], context.getString(R.string.widget_no_times));
+            views.setInt(etaViewIds[0], "setBackgroundResource", R.drawable.widget_eta_bg_scheduled);
+            views.setViewVisibility(etaViewIds[0], View.VISIBLE);
+            for (int i = 1; i < etaViewIds.length; i++) {
+                views.setViewVisibility(etaViewIds[i], View.GONE);
+            }
+            return;
+        }
+        for (int i = 0; i < etaViewIds.length; i++) {
+            if (i >= validArrivals.size()) {
+                views.setViewVisibility(etaViewIds[i], View.GONE);
+                continue;
+            }
+            final WidgetArrivalSnapshot.Arrival arrival = validArrivals.get(i);
+            views.setTextViewText(etaViewIds[i], formatMinutesAway(context, arrival.getBestArrivalTimeMs()));
+            views.setInt(etaViewIds[i], "setBackgroundResource", getEtaBackgroundResource(
+                    arrival.getPredictedArrivalTimeMs(), arrival.getScheduledArrivalTimeMs()));
+            views.setViewVisibility(etaViewIds[i], View.VISIBLE);
+        }
+    }
+
+    private static void bindUpdatedAtLabel(Context context, RemoteViews views, long fetchedAtMs) {
+        final long elapsedMs = System.currentTimeMillis() - fetchedAtMs;
+        // Round to nearest minute (adding 30s before integer division) so the label
+        // transitions at the halfway point rather than truncating to the lower minute
+        final long minutes = (elapsedMs + TimeUnit.SECONDS.toMillis(30)) / TimeUnit.MINUTES.toMillis(1);
+        final String label = minutes == 0
+                ? context.getString(R.string.widget_updated_just_now)
+                : context.getString(R.string.widget_updated_minutes_ago, minutes);
+        views.setTextViewText(R.id.widget_updated_at, label);
+    }
+
+    private static String formatMinutesAway(Context context, long arrivalTimeMs) {
+        final long msPerMin = TimeUnit.MINUTES.toMillis(1);
+        final long nowMins = System.currentTimeMillis() / msPerMin;
+        final long arrivalMins = arrivalTimeMs / msPerMin;
+        final long minutes = arrivalMins - nowMins;
+
+        if (minutes == 0) {
+            return context.getString(R.string.stop_info_eta_now);
+        } else {
+            return String.format("%s %s", minutes, context.getString(R.string.minutes_abbreviation));
+        }
+    }
+
+    private static int getEtaBackgroundResource(final long predictedArrivalTime, final long scheduledArrivalTime) {
+        if (predictedArrivalTime <= 0) {
+            return R.drawable.widget_eta_bg_scheduled;
+        }
+        final long diffMinutes = TimeUnit.MILLISECONDS.toMinutes(predictedArrivalTime - scheduledArrivalTime);
+
+        if (diffMinutes >= 1) {
+            return R.drawable.widget_eta_bg_late;
+        }
+        if (diffMinutes <= -1) {
+            return R.drawable.widget_eta_bg_early;
+        }
+        return R.drawable.widget_eta_bg_on_time;
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/widget/StopTimesWidgetConfigActivity.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/widget/StopTimesWidgetConfigActivity.java
@@ -1,0 +1,370 @@
+/*
+ * Copyright (C) 2025 Rob Godfrey (rob_godfrey@outlook.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.widget;
+
+import com.google.android.material.button.MaterialButton;
+import com.google.android.material.chip.Chip;
+import com.google.android.material.chip.ChipGroup;
+
+import org.onebusaway.android.R;
+import org.onebusaway.android.io.elements.ObaArrivalInfo;
+import org.onebusaway.android.io.request.ObaArrivalInfoRequest;
+import org.onebusaway.android.io.request.ObaArrivalInfoResponse;
+
+import android.app.PendingIntent;
+import android.appwidget.AppWidgetManager;
+import android.content.ComponentName;
+import android.content.Intent;
+import android.os.Build;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
+import android.graphics.Rect;
+import android.view.MotionEvent;
+import android.view.View;
+import android.view.Window;
+import android.view.inputmethod.InputMethodManager;
+import android.content.res.ColorStateList;
+import android.graphics.Color;
+import android.widget.EditText;
+import android.widget.RemoteViews;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.content.ContextCompat;
+
+public class StopTimesWidgetConfigActivity extends AppCompatActivity {
+
+    private static class Route {
+        final String id;
+        final String shortName;
+
+        Route(String id, String shortName) {
+            this.id = id;
+            this.shortName = shortName;
+        }
+    }
+
+    public static final String EXTRA_STOP_ID = "stop_id";
+    public static final String EXTRA_STOP_NAME = "stop_name";
+    private static final int MAX_MINUTES_AFTER = 1440;
+    private int appWidgetId = AppWidgetManager.INVALID_APPWIDGET_ID;
+
+    private EditText widgetNameInput;
+    private MaterialButton selectStopButton;
+    private MaterialButton saveButton;
+    private TextView routesLoadingText;
+    private ChipGroup chipGroup;
+
+    private String selectedStopId = null;
+    private String selectedStopName = null;
+    private String existingWidgetName = null;
+    private Set<String> existingRouteFilter = null;
+
+    private final ExecutorService executor = Executors.newSingleThreadExecutor();
+    private final Handler mainHandler = new Handler(Looper.getMainLooper());
+    private final AtomicInteger mLoadGeneration = new AtomicInteger();
+
+    private final ActivityResultLauncher<Intent> mStopPickerLauncher =
+            registerForActivityResult(new ActivityResultContracts.StartActivityForResult(), result -> {
+                if (result.getResultCode() == RESULT_OK && result.getData() != null) {
+                    selectedStopId = result.getData().getStringExtra(StopPickerActivity.EXTRA_STOP_ID);
+                    selectedStopName = result.getData().getStringExtra(StopPickerActivity.EXTRA_STOP_NAME);
+                    updateStopButton();
+                    widgetNameInput.setText(selectedStopName);
+                    updateSaveButton();
+                    loadRoutesForStop(selectedStopId);
+                }
+            });
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        supportRequestWindowFeature(Window.FEATURE_NO_TITLE);
+
+        setResult(RESULT_CANCELED); // widget is not added unless user hits the "save" button
+        setContentView(R.layout.stop_times_widget_config);
+
+        appWidgetId = getIntent().getIntExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, AppWidgetManager.INVALID_APPWIDGET_ID);
+        selectedStopId = getIntent().getStringExtra(EXTRA_STOP_ID);
+        selectedStopName = getIntent().getStringExtra(EXTRA_STOP_NAME);
+
+        // If editing an existing widget, load the saved config to populate fields
+        if (selectedStopId == null && appWidgetId != AppWidgetManager.INVALID_APPWIDGET_ID) {
+            final WidgetConfig existing = WidgetPrefs.loadConfig(this, appWidgetId);
+            if (existing != null) {
+                selectedStopId = existing.getStopId();
+                selectedStopName = existing.getStopName();
+                existingWidgetName = existing.getWidgetName();
+                existingRouteFilter = existing.getRoutes();
+            }
+        }
+
+        setupUi();
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        executor.shutdownNow();
+    }
+
+    // Hide keyboard when user taps screen if focus is on the 'Widget name' EditText
+    @Override
+    public boolean dispatchTouchEvent(MotionEvent event) {
+        if (event.getAction() == MotionEvent.ACTION_DOWN) {
+            final View focused = getCurrentFocus();
+            if (focused instanceof EditText) {
+                final Rect rect = new Rect();
+                focused.getGlobalVisibleRect(rect);
+                if (!rect.contains((int) event.getRawX(), (int) event.getRawY())) {
+                    focused.clearFocus();
+                    ((InputMethodManager) getSystemService(INPUT_METHOD_SERVICE))
+                            .hideSoftInputFromWindow(focused.getWindowToken(), 0);
+                }
+            }
+        }
+        return super.dispatchTouchEvent(event);
+    }
+
+    private void setupUi() {
+        widgetNameInput = findViewById(R.id.widget_name_input);
+        selectStopButton = findViewById(R.id.select_stop);
+        saveButton = findViewById(R.id.save_button);
+        routesLoadingText = findViewById(R.id.routes_loading);
+        chipGroup = findViewById(R.id.route_chips);
+
+        if (selectedStopName != null) {
+            updateStopButton();
+            widgetNameInput.setText(existingWidgetName != null ? existingWidgetName : selectedStopName);
+        }
+
+        widgetNameInput.setOnFocusChangeListener((v, hasFocus) -> {
+            if (hasFocus) widgetNameInput.post(widgetNameInput::selectAll);
+        });
+
+        selectStopButton.setOnClickListener(v ->
+                mStopPickerLauncher.launch(new Intent(this, StopPickerActivity.class)));
+
+        if (selectedStopId != null) {
+            loadRoutesForStop(selectedStopId);
+        }
+
+        updateSaveButton();
+        saveButton.setOnClickListener(v -> onSave());
+    }
+
+    private void updateStopButton() {
+        selectStopButton.setText(selectedStopName);
+        selectStopButton.setIconResource(R.drawable.ic_edit);
+    }
+
+    private void updateSaveButton() {
+        saveButton.setEnabled(selectedStopId != null);
+    }
+
+    private void loadRoutesForStop(String stopId) {
+        chipGroup.removeAllViews();
+        routesLoadingText.setVisibility(View.VISIBLE);
+
+        // Increment the generation so if the user picks a different stop before the current request
+        // finishes, the stale result is discarded instead of populating the chips
+        final int generation = mLoadGeneration.incrementAndGet();
+
+        executor.execute(() -> {
+            final ObaArrivalInfoResponse response =
+                    ObaArrivalInfoRequest.newRequest(this, stopId, MAX_MINUTES_AFTER).call();
+
+            final List<Route> routes = new ArrayList<>();
+            final Set<String> seen = new HashSet<>();
+            if (response != null && response.getArrivalInfo() != null) {
+                for (ObaArrivalInfo info : response.getArrivalInfo()) {
+                    if (seen.add(info.getRouteId())) {
+                        routes.add(new Route(info.getRouteId(), info.getShortName()));
+                    }
+                }
+            }
+            Collections.sort(routes, (a, b) -> compareRouteNames(a.shortName, b.shortName));
+
+            mainHandler.post(() -> {
+                if (mLoadGeneration.get() == generation) {
+                    populateRouteChips(routes);
+                }
+            });
+        });
+    }
+
+    // Sorts route names numerically if both are integers, otherwise alphabetically
+    private static int compareRouteNames(String a, String b) {
+        try {
+            return Integer.compare(Integer.parseInt(a), Integer.parseInt(b));
+        } catch (NumberFormatException e) {
+            return a.compareToIgnoreCase(b);
+        }
+    }
+
+    private void populateRouteChips(List<Route> routes) {
+        final int green = ContextCompat.getColor(this, R.color.theme_primary);
+        final int grey = ContextCompat.getColor(this, R.color.theme_muted);
+        final int[][] states = {new int[]{android.R.attr.state_checked}, new int[]{-android.R.attr.state_checked}};
+        final ColorStateList bgColors = new ColorStateList(states, new int[]{green, grey});
+        final ColorStateList textColors = new ColorStateList(states, new int[]{Color.WHITE, Color.WHITE});
+
+        // Use 32dp instead of the Material-recommended 48dp minimum touch target.
+        // With 48dp, the ChipGroup expands enough to push "Save widget" off-screen for
+        // stops with many routes. 32dp is a pragmatic compromise: it still provides some
+        // touch target expansion while keeping the dialog usable without scrolling.
+        final int minTouchTargetPx = (int) (32 * getResources().getDisplayMetrics().density);
+
+        // transparent icon to prevent chips from jumping around when the check mark appears/disappears
+        final float iconSizePx = 14 * getResources().getDisplayMetrics().density;
+        final android.graphics.drawable.GradientDrawable transparentIcon = new android.graphics.drawable.GradientDrawable();
+        transparentIcon.setColor(Color.TRANSPARENT);
+        transparentIcon.setSize((int) iconSizePx, (int) iconSizePx);
+
+        routesLoadingText.setVisibility(View.GONE);
+        chipGroup.removeAllViews();
+
+        for (final Route route : routes) {
+            final Chip chip = new Chip(this);
+            chip.setText(route.shortName);
+            chip.setTag(route.id);
+            chip.setCheckable(true);
+            chip.setChipIcon(transparentIcon);
+            chip.setChipIconVisible(true);
+            chip.setChipIconSize(iconSizePx);
+            chip.setCheckedIconVisible(true);
+            chip.setCheckedIcon(ContextCompat.getDrawable(this, R.drawable.ic_chip_check));
+            chip.setChipStrokeWidth(0);
+            chip.setRippleColor(ColorStateList.valueOf(Color.TRANSPARENT)); // hide ripple effect
+            chip.setChipBackgroundColor(bgColors);
+            chip.setTextColor(textColors);
+            chip.setChipEndPadding(chip.getChipStartPadding() + iconSizePx);
+            chip.ensureAccessibleTouchTarget(minTouchTargetPx);
+            // Restore previous selection if editing widget, otherwise default to none selected
+            boolean checked = existingRouteFilter != null && existingRouteFilter.contains(route.id);
+            chip.setChecked(checked);
+            chipGroup.addView(chip);
+        }
+    }
+
+    private void onSave() {
+        if (selectedStopId == null) return;
+
+        final Map<String, String> routeShortNames = getSelectedRouteShortNames();
+        if (routeShortNames.isEmpty()) {
+            Toast.makeText(this, R.string.widget_config_select_at_least_one_route, Toast.LENGTH_SHORT).show();
+            return;
+        }
+        if (routeShortNames.size() > 3) {
+            Toast.makeText(this, R.string.widget_config_select_no_more_than_three_routes, Toast.LENGTH_SHORT).show();
+            return;
+        }
+
+        final String enteredName = widgetNameInput.getText().toString().trim();
+        final String widgetName = enteredName.isEmpty() ? selectedStopName : enteredName;
+
+        if (appWidgetId == AppWidgetManager.INVALID_APPWIDGET_ID) {
+            // Launched from within the app before pinning, request pin with config in callback
+            pinWidgetWithConfig(widgetName, routeShortNames);
+            return;
+        }
+
+        final WidgetConfig config = new WidgetConfig(selectedStopId, selectedStopName, widgetName, routeShortNames);
+        final AppWidgetManager appWidgetManager = AppWidgetManager.getInstance(this);
+
+        WidgetPrefs.saveConfig(this, appWidgetId, config);
+        StopTimesWidget.refreshWidget(this, appWidgetManager, appWidgetId);
+
+        final Intent result = new Intent();
+        result.putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId);
+        setResult(RESULT_OK, result);
+        finish();
+    }
+
+    private Map<String, String> getSelectedRouteShortNames() {
+        final Map<String, String> selected = new HashMap<>();
+        for (int i = 0; i < chipGroup.getChildCount(); i++) {
+            final Chip chip = (Chip) chipGroup.getChildAt(i);
+            if (chip.isChecked()) {
+                selected.put((String) chip.getTag(), chip.getText().toString());
+            }
+        }
+        return selected;
+    }
+
+    private void pinWidgetWithConfig(String widgetName, Map<String, String> routeShortNames) {
+        final AppWidgetManager mgr = AppWidgetManager.getInstance(this);
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O || !mgr.isRequestPinAppWidgetSupported()) {
+            Toast.makeText(this, R.string.widget_config_add_manually, Toast.LENGTH_SHORT).show();
+            finish();
+            return;
+        }
+
+        // Save config before requesting pin. On some Android versions, the system launches the
+        // configure activity after placement, which we don't want. This lets the launch detect
+        // and silently apply the already-configured settings instead of showing the config screen
+        WidgetPrefs.savePendingPinConfig(this, new WidgetConfig(selectedStopId, selectedStopName, widgetName, routeShortNames));
+
+        final Intent callbackIntent = new Intent(this, StopTimesWidget.class);
+        callbackIntent.setAction(StopTimesWidget.ACTION_APPLY_PENDING_CONFIG);
+        callbackIntent.putExtra(StopTimesWidget.EXTRA_STOP_ID, selectedStopId);
+        callbackIntent.putExtra(StopTimesWidget.EXTRA_STOP_NAME, selectedStopName);
+        callbackIntent.putExtra(StopTimesWidget.EXTRA_WIDGET_NAME, widgetName);
+        callbackIntent.putStringArrayListExtra(StopTimesWidget.EXTRA_ROUTE_IDS, new ArrayList<>(routeShortNames.keySet()));
+        callbackIntent.putStringArrayListExtra(StopTimesWidget.EXTRA_ROUTE_NAMES, new ArrayList<>(routeShortNames.values()));
+
+        int flags = PendingIntent.FLAG_UPDATE_CURRENT;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            flags |= PendingIntent.FLAG_MUTABLE; // required so system can inject EXTRA_APPWIDGET_ID
+        }
+
+        final PendingIntent callbackPi = PendingIntent.getBroadcast(this, 0, callbackIntent, flags);
+
+        Bundle previewExtras = null;
+        // add stop name & route ID to widget preview
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            RemoteViews preview = new RemoteViews(getPackageName(), R.layout.stop_times_widget_preview);
+            preview.setTextViewText(R.id.preview_stop_name, widgetName);
+            for (int i = 0; i < chipGroup.getChildCount(); i++) {
+                final Chip chip = (Chip) chipGroup.getChildAt(i);
+                if (chip.isChecked()) {
+                    preview.setTextViewText(R.id.widget_route_1_title, chip.getText());
+                    break;
+                }
+            }
+            previewExtras = new Bundle();
+            previewExtras.putParcelable(AppWidgetManager.EXTRA_APPWIDGET_PREVIEW, preview);
+        }
+
+        mgr.requestPinAppWidget(new ComponentName(this, StopTimesWidget.class), previewExtras, callbackPi);
+        finish();
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/widget/WidgetArrivalSnapshot.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/widget/WidgetArrivalSnapshot.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2025 Rob Godfrey (rob_godfrey@outlook.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.widget;
+
+import java.util.List;
+
+/**
+ * Arrival data fetched from OBA API to be persisted in SharedPrefs. This is saved so we can
+ * update the widget periodically with a new relative time ("5 min" -> "4 min" -> "3 min")
+ * without making additional API calls.
+ */
+public final class WidgetArrivalSnapshot {
+    private final long fetchedAtMs;
+    private final List<Route> routes;
+
+    public WidgetArrivalSnapshot(long fetchedAtMs, List<Route> routes) {
+        this.fetchedAtMs = fetchedAtMs;
+        this.routes = routes;
+    }
+
+    public long getFetchedAtMs() {
+        return fetchedAtMs;
+    }
+
+    public List<Route> getRoutes() {
+        return routes;
+    }
+
+    /**
+     * A single route with its upcoming arrivals.
+     */
+    public static final class Route {
+        private final String shortName;
+        private final List<Arrival> arrivals;
+
+        public Route(String shortName, List<Arrival> arrivals) {
+            this.shortName = shortName;
+            this.arrivals = arrivals;
+        }
+
+        public String getShortName() {
+            return shortName;
+        }
+
+        public List<Arrival> getArrivals() {
+            return arrivals;
+        }
+    }
+
+    /**
+     * A single upcoming arrival for a route, holding both the scheduled and real-time predicted
+     * times. Use {@link #getBestArrivalTimeMs()} to get whichever is most accurate.
+     */
+    public static final class Arrival {
+
+        /// Unix ms, or 0 if unavailable
+        private final long predictedArrivalTimeMs;
+
+        /// Unix ms (always present)
+        private final long scheduledArrivalTimeMs;
+
+        public Arrival(long predictedArrivalTimeMs, long scheduledArrivalTimeMs) {
+            this.predictedArrivalTimeMs = predictedArrivalTimeMs;
+            this.scheduledArrivalTimeMs = scheduledArrivalTimeMs;
+        }
+
+        public long getPredictedArrivalTimeMs() {
+            return predictedArrivalTimeMs;
+        }
+
+        public long getScheduledArrivalTimeMs() {
+            return scheduledArrivalTimeMs;
+        }
+
+        /// Returns the predicted time if available, the scheduled time otherwise.
+        public long getBestArrivalTimeMs() {
+            return predictedArrivalTimeMs > 0 ? predictedArrivalTimeMs : scheduledArrivalTimeMs;
+        }
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/widget/WidgetArrivalWorker.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/widget/WidgetArrivalWorker.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright (C) 2025 Rob Godfrey (rob_godfrey@outlook.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.widget;
+
+import org.onebusaway.android.io.elements.ObaArrivalInfo;
+import org.onebusaway.android.io.request.ObaArrivalInfoRequest;
+import org.onebusaway.android.io.request.ObaArrivalInfoResponse;
+
+import android.appwidget.AppWidgetManager;
+import android.content.Context;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.work.Data;
+import androidx.work.ExistingWorkPolicy;
+import androidx.work.OneTimeWorkRequest;
+import androidx.work.WorkManager;
+import androidx.work.Worker;
+import androidx.work.WorkerParameters;
+
+import org.onebusaway.android.ui.widget.WidgetArrivalSnapshot.Arrival;
+import org.onebusaway.android.ui.widget.WidgetArrivalSnapshot.Route;
+
+/**
+ * Background worker that fetches arrival times for a widget's stop and saves the result to
+ * {@link WidgetPrefs} as a {@link WidgetArrivalSnapshot}. Once saved, it triggers
+ * {@link StopTimesWidget#updateArrivalsFromCache} to redraw the widget from the new snapshot.
+ */
+public class WidgetArrivalWorker extends Worker {
+
+    private static final String TAG = "WidgetArrivalWorker";
+    private static final int MAX_FETCH_ATTEMPTS = 3;
+
+    public WidgetArrivalWorker(@NonNull Context context, @NonNull WorkerParameters params) {
+        super(context, params);
+    }
+
+    public static void enqueue(Context context, int widgetId) {
+        final Data data = new Data.Builder()
+                .putInt(AppWidgetManager.EXTRA_APPWIDGET_ID, widgetId)
+                .build();
+
+        final OneTimeWorkRequest request = new OneTimeWorkRequest.Builder(WidgetArrivalWorker.class)
+                .setInputData(data)
+                .build();
+
+        WorkManager.getInstance(context).enqueueUniqueWork(
+                "widget_refresh_" + widgetId,
+                ExistingWorkPolicy.REPLACE,
+                request);
+    }
+
+    @NonNull
+    @Override
+    public Result doWork() {
+        final int widgetId = getInputData().getInt(AppWidgetManager.EXTRA_APPWIDGET_ID, AppWidgetManager.INVALID_APPWIDGET_ID);
+        Log.d(TAG, "doWork id=" + widgetId);
+
+        if (widgetId == AppWidgetManager.INVALID_APPWIDGET_ID) {
+            Log.w(TAG, "doWork: invalid widget ID");
+            return Result.failure();
+        }
+
+        final WidgetConfig config = WidgetPrefs.loadConfig(getApplicationContext(), widgetId);
+
+        if (config == null || config.getStopId() == null) {
+            // widget was deleted or not configured yet
+            Log.d(TAG, "doWork id=" + widgetId + " no config, skipping");
+            return Result.success();
+        }
+
+        final Map<String, String> routeShortNameMap = config.getRouteShortNameMap();
+        if (routeShortNameMap.isEmpty()) {
+            Log.w(TAG, "doWork id=" + widgetId + " no routes configured, skipping");
+            return Result.success();
+        }
+
+        final ObaArrivalInfoResponse response = fetchArrivals(config.getStopId());
+
+        if (response == null || response.getArrivalInfo() == null) {
+            Log.w(TAG, "doWork id=" + widgetId + " fetch failed, retrying");
+            StopTimesWidget.updateArrivalsFromCache(getApplicationContext(), widgetId);
+            return Result.retry();
+        }
+
+        final WidgetArrivalSnapshot snapshot = buildSnapshot(response, routeShortNameMap);
+
+        WidgetPrefs.saveSnapshot(getApplicationContext(), widgetId, snapshot);
+        Log.d(TAG, "doWork id=" + widgetId + " fetch succeeded, updating widget");
+        StopTimesWidget.updateArrivalsFromCache(getApplicationContext(), widgetId);
+
+        return Result.success();
+    }
+
+    // Fetches arrivals for the given stop, expanding the look-ahead window by 1 hour at a time
+    // until arrivals are found or the attempt limit is reached. Returns null only on a
+    // network/protocol failure; returns the last response (even if empty) when the stop simply
+    // has no upcoming arrivals within the maximum window.
+    private ObaArrivalInfoResponse fetchArrivals(String stopId) {
+        int minutesAfter = 65;
+        ObaArrivalInfoResponse lastResponse = null;
+
+        for (int attempt = 0; attempt < MAX_FETCH_ATTEMPTS; attempt++) {
+            final ObaArrivalInfoRequest request = ObaArrivalInfoRequest.newRequest(getApplicationContext(), stopId, minutesAfter);
+            final ObaArrivalInfoResponse response = request.call();
+
+            if (response == null || response.getArrivalInfo() == null) {
+                break; // network/protocol failure — no point widening the window
+            }
+            lastResponse = response;
+            if (response.getArrivalInfo().length > 0) {
+                return response;
+            }
+            minutesAfter += 60;
+        }
+
+        return lastResponse; // null on network failure; empty-arrivals response otherwise
+    }
+
+    // Converts an API response into a WidgetArrivalSnapshot, including all configured routes.
+    // Routes with no arrivals in the response are included with an empty arrivals list so the
+    // widget always displays all configured routes (showing "N/A" for those with no times).
+    private static WidgetArrivalSnapshot buildSnapshot(ObaArrivalInfoResponse response, Map<String, String> routeShortNameMap) {
+        final long now = System.currentTimeMillis();
+
+        final Map<String, List<ObaArrivalInfo>> groupedArrivals = filterArrivalsAndGroupByRoute(
+                response.getArrivalInfo(), routeShortNameMap.keySet());
+
+        final List<Route> routesWithArrivals = new ArrayList<>();
+        final List<Route> routesWithoutArrivals = new ArrayList<>();
+
+        for (final Map.Entry<String, String> entry : routeShortNameMap.entrySet()) {
+            final String routeId = entry.getKey();
+            final String shortName = entry.getValue();
+            final List<ObaArrivalInfo> arrivals = groupedArrivals.get(routeId);
+            if (arrivals != null) {
+                routesWithArrivals.add(getRoute(arrivals));
+            } else {
+                routesWithoutArrivals.add(new Route(shortName, Collections.emptyList()));
+            }
+        }
+
+        // Routes with arrivals sorted soonest-first, routes with no arrivals appended after
+        Collections.sort(routesWithArrivals, (r1, r2) ->
+                Long.compare(r1.getArrivals().get(0).getBestArrivalTimeMs(),
+                        r2.getArrivals().get(0).getBestArrivalTimeMs()));
+
+        final List<Route> allRoutes = new ArrayList<>(routesWithArrivals);
+        allRoutes.addAll(routesWithoutArrivals);
+
+        return new WidgetArrivalSnapshot(now, allRoutes);
+    }
+
+    // Groups arrivals by route ID, filtering to only the routes in routeFilter, sorts each
+    // group by soonest arrival
+    private static Map<String, List<ObaArrivalInfo>> filterArrivalsAndGroupByRoute(ObaArrivalInfo[] arrivals, Set<String> routeFilter) {
+        final Map<String, List<ObaArrivalInfo>> filteredAndGroupedRouteArrivals = new LinkedHashMap<>();
+
+        for (final ObaArrivalInfo info : arrivals) {
+            final String routeId = info.getRouteId();
+            if (routeFilter.contains(routeId)) {
+                if (!filteredAndGroupedRouteArrivals.containsKey(routeId)) {
+                    filteredAndGroupedRouteArrivals.put(routeId, new ArrayList<>());
+                }
+                filteredAndGroupedRouteArrivals.get(routeId).add(info);
+            }
+        }
+
+        for (final List<ObaArrivalInfo> group : filteredAndGroupedRouteArrivals.values()) {
+            Collections.sort(group, (a, b) -> {
+                long timeA = a.getPredictedArrivalTime() > 0 ? a.getPredictedArrivalTime() : a.getScheduledArrivalTime();
+                long timeB = b.getPredictedArrivalTime() > 0 ? b.getPredictedArrivalTime() : b.getScheduledArrivalTime();
+                return Long.compare(timeA, timeB);
+            });
+        }
+
+        return filteredAndGroupedRouteArrivals;
+    }
+
+    // Builds a snapshot of Routes from a sorted list of arrivals, capped at 4
+    private static Route getRoute(List<ObaArrivalInfo> arrivals) {
+        final String shortName = arrivals.get(0).getShortName();
+        final List<Arrival> snapshotArrivals = new ArrayList<>();
+
+        for (int i = 0; i < Math.min(arrivals.size(), 4); i++) {
+            final ObaArrivalInfo arrival = arrivals.get(i);
+            snapshotArrivals.add(new Arrival(arrival.getPredictedArrivalTime(), arrival.getScheduledArrivalTime()));
+        }
+
+        return new Route(shortName, snapshotArrivals);
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/widget/WidgetConfig.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/widget/WidgetConfig.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2025 Rob Godfrey (rob_godfrey@outlook.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.widget;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Stores the user's configuration for a single Stop Times widget.
+ * Serialized to JSON and persisted via {@link WidgetPrefs}.
+ */
+public final class WidgetConfig {
+    private final String stopId;
+    private final String stopName;
+    private final String widgetName;
+    // Maps route ID → short name (e.g. "1_100" → "44")
+    private final Map<String, String> routeShortNames;
+
+    public WidgetConfig(String stopId, String stopName, String widgetName, Map<String, String> routeShortNames) {
+        this.stopId = stopId;
+        this.stopName = stopName;
+        this.widgetName = widgetName;
+        this.routeShortNames = routeShortNames;
+    }
+
+    public String getStopId() {
+        return stopId;
+    }
+
+    public String getStopName() {
+        return stopName;
+    }
+
+    public String getWidgetName() {
+        return widgetName;
+    }
+
+    public Set<String> getRoutes() {
+        return routeShortNames != null
+                ? Collections.unmodifiableSet(routeShortNames.keySet())
+                : Collections.emptySet();
+    }
+
+    public Map<String, String> getRouteShortNameMap() {
+        return routeShortNames != null
+                ? Collections.unmodifiableMap(routeShortNames)
+                : Collections.emptyMap();
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/widget/WidgetPrefs.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/widget/WidgetPrefs.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2025 Rob Godfrey (rob_godfrey@outlook.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.widget;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
+
+import java.lang.reflect.Type;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.util.Log;
+
+import androidx.annotation.Nullable;
+
+/**
+ * Persists per-widget data to SharedPreferences using Gson for serialization.
+ * Each widget instance is keyed by its appWidgetId.
+ * <p>
+ * Two types of data are stored per widget:
+ * <p>
+ * - {@link WidgetConfig}: the user's configuration (stop, name, route filter)
+ * <p>
+ * - {@link WidgetArrivalSnapshot}: the last fetched arrival data
+ */
+public class WidgetPrefs {
+    private static final String TAG = "WidgetPrefs";
+    private static final Gson GSON = new Gson();
+    private static final String STOP_WIDGET_PREF_NAME = "stop_widgets";
+    private static final String PENDING_CONFIG_KEY = "pending_pin_config";
+
+    private WidgetPrefs() {
+    }
+
+    /// Serializes and persists a {@link WidgetConfig} for the given widget ID.
+    public static void saveConfig(Context context, int widgetId, WidgetConfig config) {
+        final String json = GSON.toJson(config);
+        stopWidgetPrefs(context).edit()
+                .putString(configKey(widgetId), json)
+                .apply();
+    }
+
+    /// Serializes and persists a {@link WidgetArrivalSnapshot} for the given widget ID.
+    public static void saveSnapshot(Context context, int widgetId, WidgetArrivalSnapshot snapshot) {
+        final String json = GSON.toJson(snapshot);
+        stopWidgetPrefs(context).edit()
+                .putString(snapshotKey(widgetId), json)
+                .apply();
+    }
+
+    /// Returns the saved {@link WidgetConfig} for the given widget ID, or {@code null} if none exists.
+    @Nullable
+    public static WidgetConfig loadConfig(Context context, int widgetId) {
+        final String json = stopWidgetPrefs(context).getString(configKey(widgetId), null);
+        return fromJson(json, WidgetConfig.class, widgetId);
+    }
+
+    /// Returns the saved {@link WidgetArrivalSnapshot} for the given widget ID, or {@code null} if none exists.
+    @Nullable
+    public static WidgetArrivalSnapshot loadSnapshot(Context context, int widgetId) {
+        final String json = stopWidgetPrefs(context).getString(snapshotKey(widgetId), null);
+        return fromJson(json, WidgetArrivalSnapshot.class, widgetId);
+    }
+
+    /// Saves a {@link WidgetConfig} as the pending pin config to be applied once the widget is placed.
+    public static void savePendingPinConfig(Context context, WidgetConfig config) {
+        final String json = GSON.toJson(config);
+        stopWidgetPrefs(context).edit()
+                .putString(PENDING_CONFIG_KEY, json)
+                .apply();
+    }
+
+    /// Returns the pending pin config saved by {@link #savePendingPinConfig} and removes it from storage,
+    /// or {@code null} if no pending config exists.
+    @Nullable
+    public static WidgetConfig loadAndClearPendingPinConfig(Context context) {
+        final SharedPreferences prefs = stopWidgetPrefs(context);
+        final String json = prefs.getString(PENDING_CONFIG_KEY, null);
+        if (json != null) {
+            prefs.edit().remove(PENDING_CONFIG_KEY).apply();
+        }
+        return fromJson(json, WidgetConfig.class, -1);
+    }
+
+    /// Removes all stored data (config and snapshot) for the given widget ID.
+    public static void delete(Context context, int widgetId) {
+        stopWidgetPrefs(context).edit()
+                .remove(configKey(widgetId))
+                .remove(snapshotKey(widgetId))
+                .apply();
+    }
+
+    @Nullable
+    private static <T> T fromJson(String json, Type type, int widgetId) {
+        if (json == null) {
+            return null;
+        }
+        try {
+            return GSON.fromJson(json, type);
+        } catch (JsonSyntaxException e) {
+            Log.e(TAG, "Failed to deserialize " + type + " for id=" + widgetId, e);
+            return null;
+        }
+    }
+
+    private static SharedPreferences stopWidgetPrefs(Context context) {
+        return context.getSharedPreferences(STOP_WIDGET_PREF_NAME, Context.MODE_PRIVATE);
+    }
+
+    private static String configKey(int widgetId) {
+        return String.format("widget_%s_config", widgetId);
+    }
+
+    private static String snapshotKey(int widgetId) {
+        return String.format("widget_%s_snapshot", widgetId);
+    }
+}

--- a/onebusaway-android/src/main/res/drawable-v21/widget_background.xml
+++ b/onebusaway-android/src/main/res/drawable-v21/widget_background.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <corners android:radius="26dp" />
+    <solid android:color="@color/widget_background" />
+</shape>

--- a/onebusaway-android/src/main/res/drawable/ic_chip_check.xml
+++ b/onebusaway-android/src/main/res/drawable/ic_chip_check.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="18dp"
+        android:height="18dp"
+        android:viewportWidth="24"
+        android:viewportHeight="24">
+    <path
+            android:fillColor="@android:color/transparent"
+            android:strokeColor="#FFFFFF"
+            android:strokeWidth="2.5"
+            android:strokeLineCap="round"
+            android:strokeLineJoin="round"
+            android:pathData="M4,12 L9,17 L20,6" />
+</vector>

--- a/onebusaway-android/src/main/res/drawable/ic_edit.xml
+++ b/onebusaway-android/src/main/res/drawable/ic_edit.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24"
+        android:viewportHeight="24">
+    <path
+            android:fillColor="@android:color/white"
+            android:pathData="M3,17.25V21h3.75L17.81,9.94l-3.75,-3.75L3,17.25zM20.71,7.04c0.39,-0.39 0.39,-1.02 0,-1.41l-2.34,-2.34c-0.39,-0.39 -1.02,-0.39 -1.41,0l-1.83,1.83 3.75,3.75 1.83,-1.83z" />
+</vector>

--- a/onebusaway-android/src/main/res/drawable/widget_eta_bg_early.xml
+++ b/onebusaway-android/src/main/res/drawable/widget_eta_bg_early.xml
@@ -1,0 +1,4 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <corners android:radius="6dp" />
+    <solid android:color="@color/stop_info_early" />
+</shape>

--- a/onebusaway-android/src/main/res/drawable/widget_eta_bg_late.xml
+++ b/onebusaway-android/src/main/res/drawable/widget_eta_bg_late.xml
@@ -1,0 +1,4 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <corners android:radius="6dp" />
+    <solid android:color="@color/stop_info_delayed" />
+</shape>

--- a/onebusaway-android/src/main/res/drawable/widget_eta_bg_on_time.xml
+++ b/onebusaway-android/src/main/res/drawable/widget_eta_bg_on_time.xml
@@ -1,0 +1,4 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <corners android:radius="6dp" />
+    <solid android:color="@color/stop_info_ontime" />
+</shape>

--- a/onebusaway-android/src/main/res/drawable/widget_eta_bg_scheduled.xml
+++ b/onebusaway-android/src/main/res/drawable/widget_eta_bg_scheduled.xml
@@ -1,0 +1,4 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <corners android:radius="6dp" />
+    <solid android:color="@color/stop_info_scheduled_time" />
+</shape>

--- a/onebusaway-android/src/main/res/drawable/widget_header_bg.xml
+++ b/onebusaway-android/src/main/res/drawable/widget_header_bg.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <corners
+            android:topLeftRadius="26dp"
+            android:topRightRadius="26dp"
+            android:bottomLeftRadius="0dp"
+            android:bottomRightRadius="0dp" />
+    <solid android:color="@color/theme_primary" />
+</shape>

--- a/onebusaway-android/src/main/res/layout/activity_stop_picker.xml
+++ b/onebusaway-android/src/main/res/layout/activity_stop_picker.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Copyright (C) 2025 Rob Godfrey (rob_godfrey@outlook.com)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:fitsSystemWindows="true"
+        android:background="@color/theme_primary">
+
+    <ListView
+            android:id="@+id/stop_list"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="?android:attr/colorBackground" />
+
+</FrameLayout>

--- a/onebusaway-android/src/main/res/layout/list_item_empty_section.xml
+++ b/onebusaway-android/src/main/res/layout/list_item_empty_section.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Copyright (C) 2025 Rob Godfrey (rob_godfrey@outlook.com)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+        android:id="@+id/list_item_empty_text"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:padding="20dp"
+        android:textSize="14sp"
+        android:textAppearance="?android:attr/textAppearanceMedium"
+        android:textColor="?android:attr/textColorSecondary" />

--- a/onebusaway-android/src/main/res/layout/stop_times_widget.xml
+++ b/onebusaway-android/src/main/res/layout/stop_times_widget.xml
@@ -1,0 +1,292 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Copyright (C) 2025 Rob Godfrey (rob_godfrey@outlook.com)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        android:id="@+id/widget_root"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        android:background="@drawable/widget_background">
+
+    <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:orientation="vertical">
+
+        <!-- Header row: title + refresh -->
+        <LinearLayout
+                android:id="@+id/stop_times_widget_header"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:gravity="center_vertical"
+                android:paddingLeft="18dp"
+                android:paddingRight="18dp"
+                android:background="@drawable/widget_header_bg"
+                android:paddingTop="6dp"
+                android:paddingBottom="6dp"
+                android:layout_marginBottom="4dp">
+
+            <TextView
+                    android:id="@+id/stop_times_widget_title"
+                    android:layout_width="0dp"
+                    android:layout_gravity="center_vertical"
+                    android:layout_weight="1"
+                    android:layout_height="wrap_content"
+                    android:textSize="15sp"
+                    android:maxLines="1"
+                    android:ellipsize="end"
+                    android:textColor="@color/widget_header_text" />
+
+            <ImageView
+                    android:id="@+id/refresh_header"
+                    android:layout_width="22dp"
+                    android:layout_height="22dp"
+                    android:src="@drawable/ic_action_navigation_refresh"
+                    android:tint="@color/widget_refresh_icon" />
+        </LinearLayout>
+
+        <!-- Spacer between header and first route row -->
+        <TextView
+                android:id="@+id/header_spacer"
+                android:layout_width="match_parent"
+                android:layout_height="4dp" />
+
+        <!-- Arrival row 1 -->
+        <LinearLayout
+                android:id="@+id/widget_route_1_row"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:gravity="center_vertical"
+                android:visibility="gone"
+                android:paddingLeft="18dp"
+                android:paddingRight="18dp">
+
+            <TextView
+                    android:id="@+id/widget_route_1_title"
+                    android:layout_width="68dp"
+                    android:layout_height="wrap_content"
+                    android:textSize="16sp"
+                    android:textStyle="bold"
+                    android:textColor="@color/widget_route_name_text" />
+
+            <TextView
+                    android:id="@+id/widget_route_1_eta_1"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:paddingLeft="10dp"
+                    android:paddingRight="10dp"
+                    android:paddingTop="4dp"
+                    android:paddingBottom="4dp"
+                    android:background="@drawable/widget_eta_bg_scheduled"
+                    android:maxLines="1"
+                    android:minWidth="50dp"
+                    android:textSize="15sp"
+                    android:textColor="@color/widget_eta_text" />
+
+            <TextView
+                    android:id="@+id/widget_route_1_eta_2"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:paddingLeft="10dp"
+                    android:paddingRight="10dp"
+                    android:paddingTop="4dp"
+                    android:paddingBottom="4dp"
+                    android:layout_marginStart="5dp"
+                    android:background="@drawable/widget_eta_bg_scheduled"
+                    android:maxLines="1"
+                    android:minWidth="50dp"
+                    android:textSize="15sp"
+                    android:textColor="@color/widget_eta_text" />
+
+            <TextView
+                    android:id="@+id/widget_route_1_eta_3"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:paddingLeft="10dp"
+                    android:paddingRight="10dp"
+                    android:paddingTop="4dp"
+                    android:paddingBottom="4dp"
+                    android:layout_marginStart="5dp"
+                    android:background="@drawable/widget_eta_bg_scheduled"
+                    android:maxLines="1"
+                    android:minWidth="50dp"
+                    android:textSize="15sp"
+                    android:textColor="@color/widget_eta_text" />
+        </LinearLayout>
+
+        <!-- Arrival row 2 -->
+        <LinearLayout
+                android:id="@+id/widget_route_2_row"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:gravity="center_vertical"
+                android:layout_marginTop="8dp"
+                android:visibility="gone"
+                android:paddingLeft="18dp"
+                android:paddingRight="18dp">
+
+            <TextView
+                    android:id="@+id/widget_route_2_title"
+                    android:layout_width="68dp"
+                    android:layout_height="wrap_content"
+                    android:textSize="16sp"
+                    android:textStyle="bold"
+                    android:textColor="@color/widget_route_name_text" />
+
+            <TextView
+                    android:id="@+id/widget_route_2_eta_1"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:paddingLeft="10dp"
+                    android:paddingRight="10dp"
+                    android:paddingTop="4dp"
+                    android:paddingBottom="4dp"
+                    android:background="@drawable/widget_eta_bg_scheduled"
+                    android:maxLines="1"
+                    android:minWidth="50dp"
+                    android:textSize="15sp"
+                    android:textColor="@color/widget_eta_text" />
+
+            <TextView
+                    android:id="@+id/widget_route_2_eta_2"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:paddingLeft="10dp"
+                    android:paddingRight="10dp"
+                    android:paddingTop="4dp"
+                    android:paddingBottom="4dp"
+                    android:layout_marginStart="5dp"
+                    android:background="@drawable/widget_eta_bg_scheduled"
+                    android:maxLines="1"
+                    android:minWidth="50dp"
+                    android:textSize="15sp"
+                    android:textColor="@color/widget_eta_text" />
+
+            <TextView
+                    android:id="@+id/widget_route_2_eta_3"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:paddingLeft="10dp"
+                    android:paddingRight="10dp"
+                    android:paddingTop="4dp"
+                    android:paddingBottom="4dp"
+                    android:layout_marginStart="5dp"
+                    android:background="@drawable/widget_eta_bg_scheduled"
+                    android:maxLines="1"
+                    android:minWidth="50dp"
+                    android:textSize="15sp"
+                    android:textColor="@color/widget_eta_text" />
+        </LinearLayout>
+
+        <!-- Arrival row 3 -->
+        <LinearLayout
+                android:id="@+id/widget_route_3_row"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:layout_marginTop="8dp"
+                android:gravity="center_vertical"
+                android:visibility="gone"
+                android:paddingLeft="18dp"
+                android:paddingRight="18dp">
+
+            <TextView
+                    android:id="@+id/widget_route_3_title"
+                    android:layout_width="68dp"
+                    android:layout_height="wrap_content"
+                    android:textSize="16sp"
+                    android:textStyle="bold"
+                    android:textColor="@color/widget_route_name_text" />
+
+            <TextView
+                    android:id="@+id/widget_route_3_eta_1"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:paddingLeft="10dp"
+                    android:paddingRight="10dp"
+                    android:paddingTop="4dp"
+                    android:paddingBottom="4dp"
+                    android:background="@drawable/widget_eta_bg_scheduled"
+                    android:maxLines="1"
+                    android:minWidth="50dp"
+                    android:textSize="15sp"
+                    android:textColor="@color/widget_eta_text" />
+
+            <TextView
+                    android:id="@+id/widget_route_3_eta_2"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:paddingLeft="10dp"
+                    android:paddingRight="10dp"
+                    android:paddingTop="4dp"
+                    android:paddingBottom="4dp"
+                    android:layout_marginStart="5dp"
+                    android:background="@drawable/widget_eta_bg_scheduled"
+                    android:maxLines="1"
+                    android:minWidth="50dp"
+                    android:textSize="15sp"
+                    android:textColor="@color/widget_eta_text" />
+
+            <TextView
+                    android:id="@+id/widget_route_3_eta_3"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:paddingLeft="10dp"
+                    android:paddingRight="10dp"
+                    android:paddingTop="4dp"
+                    android:paddingBottom="4dp"
+                    android:layout_marginStart="5dp"
+                    android:background="@drawable/widget_eta_bg_scheduled"
+                    android:maxLines="1"
+                    android:minWidth="50dp"
+                    android:textSize="15sp"
+                    android:textColor="@color/widget_eta_text" />
+        </LinearLayout>
+
+        <!-- Loading spinner, shown while fetching arrivals -->
+        <ProgressBar
+                android:id="@+id/widget_loading_spinner"
+                style="?android:attr/progressBarStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_horizontal"
+                android:indeterminateTint="@color/widget_refresh_spinner" />
+
+    </LinearLayout>
+
+    <!-- Footer -->
+    <LinearLayout
+            android:id="@+id/widget_footer"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:paddingLeft="20dp"
+            android:paddingRight="20dp">
+
+        <TextView
+                android:id="@+id/widget_updated_at"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:textSize="10sp"
+                android:paddingBottom="4dp"
+                android:textColor="@color/widget_footer_text" />
+    </LinearLayout>
+
+</LinearLayout>

--- a/onebusaway-android/src/main/res/layout/stop_times_widget_config.xml
+++ b/onebusaway-android/src/main/res/layout/stop_times_widget_config.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Copyright (C) 2025 Rob Godfrey (rob_godfrey@outlook.com)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/widget_config_background">
+
+    <LinearLayout
+            android:id="@+id/config_root"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:paddingLeft="24dp"
+            android:paddingRight="24dp"
+            android:paddingTop="24dp"
+            android:paddingBottom="16dp">
+
+        <!-- Title -->
+        <TextView
+                android:id="@+id/config_title"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/widget_config_add_stop_widget"
+                android:textAppearance="?attr/textAppearanceTitleMedium"
+                android:layout_marginBottom="20dp" />
+
+        <!-- Stop selector -->
+        <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/widget_config_selected_stop"
+                android:textAppearance="?attr/textAppearanceLabelMedium"
+                android:layout_marginBottom="6dp" />
+
+        <com.google.android.material.button.MaterialButton
+                android:id="@+id/select_stop"
+                style="@style/Widget.Material3.Button"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingLeft="12dp"
+                android:paddingRight="12dp"
+                android:text="@string/widget_config_select_a_stop"
+                android:textColor="@color/widget_config_button_text"
+                android:gravity="start|center_vertical"
+                app:icon="@drawable/ic_btn_search"
+                app:iconTint="@color/widget_config_button_text"
+                app:iconGravity="end" />
+
+        <!-- Widget name -->
+        <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/widget_config_widget_name"
+                android:textAppearance="?attr/textAppearanceLabelMedium"
+                android:layout_marginTop="16dp"
+                android:layout_marginBottom="6dp" />
+
+        <com.google.android.material.textfield.TextInputLayout
+                style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+            <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/widget_name_input"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:textSize="14sp"
+                    android:inputType="textCapWords"
+                    android:maxLines="1" />
+
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <!-- Routes -->
+        <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/widget_config_selected_routes"
+                android:textAppearance="?attr/textAppearanceLabelMedium"
+                android:layout_marginTop="20dp"
+                android:layout_marginBottom="2dp" />
+
+        <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/widget_config_chip_selection_instructions"
+                android:textAppearance="?attr/textAppearanceBodySmall"
+                android:textColor="?android:textColorSecondary"
+                android:layout_marginBottom="6dp" />
+
+        <TextView
+                android:id="@+id/routes_loading"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/widget_config_loading_routes"
+                android:textAppearance="?attr/textAppearanceBodySmall"
+                android:textColor="?android:textColorSecondary"
+                android:visibility="gone" />
+
+        <com.google.android.material.chip.ChipGroup
+                android:id="@+id/route_chips"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:singleSelection="false"
+                app:chipSpacingHorizontal="4dp"
+                app:chipSpacingVertical="6dp" />
+
+        <!-- Save button -->
+        <com.google.android.material.button.MaterialButton
+                android:id="@+id/save_button"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="24dp"
+                android:textColor="@color/widget_config_button_text"
+                android:text="@string/widget_config_save_widget" />
+
+    </LinearLayout>
+
+</ScrollView>

--- a/onebusaway-android/src/main/res/layout/stop_times_widget_preview.xml
+++ b/onebusaway-android/src/main/res/layout/stop_times_widget_preview.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Copyright (C) 2025 Rob Godfrey (rob_godfrey@outlook.com)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        android:id="@+id/widget_root"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        android:background="@drawable/widget_background">
+
+    <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:orientation="vertical">
+
+        <!-- Header row: title + refresh -->
+        <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:gravity="center_vertical"
+                android:paddingLeft="16dp"
+                android:paddingRight="16dp"
+                android:background="@color/theme_primary"
+                android:paddingTop="4dp"
+                android:paddingBottom="4dp"
+                android:layout_marginBottom="4dp">
+
+            <TextView
+                    android:id="@+id/preview_stop_name"
+                    android:layout_width="0dp"
+                    android:layout_gravity="center_vertical"
+                    android:layout_weight="1"
+                    android:layout_height="wrap_content"
+                    android:textSize="14sp"
+                    android:maxLines="1"
+                    android:text="3rd &amp; Pike"
+                    android:ellipsize="end"
+                    android:textColor="@color/widget_header_text" />
+
+            <ImageView
+                    android:id="@+id/refresh_header"
+                    android:layout_width="20dp"
+                    android:layout_height="20dp"
+                    android:src="@drawable/ic_action_navigation_refresh"
+                    android:tint="@color/widget_refresh_icon" />
+        </LinearLayout>
+
+        <!-- Arrival row 1 -->
+        <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:gravity="center_vertical"
+                android:paddingLeft="16dp"
+                android:paddingRight="16dp">
+
+            <TextView
+                    android:id="@+id/widget_route_1_title"
+                    android:layout_width="60dp"
+                    android:layout_height="wrap_content"
+                    android:text="@string/widget_preview_route_name"
+                    android:textSize="14sp"
+                    android:textStyle="bold"
+                    android:textColor="@color/widget_route_name_text" />
+
+            <TextView
+                    android:id="@+id/widget_route_1_eta_1"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:paddingLeft="10dp"
+                    android:paddingRight="10dp"
+                    android:paddingTop="2dp"
+                    android:paddingBottom="2dp"
+                    android:background="@drawable/widget_eta_bg_on_time"
+                    android:maxLines="1"
+                    android:minWidth="50dp"
+                    android:text="@string/stop_info_eta_now"
+                    android:textSize="13sp"
+                    android:textColor="@color/widget_eta_text" />
+        </LinearLayout>
+
+    </LinearLayout>
+
+    <!-- Footer -->
+    <LinearLayout
+            android:id="@+id/widget_footer"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:paddingLeft="18dp"
+            android:paddingRight="18dp">
+
+        <TextView
+                android:id="@+id/widget_updated_at"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/widget_preview_updated_at"
+                android:textSize="8sp"
+                android:paddingBottom="4dp"
+                android:textColor="@color/widget_footer_text" />
+    </LinearLayout>
+
+</LinearLayout>

--- a/onebusaway-android/src/main/res/menu-v14/arrivals_list.xml
+++ b/onebusaway-android/src/main/res/menu-v14/arrivals_list.xml
@@ -47,6 +47,8 @@
               android:icon="@drawable/ic_menu_star"/>
         <item android:id="@+id/show_stop_details"
               android:title="@string/stop_info_option_show_details"/>
+        <item android:id="@+id/add_stop_widget"
+                android:title="@string/stop_info_option_add_widget"/>
         <item android:id="@+id/report_stop_problem"
               android:title="@string/stop_info_option_report_problem"
               android:icon="@drawable/ic_menu_report_problem"/>

--- a/onebusaway-android/src/main/res/menu/arrivals_list.xml
+++ b/onebusaway-android/src/main/res/menu/arrivals_list.xml
@@ -43,6 +43,8 @@
               android:icon="@drawable/ic_menu_star"/>
         <item android:id="@+id/show_stop_details"
               android:title="@string/stop_info_option_show_details"/>
+        <item android:id="@+id/add_stop_widget"
+                android:title="@string/stop_info_option_add_widget"/>
         <item android:id="@+id/report_stop_problem"
               android:title="@string/stop_info_option_report_problem"
               android:icon="@drawable/ic_menu_report_problem"/>

--- a/onebusaway-android/src/main/res/values/attrs.xml
+++ b/onebusaway-android/src/main/res/values/attrs.xml
@@ -25,4 +25,9 @@
         <!-- Color of circle -->
         <attr name="lineColor" format="reference|color"/>
     </declare-styleable>
+    <declare-styleable name="AppWidgetAttrs">
+        <attr name="appWidgetPadding" format="dimension" />
+        <attr name="appWidgetInnerRadius" format="dimension" />
+        <attr name="appWidgetRadius" format="dimension" />
+    </declare-styleable>
 </resources>

--- a/onebusaway-android/src/main/res/values/colors.xml
+++ b/onebusaway-android/src/main/res/values/colors.xml
@@ -114,6 +114,17 @@
     <color name="trip_plan_card_background_selected">@color/md_theme_secondaryContainer</color>
     <color name="trip_plan_header_text_selected">@color/md_theme_onSecondaryContainer</color>
 
+    <!-- Widget -->
+    <color name="widget_background">@color/md_theme_surfaceContainer</color>
+    <color name="widget_header_text">@android:color/white</color>
+    <color name="widget_eta_text">@android:color/white</color>
+    <color name="widget_refresh_spinner">@color/theme_muted</color>
+    <color name="widget_refresh_icon">@color/theme_muted</color>
+    <color name="widget_route_name_text">@color/body_text_1</color>
+    <color name="widget_footer_text">@color/body_text_3</color>
+    <color name="widget_config_background">@color/md_theme_surfaceContainer</color>
+    <color name="widget_config_button_text">@android:color/white</color>
+
     <!-- Layers -->
     <color name="layer_disabled">#FF777777</color>
     <color name="layer_bikeshare_color">#3a4677</color>

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -241,6 +241,7 @@
     <string name="stop_info_option_addstar">Add star to stop</string>
     <string name="stop_info_option_show_details">Show stop details</string>
     <string name="stop_info_option_removestar">Remove star from stop</string>
+    <string name="stop_info_option_add_widget">Add widget for stop</string> <!-- TODO add translations -->
     <string name="stop_info_option_report_problem">Report stop problem</string>
     <string name="stop_info_option_night_light">Night light</string>
     <string name="stop_info_option_hide_alerts">Hide active alerts</string>
@@ -1220,6 +1221,28 @@
     <string name="transit_mode_rail">Rail only</string>
     <string name="transit_mode_bikeshare">Bikeshare only</string>
     <string name="transit_directions_bikeshare_label">Bikeshare</string>
+
+    <!-- Stop times widget -->
+    <!-- TODO add translations -->
+    <string name="widget_label">Stop Times</string>
+    <string name="widget_description">Real-time bus times for your favorite stop</string>
+    <string name="widget_config_add_stop_widget">Add stop widget</string>
+    <string name="widget_config_selected_stop">Selected stop</string>
+    <string name="widget_config_select_a_stop">Select a stop</string>
+    <string name="widget_config_widget_name">Widget name</string>
+    <string name="widget_config_selected_routes">Selected routes</string>
+    <string name="widget_config_chip_selection_instructions">Select 1–3 routes to display</string>
+    <string name="widget_config_loading_routes">Loading routes…</string>
+    <string name="widget_config_save_widget">Save widget</string>
+    <string name="widget_config_select_at_least_one_route">Select at least 1 route</string>
+    <string name="widget_config_select_no_more_than_three_routes">Select no more than 3 routes</string>
+    <string name="widget_config_add_manually">Please add the widget manually from the home screen</string>
+    <string name="widget_not_configured">Not configured</string>
+    <string name="widget_no_times">N/A</string>
+    <string name="widget_updated_just_now">Updated just now</string>
+    <string name="widget_updated_minutes_ago">Updated %d min. ago</string>
+    <string name="widget_preview_updated_at">Updated 2 min. ago</string>
+    <string name="widget_preview_route_name">D Line</string>
 
     <!-- Bikeshare info window -->
     <string name="bike_info_window_bikes_title">Bikes</string>

--- a/onebusaway-android/src/main/res/values/styles.xml
+++ b/onebusaway-android/src/main/res/values/styles.xml
@@ -269,4 +269,17 @@
     <style name="CustomText2" parent="TextAppearance.ShowcaseView.Detail.Light">
         <item name="android:textColor">@color/tutorial_text</item>
     </style>
+
+    <style name="Widget.Onebusawayandroid.AppWidget.Container" parent="android:Widget">
+        <item name="android:id">@android:id/background</item>
+        <item name="android:background">?android:attr/colorBackground</item>
+    </style>
+
+    <style name="WidgetConfigDialogTheme" parent="Theme.Material3.DayNight.Dialog">
+        <item name="colorPrimary">@color/theme_primary</item>
+        <item name="colorPrimaryVariant">@color/theme_primary_variant</item>
+        <item name="dialogCornerRadius">24dp</item>
+        <item name="android:windowMinWidthMajor">90%</item>
+        <item name="android:windowMinWidthMinor">90%</item>
+    </style>
 </resources>

--- a/onebusaway-android/src/main/res/values/themes.xml
+++ b/onebusaway-android/src/main/res/values/themes.xml
@@ -83,4 +83,13 @@
         <item name="android:textColor">@color/theme_primary</item>
     </style>
 
+    <style name="Theme.OneBusAway.AppWidgetContainerParent" parent="@android:style/Theme.DeviceDefault">
+        <item name="appWidgetRadius">16dp</item>
+        <item name="appWidgetInnerRadius">8dp</item>
+    </style>
+
+    <style name="Theme.OneBusAway.AppWidgetContainer" parent="Theme.OneBusAway.AppWidgetContainerParent">
+        <item name="appWidgetPadding">16dp</item>
+    </style>
+
 </resources>

--- a/onebusaway-android/src/main/res/xml-v31/stop_times_widget_info.xml
+++ b/onebusaway-android/src/main/res/xml-v31/stop_times_widget_info.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Copyright (C) 2025 Rob Godfrey (rob_godfrey@outlook.com)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+        android:minWidth="150dp"
+        android:minHeight="40dp"
+        android:updatePeriodMillis="0"
+        android:initialLayout="@layout/stop_times_widget"
+        android:description="@string/widget_description"
+        android:resizeMode="horizontal|vertical"
+        android:widgetCategory="home_screen"
+        android:previewLayout="@layout/stop_times_widget_preview"
+        android:targetCellHeight="1"
+        android:targetCellWidth="2"
+        android:maxResizeHeight="110dp"
+        android:configure="org.onebusaway.android.ui.widget.StopTimesWidgetConfigActivity"
+        android:widgetFeatures="reconfigurable" />

--- a/onebusaway-android/src/main/res/xml/stop_times_widget_info.xml
+++ b/onebusaway-android/src/main/res/xml/stop_times_widget_info.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Copyright (C) 2025 Rob Godfrey (rob_godfrey@outlook.com)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+        android:minWidth="150dp"
+        android:minHeight="40dp"
+        android:updatePeriodMillis="0"
+        android:initialLayout="@layout/stop_times_widget"
+        android:description="@string/widget_description"
+        android:resizeMode="horizontal|vertical"
+        android:widgetCategory="home_screen"
+        android:configure="org.onebusaway.android.ui.widget.StopTimesWidgetConfigActivity" />


### PR DESCRIPTION
Resolves #698 and #1075: Adds a home screen widget that shows arrival information. I've been wanting a widget with this functionality forever! 😁

### Design decisions open for discussion

* Widgets are per-stop, rather than like in the iOS version where there is one widget that displays the "today view"
* Widgets can display a maximum of three routes
* All selected routes will always be displayed on a widget - if there are no upcoming ETAs, the route will display `N/A` instead of a time
* ETAs older than -2 minutes are hidden so the widget won't be filled with buses that have already deparated
* ETAs refresh every five minutes via API call, or immediately when the user taps the refresh icon
* Relative time labels ("5 min" → "4 min") update every minute without additional API calls

### Notes

* Widgets have an adaptive layout that shows/hides ETA columns and rows as the widget is resized
* Tapping the widget opens the arrivals list for the configured stop
* I tested on two physical devices, one running Android 16 and one running Android 8

Android 8 relaunches the config screen after the widget is placed via `requestPinAppWidget`. I initially wanted to close this silently, but I couldn't find a reliable way to distinguish between the initial relaunch and a user-initiated edit (available Android 12+).  The current behavior on Android 8 shows the config screen pre-filled and the user taps Save or Back to dismiss it. 

### Main Files

`StopTimesWidget`: AppWidgetProvider managing widget lifecycle, alarm scheduling, and RemoteViews rendering
`WidgetArrivalWorker`: WorkManager worker that fetches arrivals from the OBA API
`StopTimesWidgetConfigActivity`: dialog configuration screen
`StopPickerActivity`: stop selection screen showing starred and recent stops from the local database
`WidgetPrefs`, `WidgetConfig`, `WidgetArrivalSnapshot`: persistence layer using SharedPreferences + Gson

### Screenshots

<img width="1317" height="958" alt="Screenshot 2026-03-19 at 10 25 25 PM" src="https://github.com/user-attachments/assets/e8cd0efe-dc8e-4e12-a544-7e9fedc23455" />

### Videos (too big to attach here and I don't feel like editing them, so they're in a CloudFlare bucket):

* Android 16, dark mode, create widgets https://birdseedbob.com/recording-1.mp4
* Android 16, light mode, edit a widget https://birdseedbob.com/recording-2.mp4
* Android 8, light mode, create widgets https://birdseedbob.com/recording-3.mp4

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `gradlew connectedObaGoogleDebugAndroidTest` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them for the initial submission of the pull request.  When addressing comments on a pull request, please push a new commit per comment when possible (reviewers will squash and merge using GitHub merge tool)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New "Stop Times" home-screen widget with live ETA badges, relative-time ticks, automatic refresh, loading/empty states, resize support and preview
  * In-app configuration flow: pick a stop, choose 1–3 routes, name the widget, pin or edit instances
  * Adds "Add widget" action to stop screens to start the configuration flow
  * New widget visuals, styles and icons for themed badges and previews

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OneBusAway/onebusaway-android/pull/1538)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->