### PR TITLE
Fix starred stops list items not clickable

### DIFF
--- a/onebusaway-android/src/main/res/layout/starred_stop_list_item.xml
+++ b/onebusaway-android/src/main/res/layout/starred_stop_list_item.xml
@@ -21,7 +21,8 @@
                 android:layout_height="wrap_content"
                 android:layout_width="fill_parent"
                 android:minHeight="77dp"
-                android:orientation="horizontal">
+                android:orientation="horizontal"
+                android:descendantFocusability="blocksDescendants">
     <ImageView
             android:id="@+id/stop_favorite"
             android:src="@drawable/ic_toggle_star"


### PR DESCRIPTION
# Description

Fixes a regression introduced by #1520 (inline arrival badges) where tapping any starred stop in the list did nothing.

`AbsListView.onTouchEvent()` checks `child.hasFocusable()` on each list item during `ACTION_DOWN`. If any descendant is focusable, it sets `TOUCH_MODE_REST` and bypasses click detection entirely. The HorizontalScrollView added for the arrival badges is focusable by default (its constructor calls `setFocusableInTouchMode(true)`), which caused `hasFocusable()` to return true for every item in the list, silently breaking all row taps.

The fix was to added `android:descendantFocusability="blocksDescendants"` to the root RelativeLayout in starred_stop_list_item.xml. This makes `hasFocusable()` return false for the list item view, restoring normal click detection in ListView.

# Testing

* Tapping a starred stop opens the arrivals list
* Long-pressig a starred stop shows the context menu
* Confirmed arrival badges still display and scroll horizontally when there are multiple arrivals

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `gradlew connectedObaGoogleDebugAndroidTest` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them for the initial submission of the pull request.  When addressing comments on a pull request, please push a new commit per comment when possible (reviewers will squash and merge using GitHub merge tool)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved focus handling for starred stops list items to enhance the responsiveness and reliability of user interactions when selecting items from the list.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OneBusAway/onebusaway-android/pull/1560)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->