### PR TITLE
Add Umami Analytics support (#1575)

### DIFF
--- a/docs/superpowers/plans/2026-06-22-umami-analytics.md
+++ b/docs/superpowers/plans/2026-06-22-umami-analytics.md
@@ -18,6 +18,17 @@
 - **AOSP code style** (`AndroidStyle.xml`). Min SDK 21, Java 1.8, target SDK 36.
 - **PR is a single squashed commit** (project rule); the per-step commits below are squashed at PR time.
 
+## Constructor-caller inventory (critical)
+
+`new ObaRegionElement(...)` has **ten** positional callers. Task 1 adds a 27th constructor parameter, so ALL ten must be updated in the same commit or the build (including androidTest) will not compile:
+
+| Caller | File:line | New 27th arg |
+|--------|-----------|--------------|
+| `ObaContract.Regions.get` | `provider/ObaContract.java:1436` | `new ObaRegionElement.UmamiAnalyticsConfig(c.getString(23), c.getString(24))` |
+| `RegionUtils.getRegionsFromProvider` | `util/RegionUtils.java:453` | `new ObaRegionElement.UmamiAnalyticsConfig(c.getString(23), c.getString(24))` |
+| `RegionUtils.getRegionFromBuildFlavor` | `util/RegionUtils.java:649` | `null` (fixed-region build flavor — no Umami) |
+| `MockRegion` ×8 | `androidTest/.../mock/MockRegion.java:74,116,158,200,242,284,324,364` | `null` (test regions — Umami disabled) |
+
 ## File Structure
 
 | File | Responsibility | Action |
@@ -26,7 +37,8 @@
 | `io/elements/ObaRegionElement.java` | Region impl — nested `UmamiAnalyticsConfig`, field, getters, constructors | Modify |
 | `provider/ObaContract.java` | Column constants + single-region cursor reader (`Regions.get`) | Modify |
 | `provider/ObaProvider.java` | DB version bump + migration | Modify |
-| `util/RegionUtils.java` | `toContentValues` write + bulk cursor reader | Modify |
+| `util/RegionUtils.java` | `toContentValues` write, bulk cursor reader, fixed-region caller | Modify |
+| `androidTest/.../mock/MockRegion.java` | 8 constructor callers (pass null) | Modify |
 | `io/UmamiAnalytics.java` | The emitter: payload build, UA, path reduction, ingest check, send | Create |
 | `io/UmamiAnalyticsReporter.kt` | Maps OBA events → emitter calls (mirror of `PlausibleAnalytics`) | Create |
 | `app/Application.java` | Build/cache the emitter per region | Modify |
@@ -35,20 +47,26 @@
 | `androidTest/.../io/test/RegionsTest.java` | Parse + persistence round-trip tests | Modify |
 | `androidTest/.../io/test/UmamiAnalyticsTest.java` | Emitter unit tests | Create |
 
-Task order is dependency-driven: model getters (1) → persistence (2) → emitter (3) → reporter (4) → Application wiring (5) → ObaAnalytics integration (6) → build/verify (7).
+Task order is dependency-driven: region model + persistence (1) → emitter (2) → reporter (3) → Application wiring (4) → ObaAnalytics integration (5) → build/verify (6).
 
 ---
 
-### Task 1: Region model — parse the nested `umamiAnalytics` object
+### Task 1: Region model & persistence
+
+Adds the 27th constructor parameter and everything that must move with it — all ten callers, the content-provider columns, the migration, and both the parse and round-trip tests — as one atomic, compiling commit.
 
 **Files:**
 - Modify: `onebusaway-android/src/main/java/org/onebusaway/android/io/elements/ObaRegion.java`
 - Modify: `onebusaway-android/src/main/java/org/onebusaway/android/io/elements/ObaRegionElement.java`
+- Modify: `onebusaway-android/src/main/java/org/onebusaway/android/provider/ObaContract.java`
+- Modify: `onebusaway-android/src/main/java/org/onebusaway/android/provider/ObaProvider.java`
+- Modify: `onebusaway-android/src/main/java/org/onebusaway/android/util/RegionUtils.java`
+- Modify: `onebusaway-android/src/androidTest/java/org/onebusaway/android/mock/MockRegion.java`
 - Create: `onebusaway-android/src/androidTest/res/raw/regions_umami_test.json`
 - Test: `onebusaway-android/src/androidTest/java/org/onebusaway/android/io/test/RegionsTest.java`
 
 **Interfaces:**
-- Produces: `ObaRegion.getUmamiAnalyticsUrl(): String` (nullable) and `ObaRegion.getUmamiAnalyticsId(): String` (nullable); nested type `ObaRegionElement.UmamiAnalyticsConfig` with `getUrl()`/`getId()`.
+- Produces: `ObaRegion.getUmamiAnalyticsUrl(): String` (nullable), `ObaRegion.getUmamiAnalyticsId(): String` (nullable); nested type `ObaRegionElement.UmamiAnalyticsConfig` with `getUrl()`/`getId()`; content-provider columns `ObaContract.Regions.UMAMI_ANALYTICS_URL` / `UMAMI_ANALYTICS_ID`.
 
 - [ ] **Step 1: Write the test fixture**
 
@@ -96,9 +114,9 @@ Create `onebusaway-android/src/androidTest/res/raw/regions_umami_test.json`:
 }
 ```
 
-- [ ] **Step 2: Write the failing test**
+- [ ] **Step 2: Write the failing tests**
 
-Add to `RegionsTest.java` (the class already extends `ObaTestCase`; ensure imports for `org.onebusaway.android.mock.Resources` and static `org.junit.Assert.assertNull`/`assertEquals` are present):
+Add to `RegionsTest.java` (ensure imports: `android.content.ContentResolver`, `android.content.ContentValues`, `org.onebusaway.android.mock.Resources`, `org.onebusaway.android.provider.ObaContract`, and static `org.junit.Assert.assertNull`/`assertEquals`/`assertNotNull`):
 
 ```java
 @Test
@@ -115,12 +133,39 @@ public void testUmamiAnalyticsParsing() throws Exception {
     assertNull(withoutUmami.getUmamiAnalyticsUrl());
     assertNull(withoutUmami.getUmamiAnalyticsId());
 }
+
+@Test
+public void testUmamiAnalyticsPersistenceRoundTrip() {
+    ContentResolver cr = getTargetContext().getContentResolver();
+    int id = 987654;
+
+    ContentValues values = new ContentValues();
+    values.put(ObaContract.Regions._ID, id);
+    values.put(ObaContract.Regions.NAME, "Umami Persist Region");
+    values.put(ObaContract.Regions.OBA_BASE_URL, "https://api.example.com/");
+    values.put(ObaContract.Regions.SIRI_BASE_URL, "");
+    values.put(ObaContract.Regions.LANGUAGE, "en_US");
+    values.put(ObaContract.Regions.CONTACT_EMAIL, "test@example.com");
+    values.put(ObaContract.Regions.SUPPORTS_OBA_DISCOVERY, 1);
+    values.put(ObaContract.Regions.SUPPORTS_OBA_REALTIME, 1);
+    values.put(ObaContract.Regions.SUPPORTS_SIRI_REALTIME, 0);
+    values.put(ObaContract.Regions.UMAMI_ANALYTICS_URL, "https://umami.example.com");
+    values.put(ObaContract.Regions.UMAMI_ANALYTICS_ID, "uuid-persist-1");
+    ObaContract.Regions.insertOrUpdate(getTargetContext(), id, values);
+
+    ObaRegion region = ObaContract.Regions.get(cr, id);
+    assertNotNull(region);
+    assertEquals("https://umami.example.com", region.getUmamiAnalyticsUrl());
+    assertEquals("uuid-persist-1", region.getUmamiAnalyticsId());
+
+    cr.delete(ObaContract.Regions.buildUri(id), null, null);
+}
 ```
 
-- [ ] **Step 3: Run the test to verify it fails**
+- [ ] **Step 3: Run the tests to verify they fail**
 
-Run: `./gradlew connectedObaGoogleDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=org.onebusaway.android.io.test.RegionsTest#testUmamiAnalyticsParsing`
-Expected: FAIL to compile — `getUmamiAnalyticsUrl()` is undefined on `ObaRegion`.
+Run: `./gradlew connectedObaGoogleDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=org.onebusaway.android.io.test.RegionsTest`
+Expected: FAIL to compile — `getUmamiAnalyticsUrl()` / `UMAMI_ANALYTICS_URL` undefined.
 
 - [ ] **Step 4: Add the interface getters**
 
@@ -140,7 +185,7 @@ In `ObaRegion.java`, immediately after the `getPlausibleAnalyticsServerUrl()` de
 
 - [ ] **Step 5: Add the nested config class to `ObaRegionElement.java`**
 
-Add this nested class directly after the existing `Bounds` class (after line 86):
+Add directly after the existing `Bounds` class (after line 86):
 
 ```java
     public static class UmamiAnalyticsConfig {
@@ -183,14 +228,14 @@ In the no-arg constructor, after `plausibleAnalyticsServerUrl = "";` (line 218):
         umamiAnalytics = null;
 ```
 
-In the all-args constructor, add a parameter at the END of the parameter list (after `String plausibleAnalyticsServerUrl`):
+In the all-args constructor, change the final parameter line (line 246) to add the 27th param:
 
 ```java
                             String plausibleAnalyticsServerUrl,
                             UmamiAnalyticsConfig umamiAnalytics) {
 ```
 
-and the matching assignment after `this.plausibleAnalyticsServerUrl = plausibleAnalyticsServerUrl;`:
+and add the assignment after `this.plausibleAnalyticsServerUrl = plausibleAnalyticsServerUrl;`:
 
 ```java
         this.umamiAnalytics = umamiAnalytics;
@@ -210,81 +255,9 @@ Add the getters after `getPlausibleAnalyticsServerUrl()` (after line 303):
     }
 ```
 
-> Note: the all-args constructor now takes 27 args. The two existing positional callers (`ObaContract.Regions.get` and `RegionUtils.getRegionsFromProvider`) are updated in Task 2 — the code will not compile until then. That is expected; this task's test is the parse path, which uses Jackson, not the constructor.
+- [ ] **Step 7: Add the content-provider column constants**
 
-- [ ] **Step 7: Run the test to verify it passes**
-
-Run: `./gradlew connectedObaGoogleDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=org.onebusaway.android.io.test.RegionsTest#testUmamiAnalyticsParsing`
-
-> If the build fails to compile because the two positional `ObaRegionElement(...)` callers now lack the new argument, complete Task 2 first, then re-run. Both tasks land in one commit pair if implemented back-to-back.
-
-Expected (after Task 2 wiring): PASS.
-
-- [ ] **Step 8: Commit**
-
-```bash
-git add onebusaway-android/src/main/java/org/onebusaway/android/io/elements/ObaRegion.java \
-        onebusaway-android/src/main/java/org/onebusaway/android/io/elements/ObaRegionElement.java \
-        onebusaway-android/src/androidTest/res/raw/regions_umami_test.json \
-        onebusaway-android/src/androidTest/java/org/onebusaway/android/io/test/RegionsTest.java
-git commit -m "Parse umamiAnalytics config from region feed"
-```
-
----
-
-### Task 2: Persistence — columns, migration, both cursor readers
-
-**Files:**
-- Modify: `onebusaway-android/src/main/java/org/onebusaway/android/provider/ObaContract.java`
-- Modify: `onebusaway-android/src/main/java/org/onebusaway/android/provider/ObaProvider.java`
-- Modify: `onebusaway-android/src/main/java/org/onebusaway/android/util/RegionUtils.java`
-- Test: `onebusaway-android/src/androidTest/java/org/onebusaway/android/io/test/RegionsTest.java`
-
-**Interfaces:**
-- Consumes: `ObaRegionElement.UmamiAnalyticsConfig` and the 27-arg constructor from Task 1.
-- Produces: content-provider columns `ObaContract.Regions.UMAMI_ANALYTICS_URL`, `ObaContract.Regions.UMAMI_ANALYTICS_ID`; a DB-rebuilt `ObaRegionElement` whose Umami getters are populated from those columns.
-
-- [ ] **Step 1: Write the failing round-trip test**
-
-Add to `RegionsTest.java` (ensure imports: `android.content.ContentResolver`, `android.content.ContentValues`, `org.onebusaway.android.provider.ObaContract`, and static `org.junit.Assert.assertNotNull`):
-
-```java
-@Test
-public void testUmamiAnalyticsPersistenceRoundTrip() {
-    ContentResolver cr = getTargetContext().getContentResolver();
-    int id = 987654;
-
-    ContentValues values = new ContentValues();
-    values.put(ObaContract.Regions._ID, id);
-    values.put(ObaContract.Regions.NAME, "Umami Persist Region");
-    values.put(ObaContract.Regions.OBA_BASE_URL, "https://api.example.com/");
-    values.put(ObaContract.Regions.SIRI_BASE_URL, "");
-    values.put(ObaContract.Regions.LANGUAGE, "en_US");
-    values.put(ObaContract.Regions.CONTACT_EMAIL, "test@example.com");
-    values.put(ObaContract.Regions.SUPPORTS_OBA_DISCOVERY, 1);
-    values.put(ObaContract.Regions.SUPPORTS_OBA_REALTIME, 1);
-    values.put(ObaContract.Regions.SUPPORTS_SIRI_REALTIME, 0);
-    values.put(ObaContract.Regions.UMAMI_ANALYTICS_URL, "https://umami.example.com");
-    values.put(ObaContract.Regions.UMAMI_ANALYTICS_ID, "uuid-persist-1");
-    ObaContract.Regions.insertOrUpdate(getTargetContext(), id, values);
-
-    ObaRegion region = ObaContract.Regions.get(cr, id);
-    assertNotNull(region);
-    assertEquals("https://umami.example.com", region.getUmamiAnalyticsUrl());
-    assertEquals("uuid-persist-1", region.getUmamiAnalyticsId());
-
-    cr.delete(ObaContract.Regions.buildUri(id), null, null);
-}
-```
-
-- [ ] **Step 2: Run the test to verify it fails**
-
-Run: `./gradlew connectedObaGoogleDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=org.onebusaway.android.io.test.RegionsTest#testUmamiAnalyticsPersistenceRoundTrip`
-Expected: FAIL to compile — `ObaContract.Regions.UMAMI_ANALYTICS_URL` is undefined.
-
-- [ ] **Step 3: Add the column constants**
-
-In `ObaContract.java` `RegionsColumns`, immediately after `PLAUSIBLE_ANALYTICS_SERVER_URL` (line 385):
+In `ObaContract.java` `RegionsColumns`, immediately after `PLAUSIBLE_ANALYTICS_SERVER_URL` (line 385, before `SIRI_BASE_URL`):
 
 ```java
         /**
@@ -304,9 +277,9 @@ In `ObaContract.java` `RegionsColumns`, immediately after `PLAUSIBLE_ANALYTICS_S
         public static final String UMAMI_ANALYTICS_ID = "umami_analytics_id";
 ```
 
-- [ ] **Step 4: Update the single-region cursor reader (`ObaContract.Regions.get`)**
+- [ ] **Step 8: Update the single-region cursor reader (`ObaContract.Regions.get`)**
 
-In `ObaContract.java` `Regions.get(...)`, append the two columns to the end of the `PROJECTION` array (after `PLAUSIBLE_ANALYTICS_SERVER_URL`):
+Append the two columns to the end of the `PROJECTION` array (after `PLAUSIBLE_ANALYTICS_SERVER_URL`, line 1426):
 
 ```java
                 PLAUSIBLE_ANALYTICS_SERVER_URL,
@@ -314,7 +287,7 @@ In `ObaContract.java` `Regions.get(...)`, append the two columns to the end of t
                 UMAMI_ANALYTICS_ID
 ```
 
-and append the matching argument to the `new ObaRegionElement(...)` call, replacing the final `c.getString(22)` line:
+and replace the final `c.getString(22)` argument (line 1461) of the `new ObaRegionElement(...)` call:
 
 ```java
                         c.getString(22), // Plausible analytics server url
@@ -324,9 +297,9 @@ and append the matching argument to the `new ObaRegionElement(...)` call, replac
                 );
 ```
 
-- [ ] **Step 5: Update the bulk cursor reader (`RegionUtils.getRegionsFromProvider`)**
+- [ ] **Step 9: Update the bulk cursor reader (`RegionUtils.getRegionsFromProvider`)**
 
-In `RegionUtils.java`, append the two columns to the `PROJECTION` array (after `PLAUSIBLE_ANALYTICS_SERVER_URL`):
+Append the two columns to the `PROJECTION` array (after `PLAUSIBLE_ANALYTICS_SERVER_URL`, line 424):
 
 ```java
                     ObaContract.Regions.PLAUSIBLE_ANALYTICS_SERVER_URL,
