### PR TITLE
Fix arrivals onBackPressed() on Android 13+

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.java
@@ -115,6 +115,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
@@ -404,6 +405,30 @@ public class HomeActivity extends AppCompatActivity
         setupNavigationDrawer();
 
         setupSlidingPanel();
+
+        getOnBackPressedDispatcher().addCallback(this, new OnBackPressedCallback(true) {
+            @Override
+            public void handleOnBackPressed() {
+                // Collapse the panel when the user presses the back button
+                if (mSlidingPanel != null) {
+                    // Collapse the sliding panel if its anchored or expanded
+                    if (mSlidingPanel.getPanelState() == PanelState.EXPANDED
+                            || mSlidingPanel.getPanelState() == PanelState.ANCHORED) {
+                        mSlidingPanel.setPanelState(PanelState.COLLAPSED);
+                        return;
+                    }
+                    // Clear focused stop and close the sliding panel if its collapsed
+                    if (mSlidingPanel.getPanelState() == PanelState.COLLAPSED) {
+                        // Clear the stop focus in map fragment, which will trigger a callback to
+                        // close the panel via ObaMapFragment.OnFocusChangedListener in onFocusChanged()
+                        mMapFragment.setFocusStop(null, null);
+                        return;
+                    }
+                }
+                setEnabled(false);
+                getOnBackPressedDispatcher().onBackPressed();
+            }
+        });
 
         setupMapState(savedInstanceState);
 
@@ -1307,27 +1332,6 @@ public class HomeActivity extends AppCompatActivity
                 mSlidingPanel.setPanelState(PanelState.ANCHORED);
             }
         }
-    }
-
-    @Override
-    public void onBackPressed() {
-        // Collapse the panel when the user presses the back button
-        if (mSlidingPanel != null) {
-            // Collapse the sliding panel if its anchored or expanded
-            if (mSlidingPanel.getPanelState() == PanelState.EXPANDED
-                    || mSlidingPanel.getPanelState() == PanelState.ANCHORED) {
-                mSlidingPanel.setPanelState(PanelState.COLLAPSED);
-                return;
-            }
-            // Clear focused stop and close the sliding panel if its collapsed
-            if (mSlidingPanel.getPanelState() == PanelState.COLLAPSED) {
-                // Clear the stop focus in map fragment, which will trigger a callback to close the
-                // panel via ObaMapFragment.OnFocusChangedListener in this.onFocusChanged()
-                mMapFragment.setFocusStop(null, null);
-                return;
-            }
-        }
-        super.onBackPressed();
     }
 
     /**


### PR DESCRIPTION
## Problem

Pressing back while viewing a stop's arrivals exited the app instead of dismissing the panel and returning to the map.

## Root cause
  
HomeActivity overrode `onBackPressed()` to handle panel dismissal, but this override was silently bypassed on Android 13+ (API 33+). Modern Android routes back presses through `WindowOnBackInvokedDispatcher` → `AndroidX` `OnBackPressedDispatcher`, whose fallback calls `ComponentActivity.super.onBackPressed()` directly — skipping subclass overrides entirely. The app has used `androidx.activity:activity-ktx:1.9.3` for about 2 years, which made this the behavior on all currently-supported devices.

## Fix

Migrate the back press logic from `onBackPressed()` into an `OnBackPressedCallback` registered with `getOnBackPressedDispatcher()` in `onCreate()`. This is the API that both the AndroidX dispatcher and the OS-level `OnBackInvokedDispatcher` actually invoke, and it works correctly on all API levels (not just 13+).

## Behavior

  - Panel expanded/anchored → collapse to header
  - Panel collapsed → dismiss arrivals, return to map
  - No panel showing → exit as before

Before:


https://github.com/user-attachments/assets/4cb8f538-efec-42cf-ac91-551fd7a573f5

After:


https://github.com/user-attachments/assets/9b857614-7b02-49b7-a413-8730c2ea781f



- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `gradlew connectedObaGoogleDebugAndroidTest` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them for the initial submission of the pull request.  When addressing comments on a pull request, please push a new commit per comment when possible (reviewers will squash and merge using GitHub merge tool)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated back button navigation handling to use modern Android framework patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OneBusAway/onebusaway-android/pull/1563?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->