### PR TITLE
Fix #1537 (Item 4): Add accessibility support for arrival badges

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/StarredStopsAdapter.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/StarredStopsAdapter.java
@@ -142,6 +142,16 @@ class StarredStopsAdapter extends SimpleCursorAdapter {
             }
             badge.setText(context.getString(R.string.starred_stop_arrival_badge,
                     routeName, etaText));
+            String contentDesc;
+            if (eta <= 0) {
+                contentDesc = context.getString(
+                        R.string.arrival_badge_content_description_now, routeName);
+            } else {
+                contentDesc = context.getString(
+                        R.string.arrival_badge_content_description_min, routeName, (int) eta);
+            }
+            badge.setContentDescription(contentDesc);
+            badge.setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_YES);
 
             badge.setTextSize(BADGE_TEXT_SIZE_SP);
             badge.setTextColor(ContextCompat.getColor(context, android.R.color.white));

--- a/onebusaway-android/src/main/res/layout/starred_stop_list_item.xml
+++ b/onebusaway-android/src/main/res/layout/starred_stop_list_item.xml
@@ -65,7 +65,8 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="4dp"
                 android:scrollbars="none"
-                android:visibility="gone">
+                android:visibility="gone"
+                android:importantForAccessibility="no">
             <LinearLayout
                     android:id="@+id/arrivals_container"
                     android:layout_width="wrap_content"

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -371,6 +371,8 @@
     </string>
     <string name="starred_stop_arrival_now">NOW</string>
     <string name="starred_stop_arrival_min">%1$d min</string>
+    <string name="arrival_badge_content_description_now">Route %1$s, arriving now</string>
+    <string name="arrival_badge_content_description_min">Route %1$s, arriving in %2$d minutes</string>
     <string name="starred_stop_arrival_badge">%1$s - %2$s</string>
     <string name="my_no_starred_routes">You have no starred routes.\n\nYou can add a star to a route
         on the arrivals screen by tapping on the star next to the route number.


### PR DESCRIPTION
I've implemented the accessibility issues for arrival badges (Item 4 of #1537).

Instead of TalkBack just reading out the tiny badge text, I updated the StarredStopsAdapter to generate a full sentence description—something like "Route 10, arriving in 5 minutes." I also silenced the HorizontalScrollView container so the screen reader doesn't get stuck on it, making it much smoother to swipe through the actual arrival times.

Tested with TalkBack on a physical device — before the fix it read  "list", after the fix it correctly announces each badge.