### PR TITLE
Make SingleFlight thread-safe with a ConcurrentHashMap

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/data/TripObservationFetcher.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/data/TripObservationFetcher.kt
@@ -68,7 +68,7 @@ class DefaultTripObservationFetcher @Inject constructor(
         @ApplicationContext private val context: Context
 ) : TripObservationFetcher {
 
-    /** Process-lifetime scope confined to the main thread; the SingleFlight maps live under it. */
+    /** Process-lifetime scope the coalesced fetches run on; the network calls hop to [fetchDispatcher]. */
     private val fetchScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
 
     /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/SingleFlight.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/SingleFlight.kt
@@ -16,8 +16,10 @@
 package org.onebusaway.android.util
 
 import android.util.Log
+import java.util.concurrent.ConcurrentHashMap
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.async
 
@@ -30,19 +32,23 @@ import kotlinx.coroutines.async
  * Failures resolve to null for every joined caller (logged once); retry policy is left to
  * callers.
  *
- * Confinement: not thread-safe. All [run] calls and [scope]'s dispatcher must be confined to a
- * single thread (in practice the main thread) — that confinement is what makes the unlocked map
- * safe.
+ * Concurrency-safe: the in-flight map is a [ConcurrentHashMap], whose atomic `computeIfAbsent`
+ * coalesces racing callers, so [run] may be invoked concurrently from any context. The coalesced
+ * block always runs on [scope]'s dispatcher, not the caller's.
  */
 class SingleFlight<K : Any, V : Any>(private val scope: CoroutineScope) {
 
-    private val inFlight = HashMap<K, Deferred<V?>>()
+    private val inFlight = ConcurrentHashMap<K, Deferred<V?>>()
 
     /** Runs [block] for [key] in [scope], or joins the in-flight execution for the same key. */
     suspend fun run(key: K, block: suspend () -> V?): V? =
             inFlight
-                    .getOrPut(key) {
-                        scope.async {
+                    // computeIfAbsent is atomic, so concurrent callers for one key share a Deferred.
+                    // The coroutine is LAZY: await() (below) starts it only after computeIfAbsent has
+                    // returned and stored the Deferred, so the finally/remove can never run
+                    // re-entrantly — even for an eager dispatcher and a non-suspending block.
+                    .computeIfAbsent(key) {
+                        scope.async(start = CoroutineStart.LAZY) {
                             try {
                                 block()
                             } catch (e: CancellationException) {
@@ -51,7 +57,6 @@ class SingleFlight<K : Any, V : Any>(private val scope: CoroutineScope) {
                                 Log.e(TAG, "Single-flight block failed for $key", e)
                                 null
                             } finally {
-                                // Runs on the scope's thread before any awaiter resumes.
                                 inFlight.remove(key)
                             }
                         }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/util/SingleFlightTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/util/SingleFlightTest.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2024-2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.util
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Covers [SingleFlight]'s coalescing contract: concurrent callers for one key share a single
+ * execution, while an entry clears on completion so a later call runs fresh.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SingleFlightTest {
+
+    @Test
+    fun `concurrent calls for the same key share one execution`() = runTest {
+        val singleFlight = SingleFlight<String, Int>(backgroundScope)
+        val firstEntered = CompletableDeferred<Unit>()
+        val release = CompletableDeferred<Unit>()
+        var executions = 0
+
+        val block: suspend () -> Int = {
+            executions++
+            firstEntered.complete(Unit)
+            release.await() // hold the in-flight execution open so the second caller has to join it
+            42
+        }
+
+        val a = async { singleFlight.run("k", block) }
+        firstEntered.await() // a is now running block and parked on release
+        val b = async { singleFlight.run("k", block) }
+        runCurrent()
+        release.complete(Unit)
+
+        assertEquals(42, a.await())
+        assertEquals(42, b.await())
+        assertEquals(1, executions) // b joined a's flight rather than running the block again
+    }
+
+    @Test
+    fun `a later call after completion runs the block again`() = runTest {
+        val singleFlight = SingleFlight<String, Int>(backgroundScope)
+        var executions = 0
+
+        // Entries clear on completion, so the second call is a fresh execution, not a joined one.
+        assertEquals(1, singleFlight.run("k") { executions++; 1 })
+        assertEquals(2, singleFlight.run("k") { executions++; 2 })
+        assertEquals(2, executions)
+    }
+
+    @Test
+    fun `an eager dispatcher with a non-suspending block clears the completed entry`() = runTest {
+        // Dispatchers.Unconfined runs the block synchronously to completion before async() returns.
+        // The block never suspends, so this exercises the path where the finally/remove could fire
+        // re-entrantly inside computeIfAbsent — which the LAZY start guards against. A stale entry
+        // would make the second call join the first's completed Deferred instead of running fresh.
+        val singleFlight = SingleFlight<String, Int>(CoroutineScope(Dispatchers.Unconfined))
+        var executions = 0
+
+        assertEquals(1, singleFlight.run("k") { ++executions })
+        assertEquals(2, singleFlight.run("k") { ++executions })
+        assertEquals(2, executions)
+    }
+
+    // The failure path (a throwing block resolves to null and clears its entry) is left to
+    // instrumented coverage: SingleFlight logs via android.util.Log.e, which is unmocked in plain
+    // JVM tests here, and this module deliberately avoids Robolectric/mocking for unit tests.
+}


### PR DESCRIPTION
Addresses the **SingleFlight main-thread confinement** item from #1583 (the first of several robustness items tracked there — this PR covers only that one; the interpolation-bounds, clock-skew, and remaining test-gap items are out of scope here).

## Problem

`SingleFlight`'s in-flight map was a plain `HashMap`, safe only because every `run()` call and the scope's dispatcher were confined to one thread (in practice the main thread). That invariant was documented only in a comment, so a future off-thread caller would silently corrupt the map.

## Fix

Replace the `HashMap` with a `ConcurrentHashMap` and coalesce racing callers via its atomic `computeIfAbsent`. This removes the confinement invariant at the root rather than guarding it with an assertion: there is no longer a confining-thread rule for a future caller to violate, so nothing to document, assert, or test against. The dedup contract is unchanged, and the overhead is negligible at this call volume (a handful of in-flight keys, at poll-tick frequency).

`computeIfAbsent` is also marginally cheaper than the old `getOrPut` on the insert path (one atomic map operation vs. a separate get + put).

The KDoc now scopes its guarantee accurately: concurrent callers may invoke `run` safely from any context, but the coalesced block still runs on the constructor `scope`'s dispatcher — not the caller's.

## Tests

Adds `SingleFlightTest` covering the coalescing contract:
- concurrent callers for one key share a single execution (the second joins the first's in-flight `Deferred` rather than re-running the block)
- an entry clears on completion, so a later call runs fresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of repeated requests so simultaneous calls for the same key more reliably share a single in-flight operation.
  * Enhanced concurrency safety to reduce the chance of duplicate work when calls happen at the same time.
* **Tests**
  * Added unit tests verifying shared execution for concurrent calls.
  * Added unit tests confirming a fresh execution runs after the previous one completes.
  * Added a test to ensure completed entries clear promptly when using an eager dispatcher.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->