### PR TITLE
Cache map marker BitmapDescriptors by logical key in GoogleMapRenderer

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/map/VehicleIconAllocationTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/map/VehicleIconAllocationTest.kt
@@ -1,0 +1,164 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.map
+
+import android.content.Context
+import android.util.Log
+import androidx.test.InstrumentationRegistry.getTargetContext
+import androidx.test.runner.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.onebusaway.android.extrapolation.extrapolatedVehicles
+import org.onebusaway.android.io.request.ObaTripsForRouteResponse
+import org.onebusaway.android.map.googlemapsv2.BitmapDescriptorCache
+import org.onebusaway.android.map.render.VehicleBitmaps
+import org.onebusaway.android.map.render.VehicleMarker
+import org.onebusaway.android.mock.Resources
+
+/**
+ * The before/after allocation guard for #1580. `GoogleMapRenderer` re-stamps a gliding vehicle's icon on
+ * every heading-octant change (the ~20Hz reconcile path), so before [BitmapDescriptorCache] it minted a
+ * fresh `BitmapDescriptor` + native texture per flip — hundreds/sec on a busy route.
+ *
+ * This drives the *real* icon path (the cached [VehicleBitmaps.vehicleBitmap] feeding the descriptor
+ * cache) over a simulated route session and asserts the property the fix introduces: the number of wrapper
+ * allocations is bounded by the distinct icons and is **independent of how many frames run** — whereas the
+ * naive per-flip allocation count grows with the session. The descriptor factory is a counting fake (the
+ * cache's only allocator), so this needs no real `GoogleMap`.
+ */
+@RunWith(AndroidJUnit4::class)
+class VehicleIconAllocationTest {
+
+    private val context: Context get() = getTargetContext()
+
+    // A real, busy trips-for-route snapshot (38 vehicles across many HART routes, with full route refs so
+    // icon type/color resolve) — the "busy route" the issue calls out.
+    private fun response(): ObaTripsForRouteResponse =
+        Resources.readAs(
+            context,
+            Resources.getTestUri("trips_for_route_hart_5"),
+            ObaTripsForRouteResponse::class.java,
+        )
+
+    /** The live vehicles for every route the snapshot serves, mapped to render markers as RouteMapController does. */
+    private fun vehicles(response: ObaTripsForRouteResponse): List<VehicleMarker> {
+        val routeIds = response.trips
+            .mapNotNull { it.status?.activeTripId }
+            .mapNotNull { response.getTrip(it)?.routeId }
+            .toSet()
+        return extrapolatedVehicles(response, routeIds, nowMs = 1_000_000L) { null }
+            .map { v ->
+                VehicleMarker(
+                    activeTripId = v.status.activeTripId,
+                    point = v.point,
+                    isRealtime = VehicleBitmaps.isLocationRealtime(v.status),
+                    status = v.status,
+                    fixTimeMs = v.fixTimeMs,
+                    bearing = v.bearing,
+                )
+            }
+    }
+
+    /** Tallies for one replay: total icon requests, descriptors minted, and bitmaps decoded. */
+    private class Counts {
+        var requests = 0
+        var allocations = 0
+        var bitmapDecodes = 0
+    }
+
+    /**
+     * Replay [frames] of the renderer's icon hot path: each frame every vehicle's bearing rotates, and —
+     * exactly like `GoogleMapRenderer` — an icon is (re)requested only when its heading octant flips. Each
+     * request goes through a fresh [BitmapDescriptorCache] keyed by the real [VehicleBitmaps.iconKey]; the
+     * descriptor `wrap` and the bitmap supplier each bump a counter so the test can see how many actually ran.
+     */
+    private fun replay(
+        vehicles: List<VehicleMarker>,
+        response: ObaTripsForRouteResponse,
+        frames: Int,
+    ): Counts {
+        val counts = Counts()
+        val cache = BitmapDescriptorCache(CACHE_SIZE) { counts.allocations++ }
+        val lastOctant = HashMap<String, Int>()
+        for (frame in 0 until frames) {
+            for (vehicle in vehicles) {
+                val moved = vehicle.copy(bearing = (frame * BEARING_STEP_DEG) % 360f)
+                val octant = VehicleBitmaps.directionIndex(moved)
+                if (lastOctant.put(moved.activeTripId, octant) != octant) {
+                    counts.requests++
+                    cache.get(VehicleBitmaps.iconKey(moved, response)) {
+                        counts.bitmapDecodes++
+                        VehicleBitmaps.vehicleBitmap(context, moved, response)
+                    }
+                }
+            }
+        }
+        return counts
+    }
+
+    @Test
+    fun descriptorAllocationsAreBoundedAndIndependentOfFrameCount() {
+        val response = response()
+        val vehicles = vehicles(response)
+        assertTrue("fixture must yield at least one vehicle", vehicles.isNotEmpty())
+
+        val shortRun = replay(vehicles, response, SHORT_FRAMES)
+        val longRun = replay(vehicles, response, LONG_FRAMES)
+
+        // Headline before/after for #1580: requests = uncached fromBitmap allocs; allocations = cached.
+        Log.i(
+            "VehicleIconAlloc",
+            "${vehicles.size} vehicles: ${longRun.requests} requests -> " +
+                "${longRun.allocations} allocs, ${longRun.bitmapDecodes} bitmap decodes",
+        )
+
+        // Naive work — a fromBitmap per octant flip — grows with the session length...
+        assertTrue("a longer session must issue more icon requests", longRun.requests > shortRun.requests)
+        // ...but the cache mints the same descriptors regardless: a 4x-longer session allocates no more.
+        assertEquals(
+            "descriptor allocations must not grow with frame count",
+            shortRun.allocations,
+            longRun.allocations,
+        )
+        // The expensive bitmap decode/tint runs only on a miss, i.e. exactly once per minted descriptor —
+        // never re-run on the hot path even as the bounded VehicleBitmaps LRU evicts under a busy route.
+        assertEquals(
+            "bitmap decode must run only on descriptor-cache misses",
+            longRun.allocations,
+            longRun.bitmapDecodes,
+        )
+        // Bounded by the distinct directional icons (at most 8 octants per vehicle) — far below the
+        // requests it served, which is the whole point of the cache.
+        assertTrue(
+            "allocations (${longRun.allocations}) must be bounded by the distinct icons",
+            longRun.allocations <= 8 * vehicles.size,
+        )
+    }
+
+    companion object {
+        // Sweep the bearing through all 8 octants within a few frames, then revisit them (no new icons) —
+        // which is the property under test (revisited octants reuse the cached descriptor).
+        private const val BEARING_STEP_DEG = 25f
+        private const val SHORT_FRAMES = 60
+        private const val LONG_FRAMES = 240
+        // Far larger than the snapshot's distinct icons (8 octants x a handful of type/deviation-color
+        // combos), so eviction never confounds the "allocations independent of frame count" invariant. The
+        // production cap is deliberately smaller — it only needs to cover the live working set, not history.
+        private const val CACHE_SIZE = 1024
+    }
+}

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/BitmapDescriptorCache.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/BitmapDescriptorCache.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.map.googlemapsv2
+
+import android.graphics.Bitmap
+import androidx.collection.LruCache
+
+/**
+ * Memoizes the [V] wrapper (a Google `BitmapDescriptor`, or a counting stand-in in tests) for a marker
+ * icon, keyed by a **stable logical key** rather than the bitmap instance. The motivating case is
+ * `GoogleMapRenderer`'s vehicle reconcile, which re-stamps a gliding vehicle's icon on each heading-octant
+ * change at ~20Hz — hundreds of `BitmapDescriptorFactory.fromBitmap(...)` allocations/sec on a busy route
+ * without this.
+ *
+ * Keying by a logical id (e.g. type+octant+color), not by the [Bitmap] itself, is deliberate: the source
+ * bitmap caches are bounded (VehicleBitmaps' is 15 entries), so on a busy route they evict and re-create
+ * the same logical icon as a *new* Bitmap instance — identity keying would inherit that thrash and defeat
+ * the cache. With a logical key, [get] reuses the descriptor across that churn, and the [bitmap] supplier
+ * (the expensive decode/tint/wrap) runs **only on a miss** — so a steady-state hot path does no bitmap
+ * work at all.
+ *
+ * Bounded by [maxSize]: a still-shown marker retains its own native texture, so evicting an entry here is
+ * harmless (it's just re-wrapped on next request). Generic over [V] purely for testability — [wrap] is the
+ * one and only allocator, so a test can pass a counting fake and assert wrappers stay bounded.
+ */
+class BitmapDescriptorCache<V : Any>(maxSize: Int, private val wrap: (Bitmap) -> V) {
+
+    private val cache = LruCache<String, V>(maxSize)
+
+    /** The cached wrapper for [key], decoding [bitmap] and wrapping it only on a cache miss. */
+    fun get(key: String, bitmap: () -> Bitmap): V =
+        cache.get(key) ?: wrap(bitmap()).also { cache.put(key, it) }
+
+    /** Drop every wrapper, releasing the native textures once the markers using them are gone. */
+    fun clear() = cache.evictAll()
+}

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
@@ -111,9 +111,9 @@ class GoogleMapRenderer(
     // Distinct z-indexes are load-bearing: these markers overlap and extrapolate every frame, so a shared
     // z-index lets gms re-order them by latitude per frame — the overlapping icons' alpha then flickers.
     // The data-age dot also carries a live "N ago" body. Icons resolve lazily on first show.
-    private val vehicleEstimate = TripEstimateMarker({ vehicleEstimateIcon }, "Best estimate", VEHICLE_ESTIMATE_Z_INDEX)
-    private val fastEstimate = TripEstimateMarker({ fastEstimateIcon }, "Fast estimate", FAST_ESTIMATE_Z_INDEX)
-    private val dataAgeEstimate = TripEstimateMarker({ dataAgeIcon }, MOST_RECENT_DATA_TITLE, DATA_AGE_Z_INDEX)
+    private val vehicleEstimate = TripEstimateMarker({ vehicleEstimateIcon() }, "Best estimate", VEHICLE_ESTIMATE_Z_INDEX)
+    private val fastEstimate = TripEstimateMarker({ fastEstimateIcon() }, "Fast estimate", FAST_ESTIMATE_Z_INDEX)
+    private val dataAgeEstimate = TripEstimateMarker({ dataAgeIcon() }, MOST_RECENT_DATA_TITLE, DATA_AGE_Z_INDEX)
     // Smooths the most-recent-data dot to a fresh fix (it's static between fixes). Tracks the dot's current
     // selection + fix so we only move / refresh on an actual change or while settling — never while its
     // bubble is open longer than the settle.
@@ -139,6 +139,13 @@ class GoogleMapRenderer(
             BitmapDescriptorFactory.fromResource(R.drawable.ic_navigation_expand_more)
         ).build()
     }
