### PR TITLE
Fix #1537: Starred stops follow-up : layout dedup, error state, parallel requests 

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/StarredStopsAdapter.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/StarredStopsAdapter.java
@@ -19,8 +19,8 @@ import android.content.Context;
 import android.database.Cursor;
 import android.graphics.drawable.GradientDrawable;
 import android.view.View;
-import android.widget.ImageView;
 import android.widget.HorizontalScrollView;
+import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.ProgressBar;
 import android.widget.TextView;
@@ -37,6 +37,8 @@ import androidx.cursoradapter.widget.SimpleCursorAdapter;
 
 /**
  * Adapter for starred stops list that displays arrival badges inline.
+ * A null value in the arrivals map indicates a fetch error for that stop,
+ * while an empty list means no upcoming arrivals.
  */
 class StarredStopsAdapter extends SimpleCursorAdapter {
 
@@ -104,22 +106,42 @@ class StarredStopsAdapter extends SimpleCursorAdapter {
         HorizontalScrollView arrivalsScroll = view.findViewById(R.id.arrivals_scroll);
         LinearLayout arrivalsContainer = view.findViewById(R.id.arrivals_container);
         ProgressBar arrivalsLoading = view.findViewById(R.id.arrivals_loading);
+        TextView arrivalsError = view.findViewById(R.id.arrivals_error);
 
         if (mArrivalsData == null) {
             // Still loading
             arrivalsScroll.setVisibility(View.GONE);
+            arrivalsError.setVisibility(View.GONE);
             arrivalsLoading.setVisibility(View.VISIBLE);
             return;
         }
 
         arrivalsLoading.setVisibility(View.GONE);
-        ArrayList<ArrivalInfo> arrivals = mArrivalsData.get(stopId);
 
-        if (arrivals == null || arrivals.isEmpty()) {
+        if (!mArrivalsData.containsKey(stopId)) {
             arrivalsScroll.setVisibility(View.GONE);
+            arrivalsError.setVisibility(View.GONE);
             return;
         }
 
+        ArrayList<ArrivalInfo> arrivals = mArrivalsData.get(stopId);
+
+        // Null value means fetch error
+        if (arrivals == null) {
+            arrivalsScroll.setVisibility(View.GONE);
+            arrivalsError.setVisibility(View.VISIBLE);
+            arrivalsError.setText(R.string.starred_stop_arrivals_error);
+            return;
+        }
+
+        // Empty list means no upcoming arrivals
+        if (arrivals.isEmpty()) {
+            arrivalsScroll.setVisibility(View.GONE);
+            arrivalsError.setVisibility(View.GONE);
+            return;
+        }
+
+        arrivalsError.setVisibility(View.GONE);
         arrivalsScroll.setVisibility(View.VISIBLE);
         arrivalsContainer.removeAllViews();
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/StarredStopsArrivalsLoader.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/StarredStopsArrivalsLoader.java
@@ -26,11 +26,18 @@ import org.onebusaway.android.util.ArrivalInfoUtils;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 import androidx.loader.content.AsyncTaskLoader;
 
 /**
- * Loader that fetches arrival info for multiple starred stops in the background.
+ * Loader that fetches arrival info for multiple starred stops in parallel.
+ * Uses a null value in the result map to indicate a fetch error for a stop,
+ * distinguishing it from an empty list (no upcoming arrivals).
  */
 public class StarredStopsArrivalsLoader
         extends AsyncTaskLoader<HashMap<String, ArrayList<ArrivalInfo>>> {
@@ -40,6 +47,8 @@ public class StarredStopsArrivalsLoader
     private static final int MINUTES_AFTER = 35;
 
     private static final int MAX_ARRIVALS_PER_STOP = 3;
+
+    private static final int THREAD_POOL_SIZE = 3;
 
     private final String[] mStopIds;
 
@@ -55,32 +64,29 @@ public class StarredStopsArrivalsLoader
         HashMap<String, ArrayList<ArrivalInfo>> result = new HashMap<>();
         long now = System.currentTimeMillis();
 
-        for (String stopId : mStopIds) {
-            ArrayList<ArrivalInfo> arrivals = new ArrayList<>();
-            try {
-                ObaArrivalInfoResponse response =
-                        ObaArrivalInfoRequest.newRequest(getContext(), stopId, MINUTES_AFTER)
-                                .call();
-                if (response != null && response.getCode() == ObaApi.OBA_OK
-                        && response.getArrivalInfo() != null) {
-                    arrivals = ArrivalInfoUtils.convertObaArrivalInfo(
-                            getContext(), response.getArrivalInfo(), null, now, false);
-                    Collections.sort(arrivals, new ArrivalInfoUtils.InfoComparator());
-                    if (arrivals.size() > MAX_ARRIVALS_PER_STOP) {
-                        arrivals = new ArrayList<>(
-                                arrivals.subList(0, MAX_ARRIVALS_PER_STOP));
-                    }
-                } else if (response != null) {
-                    Log.w(TAG, "API error for stop " + stopId
-                            + ": code=" + response.getCode());
-                } else {
-                    Log.w(TAG, "Null response for stop " + stopId);
-                }
-            } catch (Exception e) {
-                Log.w(TAG, "Failed to fetch arrivals for stop " + stopId, e);
-            }
-            result.put(stopId, arrivals);
+        if (mStopIds.length == 0) {
+            return result;
         }
+
+        ExecutorService executor = Executors.newFixedThreadPool(
+                Math.min(THREAD_POOL_SIZE, mStopIds.length));
+        List<Future<StopArrivalsResult>> futures = new ArrayList<>();
+
+        for (String stopId : mStopIds) {
+            futures.add(executor.submit(new FetchArrivalsTask(getContext(), stopId, now)));
+        }
+
+        for (int i = 0; i < mStopIds.length; i++) {
+            try {
+                StopArrivalsResult stopResult = futures.get(i).get();
+                result.put(stopResult.stopId, stopResult.arrivals);
+            } catch (Exception e) {
+                Log.w(TAG, "Failed to get result for stop " + mStopIds[i], e);
+                result.put(mStopIds[i], null);
+            }
+        }
+
+        executor.shutdown();
         return result;
     }
 
@@ -112,5 +118,63 @@ public class StarredStopsArrivalsLoader
         super.onReset();
         onStopLoading();
         mResult = null;
+    }
+
+    private static class StopArrivalsResult {
+
+        final String stopId;
+
+        final ArrayList<ArrivalInfo> arrivals;
+
+        StopArrivalsResult(String stopId, ArrayList<ArrivalInfo> arrivals) {
+            this.stopId = stopId;
+            this.arrivals = arrivals;
+        }
+    }
+
+    private static class FetchArrivalsTask implements Callable<StopArrivalsResult> {
+
+        private final Context mContext;
+
+        private final String mStopId;
+
+        private final long mNow;
+
+        FetchArrivalsTask(Context context, String stopId, long now) {
+            mContext = context;
+            mStopId = stopId;
+            mNow = now;
+        }
+
+        @Override
+        public StopArrivalsResult call() {
+            ArrayList<ArrivalInfo> arrivals = new ArrayList<>();
+            try {
+                ObaArrivalInfoResponse response =
+                        ObaArrivalInfoRequest.newRequest(mContext, mStopId, MINUTES_AFTER)
+                                .call();
+                if (response != null && response.getCode() == ObaApi.OBA_OK
+                        && response.getArrivalInfo() != null) {
+                    arrivals = ArrivalInfoUtils.convertObaArrivalInfo(
+                            mContext, response.getArrivalInfo(), null, mNow, false);
+                    Collections.sort(arrivals, new ArrivalInfoUtils.InfoComparator());
+                    if (arrivals.size() > MAX_ARRIVALS_PER_STOP) {
+                        arrivals = new ArrayList<>(
+                                arrivals.subList(0, MAX_ARRIVALS_PER_STOP));
+                    }
+                } else if (response != null) {
+                    Log.w(TAG, "API error for stop " + mStopId
+                            + ": code=" + response.getCode());
+                    return new StopArrivalsResult(mStopId, null);
+                } else {
+                    Log.w(TAG, "Null response for stop " + mStopId);
+                    return new StopArrivalsResult(mStopId, null);
+                }
+            } catch (Exception e) {
+                Log.w(TAG, "Failed to fetch arrivals for stop " + mStopId, e);
+                return new StopArrivalsResult(mStopId, null);
+            }
+            return new StopArrivalsResult(mStopId, arrivals);
+        }
     }
 }

--- a/onebusaway-android/src/main/res/layout/starred_stop_list_item.xml
+++ b/onebusaway-android/src/main/res/layout/starred_stop_list_item.xml
@@ -15,70 +15,44 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                style="@style/ListItem"
-                android:id="@+id/stop_list_container"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              android:layout_width="fill_parent"
+              android:layout_height="wrap_content"
+              android:orientation="vertical">
+
+    <include layout="@layout/stop_list_item"/>
+
+    <HorizontalScrollView
+            android:id="@+id/arrivals_scroll"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="@dimen/keyline_2"
+            android:layout_marginBottom="8dp"
+            android:scrollbars="none"
+            android:visibility="gone">
+        <LinearLayout
+                android:id="@+id/arrivals_container"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_width="fill_parent"
-                android:minHeight="77dp"
-                android:orientation="horizontal">
-    <ImageView
-            android:id="@+id/stop_favorite"
-            android:src="@drawable/ic_toggle_star"
-            android:contentDescription="@string/stop_info_favorite"
+                android:orientation="horizontal"/>
+    </HorizontalScrollView>
+
+    <ProgressBar
+            android:id="@+id/arrivals_loading"
+            style="?android:attr/progressBarStyleSmall"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:scaleType="fitCenter"
-            android:adjustViewBounds="true"
-            android:maxHeight="25dp"
-            android:maxWidth="25dp"
-            android:layout_marginLeft="5dp"
-            android:layout_centerVertical="true"
-            android:layout_alignParentLeft="true"
+            android:layout_marginLeft="@dimen/keyline_2"
+            android:layout_marginBottom="8dp"
             android:visibility="gone"/>
 
-    <LinearLayout
-            style="@style/ListItem"
-            android:layout_marginLeft="@dimen/keyline_2"
-            android:layout_alignParentLeft="true"
-            android:layout_centerVertical="true"
-            android:layout_width="fill_parent"
+    <TextView
+            android:id="@+id/arrivals_error"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:orientation="vertical">
-        <TextView
-                android:id="@+id/stop_name"
-                style="@style/Line1Text"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_vertical"
-                android:ellipsize="end"
-                android:maxLines="1"/>
-        <TextView
-                android:id="@+id/direction"
-                style="@style/Line2Text"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"/>
-
-        <HorizontalScrollView
-                android:id="@+id/arrivals_scroll"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="4dp"
-                android:scrollbars="none"
-                android:visibility="gone">
-            <LinearLayout
-                    android:id="@+id/arrivals_container"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:orientation="horizontal"/>
-        </HorizontalScrollView>
-
-        <ProgressBar
-                android:id="@+id/arrivals_loading"
-                style="?android:attr/progressBarStyleSmall"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="4dp"
-                android:visibility="gone"/>
-    </LinearLayout>
-</RelativeLayout>
+            android:layout_marginLeft="@dimen/keyline_2"
+            android:layout_marginBottom="8dp"
+            android:textSize="11sp"
+            android:textColor="?android:attr/textColorSecondary"
+            android:visibility="gone"/>
+</LinearLayout>

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -372,6 +372,7 @@
     <string name="starred_stop_arrival_now">NOW</string>
     <string name="starred_stop_arrival_min">%1$d min</string>
     <string name="starred_stop_arrival_badge">%1$s - %2$s</string>
+    <string name="starred_stop_arrivals_error">Could not load arrivals</string>
     <string name="my_no_starred_routes">You have no starred routes.\n\nYou can add a star to a route
         on the arrivals screen by tapping on the star next to the route number.
     </string>


### PR DESCRIPTION


Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [X] Run the unit tests with `gradlew connectedObaGoogleDebugAndroidTest` to make sure you didn't break anything

**Addresses items  from #1537 (follow-up to #1520).**                                                                                                                                                    
                                                                                                                                                                                                          
  - **Layout dedup**: Use `<include layout="@layout/stop_list_item" />` instead of duplicating the layout                                                                                                 
  - **Error state**: Show "Could not load arrivals" when API fails, distinguishing from "no buses scheduled"                                                                                              
  - **Parallel requests**: `ExecutorService` (3 threads) replaces serial per-stop API calls  

 addresses #1537 (items 1 to 3). Item 4 (accessibility) covered by #1544.