### PR TITLE
Make interpolateScheduleTime segments half-open so boundaries don't double-count

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/dataview/TripTrajectory.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/dataview/TripTrajectory.kt
@@ -180,8 +180,16 @@ private fun extrapolationSeries(state: TripState, schedule: List<ScheduleStop>, 
     )
 }
 
-/** A strictly-increasing distance span `[d0, d1)` mapping to the server-clock time span `[t0, t1]`. */
-internal data class ScheduleSegment(val d0: Double, val d1: Double, val t0: Long, val t1: Long)
+/**
+ * A segment with strictly increasing distance (`d0 < d1`), spanning departure time [t0] at [d0] to
+ * arrival time [t1] at [d1]. Boundary ownership (which segment claims a distance exactly on [d0]/[d1])
+ * is not a property of the segment — it lives in [interpolateScheduleTime].
+ */
+internal data class ScheduleSegment(val d0: Double, val d1: Double, val t0: Long, val t1: Long) {
+    init {
+        require(d1 > d0) { "ScheduleSegment requires strictly increasing distance, got d0=$d0 d1=$d1" }
+    }
+}
 
 /**
  * The interpolatable segments of [schedule], in trip order, with strictly increasing distance.
@@ -210,22 +218,24 @@ internal fun scheduleSegments(schedule: List<ScheduleStop>): List<ScheduleSegmen
  * Pure, so it is unit-testable. Returns 0 when fewer than two stops exist or the distance falls
  * outside every interpolatable segment.
  *
- * Each segment owns the half-open span `[d0, d1)`, so a distance exactly on a stop boundary lands in
- * a single segment (the next one) instead of being ambiguously claimed by both. The terminal segment
- * is closed `[d0, d1]` so the trip's end distance still interpolates rather than dropping to the 0
- * sentinel. Operating on [scheduleSegments] (strictly increasing by construction) means there is no
- * degenerate case left to handle here.
+ * Each segment is half-open `[d0, d1)`, so a distance exactly on a stop boundary lands in a single
+ * segment (the next one) instead of being ambiguously claimed by both. The trip's final distance,
+ * which every half-open span excludes, is mapped after the scan to the last segment's arrival so the
+ * end of the trip still resolves rather than dropping to the 0 sentinel. Operating on
+ * [scheduleSegments] (strictly increasing by construction) means there is no degenerate case left to
+ * handle here.
  */
 fun interpolateScheduleTime(schedule: List<ScheduleStop>, distanceMeters: Double): Long {
     val segments = scheduleSegments(schedule)
-    for ((index, s) in segments.withIndex()) {
-        val withinUpper = if (index == segments.lastIndex) distanceMeters <= s.d1 else distanceMeters < s.d1
-        if (distanceMeters >= s.d0 && withinUpper) {
+    for (s in segments) {
+        if (distanceMeters >= s.d0 && distanceMeters < s.d1) {
             val fraction = (distanceMeters - s.d0) / (s.d1 - s.d0)
             return s.t0 + (fraction * (s.t1 - s.t0)).toLong()
         }
     }
-    return 0L
+    // Half-open spans exclude the trip's final distance; map that exact endpoint to the last arrival.
+    val last = segments.lastOrNull() ?: return 0L
+    return if (distanceMeters == last.d1) last.t1 else 0L
 }
 
 /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/dataview/TripTrajectory.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/dataview/TripTrajectory.kt
@@ -191,7 +191,13 @@ fun interpolateScheduleTime(schedule: List<ScheduleStop>, distanceMeters: Double
     for (i in 1 until schedule.size) {
         val d0 = schedule[i - 1].distanceMeters
         val d1 = schedule[i].distanceMeters
-        if (distanceMeters in d0..d1 && d1 > d0) {
+        if (d1 <= d0) continue
+        // Each segment owns the half-open span [d0, d1), so a distance exactly on a stop boundary
+        // lands in a single segment (the next one) instead of double-counting into both. The final
+        // segment is closed [d0, d1] so the trip's end distance still interpolates rather than
+        // dropping to the 0 sentinel.
+        val withinUpper = if (i == schedule.lastIndex) distanceMeters <= d1 else distanceMeters < d1
+        if (distanceMeters >= d0 && withinUpper) {
             val fraction = (distanceMeters - d0) / (d1 - d0)
             val t0 = schedule[i - 1].departureMs
             val t1 = schedule[i].arrivalMs

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/dataview/TripTrajectory.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/dataview/TripTrajectory.kt
@@ -180,36 +180,49 @@ private fun extrapolationSeries(state: TripState, schedule: List<ScheduleStop>, 
     )
 }
 
+/** A strictly-increasing distance span `[d0, d1)` mapping to the server-clock time span `[t0, t1]`. */
+internal data class ScheduleSegment(val d0: Double, val d1: Double, val t0: Long, val t1: Long)
+
+/**
+ * The interpolatable segments of [schedule], in trip order, with strictly increasing distance.
+ *
+ * Stops sharing a distance (GTFS shape_dist_traveled ties, or backward data) collapse rather than
+ * forming zero-length segments: the segment *entering* a distance ends at the first such stop's
+ * arrival, and the segment *leaving* it starts at the last such stop's departure — which the pairwise
+ * construction yields for free, since a degenerate pair is dropped and the next real pair's lower
+ * bound is the last stop of the run. The result has no degenerate segment, so the caller never has to
+ * guard against one (no divide-by-zero, no ambiguous boundary ownership).
+ */
+internal fun scheduleSegments(schedule: List<ScheduleStop>): List<ScheduleSegment> =
+    (1 until schedule.size).mapNotNull { i ->
+        val prev = schedule[i - 1]
+        val next = schedule[i]
+        if (next.distanceMeters > prev.distanceMeters) {
+            ScheduleSegment(prev.distanceMeters, next.distanceMeters, prev.departureMs, next.arrivalMs)
+        } else {
+            null
+        }
+    }
+
 /**
  * The server-clock time the [schedule] says the vehicle reaches [distanceMeters], linearly
  * interpolated within the bracketing stop pair (previous stop's departure to next stop's arrival).
  * Pure, so it is unit-testable. Returns 0 when fewer than two stops exist or the distance falls
  * outside every interpolatable segment.
+ *
+ * Each segment owns the half-open span `[d0, d1)`, so a distance exactly on a stop boundary lands in
+ * a single segment (the next one) instead of being ambiguously claimed by both. The terminal segment
+ * is closed `[d0, d1]` so the trip's end distance still interpolates rather than dropping to the 0
+ * sentinel. Operating on [scheduleSegments] (strictly increasing by construction) means there is no
+ * degenerate case left to handle here.
  */
 fun interpolateScheduleTime(schedule: List<ScheduleStop>, distanceMeters: Double): Long {
-    if (schedule.size < 2) return 0L
-    // The terminal segment is the last *interpolatable* pair, not the literal last index: degenerate
-    // (zero-length) stop pairs can trail the trip end when GTFS stops share shape_dist_traveled, and
-    // those get skipped below, so keying the closed bound on schedule.lastIndex would let the trip's
-    // max distance fall through to the 0 sentinel.
-    val lastInterpolatable = (1 until schedule.size).lastOrNull { i ->
-        schedule[i].distanceMeters > schedule[i - 1].distanceMeters
-    }
-    for (i in 1 until schedule.size) {
-        val d0 = schedule[i - 1].distanceMeters
-        val d1 = schedule[i].distanceMeters
-        if (d1 <= d0) continue
-        // Each segment owns the half-open span [d0, d1), so a distance exactly on a stop boundary
-        // lands in a single segment (the next one) instead of being ambiguously claimed by both — the
-        // old inclusive bound silently handed it to the earlier segment by iteration order. The
-        // terminal segment is closed [d0, d1] so the trip's end distance still interpolates rather
-        // than dropping to the 0 sentinel.
-        val withinUpper = if (i == lastInterpolatable) distanceMeters <= d1 else distanceMeters < d1
-        if (distanceMeters >= d0 && withinUpper) {
-            val fraction = (distanceMeters - d0) / (d1 - d0)
-            val t0 = schedule[i - 1].departureMs
-            val t1 = schedule[i].arrivalMs
-            return t0 + (fraction * (t1 - t0)).toLong()
+    val segments = scheduleSegments(schedule)
+    for ((index, s) in segments.withIndex()) {
+        val withinUpper = if (index == segments.lastIndex) distanceMeters <= s.d1 else distanceMeters < s.d1
+        if (distanceMeters >= s.d0 && withinUpper) {
+            val fraction = (distanceMeters - s.d0) / (s.d1 - s.d0)
+            return s.t0 + (fraction * (s.t1 - s.t0)).toLong()
         }
     }
     return 0L

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/dataview/TripTrajectory.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/dataview/TripTrajectory.kt
@@ -188,15 +188,23 @@ private fun extrapolationSeries(state: TripState, schedule: List<ScheduleStop>, 
  */
 fun interpolateScheduleTime(schedule: List<ScheduleStop>, distanceMeters: Double): Long {
     if (schedule.size < 2) return 0L
+    // The terminal segment is the last *interpolatable* pair, not the literal last index: degenerate
+    // (zero-length) stop pairs can trail the trip end when GTFS stops share shape_dist_traveled, and
+    // those get skipped below, so keying the closed bound on schedule.lastIndex would let the trip's
+    // max distance fall through to the 0 sentinel.
+    val lastInterpolatable = (1 until schedule.size).lastOrNull { i ->
+        schedule[i].distanceMeters > schedule[i - 1].distanceMeters
+    }
     for (i in 1 until schedule.size) {
         val d0 = schedule[i - 1].distanceMeters
         val d1 = schedule[i].distanceMeters
         if (d1 <= d0) continue
         // Each segment owns the half-open span [d0, d1), so a distance exactly on a stop boundary
-        // lands in a single segment (the next one) instead of double-counting into both. The final
-        // segment is closed [d0, d1] so the trip's end distance still interpolates rather than
-        // dropping to the 0 sentinel.
-        val withinUpper = if (i == schedule.lastIndex) distanceMeters <= d1 else distanceMeters < d1
+        // lands in a single segment (the next one) instead of being ambiguously claimed by both — the
+        // old inclusive bound silently handed it to the earlier segment by iteration order. The
+        // terminal segment is closed [d0, d1] so the trip's end distance still interpolates rather
+        // than dropping to the 0 sentinel.
+        val withinUpper = if (i == lastInterpolatable) distanceMeters <= d1 else distanceMeters < d1
         if (distanceMeters >= d0 && withinUpper) {
             val fraction = (distanceMeters - d0) / (d1 - d0)
             val t0 = schedule[i - 1].departureMs

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/dataview/TripTrajectoryTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/dataview/TripTrajectoryTest.kt
@@ -142,6 +142,31 @@ class TripTrajectoryTest {
         assertEquals(0L, interpolateScheduleTime(emptyList(), 0.0))
     }
 
+    @Test
+    fun `a distance exactly on an interior stop maps to a single segment, not both`() {
+        val schedule = listOf(
+            stop(0.0, 1_000L, departMs = 2_000L),
+            stop(100.0, 6_000L, departMs = 7_000L), // dwell: arrives 6000, departs 7000
+            stop(200.0, 10_000L),
+        )
+        // Exactly at the middle stop, the half-open [d0, d1) segments give it to the *next* segment,
+        // so it reads the departure (7000) deterministically rather than ambiguously matching the
+        // prior segment's arrival (6000).
+        assertEquals(7_000L, interpolateScheduleTime(schedule, 100.0))
+    }
+
+    @Test
+    fun `a distance exactly at the final stop interpolates to its arrival`() {
+        val schedule = listOf(
+            stop(0.0, 1_000L),
+            stop(100.0, 6_000L),
+            stop(200.0, 10_000L),
+        )
+        // The closed final segment keeps the trip's end distance interpolatable (arrival at the last
+        // stop), rather than falling through to the 0 sentinel.
+        assertEquals(10_000L, interpolateScheduleTime(schedule, 200.0))
+    }
+
     // --- formatDeviationLabel ---
 
     @Test

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/dataview/TripTrajectoryTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/dataview/TripTrajectoryTest.kt
@@ -167,6 +167,39 @@ class TripTrajectoryTest {
         assertEquals(10_000L, interpolateScheduleTime(schedule, 200.0))
     }
 
+    @Test
+    fun `the trip-end distance stays interpolatable when degenerate stops trail the end`() {
+        val schedule = listOf(
+            stop(0.0, 1_000L),
+            stop(100.0, 6_000L),
+            stop(100.0, 10_000L), // trailing zero-length pair (shared shape_dist_traveled)
+        )
+        // The terminal segment is the last *interpolatable* pair (0 -> 100), which stays closed, so
+        // the max distance reads that segment's arrival (6000) instead of falling through to 0.
+        assertEquals(6_000L, interpolateScheduleTime(schedule, 100.0))
+    }
+
+    @Test
+    fun `a distance exactly at the first stop interpolates to the start time`() {
+        val schedule = listOf(stop(0.0, 1_000L, departMs = 2_000L), stop(100.0, 6_000L))
+        // The span is lower-inclusive, so the trip origin resolves to the first segment's start
+        // (stop0's departure, 2000) rather than the sentinel.
+        assertEquals(2_000L, interpolateScheduleTime(schedule, 0.0))
+    }
+
+    @Test
+    fun `an interior degenerate segment is skipped and a later segment interpolates`() {
+        val schedule = listOf(
+            stop(0.0, 1_000L),
+            stop(100.0, 6_000L, departMs = 7_000L),
+            stop(100.0, 8_000L), // degenerate middle pair: skipped
+            stop(200.0, 12_000L),
+        )
+        // 150 lands in the 100 -> 200 segment (departure 8000 to arrival 12000), proving the loop
+        // advances past the degenerate middle pair.
+        assertEquals(10_000L, interpolateScheduleTime(schedule, 150.0))
+    }
+
     // --- formatDeviationLabel ---
 
     @Test

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/dataview/TripTrajectoryTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/dataview/TripTrajectoryTest.kt
@@ -200,6 +200,44 @@ class TripTrajectoryTest {
         assertEquals(10_000L, interpolateScheduleTime(schedule, 150.0))
     }
 
+    // --- scheduleSegments ---
+
+    @Test
+    fun `segments span each stop pair from the prior departure to the next arrival`() {
+        val schedule = listOf(stop(0.0, 1_000L, departMs = 2_000L), stop(100.0, 6_000L))
+        assertEquals(listOf(ScheduleSegment(0.0, 100.0, 2_000L, 6_000L)), scheduleSegments(schedule))
+    }
+
+    @Test
+    fun `fewer than two stops yields no segments`() {
+        assertTrue(scheduleSegments(emptyList()).isEmpty())
+        assertTrue(scheduleSegments(listOf(stop(0.0, 1_000L))).isEmpty())
+    }
+
+    @Test
+    fun `a trailing zero-length stop pair is dropped`() {
+        val schedule = listOf(stop(0.0, 1_000L), stop(100.0, 6_000L), stop(100.0, 10_000L))
+        // The degenerate 100 -> 100 pair produces no segment; the real 0 -> 100 segment remains the last.
+        assertEquals(listOf(ScheduleSegment(0.0, 100.0, 1_000L, 6_000L)), scheduleSegments(schedule))
+    }
+
+    @Test
+    fun `a run of equal-distance stops collapses to first-arrival-in, last-departure-out`() {
+        val schedule = listOf(
+            stop(0.0, 1_000L),
+            stop(100.0, 6_000L, departMs = 7_000L), // first at 100: its arrival (6000) ends the entering segment
+            stop(100.0, 8_000L), // last at 100: its departure (8000) starts the leaving segment
+            stop(200.0, 12_000L),
+        )
+        assertEquals(
+            listOf(
+                ScheduleSegment(0.0, 100.0, 1_000L, 6_000L),
+                ScheduleSegment(100.0, 200.0, 8_000L, 12_000L),
+            ),
+            scheduleSegments(schedule),
+        )
+    }
+
     // --- formatDeviationLabel ---
 
     @Test

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/dataview/TripTrajectoryTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/dataview/TripTrajectoryTest.kt
@@ -18,6 +18,7 @@ package org.onebusaway.android.ui.dataview
 import kotlin.math.sqrt
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.onebusaway.android.extrapolation.data.TripState
 import org.onebusaway.android.extrapolation.math.prob.ProbDistribution
@@ -248,6 +249,14 @@ class TripTrajectoryTest {
             ),
             scheduleSegments(schedule),
         )
+    }
+
+    @Test
+    fun `a ScheduleSegment rejects non-increasing distance`() {
+        // The factory never emits a degenerate segment, but the guard catches any future
+        // out-of-factory construction with d1 <= d0 loudly instead of dividing by zero downstream.
+        assertThrows(IllegalArgumentException::class.java) { ScheduleSegment(100.0, 100.0, 0L, 1L) }
+        assertThrows(IllegalArgumentException::class.java) { ScheduleSegment(100.0, 50.0, 0L, 1L) }
     }
 
     // --- formatDeviationLabel ---

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/dataview/TripTrajectoryTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/dataview/TripTrajectoryTest.kt
@@ -213,6 +213,33 @@ class TripTrajectoryTest {
         assertEquals(10_000L, interpolateScheduleTime(schedule, 150.0))
     }
 
+    @Test
+    fun `backward distance data yields overlapping segments resolved by first match`() {
+        // Non-monotonic shape_dist_traveled: stop2 sits behind stop1, so the segments overlap --
+        // (0 -> 100) and (50 -> 150) both claim the [50, 100) range.
+        val schedule = listOf(
+            stop(0.0, 1_000L, departMs = 2_000L),
+            stop(100.0, 6_000L),
+            stop(50.0, 8_000L, departMs = 9_000L),
+            stop(150.0, 12_000L),
+        )
+        // 75 lies in both segments; first-match gives it to (0 -> 100): 2000 + 0.75 * (6000 - 2000).
+        assertEquals(5_000L, interpolateScheduleTime(schedule, 75.0))
+        // 120 lies only in (50 -> 150), so the later overlapping segment is still reachable:
+        // 9000 + 0.7 * (12000 - 9000).
+        assertEquals(11_100L, interpolateScheduleTime(schedule, 120.0))
+    }
+
+    @Test
+    fun `a non-finite distance degrades to the sentinel rather than the divide`() {
+        // The production caller guards finiteness, but the function itself must not feed NaN/Infinity
+        // into the fraction: each fails every half-open comparison and the endpoint check, so 0L.
+        val schedule = listOf(stop(0.0, 1_000L), stop(100.0, 3_000L))
+        assertEquals(0L, interpolateScheduleTime(schedule, Double.NaN))
+        assertEquals(0L, interpolateScheduleTime(schedule, Double.POSITIVE_INFINITY))
+        assertEquals(0L, interpolateScheduleTime(schedule, Double.NEGATIVE_INFINITY))
+    }
+
     // --- scheduleSegments ---
 
     @Test
@@ -249,6 +276,18 @@ class TripTrajectoryTest {
             ),
             scheduleSegments(schedule),
         )
+    }
+
+    @Test
+    fun `a leading equal-distance run collapses to last-departure-out at the origin`() {
+        // Symmetric to the mid-trip run: a degenerate pair at the very start drops, so the origin
+        // segment starts at the *second* stop's departure (4000), not the first stop's (2000).
+        val schedule = listOf(
+            stop(0.0, 1_000L, departMs = 2_000L),
+            stop(0.0, 3_000L, departMs = 4_000L),
+            stop(100.0, 8_000L),
+        )
+        assertEquals(listOf(ScheduleSegment(0.0, 100.0, 4_000L, 8_000L)), scheduleSegments(schedule))
     }
 
     @Test

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/dataview/TripTrajectoryTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/dataview/TripTrajectoryTest.kt
@@ -143,6 +143,18 @@ class TripTrajectoryTest {
     }
 
     @Test
+    fun `a distance below the first stop returns the sentinel, not a negative-fraction time`() {
+        // Guards the lower-bound check: without it, -10 on a [0,100] schedule would compute a negative
+        // fraction and return a time before the first departure instead of the 0 sentinel.
+        val schedule = listOf(stop(0.0, 1_000L), stop(100.0, 3_000L))
+        assertEquals(0L, interpolateScheduleTime(schedule, -10.0))
+
+        // Same below-origin case when the first stop is not at distance 0.
+        val offsetSchedule = listOf(stop(50.0, 1_000L), stop(150.0, 3_000L))
+        assertEquals(0L, interpolateScheduleTime(offsetSchedule, 40.0))
+    }
+
+    @Test
     fun `a distance exactly on an interior stop maps to a single segment, not both`() {
         val schedule = listOf(
             stop(0.0, 1_000L, departMs = 2_000L),
@@ -162,8 +174,8 @@ class TripTrajectoryTest {
             stop(100.0, 6_000L),
             stop(200.0, 10_000L),
         )
-        // The closed final segment keeps the trip's end distance interpolatable (arrival at the last
-        // stop), rather than falling through to the 0 sentinel.
+        // The trip's end distance is excluded by the half-open segments, so it's mapped to the last
+        // segment's arrival (the final stop, 10000) rather than falling through to the 0 sentinel.
         assertEquals(10_000L, interpolateScheduleTime(schedule, 200.0))
     }
 
@@ -174,8 +186,8 @@ class TripTrajectoryTest {
             stop(100.0, 6_000L),
             stop(100.0, 10_000L), // trailing zero-length pair (shared shape_dist_traveled)
         )
-        // The terminal segment is the last *interpolatable* pair (0 -> 100), which stays closed, so
-        // the max distance reads that segment's arrival (6000) instead of falling through to 0.
+        // The last *interpolatable* pair is 0 -> 100 (the trailing 100 -> 100 pair forms no segment),
+        // so the max distance maps to that segment's arrival (6000) instead of falling through to 0.
         assertEquals(6_000L, interpolateScheduleTime(schedule, 100.0))
     }
 


### PR DESCRIPTION
Addresses the **`interpolateScheduleTime` boundary** item from #1583 (one of several robustness items tracked there — this PR covers only that one; the SingleFlight item is in #1588, and the clock-skew and remaining test-gap items are out of scope here).

## Problem

`interpolateScheduleTime` tested each segment with `distanceMeters in d0..d1` — inclusive on both ends. A distance exactly on an interior stop boundary (`d1` of one segment equals `d0` of the next) matched **two** adjacent segments at once. Forward iteration disambiguated only by accident (the earlier segment won, returning that stop's *arrival*), so the result depended on iteration order rather than on a well-defined ownership rule.

## Fix

Give each segment the half-open span `[d0, d1)`, so a boundary distance lands in exactly one segment (the next one — reading the stop's *departure*) deterministically by construction. The final segment stays closed `[d0, d1]` so the trip's end distance still interpolates to the last stop's arrival rather than dropping to the `0` sentinel. The degenerate-segment guard (`d1 <= d0`, which also prevents a divide-by-zero) is lifted into an early `continue` for clarity.

## Behavior impact

- **Interior boundaries:** arrival → departure (the intended de-double-counting).
- **Strictly-interior distances, both endpoints, out-of-span, and < 2 stops:** unchanged — the existing tests pass untouched (two-stop schedules have no interior boundary).

## Tests

- An interior-boundary regression test (a distance exactly on the middle stop now reads the departure deterministically; the old inclusive code returned the prior segment's arrival).
- A final-endpoint test guarding that the closed last segment keeps the trip's end distance interpolatable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved trip time interpolation at stop boundaries so exact interior-stop distances resolve consistently.
  * Corrected final-stop handling to always return the last valid scheduled arrival time, even with trailing degenerate entries.
  * Added more robust handling for degenerate/overlapping schedules and non-finite distances.
* **Tests**
  * Expanded unit tests covering sentinel behavior, exact boundary mapping (first/interior/final), skipped degenerate segments, and segment construction rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->