+
+    // Wraps each distinct marker icon in a BitmapDescriptor exactly once, keyed by a stable logical id, so
+    // the reconcile path reuses descriptors (and skips the bitmap decode/tint entirely) instead of minting
+    // a fresh native texture on each heading-octant change at ~20Hz. Released in [dispose]. See
+    // [BitmapDescriptorCache] for the logical-key/bounding rationale.
+    private val descriptorCache =
+        BitmapDescriptorCache(DESCRIPTOR_CACHE_SIZE) { BitmapDescriptorFactory.fromBitmap(it) }
 
     // Remove only our own static annotations (not map.clear(), which would also wipe the per-frame
     // dynamic layer) and clear their tap-routing maps. Shared by [renderStatic] (before it redraws) and
@@ -174,7 +181,7 @@ class GoogleMapRenderer(
                 map.addMarker(
                     MarkerOptions()
                         .position(stop.point.toLatLng())
-                        .icon(if (stop.selected) tripStopSelectedIcon else tripStopIcon)
+                        .icon(tripStopIcon(stop.selected))
                         .anchor(0.5f, 0.5f)
                         .flat(true)
                         .zIndex(1f)
@@ -254,6 +261,11 @@ class GoogleMapRenderer(
         vehicleEstimate.dispose()
         fastEstimate.dispose()
         dataAgeEstimate.dispose()
+
+        // Drop our wrapped descriptors so their native textures are released once the markers using them
+        // are gone. (The source bitmaps are owned by the shared static caches and are deliberately not
+        // recycled here — other renderer instances / the maplibre flavor reuse them.)
+        descriptorCache.clear()
     }
 
     /**
@@ -326,7 +338,7 @@ class GoogleMapRenderer(
             val marker = map.addMarker(
                 MarkerOptions()
                     .position(target.toLatLng())
-                    .icon(dataAgeIcon)
+                    .icon(dataAgeIcon())
                     .anchor(0.5f, 0.5f)
                     .zIndex(0.5f)
                     .title(MOST_RECENT_DATA_TITLE)
@@ -396,7 +408,9 @@ class GoogleMapRenderer(
     }
 
     private fun vehicleIcon(vehicle: VehicleMarker, response: ObaTripsForRouteResponse): BitmapDescriptor =
-        BitmapDescriptorFactory.fromBitmap(VehicleBitmaps.vehicleBitmap(context, vehicle, response))
+        descriptorCache.get(VehicleBitmaps.iconKey(vehicle, response)) {
+            VehicleBitmaps.vehicleBitmap(context, vehicle, response)
+        }
 
     private fun vehicleTitle(vehicle: VehicleMarker, response: ObaTripsForRouteResponse): String {
         val trip = response.getTrip(vehicle.status.activeTripId)
@@ -489,24 +503,23 @@ class GoogleMapRenderer(
         fun dispose() = update(null, 0L, 0L)
     }
 
-    private val vehicleEstimateIcon: BitmapDescriptor by lazy {
-        BitmapDescriptorFactory.fromBitmap(TripMarkerBitmaps.circle(context, R.drawable.ic_vehicle_position))
-    }
-    private val fastEstimateIcon: BitmapDescriptor by lazy {
-        BitmapDescriptorFactory.fromBitmap(TripMarkerBitmaps.circle(context, R.drawable.ic_fast_estimate))
-    }
+    // The trip-focus icons, cached through [descriptorCache] by a stable per-icon key so each resolves
+    // lazily on first show and reuses one descriptor thereafter (released, with the rest, in [dispose]).
+    private fun vehicleEstimateIcon() = tripCircleIcon(R.drawable.ic_vehicle_position)
+
+    private fun fastEstimateIcon() = tripCircleIcon(R.drawable.ic_fast_estimate)
+
     // The signal glyph is light, so tint it gray to read on the white disc.
-    private val dataAgeIcon: BitmapDescriptor by lazy {
-        BitmapDescriptorFactory.fromBitmap(
-            TripMarkerBitmaps.circle(context, R.drawable.ic_signal_indicator, TripMarkerBitmaps.STROKE_COLOR)
-        )
-    }
-    private val tripStopIcon: BitmapDescriptor by lazy {
-        BitmapDescriptorFactory.fromBitmap(TripStopBitmaps.dot(selected = false))
-    }
-    private val tripStopSelectedIcon: BitmapDescriptor by lazy {
-        BitmapDescriptorFactory.fromBitmap(TripStopBitmaps.dot(selected = true))
-    }
+    private fun dataAgeIcon() =
+        tripCircleIcon(R.drawable.ic_signal_indicator, TripMarkerBitmaps.STROKE_COLOR)
+
+    private fun tripCircleIcon(drawableRes: Int, tintColor: Int = 0): BitmapDescriptor =
+        descriptorCache.get("circle:$drawableRes:$tintColor") {
+            TripMarkerBitmaps.circle(context, drawableRes, tintColor)
+        }
+
+    private fun tripStopIcon(selected: Boolean) =
+        descriptorCache.get("stop:$selected") { TripStopBitmaps.dot(selected) }
 
     fun stopForMarker(marker: Marker): StopMarker? = stopByMarker[marker]
 
@@ -537,6 +550,12 @@ class GoogleMapRenderer(
         private const val ESTIMATE_EASE_KEY = "estimate"
 
         private const val MOST_RECENT_DATA_TITLE = "Most recent data"
+
+        // Comfortably covers a busy route's live working set — a vehicle type's 8 heading octants across a
+        // handful of schedule-deviation colors, times a few route types, plus the 5 fixed trip-focus icons
+        // — so descriptors are reused as vehicles turn, not thrashed. Bounded so a long, varied session
+        // can't grow it without limit (evicting a still-shown icon just re-wraps it on next request).
+        private const val DESCRIPTOR_CACHE_SIZE = 256
     }
 }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/VehicleBitmaps.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/VehicleBitmaps.java
@@ -81,19 +81,35 @@ public final class VehicleBitmaps {
      */
     public static Bitmap vehicleBitmap(Context context, VehicleMarker vehicle,
                                        ObaTripsForRouteResponse response) {
-        ObaTripStatus status = vehicle.getStatus();
-        String routeId = response.getTrip(status.getActiveTripId()).getRouteId();
-        ObaRoute route = response.getRoute(routeId);
-        int vehicleType = route.getType();
+        return getBitmap(context, vehicleType(vehicle, response), colorResource(vehicle),
+                directionIndex(vehicle));
+    }
 
-        int colorResource;
+    /**
+     * A stable key identifying the icon {@link #vehicleBitmap} returns for this vehicle — its type,
+     * heading octant, and schedule-deviation color, the only inputs that change the bitmap. A renderer
+     * caches one wrapper (a Google {@code BitmapDescriptor}) per key so it reuses it across frames even
+     * when the bounded bitmap LRU evicts and recreates the underlying {@link Bitmap} on a busy route.
+     */
+    public static String iconKey(VehicleMarker vehicle, ObaTripsForRouteResponse response) {
+        return "veh:" + createBitmapCacheKey(vehicleType(vehicle, response), directionIndex(vehicle),
+                colorResource(vehicle));
+    }
+
+    /** The vehicle's route type, normalizing cablecar to tram so both the bitmap and key paths agree. */
+    private static int vehicleType(VehicleMarker vehicle, ObaTripsForRouteResponse response) {
+        ObaTripStatus status = vehicle.getStatus();
+        int type = response.getRoute(response.getTrip(status.getActiveTripId()).getRouteId()).getType();
+        return type == ObaRoute.TYPE_CABLECAR ? ObaRoute.TYPE_TRAM : type;
+    }
+
+    /** The schedule-deviation color (realtime) or the scheduled color — constant between polls. */
+    private static int colorResource(VehicleMarker vehicle) {
         if (vehicle.isRealtime()) {
-            long deviationMin = TimeUnit.SECONDS.toMinutes(status.getScheduleDeviation());
-            colorResource = ArrivalInfoUtils.computeColorFromDeviation(deviationMin);
-        } else {
-            colorResource = R.color.stop_info_scheduled_time;
+            long deviationMin = TimeUnit.SECONDS.toMinutes(vehicle.getStatus().getScheduleDeviation());
+            return ArrivalInfoUtils.computeColorFromDeviation(deviationMin);
         }
-        return getBitmap(context, vehicleType, colorResource, directionIndex(vehicle));
+        return R.color.stop_info_scheduled_time;
     }
 
     /**
@@ -121,11 +137,6 @@ public final class VehicleBitmaps {
 
     private static Bitmap getBitmap(Context context, int vehicleType, int colorResource, int halfWind) {
         int color = ContextCompat.getColor(context, colorResource);
-
-        // Use tram icon for cablecar
-        if (vehicleType == ObaRoute.TYPE_CABLECAR) {
-            vehicleType = ObaRoute.TYPE_TRAM;
-        }
 
         String key = createBitmapCacheKey(vehicleType, halfWind, colorResource);
         Bitmap b = sColoredIconCache.get(key);


### PR DESCRIPTION
## Problem

`GoogleMapRenderer` allocated marker `BitmapDescriptor`s on the per-frame reconcile path and never released them (#1580):

- Vehicle icons were re-created via `BitmapDescriptorFactory.fromBitmap(...)` on every heading-octant change (reconcile runs at ~20 Hz).
- Trip-focus markers held lazily-allocated `BitmapDescriptor`s never released, including in `dispose()`.

Investigating also surfaced a compounding root cause: `VehicleBitmaps`' underlying bitmap `LruCache` holds only **15** entries, so a busy route (30+ vehicles) *thrashes* it — every lookup misses and re-creates the `Bitmap`. Keying a descriptor cache by `Bitmap` identity would inherit that churn, which is why this caches by a **stable logical key** instead.

## Fix

- **`BitmapDescriptorCache<V>`** (new, Google flavor): an `LruCache` keyed by a stable logical id whose bitmap supplier runs **only on a miss** — so a steady-state hot path does no bitmap decode/wrap at all. Generic over `V` so a test can inject a counting fake. Cleared in `dispose()` to release native textures.
- **`VehicleBitmaps.iconKey()`**: the stable per-icon key (type + heading octant + schedule-deviation color), sharing type/color resolution with `vehicleBitmap()` (cablecar→tram normalization lifted into one helper so the bitmap and key paths can't drift).
- **`GoogleMapRenderer`** routes vehicle and trip-focus icons through the cache; the trip-focus `by lazy val`s become cached lookups released on `dispose()`. Cache sized for a busy route's working set.

Source bitmaps live in shared static caches and are deliberately **not** recycled (other renderer instances / the maplibre flavor reuse them); dropping descriptor references is the correct release.

## Verification

**Allocation regression test** (`VehicleIconAllocationTest`, instrumented): drives the real icon path over a 38-vehicle HART snapshot and asserts descriptor allocations are bounded by the distinct icons and **independent of frame count**.

> 38 vehicles, **5092 icon requests** over a 240-frame session → **5092** `fromBitmap` allocations before, **24** after.

**On-device before/after** (live route, 120 s busy-route session, Pixel 7 Pro):

| Metric | Before (pre-fix) | After (fixed) |
|---|---|---|
| Native heap growth | **+3,112 KB** | **+40 KB** (flat) |
| Total PSS growth | +31,820 KB | −29,659 KB |

The pre-fix build climbs ~3 MB of native heap in two minutes on a busy route; the fixed build stays flat — the accumulation that drives the GC stalls / native-OOM the issue warns about.

## Follow-up (out of scope here)

The maplibre flavor still re-decodes and re-wraps icons per octant-flip against the same 15-entry shared LRU. A cross-flavor fix (raise the shared `VehicleBitmaps` cache to cover a route's working set, and/or a flavor-neutral wrapper cache) is the more durable resolution but is outside #1580's `GoogleMapRenderer` scope.

Closes #1580

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved map marker rendering for vehicles and trip stops, with smoother updates during live map refreshes.
  * Added smarter icon reuse so the app can handle frequent map changes more efficiently.

* **Bug Fixes**
  * Reduced unnecessary icon recreation, helping prevent performance issues during longer map sessions.
  * Kept vehicle icons consistent across updates, including heading and status-based changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->