### PR TITLE
Tidy SingleFlight comments and add failure-path tests

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/data/TripObservationFetcher.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/data/TripObservationFetcher.kt
@@ -68,7 +68,10 @@ class DefaultTripObservationFetcher @Inject constructor(
         @ApplicationContext private val context: Context
 ) : TripObservationFetcher {
 
-    /** Process-lifetime scope the coalesced fetches run on; the network calls hop to [fetchDispatcher]. */
+    /**
+     * Process-lifetime scope the coalesced fetches run on; the network calls hop to
+     * [fetchDispatcher].
+     */
     private val fetchScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
 
     /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/SingleFlight.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/SingleFlight.kt
@@ -46,7 +46,8 @@ class SingleFlight<K : Any, V : Any>(private val scope: CoroutineScope) {
                     // computeIfAbsent is atomic, so concurrent callers for one key share a Deferred.
                     // The coroutine is LAZY: await() (below) starts it only after computeIfAbsent has
                     // returned and stored the Deferred, so the finally/remove can never run
-                    // re-entrantly — even for an eager dispatcher and a non-suspending block.
+                    // re-entrantly — even for an inline/undispatched dispatcher and a
+                    // non-suspending block.
                     .computeIfAbsent(key) {
                         scope.async(start = CoroutineStart.LAZY) {
                             try {

--- a/onebusaway-android/src/test/java/org/onebusaway/android/util/SingleFlightTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/util/SingleFlightTest.kt
@@ -15,6 +15,7 @@
  */
 package org.onebusaway.android.util
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -23,6 +24,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
@@ -69,11 +71,13 @@ class SingleFlightTest {
     }
 
     @Test
-    fun `an eager dispatcher with a non-suspending block clears the completed entry`() = runTest {
-        // Dispatchers.Unconfined runs the block synchronously to completion before async() returns.
-        // The block never suspends, so this exercises the path where the finally/remove could fire
-        // re-entrantly inside computeIfAbsent — which the LAZY start guards against. A stale entry
-        // would make the second call join the first's completed Deferred instead of running fresh.
+    fun `an inline dispatcher with a non-suspending block clears the completed entry`() = runTest {
+        // Dispatchers.Unconfined runs continuations inline on the current thread. Were the async
+        // start eager rather than LAZY, the block would run inside async() — which is called inside
+        // computeIfAbsent's mapping function — so the finally/remove would fire re-entrantly there.
+        // The LAZY start defers execution to await() (below), which runs after computeIfAbsent has
+        // returned and stored the Deferred. A stale entry would make the second call join the
+        // first's completed Deferred instead of running fresh.
         val singleFlight = SingleFlight<String, Int>(CoroutineScope(Dispatchers.Unconfined))
         var executions = 0
 
@@ -82,7 +86,34 @@ class SingleFlightTest {
         assertEquals(2, executions)
     }
 
-    // The failure path (a throwing block resolves to null and clears its entry) is left to
-    // instrumented coverage: SingleFlight logs via android.util.Log.e, which is unmocked in plain
-    // JVM tests here, and this module deliberately avoids Robolectric/mocking for unit tests.
+    @Test
+    fun `a cancelled block propagates instead of resolving to null`() = runTest {
+        val singleFlight = SingleFlight<String, Int>(backgroundScope)
+
+        // CancellationException is rethrown ahead of the catch-to-null, so a stopped flight surfaces
+        // as cancellation to the caller rather than masquerading as a null (no-result) success.
+        val thrown = runCatching {
+            singleFlight.run("k") { throw CancellationException("stop") }
+        }.exceptionOrNull()
+
+        assertTrue(thrown is CancellationException)
+    }
+
+    @Test
+    fun `the entry clears after a cancelled flight so a later call runs fresh`() = runTest {
+        val singleFlight = SingleFlight<String, Int>(backgroundScope)
+        var executions = 0
+
+        // The finally/remove runs even when the block is cancelled, so the entry does not linger.
+        runCatching { singleFlight.run("k") { executions++; throw CancellationException("stop") } }
+
+        assertEquals(7, singleFlight.run("k") { executions++; 7 })
+        assertEquals(2, executions) // the second call ran fresh rather than joining a dead flight
+    }
+
+    // One failure branch stays uncovered: a *non-cancellation* exception resolves to null for every
+    // joined caller. That path logs via android.util.Log.e, which is unmocked in plain JVM tests
+    // (this module avoids Robolectric/mocking for unit tests), so it is currently untested — a
+    // candidate for an instrumented test. The cancellation-propagation and entry-cleared-on-
+    // cancellation branches above never reach Log, so they are exercised here.
 }


### PR DESCRIPTION
Fast-follow to #1588, addressing review feedback on that PR. **No runtime behavior changes** — this is comment accuracy plus added test coverage. Rebased onto `main` now that #1588 has merged, so the diff is just the cleanup described here.

## What and why

The implementation in #1588 is correct, but two comments it added were misleading, and a couple of cheap failure-path tests were missing. Fixing those here rather than churning the original PR.

### Comment accuracy
- **Test-3 comment contradicted the code.** It stated `Dispatchers.Unconfined` "runs the block synchronously to completion before `async()` returns" — but the code uses `CoroutineStart.LAZY`, so `async()` returns *without* running the block; `await()` starts it. The comment was describing the eager-start counterfactual (the hazard LAZY prevents) as if it were what actually happens. Reworded, and renamed the test to "an inline dispatcher…" rather than "an eager dispatcher…".
- **Failure-path note over-claimed coverage.** It said the throwing-block path was "left to instrumented coverage," but no instrumented `SingleFlight` test exists anywhere. It now states honestly that the non-cancellation `Log.e`→null branch is currently untested (a candidate for an instrumented test).
- Precise "inline/undispatched dispatcher" wording in `SingleFlight`'s inline comment (eagerness is a property of `CoroutineStart`, not the dispatcher).
- Wrapped `TripObservationFetcher`'s 107-char KDoc line to AOSP's 100-column limit.

### Added tests
Two JVM-testable failure-path guarantees that the LAZY guard's contract deserves — neither hits `android.util.Log`, so they run cleanly without Robolectric/mocking:
- `a cancelled block propagates instead of resolving to null` — verifies `CancellationException` is rethrown ahead of the catch-to-null.
- `the entry clears after a cancelled flight so a later call runs fresh` — verifies the `finally`/remove runs even when the block is cancelled, so the key doesn't linger.

## Out of scope
The non-cancellation `Exception`→null branch still isn't unit-tested here; it logs via `android.util.Log.e`, which is unmocked in plain JVM tests. The comment now says so plainly instead of pointing at coverage that doesn't exist.

## Tests
`./gradlew :onebusaway-android:testObaGoogleDebugUnitTest --tests "org.onebusaway.android.util.SingleFlightTest"` — all 5 pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved concurrency-safe coalescing so simultaneous identical requests share a single in-flight result rather than duplicating work.
  * Ensured completed and cancelled in-flight requests are properly cleared, so later requests run fresh and don’t join stale results.
* **Documentation**
  * Clarified request-fetching coroutine scope behavior and how shared in-flight executions run and clean up.
* **Tests**
  * Added unit tests covering concurrent sharing, post-completion behavior, dispatcher edge cases, and cancellation propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->