### PR TITLE
Drive map stop icons from an LRU cache, not each API fetch

### DIFF
--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
@@ -58,9 +58,10 @@ import java.util.concurrent.TimeUnit
  * `ObaMapContent` + the `VehicleMarkerLayer`/`TripMarkerLayer` Compose overlays.
  *
  * Two redraw paths, the same two recomposition boundaries the Compose flavor had:
- *  - [renderStatic] (stops / route polylines / bikes / generics / trip-stop dots) is a clear-and-redraw
- *    of just the static annotations, driven by snapshot/trip-stop changes (viewport loads, the vehicle
- *    poll, focus) — a bounded cost.
+ *  - [renderStatic] clear-and-redraws the static annotations (route polylines / bikes / generics /
+ *    trip-stop dots) and reconciles the stop markers in place ([reconcileStopMarkers], so unchanged
+ *    stops don't blink), driven by snapshot/trip-stop changes (viewport loads, the vehicle poll,
+ *    focus) — a bounded cost.
  *  - [renderDynamic] (the live route vehicles + the trip-focus band/estimate markers) is pulled at
  *    ~20Hz by the adapter's frame loop. It moves native markers **in place** to their freshly
  *    extrapolated positions (so the icons glide with the map, an open info window survives, and there's
@@ -75,6 +76,13 @@ class GoogleMapRenderer(
     private val renderState: MapRenderState,
 ) {
     private val stopByMarker = HashMap<Marker, StopMarker>()
+
+    // Stop markers tracked by stop id so [reconcileStopMarkers] can diff them in place (add new,
+    // remove gone, re-icon only on a focus flip) instead of clear-and-redraw — keeping unchanged stops
+    // from blinking on every static redraw. Like the vehicle markers, these are NOT in [staticMarkers]
+    // and so survive [clearStatic]; [renderedFocusedStopId] is the focus the icons were last drawn for.
+    private val stopMarkersByStopId = HashMap<String, Marker>()
+    private var renderedFocusedStopId: String? = null
 
     private val bikeByMarker = HashMap<Marker, BikeMarker>()
 
@@ -147,15 +155,16 @@ class GoogleMapRenderer(
     private val descriptorCache =
         BitmapDescriptorCache(DESCRIPTOR_CACHE_SIZE) { BitmapDescriptorFactory.fromBitmap(it) }
 
-    // Remove only our own static annotations (not map.clear(), which would also wipe the per-frame
-    // dynamic layer) and clear their tap-routing maps. Shared by [renderStatic] (before it redraws) and
-    // [dispose].
+    // Remove the redrawn static annotations — polylines, trip-stop dots, bikes, generic markers (not
+    // map.clear(), which would also wipe the per-frame dynamic layer) — and clear the bike tap map
+    // [bikeByMarker]. The reconciled stop markers are tracked apart in [stopMarkersByStopId] and
+    // deliberately survive (their tap map [stopByMarker] is left intact too). Shared by [renderStatic]
+    // (before it redraws) and [dispose].
     private fun clearStatic() {
         staticMarkers.forEach { it.remove() }
         staticMarkers.clear()
         staticPolylines.forEach { it.remove() }
         staticPolylines.clear()
-        stopByMarker.clear()
         bikeByMarker.clear()
     }
 
@@ -189,22 +198,7 @@ class GoogleMapRenderer(
             )
         }
 
-        for (stop in snapshot.stops) {
-            val icon = if (stop.id == snapshot.focusedStopId) {
-                StopIconFactory.focusedStopIcon(stop.direction, stop.routeType)
-            } else {
-                StopIconFactory.stopIcon(stop.direction, stop.routeType)
-            }
-            val marker = map.addMarker(
-                MarkerOptions()
-                    .position(stop.point.toLatLng())
-                    .icon(icon)
-                    .flat(true)
-                    .anchor(StopIconFactory.anchorX(stop.direction), StopIconFactory.anchorY(stop.direction))
-            )!!
-            staticMarkers.add(marker)
-            stopByMarker[marker] = stop
-        }
+        reconcileStopMarkers(snapshot.stops, snapshot.focusedStopId)
 
         if (snapshot.bikeshareVisible) {
             val band = bikeZoomBand(map.cameraPosition.zoom)
@@ -237,6 +231,49 @@ class GoogleMapRenderer(
     }
 
     /**
+     * Diff the stop markers against [stops] in place (the [reconcileVehicleMarkers] pattern): remove
+     * markers whose id has left, add markers for new ids, and re-icon an existing marker only when its
+     * focused state flips. Unchanged stops keep their native marker, so they don't blink on a static
+     * redraw. Tracked in [stopMarkersByStopId] (not [staticMarkers]) so [clearStatic] leaves them be.
+     */
+    private fun reconcileStopMarkers(stops: List<StopMarker>, focusedStopId: String?) {
+        val liveIds = stops.mapTo(HashSet()) { it.id }
+        val gone = stopMarkersByStopId.iterator()
+        while (gone.hasNext()) {
+            val entry = gone.next()
+            if (entry.key !in liveIds) {
+                stopByMarker.remove(entry.value)
+                entry.value.remove()
+                gone.remove()
+            }
+        }
+        for (stop in stops) {
+            val isFocused = stop.id == focusedStopId
+            val existing = stopMarkersByStopId[stop.id]
+            if (existing == null) {
+                val marker = map.addMarker(
+                    MarkerOptions()
+                        .position(stop.point.toLatLng())
+                        .icon(stopIcon(stop, isFocused))
+                        .flat(true)
+                        .anchor(StopIconFactory.anchorX(stop.direction), StopIconFactory.anchorY(stop.direction))
+                )!!
+                stopMarkersByStopId[stop.id] = marker
+                stopByMarker[marker] = stop
+            } else if ((stop.id == renderedFocusedStopId) != isFocused) {
+                // Re-icon only the marker that just lost focus and the one that just gained it (their
+                // focus state flipped).
+                existing.setIcon(stopIcon(stop, isFocused))
+            }
+        }
+        renderedFocusedStopId = focusedStopId
+    }
+
+    private fun stopIcon(stop: StopMarker, focused: Boolean): BitmapDescriptor =
+        if (focused) StopIconFactory.focusedStopIcon(stop.direction, stop.routeType)
+        else StopIconFactory.stopIcon(stop.direction, stop.routeType)
+
+    /**
      * Tear down every native annotation and drop all marker-smoothing state. The adapter calls this from
      * its onDispose, before `MapView.onDestroy()`. Forget the smoother state first, then remove the
      * markers/polylines it tracked.
@@ -246,6 +283,11 @@ class GoogleMapRenderer(
         dotSmoother.retainOnly(emptySet())
 
         clearStatic()
+
+        stopMarkersByStopId.values.forEach { it.remove() }
+        stopMarkersByStopId.clear()
+        stopByMarker.clear()
+        renderedFocusedStopId = null
 
         vehicleMarkersByTripId.values.forEach { it.remove() }
         vehicleMarkersByTripId.clear()

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/contract/ObaWebService.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/contract/ObaWebService.kt
@@ -82,6 +82,10 @@ interface ObaWebService {
      * stops-for-location — stops near [lat]/[lon], optionally filtered by a code/name [query] and
      * bounded by [radius] (meters). Omitted (null) parameters are dropped from the request.
      * {http://developer.onebusaway.org/.../api/where/methods/stops-for-location.html}
+     *
+     * [maxCount] caps how many stops the server returns; it applies its own hard upper limit no matter
+     * how large this is set, and reports `limitExceeded` when more stops matched than were returned.
+     * When null the server's per-method default applies.
      */
     @GET("api/where/stops-for-location.json")
     suspend fun stopsForLocation(
@@ -92,6 +96,7 @@ interface ObaWebService {
         // The map fetches by bounding-box span instead of radius; both are optional and dropped when null.
         @Query("latSpan") latSpan: Double? = null,
         @Query("lonSpan") lonSpan: Double? = null,
+        @Query("maxCount") maxCount: Int? = null,
     ): ObaEnvelope<ListWithReferences<StopReference>>
 
     /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/data/MapDataSource.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/data/MapDataSource.kt
@@ -35,7 +35,14 @@ import org.onebusaway.android.util.PolylineDecoder
  */
 interface MapDataSource {
 
-    suspend fun nearbyStops(lat: Double, lon: Double, latSpan: Double, lonSpan: Double): Result<NearbyStops?>
+    /**
+     * [maxCount] caps how many stops the server returns (the map's LRU cache size): a dense viewport
+     * fills the cache in fewer pans. The server clamps this to its own hard limit and sets
+     * `limitExceeded` when more stops matched than were returned; null leaves the server default.
+     */
+    suspend fun nearbyStops(
+        lat: Double, lon: Double, latSpan: Double, lonSpan: Double, maxCount: Int? = null,
+    ): Result<NearbyStops?>
 
     suspend fun routeMap(routeId: String): Result<RouteMapData?>
 }
@@ -45,10 +52,11 @@ class DefaultMapDataSource @Inject constructor(
 ) : MapDataSource {
 
     override suspend fun nearbyStops(
-        lat: Double, lon: Double, latSpan: Double, lonSpan: Double,
+        lat: Double, lon: Double, latSpan: Double, lonSpan: Double, maxCount: Int?,
     ): Result<NearbyStops?> = api.callOrNull { service ->
-        val data = service.stopsForLocation(lat = lat, lon = lon, latSpan = latSpan, lonSpan = lonSpan)
-            .requireData()
+        val data = service.stopsForLocation(
+            lat = lat, lon = lon, latSpan = latSpan, lonSpan = lonSpan, maxCount = maxCount,
+        ).requireData()
         NearbyStops(
             stops = data.list.map(::DtoStop),
             routes = data.references.routes.map(::DtoRoute),

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapDecisions.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapDecisions.kt
@@ -110,17 +110,21 @@ internal fun retainOnlyFocusedStop(accum: LinkedHashMap<String, StopMarker>, foc
 }
 
 /**
- * The stop-accumulation cap: once [accum] reaches [cap] stops, clear it (keeping only the focused
- * stop) so the next batch starts fresh — bounding the marker count as the user pans. No-op below the
- * cap. Pure, so the (easily-broken) keep-the-focused-stop-on-cap behavior is unit-testable.
+ * The stop-accumulation LRU trim: evicts least-recently-used stops until [accum] holds at most [cap],
+ * in place. [accum] is access-ordered, so its iterator walks eldest (least-recently-used) first; the
+ * entry for [focusedId] is always skipped so the focused stop is never evicted. No-op at/under the
+ * cap. Replaces the old clear-everything cap; pure, so the keep-the-focused-stop eviction is
+ * unit-testable.
  */
-internal fun capStopAccumulation(
+internal fun trimStopCache(
     accum: LinkedHashMap<String, StopMarker>,
     focusedId: String?,
     cap: Int,
 ) {
-    if (accum.size >= cap) {
-        retainOnlyFocusedStop(accum, focusedId)
+    if (accum.size <= cap) return
+    val it = accum.entries.iterator()
+    while (accum.size > cap && it.hasNext()) {
+        if (it.next().key != focusedId) it.remove()
     }
 }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
@@ -126,6 +126,12 @@ class MapViewModel @Inject constructor(
         locationRepository = locationRepository,
         scope = viewModelScope,
         routeActive = { routeController.isActive },
+        cacheSize = {
+            prefsRepository.getInt(
+                R.string.preference_key_map_stop_cache_size,
+                StopsMapController.DEFAULT_STOP_CACHE_SIZE,
+            )
+        },
     )
 
     // ----- Map-host surface (delegated) -----

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/StopsMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/StopsMapController.kt
@@ -60,13 +60,16 @@ class StopsMapController(
     private val locationRepository: LocationRepository,
     private val scope: CoroutineScope,
     private val routeActive: () -> Boolean = { false },
+    // The LRU cache size, read on each load so a change in advanced settings applies on the next pan.
+    private val cacheSize: () -> Int = { DEFAULT_STOP_CACHE_SIZE },
 ) {
 
     private val renderState get() = host.renderState
 
-    // Stop accumulation across pans (capped, keeping the focused stop) + the routes cache used to
-    // resolve a stop's icon route type and to report a stop's routes to focus listeners.
-    private val stopAccum = LinkedHashMap<String, StopMarker>()
+    // Stop accumulation across pans, as an access-ordered LRU (a re-seen stop bumps to most-recently-
+    // used; once over the configured [cacheSize] the least-recently-seen non-focused stops evict) + the
+    // routes cache used to resolve a stop's icon route type and to report a stop's routes to listeners.
+    private val stopAccum = LinkedHashMap<String, StopMarker>(16, 0.75f, true)
 
     private val cachedRoutes = HashMap<String, ObaRoute>()
 
@@ -105,7 +108,7 @@ class StopsMapController(
                 flow {
                     host.setProgress(true)
                     val result = mapDataSource
-                        .nearbyStops(snapshot.center.latitude, snapshot.center.longitude, snapshot.latSpan, snapshot.lonSpan)
+                        .nearbyStops(snapshot.center.latitude, snapshot.center.longitude, snapshot.latSpan, snapshot.lonSpan, cacheSize())
                     // Only a usable load updates the fulfillment gate: a success — OK stops, or a null
                     // no-op (e.g. no stops endpoint, which intentionally fulfills future same-center
                     // viewports). A failure (error code / transport) showed no stops, so leave the gate
@@ -212,11 +215,18 @@ class StopsMapController(
 
     fun showStops(stops: List<ObaStop>, routes: List<ObaRoute>) {
         cacheRoutes(routes)
-        capStopAccumulation(stopAccum, renderState.snapshot.value.focusedStopId, FUZZY_MAX_STOP_COUNT)
         for (stop in stops) {
-            if (!stopAccum.containsKey(stop.id)) {
-                stopAccum[stop.id] = toStopMarker(stop)
-            }
+            // getOrPut's get() on a hit bumps the entry to most-recently-used (access order) while
+            // keeping the same StopMarker instance, so a stationary re-poll of the same set yields an
+            // equal list the StateFlow conflates and the renderer never runs (reordering only breaks
+            // that equality when the accumulation holds more than the fetch; either way the renderer's
+            // reconcileStopMarkers keeps unchanged stops from blinking). A miss inserts a fresh marker.
+            stopAccum.getOrPut(stop.id) { toStopMarker(stop) }
+        }
+        // Route mode feeds the whole route's stops in one batch, so don't evict them against each
+        // other; the viewport loader (the only capped accumulator) is stopped while a route shows.
+        if (!routeActive()) {
+            trimStopCache(stopAccum, renderState.snapshot.value.focusedStopId, cacheSize())
         }
         renderState.setStops(ArrayList(stopAccum.values))
     }
@@ -269,6 +279,7 @@ class StopsMapController(
     companion object {
         private const val TAG = "StopsMapController"
 
-        private const val FUZZY_MAX_STOP_COUNT = 200
+        /** Default map stop LRU cache size; overridable via the advanced settings cache-size option. */
+        const val DEFAULT_STOP_CACHE_SIZE = 200
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/StopsMapViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/StopsMapViewModel.kt
@@ -23,6 +23,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import kotlinx.coroutines.flow.StateFlow
+import org.onebusaway.android.R
 import org.onebusaway.android.api.data.MapDataSource
 import org.onebusaway.android.models.ObaStop
 import org.onebusaway.android.location.LocationRepository
@@ -71,6 +72,12 @@ class StopsMapViewModel @Inject constructor(
         regionRepo = regionRepo,
         locationRepository = locationRepository,
         scope = viewModelScope,
+        cacheSize = {
+            prefsRepository.getInt(
+                R.string.preference_key_map_stop_cache_size,
+                StopsMapController.DEFAULT_STOP_CACHE_SIZE,
+            )
+        },
     )
 
     init {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/settings/AdvancedSettingsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/settings/AdvancedSettingsScreen.kt
@@ -29,10 +29,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import org.onebusaway.android.R
+import org.onebusaway.android.map.StopsMapController
 import org.onebusaway.android.ui.compose.components.ObaTopAppBar
 import org.onebusaway.android.ui.compose.findActivity
 import org.onebusaway.android.ui.settings.components.ClickPreferenceItem
@@ -122,6 +124,21 @@ fun AdvancedSettingsRoute(
                 else -> true
             }
         },
+        onMapStopCacheSizeChange = { value ->
+            viewModel.onMapStopCacheSizeChanged(value).also { accepted ->
+                if (!accepted) {
+                    Toast.makeText(
+                        context,
+                        resources.getString(
+                            R.string.preferences_map_stop_cache_size_error,
+                            MAP_STOP_CACHE_SIZE_MIN,
+                            MAP_STOP_CACHE_SIZE_MAX,
+                        ),
+                        Toast.LENGTH_SHORT,
+                    ).show()
+                }
+            }
+        },
         onResetDonationTimestamps = viewModel::onResetDonationTimestamps,
     )
 }
@@ -134,6 +151,7 @@ fun AdvancedSettingsScreen(
     onDisplayTestAlerts: (Boolean) -> Unit,
     onObaUrlChange: (String) -> Boolean,
     onOtpUrlChange: (String) -> Boolean,
+    onMapStopCacheSizeChange: (String) -> Boolean,
     onResetDonationTimestamps: () -> Unit,
 ) {
     val appName = stringResource(R.string.app_name)
@@ -165,6 +183,17 @@ fun AdvancedSettingsScreen(
                     summary = stringResource(R.string.display_test_wide_alerts_for_regions),
                     checked = state.displayTestAlerts,
                     onCheckedChange = onDisplayTestAlerts,
+                )
+                EditTextPreferenceItem(
+                    title = stringResource(R.string.preferences_map_stop_cache_size_title),
+                    summary = stringResource(
+                        R.string.preferences_map_stop_cache_size_summary,
+                        state.mapStopCacheSize,
+                    ),
+                    currentValue = state.mapStopCacheSize.toString(),
+                    hint = StopsMapController.DEFAULT_STOP_CACHE_SIZE.toString(),
+                    onValueChange = onMapStopCacheSizeChange,
+                    keyboardType = KeyboardType.Number,
                 )
                 EditTextPreferenceItem(
                     title = stringResource(R.string.preferences_oba_api_servername_title, appName),

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/settings/AdvancedSettingsViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/settings/AdvancedSettingsViewModel.kt
@@ -34,8 +34,9 @@ import kotlinx.coroutines.launch
 import org.onebusaway.android.BuildConfig
 import org.onebusaway.android.R
 import org.onebusaway.android.app.Application
-import org.onebusaway.android.region.Region
+import org.onebusaway.android.map.StopsMapController
 import org.onebusaway.android.preferences.PreferencesRepository
+import org.onebusaway.android.region.Region
 import org.onebusaway.android.region.ApiUrlValidator
 import org.onebusaway.android.region.RegionRepository
 import org.onebusaway.android.region.RegionState
@@ -82,6 +83,10 @@ class AdvancedSettingsViewModel @Inject constructor(
             displayTestAlerts = prefs.getBoolean(R.string.preferences_display_test_alerts, false),
             customObaApiUrl = prefs.getString(R.string.preference_key_oba_api_url, null),
             customOtpApiUrl = prefs.getString(R.string.preference_key_otp_api_url, null),
+            mapStopCacheSize = prefs.getInt(
+                R.string.preference_key_map_stop_cache_size,
+                StopsMapController.DEFAULT_STOP_CACHE_SIZE,
+            ),
         ),
         region = region?.let { AdvancedRegionInfo(it.experimental) },
         useFixedRegion = BuildConfig.USE_FIXED_REGION,
@@ -94,6 +99,12 @@ class AdvancedSettingsViewModel @Inject constructor(
 
     fun onDisplayTestAlertsChanged(value: Boolean) =
         prefs.setBoolean(R.string.preferences_display_test_alerts, value)
+
+    /**
+     * Apply an edit to the map stop LRU cache size. Returns true if the input was a valid in-range
+     * number (and was persisted); false otherwise so the dialog stays open (reject-on-invalid).
+     */
+    fun onMapStopCacheSizeChanged(text: String): Boolean = applyMapStopCacheSize(text, prefs)
 
     /**
      * Apply an experimental-regions toggle (the screen owns the enable/disable confirmation dialogs).
@@ -172,6 +183,18 @@ internal suspend fun applyExperimentalRegionsToggle(
     resetOtpVersionOnRegionChange(regionRepository.refresh(), regionRepository.state) {
         prefs.setBoolean(R.string.preference_key_otp_api_url_version, false)
     }
+}
+
+/**
+ * The map-stop-cache-size edit's domain effect, split from [AdvancedSettingsViewModel.onMapStopCacheSizeChanged]
+ * so it's free of Android dependencies and unit-tested directly (see AdvancedSettingsViewModelTest): on a
+ * valid in-range [text] (see [parseStopCacheSize]) persist the size and return true; on an invalid entry
+ * persist nothing and return false so the screen keeps the field open with the range error.
+ */
+internal fun applyMapStopCacheSize(text: String, prefs: PreferencesRepository): Boolean {
+    val size = parseStopCacheSize(text) ?: return false
+    prefs.setInt(R.string.preference_key_map_stop_cache_size, size)
+    return true
 }
 
 /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/settings/SettingsUiState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/settings/SettingsUiState.kt
@@ -137,7 +137,20 @@ data class AdvancedPrefSnapshot(
     val displayTestAlerts: Boolean,
     val customObaApiUrl: String?,
     val customOtpApiUrl: String?,
+    val mapStopCacheSize: Int,
 )
+
+/** Bounds for the map stop LRU cache size advanced option (see [parseStopCacheSize]). */
+const val MAP_STOP_CACHE_SIZE_MIN = 10
+const val MAP_STOP_CACHE_SIZE_MAX = 2000
+
+/**
+ * Parses the advanced map-stop-cache-size input: the trimmed [text] as an integer within
+ * [[MAP_STOP_CACHE_SIZE_MIN], [MAP_STOP_CACHE_SIZE_MAX]], or null if it's not a number or out of
+ * range (the screen keeps its dialog open on null). Pure, so the validation is JVM-unit-testable.
+ */
+fun parseStopCacheSize(text: String): Int? =
+    text.trim().toIntOrNull()?.takeIf { it in MAP_STOP_CACHE_SIZE_MIN..MAP_STOP_CACHE_SIZE_MAX }
 
 /** Region info the advanced screen needs; null means no region (custom API in use). */
 data class AdvancedRegionInfo(val isExperimental: Boolean)
@@ -151,6 +164,7 @@ data class AdvancedSettingsUiState(
     val customObaApiUrlSummary: String,
     val customOtpApiUrlSummary: String,
     val currentRegionIsExperimental: Boolean,
+    val mapStopCacheSize: Int,
 )
 
 /**
@@ -180,6 +194,7 @@ fun buildAdvancedSettingsUiState(
         customObaApiUrlSummary = obaSummary,
         customOtpApiUrlSummary = otpSummary,
         currentRegionIsExperimental = region?.isExperimental == true,
+        mapStopCacheSize = prefs.mapStopCacheSize,
     )
 }
 

--- a/onebusaway-android/src/main/res/values/donottranslate.xml
+++ b/onebusaway-android/src/main/res/values/donottranslate.xml
@@ -29,6 +29,7 @@
     <string name="preference_key_last_region_update">preference_last_region_update</string>
     <string name="preference_key_auto_select_region">preference_auto_select_region</string>
     <string name="preference_key_experimental_regions">preference_experimental_regions</string>
+    <string name="preference_key_map_stop_cache_size">preferences_map_stop_cache_size</string>
     <string name="preferences_key_analytics">preference_google_analytics</string>
     <string name="preference_key_preferred_units">preference_preferred_units</string>
     <string name="preference_key_preferred_temperature_units">preference_preferred_temperature_units</string>

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -647,6 +647,9 @@
     <string name="preferences_experimental_regions_title">Experimental regions</string>
     <string name="preferences_experimental_regions_summary">Enables regions that may be unstable
     </string>
+    <string name="preferences_map_stop_cache_size_title">Map stop cache size</string>
+    <string name="preferences_map_stop_cache_size_summary">Max bus stops kept on the map while panning (currently %1$d)</string>
+    <string name="preferences_map_stop_cache_size_error">Enter a number between %1$d and %2$d</string>
     <string name="preferences_experimental_regions_enable_warning">Experimental regions may be
         unstable and without real-time info! Go ahead?
     </string>

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
@@ -55,9 +55,10 @@ import org.onebusaway.android.util.getRouteDisplayName
  * handlers.
  *
  * Two redraw paths, mirroring the Google flavor's two recomposition boundaries:
- *  - [renderStatic] (stops / route polylines / bikes / generics / trip-stop dots) is a clear-and-redraw
- *    of just the static annotations, driven by snapshot/trip-stop changes (viewport loads, the vehicle
- *    poll, focus) — a bounded cost.
+ *  - [renderStatic] clear-and-redraws the static annotations (route polylines / bikes / generics /
+ *    trip-stop dots) and reconciles the stop markers in place ([reconcileStopMarkers], so unchanged
+ *    stops don't blink), driven by snapshot/trip-stop changes (viewport loads, the vehicle poll,
+ *    focus) — a bounded cost.
  *  - [renderDynamic] (the live vehicle markers + the trip-focus band/estimate markers) is pulled each
  *    display frame by the adapter's vsync loop. It updates marker positions **in place** (so an open
  *    info window survives and there's no per-frame flicker) and only adds/removes annotations as the
@@ -72,6 +73,14 @@ class MapLibreRenderer(
     private val renderState: MapRenderState,
 ) {
     private val stopByMarker = HashMap<Marker, StopMarker>()
+
+    // Stop markers tracked by stop id so [reconcileStopMarkers] can diff them in place (add new,
+    // remove gone, re-icon only on a focus flip) instead of clear-and-redraw — keeping unchanged stops
+    // from blinking on every static redraw. Like the vehicle markers, these are NOT in
+    // [staticAnnotations] and so survive a static redraw; [renderedFocusedStopId] is the focus the
+    // icons were last drawn for. They live until MapView.onDestroy(), like vehicleMarkersByTripId.
+    private val stopMarkersByStopId = HashMap<String, Marker>()
+    private var renderedFocusedStopId: String? = null
 
     private val bikeByMarker = HashMap<Marker, BikeMarker>()
 
@@ -119,7 +128,8 @@ class MapLibreRenderer(
             map.removeAnnotations(staticAnnotations)
             staticAnnotations.clear()
         }
-        stopByMarker.clear()
+        // Stop markers are reconciled in place (not in staticAnnotations), so they survive this; only
+        // the bike tap map is cleared here.
         bikeByMarker.clear()
 
         for (polyline in snapshot.routePolylines) {
@@ -142,18 +152,7 @@ class MapLibreRenderer(
             )
         }
 
-        for (stop in snapshot.stops) {
-            val icon = if (stop.id == snapshot.focusedStopId) {
-                MapLibreStopIcons.focusedIconForDirection(context, stop.direction)
-            } else {
-                MapLibreStopIcons.iconForDirection(context, stop.direction)
-            }
-            val marker = map.addMarker(
-                MarkerOptions().position(stop.point.toLatLng()).icon(icon)
-            )
-            staticAnnotations.add(marker)
-            stopByMarker[marker] = stop
-        }
+        reconcileStopMarkers(snapshot.stops, snapshot.focusedStopId)
 
         if (snapshot.bikeshareVisible) {
             val band = bikeZoomBand(map.cameraPosition.zoom.toFloat())
@@ -189,6 +188,45 @@ class MapLibreRenderer(
             )
         }
     }
+
+    /**
+     * Diff the stop markers against [stops] in place (the [reconcileVehicleMarkers] pattern): remove
+     * markers whose id has left, add markers for new ids, and re-icon an existing marker only when its
+     * focused state flips. Unchanged stops keep their native marker, so they don't blink on a static
+     * redraw. Tracked in [stopMarkersByStopId] (not [staticAnnotations]) so a static redraw leaves them.
+     */
+    private fun reconcileStopMarkers(stops: List<StopMarker>, focusedStopId: String?) {
+        val liveIds = stops.mapTo(HashSet()) { it.id }
+        val gone = stopMarkersByStopId.iterator()
+        while (gone.hasNext()) {
+            val entry = gone.next()
+            if (entry.key !in liveIds) {
+                map.removeAnnotation(entry.value)
+                stopByMarker.remove(entry.value)
+                gone.remove()
+            }
+        }
+        for (stop in stops) {
+            val isFocused = stop.id == focusedStopId
+            val existing = stopMarkersByStopId[stop.id]
+            if (existing == null) {
+                val marker = map.addMarker(
+                    MarkerOptions().position(stop.point.toLatLng()).icon(stopIcon(stop, isFocused))
+                )
+                stopMarkersByStopId[stop.id] = marker
+                stopByMarker[marker] = stop
+            } else if ((stop.id == renderedFocusedStopId) != isFocused) {
+                // Re-icon only the marker that just lost focus and the one that just gained it (their
+                // focus state flipped).
+                existing.icon = stopIcon(stop, isFocused)
+            }
+        }
+        renderedFocusedStopId = focusedStopId
+    }
+
+    private fun stopIcon(stop: StopMarker, focused: Boolean): Icon =
+        if (focused) MapLibreStopIcons.focusedIconForDirection(context, stop.direction)
+        else MapLibreStopIcons.iconForDirection(context, stop.direction)
 
     /**
      * Update the dynamic layer for one display frame: the route's live [vehicles] (null off route mode)

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/StopAccumulationTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/StopAccumulationTest.kt
@@ -24,11 +24,12 @@ import org.onebusaway.android.map.render.GeoPoint
 import org.onebusaway.android.map.render.StopMarker
 
 /**
- * Unit tests for the stop-accumulation logic [MapViewModel.showStops] / [MapViewModel.clearStops]
- * delegate to — the easily-broken part of the data-shaping: the 200-cap clears the accumulation *but
- * keeps the focused stop*, and the same focus-retention drives `clearStops(false)`. Split into pure
- * functions ([capStopAccumulation] / [retainOnlyFocusedStop]) over plain [StopMarker]s so it runs on
- * the JVM — the per-stop marker build (which touches an Android `Location`) is exercised on device.
+ * Unit tests for the stop-accumulation logic [StopsMapController.showStops] / [StopsMapController.clearStops]
+ * delegate to — the easily-broken part of the data-shaping: the LRU trim evicts least-recently-used
+ * stops down to the 200-cap *but never the focused stop*, and the same focus-retention drives
+ * `clearStops(false)`. Split into pure functions ([trimStopCache] / [retainOnlyFocusedStop]) over
+ * plain [StopMarker]s so it runs on the JVM — the per-stop marker build (which touches an Android
+ * `Location`) is exercised on device.
  */
 class StopAccumulationTest {
 
@@ -40,34 +41,53 @@ class StopAccumulationTest {
 
     private fun LinkedHashMap<String, StopMarker>.ids() = keys.toSet()
 
-    // --- capStopAccumulation ---
+    // --- trimStopCache (the LRU eviction; accumOf is insertion- = eldest-first order) ---
 
     @Test
-    fun `below the cap is a no-op`() {
-        val accum = accumOf("a", "b")
-        capStopAccumulation(accum, focusedId = "a", cap = 5)
-        assertEquals(setOf("a", "b"), accum.ids())
+    fun `at or below the cap is a no-op`() {
+        val accum = accumOf("a", "b", "c")
+        trimStopCache(accum, focusedId = "a", cap = 3)
+        assertEquals(setOf("a", "b", "c"), accum.ids())
     }
 
     @Test
-    fun `at the cap clears the accumulation but keeps the focused stop`() {
-        val accum = accumOf("a", "b", "c")
-        capStopAccumulation(accum, focusedId = "b", cap = 3)
-        assertEquals(setOf("b"), accum.ids())
+    fun `over the cap evicts eldest-first down to the cap`() {
+        val accum = accumOf("a", "b", "c", "d")
+        trimStopCache(accum, focusedId = null, cap = 2)
+        assertEquals(setOf("c", "d"), accum.ids())
     }
 
     @Test
-    fun `at the cap with no focus clears everything`() {
-        val accum = accumOf("a", "b", "c")
-        capStopAccumulation(accum, focusedId = null, cap = 3)
-        assertEquals(emptySet<String>(), accum.ids())
+    fun `over the cap never evicts the focused stop`() {
+        val accum = accumOf("a", "b", "c", "d")
+        // "a" is the eldest, but being focused it's skipped; the next-eldest evict instead.
+        trimStopCache(accum, focusedId = "a", cap = 2)
+        assertEquals(setOf("a", "d"), accum.ids())
     }
 
     @Test
-    fun `at the cap with a focus id that is not accumulated clears everything`() {
+    fun `over the cap with no focus evicts pure eldest`() {
         val accum = accumOf("a", "b", "c")
-        capStopAccumulation(accum, focusedId = "gone", cap = 3)
-        assertEquals(emptySet<String>(), accum.ids())
+        trimStopCache(accum, focusedId = null, cap = 1)
+        assertEquals(setOf("c"), accum.ids())
+    }
+
+    @Test
+    fun `the access-ordered LRU bumps a re-seen stop so it outlives an untouched eldest`() {
+        // The eviction is only "least-recently-USED" because stopAccum is access-ordered and showStops
+        // re-touches each fetched stop. Build the map exactly as StopsMapController.stopAccum (access
+        // order) and re-see the insertion-eldest "a" the way showStops does (getOrPut's get() on a hit
+        // bumps it to most-recently-used), leaving "b" the eldest.
+        val accum = LinkedHashMap<String, StopMarker>(16, 0.75f, true)
+        listOf("a", "b", "c").forEach { accum[it] = marker(it) }
+        accum.getOrPut("a") { marker("a") }
+
+        trimStopCache(accum, focusedId = null, cap = 2)
+
+        // LRU: the now-eldest "b" is evicted and the bumped "a" survives. A plain (insertion-ordered)
+        // map — or dropping the getOrPut bump — would instead evict the first-inserted "a" and keep "b",
+        // so this test fails if stopAccum loses its access-order config or showStops stops re-touching.
+        assertEquals(setOf("a", "c"), accum.ids())
     }
 
     // --- retainOnlyFocusedStop (the clearStops(false) path) ---

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/settings/AdvancedSettingsViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/settings/AdvancedSettingsViewModelTest.kt
@@ -40,6 +40,10 @@ import org.onebusaway.android.testing.FakePreferencesRepository
  * and `refresh()`'s actual result drives [resetOtpVersionOnRegionChange]. (The precedence of the reset rule
  * itself is covered by [RegionOtpResetTest]; the analytics report needs a Context and is left to
  * instrumented coverage.)
+ *
+ * Also covers [applyMapStopCacheSize] — the Context-free half of
+ * [AdvancedSettingsViewModel.onMapStopCacheSizeChanged]: persist + accept a valid size, reject + persist
+ * nothing on an invalid one.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class AdvancedSettingsViewModelTest {
@@ -93,6 +97,23 @@ class AdvancedSettingsViewModelTest {
             assertNotNull("nothing to clear when the region wasn't experimental", repo.region.value)
             assertFalse("the toggle is persisted", prefs.getBoolean(EXPERIMENTAL, true))
         }
+
+    private val MAP_STOP_CACHE_SIZE = R.string.preference_key_map_stop_cache_size
+
+    @Test
+    fun `a valid map stop cache size is accepted and persisted`() {
+        val prefs = FakePreferencesRepository()
+        assertTrue("a valid in-range size is accepted", applyMapStopCacheSize("250", prefs))
+        assertEquals("the size is persisted", 250, prefs.getInt(MAP_STOP_CACHE_SIZE, -1))
+    }
+
+    @Test
+    fun `an invalid map stop cache size is rejected and persists nothing`() {
+        val prefs = FakePreferencesRepository()
+        assertFalse("an out-of-range size is rejected", applyMapStopCacheSize("99999", prefs))
+        assertFalse("a non-numeric size is rejected", applyMapStopCacheSize("abc", prefs))
+        assertEquals("nothing was persisted", -1, prefs.getInt(MAP_STOP_CACHE_SIZE, -1))
+    }
 
     @Test
     fun `a re-resolve that needs a manual pick defers the OTP reset until the user chooses`() = runTest {

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/settings/SettingsUiStateTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/settings/SettingsUiStateTest.kt
@@ -17,6 +17,7 @@ package org.onebusaway.android.ui.settings
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -128,6 +129,7 @@ class SettingsUiStateTest {
         displayTestAlerts = false,
         customObaApiUrl = null,
         customOtpApiUrl = null,
+        mapStopCacheSize = 200,
     )
 
     private fun buildAdv(
@@ -182,5 +184,28 @@ class SettingsUiStateTest {
         assertTrue(buildAdv(region = AdvancedRegionInfo(isExperimental = true)).currentRegionIsExperimental)
         assertFalse(buildAdv(region = AdvancedRegionInfo(isExperimental = false)).currentRegionIsExperimental)
         assertFalse(buildAdv(region = null).currentRegionIsExperimental)
+    }
+
+    @Test
+    fun `map stop cache size carries through to the ui state`() {
+        assertEquals(500, buildAdv(prefs = advPrefs.copy(mapStopCacheSize = 500)).mapStopCacheSize)
+    }
+
+    // --- parseStopCacheSize ---
+
+    @Test
+    fun `parseStopCacheSize accepts an in-range number`() {
+        assertEquals(200, parseStopCacheSize("200"))
+        assertEquals(MAP_STOP_CACHE_SIZE_MIN, parseStopCacheSize("  $MAP_STOP_CACHE_SIZE_MIN  "))
+        assertEquals(MAP_STOP_CACHE_SIZE_MAX, parseStopCacheSize(MAP_STOP_CACHE_SIZE_MAX.toString()))
+    }
+
+    @Test
+    fun `parseStopCacheSize rejects non-numbers and out-of-range values`() {
+        assertNull(parseStopCacheSize(""))
+        assertNull(parseStopCacheSize("abc"))
+        assertNull(parseStopCacheSize("12.5"))
+        assertNull(parseStopCacheSize((MAP_STOP_CACHE_SIZE_MIN - 1).toString()))
+        assertNull(parseStopCacheSize((MAP_STOP_CACHE_SIZE_MAX + 1).toString()))
     }
 }


### PR DESCRIPTION
## Problem

Bus stop icons on the map were driven directly by the result of each viewport API fetch (fired at the end of every zoom/pan). Two issues:

1. **Blink** — every stop marker was destroyed and re-created at the end of each map move (both flavor renderers clear-and-redraw the whole stop layer on every snapshot), so the stop layer visibly flashed even when nothing changed.
2. **Random subset / loss** — `stops-for-location` caps its result and returns an arbitrary subset of the window's stops, so panning showed a shifting random subset; worse, the old accumulator nuked itself down to just the focused stop on reaching 200 stops.

## Approach — two layers

**LRU accumulation (`StopsMapController`)** — stops accumulate across pans in an access-ordered `LinkedHashMap` LRU. A re-seen stop is bumped to most-recently-used while keeping the same `StopMarker` instance, so an unchanged fetch yields an `equals` list the `StateFlow` conflates (the renderer never runs). Eviction (`trimStopCache`) walks eldest-first, never drops the focused stop, and is skipped in route mode (the route feeds its whole stop set in one batch, and the viewport loader is stopped while a route shows).

**Marker diffing (both renderers)** — `reconcileStopMarkers` diffs stop markers by id (mirroring the existing `reconcileVehicleMarkers`): add new, remove gone, re-icon only on a focus flip. Unchanged markers keep their native marker and survive a static redraw, so they no longer blink.

## Also

- Request `maxCount = cache size` from `stops-for-location` (new `maxCount` query param on `ObaWebService.stopsForLocation`, threaded through `MapDataSource.nearbyStops`) so a dense viewport fills the cache in fewer pans; the server still clamps to its hard ceiling and reports `limitExceeded`.
- New **Advanced settings** option "Map stop cache size" (10–2000, default 200), behind `PreferencesRepository`, read per-load so a change applies on the next pan.

## Tests

- `StopAccumulationTest` rewritten for `trimStopCache` (no-op at/under cap; eldest-first eviction; never evicts focused; null-focus eldest); `retainOnlyFocusedStop` tests kept.
- `SettingsUiStateTest` covers `parseStopCacheSize` (accept in-range / reject non-numbers + out-of-range) and the cache-size carry-through.

Both Google and MapLibre flavors compile; unit tests pass. Installed and launched on a Pixel 7 Pro.

## Out of scope (deliberate)

- Vehicle / bike / polyline / trip-stop layers keep their current clear-and-redraw (vehicles already reconcile at ~20Hz).
- No change to the fetch trigger, debounce, or `stopRequestFulfilled` gating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an advanced setting for **Map stop cache size** to control how many nearby stops are cached and displayed.
  * Added input validation with an inline error when the value is outside the allowed range.
* **Bug Fixes**
  * Improved map stop-marker rendering to keep markers stable across redraws, reducing blinking/flicker.
  * Updated caching/eviction to use an LRU-style approach while preserving the currently focused stop.
* **Other**
  * Nearby-stop results can now be capped based on the selected setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->