@@ -334,7 +307,7 @@ In `RegionUtils.java`, append the two columns to the `PROJECTION` array (after `
                     ObaContract.Regions.UMAMI_ANALYTICS_ID
 ```
 
-and replace the final `c.getString(22)` argument in the `new ObaRegionElement(...)` call:
+and replace the final `c.getString(22)` argument (line 478) of the `new ObaRegionElement(...)` call:
 
 ```java
                         c.getString(22), // Plausible analytics server url
@@ -344,16 +317,44 @@ and replace the final `c.getString(22)` argument in the `new ObaRegionElement(..
                 ));
 ```
 
-- [ ] **Step 6: Write the two columns in `RegionUtils.toContentValues`**
+- [ ] **Step 10: Update the fixed-region caller (`RegionUtils.getRegionFromBuildFlavor`)**
 
-In `RegionUtils.java` `toContentValues`, after the `PLAUSIBLE_ANALYTICS_SERVER_URL` put (line 749):
+Replace the final argument (line 669) `BuildConfig.FIXED_REGION_PLAUSIBLE_ANALYTICS_SERVER_URL);`:
+
+```java
+                BuildConfig.FIXED_REGION_PLAUSIBLE_ANALYTICS_SERVER_URL,
+                null);   // No Umami config for the fixed-region build flavor
+```
+
+- [ ] **Step 11: Update the 8 `MockRegion` callers**
+
+In `MockRegion.java`, each of the eight `new ObaRegionElement(...)` calls (lines 74, 116, 158, 200, 242, 284, 324, 364) currently ends with:
+
+```java
+                "https://onebusaway.co",
+                null);
+```
+
+Change every one of the eight to:
+
+```java
+                "https://onebusaway.co",
+                null,
+                null);   // UmamiAnalyticsConfig — disabled in test regions
+```
+
+(The trailing `null` is the new 27th `UmamiAnalyticsConfig` argument. The `"https://onebusaway.co"` line is the sidecar URL and the preceding `null` is the Plausible URL — both unchanged.)
+
+- [ ] **Step 12: Write the two columns in `RegionUtils.toContentValues`**
+
+After the `PLAUSIBLE_ANALYTICS_SERVER_URL` put (line 749):
 
 ```java
         values.put(ObaContract.Regions.UMAMI_ANALYTICS_URL, region.getUmamiAnalyticsUrl());
         values.put(ObaContract.Regions.UMAMI_ANALYTICS_ID, region.getUmamiAnalyticsId());
 ```
 
-- [ ] **Step 7: Bump the DB version and add the migration**
+- [ ] **Step 13: Bump the DB version and add the migration**
 
 In `ObaProvider.java`, change the version constant (line 52):
 
@@ -380,24 +381,28 @@ Then in `onUpgrade`, add `++oldVersion;` to the end of the existing `if (oldVers
 
 > `onCreate` calls `onUpgrade(db, 12, DATABASE_VERSION)`, so fresh installs replay this chain and get the columns. The round-trip test runs against a fresh DB, so it also verifies the migration produced the columns. The `++oldVersion;` added to the v32 block is required so the v33 block executes.
 
-- [ ] **Step 8: Run the test to verify it passes**
+- [ ] **Step 14: Run the tests to verify they pass**
 
 Run: `./gradlew connectedObaGoogleDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=org.onebusaway.android.io.test.RegionsTest`
 Expected: PASS for both `testUmamiAnalyticsParsing` and `testUmamiAnalyticsPersistenceRoundTrip`.
 
-- [ ] **Step 9: Commit**
+- [ ] **Step 15: Commit**
 
 ```bash
-git add onebusaway-android/src/main/java/org/onebusaway/android/provider/ObaContract.java \
+git add onebusaway-android/src/main/java/org/onebusaway/android/io/elements/ObaRegion.java \
+        onebusaway-android/src/main/java/org/onebusaway/android/io/elements/ObaRegionElement.java \
+        onebusaway-android/src/main/java/org/onebusaway/android/provider/ObaContract.java \
         onebusaway-android/src/main/java/org/onebusaway/android/provider/ObaProvider.java \
         onebusaway-android/src/main/java/org/onebusaway/android/util/RegionUtils.java \
+        onebusaway-android/src/androidTest/java/org/onebusaway/android/mock/MockRegion.java \
+        onebusaway-android/src/androidTest/res/raw/regions_umami_test.json \
         onebusaway-android/src/androidTest/java/org/onebusaway/android/io/test/RegionsTest.java
-git commit -m "Persist umamiAnalytics fields in regions content provider"
+git commit -m "Parse and persist umamiAnalytics config from region feed"
 ```
 
 ---
 
-### Task 3: The `UmamiAnalytics` emitter
+### Task 2: The `UmamiAnalytics` emitter
 
 **Files:**
 - Create: `onebusaway-android/src/main/java/org/onebusaway/android/io/UmamiAnalytics.java`
@@ -746,14 +751,14 @@ git commit -m "Add fire-and-forget Umami analytics emitter"
 
 ---
 
-### Task 4: `UmamiAnalyticsReporter` — map OBA events to emitter calls
+### Task 3: `UmamiAnalyticsReporter` — map OBA events to emitter calls
 
 **Files:**
 - Create: `onebusaway-android/src/main/java/org/onebusaway/android/io/UmamiAnalyticsReporter.kt`
 - Test: `onebusaway-android/src/androidTest/java/org/onebusaway/android/io/test/UmamiAnalyticsTest.java`
 
 **Interfaces:**
-- Consumes: `UmamiAnalytics` from Task 3; `PlausibleAnalytics.REPORT_SEARCH_EVENT_URL`.
+- Consumes: `UmamiAnalytics` from Task 2; `PlausibleAnalytics.REPORT_SEARCH_EVENT_URL`.
 - Produces: `UmamiAnalyticsReporter.reportUiEvent(UmamiAnalytics?, String, String, String?)`, `reportSearchEvent(UmamiAnalytics?, String)`, `reportViewStopEvent(UmamiAnalytics?, String, String)` — each a no-op when the emitter is null. Mirrors `PlausibleAnalytics`.
 
 - [ ] **Step 1: Write the failing null-safety test**
@@ -826,13 +831,13 @@ git commit -m "Add UmamiAnalyticsReporter mirroring PlausibleAnalytics"
 
 ---
 
-### Task 5: Build and cache the emitter per region in `Application`
+### Task 4: Build and cache the emitter per region in `Application`
 
 **Files:**
 - Modify: `onebusaway-android/src/main/java/org/onebusaway/android/app/Application.java`
 
 **Interfaces:**
-- Consumes: `UmamiAnalytics` (Task 3); `ObaRegion.getUmamiAnalyticsUrl()/getUmamiAnalyticsId()` (Task 1).
+- Consumes: `UmamiAnalytics` (Task 2); `ObaRegion.getUmamiAnalyticsUrl()/getUmamiAnalyticsId()` (Task 1).
 - Produces: `Application.getUmamiInstance(): UmamiAnalytics` (nullable; null when the current region has no Umami config). Rebuilt whenever the region changes, alongside the Plausible instance.
 
 - [ ] **Step 1: Add the field**
@@ -880,16 +885,16 @@ After the `buildPlausibleInstance` method (after line 389), add:
 
 - [ ] **Step 3: Rebuild the emitter on region change**
 
-In `Application.java` there are two places that call `buildPlausibleInstance(...)` to refresh on region change. Add a `buildUmamiInstance(...)` call immediately after each:
+Add a `buildUmamiInstance(...)` call immediately after each existing `buildPlausibleInstance(...)` call.
 
-After the `buildPlausibleInstance(region);` call inside `setCurrentRegion` (line 352):
+After `buildPlausibleInstance(region);` inside `setCurrentRegion` (line 352):
 
 ```java
                 buildPlausibleInstance(region);
                 buildUmamiInstance(region);
 ```
 
-After the `buildPlausibleInstance(getCurrentRegion());` call near line 608 (the region-init path that precedes `ObaAnalytics.setRegion(...)`):
+After `buildPlausibleInstance(getCurrentRegion());` near line 608 (the region-init path that precedes `ObaAnalytics.setRegion(...)`):
 
 ```java
             buildPlausibleInstance(getCurrentRegion());
@@ -897,7 +902,7 @@ After the `buildPlausibleInstance(getCurrentRegion());` call near line 608 (the 
             ObaAnalytics.setRegion(mPlausible, mFirebaseAnalytics, getCurrentRegion().getName());
 ```
 
-> `URI` / `URISyntaxException` are already imported in this file (used by `buildPlausibleInstance`).
+> `URI` / `URISyntaxException` are already imported in this file (used by `buildPlausibleInstance`). The line-352 call is nested inside an `if (regionChanged && region.getOtpBaseUrl() != null)` block — this mirrors the existing Plausible behavior exactly, and `getUmamiInstance()` lazily rebuilds from `getCurrentRegion()` on first use, so the emitter self-heals for regions reached by other paths.
 
 - [ ] **Step 4: Verify it compiles**
 
@@ -913,13 +918,13 @@ git commit -m "Build and cache Umami emitter per region in Application"
 
 ---
 
-### Task 6: Emit Umami events from `ObaAnalytics`
+### Task 5: Emit Umami events from `ObaAnalytics`
 
 **Files:**
 - Modify: `onebusaway-android/src/main/java/org/onebusaway/android/io/ObaAnalytics.java`
 
 **Interfaces:**
-- Consumes: `Application.getUmamiInstance()` (Task 5); `UmamiAnalyticsReporter` (Task 4); `UmamiAnalytics.setRegionName` (Task 3).
+- Consumes: `Application.getUmamiInstance()` (Task 4); `UmamiAnalyticsReporter` (Task 3); `UmamiAnalytics.setRegionName` (Task 2).
 - Produces: no signature changes — Umami is fetched internally, so the ~79 existing call sites are untouched.
 
 - [ ] **Step 1: Emit on UI events**
@@ -961,14 +966,14 @@ In `setRegion`, after `analytics.setUserProperty(...)` (line 202):
         }
 ```
 
-> `Application`, `UmamiAnalytics`, and `UmamiAnalyticsReporter` are all reachable: `Application` is already imported and used here; the two Umami types share the `org.onebusaway.android.io` package with `ObaAnalytics`, so no import is needed.
+> `Application` is already imported and used here; `UmamiAnalytics`/`UmamiAnalyticsReporter` share the `org.onebusaway.android.io` package with `ObaAnalytics`, so no imports are needed. The custom-URL `setRegion` path (region null) reaches `getUmamiInstance()`, which returns null and is guarded by the `if (umami != null)` check — no NPE.
 
-- [ ] **Step 5: Verify it compiles and the full suite passes**
+- [ ] **Step 5: Verify it compiles**
 
 Run: `./gradlew assembleObaGoogleDebug`
 Expected: BUILD SUCCESSFUL.
 
-> No new unit test is added here: `ObaAnalytics` depends on static `FirebaseAnalytics` and `Application` singletons that the existing instrumented suite does not mock (there is no `ObaAnalyticsTest` today). This task is verified by compilation, by the emitter/reporter tests from Tasks 3–4, and by the manual dashboard verification in Task 7.
+> No new unit test is added here: `ObaAnalytics` depends on static `FirebaseAnalytics` and `Application` singletons that the existing instrumented suite does not mock (there is no `ObaAnalyticsTest` today). This task is verified by compilation, by the emitter/reporter tests from Tasks 2–3, and by the manual dashboard verification in Task 6.
 
 - [ ] **Step 6: Commit**
 
@@ -979,7 +984,7 @@ git commit -m "Emit Umami events alongside Plausible from ObaAnalytics"
 
 ---
 
-### Task 7: Full build, test suite, and manual verification
+### Task 6: Full build, test suite, and manual verification
 
 **Files:** none (verification only).
 

--- a/docs/superpowers/plans/2026-06-22-umami-analytics.md
+++ b/docs/superpowers/plans/2026-06-22-umami-analytics.md
@@ -1,0 +1,1013 @@
+# Umami Analytics Support Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add native Umami analytics as a third, region-configured analytics sink alongside the existing Firebase and Plausible integrations.
+
+**Architecture:** Each region's feed entry may carry a `umamiAnalytics: { url, id }` object. The region model parses it (nested for JSON, two flat `TEXT` columns for the content provider). A hand-rolled `UmamiAnalytics` emitter (over `HttpURLConnection`, on a background executor) POSTs fire-and-forget events to `<url>/api/send` with a device-like `User-Agent`. `ObaAnalytics` fetches the emitter internally from `Application` (no call-site changes) and mirrors every event it already sends to Plausible.
+
+**Tech Stack:** Java + Kotlin, Android `HttpURLConnection`, `org.json`, Jackson (region deserialization), SQLite content provider, JUnit instrumented tests (androidTest).
+
+## Global Constraints
+
+- **No new dependencies.** Use `HttpURLConnection` + `org.json`; do not add OkHttp/Retrofit.
+- **Fail-safe telemetry.** Umami code must never throw into callers; swallow all exceptions, log at most. Network is fire-and-forget on a background executor with ~5s timeouts.
+- **Disabled when unconfigured.** If `umamiAnalytics` (or either of `url`/`id`) is null/missing, Umami is disabled for that region — no requests.
+- **Respect opt-out.** Umami emits only when the existing `isAnalyticsActive()` gate (`preferences_key_analytics`, default true) is on. No new preference UI.
+- **Device-like User-Agent.** Exactly `OneBusAway/<versionName> (Android <release>; <model>)`, overriding `HttpURLConnection`'s default, or Umami's `isbot` filter silently drops events.
+- **AOSP code style** (`AndroidStyle.xml`). Min SDK 21, Java 1.8, target SDK 36.
+- **PR is a single squashed commit** (project rule); the per-step commits below are squashed at PR time.
+
+## File Structure
+
+| File | Responsibility | Action |
+|------|----------------|--------|
+| `io/elements/ObaRegion.java` | Region interface — add two Umami getters | Modify |
+| `io/elements/ObaRegionElement.java` | Region impl — nested `UmamiAnalyticsConfig`, field, getters, constructors | Modify |
+| `provider/ObaContract.java` | Column constants + single-region cursor reader (`Regions.get`) | Modify |
+| `provider/ObaProvider.java` | DB version bump + migration | Modify |
+| `util/RegionUtils.java` | `toContentValues` write + bulk cursor reader | Modify |
+| `io/UmamiAnalytics.java` | The emitter: payload build, UA, path reduction, ingest check, send | Create |
+| `io/UmamiAnalyticsReporter.kt` | Maps OBA events → emitter calls (mirror of `PlausibleAnalytics`) | Create |
+| `app/Application.java` | Build/cache the emitter per region | Modify |
+| `io/ObaAnalytics.java` | Fetch emitter internally; emit alongside Plausible | Modify |
+| `androidTest/res/raw/regions_umami_test.json` | Parse-test fixture | Create |
+| `androidTest/.../io/test/RegionsTest.java` | Parse + persistence round-trip tests | Modify |
+| `androidTest/.../io/test/UmamiAnalyticsTest.java` | Emitter unit tests | Create |
+
+Task order is dependency-driven: model getters (1) → persistence (2) → emitter (3) → reporter (4) → Application wiring (5) → ObaAnalytics integration (6) → build/verify (7).
+
+---
+
+### Task 1: Region model — parse the nested `umamiAnalytics` object
+
+**Files:**
+- Modify: `onebusaway-android/src/main/java/org/onebusaway/android/io/elements/ObaRegion.java`
+- Modify: `onebusaway-android/src/main/java/org/onebusaway/android/io/elements/ObaRegionElement.java`
+- Create: `onebusaway-android/src/androidTest/res/raw/regions_umami_test.json`
+- Test: `onebusaway-android/src/androidTest/java/org/onebusaway/android/io/test/RegionsTest.java`
+
+**Interfaces:**
+- Produces: `ObaRegion.getUmamiAnalyticsUrl(): String` (nullable) and `ObaRegion.getUmamiAnalyticsId(): String` (nullable); nested type `ObaRegionElement.UmamiAnalyticsConfig` with `getUrl()`/`getId()`.
+
+- [ ] **Step 1: Write the test fixture**
+
+Create `onebusaway-android/src/androidTest/res/raw/regions_umami_test.json`:
+
+```json
+{
+  "code": 200,
+  "text": "OK",
+  "version": 3,
+  "data": {
+    "limitExceeded": false,
+    "list": [
+      {
+        "id": 0,
+        "regionName": "Umami Region",
+        "active": true,
+        "obaBaseUrl": "https://api.umami.example.com/",
+        "siriBaseUrl": null,
+        "umamiAnalytics": { "url": "https://umami.example.com", "id": "abc-123-uuid" },
+        "bounds": [ { "lat": 27.9, "lon": -82.4, "latSpan": 0.5, "lonSpan": 0.5 } ],
+        "language": "en_US",
+        "contactEmail": "test@example.com",
+        "supportsObaDiscoveryApis": true,
+        "supportsObaRealtimeApis": true,
+        "supportsSiriRealtimeApis": false,
+        "experimental": false
+      },
+      {
+        "id": 1,
+        "regionName": "No Umami Region",
+        "active": true,
+        "obaBaseUrl": "https://api.noumami.example.com/",
+        "siriBaseUrl": null,
+        "bounds": [ { "lat": 47.6, "lon": -122.3, "latSpan": 0.5, "lonSpan": 0.5 } ],
+        "language": "en_US",
+        "contactEmail": "test@example.com",
+        "supportsObaDiscoveryApis": true,
+        "supportsObaRealtimeApis": true,
+        "supportsSiriRealtimeApis": false,
+        "experimental": false
+      }
+    ]
+  }
+}
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Add to `RegionsTest.java` (the class already extends `ObaTestCase`; ensure imports for `org.onebusaway.android.mock.Resources` and static `org.junit.Assert.assertNull`/`assertEquals` are present):
+
+```java
+@Test
+public void testUmamiAnalyticsParsing() throws Exception {
+    ObaRegionsResponse response = Resources.readAs(getTargetContext(),
+            Resources.getTestUri("regions_umami_test"), ObaRegionsResponse.class);
+    ObaRegion[] regions = response.getRegions();
+
+    ObaRegion withUmami = regions[0];
+    assertEquals("https://umami.example.com", withUmami.getUmamiAnalyticsUrl());
+    assertEquals("abc-123-uuid", withUmami.getUmamiAnalyticsId());
+
+    ObaRegion withoutUmami = regions[1];
+    assertNull(withoutUmami.getUmamiAnalyticsUrl());
+    assertNull(withoutUmami.getUmamiAnalyticsId());
+}
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `./gradlew connectedObaGoogleDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=org.onebusaway.android.io.test.RegionsTest#testUmamiAnalyticsParsing`
+Expected: FAIL to compile — `getUmamiAnalyticsUrl()` is undefined on `ObaRegion`.
+
+- [ ] **Step 4: Add the interface getters**
+
+In `ObaRegion.java`, immediately after the `getPlausibleAnalyticsServerUrl()` declaration (around line 79):
+
+```java
+    /**
+     * @return The Umami analytics server URL for this region, or null if not configured.
+     */
+    public String getUmamiAnalyticsUrl();
+
+    /**
+     * @return The Umami analytics website ID for this region, or null if not configured.
+     */
+    public String getUmamiAnalyticsId();
+```
+
+- [ ] **Step 5: Add the nested config class to `ObaRegionElement.java`**
+
+Add this nested class directly after the existing `Bounds` class (after line 86):
+
+```java
+    public static class UmamiAnalyticsConfig {
+
+        private final String url;
+
+        private final String id;
+
+        UmamiAnalyticsConfig() {
+            url = null;
+            id = null;
+        }
+
+        public UmamiAnalyticsConfig(String url, String id) {
+            this.url = url;
+            this.id = id;
+        }
+
+        public String getUrl() {
+            return url;
+        }
+
+        public String getId() {
+            return id;
+        }
+    }
+```
+
+- [ ] **Step 6: Add the field, getters, and constructor wiring in `ObaRegionElement.java`**
+
+Add the field after `plausibleAnalyticsServerUrl` (after line 148):
+
+```java
+    private final UmamiAnalyticsConfig umamiAnalytics;
+```
+
+In the no-arg constructor, after `plausibleAnalyticsServerUrl = "";` (line 218):
+
+```java
+        umamiAnalytics = null;
+```
+
+In the all-args constructor, add a parameter at the END of the parameter list (after `String plausibleAnalyticsServerUrl`):
+
+```java
+                            String plausibleAnalyticsServerUrl,
+                            UmamiAnalyticsConfig umamiAnalytics) {
+```
+
+and the matching assignment after `this.plausibleAnalyticsServerUrl = plausibleAnalyticsServerUrl;`:
+
+```java
+        this.umamiAnalytics = umamiAnalytics;
+```
+
+Add the getters after `getPlausibleAnalyticsServerUrl()` (after line 303):
+
+```java
+    @Override
+    public String getUmamiAnalyticsUrl() {
+        return umamiAnalytics != null ? umamiAnalytics.getUrl() : null;
+    }
+
+    @Override
+    public String getUmamiAnalyticsId() {
+        return umamiAnalytics != null ? umamiAnalytics.getId() : null;
+    }
+```
+
+> Note: the all-args constructor now takes 27 args. The two existing positional callers (`ObaContract.Regions.get` and `RegionUtils.getRegionsFromProvider`) are updated in Task 2 — the code will not compile until then. That is expected; this task's test is the parse path, which uses Jackson, not the constructor.
+
+- [ ] **Step 7: Run the test to verify it passes**
+
+Run: `./gradlew connectedObaGoogleDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=org.onebusaway.android.io.test.RegionsTest#testUmamiAnalyticsParsing`
+
+> If the build fails to compile because the two positional `ObaRegionElement(...)` callers now lack the new argument, complete Task 2 first, then re-run. Both tasks land in one commit pair if implemented back-to-back.
+
+Expected (after Task 2 wiring): PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add onebusaway-android/src/main/java/org/onebusaway/android/io/elements/ObaRegion.java \
+        onebusaway-android/src/main/java/org/onebusaway/android/io/elements/ObaRegionElement.java \
+        onebusaway-android/src/androidTest/res/raw/regions_umami_test.json \
+        onebusaway-android/src/androidTest/java/org/onebusaway/android/io/test/RegionsTest.java
+git commit -m "Parse umamiAnalytics config from region feed"
+```
+
+---
+
+### Task 2: Persistence — columns, migration, both cursor readers
+
+**Files:**
+- Modify: `onebusaway-android/src/main/java/org/onebusaway/android/provider/ObaContract.java`
+- Modify: `onebusaway-android/src/main/java/org/onebusaway/android/provider/ObaProvider.java`
+- Modify: `onebusaway-android/src/main/java/org/onebusaway/android/util/RegionUtils.java`
+- Test: `onebusaway-android/src/androidTest/java/org/onebusaway/android/io/test/RegionsTest.java`
+
+**Interfaces:**
+- Consumes: `ObaRegionElement.UmamiAnalyticsConfig` and the 27-arg constructor from Task 1.
+- Produces: content-provider columns `ObaContract.Regions.UMAMI_ANALYTICS_URL`, `ObaContract.Regions.UMAMI_ANALYTICS_ID`; a DB-rebuilt `ObaRegionElement` whose Umami getters are populated from those columns.
+
+- [ ] **Step 1: Write the failing round-trip test**
+
+Add to `RegionsTest.java` (ensure imports: `android.content.ContentResolver`, `android.content.ContentValues`, `org.onebusaway.android.provider.ObaContract`, and static `org.junit.Assert.assertNotNull`):
+
+```java
+@Test
+public void testUmamiAnalyticsPersistenceRoundTrip() {
+    ContentResolver cr = getTargetContext().getContentResolver();
+    int id = 987654;
+
+    ContentValues values = new ContentValues();
+    values.put(ObaContract.Regions._ID, id);
+    values.put(ObaContract.Regions.NAME, "Umami Persist Region");
+    values.put(ObaContract.Regions.OBA_BASE_URL, "https://api.example.com/");
+    values.put(ObaContract.Regions.SIRI_BASE_URL, "");
+    values.put(ObaContract.Regions.LANGUAGE, "en_US");
+    values.put(ObaContract.Regions.CONTACT_EMAIL, "test@example.com");
+    values.put(ObaContract.Regions.SUPPORTS_OBA_DISCOVERY, 1);
+    values.put(ObaContract.Regions.SUPPORTS_OBA_REALTIME, 1);
+    values.put(ObaContract.Regions.SUPPORTS_SIRI_REALTIME, 0);
+    values.put(ObaContract.Regions.UMAMI_ANALYTICS_URL, "https://umami.example.com");
+    values.put(ObaContract.Regions.UMAMI_ANALYTICS_ID, "uuid-persist-1");
+    ObaContract.Regions.insertOrUpdate(getTargetContext(), id, values);
+
+    ObaRegion region = ObaContract.Regions.get(cr, id);
+    assertNotNull(region);
+    assertEquals("https://umami.example.com", region.getUmamiAnalyticsUrl());
+    assertEquals("uuid-persist-1", region.getUmamiAnalyticsId());
+
+    cr.delete(ObaContract.Regions.buildUri(id), null, null);
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `./gradlew connectedObaGoogleDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=org.onebusaway.android.io.test.RegionsTest#testUmamiAnalyticsPersistenceRoundTrip`
+Expected: FAIL to compile — `ObaContract.Regions.UMAMI_ANALYTICS_URL` is undefined.
+
+- [ ] **Step 3: Add the column constants**
+
+In `ObaContract.java` `RegionsColumns`, immediately after `PLAUSIBLE_ANALYTICS_SERVER_URL` (line 385):
+
+```java
+        /**
+         * The Umami analytics server URL for the region.
+         * <P>
+         * Type: TEXT
+         * </P>
+         */
+        public static final String UMAMI_ANALYTICS_URL = "umami_analytics_url";
+
+        /**
+         * The Umami analytics website ID for the region.
+         * <P>
+         * Type: TEXT
+         * </P>
+         */
+        public static final String UMAMI_ANALYTICS_ID = "umami_analytics_id";
+```
+
+- [ ] **Step 4: Update the single-region cursor reader (`ObaContract.Regions.get`)**
+
+In `ObaContract.java` `Regions.get(...)`, append the two columns to the end of the `PROJECTION` array (after `PLAUSIBLE_ANALYTICS_SERVER_URL`):
+
+```java
+                PLAUSIBLE_ANALYTICS_SERVER_URL,
+                UMAMI_ANALYTICS_URL,
+                UMAMI_ANALYTICS_ID
+```
+
+and append the matching argument to the `new ObaRegionElement(...)` call, replacing the final `c.getString(22)` line:
+
+```java
+                        c.getString(22), // Plausible analytics server url
+                        new ObaRegionElement.UmamiAnalyticsConfig(
+                                c.getString(23),  // Umami analytics URL
+                                c.getString(24))  // Umami analytics website ID
+                );
+```
+
+- [ ] **Step 5: Update the bulk cursor reader (`RegionUtils.getRegionsFromProvider`)**
+
+In `RegionUtils.java`, append the two columns to the `PROJECTION` array (after `PLAUSIBLE_ANALYTICS_SERVER_URL`):
+
+```java
+                    ObaContract.Regions.PLAUSIBLE_ANALYTICS_SERVER_URL,
+                    ObaContract.Regions.UMAMI_ANALYTICS_URL,
+                    ObaContract.Regions.UMAMI_ANALYTICS_ID
+```
+
+and replace the final `c.getString(22)` argument in the `new ObaRegionElement(...)` call:
+
+```java
+                        c.getString(22), // Plausible analytics server url
+                        new ObaRegionElement.UmamiAnalyticsConfig(
+                                c.getString(23),  // Umami analytics URL
+                                c.getString(24))  // Umami analytics website ID
+                ));
+```
+
+- [ ] **Step 6: Write the two columns in `RegionUtils.toContentValues`**
+
+In `RegionUtils.java` `toContentValues`, after the `PLAUSIBLE_ANALYTICS_SERVER_URL` put (line 749):
+
+```java
+        values.put(ObaContract.Regions.UMAMI_ANALYTICS_URL, region.getUmamiAnalyticsUrl());
+        values.put(ObaContract.Regions.UMAMI_ANALYTICS_ID, region.getUmamiAnalyticsId());
+```
+
+- [ ] **Step 7: Bump the DB version and add the migration**
+
+In `ObaProvider.java`, change the version constant (line 52):
+
+```java
+        private static final int DATABASE_VERSION = 34;
+```
+
+Then in `onUpgrade`, add `++oldVersion;` to the end of the existing `if (oldVersion == 32)` block and append a new block, so the tail reads:
+
+```java
+            if (oldVersion == 32){
+                db.execSQL("ALTER TABLE " + ObaContract.Regions.PATH +
+                        " ADD COLUMN " + ObaContract.Regions.PLAUSIBLE_ANALYTICS_SERVER_URL + " VARCHAR DEFAULT NULL");
+                ++oldVersion;
+            }
+            if (oldVersion == 33){
+                db.execSQL("ALTER TABLE " + ObaContract.Regions.PATH +
+                        " ADD COLUMN " + ObaContract.Regions.UMAMI_ANALYTICS_URL + " VARCHAR DEFAULT NULL");
+                db.execSQL("ALTER TABLE " + ObaContract.Regions.PATH +
+                        " ADD COLUMN " + ObaContract.Regions.UMAMI_ANALYTICS_ID + " VARCHAR DEFAULT NULL");
+                ++oldVersion;
+            }
+```
+
+> `onCreate` calls `onUpgrade(db, 12, DATABASE_VERSION)`, so fresh installs replay this chain and get the columns. The round-trip test runs against a fresh DB, so it also verifies the migration produced the columns. The `++oldVersion;` added to the v32 block is required so the v33 block executes.
+
+- [ ] **Step 8: Run the test to verify it passes**
+
+Run: `./gradlew connectedObaGoogleDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=org.onebusaway.android.io.test.RegionsTest`
+Expected: PASS for both `testUmamiAnalyticsParsing` and `testUmamiAnalyticsPersistenceRoundTrip`.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add onebusaway-android/src/main/java/org/onebusaway/android/provider/ObaContract.java \
+        onebusaway-android/src/main/java/org/onebusaway/android/provider/ObaProvider.java \
+        onebusaway-android/src/main/java/org/onebusaway/android/util/RegionUtils.java \
+        onebusaway-android/src/androidTest/java/org/onebusaway/android/io/test/RegionsTest.java
+git commit -m "Persist umamiAnalytics fields in regions content provider"
+```
+
+---
+
+### Task 3: The `UmamiAnalytics` emitter
+
+**Files:**
+- Create: `onebusaway-android/src/main/java/org/onebusaway/android/io/UmamiAnalytics.java`
+- Test: `onebusaway-android/src/androidTest/java/org/onebusaway/android/io/test/UmamiAnalyticsTest.java`
+
+**Interfaces:**
+- Produces: `new UmamiAnalytics(String serverUrl, String websiteId, String hostname)`; `void setRegionName(String)`; `void event(String name, String pageUrl, Map<String,Object> props)`; `void pageView(String pageUrl, Map<String,Object> props)`. Package-private pure helpers: `String buildPayload(String name, String path, Map)`, `static String reducePath(String)`, `static boolean isSuccessfulIngest(int, String)`, `static String buildUserAgent()`, `static Map<String,Object> sanitizeProps(Map)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `UmamiAnalyticsTest.java`:
+
+```java
+package org.onebusaway.android.io.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import org.json.JSONObject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.onebusaway.android.io.UmamiAnalytics;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RunWith(AndroidJUnit4.class)
+public class UmamiAnalyticsTest {
+
+    private UmamiAnalytics newClient() {
+        return new UmamiAnalytics("https://umami.example.com/", "wid-1", "api.example.com");
+    }
+
+    @Test
+    public void testEventPayload() throws Exception {
+        UmamiAnalytics client = newClient();
+        client.setRegionName("Tampa Bay");
+        Map<String, Object> props = new HashMap<>();
+        props.put("query", "bus");
+        String json = client.buildPayload("Search", "/search", props);
+
+        JSONObject root = new JSONObject(json);
+        assertEquals("event", root.getString("type"));
+        JSONObject payload = root.getJSONObject("payload");
+        assertEquals("wid-1", payload.getString("website"));
+        assertEquals("api.example.com", payload.getString("hostname"));
+        assertEquals("/search", payload.getString("url"));
+        assertEquals("Search", payload.getString("name"));
+        JSONObject data = payload.getJSONObject("data");
+        assertEquals("bus", data.getString("query"));
+        assertEquals("Tampa Bay", data.getString("RegionName"));
+    }
+
+    @Test
+    public void testPageviewHasNoName() throws Exception {
+        String json = newClient().buildPayload(null, "/stop", null);
+        JSONObject payload = new JSONObject(json).getJSONObject("payload");
+        assertFalse(payload.has("name"));
+        assertEquals("/stop", payload.getString("url"));
+    }
+
+    @Test
+    public void testReducePath() {
+        assertEquals("/map", UmamiAnalytics.reducePath("app://localhost/map"));
+        assertEquals("/", UmamiAnalytics.reducePath("app://localhost"));
+        assertEquals("/", UmamiAnalytics.reducePath(null));
+        assertEquals("/search", UmamiAnalytics.reducePath("app://localhost/search?q=x"));
+    }
+
+    @Test
+    public void testIsSuccessfulIngest() {
+        assertFalse(UmamiAnalytics.isSuccessfulIngest(200, "{\"beep\":\"boop\"}"));
+        assertTrue(UmamiAnalytics.isSuccessfulIngest(200, "some.jwt.token"));
+        assertFalse(UmamiAnalytics.isSuccessfulIngest(500, "error"));
+    }
+
+    @Test
+    public void testUserAgentFormat() {
+        String ua = UmamiAnalytics.buildUserAgent();
+        assertTrue(ua.startsWith("OneBusAway/"));
+        assertTrue(ua.contains("Android"));
+    }
+
+    @Test
+    public void testSanitizePropsDropsNullAndStringifies() {
+        Map<String, Object> in = new HashMap<>();
+        in.put("a", "x");
+        in.put("b", null);
+        in.put("c", new Object() { public String toString() { return "obj"; } });
+        Map<String, Object> out = UmamiAnalytics.sanitizeProps(in);
+        assertEquals("x", out.get("a"));
+        assertFalse(out.containsKey("b"));
+        assertEquals("obj", out.get("c"));
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `./gradlew connectedObaGoogleDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=org.onebusaway.android.io.test.UmamiAnalyticsTest`
+Expected: FAIL to compile — `UmamiAnalytics` does not exist.
+
+- [ ] **Step 3: Create the emitter**
+
+Create `UmamiAnalytics.java`:
+
+```java
+package org.onebusaway.android.io;
+
+import android.os.Build;
+import android.util.Log;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.onebusaway.android.BuildConfig;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+/**
+ * Fire-and-forget Umami analytics emitter. POSTs events to {@code <serverUrl>/api/send}
+ * with a device-like User-Agent. All failures are swallowed; this class never throws
+ * into its callers. Disabled regions never construct an instance (see Application).
+ */
+public class UmamiAnalytics {
+
+    private static final String TAG = "UmamiAnalytics";
+
+    private static final int TIMEOUT_MS = 5000;
+
+    private static final Executor EXECUTOR = Executors.newSingleThreadExecutor();
+
+    private final String mSendUrl;
+
+    private final String mWebsiteId;
+
+    private final String mHostname;
+
+    private final String mUserAgent;
+
+    private volatile String mRegionName;
+
+    public UmamiAnalytics(String serverUrl, String websiteId, String hostname) {
+        mSendUrl = joinUrl(serverUrl, "api/send");
+        mWebsiteId = websiteId;
+        mHostname = hostname;
+        mUserAgent = buildUserAgent();
+    }
+
+    /** Persistent default data merged into every event (e.g. region name). */
+    public void setRegionName(String regionName) {
+        mRegionName = regionName;
+    }
+
+    public void pageView(String pageUrl, Map<String, Object> props) {
+        send(null, pageUrl, props);
+    }
+
+    public void event(String name, String pageUrl, Map<String, Object> props) {
+        send(name, pageUrl, props);
+    }
+
+    private void send(String name, String pageUrl, Map<String, Object> props) {
+        final String payload;
+        try {
+            payload = buildPayload(name, reducePath(pageUrl), props);
+        } catch (Exception e) {
+            Log.w(TAG, "Failed to build Umami payload", e);
+            return;
+        }
+        EXECUTOR.execute(new Runnable() {
+            @Override
+            public void run() {
+                post(payload);
+            }
+        });
+    }
+
+    private void post(String payload) {
+        HttpURLConnection conn = null;
+        try {
+            conn = (HttpURLConnection) new URL(mSendUrl).openConnection();
+            conn.setConnectTimeout(TIMEOUT_MS);
+            conn.setReadTimeout(TIMEOUT_MS);
+            conn.setRequestMethod("POST");
+            conn.setDoOutput(true);
+            conn.setRequestProperty("Content-Type", "application/json");
+            conn.setRequestProperty("User-Agent", mUserAgent);
+            byte[] body = payload.getBytes(StandardCharsets.UTF_8);
+            try (OutputStream os = conn.getOutputStream()) {
+                os.write(body);
+            }
+            int code = conn.getResponseCode();
+            String responseBody = readBody(conn);
+            if (!isSuccessfulIngest(code, responseBody)) {
+                Log.w(TAG, "Umami rejected event (code=" + code + ", body=" + responseBody
+                        + "). Check User-Agent / website config.");
+            }
+        } catch (Exception e) {
+            Log.w(TAG, "Umami send failed", e);
+        } finally {
+            if (conn != null) {
+                conn.disconnect();
+            }
+        }
+    }
+
+    String buildPayload(String name, String path, Map<String, Object> props) throws JSONException {
+        JSONObject payload = new JSONObject();
+        payload.put("website", mWebsiteId);
+        payload.put("hostname", mHostname);
+        payload.put("url", path);
+        if (name != null) {
+            payload.put("name", name);
+        }
+        JSONObject data = new JSONObject();
+        if (mRegionName != null) {
+            data.put("RegionName", mRegionName);
+        }
+        for (Map.Entry<String, Object> entry : sanitizeProps(props).entrySet()) {
+            data.put(entry.getKey(), entry.getValue());
+        }
+        if (data.length() > 0) {
+            payload.put("data", data);
+        }
+        JSONObject root = new JSONObject();
+        root.put("type", "event");
+        root.put("payload", payload);
+        return root.toString();
+    }
+
+    static String reducePath(String pageUrl) {
+        if (pageUrl == null) {
+            return "/";
+        }
+        try {
+            String path = new URI(pageUrl).getPath();
+            if (path == null || path.isEmpty()) {
+                return "/";
+            }
+            return path;
+        } catch (Exception e) {
+            return "/";
+        }
+    }
+
+    /**
+     * Umami returns HTTP 200 even when it silently drops a request (bot-like User-Agent or
+     * bad config), replying with {@code {"beep":"boop"}}. Treat that as a failure.
+     */
+    static boolean isSuccessfulIngest(int httpCode, String body) {
+        if (httpCode < 200 || httpCode >= 300) {
+            return false;
+        }
+        if (body == null) {
+            return true;
+        }
+        String trimmed = body.trim();
+        if (trimmed.isEmpty()) {
+            return true;
+        }
+        return !trimmed.contains("\"beep\"");
+    }
+
+    static String buildUserAgent() {
+        return "OneBusAway/" + BuildConfig.VERSION_NAME
+                + " (Android " + Build.VERSION.RELEASE + "; " + Build.MODEL + ")";
+    }
+
+    static Map<String, Object> sanitizeProps(Map<String, Object> props) {
+        Map<String, Object> out = new HashMap<>();
+        if (props == null) {
+            return out;
+        }
+        for (Map.Entry<String, Object> entry : props.entrySet()) {
+            if (entry.getKey() == null || entry.getValue() == null) {
+                continue;
+            }
+            Object value = entry.getValue();
+            if (value instanceof String || value instanceof Number || value instanceof Boolean) {
+                out.put(entry.getKey(), value);
+            } else {
+                out.put(entry.getKey(), String.valueOf(value));
+            }
+        }
+        return out;
+    }
+
+    private static String joinUrl(String base, String suffix) {
+        if (base == null) {
+            base = "";
+        }
+        return base.endsWith("/") ? base + suffix : base + "/" + suffix;
+    }
+
+    private static String readBody(HttpURLConnection conn) {
+        InputStream stream = null;
+        try {
+            stream = conn.getInputStream();
+        } catch (Exception e) {
+            stream = conn.getErrorStream();
+        }
+        if (stream == null) {
+            return null;
+        }
+        StringBuilder sb = new StringBuilder();
+        try (BufferedReader reader =
+                     new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                sb.append(line);
+            }
+        } catch (Exception e) {
+            return null;
+        }
+        return sb.toString();
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `./gradlew connectedObaGoogleDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=org.onebusaway.android.io.test.UmamiAnalyticsTest`
+Expected: PASS (all six tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add onebusaway-android/src/main/java/org/onebusaway/android/io/UmamiAnalytics.java \
+        onebusaway-android/src/androidTest/java/org/onebusaway/android/io/test/UmamiAnalyticsTest.java
+git commit -m "Add fire-and-forget Umami analytics emitter"
+```
+
+---
+
+### Task 4: `UmamiAnalyticsReporter` — map OBA events to emitter calls
+
+**Files:**
+- Create: `onebusaway-android/src/main/java/org/onebusaway/android/io/UmamiAnalyticsReporter.kt`
+- Test: `onebusaway-android/src/androidTest/java/org/onebusaway/android/io/test/UmamiAnalyticsTest.java`
+
+**Interfaces:**
+- Consumes: `UmamiAnalytics` from Task 3; `PlausibleAnalytics.REPORT_SEARCH_EVENT_URL`.
+- Produces: `UmamiAnalyticsReporter.reportUiEvent(UmamiAnalytics?, String, String, String?)`, `reportSearchEvent(UmamiAnalytics?, String)`, `reportViewStopEvent(UmamiAnalytics?, String, String)` — each a no-op when the emitter is null. Mirrors `PlausibleAnalytics`.
+
+- [ ] **Step 1: Write the failing null-safety test**
+
+Add to `UmamiAnalyticsTest.java`:
+
+```java
+@Test
+public void testReporterNullEmitterIsNoOp() {
+    // Must not throw when Umami is unconfigured (null emitter).
+    org.onebusaway.android.io.UmamiAnalyticsReporter.reportUiEvent(null, "app://localhost/map", "id", "state");
+    org.onebusaway.android.io.UmamiAnalyticsReporter.reportSearchEvent(null, "bus");
+    org.onebusaway.android.io.UmamiAnalyticsReporter.reportViewStopEvent(null, "stop-1", "DISTANCE_1");
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `./gradlew connectedObaGoogleDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=org.onebusaway.android.io.test.UmamiAnalyticsTest#testReporterNullEmitterIsNoOp`
+Expected: FAIL to compile — `UmamiAnalyticsReporter` does not exist.
+
+- [ ] **Step 3: Create the reporter**
+
+Create `UmamiAnalyticsReporter.kt` (mirrors `PlausibleAnalytics.kt`; event names match the Plausible labels so the two sinks report identically):
+
+```kotlin
+package org.onebusaway.android.io
+
+/**
+ * Maps OneBusAway analytics events to [UmamiAnalytics] emitter calls. Mirrors
+ * [PlausibleAnalytics] so Umami receives the same events as Plausible. Every method
+ * is a no-op when [umami] is null (region without Umami config).
+ */
+object UmamiAnalyticsReporter {
+
+    private const val REPORT_VIEW_STOP_EVENT_URL = "app://localhost/stop"
+
+    @JvmStatic
+    fun reportUiEvent(umami: UmamiAnalytics?, pageURL: String, id: String, state: String?) {
+        if (umami == null) return
+        umami.event("Item Selected", pageURL, mapOf("item_id" to id, "item_variant" to state))
+    }
+
+    @JvmStatic
+    fun reportSearchEvent(umami: UmamiAnalytics?, query: String) {
+        if (umami == null) return
+        umami.event("Search", PlausibleAnalytics.REPORT_SEARCH_EVENT_URL, mapOf("query" to query))
+    }
+
+    @JvmStatic
+    fun reportViewStopEvent(umami: UmamiAnalytics?, id: String, stopDistance: String) {
+        if (umami == null) return
+        umami.pageView(REPORT_VIEW_STOP_EVENT_URL, mapOf("id" to id, "distance" to stopDistance))
+    }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `./gradlew connectedObaGoogleDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=org.onebusaway.android.io.test.UmamiAnalyticsTest#testReporterNullEmitterIsNoOp`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add onebusaway-android/src/main/java/org/onebusaway/android/io/UmamiAnalyticsReporter.kt \
+        onebusaway-android/src/androidTest/java/org/onebusaway/android/io/test/UmamiAnalyticsTest.java
+git commit -m "Add UmamiAnalyticsReporter mirroring PlausibleAnalytics"
+```
+
+---
+
+### Task 5: Build and cache the emitter per region in `Application`
+
+**Files:**
+- Modify: `onebusaway-android/src/main/java/org/onebusaway/android/app/Application.java`
+
+**Interfaces:**
+- Consumes: `UmamiAnalytics` (Task 3); `ObaRegion.getUmamiAnalyticsUrl()/getUmamiAnalyticsId()` (Task 1).
+- Produces: `Application.getUmamiInstance(): UmamiAnalytics` (nullable; null when the current region has no Umami config). Rebuilt whenever the region changes, alongside the Plausible instance.
+
+- [ ] **Step 1: Add the field**
+
+In `Application.java`, after `private Plausible mPlausible;` (line 106):
+
+```java
+    private org.onebusaway.android.io.UmamiAnalytics mUmami;
+```
+
+- [ ] **Step 2: Add the accessor and builder**
+
+After the `buildPlausibleInstance` method (after line 389), add:
+
+```java
+    public org.onebusaway.android.io.UmamiAnalytics getUmamiInstance() {
+        if (mUmami == null) {
+            buildUmamiInstance(getCurrentRegion());
+        }
+        return mUmami;
+    }
+
+    private void buildUmamiInstance(ObaRegion region) {
+        mUmami = null;
+        if (region == null
+                || region.getObaBaseUrl() == null
+                || region.getUmamiAnalyticsUrl() == null
+                || region.getUmamiAnalyticsId() == null) {
+            return;
+        }
+        String host;
+        try {
+            host = new URI(region.getObaBaseUrl()).getHost();
+        } catch (URISyntaxException e) {
+            // Fire-and-forget telemetry must never throw on a malformed URL.
+            return;
+        }
+        if (host == null) {
+            return;
+        }
+        mUmami = new org.onebusaway.android.io.UmamiAnalytics(
+                region.getUmamiAnalyticsUrl(), region.getUmamiAnalyticsId(), host);
+    }
+```
+
+- [ ] **Step 3: Rebuild the emitter on region change**
+
+In `Application.java` there are two places that call `buildPlausibleInstance(...)` to refresh on region change. Add a `buildUmamiInstance(...)` call immediately after each:
+
+After the `buildPlausibleInstance(region);` call inside `setCurrentRegion` (line 352):
+
+```java
+                buildPlausibleInstance(region);
+                buildUmamiInstance(region);
+```
+
+After the `buildPlausibleInstance(getCurrentRegion());` call near line 608 (the region-init path that precedes `ObaAnalytics.setRegion(...)`):
+
+```java
+            buildPlausibleInstance(getCurrentRegion());
+            buildUmamiInstance(getCurrentRegion());
+            ObaAnalytics.setRegion(mPlausible, mFirebaseAnalytics, getCurrentRegion().getName());
+```
+
+> `URI` / `URISyntaxException` are already imported in this file (used by `buildPlausibleInstance`).
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `./gradlew assembleObaGoogleDebug`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add onebusaway-android/src/main/java/org/onebusaway/android/app/Application.java
+git commit -m "Build and cache Umami emitter per region in Application"
+```
+
+---
+
+### Task 6: Emit Umami events from `ObaAnalytics`
+
+**Files:**
+- Modify: `onebusaway-android/src/main/java/org/onebusaway/android/io/ObaAnalytics.java`
+
+**Interfaces:**
+- Consumes: `Application.getUmamiInstance()` (Task 5); `UmamiAnalyticsReporter` (Task 4); `UmamiAnalytics.setRegionName` (Task 3).
+- Produces: no signature changes — Umami is fetched internally, so the ~79 existing call sites are untouched.
+
+- [ ] **Step 1: Emit on UI events**
+
+In `reportUiEvent`, after `PlausibleAnalytics.reportUiEvent(plausible, pageURl, id, state);` (line 93):
+
+```java
+        PlausibleAnalytics.reportUiEvent(plausible, pageURl, id, state);
+        UmamiAnalyticsReporter.reportUiEvent(Application.get().getUmamiInstance(), pageURl, id, state);
+```
+
+- [ ] **Step 2: Emit on search events**
+
+In `reportSearchEvent`, after `PlausibleAnalytics.reportSearchEvent(plausible, searchTerm);` (line 129):
+
+```java
+        PlausibleAnalytics.reportSearchEvent(plausible, searchTerm);
+        UmamiAnalyticsReporter.reportSearchEvent(Application.get().getUmamiInstance(), searchTerm);
+```
+
+- [ ] **Step 3: Emit on view-stop events**
+
+In the private `reportViewStopEvent(...)` overload, after `PlausibleAnalytics.reportViewStopEvent(plausible, stopId, proximityToStopCategory);` (line 190):
+
+```java
+        PlausibleAnalytics.reportViewStopEvent(plausible, stopId, proximityToStopCategory);
+        UmamiAnalyticsReporter.reportViewStopEvent(Application.get().getUmamiInstance(), stopId, proximityToStopCategory);
+```
+
+- [ ] **Step 4: Set the region as default data in `setRegion`**
+
+In `setRegion`, after `analytics.setUserProperty(...)` (line 202):
+
+```java
+        analytics.setUserProperty(Application.get().getString(R.string.analytics_label_region_name), regionName);
+        UmamiAnalytics umami = Application.get().getUmamiInstance();
+        if (umami != null) {
+            umami.setRegionName(regionName);
+        }
+```
+
+> `Application`, `UmamiAnalytics`, and `UmamiAnalyticsReporter` are all reachable: `Application` is already imported and used here; the two Umami types share the `org.onebusaway.android.io` package with `ObaAnalytics`, so no import is needed.
+
+- [ ] **Step 5: Verify it compiles and the full suite passes**
+
+Run: `./gradlew assembleObaGoogleDebug`
+Expected: BUILD SUCCESSFUL.
+
+> No new unit test is added here: `ObaAnalytics` depends on static `FirebaseAnalytics` and `Application` singletons that the existing instrumented suite does not mock (there is no `ObaAnalyticsTest` today). This task is verified by compilation, by the emitter/reporter tests from Tasks 3–4, and by the manual dashboard verification in Task 7.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add onebusaway-android/src/main/java/org/onebusaway/android/io/ObaAnalytics.java
+git commit -m "Emit Umami events alongside Plausible from ObaAnalytics"
+```
+
+---
+
+### Task 7: Full build, test suite, and manual verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the full region + Umami test suite**
+
+Run: `./gradlew connectedObaGoogleDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=org.onebusaway.android.io.test.RegionsTest,org.onebusaway.android.io.test.UmamiAnalyticsTest`
+Expected: PASS — all parse, persistence, and emitter tests green.
+
+- [ ] **Step 2: Build the debug APK and install**
+
+Run: `./gradlew installObaGoogleDebug`
+Expected: BUILD SUCCESSFUL, app installs.
+
+- [ ] **Step 3: Manual dashboard verification**
+
+With a build whose current region has live `umamiAnalytics` config (temporarily add a `umamiAnalytics` object to that region's entry in `src/main/res/raw/regions_v3.json`, or point at a region server that serves it):
+- Launch the app, view a stop, run a search.
+- Confirm events appear in the Umami dashboard under the correct website ID, with `url` paths like `/stop`, `/search`, `/map`, and `RegionName` present in event data.
+- Switch to / start in a region with **no** `umamiAnalytics` and confirm **no** events are sent.
+- Toggle the "send anonymous data" preference off and confirm Umami stops emitting.
+- Watch logcat for `UmamiAnalytics` warnings — a `{"beep":"boop"}` rejection log indicates the User-Agent or website config is wrong.
+
+- [ ] **Step 4: Revert any temporary `regions_v3.json` test edit**
+
+Ensure no debugging change to `regions_v3.json` is committed unless intentionally enabling Umami for a production region.
+
+---
+
+## Notes on iOS parity
+
+This plan mirrors the shipped iOS implementation (`~/repos/onebusaway/ios`): identical `{type:"event", payload:{website,hostname,url,name?,data?}}` wire format, reduced `url` paths, `hostname` = region OBA host, region name as default data on every event, device-like User-Agent, and beep-boop ingest detection. Intentional differences: Android reuses its existing per-call `isAnalyticsActive()` opt-out gate rather than nil-ing the emitter, and event *name strings* follow Android's existing Plausible labels (`"Item Selected"`, `"Search"`).

--- a/docs/superpowers/specs/2026-06-22-umami-analytics-design.md
+++ b/docs/superpowers/specs/2026-06-22-umami-analytics-design.md
@@ -3,6 +3,12 @@
 **Issue:** [#1575](https://github.com/OneBusAway/onebusaway-android/issues/1575)
 **Date:** 2026-06-22
 **Status:** Approved design, pending implementation plan
+**Reference implementation:** iOS shipped this on its `umami` branch — see
+`~/repos/onebusaway/ios` (`Apps/Shared/Analytics/UmamiAnalytics.swift`,
+`Apps/Shared/Analytics/AnalyticsOrchestrator.swift`,
+`OBAKitCore/Models/Region.swift`, `OBAKit/Analytics/Analytics.swift`,
+`docs/superpowers/specs/2026-06-21-umami-analytics-design.md`). This design
+aims for wire-level and behavioral parity with iOS.
 
 ## Overview
 
@@ -25,13 +31,15 @@ differences: it needs **two** region fields (`url` + `id`) nested under a
 - **Umami's role:** additive. Firebase and Plausible are untouched; Umami
   becomes a third sink wired into the same `ObaAnalytics` methods. Plausible is
   **not** removed as part of this work.
-- **Client:** hand-rolled OkHttp client (`UmamiAnalytics`), not an SDK. The
-  issue mandates API-only POSTs to `/api/send`, fire-and-forget, fast timeouts,
-  and a custom `User-Agent`. No well-maintained Umami Android SDK exists, and the
-  existing Plausible integration is itself a custom fork.
+- **Client:** hand-rolled OkHttp client, not an SDK. The issue mandates API-only
+  POSTs to `/api/send`, fire-and-forget, fast timeouts, and a custom
+  `User-Agent`. No well-maintained Umami Android SDK exists, and the existing
+  Plausible integration is itself a custom fork.
 - **Event scope:** mirror Plausible exactly. Wherever `ObaAnalytics` already
   receives a `Plausible` instance, it also receives the Umami client and emits
   the same events. No new event taxonomy.
+- **Region name on every event:** match iOS — the client holds persistent
+  "default data" (region name) that is merged into every event's `data`.
 
 ## 1. Region model & persistence
 
@@ -41,73 +49,116 @@ The feed nests the config:
 "umamiAnalytics": { "url": "https://...", "id": "<website-uuid>" }
 ```
 
-- Add a nested `UmamiAnalytics` element class (Jackson-bound `url`, `id`) inside
-  `ObaRegionElement`, parallel to the existing `Bounds` / `Open311Server` nested
-  elements.
+- Add a nested Jackson-bound element class to `ObaRegionElement` named
+  **`UmamiAnalyticsConfig`** (`url`, `id`) — deliberately *not* `UmamiAnalytics`,
+  to avoid colliding with the OkHttp client class (iOS hit and renamed around
+  this exact collision). It binds by field name like the existing `Bounds` /
+  `Open311Server` nested elements (`JacksonSerializer` uses `ANY` field
+  visibility and `FAIL_ON_UNKNOWN_PROPERTIES=false`).
 - Add `getUmamiAnalyticsUrl()` and `getUmamiAnalyticsId()` to the `ObaRegion`
-  interface, returning the nested object's values (or `null` when the object is
-  absent). `ObaRegionElement` implements them by reading the nested object.
+  interface, returning the config's values (or `null` when absent).
 - Persist as two flat `TEXT` columns — `UMAMI_ANALYTICS_URL` and
-  `UMAMI_ANALYTICS_ID` — in `ObaContract.RegionsColumns`, wired through
-  `RegionUtils.toContentValues()` and the cursor-read path, exactly as
+  `UMAMI_ANALYTICS_ID` — in `ObaContract.RegionsColumns`, exactly as
   `PLAUSIBLE_ANALYTICS_SERVER_URL` is handled today.
-- Bump the content-provider database version and add a migration that adds the
-  two columns on upgrade.
-- **Disabled semantics:** if either field (or the `umamiAnalytics` object) is
+- Bump the content-provider database version (currently 33 → 34) and add an
+  `if (oldVersion == 33)` migration block with two `ALTER TABLE ... ADD COLUMN`
+  statements, mirroring the Plausible migration at `oldVersion == 32`.
+- **Flat-vs-nested round-trip (important):** JSON parsing produces a nested
+  `UmamiAnalyticsConfig` object, but the content provider **rebuilds**
+  `ObaRegionElement` from the two flat `TEXT` columns — it does not reconstruct
+  the nested object. The getters must therefore return correct values whether
+  the element was JSON-parsed (nested object present) or DB-rebuilt (flat values
+  only). Concretely: `ObaRegionElement` carries the two flat string fields, the
+  getters read those, and the JSON path also populates them from the nested
+  object. (Plausible sidesteps this by being flat end-to-end; Umami cannot,
+  because the feed is nested.)
+- **Disabled semantics:** if the `umamiAnalytics` object or either field is
   null/missing, Umami is disabled for that region.
 
-**Files touched:** `io/elements/ObaRegion.java`,
-`io/elements/ObaRegionElement.java`, `provider/ObaContract.java`,
-`provider/ObaProvider.java` (DB version + migration),
-`util/RegionUtils.java`.
+**Files touched:**
 
-## 2. The Umami client (`UmamiAnalytics`)
+- `io/elements/ObaRegion.java` — two new getters.
+- `io/elements/ObaRegionElement.java` — nested `UmamiAnalyticsConfig`, two flat
+  fields, getters, **and both constructors** (the no-arg default and the full
+  positional constructor — every caller of the positional constructor updates).
+- `provider/ObaContract.java` — column constants **and** the second, positional
+  cursor reader at `~:1438-1462` (`new ObaRegionElement(... c.getString(22))`):
+  append the two columns at indices 23/24. *This reader is independent of
+  `RegionUtils` and silently drops columns if missed.*
+- `provider/ObaProvider.java` — DB version bump + migration.
+- `util/RegionUtils.java` — `toContentValues()` writes the two columns, and the
+  positional cursor reader at `~:401-479` (projection currently ends at index 22)
+  reads them at indices 23/24.
+
+## 2. The Umami client
 
 New class `org.onebusaway.android.io.UmamiAnalytics`, sibling to `ObaAnalytics`,
 wrapping OkHttp.
 
-- **Construction:** built from the current region's `url` + `id`. A factory
-  helper returns `null` (or a no-op instance) when the region has no Umami
-  config, so callers stay clean.
+- **Construction:** built from the current region's `url` + `id`, plus mutable
+  default data (region name). A factory helper returns `null` (or a no-op
+  instance) when the region has no Umami config, so callers stay clean.
 - **Public API:** mirrors how Plausible is used — `event(String name,
   Map<String,Object> props)` for custom events and `pageview(String path)`
-  (no `name` field). `ObaAnalytics` calls these.
-- **Payload** — JSON POST to `<url>/api/send`:
+  (no `name` field) — plus a `setDefaultData`/`setRegionName` setter for the
+  persistent region-name property. `ObaAnalytics` calls these.
+- **Payload** — JSON POST to `<url>/api/send` (identical to iOS):
 
   ```json
   { "type": "event",
     "payload": { "website": "<id>", "hostname": "<host>", "url": "<path>",
-                 "name": "<eventName>", "data": { ...props } } }
+                 "name": "<eventName>", "data": { ...defaultData, ...props } } }
   ```
 
   Omitting `name` records a pageview; including it records a custom event.
+  `data` is omitted when empty. Default data (region name) is merged into every
+  event.
 - **Hostname / url path:** native apps have no real URL.
-  - `hostname` = the host of the region's OBA base URL (stable per region;
-    groups data correctly per website in the dashboard).
-  - `url` = the screen/element path already passed into `reportUiEvent`
-    (existing `pageURl` / `id` arguments).
+  - `hostname` = the host of the region's OBA base URL. Derive it **without
+    throwing** — swallow a malformed-URI error and skip the send, rather than
+    rethrowing as `RuntimeException` the way the existing Plausible path does
+    (`Application.buildPlausibleInstance`). This is fire-and-forget telemetry.
+  - `url` = a **reduced path**, matching iOS. Reduce the existing `pageURl`/`id`
+    argument (e.g. `app://localhost/map`) to its path (`/map`) via
+    `new URI(pageUrl).getPath()`; pathless → `/`; drop any query. Without this,
+    Android would report `app://localhost/...` while iOS reports `/...`, so the
+    same screen would appear as different pages in the dashboard.
 - **User-Agent:** `OneBusAway/<versionName> (Android <Build.VERSION.RELEASE>;
   <Build.MODEL>)`, set explicitly on every request, overriding OkHttp's default
-  so Umami's `isbot` check does not silently reject it.
+  (`okhttp/<version>`). Must be non-empty and device-like so Umami's `isbot`
+  filter does not reject it. (`Build.MODEL` is acceptable — it is device-like.)
+- **Success / "beep-boop" detection (critical):** a dropped event returns
+  **HTTP 200**, not an error. Umami replies `{"beep":"boop"}` (or a body lacking
+  `cache`/`sessionId`/`visitId`) when it rejects the request — typically a
+  bot-like User-Agent or bad config. Inspect the 200 body and treat such a
+  response as a (logged, swallowed) failure, mirroring iOS `isSuccessfulIngest`.
+  Without this, a broken User-Agent fails silently with no signal.
 - **Fail-safe:** asynchronous fire-and-forget (`enqueue`), short connect/read/
-  write timeouts (~3–5s), all exceptions and non-2xx responses swallowed (at
-  most logged). Never throws into callers.
+  write timeouts (~3–5s), all exceptions and rejection responses swallowed (at
+  most logged). Serialize props safely: drop or stringify any non-JSON value in
+  the `Map<String,Object>` so a stray prop can't throw on the analytics path.
+  Never throws into callers.
 
 ## 3. `ObaAnalytics` integration & privacy
 
 - Each `ObaAnalytics` method that currently takes a `Plausible plausible`
   parameter gains a parallel nullable `UmamiAnalytics umami` parameter. Right
   after the existing Plausible call, it makes the equivalent Umami call. Methods
-  affected: `reportUiEvent`, `reportSearchEvent`, `reportViewStopEvent`,
-  `setRegion`. Their call sites pass the Umami instance alongside the Plausible
-  one they already pass.
-- **Instance source:** the same places that build the `Plausible` object from
-  the current region also build the `UmamiAnalytics` instance from the region's
-  `url`/`id`, or leave it null when unconfigured.
+  affected: `reportUiEvent` (`io/ObaAnalytics.java:83`), `reportSearchEvent`
+  (`:119`), `reportViewStopEvent` (`:142,180`), `setRegion` (`:198`). Their call
+  sites pass the Umami instance alongside the Plausible one they already pass.
+- **`setRegion` behavior:** in addition to the Firebase/Plausible region
+  property, it sets the Umami client's persistent default data to the region
+  name, so every subsequent Umami event carries it (iOS parity).
+- **Instance source:** add `getUmamiInstance()` / `buildUmamiInstance()` to
+  `app/Application.java`, parallel to the existing `getPlausibleInstance()` /
+  `buildPlausibleInstance()` (`~:367,379-388`) — the single construction seam.
+  It returns null when the region has no Umami config.
 - **Privacy opt-out:** reuse the existing gate. `ObaAnalytics` already consults
-  the user's "send anonymous data" preference (`isAnalyticsActive()`); the Umami
-  calls sit behind that same check. Opt-out suppresses Umami exactly as it does
-  Firebase/Plausible. No new preference UI.
+  the user's "send anonymous data" preference (`isAnalyticsActive()`,
+  `preferences_key_analytics`, default true); the Umami calls sit behind that
+  same check. Opt-out suppresses Umami exactly as it does Firebase/Plausible. No
+  new preference UI.
 - **Null-safety:** every Umami call is guarded — a null client (unconfigured
   region) or an opted-out user is a no-op.
 
@@ -117,11 +168,16 @@ wrapping OkHttp.
   fixture with `umamiAnalytics` present → getters populated; object absent/null
   → both getters null; only one of the two fields present → treated as disabled.
 - **Persistence round-trip:** save a region via `RegionUtils.toContentValues()`,
-  read it back through the provider, assert both new columns survive; verify the
-  DB migration adds the columns on upgrade.
-- **Payload construction:** unit-test the JSON body and the `User-Agent` header
-  (pageview vs. named event; props serialization). Because the network call is
-  fire-and-forget, assert on the request that *would* be sent, not on delivery.
+  read it back through the provider, assert both new columns survive **and that
+  the DB-rebuilt `ObaRegionElement` (not just a JSON-parsed one) yields populated
+  Umami getters**; verify the migration adds the columns on upgrade.
+- **Payload construction:** unit-test the JSON body, the reduced `url` path
+  (`app://localhost/map` → `/map`, pathless → `/`), the merged default data, and
+  the `User-Agent` header (pageview vs. named event; props serialization;
+  non-JSON props dropped). Because the network call is fire-and-forget, assert on
+  the request that *would* be sent, not on delivery.
+- **Success detection:** test that a `{"beep":"boop"}` 200 body is treated as a
+  failure (logged, swallowed) and a valid ingest body as success.
 - **Manual verification** (issue's real acceptance test): a debug build pointed
   at a region with live Umami config produces events in the dashboard under the
   correct website; an unconfigured region produces none.
@@ -131,7 +187,7 @@ wrapping OkHttp.
 
 - App parses `umamiAnalytics` per region and disables analytics when null. ✅ §1
 - Real device events appear in the Umami dashboard under the correct website.
-  ✅ §2 / manual test §4
+  ✅ §2 (incl. beep-boop detection) / manual test §4
 - No events emit for unconfigured regions. ✅ §1 disabled semantics, §3
   null-safety
 - Analytics failures don't impact user-facing functionality. ✅ §2 fail-safe

--- a/docs/superpowers/specs/2026-06-22-umami-analytics-design.md
+++ b/docs/superpowers/specs/2026-06-22-umami-analytics-design.md
@@ -1,0 +1,144 @@
+# Umami Analytics Support — Design
+
+**Issue:** [#1575](https://github.com/OneBusAway/onebusaway-android/issues/1575)
+**Date:** 2026-06-22
+**Status:** Approved design, pending implementation plan
+
+## Overview
+
+Add native Umami analytics as a **third parallel analytics sink** alongside the
+existing Firebase and Plausible integrations. Umami configuration is discovered
+per-region through the feed the app already fetches. Events are emitted via
+direct API calls (no JavaScript tracker), fire-and-forget, and analytics
+failures never affect user-facing functionality.
+
+Umami is structurally a near-twin of the existing Plausible integration:
+`ObaRegion` already exposes `getPlausibleAnalyticsServerUrl()`, persisted as a
+content-provider column, and `ObaAnalytics` methods already accept a `Plausible`
+instance alongside `FirebaseAnalytics`. Umami follows the same pattern, with two
+differences: it needs **two** region fields (`url` + `id`) nested under a
+`umamiAnalytics` object, and a hand-rolled API client that sends a device-like
+`User-Agent`.
+
+### Decisions
+
+- **Umami's role:** additive. Firebase and Plausible are untouched; Umami
+  becomes a third sink wired into the same `ObaAnalytics` methods. Plausible is
+  **not** removed as part of this work.
+- **Client:** hand-rolled OkHttp client (`UmamiAnalytics`), not an SDK. The
+  issue mandates API-only POSTs to `/api/send`, fire-and-forget, fast timeouts,
+  and a custom `User-Agent`. No well-maintained Umami Android SDK exists, and the
+  existing Plausible integration is itself a custom fork.
+- **Event scope:** mirror Plausible exactly. Wherever `ObaAnalytics` already
+  receives a `Plausible` instance, it also receives the Umami client and emits
+  the same events. No new event taxonomy.
+
+## 1. Region model & persistence
+
+The feed nests the config:
+
+```json
+"umamiAnalytics": { "url": "https://...", "id": "<website-uuid>" }
+```
+
+- Add a nested `UmamiAnalytics` element class (Jackson-bound `url`, `id`) inside
+  `ObaRegionElement`, parallel to the existing `Bounds` / `Open311Server` nested
+  elements.
+- Add `getUmamiAnalyticsUrl()` and `getUmamiAnalyticsId()` to the `ObaRegion`
+  interface, returning the nested object's values (or `null` when the object is
+  absent). `ObaRegionElement` implements them by reading the nested object.
+- Persist as two flat `TEXT` columns — `UMAMI_ANALYTICS_URL` and
+  `UMAMI_ANALYTICS_ID` — in `ObaContract.RegionsColumns`, wired through
+  `RegionUtils.toContentValues()` and the cursor-read path, exactly as
+  `PLAUSIBLE_ANALYTICS_SERVER_URL` is handled today.
+- Bump the content-provider database version and add a migration that adds the
+  two columns on upgrade.
+- **Disabled semantics:** if either field (or the `umamiAnalytics` object) is
+  null/missing, Umami is disabled for that region.
+
+**Files touched:** `io/elements/ObaRegion.java`,
+`io/elements/ObaRegionElement.java`, `provider/ObaContract.java`,
+`provider/ObaProvider.java` (DB version + migration),
+`util/RegionUtils.java`.
+
+## 2. The Umami client (`UmamiAnalytics`)
+
+New class `org.onebusaway.android.io.UmamiAnalytics`, sibling to `ObaAnalytics`,
+wrapping OkHttp.
+
+- **Construction:** built from the current region's `url` + `id`. A factory
+  helper returns `null` (or a no-op instance) when the region has no Umami
+  config, so callers stay clean.
+- **Public API:** mirrors how Plausible is used — `event(String name,
+  Map<String,Object> props)` for custom events and `pageview(String path)`
+  (no `name` field). `ObaAnalytics` calls these.
+- **Payload** — JSON POST to `<url>/api/send`:
+
+  ```json
+  { "type": "event",
+    "payload": { "website": "<id>", "hostname": "<host>", "url": "<path>",
+                 "name": "<eventName>", "data": { ...props } } }
+  ```
+
+  Omitting `name` records a pageview; including it records a custom event.
+- **Hostname / url path:** native apps have no real URL.
+  - `hostname` = the host of the region's OBA base URL (stable per region;
+    groups data correctly per website in the dashboard).
+  - `url` = the screen/element path already passed into `reportUiEvent`
+    (existing `pageURl` / `id` arguments).
+- **User-Agent:** `OneBusAway/<versionName> (Android <Build.VERSION.RELEASE>;
+  <Build.MODEL>)`, set explicitly on every request, overriding OkHttp's default
+  so Umami's `isbot` check does not silently reject it.
+- **Fail-safe:** asynchronous fire-and-forget (`enqueue`), short connect/read/
+  write timeouts (~3–5s), all exceptions and non-2xx responses swallowed (at
+  most logged). Never throws into callers.
+
+## 3. `ObaAnalytics` integration & privacy
+
+- Each `ObaAnalytics` method that currently takes a `Plausible plausible`
+  parameter gains a parallel nullable `UmamiAnalytics umami` parameter. Right
+  after the existing Plausible call, it makes the equivalent Umami call. Methods
+  affected: `reportUiEvent`, `reportSearchEvent`, `reportViewStopEvent`,
+  `setRegion`. Their call sites pass the Umami instance alongside the Plausible
+  one they already pass.
+- **Instance source:** the same places that build the `Plausible` object from
+  the current region also build the `UmamiAnalytics` instance from the region's
+  `url`/`id`, or leave it null when unconfigured.
+- **Privacy opt-out:** reuse the existing gate. `ObaAnalytics` already consults
+  the user's "send anonymous data" preference (`isAnalyticsActive()`); the Umami
+  calls sit behind that same check. Opt-out suppresses Umami exactly as it does
+  Firebase/Plausible. No new preference UI.
+- **Null-safety:** every Umami call is guarded — a null client (unconfigured
+  region) or an opted-out user is a no-op.
+
+## 4. Testing
+
+- **Region parsing** (androidTest, alongside existing region tests): feed
+  fixture with `umamiAnalytics` present → getters populated; object absent/null
+  → both getters null; only one of the two fields present → treated as disabled.
+- **Persistence round-trip:** save a region via `RegionUtils.toContentValues()`,
+  read it back through the provider, assert both new columns survive; verify the
+  DB migration adds the columns on upgrade.
+- **Payload construction:** unit-test the JSON body and the `User-Agent` header
+  (pageview vs. named event; props serialization). Because the network call is
+  fire-and-forget, assert on the request that *would* be sent, not on delivery.
+- **Manual verification** (issue's real acceptance test): a debug build pointed
+  at a region with live Umami config produces events in the dashboard under the
+  correct website; an unconfigured region produces none.
+- **No-regression:** Firebase and Plausible event paths are unchanged.
+
+## Acceptance criteria (from issue #1575)
+
+- App parses `umamiAnalytics` per region and disables analytics when null. ✅ §1
+- Real device events appear in the Umami dashboard under the correct website.
+  ✅ §2 / manual test §4
+- No events emit for unconfigured regions. ✅ §1 disabled semantics, §3
+  null-safety
+- Analytics failures don't impact user-facing functionality. ✅ §2 fail-safe
+
+## Out of scope (YAGNI)
+
+- No new event types beyond what Plausible already receives.
+- No batching, retry, or offline queue.
+- No per-event opt-out UI (reuse existing preference).
+- No removal of Plausible.

--- a/docs/superpowers/specs/2026-06-22-umami-analytics-design.md
+++ b/docs/superpowers/specs/2026-06-22-umami-analytics-design.md
@@ -31,10 +31,13 @@ differences: it needs **two** region fields (`url` + `id`) nested under a
 - **Umami's role:** additive. Firebase and Plausible are untouched; Umami
   becomes a third sink wired into the same `ObaAnalytics` methods. Plausible is
   **not** removed as part of this work.
-- **Client:** hand-rolled OkHttp client, not an SDK. The issue mandates API-only
-  POSTs to `/api/send`, fire-and-forget, fast timeouts, and a custom
-  `User-Agent`. No well-maintained Umami Android SDK exists, and the existing
-  Plausible integration is itself a custom fork.
+- **Client:** hand-rolled client over `HttpURLConnection` (the app's existing
+  `ObaApi` networking primitive) on a background executor — **no new
+  dependency.** OkHttp is not a declared dependency or imported anywhere in the
+  app, and adding one for fire-and-forget telemetry isn't warranted. The issue
+  mandates API-only POSTs to `/api/send`, fire-and-forget, fast timeouts, and a
+  custom `User-Agent`. No well-maintained Umami Android SDK exists, and the
+  existing Plausible integration is itself a custom fork.
 - **Event scope:** mirror Plausible exactly. Wherever `ObaAnalytics` already
   receives a `Plausible` instance, it also receives the Umami client and emits
   the same events. No new event taxonomy.
@@ -93,7 +96,7 @@ The feed nests the config:
 ## 2. The Umami client
 
 New class `org.onebusaway.android.io.UmamiAnalytics`, sibling to `ObaAnalytics`,
-wrapping OkHttp.
+wrapping `HttpURLConnection` calls dispatched on a background executor.
 
 - **Construction:** built from the current region's `url` + `id`, plus mutable
   default data (region name). A factory helper returns `null` (or a no-op
@@ -133,23 +136,28 @@ wrapping OkHttp.
   bot-like User-Agent or bad config. Inspect the 200 body and treat such a
   response as a (logged, swallowed) failure, mirroring iOS `isSuccessfulIngest`.
   Without this, a broken User-Agent fails silently with no signal.
-- **Fail-safe:** asynchronous fire-and-forget (`enqueue`), short connect/read/
-  write timeouts (~3–5s), all exceptions and rejection responses swallowed (at
-  most logged). Serialize props safely: drop or stringify any non-JSON value in
-  the `Map<String,Object>` so a stray prop can't throw on the analytics path.
-  Never throws into callers.
+- **User-Agent:** must override `HttpURLConnection`'s default agent string,
+  which is `Dalvik/...` / `Java/...`-style and would otherwise risk Umami's
+  `isbot` rejection.
+- **Fail-safe:** fire-and-forget on a background `Executor`, short connect/read
+  timeouts (~3–5s), all exceptions and rejection responses swallowed (at most
+  logged). Serialize props safely: drop or stringify any non-JSON value in the
+  `Map<String,Object>` so a stray prop can't throw on the analytics path. Never
+  throws into callers.
 
 ## 3. `ObaAnalytics` integration & privacy
 
-- Each `ObaAnalytics` method that currently takes a `Plausible plausible`
-  parameter gains a parallel nullable `UmamiAnalytics umami` parameter. Right
-  after the existing Plausible call, it makes the equivalent Umami call. Methods
-  affected: `reportUiEvent` (`io/ObaAnalytics.java:83`), `reportSearchEvent`
-  (`:119`), `reportViewStopEvent` (`:142,180`), `setRegion` (`:198`). Their call
-  sites pass the Umami instance alongside the Plausible one they already pass.
-- **`setRegion` behavior:** in addition to the Firebase/Plausible region
-  property, it sets the Umami client's persistent default data to the region
-  name, so every subsequent Umami event carries it (iOS parity).
+- **No call-site changes.** Rather than threading a new parameter through all
+  ~79 `ObaAnalytics` call sites, each affected `ObaAnalytics` method fetches the
+  Umami instance internally via `Application.get().getUmamiInstance()` (the class
+  already calls `Application.get()` for prefs/strings). Right after the existing
+  Plausible call, it makes the equivalent Umami call through a
+  `UmamiAnalyticsReporter` helper. Methods affected: `reportUiEvent`
+  (`io/ObaAnalytics.java:83`), `reportSearchEvent` (`:119`),
+  `reportViewStopEvent` (`:180`), `setRegion` (`:198`).
+- **`setRegion` behavior:** in addition to the Firebase region property, it sets
+  the Umami client's persistent default data to the region name, so every
+  subsequent Umami event carries it (iOS parity).
 - **Instance source:** add `getUmamiInstance()` / `buildUmamiInstance()` to
   `app/Application.java`, parallel to the existing `getPlausibleInstance()` /
   `buildPlausibleInstance()` (`~:367,379-388`) — the single construction seam.

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/io/test/RegionsTest.java
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/io/test/RegionsTest.java
@@ -22,12 +22,17 @@ import org.onebusaway.android.R;
 import org.onebusaway.android.io.elements.ObaRegion;
 import org.onebusaway.android.io.request.ObaRegionsRequest;
 import org.onebusaway.android.io.request.ObaRegionsResponse;
+import org.onebusaway.android.mock.Resources;
+import org.onebusaway.android.provider.ObaContract;
 
 import android.content.ContentResolver;
+import android.content.ContentValues;
 import android.net.Uri;
 
 import static androidx.test.InstrumentationRegistry.getTargetContext;
+import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNotNull;
+import static junit.framework.Assert.assertNull;
 import static junit.framework.Assert.assertTrue;
 
 /**
@@ -60,5 +65,47 @@ public class RegionsTest extends ObaTestCase {
                 new ObaRegionsRequest.Builder(getTargetContext());
         ObaRegionsRequest request = builder.build();
         assertNotNull(request);
+    }
+
+    @Test
+    public void testUmamiAnalyticsParsing() throws Exception {
+        ObaRegionsResponse response = Resources.readAs(getTargetContext(),
+                Resources.getTestUri("regions_umami_test"), ObaRegionsResponse.class);
+        ObaRegion[] regions = response.getRegions();
+
+        ObaRegion withUmami = regions[0];
+        assertEquals("https://umami.example.com", withUmami.getUmamiAnalyticsUrl());
+        assertEquals("abc-123-uuid", withUmami.getUmamiAnalyticsId());
+
+        ObaRegion withoutUmami = regions[1];
+        assertNull(withoutUmami.getUmamiAnalyticsUrl());
+        assertNull(withoutUmami.getUmamiAnalyticsId());
+    }
+
+    @Test
+    public void testUmamiAnalyticsPersistenceRoundTrip() {
+        ContentResolver cr = getTargetContext().getContentResolver();
+        int id = 987654;
+
+        ContentValues values = new ContentValues();
+        values.put(ObaContract.Regions._ID, id);
+        values.put(ObaContract.Regions.NAME, "Umami Persist Region");
+        values.put(ObaContract.Regions.OBA_BASE_URL, "https://api.example.com/");
+        values.put(ObaContract.Regions.SIRI_BASE_URL, "");
+        values.put(ObaContract.Regions.LANGUAGE, "en_US");
+        values.put(ObaContract.Regions.CONTACT_EMAIL, "test@example.com");
+        values.put(ObaContract.Regions.SUPPORTS_OBA_DISCOVERY, 1);
+        values.put(ObaContract.Regions.SUPPORTS_OBA_REALTIME, 1);
+        values.put(ObaContract.Regions.SUPPORTS_SIRI_REALTIME, 0);
+        values.put(ObaContract.Regions.UMAMI_ANALYTICS_URL, "https://umami.example.com");
+        values.put(ObaContract.Regions.UMAMI_ANALYTICS_ID, "uuid-persist-1");
+        ObaContract.Regions.insertOrUpdate(getTargetContext(), id, values);
+
+        ObaRegion region = ObaContract.Regions.get(cr, id);
+        assertNotNull(region);
+        assertEquals("https://umami.example.com", region.getUmamiAnalyticsUrl());
+        assertEquals("uuid-persist-1", region.getUmamiAnalyticsId());
+
+        cr.delete(ObaContract.Regions.buildUri(id), null, null);
     }
 }

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/io/test/UmamiAnalyticsTest.java
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/io/test/UmamiAnalyticsTest.java
@@ -82,4 +82,12 @@ public class UmamiAnalyticsTest {
         assertFalse(out.containsKey("b"));
         assertEquals("obj", out.get("c"));
     }
+
+    @Test
+    public void testReporterNullEmitterIsNoOp() {
+        // Must not throw when Umami is unconfigured (null emitter).
+        org.onebusaway.android.io.UmamiAnalyticsReporter.reportUiEvent(null, "app://localhost/map", "id", "state");
+        org.onebusaway.android.io.UmamiAnalyticsReporter.reportSearchEvent(null, "bus");
+        org.onebusaway.android.io.UmamiAnalyticsReporter.reportViewStopEvent(null, "stop-1", "DISTANCE_1");
+    }
 }

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/io/test/UmamiAnalyticsTest.java
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/io/test/UmamiAnalyticsTest.java
@@ -1,0 +1,85 @@
+package org.onebusaway.android.io.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import androidx.test.runner.AndroidJUnit4;
+
+import org.json.JSONObject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.onebusaway.android.io.UmamiAnalytics;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RunWith(AndroidJUnit4.class)
+public class UmamiAnalyticsTest {
+
+    private UmamiAnalytics newClient() {
+        return new UmamiAnalytics("https://umami.example.com/", "wid-1", "api.example.com");
+    }
+
+    @Test
+    public void testEventPayload() throws Exception {
+        UmamiAnalytics client = newClient();
+        client.setRegionName("Tampa Bay");
+        Map<String, Object> props = new HashMap<>();
+        props.put("query", "bus");
+        String json = client.buildPayload("Search", "/search", props);
+
+        JSONObject root = new JSONObject(json);
+        assertEquals("event", root.getString("type"));
+        JSONObject payload = root.getJSONObject("payload");
+        assertEquals("wid-1", payload.getString("website"));
+        assertEquals("api.example.com", payload.getString("hostname"));
+        assertEquals("/search", payload.getString("url"));
+        assertEquals("Search", payload.getString("name"));
+        JSONObject data = payload.getJSONObject("data");
+        assertEquals("bus", data.getString("query"));
+        assertEquals("Tampa Bay", data.getString("RegionName"));
+    }
+
+    @Test
+    public void testPageviewHasNoName() throws Exception {
+        String json = newClient().buildPayload(null, "/stop", null);
+        JSONObject payload = new JSONObject(json).getJSONObject("payload");
+        assertFalse(payload.has("name"));
+        assertEquals("/stop", payload.getString("url"));
+    }
+
+    @Test
+    public void testReducePath() {
+        assertEquals("/map", UmamiAnalytics.reducePath("app://localhost/map"));
+        assertEquals("/", UmamiAnalytics.reducePath("app://localhost"));
+        assertEquals("/", UmamiAnalytics.reducePath(null));
+        assertEquals("/search", UmamiAnalytics.reducePath("app://localhost/search?q=x"));
+    }
+
+    @Test
+    public void testIsSuccessfulIngest() {
+        assertFalse(UmamiAnalytics.isSuccessfulIngest(200, "{\"beep\":\"boop\"}"));
+        assertTrue(UmamiAnalytics.isSuccessfulIngest(200, "some.jwt.token"));
+        assertFalse(UmamiAnalytics.isSuccessfulIngest(500, "error"));
+    }
+
+    @Test
+    public void testUserAgentFormat() {
+        String ua = UmamiAnalytics.buildUserAgent();
+        assertTrue(ua.startsWith("OneBusAway/"));
+        assertTrue(ua.contains("Android"));
+    }
+
+    @Test
+    public void testSanitizePropsDropsNullAndStringifies() {
+        Map<String, Object> in = new HashMap<>();
+        in.put("a", "x");
+        in.put("b", null);
+        in.put("c", new Object() { public String toString() { return "obj"; } });
+        Map<String, Object> out = UmamiAnalytics.sanitizeProps(in);
+        assertEquals("x", out.get("a"));
+        assertFalse(out.containsKey("b"));
+        assertEquals("obj", out.get("c"));
+    }
+}

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/mock/MockRegion.java
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/mock/MockRegion.java
@@ -97,7 +97,8 @@ public class MockRegion {
                 false,
                 false,
                 "https://onebusaway.co",
-                null);
+                null,
+                null);   // UmamiAnalyticsConfig — disabled in test regions
     }
 
     /**
@@ -139,7 +140,8 @@ public class MockRegion {
                 false,
                 false,
                 "https://onebusaway.co",
-                null);
+                null,
+                null);   // UmamiAnalyticsConfig — disabled in test regions
     }
 
     /**
@@ -181,7 +183,8 @@ public class MockRegion {
                 false,
                 false,
                 "https://onebusaway.co",
-                null);
+                null,
+                null);   // UmamiAnalyticsConfig — disabled in test regions
     }
 
     /**
@@ -223,7 +226,8 @@ public class MockRegion {
                 false,
                 false,
                 "https://onebusaway.co",
-                null);
+                null,
+                null);   // UmamiAnalyticsConfig — disabled in test regions
     }
 
     /**
@@ -265,7 +269,8 @@ public class MockRegion {
                 false,
                 false,
                 "https://onebusaway.co",
-                null);
+                null,
+                null);   // UmamiAnalyticsConfig — disabled in test regions
     }
 
     /**
@@ -307,7 +312,8 @@ public class MockRegion {
                 false,
                 false,
                 "https://onebusaway.co",
-                null);
+                null,
+                null);   // UmamiAnalyticsConfig — disabled in test regions
     }
 
     /**
@@ -347,7 +353,8 @@ public class MockRegion {
                 false,
                 false,
                 "https://onebusaway.co",
-                null);
+                null,
+                null);   // UmamiAnalyticsConfig — disabled in test regions
     }
 
     /**
@@ -387,6 +394,7 @@ public class MockRegion {
                 false,
                 false,
                 "https://onebusaway.co",
-                null);
+                null,
+                null);   // UmamiAnalyticsConfig — disabled in test regions
     }
 }

--- a/onebusaway-android/src/androidTest/res/raw/regions_umami_test.json
+++ b/onebusaway-android/src/androidTest/res/raw/regions_umami_test.json
@@ -1,0 +1,39 @@
+{
+  "code": 200,
+  "text": "OK",
+  "version": 3,
+  "data": {
+    "limitExceeded": false,
+    "list": [
+      {
+        "id": 0,
+        "regionName": "Umami Region",
+        "active": true,
+        "obaBaseUrl": "https://api.umami.example.com/",
+        "siriBaseUrl": null,
+        "umamiAnalytics": { "url": "https://umami.example.com", "id": "abc-123-uuid" },
+        "bounds": [ { "lat": 27.9, "lon": -82.4, "latSpan": 0.5, "lonSpan": 0.5 } ],
+        "language": "en_US",
+        "contactEmail": "test@example.com",
+        "supportsObaDiscoveryApis": true,
+        "supportsObaRealtimeApis": true,
+        "supportsSiriRealtimeApis": false,
+        "experimental": false
+      },
+      {
+        "id": 1,
+        "regionName": "No Umami Region",
+        "active": true,
+        "obaBaseUrl": "https://api.noumami.example.com/",
+        "siriBaseUrl": null,
+        "bounds": [ { "lat": 47.6, "lon": -122.3, "latSpan": 0.5, "lonSpan": 0.5 } ],
+        "language": "en_US",
+        "contactEmail": "test@example.com",
+        "supportsObaDiscoveryApis": true,
+        "supportsObaRealtimeApis": true,
+        "supportsSiriRealtimeApis": false,
+        "experimental": false
+      }
+    ]
+  }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/app/Application.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/app/Application.java
@@ -105,6 +105,8 @@ public class Application extends android.app.Application {
 
     private Plausible mPlausible;
 
+    private org.onebusaway.android.io.UmamiAnalytics mUmami;
+
     @Override
     public void onCreate() {
         super.onCreate();
@@ -350,6 +352,7 @@ public class Application extends android.app.Application {
                 setCustomOtpApiUrl(null);
                 setUseOldOtpApiUrlVersion(false);
                 buildPlausibleInstance(region);
+                buildUmamiInstance(region);
             }
         } else {
             //User must have just entered a custom API URL via Preferences, so clear the region info
@@ -386,6 +389,35 @@ public class Application extends android.app.Application {
             throw new RuntimeException(e);
         }
         mPlausible = new Plausible(this, domain, region.getPlausibleAnalyticsServerUrl());
+    }
+
+    public org.onebusaway.android.io.UmamiAnalytics getUmamiInstance() {
+        if (mUmami == null) {
+            buildUmamiInstance(getCurrentRegion());
+        }
+        return mUmami;
+    }
+
+    private void buildUmamiInstance(ObaRegion region) {
+        mUmami = null;
+        if (region == null
+                || region.getObaBaseUrl() == null
+                || region.getUmamiAnalyticsUrl() == null
+                || region.getUmamiAnalyticsId() == null) {
+            return;
+        }
+        String host;
+        try {
+            host = new URI(region.getObaBaseUrl()).getHost();
+        } catch (URISyntaxException e) {
+            // Fire-and-forget telemetry must never throw on a malformed URL.
+            return;
+        }
+        if (host == null) {
+            return;
+        }
+        mUmami = new org.onebusaway.android.io.UmamiAnalytics(
+                region.getUmamiAnalyticsUrl(), region.getUmamiAnalyticsId(), host);
     }
 
 
@@ -606,6 +638,7 @@ public class Application extends android.app.Application {
         mFirebaseAnalytics = FirebaseAnalytics.getInstance(this);
         if (getCustomApiUrl() == null && getCurrentRegion() != null) {
             buildPlausibleInstance(getCurrentRegion());
+            buildUmamiInstance(getCurrentRegion());
             ObaAnalytics.setRegion(mPlausible, mFirebaseAnalytics, getCurrentRegion().getName());
         } else if (Application.get().getCustomApiUrl() != null) {
             String customUrl = null;

--- a/onebusaway-android/src/main/java/org/onebusaway/android/io/ObaAnalytics.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/io/ObaAnalytics.java
@@ -91,6 +91,7 @@ public class ObaAnalytics {
         }
         analytics.logEvent(FirebaseAnalytics.Event.SELECT_CONTENT, bundle);
         PlausibleAnalytics.reportUiEvent(plausible, pageURl, id, state);
+        UmamiAnalyticsReporter.reportUiEvent(Application.get().getUmamiInstance(), pageURl, id, state);
     }
 
     /**
@@ -127,6 +128,7 @@ public class ObaAnalytics {
         }
         analytics.logEvent(FirebaseAnalytics.Event.SEARCH, bundle);
         PlausibleAnalytics.reportSearchEvent(plausible, searchTerm);
+        UmamiAnalyticsReporter.reportSearchEvent(Application.get().getUmamiInstance(), searchTerm);
     }
 
     /**
@@ -188,6 +190,7 @@ public class ObaAnalytics {
         bundle.putString(FirebaseAnalytics.Param.LOCATION_ID, proximityToStopCategory);
         analytics.logEvent(FirebaseAnalytics.Event.VIEW_ITEM, bundle);
         PlausibleAnalytics.reportViewStopEvent(plausible, stopId, proximityToStopCategory);
+        UmamiAnalyticsReporter.reportViewStopEvent(Application.get().getUmamiInstance(), stopId, proximityToStopCategory);
     }
 
     /**
@@ -200,6 +203,10 @@ public class ObaAnalytics {
             return;
         }
         analytics.setUserProperty(Application.get().getString(R.string.analytics_label_region_name), regionName);
+        UmamiAnalytics umami = Application.get().getUmamiInstance();
+        if (umami != null) {
+            umami.setRegionName(regionName);
+        }
     }
 
     /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/io/UmamiAnalytics.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/io/UmamiAnalytics.java
@@ -1,0 +1,221 @@
+package org.onebusaway.android.io;
+
+import android.os.Build;
+import android.util.Log;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.onebusaway.android.BuildConfig;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+/**
+ * Fire-and-forget Umami analytics emitter. POSTs events to {@code <serverUrl>/api/send}
+ * with a device-like User-Agent. All failures are swallowed; this class never throws
+ * into its callers. Disabled regions never construct an instance (see Application).
+ */
+public class UmamiAnalytics {
+
+    private static final String TAG = "UmamiAnalytics";
+
+    private static final int TIMEOUT_MS = 5000;
+
+    private static final Executor EXECUTOR = Executors.newSingleThreadExecutor();
+
+    private final String mSendUrl;
+
+    private final String mWebsiteId;
+
+    private final String mHostname;
+
+    private final String mUserAgent;
+
+    private volatile String mRegionName;
+
+    public UmamiAnalytics(String serverUrl, String websiteId, String hostname) {
+        mSendUrl = joinUrl(serverUrl, "api/send");
+        mWebsiteId = websiteId;
+        mHostname = hostname;
+        mUserAgent = buildUserAgent();
+    }
+
+    /** Persistent default data merged into every event (e.g. region name). */
+    public void setRegionName(String regionName) {
+        mRegionName = regionName;
+    }
+
+    public void pageView(String pageUrl, Map<String, Object> props) {
+        send(null, pageUrl, props);
+    }
+
+    public void event(String name, String pageUrl, Map<String, Object> props) {
+        send(name, pageUrl, props);
+    }
+
+    private void send(String name, String pageUrl, Map<String, Object> props) {
+        final String payload;
+        try {
+            payload = buildPayload(name, reducePath(pageUrl), props);
+        } catch (Exception e) {
+            Log.w(TAG, "Failed to build Umami payload", e);
+            return;
+        }
+        EXECUTOR.execute(new Runnable() {
+            @Override
+            public void run() {
+                post(payload);
+            }
+        });
+    }
+
+    private void post(String payload) {
+        HttpURLConnection conn = null;
+        try {
+            conn = (HttpURLConnection) new URL(mSendUrl).openConnection();
+            conn.setConnectTimeout(TIMEOUT_MS);
+            conn.setReadTimeout(TIMEOUT_MS);
+            conn.setRequestMethod("POST");
+            conn.setDoOutput(true);
+            conn.setRequestProperty("Content-Type", "application/json");
+            conn.setRequestProperty("User-Agent", mUserAgent);
+            byte[] body = payload.getBytes(StandardCharsets.UTF_8);
+            try (OutputStream os = conn.getOutputStream()) {
+                os.write(body);
+            }
+            int code = conn.getResponseCode();
+            String responseBody = readBody(conn);
+            if (!isSuccessfulIngest(code, responseBody)) {
+                Log.w(TAG, "Umami rejected event (code=" + code + ", body=" + responseBody
+                        + "). Check User-Agent / website config.");
+            }
+        } catch (Exception e) {
+            Log.w(TAG, "Umami send failed", e);
+        } finally {
+            if (conn != null) {
+                conn.disconnect();
+            }
+        }
+    }
+
+    public String buildPayload(String name, String path, Map<String, Object> props) throws JSONException {
+        JSONObject payload = new JSONObject();
+        payload.put("website", mWebsiteId);
+        payload.put("hostname", mHostname);
+        payload.put("url", path);
+        if (name != null) {
+            payload.put("name", name);
+        }
+        JSONObject data = new JSONObject();
+        if (mRegionName != null) {
+            data.put("RegionName", mRegionName);
+        }
+        for (Map.Entry<String, Object> entry : sanitizeProps(props).entrySet()) {
+            data.put(entry.getKey(), entry.getValue());
+        }
+        if (data.length() > 0) {
+            payload.put("data", data);
+        }
+        JSONObject root = new JSONObject();
+        root.put("type", "event");
+        root.put("payload", payload);
+        return root.toString();
+    }
+
+    public static String reducePath(String pageUrl) {
+        if (pageUrl == null) {
+            return "/";
+        }
+        try {
+            String path = new URI(pageUrl).getPath();
+            if (path == null || path.isEmpty()) {
+                return "/";
+            }
+            return path;
+        } catch (Exception e) {
+            return "/";
+        }
+    }
+
+    /**
+     * Umami returns HTTP 200 even when it silently drops a request (bot-like User-Agent or
+     * bad config), replying with {@code {"beep":"boop"}}. Treat that as a failure.
+     */
+    public static boolean isSuccessfulIngest(int httpCode, String body) {
+        if (httpCode < 200 || httpCode >= 300) {
+            return false;
+        }
+        if (body == null) {
+            return true;
+        }
+        String trimmed = body.trim();
+        if (trimmed.isEmpty()) {
+            return true;
+        }
+        return !trimmed.contains("\"beep\"");
+    }
+
+    public static String buildUserAgent() {
+        return "OneBusAway/" + BuildConfig.VERSION_NAME
+                + " (Android " + Build.VERSION.RELEASE + "; " + Build.MODEL + ")";
+    }
+
+    public static Map<String, Object> sanitizeProps(Map<String, Object> props) {
+        Map<String, Object> out = new HashMap<>();
+        if (props == null) {
+            return out;
+        }
+        for (Map.Entry<String, Object> entry : props.entrySet()) {
+            if (entry.getKey() == null || entry.getValue() == null) {
+                continue;
+            }
+            Object value = entry.getValue();
+            if (value instanceof String || value instanceof Number || value instanceof Boolean) {
+                out.put(entry.getKey(), value);
+            } else {
+                out.put(entry.getKey(), String.valueOf(value));
+            }
+        }
+        return out;
+    }
+
+    private static String joinUrl(String base, String suffix) {
+        if (base == null) {
+            base = "";
+        }
+        return base.endsWith("/") ? base + suffix : base + "/" + suffix;
+    }
+
+    private static String readBody(HttpURLConnection conn) {
+        InputStream stream = null;
+        try {
+            stream = conn.getInputStream();
+        } catch (Exception e) {
+            stream = conn.getErrorStream();
+        }
+        if (stream == null) {
+            return null;
+        }
+        StringBuilder sb = new StringBuilder();
+        try (BufferedReader reader =
+                     new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                sb.append(line);
+            }
+        } catch (Exception e) {
+            return null;
+        }
+        return sb.toString();
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/io/UmamiAnalyticsReporter.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/io/UmamiAnalyticsReporter.kt
@@ -1,0 +1,29 @@
+package org.onebusaway.android.io
+
+/**
+ * Maps OneBusAway analytics events to [UmamiAnalytics] emitter calls. Mirrors
+ * [PlausibleAnalytics] so Umami receives the same events as Plausible. Every method
+ * is a no-op when [umami] is null (region without Umami config).
+ */
+object UmamiAnalyticsReporter {
+
+    private const val REPORT_VIEW_STOP_EVENT_URL = "app://localhost/stop"
+
+    @JvmStatic
+    fun reportUiEvent(umami: UmamiAnalytics?, pageURL: String, id: String, state: String?) {
+        if (umami == null) return
+        umami.event("Item Selected", pageURL, mapOf("item_id" to id, "item_variant" to state))
+    }
+
+    @JvmStatic
+    fun reportSearchEvent(umami: UmamiAnalytics?, query: String) {
+        if (umami == null) return
+        umami.event("Search", PlausibleAnalytics.REPORT_SEARCH_EVENT_URL, mapOf("query" to query))
+    }
+
+    @JvmStatic
+    fun reportViewStopEvent(umami: UmamiAnalytics?, id: String, stopDistance: String) {
+        if (umami == null) return
+        umami.pageView(REPORT_VIEW_STOP_EVENT_URL, mapOf("id" to id, "distance" to stopDistance))
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/io/elements/ObaRegion.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/io/elements/ObaRegion.java
@@ -79,6 +79,16 @@ public interface ObaRegion {
     public String getPlausibleAnalyticsServerUrl();
 
     /**
+     * @return The Umami analytics server URL for this region, or null if not configured.
+     */
+    public String getUmamiAnalyticsUrl();
+
+    /**
+     * @return The Umami analytics website ID for this region, or null if not configured.
+     */
+    public String getUmamiAnalyticsId();
+
+    /**
      * @return The base SIRI URL for this region, or null if it doesn't use SIRI.
      */
     public String getSiriBaseUrl();

--- a/onebusaway-android/src/main/java/org/onebusaway/android/io/elements/ObaRegionElement.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/io/elements/ObaRegionElement.java
@@ -85,6 +85,31 @@ public class ObaRegionElement implements ObaRegion {
         }
     }
 
+    public static class UmamiAnalyticsConfig {
+
+        private final String url;
+
+        private final String id;
+
+        UmamiAnalyticsConfig() {
+            url = null;
+            id = null;
+        }
+
+        public UmamiAnalyticsConfig(String url, String id) {
+            this.url = url;
+            this.id = id;
+        }
+
+        public String getUrl() {
+            return url;
+        }
+
+        public String getId() {
+            return id;
+        }
+    }
+
     public static class Open311Server implements ObaRegion.Open311Server {
 
         public static final Open311Server[] EMPTY_ARRAY = new Open311Server[]{};
@@ -146,6 +171,8 @@ public class ObaRegionElement implements ObaRegion {
     private final String sidecarBaseUrl;
 
     private final String plausibleAnalyticsServerUrl;
+
+    private final UmamiAnalyticsConfig umamiAnalytics;
 
     private final String siriBaseUrl;
 
@@ -216,6 +243,7 @@ public class ObaRegionElement implements ObaRegion {
         enrollParticipantsInStudy = false;
         sidecarBaseUrl = "";
         plausibleAnalyticsServerUrl = "";
+        umamiAnalytics = null;
     }
 
     public ObaRegionElement(long id,
@@ -243,7 +271,8 @@ public class ObaRegionElement implements ObaRegion {
                             boolean travelBehaviorDataCollectionEnabled,
                             boolean enrollParticipantsInStudy,
                             String sidecarBaseUrl,
-                            String plausibleAnalyticsServerUrl) {
+                            String plausibleAnalyticsServerUrl,
+                            UmamiAnalyticsConfig umamiAnalytics) {
         this.id = id;
         this.regionName = name;
         this.active = active;
@@ -270,6 +299,7 @@ public class ObaRegionElement implements ObaRegion {
         this.enrollParticipantsInStudy = enrollParticipantsInStudy;
         this.sidecarBaseUrl = sidecarBaseUrl;
         this.plausibleAnalyticsServerUrl = plausibleAnalyticsServerUrl;
+        this.umamiAnalytics = umamiAnalytics;
     }
 
     @Override
@@ -300,6 +330,16 @@ public class ObaRegionElement implements ObaRegion {
     @Override
     public String getPlausibleAnalyticsServerUrl() {
         return plausibleAnalyticsServerUrl;
+    }
+
+    @Override
+    public String getUmamiAnalyticsUrl() {
+        return umamiAnalytics != null ? umamiAnalytics.getUrl() : null;
+    }
+
+    @Override
+    public String getUmamiAnalyticsId() {
+        return umamiAnalytics != null ? umamiAnalytics.getId() : null;
     }
 
     @Override

--- a/onebusaway-android/src/main/java/org/onebusaway/android/provider/ObaContract.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/provider/ObaContract.java
@@ -385,6 +385,22 @@ public final class ObaContract {
         public static final String PLAUSIBLE_ANALYTICS_SERVER_URL = "plausible_analytics_server_url";
 
         /**
+         * The Umami analytics server URL for the region.
+         * <P>
+         * Type: TEXT
+         * </P>
+         */
+        public static final String UMAMI_ANALYTICS_URL = "umami_analytics_url";
+
+        /**
+         * The Umami analytics website ID for the region.
+         * <P>
+         * Type: TEXT
+         * </P>
+         */
+        public static final String UMAMI_ANALYTICS_ID = "umami_analytics_id";
+
+        /**
          * The base SIRI URL.
          * <P>
          * Type: TEXT
@@ -1423,7 +1439,9 @@ public final class ObaContract {
                     TRAVEL_BEHAVIOR_DATA_COLLECTION,
                     ENROLL_PARTICIPANTS_IN_STUDY,
                     SIDECAR_BASE_URL,
-                    PLAUSIBLE_ANALYTICS_SERVER_URL
+                    PLAUSIBLE_ANALYTICS_SERVER_URL,
+                    UMAMI_ANALYTICS_URL,
+                    UMAMI_ANALYTICS_ID
             };
 
             Cursor c = cr.query(buildUri((int) id), PROJECTION, null, null, null);
@@ -1458,7 +1476,10 @@ public final class ObaContract {
                             c.getInt(19) > 0, // Travel behavior data collection
                             c.getInt(20) > 0, // Enroll participants in travel behavior study
                             c.getString(21), // Sidecar Base URL
-                            c.getString(22) // Plausible analytics server url
+                            c.getString(22), // Plausible analytics server url
+                            new ObaRegionElement.UmamiAnalyticsConfig(
+                                    c.getString(23),  // Umami analytics URL
+                                    c.getString(24))  // Umami analytics website ID
                     );
                 } finally {
                     c.close();

--- a/onebusaway-android/src/main/java/org/onebusaway/android/provider/ObaContract.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/provider/ObaContract.java
@@ -1451,6 +1451,12 @@ public final class ObaContract {
                         return null;
                     }
                     c.moveToFirst();
+                    String umamiUrl = c.getString(23);
+                    String umamiId = c.getString(24);
+                    ObaRegionElement.UmamiAnalyticsConfig umamiConfig =
+                            (umamiUrl != null || umamiId != null)
+                                    ? new ObaRegionElement.UmamiAnalyticsConfig(umamiUrl, umamiId)
+                                    : null;
                     return new ObaRegionElement(id,   // id
                             c.getString(1),             // Name
                             true,                       // Active
@@ -1477,9 +1483,7 @@ public final class ObaContract {
                             c.getInt(20) > 0, // Enroll participants in travel behavior study
                             c.getString(21), // Sidecar Base URL
                             c.getString(22), // Plausible analytics server url
-                            new ObaRegionElement.UmamiAnalyticsConfig(
-                                    c.getString(23),  // Umami analytics URL
-                                    c.getString(24))  // Umami analytics website ID
+                            umamiConfig      // Umami analytics config (null when unconfigured)
                     );
                 } finally {
                     c.close();

--- a/onebusaway-android/src/main/java/org/onebusaway/android/provider/ObaProvider.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/provider/ObaProvider.java
@@ -49,7 +49,7 @@ public class ObaProvider extends ContentProvider {
 
     private class OpenHelper extends SQLiteOpenHelper {
 
-        private static final int DATABASE_VERSION = 33;
+        private static final int DATABASE_VERSION = 34;
 
         public OpenHelper(Context context) {
             super(context, DATABASE_NAME, null, DATABASE_VERSION);
@@ -322,6 +322,14 @@ public class ObaProvider extends ContentProvider {
             if (oldVersion == 32){
                 db.execSQL("ALTER TABLE " + ObaContract.Regions.PATH +
                         " ADD COLUMN " + ObaContract.Regions.PLAUSIBLE_ANALYTICS_SERVER_URL + " VARCHAR DEFAULT NULL");
+                ++oldVersion;
+            }
+            if (oldVersion == 33){
+                db.execSQL("ALTER TABLE " + ObaContract.Regions.PATH +
+                        " ADD COLUMN " + ObaContract.Regions.UMAMI_ANALYTICS_URL + " VARCHAR DEFAULT NULL");
+                db.execSQL("ALTER TABLE " + ObaContract.Regions.PATH +
+                        " ADD COLUMN " + ObaContract.Regions.UMAMI_ANALYTICS_ID + " VARCHAR DEFAULT NULL");
+                ++oldVersion;
             }
         }
 
@@ -635,6 +643,10 @@ public class ObaProvider extends ContentProvider {
                 .put(ObaContract.Regions.SIDECAR_BASE_URL, ObaContract.Regions.SIDECAR_BASE_URL);
         sRegionsProjectionMap
                 .put(ObaContract.Regions.PLAUSIBLE_ANALYTICS_SERVER_URL, ObaContract.Regions.PLAUSIBLE_ANALYTICS_SERVER_URL);
+        sRegionsProjectionMap
+                .put(ObaContract.Regions.UMAMI_ANALYTICS_URL, ObaContract.Regions.UMAMI_ANALYTICS_URL);
+        sRegionsProjectionMap
+                .put(ObaContract.Regions.UMAMI_ANALYTICS_ID, ObaContract.Regions.UMAMI_ANALYTICS_ID);
     }
 
     private SQLiteDatabase mDb;

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/RegionUtils.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/RegionUtils.java
@@ -452,6 +452,13 @@ public class RegionUtils {
                         open311Servers.toArray(new ObaRegionElement.Open311Server[]{}) :
                         null;
 
+                String umamiUrl = c.getString(23);
+                String umamiId = c.getString(24);
+                ObaRegionElement.UmamiAnalyticsConfig umamiConfig =
+                        (umamiUrl != null || umamiId != null)
+                                ? new ObaRegionElement.UmamiAnalyticsConfig(umamiUrl, umamiId)
+                                : null;
+
                 results.add(new ObaRegionElement(id,   // id
                         c.getString(1),             // Name
                         true,                       // Active
@@ -478,9 +485,7 @@ public class RegionUtils {
                         c.getInt(20) > 0, // enrolling participants for travel behavior data collection
                         c.getString(21), //Sidecar base URL
                         c.getString(22), // Plausible analytics server url
-                        new ObaRegionElement.UmamiAnalyticsConfig(
-                                c.getString(23),  // Umami analytics URL
-                                c.getString(24))  // Umami analytics website ID
+                        umamiConfig      // Umami analytics config (null when unconfigured)
                 ));
 
             } while (c.moveToNext());

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/RegionUtils.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/RegionUtils.java
@@ -421,7 +421,9 @@ public class RegionUtils {
                     ObaContract.Regions.TRAVEL_BEHAVIOR_DATA_COLLECTION,
                     ObaContract.Regions.ENROLL_PARTICIPANTS_IN_STUDY,
                     ObaContract.Regions.SIDECAR_BASE_URL,
-                    ObaContract.Regions.PLAUSIBLE_ANALYTICS_SERVER_URL
+                    ObaContract.Regions.PLAUSIBLE_ANALYTICS_SERVER_URL,
+                    ObaContract.Regions.UMAMI_ANALYTICS_URL,
+                    ObaContract.Regions.UMAMI_ANALYTICS_ID
             };
 
             ContentResolver cr = context.getContentResolver();
@@ -475,7 +477,10 @@ public class RegionUtils {
                         c.getInt(19) > 0, // travel behavior data collection enabled for region
                         c.getInt(20) > 0, // enrolling participants for travel behavior data collection
                         c.getString(21), //Sidecar base URL
-                        c.getString(22) // Plausible analytics server url
+                        c.getString(22), // Plausible analytics server url
+                        new ObaRegionElement.UmamiAnalyticsConfig(
+                                c.getString(23),  // Umami analytics URL
+                                c.getString(24))  // Umami analytics website ID
                 ));
 
             } while (c.moveToNext());
@@ -666,7 +671,8 @@ public class RegionUtils {
                 BuildConfig.FIXED_REGION_TRAVEL_BEHAVIOR_DATA_COLLECTION,
                 BuildConfig.FIXED_REGION_ENROLL_PARTICIPANTS_IN_STUDY,
                 BuildConfig.FIXED_REGION_SIDECAR_BASE_URL,
-                BuildConfig.FIXED_REGION_PLAUSIBLE_ANALYTICS_SERVER_URL);
+                BuildConfig.FIXED_REGION_PLAUSIBLE_ANALYTICS_SERVER_URL,
+                null);   // No Umami config for the fixed-region build flavor
         return region;
     }
 
@@ -747,6 +753,8 @@ public class RegionUtils {
                 region.isEnrollParticipantsInStudy() ? 1 : 0);
         values.put(ObaContract.Regions.SIDECAR_BASE_URL, region.getSidecarBaseUrl());
         values.put(ObaContract.Regions.PLAUSIBLE_ANALYTICS_SERVER_URL, region.getPlausibleAnalyticsServerUrl());
+        values.put(ObaContract.Regions.UMAMI_ANALYTICS_URL, region.getUmamiAnalyticsUrl());
+        values.put(ObaContract.Regions.UMAMI_ANALYTICS_ID, region.getUmamiAnalyticsId());
         return values;
     }
 


### PR DESCRIPTION
## Summary

Adds native **Umami analytics** support as a third, region-configured analytics sink alongside the existing Firebase and Plausible integrations. Closes #1575.

Analytics config is discovered per-region from the existing region feed: each region may carry `"umamiAnalytics": { "url": "...", "id": "<website-uuid>" }`. When that object (or either field) is null/missing, Umami is disabled for that region — no requests are made. Events are sent fire-and-forget to `<url>/api/send` and analytics failures never affect user-facing functionality.

This mirrors the shipped iOS implementation (`onebusaway-ios`, `umami` branch) at the wire level and in behavior.

## What's included

- **Region model & persistence** — parse the nested `umamiAnalytics` object (`ObaRegionElement.UmamiAnalyticsConfig`), expose `getUmamiAnalyticsUrl()`/`getUmamiAnalyticsId()`, persist as two `TEXT` columns with a content-provider DB migration (v33 → v34, columns default `NULL`, replayed on fresh install).
- **`UmamiAnalytics` emitter** — hand-rolled over `HttpURLConnection` on a background executor (no new dependencies). Builds the `{type:"event", payload:{website,hostname,url,name?,data?}}` payload, reduces the screen path (`app://localhost/map` → `/map`), merges the region name as default data on every event, and sends a **device-like `User-Agent`** (`OneBusAway/<version> (Android ...)`) so Umami's `isbot` filter doesn't silently reject events. Detects the HTTP-200 `{"beep":"boop"}` rejection as a failure. Short timeouts; all exceptions swallowed/logged.
- **`UmamiAnalyticsReporter`** — mirrors `PlausibleAnalytics`, so Umami receives the same events.
- **`Application` wiring** — `getUmamiInstance()` / `buildUmamiInstance()` build and cache the emitter per region (rebuilt on region change; malformed-URI swallowed).
- **`ObaAnalytics` integration** — emits Umami events alongside Plausible, fetched internally (no changes to the ~79 call sites), behind the existing `isAnalyticsActive()` opt-out gate.

## Key behaviors

- **Disabled when unconfigured:** no emitter, no requests for regions without `umamiAnalytics`.
- **Privacy opt-out honored:** Umami emits only when the user's "send anonymous data" preference is on, same gate as Firebase/Plausible.
- **Fail-safe:** never throws into callers, never blocks the UI thread.

## Testing

- Instrumented tests (11 passing): region parse (populated vs. null), content-provider round-trip, and emitter unit tests (payload shape, pageview-has-no-name, path reduction, beep-boop detection, User-Agent format, prop sanitization, null-reporter no-op).
- `./gradlew assembleObaGoogleDebug` and the focused `connectedObaGoogleDebugAndroidTest` suite both green.

Design doc, spec, and implementation plan are included under `docs/superpowers/`.

## Not covered here

Manual Umami-dashboard verification against a live region (issue #1575's real-device acceptance check) — to be confirmed once a region serves live `umamiAnalytics` config.
