### PR TITLE
Bump Jackson 2.12.4 → 2.13.5 (highest version allowed by the minSdk 21 ceiling)

### DIFF
--- a/onebusaway-android/build.gradle
+++ b/onebusaway-android/build.gradle
@@ -240,9 +240,11 @@ dependencies {
     // Open311 client library
     implementation 'com.github.OneBusAway:open311-client:1.0.10'
     // JSON data binding for OBA REST API responses
-    implementation 'com.fasterxml.jackson.core:jackson-core:2.12.4'
-    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.12.4'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.4'
+    // NOTE: 2.13.x is the last Jackson line supporting Android SDK 21+ (2.14+ requires SDK 26,
+    // and core library desugaring does not help) - do not bump further while minSdk is 21
+    implementation 'com.fasterxml.jackson.core:jackson-core:2.13.5'
+    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.13.5'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.5'
     // Bottom sliding panel
     implementation 'com.github.hannesa2:AndroidSlidingUpPanel:4.6.1'
     // For floating action button speed dial

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/JacksonConfig.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/JacksonConfig.java
@@ -199,7 +199,7 @@ public class JacksonConfig {
              *
              * Instantiate the object like normal.
              */
-            reader = initObjectMapper().reader(Response.class);
+            reader = initObjectMapper().readerFor(Response.class);
         }
         return reader;
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/io/JacksonSerializer.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/io/JacksonSerializer.java
@@ -52,7 +52,7 @@ public class JacksonSerializer implements ObaApi.SerializationHandler {
 
     static {
         mMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-        mMapper.setVisibilityChecker(
+        mMapper.setVisibility(
                 VisibilityChecker.Std.defaultInstance()
                         .withFieldVisibility(JsonAutoDetect.Visibility.ANY));
     }
@@ -151,7 +151,7 @@ public class JacksonSerializer implements ObaApi.SerializationHandler {
         JsonGenerator jsonGenerator;
 
         try {
-            jsonGenerator = new MappingJsonFactory().createJsonGenerator(writer);
+            jsonGenerator = new MappingJsonFactory().createGenerator(writer);
             mMapper.writeValue(jsonGenerator, obj);
 
             return writer.toString();


### PR DESCRIPTION
> [!NOTE]
> Stacked on #1554 (`animated-markers`) — only the final commit (`Bump Jackson 2.12.4 -> 2.13.5 and clear deprecated Jackson API usage`) is new here; the rest of the diff disappears once #1554 merges.

## Summary

Bumps `jackson-core` / `jackson-annotations` / `jackson-databind` from 2.12.4 (mid-2021) to **2.13.5**, and clears the Jackson APIs deprecated within 2.x:

- `MappingJsonFactory.createJsonGenerator()` → `createGenerator()` (`JacksonSerializer.java`)
- `ObjectMapper.setVisibilityChecker()` → `setVisibility()` (`JacksonSerializer.java`)
- `ObjectMapper.reader(Class)` → `readerFor(Class)` (`JacksonConfig.java`)

## Why 2.13.5 and not the latest 2.x

**2.13.5 is the highest Jackson version allowable on this project's SDK ceiling.** Per [Jackson's release wiki](https://github.com/FasterXML/jackson/wiki/Jackson-Releases), 2.13 is the last branch supporting Android SDK 21+ — Jackson 2.14+ requires SDK 26 and crashes on API 21–25 devices at `ObjectMapper` instantiation (`NoClassDefFoundError: java.lang.BootstrapMethodError`; see [square/retrofit#4131](https://github.com/square/retrofit/issues/4131)). Core library desugaring does not help, since `java.lang.invoke` is not in `desugar_jdk_libs`. As `minSdk 21` is a deliberate project decision for broad device support, any further Jackson advance is gated on that decision. A comment in `build.gradle` now documents this so the pin isn't bumped past the ceiling accidentally.

Even so, the bump captures the known databind security fixes missing from 2.12.4 — CVE-2020-36518 (deep-nesting DoS) and CVE-2022-42003/42004 (resource exhaustion) — and uniformly lifts the stale transitive Jackson requests (2.5.3/2.7.3/2.9.x via `geojson-jackson` and others) to 2.13.5.

## Test plan

- [x] `./gradlew compileObaGoogleDebugSources` — clean build
- [x] `./gradlew testObaGoogleDebugUnitTest` — all JVM unit tests pass
- [x] Verified the runtime classpath resolves every Jackson artifact to 2.13.5
- [x] On-device instrumented tests for the serialization layer (`JacksonTest`, `ObaArrivalInfoTest`) — 18/18 passed on a Pixel 7 Pro (Android 16)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated JSON handling libraries to a newer supported version for improved compatibility and stability on Android.
  * Adjusted JSON reader/serializer behavior to better support data parsing and writing without changing app-facing behavior.
  * Added a compatibility note to prevent upgrading beyond the Android-supported JSON version line while older Android support remains in place.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->