### PR TITLE
Resolve prefs off the composable hot path (#1605)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/arrivals/ArrivalsSheetHost.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/arrivals/ArrivalsSheetHost.kt
@@ -15,7 +15,6 @@
  */
 package org.onebusaway.android.ui.home.arrivals
 
-import android.content.Context
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,6 +34,7 @@ import androidx.lifecycle.viewmodel.viewModelFactory
 import kotlinx.coroutines.flow.first
 import org.onebusaway.android.R
 import org.onebusaway.android.app.di.PreferencesEntryPoint
+import org.onebusaway.android.preferences.PreferencesRepository
 import org.onebusaway.android.ui.arrivals.ArrivalsLoaded
 import org.onebusaway.android.ui.arrivals.components.ArrivalsPanel
 import org.onebusaway.android.ui.arrivals.ArrivalsUiState
@@ -86,6 +86,9 @@ internal fun ArrivalsSheetHost(
             LocalViewModelStoreOwner provides rememberClearedViewModelStoreOwner(stop.id)
         ) {
             val context = LocalContext.current
+            // Resolve the Hilt entry point once per stop rather than on each recomposition / each
+            // arrivals load (matches the remember { RegionEntryPoint.get(...) } pattern elsewhere).
+            val prefs = remember { PreferencesEntryPoint.get(context) }
             val viewModel: ArrivalsViewModel = viewModel(
                 factory = viewModelFactory {
                     initializer {
@@ -139,7 +142,7 @@ internal fun ArrivalsSheetHost(
                 viewModel.arrivalsLoaded.collect { loaded ->
                     onArrivalsLoaded(loaded)
                     if (tutorialState != null) {
-                        maybeStartArrivalTutorial(context, tutorialState, loaded.hasArrivals) {
+                        maybeStartArrivalTutorial(prefs, tutorialState, loaded.hasArrivals) {
                             // Suspend until the sheet is actually on screen (see the helper KDoc).
                             snapshotFlow { sheetVisibleState.value }.first { it }
                         }
@@ -163,14 +166,13 @@ internal fun ArrivalsSheetHost(
  * commit to starting, so a lost-then-retried response can't double-show.
  */
 private suspend fun maybeStartArrivalTutorial(
-    context: Context,
+    prefs: PreferencesRepository,
     tutorialState: TutorialState,
     hasArrivals: Boolean,
     awaitSheetVisible: suspend () -> Unit,
 ) {
     if (tutorialState.active) return
     if (!hasArrivals) return
-    val prefs = PreferencesEntryPoint.get(context)
     val pending = ArrivalTutorial.pendingSteps(prefs)
     if (pending.isEmpty()) return
     awaitSheetVisible()

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/weather/WeatherCard.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/weather/WeatherCard.kt
@@ -44,7 +44,6 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import java.util.Locale
 import org.onebusaway.android.R
-import org.onebusaway.android.app.di.PreferencesEntryPoint
 
 /**
  * Self-wiring weather feature module: collects [WeatherViewModel] state, re-reads the hide-weather
@@ -60,7 +59,7 @@ fun WeatherFeature(viewModel: WeatherViewModel, onNearby: Boolean, modifier: Mod
     if (onNearby && !state.hidden && data != null) {
         WeatherCard(
             iconRes = weatherIconRes(data.icon),
-            tempText = formatTemperature(context, data.temperatureF),
+            tempText = formatTemperature(context, data.temperatureF, state.preferredTempUnits),
             // Fog/wind icons are shown unscaled rather than center-cropped.
             fitIcon = data.icon == "fog" || data.icon == "wind",
             onClick = {
@@ -119,11 +118,14 @@ private fun weatherIconRes(condition: String): Int = when (condition.replace("-"
     else -> R.drawable.clear_day
 }
 
-/** Formats a Fahrenheit forecast temperature into the user's preferred unit, localized, e.g. "29°C". */
-private fun formatTemperature(context: Context, tempF: Double): String {
+/**
+ * Formats a Fahrenheit forecast temperature into the user's preferred unit, localized, e.g. "29°C".
+ * [preferredUnits] is the reactively-observed units preference from [WeatherViewModel]; null (never
+ * set) is treated as the locale-driven automatic default.
+ */
+private fun formatTemperature(context: Context, tempF: Double, preferredUnits: String?): String {
     val automatic = context.getString(R.string.preferences_preferred_units_option_automatic)
-    val preferred = PreferencesEntryPoint.get(context)
-        .getString(R.string.preference_key_preferred_temperature_units, automatic)
+    val preferred = preferredUnits ?: automatic
 
     // "Automatic" follows the locale default (Fahrenheit only in the US and a few others);
     // otherwise honor the explicit Celsius/Fahrenheit choice.

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/weather/WeatherViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/weather/WeatherViewModel.kt
@@ -30,8 +30,15 @@ import org.onebusaway.android.R
 import org.onebusaway.android.preferences.PreferencesRepository
 import org.onebusaway.android.region.RegionRepository
 
-/** The weather chip's state: the forecast (null until fetched) + the hide-weather preference. */
-data class WeatherUiState(val data: WeatherData? = null, val hidden: Boolean = false)
+/**
+ * The weather chip's state: the forecast (null until fetched), the hide-weather preference, and the
+ * preferred temperature-units preference (null = never set → the formatter uses the locale default).
+ */
+data class WeatherUiState(
+    val data: WeatherData? = null,
+    val hidden: Boolean = false,
+    val preferredTempUnits: String? = null,
+)
 
 /**
  * Owns the weather chip as a self-contained feature module (mirrors [org.onebusaway.android.ui.home.donation.DonationViewModel]/SurveyViewModel):
@@ -66,6 +73,14 @@ class WeatherViewModel @Inject constructor(
             preferencesRepository
                 .observeBoolean(R.string.preference_key_display_weather_view, true)
                 .collect { enabled -> _state.update { it.copy(hidden = !enabled) } }
+        }
+        // Observe the preferred temperature-units preference reactively so the chip re-renders when the
+        // user changes units, and the DI lookup stays out of the composable body (was read ad hoc via
+        // PreferencesEntryPoint in formatTemperature on each recomposition).
+        viewModelScope.launch {
+            preferencesRepository
+                .observeString(R.string.preference_key_preferred_temperature_units, null)
+                .collect { units -> _state.update { it.copy(preferredTempUnits = units) } }
         }
     }
 


### PR DESCRIPTION
Fixes #1605.

Two Compose UI paths called `PreferencesEntryPoint.get(context)` directly in the recomposition path, which re-ran the Hilt entry-point lookup on each recomposition and read the value non-reactively.

## Changes

**`WeatherCard.kt`** — `formatTemperature()` was called from the `WeatherFeature` composable body, so the entry-point lookup + preference read ran on every recomposition. Made it **reactive** instead: `WeatherViewModel` already injects `PreferencesRepository`, so it now observes the preferred-units string (`observeString`), exposes it on `WeatherUiState`, and the composable passes it into `formatTemperature`. The chip now re-renders when the user changes units in settings, and no DI lookup remains in the composable body. Behavior is preserved — an unset preference resolves to `null`, which the formatter treats as the locale-driven "automatic" default, exactly as before.

**`ArrivalsSheetHost.kt`** — resolves the entry point once per stop via `remember { PreferencesEntryPoint.get(context) }` and threads the `PreferencesRepository` into `maybeStartArrivalTutorial`, matching the `remember { RegionEntryPoint.get(...) }` pattern already used in `TripPlanScreen`.

## Verification

- `./gradlew :onebusaway-android:compileObaGoogleDebugKotlin` — BUILD SUCCESSFUL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Weather temperatures now follow your selected temperature unit preference in the home weather card.
  * Arrival tutorials continue to start only when the arrivals sheet is visible and arrivals are loaded.

* **Bug Fixes**
  * Improved consistency in weather temperature display when preference settings change.
  * Made arrival tutorial timing more reliable by re-checking visibility before launching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->