### PR TITLE
Add trajectory store-hydration and SingleFlight concurrent-dedup tests

### DIFF
--- a/onebusaway-android/src/test/java/org/onebusaway/android/extrapolation/data/TripStateTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/extrapolation/data/TripStateTest.kt
@@ -15,7 +15,6 @@
  */
 package org.onebusaway.android.extrapolation.data
 
-import android.location.Location
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertSame
@@ -25,8 +24,7 @@ import org.onebusaway.android.extrapolation.ExtrapolationResult
 import org.onebusaway.android.io.elements.ObaRoute
 import org.onebusaway.android.io.elements.ObaTripSchedule
 import org.onebusaway.android.io.elements.ObaTripStatus
-import org.onebusaway.android.io.elements.Occupancy
-import org.onebusaway.android.io.elements.Status
+import org.onebusaway.android.testing.testTripStatus
 
 class TripStateTest {
 
@@ -502,7 +500,7 @@ class TripStateTest {
             predicted: Boolean = false,
             hasLocation: Boolean = false,
             activeTripId: String? = "trip1"
-    ): ObaTripStatus = TestTripStatus(
+    ): ObaTripStatus = testTripStatus(
             distanceAlongTrip = distanceAlongTrip,
             totalDistanceAlongTrip = totalDistanceAlongTrip,
             lastUpdateTime = lastUpdateTime,
@@ -548,63 +546,5 @@ class TripStateTest {
         val field = obj.javaClass.getDeclaredField(fieldName)
         field.isAccessible = true
         field.set(obj, value)
-    }
-}
-
-/**
- * Minimal ObaTripStatus for JVM tests. Returns null for all Location-typed methods
- * so that android.location.Location stub methods are never called.
- */
-private class TestTripStatus(
-        private val distanceAlongTrip: Double?,
-        private val totalDistanceAlongTrip: Double?,
-        private val lastUpdateTime: Long,
-        private val predicted: Boolean,
-        private val hasLocation: Boolean,
-        private val activeTripId: String?
-) : ObaTripStatus {
-    override fun getServiceDate(): Long = 0L
-    override fun isPredicted(): Boolean = predicted
-    override fun getScheduleDeviation(): Long = 0L
-    override fun getVehicleId(): String? = null
-    override fun getClosestStop(): String? = null
-    override fun getClosestStopTimeOffset(): Long = 0L
-    override fun getPosition(): Location? = null
-    override fun getActiveTripId(): String? = activeTripId
-    override fun getDistanceAlongTrip(): Double? = distanceAlongTrip
-    override fun getScheduledDistanceAlongTrip(): Double? = null
-    override fun getTotalDistanceAlongTrip(): Double? = totalDistanceAlongTrip
-    override fun getOrientation(): Double? = null
-    override fun getNextStop(): String? = null
-    override fun getNextStopTimeOffset(): Long? = null
-    override fun getPhase(): String? = null
-    override fun getStatus(): Status? = null
-    override fun getLastUpdateTime(): Long = lastUpdateTime
-    override fun getLastKnownLocation(): Location? =
-            if (hasLocation) FAKE_LOCATION else null
-    override fun getLastLocationUpdateTime(): Long = 0L
-    override fun getLastKnownDistanceAlongTrip(): Double? = null
-    override fun getLastKnownOrientation(): Double? = null
-    override fun getBlockTripSequence(): Int = 0
-    override fun getOccupancyStatus(): Occupancy? = null
-
-    companion object {
-        /**
-         * A non-null Location sentinel. On the JVM test classpath the android.jar
-         * stubs are present so the class resolves, but its methods throw "Stub!".
-         * We only ever null-check this, never call methods on it.
-         */
-        private val FAKE_LOCATION: Location? = try {
-            Location("test")
-        } catch (e: RuntimeException) {
-            // android.jar stubs throw — but we just need a non-null reference
-            // Use Unsafe to allocate without calling the constructor
-            val unsafeClass = Class.forName("sun.misc.Unsafe")
-            val f = unsafeClass.getDeclaredField("theUnsafe")
-            f.isAccessible = true
-            val unsafe = f.get(null)
-            val allocate = unsafeClass.getMethod("allocateInstance", Class::class.java)
-            allocate.invoke(unsafe, Location::class.java) as Location
-        }
     }
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/testing/TestTripStatus.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/testing/TestTripStatus.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.testing
+
+import android.location.Location
+import org.onebusaway.android.io.elements.ObaTripStatus
+import org.onebusaway.android.io.elements.Occupancy
+import org.onebusaway.android.io.elements.Status
+
+/**
+ * A minimal [ObaTripStatus] for JVM unit tests. Location-typed accessors return null by default, so
+ * the android.location.Location stubs (which throw "Stub!") are never invoked — no Robolectric
+ * needed. Pass [hasLocation] = true when a test needs `getLastKnownLocation()` to be non-null (e.g.
+ * to exercise `isLocationRealtime`); the returned sentinel is only ever null-checked, never called.
+ */
+fun testTripStatus(
+    distanceAlongTrip: Double? = null,
+    totalDistanceAlongTrip: Double? = null,
+    lastUpdateTime: Long = 0L,
+    vehicleId: String? = null,
+    activeTripId: String? = null,
+    predicted: Boolean = false,
+    hasLocation: Boolean = false,
+): ObaTripStatus = TestTripStatus(
+    distanceAlongTrip = distanceAlongTrip,
+    totalDistanceAlongTrip = totalDistanceAlongTrip,
+    lastUpdateTime = lastUpdateTime,
+    vehicleId = vehicleId,
+    activeTripId = activeTripId,
+    predicted = predicted,
+    hasLocation = hasLocation,
+)
+
+private class TestTripStatus(
+    private val distanceAlongTrip: Double?,
+    private val totalDistanceAlongTrip: Double?,
+    private val lastUpdateTime: Long,
+    private val vehicleId: String?,
+    private val activeTripId: String?,
+    private val predicted: Boolean,
+    private val hasLocation: Boolean,
+) : ObaTripStatus {
+    override fun getServiceDate(): Long = 0L
+    override fun isPredicted(): Boolean = predicted
+    override fun getScheduleDeviation(): Long = 0L
+    override fun getVehicleId(): String? = vehicleId
+    override fun getClosestStop(): String? = null
+    override fun getClosestStopTimeOffset(): Long = 0L
+    override fun getPosition(): Location? = null
+    override fun getActiveTripId(): String? = activeTripId
+    override fun getDistanceAlongTrip(): Double? = distanceAlongTrip
+    override fun getScheduledDistanceAlongTrip(): Double? = null
+    override fun getTotalDistanceAlongTrip(): Double? = totalDistanceAlongTrip
+    override fun getOrientation(): Double? = null
+    override fun getNextStop(): String? = null
+    override fun getNextStopTimeOffset(): Long? = null
+    override fun getPhase(): String? = null
+    override fun getStatus(): Status? = null
+    override fun getLastUpdateTime(): Long = lastUpdateTime
+    override fun getLastKnownLocation(): Location? = if (hasLocation) FAKE_LOCATION else null
+    override fun getLastLocationUpdateTime(): Long = 0L
+    override fun getLastKnownDistanceAlongTrip(): Double? = null
+    override fun getLastKnownOrientation(): Double? = null
+    override fun getBlockTripSequence(): Int = 0
+    override fun getOccupancyStatus(): Occupancy? = null
+
+    companion object {
+        /**
+         * A non-null [Location] sentinel. The android.jar stubs on the JVM test classpath let the
+         * class resolve but make its constructor and methods throw "Stub!", so we allocate without
+         * the constructor and only ever null-check the reference — never call methods on it.
+         */
+        private val FAKE_LOCATION: Location = try {
+            Location("test")
+        } catch (e: RuntimeException) {
+            val unsafeClass = Class.forName("sun.misc.Unsafe")
+            val theUnsafe = unsafeClass.getDeclaredField("theUnsafe").apply { isAccessible = true }
+            val unsafe = theUnsafe.get(null)
+            val allocate = unsafeClass.getMethod("allocateInstance", Class::class.java)
+            allocate.invoke(unsafe, Location::class.java) as Location
+        }
+    }
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/dataview/TripTrajectoryViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/dataview/TripTrajectoryViewModelTest.kt
@@ -19,8 +19,10 @@ import androidx.lifecycle.SavedStateHandle
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.transform
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -31,6 +33,7 @@ import org.onebusaway.android.extrapolation.data.TripState
 import org.onebusaway.android.io.request.ObaTripDetailsResponse
 import org.onebusaway.android.io.request.ObaTripsForRouteResponse
 import org.onebusaway.android.testing.MainDispatcherRule
+import org.onebusaway.android.testing.testTripStatus
 import org.onebusaway.android.ui.nav.NavRoutes
 import org.onebusaway.android.util.Polyline
 import org.junit.Test
@@ -52,6 +55,35 @@ class TripTrajectoryViewModelTest {
                 detailsCollections++
                 awaitCancellation()
             }
+
+        override fun routeVehiclesStream(routeId: String, intervalMs: Long): Flow<ObaTripsForRouteResponse> =
+            emptyFlow()
+
+        override suspend fun ensureShape(tripId: String, shapeId: String): Polyline? = null
+    }
+
+    /**
+     * A repository whose details stream, once collected, records each pushed snapshot into the store
+     * that [lookupTripState] serves — the one-way record path the screen relies on. [record] pushes
+     * a snapshot; the collected stream applies it, so a refresh() afterward sees exactly what the
+     * stream recorded.
+     */
+    private class HydratingRepo : TripObservationRepository {
+        // Capacity 1 so record()'s emit doesn't suspend waiting for the collector on the test thread.
+        private val records = MutableSharedFlow<TripState>(extraBufferCapacity = 1)
+
+        @Volatile
+        private var stored: TripState? = null
+
+        suspend fun record(state: TripState) {
+            records.emit(state)
+        }
+
+        override fun lookupTripState(tripId: String?): TripState? = stored
+
+        override fun tripDetailsStream(tripId: String, intervalMs: Long): Flow<ObaTripDetailsResponse> =
+            // Records on collection; emits nothing — the ViewModel only collects for the side effect.
+            records.transform<TripState, ObaTripDetailsResponse> { stored = it }
 
         override fun routeVehiclesStream(routeId: String, intervalMs: Long): Flow<ObaTripsForRouteResponse> =
             emptyFlow()
@@ -94,5 +126,35 @@ class TripTrajectoryViewModelTest {
         vm.refresh(nowMs = 10_000L)
 
         assertEquals(0, vm.state.value.sampleCount)
+    }
+
+    @Test
+    fun `end-to-end - collecting the stream hydrates the store that refresh reads`() = runTest {
+        val repo = HydratingRepo()
+        val vm = viewModel(repo)
+        runCurrent() // init's collector subscribes to the details stream
+
+        // Nothing recorded yet: the store is empty, so refresh reflects an empty trajectory.
+        vm.refresh(nowMs = 10_000L)
+        assertEquals(0, vm.state.value.sampleCount)
+
+        // A poll records a vehicle status into the store via the collected stream.
+        repo.record(
+            TripState("trip1").withStatus(
+                testTripStatus(distanceAlongTrip = 500.0, lastUpdateTime = 5_000L, vehicleId = "bus7"),
+                serverTimeMs = 5_000L,
+                localTimeMs = 5_000L,
+            )
+        )
+        runCurrent()
+
+        // refresh now rebuilds the ui state from the hydrated snapshot.
+        vm.refresh(nowMs = 10_000L)
+        val state = vm.state.value
+        assertEquals("trip1", state.tripId)
+        assertEquals("bus7", state.vehicleId)
+        assertEquals(1, state.sampleCount)
+        assertEquals(1, state.trajectory.observations.size)
+        assertEquals(500.0, state.trajectory.observations.first().distanceMeters, 0.0)
     }
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/util/SingleFlightTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/util/SingleFlightTest.kt
@@ -23,11 +23,14 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
  * Covers [SingleFlight]'s coalescing contract: concurrent callers for one key share a single
- * execution, while an entry clears on completion so a later call runs fresh.
+ * execution, distinct keys run independently, and an entry clears on completion so a later call
+ * runs fresh — including the eager-dispatcher edge case where a non-suspending block completes
+ * before LAZY start, which would strand a stale entry if the clear fired re-entrantly.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class SingleFlightTest {
@@ -55,6 +58,33 @@ class SingleFlightTest {
         assertEquals(42, a.await())
         assertEquals(42, b.await())
         assertEquals(1, executions) // b joined a's flight rather than running the block again
+    }
+
+    @Test
+    fun `distinct keys run independently`() = runTest {
+        val singleFlight = SingleFlight<String, Int>(backgroundScope)
+        val aEntered = CompletableDeferred<Unit>()
+        val release = CompletableDeferred<Unit>()
+        var bStarted = false
+
+        // Hold key "a" in flight so "b" has to start while "a" is still running — a global lock
+        // around execution would serialize them and "b" couldn't begin until "a" was released.
+        val aBlock: suspend () -> Int = {
+            aEntered.complete(Unit)
+            release.await()
+            1
+        }
+        val bBlock: suspend () -> Int = { bStarted = true; 2 }
+
+        val a = async { singleFlight.run("a", aBlock) }
+        aEntered.await() // a is now running aBlock and parked on release
+        val b = async { singleFlight.run("b", bBlock) }
+        runCurrent()
+
+        assertTrue("b ran while a was still in flight", bStarted) // distinct keys aren't serialized
+        release.complete(Unit)
+        assertEquals(1, a.await())
+        assertEquals(2, b.await()) // b got its own result, so it was never coalesced into a
     }
 
     @Test


### PR DESCRIPTION
Addresses the **test gaps** item from #1583 (the extrapolation-layer hardening tracker). This PR adds the missing tests only — it does **not** close the issue, since the other items there (SingleFlight thread assertion, `interpolateScheduleTime` boundary, clock-skew offset) are separate code changes.

## What's added

- **End-to-end `TripTrajectoryViewModel` store-hydration test** — exercises the full `collect → record → refresh → verify` path: the ViewModel collects the details stream, a recorded snapshot hydrates the store, and `refresh()` rebuilds the UI state from it. The pre-existing ViewModel tests used a static-snapshot fake and never covered this integration.
- **`SingleFlight` concurrent-dedup tests** (new `SingleFlightTest`) — concurrent same-key calls share a single execution, distinct keys run independently, and an in-flight entry self-clears so a later call runs fresh. Driven on a single virtual thread (the confinement the unlocked map requires) and kept on the success path so `android.util.Log` is never hit (no Robolectric needed).

## Cleanup folded in

- Adds a shared `testTripStatus()` JVM fixture in the `testing` package and migrates `TripStateTest`'s file-private `ObaTripStatus` stub onto it, removing the duplicate (incl. the duplicated `Unsafe`/`FAKE_LOCATION` trick).

## Verification

All affected unit tests pass: `SingleFlightTest` (3), `TripTrajectoryViewModelTest` (4), `TripStateTest` (27) — 0 skipped, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a JVM `testTripStatus` helper to standardize creation of trip status test data and reduced duplicated per-test implementations.
  * Updated trip state tests to use the shared helper for building trip status instances.
  * Expanded trip trajectory ViewModel tests with a hydrating fake repository that refreshes UI state from a trip-details stream.
  * Strengthened `SingleFlight` tests with clearer edge-case documentation and a new assertion that distinct keys don’t coalesce.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->