### PR TITLE
Strengthen BitmapDescriptor cache tests + polish docs (#1590)

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/map/VehicleIconAllocationTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/map/VehicleIconAllocationTest.kt
@@ -16,19 +16,23 @@
 package org.onebusaway.android.map
 
 import android.content.Context
+import android.graphics.Bitmap
 import android.util.Log
 import androidx.test.InstrumentationRegistry.getTargetContext
 import androidx.test.runner.AndroidJUnit4
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.onebusaway.android.extrapolation.extrapolatedVehicles
+import org.onebusaway.android.io.elements.ObaTripStatus
 import org.onebusaway.android.io.request.ObaTripsForRouteResponse
 import org.onebusaway.android.map.googlemapsv2.BitmapDescriptorCache
 import org.onebusaway.android.map.render.VehicleBitmaps
 import org.onebusaway.android.map.render.VehicleMarker
 import org.onebusaway.android.mock.Resources
+import java.util.concurrent.TimeUnit
 
 /**
  * The before/after allocation guard for #1580. `GoogleMapRenderer` re-stamps a gliding vehicle's icon on
@@ -74,11 +78,12 @@ class VehicleIconAllocationTest {
             }
     }
 
-    /** Tallies for one replay: total icon requests, descriptors minted, and bitmaps decoded. */
+    /** Tallies for one replay: total icon requests, descriptors minted, bitmaps decoded, and distinct keys. */
     private class Counts {
         var requests = 0
         var allocations = 0
         var bitmapDecodes = 0
+        val keys = HashSet<String>()
     }
 
     /**
@@ -101,7 +106,9 @@ class VehicleIconAllocationTest {
                 val octant = VehicleBitmaps.directionIndex(moved)
                 if (lastOctant.put(moved.activeTripId, octant) != octant) {
                     counts.requests++
-                    cache.get(VehicleBitmaps.iconKey(moved, response)) {
+                    val key = VehicleBitmaps.iconKey(moved, response)
+                    counts.keys.add(key)
+                    cache.get(key) {
                         counts.bitmapDecodes++
                         VehicleBitmaps.vehicleBitmap(context, moved, response)
                     }
@@ -142,13 +149,122 @@ class VehicleIconAllocationTest {
             longRun.allocations,
             longRun.bitmapDecodes,
         )
-        // Bounded by the distinct directional icons (at most 8 octants per vehicle) — far below the
-        // requests it served, which is the whole point of the cache.
+        // The sharing property, asserted exactly: the cache mints one descriptor per *distinct* icon key,
+        // not one per request and not one per vehicle. A regression that keyed per-activeTripId (or dropped
+        // a shared dimension) would break this equality — the loose `<= 8 * vehicles.size` bound wouldn't.
+        assertEquals(
+            "the cache must mint exactly one descriptor per distinct icon key",
+            longRun.keys.size,
+            longRun.allocations,
+        )
         assertTrue(
-            "allocations (${longRun.allocations}) must be bounded by the distinct icons",
-            longRun.allocations <= 8 * vehicles.size,
+            "descriptors must actually be shared — far fewer allocations than requests",
+            longRun.allocations < longRun.requests,
         )
     }
+
+    /**
+     * The cache's correctness contract: equal [VehicleBitmaps.iconKey] ⟺ equal bitmap (they share
+     * `createBitmapCacheKey`). A key *collision* — two vehicles that should show different icons resolving
+     * to one key — would only *lower* the allocation count, so the bound tests above would still pass while
+     * the wrong icon was served. Sampling every vehicle across all 8 octants and grouping by `iconKey`, each
+     * group must therefore resolve to a single bitmap; a dropped key dimension (e.g. forgetting color) would
+     * merge differing bitmaps into one group and fail here.
+     */
+    @Test
+    fun equalIconKeysResolveToEqualBitmaps() {
+        val response = response()
+        val vehicles = vehicles(response)
+        assertTrue("fixture must yield at least one vehicle", vehicles.isNotEmpty())
+
+        // bearing = octant * 45° lands at each octant's center, so the sample spans all 8 directions.
+        val samples = vehicles.flatMap { vehicle ->
+            (0 until 8).map { octant ->
+                val moved = vehicle.copy(bearing = octant * 45f)
+                VehicleBitmaps.iconKey(moved, response) to
+                    VehicleBitmaps.vehicleBitmap(context, moved, response)
+            }
+        }
+        val byKey = samples.groupBy({ it.first }, { it.second })
+
+        // Non-vacuous: the sample must actually exercise sharing (several vehicles/octants per key).
+        assertTrue("expected multiple distinct icon keys", byKey.size > 1)
+        assertTrue("expected at least one key shared by multiple samples", samples.size > byKey.size)
+
+        for ((key, bitmaps) in byKey) {
+            val reference = bitmaps.first()
+            for (bitmap in bitmaps) {
+                assertTrue("all bitmaps for iconKey '$key' must be identical", bitmap.sameAs(reference))
+            }
+        }
+    }
+
+    /**
+     * The replay holds `nowMs` fixed and only rotates bearing, so schedule-deviation color never varies —
+     * leaving the key's color dimension unexercised. Hold a vehicle's octant fixed and change only its
+     * deviation (early vs. late, distinct colors): the key must change and the cache must mint a second
+     * descriptor, proving color participates in the key.
+     */
+    @Test
+    fun changedScheduleDeviationMintsANewDescriptor() {
+        val response = response()
+        val vehicle = vehicles(response).firstOrNull()
+        assertTrue("fixture must yield at least one vehicle", vehicle != null)
+
+        val early = withRealtimeDeviation(vehicle!!, TimeUnit.MINUTES.toSeconds(-10))
+        val late = withRealtimeDeviation(vehicle, TimeUnit.MINUTES.toSeconds(10))
+
+        val earlyKey = VehicleBitmaps.iconKey(early, response)
+        val lateKey = VehicleBitmaps.iconKey(late, response)
+        assertNotEquals("deviation color must be part of the icon key", earlyKey, lateKey)
+
+        val counts = Counts()
+        val cache = BitmapDescriptorCache(CACHE_SIZE) { counts.allocations++ }
+        cache.get(earlyKey) { VehicleBitmaps.vehicleBitmap(context, early, response) }
+        cache.get(lateKey) { VehicleBitmaps.vehicleBitmap(context, late, response) }
+        assertEquals("a changed deviation color must mint a second descriptor", 2, counts.allocations)
+    }
+
+    /**
+     * The cache's eviction + [BitmapDescriptorCache.clear] contract, which the production [CACHE_SIZE] is
+     * deliberately large enough to never hit. Drive past `maxSize` distinct keys and confirm an evicted key
+     * re-invokes its supplier, and that a `get` after `clear()` is a miss.
+     */
+    @Test
+    fun evictedKeyAndPostClearGetReinvokeTheSupplier() {
+        val bitmap = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888)
+        var supplied = 0
+        val cache = BitmapDescriptorCache<Int>(2) { 0 }
+        fun get(key: String) = cache.get(key) { supplied++; bitmap }
+
+        get("a")
+        get("b")            // cache now holds [a, b]
+        get("c")            // exceeds maxSize: evicts a (LRU)
+        assertEquals("three distinct keys are three misses", 3, supplied)
+
+        get("b")            // still cached -> hit
+        assertEquals("a cached key must not re-supply", 3, supplied)
+
+        get("a")            // evicted -> miss, supplier re-invoked
+        assertEquals("an evicted key must re-invoke the supplier", 4, supplied)
+
+        cache.clear()
+        get("b")            // after clear -> miss
+        assertEquals("get after clear must re-invoke the supplier", 5, supplied)
+    }
+
+    /**
+     * Force the realtime color path and stamp [deviationSeconds] onto a copy of [vehicle], pinning the
+     * bearing so the heading octant is fixed — only the deviation color varies between the variants.
+     */
+    private fun withRealtimeDeviation(vehicle: VehicleMarker, deviationSeconds: Long): VehicleMarker =
+        vehicle.copy(
+            isRealtime = true,
+            bearing = 0f,
+            status = object : ObaTripStatus by vehicle.status {
+                override fun getScheduleDeviation(): Long = deviationSeconds
+            },
+        )
 
     companion object {
         // Sweep the bearing through all 8 octants within a few frames, then revisit them (no new icons) —

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/BitmapDescriptorCache.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/BitmapDescriptorCache.kt
@@ -26,21 +26,29 @@ import androidx.collection.LruCache
  * without this.
  *
  * Keying by a logical id (e.g. type+octant+color), not by the [Bitmap] itself, is deliberate: the source
- * bitmap caches are bounded (VehicleBitmaps' is 15 entries), so on a busy route they evict and re-create
- * the same logical icon as a *new* Bitmap instance — identity keying would inherit that thrash and defeat
- * the cache. With a logical key, [get] reuses the descriptor across that churn, and the [bitmap] supplier
- * (the expensive decode/tint/wrap) runs **only on a miss** — so a steady-state hot path does no bitmap
+ * bitmap caches are small, bounded LRUs, so on a busy route they evict and re-create the same logical icon
+ * as a *new* Bitmap instance — identity keying would inherit that thrash and defeat the cache. With a
+ * logical key, [get] reuses the descriptor across that churn, and the bitmap supplier (the expensive
+ * decode/tint that produces the Bitmap) runs **only on a miss** — so a steady-state hot path does no bitmap
  * work at all.
  *
- * Bounded by [maxSize]: a still-shown marker retains its own native texture, so evicting an entry here is
- * harmless (it's just re-wrapped on next request). Generic over [V] purely for testability — [wrap] is the
- * one and only allocator, so a test can pass a counting fake and assert wrappers stay bounded.
+ * Bounded by the constructor's `maxSize`: a still-shown marker retains its own native texture, so evicting
+ * an entry here is harmless (it's just re-wrapped on next request). Generic over [V] purely for
+ * testability — [wrap] is the one and only allocator, so a test can pass a counting fake and assert
+ * wrappers stay bounded.
+ *
+ * **Not thread-safe.** Both [get] and [clear] are non-atomic check-then-act over the backing LRU and are
+ * expected to run on the main thread only (the renderer's reconcile/draw path), so no synchronization.
  */
 class BitmapDescriptorCache<V : Any>(maxSize: Int, private val wrap: (Bitmap) -> V) {
 
     private val cache = LruCache<String, V>(maxSize)
 
-    /** The cached wrapper for [key], decoding [bitmap] and wrapping it only on a cache miss. */
+    /**
+     * The cached wrapper for [key], invoking [bitmap] and wrapping its result only on a cache miss.
+     *
+     * @param bitmap supplies the source [Bitmap] to wrap; called only when [key] is absent.
+     */
     fun get(key: String, bitmap: () -> Bitmap): V =
         cache.get(key) ?: wrap(bitmap()).also { cache.put(key, it) }
 

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
@@ -505,12 +505,12 @@ class GoogleMapRenderer(
 
     // The trip-focus icons, cached through [descriptorCache] by a stable per-icon key so each resolves
     // lazily on first show and reuses one descriptor thereafter (released, with the rest, in [dispose]).
-    private fun vehicleEstimateIcon() = tripCircleIcon(R.drawable.ic_vehicle_position)
+    private fun vehicleEstimateIcon(): BitmapDescriptor = tripCircleIcon(R.drawable.ic_vehicle_position)
 
-    private fun fastEstimateIcon() = tripCircleIcon(R.drawable.ic_fast_estimate)
+    private fun fastEstimateIcon(): BitmapDescriptor = tripCircleIcon(R.drawable.ic_fast_estimate)
 
     // The signal glyph is light, so tint it gray to read on the white disc.
-    private fun dataAgeIcon() =
+    private fun dataAgeIcon(): BitmapDescriptor =
         tripCircleIcon(R.drawable.ic_signal_indicator, TripMarkerBitmaps.STROKE_COLOR)
 
     private fun tripCircleIcon(drawableRes: Int, tintColor: Int = 0): BitmapDescriptor =
@@ -518,7 +518,7 @@ class GoogleMapRenderer(
             TripMarkerBitmaps.circle(context, drawableRes, tintColor)
         }
 
-    private fun tripStopIcon(selected: Boolean) =
+    private fun tripStopIcon(selected: Boolean): BitmapDescriptor =
         descriptorCache.get("stop:$selected") { TripStopBitmaps.dot(selected) }
 
     fun stopForMarker(marker: Marker): StopMarker? = stopByMarker[marker]

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/VehicleBitmaps.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/VehicleBitmaps.java
@@ -20,6 +20,7 @@ import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 
+import androidx.annotation.VisibleForTesting;
 import androidx.collection.LruCache;
 import androidx.core.content.ContextCompat;
 
@@ -100,7 +101,16 @@ public final class VehicleBitmaps {
     private static int vehicleType(VehicleMarker vehicle, ObaTripsForRouteResponse response) {
         ObaTripStatus status = vehicle.getStatus();
         int type = response.getRoute(response.getTrip(status.getActiveTripId()).getRouteId()).getType();
-        return type == ObaRoute.TYPE_CABLECAR ? ObaRoute.TYPE_TRAM : type;
+        return normalizeVehicleType(type);
+    }
+
+    /**
+     * Collapses cablecar onto tram so a cablecar route and the equivalent tram route resolve to the same
+     * icon (and therefore the same {@link #iconKey}); every other type passes through unchanged.
+     */
+    @VisibleForTesting
+    static int normalizeVehicleType(int routeType) {
+        return routeType == ObaRoute.TYPE_CABLECAR ? ObaRoute.TYPE_TRAM : routeType;
     }
 
     /** The schedule-deviation color (realtime) or the scheduled color — constant between polls. */
@@ -113,9 +123,10 @@ public final class VehicleBitmaps {
     }
 
     /**
-     * The 8-way heading slot (or the undirected slot) the icon for [vehicle] uses. Exposed so the
-     * renderer can cheaply detect when a gliding vehicle's direction arrow needs re-stamping — the
-     * tinted bitmap only changes when this index does (the color is constant between polls).
+     * The 8-way heading slot (0..7) the icon for [vehicle] uses. Exposed so the renderer can cheaply
+     * detect when a gliding vehicle's direction arrow needs re-stamping — the tinted bitmap only changes
+     * when this index does (the color is constant between polls). A live vehicle always has a heading, so
+     * the undirected slot ({@code NUM_DIRECTIONS - 1}) isn't reachable from here.
      */
     public static int directionIndex(VehicleMarker vehicle) {
         // The path bearing is already a compass direction; the server orientation needs converting.

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/render/VehicleBitmapsTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/render/VehicleBitmapsTest.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.map.render
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.onebusaway.android.io.elements.ObaRoute
+
+/** Pure-logic guards for [VehicleBitmaps]'s route-type normalization (the cablecar→tram promise). */
+class VehicleBitmapsTest {
+
+    /**
+     * `iconKey` and `vehicleBitmap` both route through [VehicleBitmaps.normalizeVehicleType], so a cablecar
+     * route must collapse onto tram — otherwise the two paths could disagree (or mint a second icon for a
+     * vehicle that should share tram's).
+     */
+    @Test
+    fun cablecarNormalizesToTram() {
+        assertEquals(
+            ObaRoute.TYPE_TRAM,
+            VehicleBitmaps.normalizeVehicleType(ObaRoute.TYPE_CABLECAR),
+        )
+        assertEquals(
+            "a cablecar route resolves to the same type as a tram route",
+            VehicleBitmaps.normalizeVehicleType(ObaRoute.TYPE_TRAM),
+            VehicleBitmaps.normalizeVehicleType(ObaRoute.TYPE_CABLECAR),
+        )
+    }
+
+    /** Every other route type passes through untouched. */
+    @Test
+    fun otherTypesPassThrough() {
+        for (type in intArrayOf(
+            ObaRoute.TYPE_TRAM,
+            ObaRoute.TYPE_SUBWAY,
+            ObaRoute.TYPE_RAIL,
+            ObaRoute.TYPE_BUS,
+            ObaRoute.TYPE_FERRY,
+        )) {
+            assertEquals(type.toLong(), VehicleBitmaps.normalizeVehicleType(type).toLong())
+        }
+    }
+}


### PR DESCRIPTION
Closes #1590. Follow-up to #1585 — the non-blocking test and doc improvements deferred from that PR's review.

### Test strengthening
- **Tightened the loose allocation bound.** `VehicleIconAllocationTest` replaces `allocations <= 8 * vehicles.size` with an exact `allocations == distinct icon keys` assertion — a regression that keyed per-`activeTripId` (or dropped a shared dimension) now fails; the old bound would have passed it.
- **iconKey ⟺ bitmap agreement.** New test samples every vehicle across all 8 octants, groups by `iconKey`, and asserts each group resolves to a single bitmap. Catches a key collision, which only *lowers* the allocation count and so slipped past every prior assertion.
- **Color/deviation dimension.** New test holds the octant fixed and varies only the schedule deviation (early vs. late), asserting a second descriptor is minted — proving color participates in the key (the replay held `nowMs` fixed, so this was unexercised).
- **Eviction + `clear()` coverage.** New test drives past `maxSize` to confirm an evicted key re-invokes its supplier, and that a `get` after `clear()` is a miss.
- **cablecar→tram normalization.** Extracted a `@VisibleForTesting VehicleBitmaps.normalizeVehicleType` pure-function seam and locked the agreement with a JVM unit test.

### Comment / doc polish
- `BitmapDescriptorCache`: dropped the rot-prone "15 entries" detail (→ "small, bounded LRUs"), fixed the unresolvable `[bitmap]`/`[maxSize]` KDoc links, separated the bitmap supplier from the `wrap` lambda, and documented the main-thread-only (non-atomic check-then-act) precondition.
- `VehicleBitmaps.directionIndex`: corrected the Javadoc — `getHalfWindIndex(..., 8)` only returns 0..7, so the "undirected slot" is unreachable here.
- `GoogleMapRenderer`: annotated `vehicleEstimateIcon`/`fastEstimateIcon`/`dataAgeIcon`/`tripStopIcon` with their `BitmapDescriptor` return types.

### Deliberately deferred
- **Extracting the renderer's octant-flip guard into a testable seam** (the issue's "consider" item) — that's a `GoogleMapRenderer` reconcile-path refactor, larger than this cleanup; left out to keep the change focused.
- The cablecar→tram check is a `normalizeVehicleType` unit test rather than fixture-driven, since the HART fixture is buses-only and `ObaTripsForRouteResponse` is `final`.

### Testing
- `testObaGoogleDebugUnitTest` (new `VehicleBitmapsTest`) — passing.
- `connectedObaGoogleDebugAndroidTest --tests VehicleIconAllocationTest` — all 4 tests passing on a Pixel 7 Pro (API 16 image).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vehicle icon consistency so visually identical vehicles reuse the same icon.
  * Reduced unnecessary icon reloads, including when vehicle status changes or cached icons are refreshed.
  * Fixed icon handling after cache eviction and reset so missing icons are recreated correctly.

* **Tests**
  * Added coverage for icon reuse, cache refresh behavior, and vehicle type normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->