### PR TITLE
Fix realtime indicator animation not restarting on view recycling

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/view/RealtimeIndicatorView.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/view/RealtimeIndicatorView.java
@@ -96,6 +96,16 @@ public class RealtimeIndicatorView extends View {
         ensureInit();
     }
 
+    @Override
+    protected void onVisibilityChanged(View changedView, int visibility) {
+        super.onVisibilityChanged(changedView, visibility);
+        if (visibility == VISIBLE) {
+            initAnimation();
+        } else {
+            clearAnimation();
+        }
+    }
+
     private void setOnMeasureCallback() {
         getViewTreeObserver().addOnGlobalLayoutListener(
                 new ViewTreeObserver.OnGlobalLayoutListener() {
@@ -136,6 +146,9 @@ public class RealtimeIndicatorView extends View {
      * Setup the animation
      */
     private synchronized void initAnimation() {
+        // Cancel any existing animation before starting a new one
+        clearAnimation();
+
         // Animate circle expand/contract
         mAnimation1 = new Animation() {
             @Override


### PR DESCRIPTION
## Summary
Restart animation when view becomes visible again after being recycled by the list adapter. Clear old animations before starting new ones to prevent stacking.

Fixes #818

## Changes
- Override `onVisibilityChanged()` in `RealtimeIndicatorView` to restart animation when view becomes `VISIBLE` and stop it when hidden
- Call `clearAnimation()` at the start of `initAnimation()` to prevent animation stacking on recycled views

## Test plan
- [ ] Open a stop with many arrivals (transit center)
- [ ] Scroll down until initial arrivals go offscreen
- [ ] Scroll back up – indicators should still animate
- [ ] Indicator colors should match "min" text color

---

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.
- [x] Run the unit tests with `gradlew connectedObaGoogleDebugAndroidTest` to make sure you didn't break anything
- [x] If you have multiple commits please combine them into one commit by squashing them for the initial submission of the pull request.