### PR TITLE
Queue staged deep-link routes so rapid distinct intents aren't dropped

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.kt
@@ -121,7 +121,7 @@ class HomeActivity : AppCompatActivity() {
             val navController = rememberNavController()
             AccessibilityAnalyticsEffect()
             HomeAnalyticsEffect(viewModel.analyticsEvents)
-            DeepLinkEffect(navController, viewModel.deepLinkRoute, viewModel::onDeepLinkRouteConsumed)
+            DeepLinkEffect(navController, viewModel.deepLinkRoutes)
             // The welcome tutorial (now the Compose green welcome + map-stop spotlight sequence) is
             // started by HomeScreen off the same showWelcomeTutorial latch — no host effect needed.
             SettingsRehomeEffect(navController)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeNavHost.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeNavHost.kt
@@ -39,6 +39,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
 import org.onebusaway.android.map.compose.TripMapScreen
 import com.google.firebase.analytics.FirebaseAnalytics
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import org.onebusaway.android.R
@@ -148,24 +149,21 @@ fun HomeNavHost(
 }
 
 /**
- * Consumes a staged deep-link route (the [HomeViewModel.deepLinkRoute] latch) once the NavHost is ready
- * (and on each `onNewIntent`): navigates to it, popping up to HOME, then clears the latch via
- * [onConsumed]. Lifted verbatim from the former inline `onCreate` effect.
+ * Drains the queue of staged deep-link routes ([HomeViewModel.deepLinkRoutes]) once the NavHost is ready
+ * (and as each `onNewIntent` enqueues more): navigates to each, popping up to HOME. The queue (vs. the
+ * former single-value latch) delivers rapid, distinct back-to-back intents exactly once each (#1582).
  */
 @Composable
 internal fun DeepLinkEffect(
     navController: NavHostController,
-    deepLinkRoute: StateFlow<String?>,
-    onConsumed: () -> Unit,
+    deepLinkRoutes: Flow<String>,
 ) {
-    val pending by deepLinkRoute.collectAsStateWithLifecycle()
-    LaunchedEffect(pending) {
-        pending?.let { route ->
+    LaunchedEffect(navController) {
+        deepLinkRoutes.collect { route ->
             navController.navigate(route) {
                 popUpTo(NavRoutes.HOME) { inclusive = false }
                 launchSingleTop = true
             }
-            onConsumed()
         }
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
@@ -29,12 +29,15 @@ import org.onebusaway.android.location.LocationRepository
 import org.onebusaway.android.preferences.PreferencesRepository
 import org.onebusaway.android.region.RegionRepository
 import org.onebusaway.android.region.RegionStatus
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
@@ -107,16 +110,19 @@ class HomeViewModel @Inject constructor(
     private val _paymentWarning = MutableStateFlow<ObaRegion?>(null)
     val paymentWarning: StateFlow<ObaRegion?> = _paymentWarning.asStateFlow()
 
-    // A NavHost route staged from a non-composable entry point (an incoming intent, or the nav-drawer /
+    // NavHost routes staged from non-composable entry points (an incoming intent, or the nav-drawer /
     // search / recent-stops actions) for the host's DeepLinkEffect to navigate to once the NavHost is
-    // composed. A retained StateFlow (not a replay-0 event) so a route staged in onCreate before
-    // composition isn't lost; set via [stageDeepLinkRoute], cleared by [onDeepLinkRouteConsumed].
-    private val _deepLinkRoute = MutableStateFlow<String?>(null)
-    val deepLinkRoute: StateFlow<String?> = _deepLinkRoute.asStateFlow()
+    // composed. A queued Channel (not a latched StateFlow) so rapid, distinct back-to-back intents are
+    // each delivered exactly once rather than overwriting one another before the collector consumes them
+    // (#1582). UNLIMITED-buffered so a route staged in onCreate before composition isn't lost, and so
+    // [stageDeepLinkRoute]'s trySend never has to drop. Sent via [stageDeepLinkRoute].
+    private val _deepLinkRoutes = Channel<String>(Channel.UNLIMITED)
+    val deepLinkRoutes: Flow<String> = _deepLinkRoutes.receiveAsFlow()
 
     // One-shot welcome-tutorial request (the TUTORIAL_WELCOME launch extra, the help "Show tutorials"
     // action, or the what's-new opt-out's "yes"); HomeScreen starts the Compose welcome + map-stop
-    // spotlight sequence off this latch once composed. Mirrors [deepLinkRoute].
+    // spotlight sequence off this latch once composed. A latch (not a queue like [deepLinkRoutes])
+    // because the request is idempotent — a repeat just re-shows the same one-shot tutorial.
     private val _showWelcomeTutorial = MutableStateFlow(false)
     val showWelcomeTutorial: StateFlow<Boolean> = _showWelcomeTutorial.asStateFlow()
 
@@ -178,12 +184,9 @@ class HomeViewModel @Inject constructor(
 
     /** Stage [route] for the NavHost to open once composed (null stages nothing / stays on the map). */
     fun stageDeepLinkRoute(route: String?) {
-        _deepLinkRoute.value = route
-    }
-
-    /** DeepLinkEffect navigated to the staged route; clear the latch so it isn't re-navigated. */
-    fun onDeepLinkRouteConsumed() {
-        _deepLinkRoute.value = null
+        // trySend always succeeds on an UNLIMITED channel; null routes (e.g. an intent with no mapped
+        // destination) simply enqueue nothing, leaving the map on screen.
+        if (route != null) _deepLinkRoutes.trySend(route)
     }
 
     /** Stage the welcome tutorial for the host to show once composed (the launching intent requested it). */

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
@@ -328,6 +328,51 @@ class HomeViewModelTest {
         assertEquals(stop, viewModel(savedState = handle).uiState.value.focusedStop)
     }
 
+    // --- staged deep-link routes (queued, not latched: #1582) ---
+
+    @Test
+    fun `rapid distinct staged routes are each delivered exactly once`() = runTest {
+        val vm = viewModel()
+        val routes = mutableListOf<String>()
+        val job = launch { vm.deepLinkRoutes.collect { routes.add(it) } }
+
+        // Burst three distinct routes before the collector has drained any (e.g. FCM A -> B -> A).
+        vm.stageDeepLinkRoute("a")
+        vm.stageDeepLinkRoute("b")
+        vm.stageDeepLinkRoute("a")
+        advanceUntilIdle()
+
+        // A latch would have dropped "a" and "b"; the queue delivers all three in order.
+        assertEquals(listOf("a", "b", "a"), routes)
+        job.cancel()
+    }
+
+    @Test
+    fun `a route staged before the collector subscribes is not lost`() = runTest {
+        val vm = viewModel()
+        vm.stageDeepLinkRoute("home") // staged in onCreate, before the NavHost composes
+
+        val routes = mutableListOf<String>()
+        val job = launch { vm.deepLinkRoutes.collect { routes.add(it) } }
+        advanceUntilIdle()
+
+        assertEquals(listOf("home"), routes)
+        job.cancel()
+    }
+
+    @Test
+    fun `a null staged route enqueues nothing`() = runTest {
+        val vm = viewModel()
+        val routes = mutableListOf<String>()
+        val job = launch { vm.deepLinkRoutes.collect { routes.add(it) } }
+
+        vm.stageDeepLinkRoute(null) // an intent with no mapped destination
+        advanceUntilIdle()
+
+        assertTrue(routes.isEmpty())
+        job.cancel()
+    }
+
     // --- region refresh (events + manual-picker dialog) ---
 
     @Test


### PR DESCRIPTION
Fixes #1582

## Problem

The staged deep-link route was a `StateFlow<String?>` latch (`HomeViewModel.deepLinkRoute`), set before `setContent` and cleared by `DeepLinkEffect` after navigating. Rapid, *distinct* incoming intents (e.g. FCM A → B → A, or pinned-shortcut bursts) could overwrite the latch before the collector consumed the previous value, dropping a navigation. A `StateFlow` conflates rapid sets, so the intermediate values are lost.

## Fix

Replace the single-value `StateFlow<String?>` latch with an `UNLIMITED`-buffered `Channel<String>`, exposed as `deepLinkRoutes: Flow<String>`:

- Each staged route is delivered **exactly once, in order** — distinct back-to-back intents are no longer collapsed.
- `UNLIMITED` buffering preserves the original "route staged in `onCreate` before the NavHost composes isn't lost" guarantee, and means `stageDeepLinkRoute`'s `trySend` never has to drop.
- `DeepLinkEffect` now drains the flow instead of observing a latch, so the `onDeepLinkRouteConsumed()` clear step is gone (a queue removes items on receive — there's no latch to reset).

This follows the existing `Channel + receiveAsFlow()` one-shot-event convention already used by `SettingsViewModel`, `AdvancedSettingsViewModel`, and `TripInfoViewModel`.

The sibling `showWelcomeTutorial` latch is deliberately left as a `StateFlow<Boolean>` — it's a valueless, idempotent edge-trigger with nothing to drop, so a latch remains the simpler correct choice (documented inline).

## Tests

Adds three `HomeViewModelTest` regression tests that lock in the queue semantics:
- rapid distinct burst (A → B → A) is delivered exactly once, in order
- a route staged before the collector subscribes is not lost
- a null staged route (intent with no mapped destination) enqueues nothing

Confirmed the burst test fails against the pre-fix latch (`expected:<[a, b, a]> but was:<[a]>`) and passes with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deep links now queue and process in order, reducing the chance of missed or overwritten navigation requests.
  * Routes triggered before the app finishes loading are now more reliably handled.
  * Empty deep-link requests are ignored, avoiding unnecessary navigation behavior.

* **Tests**
  * Added coverage for ordered delivery, queued routes, and ignoring empty requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->