### PR TITLE
Fix #1539: Change ObaStudyRequest.Builder.mUri to an instance field

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/io/request/survey/ObaStudyRequest.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/io/request/survey/ObaStudyRequest.java
@@ -25,18 +25,18 @@ public final class ObaStudyRequest extends RequestBase implements Callable<Study
 
     public static class Builder {
 
-        private static Uri URI = null;
+        private Uri mUri = null;
 
         public Builder(Context context) {
             String baseUrl = Application.get().getCurrentRegion().getSidecarBaseUrl();
             if(baseUrl == null) return;
             String studyAPIURL = baseUrl + Application.get().getResources().getString(R.string.studies_api_endpoint);
             studyAPIURL = studyAPIURL.replace("regionID", String.valueOf(Application.get().getCurrentRegion().getId()));
-            URI = Uri.parse(studyAPIURL).buildUpon().appendQueryParameter("user_id", SurveyPreferences.getUserUUID(context)).build();
+            mUri = Uri.parse(studyAPIURL).buildUpon().appendQueryParameter("user_id", SurveyPreferences.getUserUUID(context)).build();
         }
 
         public ObaStudyRequest build() {
-            return new ObaStudyRequest(URI);
+            return new ObaStudyRequest(mUri);
         }
     }
 


### PR DESCRIPTION
This PR fixes a bug where the `URI` field in `ObaStudyRequest.Builder` was declared as `static`. 

Because it was static, the URI was shared across all Builder instances. This could cause a "stale data" issue where a new request might accidentally reuse the URI from a previous successful call if a subsequent initialization failed.
I've changed this to an instance field `mUri` as suggested in the description of the #1539  issue to ensure each Builder maintains its own state.