### PR TITLE
Fix #1564 - Launcher shortcuts crash and ignore destination

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/MySearchFragmentOnCreateViewTest.java
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/MySearchFragmentOnCreateViewTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2026 OneBusAway
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui;
+
+import android.app.Instrumentation;
+import android.content.Context;
+import android.view.ContextThemeWrapper;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.FrameLayout;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.onebusaway.android.R;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import androidx.test.InstrumentationRegistry;
+import androidx.test.runner.AndroidJUnit4;
+
+import static junit.framework.Assert.assertNotNull;
+
+/**
+ * Regression test for issue #1564 — launcher shortcuts crash because
+ * {@link MySearchStopsFragment} and {@link MySearchRoutesFragment} returned a
+ * null view when their container was null. ViewPager2's FragmentStateAdapter
+ * always passes a null container, so any tabbed activity hosting these
+ * fragments crashed with "Content view not yet created" when the fragment's
+ * lifecycle advanced.
+ */
+@RunWith(AndroidJUnit4.class)
+public class MySearchFragmentOnCreateViewTest {
+
+    private Instrumentation mInstrumentation;
+
+    private LayoutInflater mInflater;
+
+    @Before
+    public void setUp() {
+        mInstrumentation = InstrumentationRegistry.getInstrumentation();
+        Context target = mInstrumentation.getTargetContext();
+        Context themed = new ContextThemeWrapper(target, R.style.Theme_OneBusAway_NoActionBar);
+        mInflater = LayoutInflater.from(themed);
+    }
+
+    @Test
+    public void mySearchStopsFragment_onCreateView_returnsViewWhenContainerNull() {
+        View view = inflateOnMainThread(MySearchStopsFragment.class, null);
+        assertNotNull(
+                "MySearchStopsFragment must inflate a view when ViewPager2 passes a null container",
+                view);
+    }
+
+    @Test
+    public void mySearchRoutesFragment_onCreateView_returnsViewWhenContainerNull() {
+        View view = inflateOnMainThread(MySearchRoutesFragment.class, null);
+        assertNotNull(
+                "MySearchRoutesFragment must inflate a view when ViewPager2 passes a null container",
+                view);
+    }
+
+    @Test
+    public void mySearchStopsFragment_onCreateView_returnsViewWhenContainerNonNull() {
+        View view = inflateOnMainThread(MySearchStopsFragment.class, newContainer());
+        assertNotNull(
+                "MySearchStopsFragment must inflate a view when hosted by a FragmentContainerView",
+                view);
+    }
+
+    @Test
+    public void mySearchRoutesFragment_onCreateView_returnsViewWhenContainerNonNull() {
+        View view = inflateOnMainThread(MySearchRoutesFragment.class, newContainer());
+        assertNotNull(
+                "MySearchRoutesFragment must inflate a view when hosted by a FragmentContainerView",
+                view);
+    }
+
+    private ViewGroup newContainer() {
+        final AtomicReference<ViewGroup> ref = new AtomicReference<>();
+        mInstrumentation.runOnMainSync(() -> ref.set(new FrameLayout(mInflater.getContext())));
+        return ref.get();
+    }
+
+    /**
+     * Construct the fragment and call {@code onCreateView} on the main thread. Both steps need a
+     * Looper — the fragments extend {@link ListFragment}, which instantiates a {@link
+     * android.os.Handler} in its constructor.
+     */
+    private <T extends MySearchFragmentBase> View inflateOnMainThread(final Class<T> fragmentClass,
+            final ViewGroup container) {
+        final AtomicReference<View> result = new AtomicReference<>();
+        final AtomicReference<Throwable> error = new AtomicReference<>();
+        mInstrumentation.runOnMainSync(() -> {
+            try {
+                T fragment = fragmentClass.getDeclaredConstructor().newInstance();
+                result.set(fragment.onCreateView(mInflater, container, null));
+            } catch (Throwable t) {
+                error.set(t);
+            }
+        });
+        if (error.get() != null) {
+            throw new AssertionError(error.get());
+        }
+        return result.get();
+    }
+}

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/util/test/ShortcutIntentFlagsTest.java
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/util/test/ShortcutIntentFlagsTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2026 OneBusAway
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.util.test;
+
+import android.app.Instrumentation;
+import android.content.Context;
+import android.content.Intent;
+import android.view.ContextThemeWrapper;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.onebusaway.android.R;
+import org.onebusaway.android.ui.HomeActivity;
+import org.onebusaway.android.util.UIUtils;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import androidx.core.content.pm.ShortcutInfoCompat;
+import androidx.test.InstrumentationRegistry;
+import androidx.test.runner.AndroidJUnit4;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertTrue;
+
+/**
+ * Regression test for issue #1564 — when the app is already running in the background, tapping a
+ * launcher shortcut brought the app's last state to the foreground instead of the shortcut's
+ * destination. The documented pattern for launcher shortcuts is {@link
+ * Intent#FLAG_ACTIVITY_NEW_TASK} combined with {@link Intent#FLAG_ACTIVITY_CLEAR_TASK} so that
+ * tapping a shortcut always opens a fresh task rooted at the target activity.
+ */
+@RunWith(AndroidJUnit4.class)
+public class ShortcutIntentFlagsTest {
+
+    @Test
+    public void makeShortcutInfo_setsNewTaskAndClearTaskFlags() {
+        Instrumentation instr = InstrumentationRegistry.getInstrumentation();
+        final Context themed = new ContextThemeWrapper(instr.getTargetContext(),
+                R.style.Theme_OneBusAway_NoActionBar);
+
+        Intent destIntent = new Intent(themed, HomeActivity.class);
+        final AtomicReference<ShortcutInfoCompat> shortcutRef = new AtomicReference<>();
+
+        instr.runOnMainSync(() -> shortcutRef.set(
+                UIUtils.makeShortcutInfo(themed, "test", destIntent, R.drawable.ic_drawer_star)));
+
+        Intent shortcutIntent = shortcutRef.get().getIntent();
+        int flags = shortcutIntent.getFlags();
+        assertTrue("Shortcut intent must set FLAG_ACTIVITY_NEW_TASK so that the launcher opens it"
+                + " in a fresh task",
+                (flags & Intent.FLAG_ACTIVITY_NEW_TASK) != 0);
+        assertTrue("Shortcut intent must set FLAG_ACTIVITY_CLEAR_TASK so that tapping the shortcut"
+                + " replaces the app's existing back stack with the shortcut destination",
+                (flags & Intent.FLAG_ACTIVITY_CLEAR_TASK) != 0);
+        assertEquals("ShortcutInfoCompat requires the intent action to be set; without ACTION_VIEW"
+                + " requestPinShortcut throws IllegalArgumentException",
+                Intent.ACTION_VIEW, shortcutIntent.getAction());
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/MySearchRoutesFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/MySearchRoutesFragment.java
@@ -70,12 +70,7 @@ public class MySearchRoutesFragment extends MySearchFragmentBase
     public View onCreateView(LayoutInflater inflater,
             ViewGroup root,
             Bundle savedInstanceState) {
-        if (root == null) {
-            // Currently in a layout without a container, so no
-            // reason to create our view.
-            return null;
-        }
-        return inflater.inflate(R.layout.my_search_route_list, null);
+        return inflater.inflate(R.layout.my_search_route_list, root, false);
     }
 
     @Override

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/MySearchStopsFragment.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/MySearchStopsFragment.java
@@ -70,12 +70,7 @@ public class MySearchStopsFragment extends MySearchFragmentBase
     public View onCreateView(LayoutInflater inflater,
             ViewGroup root,
             Bundle savedInstanceState) {
-        if (root == null) {
-            // Currently in a layout without a container, so no
-            // reason to create our view.
-            return null;
-        }
-        return inflater.inflate(R.layout.my_search_stop_list, null);
+        return inflater.inflate(R.layout.my_search_stop_list, root, false);
     }
 
     @Override

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/UIUtils.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/UIUtils.java
@@ -639,8 +639,10 @@ public final class UIUtils {
      */
     public static ShortcutInfoCompat makeShortcutInfo(Context context, String name,
             Intent destIntent, @DrawableRes int icon) {
-        // Make sure the shortcut Activity always launches on top (#626)
-        destIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        // Launcher shortcuts must open a fresh task rooted at the destination; without
+        // CLEAR_TASK, tapping a shortcut while the app is in the background just resumes
+        // the app's last screen (#1564 — supersedes the CLEAR_TOP-only flag from #626).
+        destIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
         destIntent.setAction(Intent.ACTION_VIEW);
 
         Drawable drawableIcon = ResourcesCompat


### PR DESCRIPTION
## Summary

Fixes #1564. Two distinct bugs in the launcher-shortcut path, with the same root cause area but different mechanisms:

- **Crash on cold launch.** `MySearchStopsFragment` and `MySearchRoutesFragment` returned `null` from `onCreateView` when the container was null. ViewPager2's `FragmentStateAdapter` (introduced by the recent Toolbar/edge-to-edge migration in commits `d550495a` / `999ff8ad`) hosts fragments headlessly and always passes a null container, so `MySearchFragmentBase.onActivityCreated` then crashed at `getListView()` with `IllegalStateException: Content view not yet created`. Fixed by inflating against the (possibly-null) container with `attachToRoot=false` — the canonical fragment idiom that works for both headless and rooted hosts.
- **Wrong destination when the app is already running.** `UIUtils.makeShortcutInfo` was setting only `FLAG_ACTIVITY_CLEAR_TOP` (from the old #626 fix), so tapping a shortcut while the app was backgrounded just resumed the app's last screen. Switched to `FLAG_ACTIVITY_NEW_TASK | FLAG_ACTIVITY_CLEAR_TASK`, the documented pattern for launcher shortcuts.

Adds instrumented regression tests for both fixes.

## Test plan

- [x] `./gradlew test connectedObaGoogleDebugAndroidTest` — all 223 tests pass.
- [x] Tap **Starred Stops** shortcut intent (cold launch): activity opens directly to the Starred tab, no crash.
- [x] Tap **Recent Stops** shortcut intent (cold launch): activity opens directly to the Recent tab.
- [x] Tap **Recent Routes** shortcut intent (cold launch): activity opens directly to the Recent tab.
- [x] Tap shortcut intent while the app is backgrounded on HomeActivity: opens the shortcut's destination tab, not HomeActivity.
- [x] Launch HomeActivity normally: no regression.

## Notes for reviewers

- **Existing pinned shortcuts on user devices still carry the old flags.** The launcher owns the pinned intent, so this fix only applies to shortcuts pinned *after* the user installs the new version. Users who already had shortcuts will need to re-pin to benefit from the `NEW_TASK | CLEAR_TASK` change. The crash fix takes effect immediately for everyone, since the old shortcuts still target the same activity classes.
- The change to `inflate(layout, root, false)` (vs. the old `inflate(layout, null)`) means the inflated view now receives `LayoutParams` generated from the root when one is present. Both affected layouts (`my_search_stop_list.xml`, `my_search_route_list.xml`) already declare `fill_parent` x `fill_parent`, and the fragment is always re-parented by the host, so this is equivalent in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression tests verifying search result screens display correctly and launcher shortcuts behave as expected.

* **Bug Fixes**
  * Fixed search screens to display correctly when used in different app layout configurations.
  * Fixed launcher shortcuts to properly reset the app task when launched from the home screen.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OneBusAway/onebusaway-android/pull/1565?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->