### PR TITLE
Fix #1566 - Migrate remaining onBackPressed() overrides to OnBackPressedCallback

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/InfrastructureIssueActivity.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/InfrastructureIssueActivity.java
@@ -36,6 +36,7 @@ import android.widget.RelativeLayout;
 import android.widget.Spinner;
 import android.widget.TextView;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.appcompat.widget.Toolbar;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
@@ -295,6 +296,20 @@ public class InfrastructureIssueActivity extends BaseReportActivity implements
         initLocation();
 
         setActionBarTitle(savedInstanceState);
+
+        getOnBackPressedDispatcher().addCallback(this, new OnBackPressedCallback(true) {
+            @Override
+            public void handleOnBackPressed() {
+                // Temporarily disable this callback so the back press reaches the default
+                // behavior (popping the fragment back stack or finishing the activity), then
+                // re-enable it for subsequent back presses
+                setEnabled(false);
+                getOnBackPressedDispatcher().onBackPressed();
+                setEnabled(true);
+                // If a fragment closes via back button, show 'Choose a Problem' category
+                mServicesSpinner.setSelection(0);
+            }
+        });
     }
 
     /**
@@ -716,13 +731,6 @@ public class InfrastructureIssueActivity extends BaseReportActivity implements
     @Override
     public void onReportSent() {
         (new ReportSuccessDialog()).show(getSupportFragmentManager(), ReportSuccessDialog.TAG);
-    }
-
-    @Override
-    public void onBackPressed() {
-        super.onBackPressed();
-        // If a fragment closes via back button, show 'Choose a Problem' category
-        mServicesSpinner.setSelection(0);
     }
 
     @Override

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/TripPlanActivity.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/TripPlanActivity.java
@@ -30,6 +30,7 @@ import android.view.ViewTreeObserver;
 import android.widget.ListView;
 import android.widget.Toast;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
@@ -106,6 +107,19 @@ public class TripPlanActivity extends AppCompatActivity implements TripRequest.C
 
         Bundle bundle = (savedInstanceState == null) ? new Bundle() : savedInstanceState;
         mBuilder = new TripRequestBuilder(bundle);
+
+        getOnBackPressedDispatcher().addCallback(this, new OnBackPressedCallback(true) {
+            @Override
+            public void handleOnBackPressed() {
+                // Collapse the sliding panel when the user presses the back button
+                if (mPanel != null && mPanel.getPanelState() == PanelState.EXPANDED) {
+                    mPanel.setPanelState(PanelState.COLLAPSED);
+                    return;
+                }
+                setEnabled(false);
+                getOnBackPressedDispatcher().onBackPressed();
+            }
+        });
     }
 
     @Override
@@ -258,19 +272,10 @@ public class TripPlanActivity extends AppCompatActivity implements TripRequest.C
     }
 
     @Override
-    public void onBackPressed() {
-        if (mPanel != null && mPanel.getPanelState() == PanelState.EXPANDED) {
-            mPanel.setPanelState(PanelState.COLLAPSED);
-        } else {
-            super.onBackPressed();
-        }
-    }
-
-    @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         if (item.getItemId() == android.R.id.home) {
             // Ensure the software and hardware back buttons have the same behavior
-            onBackPressed();
+            getOnBackPressedDispatcher().onBackPressed();
             return true;
         }
         return super.onOptionsItemSelected(item);


### PR DESCRIPTION
Fixes #1566

## Background

On Android 13+ (API 33+), back presses route through `WindowOnBackInvokedDispatcher` → AndroidX `OnBackPressedDispatcher`, whose fallback calls `ComponentActivity.super.onBackPressed()` directly — silently bypassing subclass overrides. #1563 fixed this for `HomeActivity`; this PR migrates the two remaining activities the same way.

## Changes

**`TripPlanActivity`**
- Registers an `OnBackPressedCallback` in `onCreate()` that collapses the sliding itinerary panel when expanded, otherwise disables itself and re-dispatches — mirroring the #1563 pattern.
- `onOptionsItemSelected` (toolbar up button) now calls `getOnBackPressedDispatcher().onBackPressed()` instead of the deprecated `onBackPressed()`, keeping software and hardware back consistent.
- Restored behavior on Android 13+: back with the panel expanded collapses it instead of finishing the whole activity.

**`InfrastructureIssueActivity`**
- Registers an `OnBackPressedCallback` in `onCreate()` that temporarily disables itself, re-dispatches (so the fragment back stack pops, or the activity finishes), then re-enables itself and resets `mServicesSpinner`.
- The re-enable deliberately differs from the `HomeActivity`/`TripPlanActivity` pattern: this activity survives repeated back presses while report fragments pop, and the spinner reset must run after each one — matching the original `super.onBackPressed(); setSelection(0)` semantics.
- Restored behavior on Android 13+: after backing out of a report form, the category spinner resets to "Choose a problem" so it stays consistent with the visible screen (previously the spinner kept the stale selection, and re-selecting the same category wouldn't reopen the form).

`SurveyViewUtils.java` (`BottomSheetDialog.onBackPressed()`) is untouched, as scoped out by the issue. No Activity `onBackPressed()` overrides remain in the app.

## Testing

- Compiles cleanly (`compileObaGoogleDebugJavaWithJavac`).
- Manually verified the report-a-problem flow on an API 33+ emulator: backing out of a report form pops the form and resets the spinner on each press; back at the top level exits the activity. Behavior on API < 33 is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Back-button navigation improved in infrastructure issue reporting screen
  * Back-button behavior refined for trip planning screen navigation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->