### PR TITLE
Convert MathUtils from Java to Kotlin

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/MathUtils.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/MathUtils.kt
@@ -13,29 +13,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.onebusaway.android.util;
+package org.onebusaway.android.util
 
 /**
  * A utility class containing arithmetic and geometry helper methods.
  *
  * (from Glass Compass sample - https://github.com/googleglass/gdk-compass-sample/)
  */
-public class MathUtils {
+object MathUtils {
 
     /** The number of half winds for boxing the compass. */
-    private static final int NUMBER_OF_HALF_WINDS = 16;
+    private const val NUMBER_OF_HALF_WINDS = 16
 
     /**
-     * Calculates {@code a mod b} in a way that respects negative values (for example,
-     * {@code mod(-1, 5) == 4}, rather than {@code -1}).
+     * Calculates `a mod b` in a way that respects negative values (for example,
+     * `mod(-1, 5) == 4`, rather than `-1`).
      *
      * @param a the dividend
      * @param b the divisor
-     * @return {@code a mod b}
+     * @return `a mod b`
      */
-    public static float mod(float a, float b) {
-        return (a % b + b) % b;
-    }
+    @JvmStatic
+    fun mod(a: Float, b: Float): Float = (a % b + b) % b
 
     /**
      * Converts the specified heading angle into an index between 0-15 that can be used to retrieve
@@ -45,39 +44,38 @@ public class MathUtils {
      * @param heading the heading angle
      * @return the index of the direction name for the angle
      */
-    public static int getHalfWindIndex(float heading) {
-        return getHalfWindIndex(heading, NUMBER_OF_HALF_WINDS);
-    }
+    @JvmStatic
+    fun getHalfWindIndex(heading: Float): Int = getHalfWindIndex(heading, NUMBER_OF_HALF_WINDS)
 
     /**
-     * Converts the specified heading angle into an index between 0 and numHalfWinds-1 that can be used to retrieve
-     * the direction name for that heading (known as "boxing the compass", down to the half-wind
-     * level).
+     * Converts the specified heading angle into an index between 0 and numHalfWinds-1 that can be
+     * used to retrieve the direction name for that heading (known as "boxing the compass", down to
+     * the half-wind level).
      *
      * @param heading the heading angle
      * @param numHalfWinds number of half winds to divide the compass into
      * @return the index of the direction name for the angle
      */
-    public static int getHalfWindIndex(float heading, int numHalfWinds) {
-        float partitionSize = 360.0f / numHalfWinds;
-        float displacedHeading = MathUtils.mod(heading + partitionSize / 2, 360.0f);
-        return (int) (displacedHeading / partitionSize);
+    @JvmStatic
+    fun getHalfWindIndex(heading: Float, numHalfWinds: Int): Int {
+        val partitionSize = 360.0f / numHalfWinds
+        val displacedHeading = mod(heading + partitionSize / 2, 360.0f)
+        return (displacedHeading / partitionSize).toInt()
     }
 
     /**
      * Converts from OBA orientation to direction.
      *
-     * From OBA REST API docs for trip status (http://developer.onebusaway.org/modules/onebusaway-application-modules/current/api/where/elements/trip-status.html)
+     * From OBA REST API docs for trip status
+     * (http://developer.onebusaway.org/modules/onebusaway-application-modules/current/api/where/elements/trip-status.html)
      * : "orientation - ...0º is east, 90º is north, 180º is west, and 270º is south."
      *
      * @param orientation 0º is east, 90º is north, 180º is west, and 270º is south
      * @return direction, where 0º is north, 90º is east, 180º is south, and 270º is west
      */
-    public static double toDirection(double orientation) {
-        double direction = (-orientation + 90) % 360;
-        if (direction < 0) {
-            direction += 360;
-        }
-        return direction;
+    @JvmStatic
+    fun toDirection(orientation: Double): Double {
+        val direction = (-orientation + 90) % 360
+        return if (direction < 0) direction + 360 else direction
     }
 }


### PR DESCRIPTION
Part of the ongoing Java → Kotlin modernization effort. `MathUtils` is a pure arithmetic/geometry utility class with no Android dependencies, making it a clean, low-risk starting point for the migration.

Changes:
- Replaced `public class` with `object` (Kotlin singleton pattern)
- `private static final int` → `const val`
- `toDirection()` negative-check simplified to an `if` expression
- Added `@JvmStatic` on all methods to preserve existing Java call sites (`VehicleOverlay.java`, `ArrowView.java`, `OrientationHelper.java`) without modification

Related issues: N/A

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.
- [x] Run the unit tests with `gradlew connectedObaGoogleDebugAndroidTest` to make sure you didn't break anything
