### PR TITLE
Add test coverage for the trajectory extrapolation-overlay clock-skew lift (#1604)

### DIFF
--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/dataview/TripTrajectoryTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/dataview/TripTrajectoryTest.kt
@@ -20,8 +20,13 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
+import org.onebusaway.android.api.adapters.StopTimeData
+import org.onebusaway.android.api.adapters.TripScheduleData
 import org.onebusaway.android.extrapolation.data.TripState
 import org.onebusaway.android.extrapolation.math.prob.ProbDistribution
+import org.onebusaway.android.models.ObaRoute
+import org.onebusaway.android.models.ObaTripSchedule
+import org.onebusaway.android.testing.testTripStatus
 import org.junit.Test
 
 class TripTrajectoryTest {
@@ -130,6 +135,82 @@ class TripTrajectoryTest {
         val trajectory = buildTrajectory(state, nowMs = 1_002_000L)
         // The local "now" (1_002_000) is plotted at its server-clock equivalent (+5s skew).
         assertEquals(1_007_000L, trajectory.nowMs)
+    }
+
+    // --- buildTrajectory: extrapolation-overlay now line (clock skew) ---
+    //
+    // The now-line tests above only exercise TripTrajectory.nowMs. These drive a real anchor so
+    // extrapolate() succeeds and the overlay is non-null, guarding the ExtrapolationSeries.nowMs
+    // lift in extrapolationSeries() — the operand of the user-facing schedule-deviation label.
+    // Reverting that lift to `nowMs = nowMs` (the pre-#1594 bug) must fail these.
+
+    /**
+     * A grade-separated trip whose anchor was seen at [anchorServerMs] on the server clock and
+     * [anchorLocalMs] on the local clock, mid-route. Grade-separated + a schedule routes
+     * extrapolate() through schedule replay, which succeeds mid-route, so buildTrajectory() emits a
+     * non-null extrapolation overlay.
+     */
+    private fun skewedRailState(anchorServerMs: Long, anchorLocalMs: Long): TripState =
+        TripState.empty("trip1")
+            .withStatus(
+                testTripStatus(distanceAlongTrip = 500.0, lastUpdateTime = anchorServerMs, activeTripId = "trip1"),
+                serverTimeMs = anchorServerMs,
+                localTimeMs = anchorLocalMs,
+            )
+            .withSchedule(railSchedule)
+            .withRouteType(ObaRoute.TYPE_SUBWAY)
+
+    /** Three stops at 0/1000/3000 m — enough for schedule replay to succeed mid-route. */
+    private val railSchedule = makeSchedule(
+        Triple(0.0, 0L, 0L),
+        Triple(1000.0, 100L, 130L),
+        Triple(3000.0, 330L, 330L),
+    )
+
+    private fun makeSchedule(vararg stops: Triple<Double, Long, Long>): ObaTripSchedule {
+        val stopTimes: Array<ObaTripSchedule.StopTime> = Array(stops.size) { i ->
+            val (dist, arrive, depart) = stops[i]
+            StopTimeData(stopId = "stop_$i", arrivalTime = arrive, departureTime = depart, distanceAlongTrip = dist)
+        }
+        return TripScheduleData(stopTimes)
+    }
+
+    @Test
+    fun `the extrapolation overlay now line is lifted onto the server clock by the anchor skew`() {
+        // Anchor seen at server 105_000 / local 100_000 -> server runs 5s ahead.
+        val state = skewedRailState(anchorServerMs = 105_000L, anchorLocalMs = 100_000L)
+        val trajectory = buildTrajectory(state, nowMs = 102_000L)
+
+        val extrapolation = requireNotNull(trajectory.extrapolation) {
+            "a mid-route grade-separated anchor should yield an overlay"
+        }
+        // Local "now" (102_000) plotted at its server-clock equivalent (+5s skew). Reverting the
+        // toServerClock lift in extrapolationSeries() to `nowMs = nowMs` would leave this at 102_000.
+        assertEquals(107_000L, extrapolation.nowMs)
+    }
+
+    @Test
+    fun `the overlay now line and the trajectory now line share the server-clock axis`() {
+        val state = skewedRailState(anchorServerMs = 105_000L, anchorLocalMs = 100_000L)
+        val trajectory = buildTrajectory(state, nowMs = 102_000L)
+
+        // Guards the "now line drifts off-axis" symptom (#1583): the overlay's now line must sit on
+        // the same server-clock axis as the trajectory's, not lag on the raw local clock. (A bounds
+        // check would be tautological — buildTrajectory derives the bounds from this very value.)
+        val extrapolation = requireNotNull(trajectory.extrapolation)
+        assertEquals(trajectory.nowMs, extrapolation.nowMs)
+    }
+
+    @Test
+    fun `the extrapolation overlay now line drops onto the server clock when the server is behind`() {
+        // Anchor seen at server 97_000 / local 100_000 -> server runs 3s behind: exercises the
+        // subtraction branch of toServerClock the +5s cases never reach.
+        val state = skewedRailState(anchorServerMs = 97_000L, anchorLocalMs = 100_000L)
+        val trajectory = buildTrajectory(state, nowMs = 102_000L)
+
+        val extrapolation = requireNotNull(trajectory.extrapolation)
+        // toServerClock(102_000) = 102_000 + (97_000 - 100_000) = 99_000.
+        assertEquals(99_000L, extrapolation.nowMs)
     }
 
     // --- interpolateScheduleTime ---


### PR DESCRIPTION
Follow-up to #1594. Closes #1604.

## Problem

PR #1594 fixed client/server clock skew in the trajectory now line by wiring `TripState.toServerClock()` through `buildTrajectory()`, but its regression tests only guarded `TripTrajectory.nowMs`. The **extrapolation overlay** now line — `ExtrapolationSeries.nowMs` (the `toServerClock` lift in `extrapolationSeries()`) — had no coverage: both existing `buildTrajectory` tests built state with no anchor/history, so `extrapolate()` returned `NoData` and the overlay was always null. As a result, reverting the lift to `nowMs = nowMs` (the pre-fix bug) passed every test.

That overlay `nowMs` is the operand of the user-facing schedule-deviation label — the exact symptom #1594 set out to fix — so it was worth a regression guard.

## What this adds

Three tests in `TripTrajectoryTest` that drive a **real** mid-route anchor through `withStatus` on a grade-separated trip (so schedule replay succeeds and the overlay is non-null), plus a `skewedRailState` helper:

- **positive skew** (server 5s ahead) — asserts the overlay now line is lifted onto the server clock (`107_000`); a revert to `nowMs = nowMs` leaves it at `102_000` and fails.
- **axis agreement** — asserts the overlay now line and the trajectory now line share the server-clock axis (`assertEquals(trajectory.nowMs, extrapolation.nowMs)`), guarding the "now line drifts off-axis" symptom from #1583.
- **negative skew** (server 3s behind) — exercises the subtraction branch of `toServerClock` the `+5s` cases never reach (`99_000`).

## Verification

- All 30 `TripTrajectoryTest` tests pass.
- Mutation-checked: reverting the `toServerClock` lift makes exactly these three tests fail, confirming they regression-guard it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded trajectory test coverage for live trip positioning when device and server clocks are out of sync.
  * Added checks to ensure the “now” indicator stays aligned correctly for both ahead-of-time and behind-time clock skew scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->