### PR TITLE
Fix client/server clock skew in the trajectory now line

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/data/TripState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/data/TripState.kt
@@ -173,6 +173,15 @@ data class TripState(
     fun withSchedule(schedule: ObaTripSchedule): TripState =
             if (this.schedule == null) copy(schedule = schedule) else this
 
+    /**
+     * Converts a local-device-clock instant to the server clock, using the skew measured at the
+     * anchor (its paired [anchorTimeMs]/[anchorLocalTimeMs]). Returns [localTimeMs] unchanged when
+     * no anchor data exists yet, since no skew can be measured. Lets consumers plot a local "now"
+     * against server-clock data (schedule, observations) without it drifting under clock skew.
+     */
+    fun toServerClock(localTimeMs: Long): Long =
+            if (anchorLocalTimeMs > 0) localTimeMs + (anchorTimeMs - anchorLocalTimeMs) else localTimeMs
+
     fun extrapolate(queryTimeMs: Long): ExtrapolationResult {
         val currentAnchor = anchor ?: return ExtrapolationResult.NoData
         val lastDist = currentAnchor.distanceAlongTrip ?: return ExtrapolationResult.NoData

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/dataview/TripTrajectory.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/dataview/TripTrajectory.kt
@@ -61,10 +61,10 @@ data class TripTrajectory(
     val extrapolation: ExtrapolationSeries? = null,
     val bounds: DataBounds = DataBounds(0.0, 0.0, 0L, 0L),
     /**
-     * "Now" the graph was built at — the horizontal now line, rising over time. NOTE: the caller
-     * passes a local clock (System.currentTimeMillis), but the time axis is laid out in server-clock
-     * values, so client/server skew shifts the now line off the latest observation. (Carried over
-     * from the upstream view's TODO; fix by offsetting via a history entry's server/local time pair.)
+     * "Now" the graph was built at — the horizontal now line, rising over time. Already in the
+     * server-clock domain the time axis is laid out in: [buildTrajectory] converts the caller's
+     * local clock using the anchor's server/local skew, so the now line tracks the latest
+     * observation even when the device clock drifts from the server's.
      */
     val nowMs: Long = 0L,
 )
@@ -128,8 +128,15 @@ fun dataBounds(distances: List<Double>, times: List<Long>, padFraction: Double =
  * observations, the schedule (with dwell), and — when [TripState.extrapolate] succeeds with a finite
  * estimate — the extrapolation overlay. Pure distance/time arithmetic (no geometry), so the screen
  * just draws it and the projection is testable.
+ *
+ * [nowMs] is the caller's **local** clock; the time axis is server-clock. They're reconciled via
+ * [TripState.toServerClock], so the plotted "now" sits on the server-clock axis while
+ * [TripState.extrapolate] still receives the local time it expects (it compares against the anchor's
+ * local clock).
  */
 fun buildTrajectory(state: TripState, nowMs: Long): TripTrajectory {
+    val serverNowMs = state.toServerClock(nowMs)
+
     val observations = state.history.mapNotNull { entry ->
         val dist = entry.status.distanceAlongTrip ?: return@mapNotNull null
         val time = entry.status.lastUpdateTime.takeIf { it > 0 } ?: entry.serverTimeMs
@@ -153,13 +160,13 @@ fun buildTrajectory(state: TripState, nowMs: Long): TripTrajectory {
         extrapolation?.let { add(it.anchor.distanceMeters); add(it.medianMeters); add(it.highMeters) }
     }
     val times = buildList {
-        add(nowMs) // keep the now line in-bounds even before any extrapolation exists
+        add(serverNowMs) // keep the now line in-bounds even before any extrapolation exists
         observations.forEach { add(it.timeMs) }
         schedule.forEach { add(it.arrivalMs); add(it.departureMs) }
         extrapolation?.let { add(it.anchor.timeMs); add(it.nowMs) }
     }
 
-    return TripTrajectory(observations, schedule, extrapolation, dataBounds(distances, times), nowMs)
+    return TripTrajectory(observations, schedule, extrapolation, dataBounds(distances, times), serverNowMs)
 }
 
 private fun extrapolationSeries(state: TripState, schedule: List<ScheduleStop>, nowMs: Long): ExtrapolationSeries? {
@@ -171,7 +178,7 @@ private fun extrapolationSeries(state: TripState, schedule: List<ScheduleStop>, 
     if (!median.isFinite() || !low.isFinite() || !high.isFinite()) return null
     return ExtrapolationSeries(
         anchor = TrajectoryPoint(anchorDist, state.anchorTimeMs),
-        nowMs = nowMs,
+        nowMs = state.toServerClock(nowMs),
         medianMeters = median,
         lowMeters = low,
         highMeters = high,

--- a/onebusaway-android/src/test/java/org/onebusaway/android/extrapolation/data/TripStateTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/extrapolation/data/TripStateTest.kt
@@ -42,6 +42,25 @@ class TripStateTest {
     }
 
     @Test
+    fun `toServerClock leaves the time unchanged when there is no anchor`() {
+        // No skew can be measured without an anchor, so the local clock passes through.
+        assertEquals(12_345L, TripState.empty("trip1").toServerClock(12_345L))
+    }
+
+    @Test
+    fun `toServerClock lifts a local instant by the anchor skew`() {
+        // Anchor seen at server 105_000 / local 100_000 → server runs 5s ahead.
+        val state =
+                TripState.empty("trip1")
+                        .withStatus(
+                                status(distanceAlongTrip = 500.0, lastUpdateTime = 105_000L),
+                                serverTimeMs = 105_000L,
+                                localTimeMs = 100_000L
+                        )
+        assertEquals(107_000L, state.toServerClock(102_000L))
+    }
+
+    @Test
     fun `extrapolate returns NoData when anchor has null distance`() {
         val state =
                 TripState.empty("trip1")

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/dataview/TripTrajectoryTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/dataview/TripTrajectoryTest.kt
@@ -115,6 +115,22 @@ class TripTrajectoryTest {
         assertTrue(trajectory.bounds.maxTime > trajectory.bounds.minTime)
     }
 
+    @Test
+    fun `the now line is left on the local clock when no anchor skew is known`() {
+        // No anchor yet (anchorLocalTimeMs == 0) -> no measurable skew -> nowMs unshifted.
+        val trajectory = buildTrajectory(TripState("trip1"), nowMs = 10_000L)
+        assertEquals(10_000L, trajectory.nowMs)
+    }
+
+    @Test
+    fun `the now line is lifted onto the server clock by the anchor skew`() {
+        // Anchor seen at server-clock 1_005_000 / local-clock 1_000_000 -> server runs 5s ahead.
+        val state = TripState("trip1").copy(anchorTimeMs = 1_005_000L, anchorLocalTimeMs = 1_000_000L)
+        val trajectory = buildTrajectory(state, nowMs = 1_002_000L)
+        // The local "now" (1_002_000) is plotted at its server-clock equivalent (+5s skew).
+        assertEquals(1_007_000L, trajectory.nowMs)
+    }
+
     // --- interpolateScheduleTime ---
 
     private fun stop(dist: Double, arriveMs: Long, departMs: Long = arriveMs) =


### PR DESCRIPTION
## Summary

Addresses the third item in #1583: client/server clock skew in the trajectory view (`TripTrajectory.kt`).

The trajectory view's "now" line is laid out on a **server-clock** time axis, but `buildTrajectory()` was handed `System.currentTimeMillis()` (a **local** clock). Any client/server skew therefore shifted the now line off the latest observation and corrupted the schedule-deviation label (computed as now minus scheduled time, mixing clock domains).

## What changed

- Add `TripState.toServerClock(localTimeMs)`, which lifts a local-clock instant onto the server clock using the skew measured at the anchor (its paired `anchorTimeMs` / `anchorLocalTimeMs`). Falls back to no shift when no anchor data exists yet (skew unmeasurable).
- `buildTrajectory()` converts the local "now" through it for everything plotted (the now line, bounds, and the extrapolation overlay's `nowMs`), while `TripState.extrapolate()` still receives the local time it expects — it compares against the anchor's *local* clock, so feeding it server time would mis-classify fresh data as stale.
- The conversion lives on `TripState`, the type that already pairs both clock domains, so the skew has a single source of truth.

This removes the standing `TODO` carried over from the upstream view.

## Tests

- `TripStateTest`: `toServerClock` passthrough with no anchor, and a +5s skew lift.
- `TripTrajectoryTest`: the now line stays on the local clock when no skew is known, and is lifted onto the server clock by the anchor skew.

All affected unit tests pass (`./gradlew :onebusaway-android:testObaGoogleDebugUnitTest`).

Refs #1583 (does not close it — the other items in that issue remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Time-based trajectory calculations now align the current position marker with the server clock when timing information is available.
  * Added a helper to translate local device time into the server-time domain for more consistent plotting.

* **Bug Fixes**
  * Improved handling when no timing anchor is available, keeping timestamps unchanged instead of shifting them.
  * Updated trajectory rendering so the “now” point stays within the displayed time range using the corrected clock source.

* **Tests**
  * Added coverage for both anchored and unanchored time-conversion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->