### PR TITLE
Surface region-load failures and harden map-reveal/OTP-reset edges (#1602)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/region/RegionRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/region/RegionRepository.kt
@@ -17,6 +17,8 @@ package org.onebusaway.android.region
 
 import android.content.Context
 import android.content.pm.PackageManager
+import android.util.Log
+import com.google.firebase.crashlytics.FirebaseCrashlytics
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -125,6 +127,8 @@ sealed interface RegionState {
 /** Mirrors `HomeActivity`'s `checkRegionVer` preference key so the same slot is read/written. */
 private const val CHECK_REGION_VER = "checkRegionVer"
 
+private const val TAG = "RegionRepository"
+
 /**
  * Default implementation. The observable state lives in a [RegionStateHolder] (so its transitions stay
  * JVM-testable); resolution ([refresh]) is the `Context`-coupled IO ported from
@@ -204,6 +208,12 @@ class DefaultRegionRepository @Inject constructor(
 
         val results = RegionUtils.getRegions(context, force)
         if (results == null) {
+            // Catastrophic: no network, no cache, and the server was unreachable, so region info
+            // couldn't be loaded from any source. Log it and record a non-fatal so the failure rate
+            // is trackable; the Failed state drives a retryable affordance at the picker host.
+            Log.e(TAG, "Region load failed: no regions available from network or cache")
+            FirebaseCrashlytics.getInstance()
+                .recordException(IllegalStateException("Region load failed: no regions available"))
             holder.failed()
             return@withContext RegionStatus.Failed
         }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.kt
@@ -17,6 +17,7 @@
  */
 package org.onebusaway.android.ui
 
+import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
@@ -323,6 +324,20 @@ class HomeActivity : AppCompatActivity() {
         fun navIntent(context: Context, route: String): Intent =
             Intent(context, HomeActivity::class.java).putExtra(NavRoutes.EXTRA_NAV_ROUTE, route)
     }
+}
+
+/**
+ * Re-enters [HomeActivity] at [route] from a launcher facade (the standalone-host fallback the launcher
+ * objects use when the caller holds no NavController). Adds [Intent.FLAG_ACTIVITY_NEW_TASK] only when
+ * [this] is not an Activity — required to `startActivity` from a service/receiver context — so an Activity
+ * caller keeps the normal same-task behavior. Deliberately not folded into [HomeActivity.navIntent], which
+ * is a pure intent factory whose result is also wrapped in PendingIntents (e.g. the trip-feedback
+ * notification in NavigationService): a context-dependent flag side effect would be wrong there.
+ */
+fun Context.startHomeActivity(route: String) {
+    val intent = HomeActivity.navIntent(this, route)
+    if (this !is Activity) intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    startActivity(intent)
 }
 
 /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalActionHandlers.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalActionHandlers.kt
@@ -80,6 +80,12 @@ fun createArrivalActionHandler(
             Toast.makeText(activity, R.string.reminder_not_enabled, Toast.LENGTH_SHORT).show()
             return
         }
+        // A partial/omitted API response can leave tripId/stopId blank (they default to ""); the editor
+        // can't open without both, so bail with a toast rather than tripping ReminderEditorArgs' require().
+        if (arrival.tripId.isBlank() || arrival.stopId.isBlank()) {
+            Toast.makeText(activity, R.string.failed_to_set_reminder, Toast.LENGTH_SHORT).show()
+            return
+        }
         onEditReminder(
             ReminderEditorArgs(
                 tripId = arrival.tripId,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeNavHost.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeNavHost.kt
@@ -19,6 +19,7 @@ package org.onebusaway.android.ui.home
 
 import android.content.Context
 import android.content.Intent
+import android.util.Log
 import android.view.accessibility.AccessibilityManager
 import androidx.annotation.StringRes
 import androidx.compose.runtime.Composable
@@ -43,6 +44,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
 import com.google.firebase.analytics.FirebaseAnalytics
+import com.google.firebase.crashlytics.FirebaseCrashlytics
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -72,8 +74,7 @@ import org.onebusaway.android.ui.nav.NavHelp
 import org.onebusaway.android.ui.nav.NavRoutes
 import org.onebusaway.android.ui.nav.RESULT_MAP_ROUTE_ID
 import org.onebusaway.android.ui.nav.RESULT_MAP_STOP_ID
-import org.onebusaway.android.ui.nav.RESULT_MAP_STOP_LAT
-import org.onebusaway.android.ui.nav.RESULT_MAP_STOP_LON
+import org.onebusaway.android.ui.nav.consumeStopReveal
 import org.onebusaway.android.ui.nav.navigateFromHome
 import org.onebusaway.android.ui.settings.settingsGraph
 import org.onebusaway.android.ui.survey.SurveyViewModel
@@ -84,12 +85,15 @@ import org.onebusaway.android.ui.tutorial.ArrivalTutorial
 import org.onebusaway.android.util.ExternalIntents
 import org.onebusaway.android.util.PreferenceUtils
 
+private const val TAG = "HomeNavHost"
+
 /**
  * The HOME destination's dependency surface — the one destination that consumes the full home bundle
- * (the feature ViewModels, the list VMs, the arrivals factory, the callbacks, and the map seed). Built
- * once in [HomeActivity.onCreate] and passed to [HomeNavHost]. Every *other* destination instead
- * recovers the host via `LocalContext.current.findActivity()` and reads its (non-private) members, so
- * only HOME needs this holder (the six feature VMs + the list VMs are private to the activity).
+ * (the feature ViewModels, the list VMs, the arrivals factory, the Activity-bound [activityActions], and
+ * the map seed). Built once in [HomeActivity.onCreate] and passed to [HomeNavHost]. Every *other*
+ * destination instead recovers the host via `LocalContext.current.findActivity()` and reads its
+ * (non-private) members, so only HOME needs this holder (the six feature VMs + the list VMs are private
+ * to the activity).
  */
 class HomeDestinationDeps(
     val homeViewModel: HomeViewModel,
@@ -132,18 +136,23 @@ fun HomeNavHost(
                 }
             }
             LaunchedEffect(revealStopId) {
-                revealStopId?.let { stopId ->
-                    val lat = handle.get<Double>(RESULT_MAP_STOP_LAT)
-                    val lon = handle.get<Double>(RESULT_MAP_STOP_LON)
-                    if (lat != null && lon != null) {
-                        home.homeViewModel.onStopFocused(FocusedStop(stopId, null, null, lat, lon))
-                        home.homeViewModel.markPendingMapFocus()
-                    }
-                    // Consume all three keys together (STOP_ID gates application; lat/lon are nulled for
-                    // symmetry so a stale pair can't linger past the reveal).
-                    handle[RESULT_MAP_STOP_ID] = null
-                    handle[RESULT_MAP_STOP_LAT] = null
-                    handle[RESULT_MAP_STOP_LON] = null
+                if (revealStopId == null) return@LaunchedEffect
+                // Read + consume all three keys atomically via the typed helper (which owns the key names
+                // and Double types). A non-null result applies the focus; a null result here means STOP_ID
+                // was present but lat/lon were missing.
+                val reveal = handle.consumeStopReveal()
+                if (reveal != null) {
+                    home.homeViewModel.onStopFocused(
+                        FocusedStop(reveal.stopId, null, null, reveal.lat, reveal.lon)
+                    )
+                    home.homeViewModel.markPendingMapFocus()
+                } else {
+                    // Keys already consumed; record the dropped focus so the latent path is findable
+                    // (see consumeStopReveal for why this is only reachable on a corrupted handle).
+                    Log.w(TAG, "Dropped a partial stop reveal: stop id present but lat/lon missing")
+                    FirebaseCrashlytics.getInstance().recordException(
+                        IllegalStateException("Partial stop reveal: stop id present but lat/lon missing")
+                    )
                 }
             }
             val state by home.homeViewModel.uiState.collectAsStateWithLifecycle()

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/RegionPickerHost.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/RegionPickerHost.kt
@@ -23,8 +23,12 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -36,15 +40,42 @@ import org.onebusaway.android.region.Region
 
 /**
  * Renders the forced-choice region picker when [RegionPickerViewModel] reports the repository needs a manual
- * selection. Hosted at the activity's setContent root (a sibling of the NavHost) so the dialog — which is in
- * its own window — overlays whatever screen triggered the refresh (Home on cold launch, or the Advanced
- * settings screen when the experimental-regions toggle forces a re-resolve).
+ * selection, or a retryable "couldn't load regions" dialog when resolution failed catastrophically. Hosted
+ * at the activity's setContent root (a sibling of the NavHost) so the dialogs — each in their own window —
+ * overlay whatever screen triggered the refresh (Home on cold launch, or the Advanced settings screen when
+ * the experimental-regions toggle forces a re-resolve).
  */
 @Composable
 fun RegionPickerHost() {
     val viewModel: RegionPickerViewModel = hiltViewModel()
     val regions by viewModel.picker.collectAsStateWithLifecycle()
+    val failed by viewModel.failed.collectAsStateWithLifecycle()
+    // NeedsManualChoice and Failed are mutually exclusive repository states, so at most one shows.
     regions?.let { RegionChooserDialog(it, viewModel::choose) }
+    if (failed) RegionLoadFailedDialog(onRetry = viewModel::retry)
+}
+
+/**
+ * The catastrophic-failure affordance (no network, no cache, server unreachable): a dialog explaining the
+ * app couldn't load region info with a Retry that re-attempts resolution. Dismissible (back/scrim) unlike
+ * the forced picker — a cached region may still let the app function, so we don't hard-block the user.
+ */
+@Composable
+private fun RegionLoadFailedDialog(onRetry: () -> Unit) {
+    // Dismiss simply drops the dialog for this attempt; the state re-surfaces on the next failed refresh.
+    var dismissed by remember { mutableStateOf(false) }
+    if (dismissed) return
+    AlertDialog(
+        onDismissRequest = { dismissed = true },
+        title = { Text(stringResource(R.string.region_load_failed_title)) },
+        text = { Text(stringResource(R.string.region_load_failed_message)) },
+        confirmButton = {
+            TextButton(onClick = onRetry) { Text(stringResource(R.string.retry)) }
+        },
+        dismissButton = {
+            TextButton(onClick = { dismissed = true }) { Text(stringResource(R.string.dismiss)) }
+        },
+    )
 }
 
 /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/RegionPickerViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/RegionPickerViewModel.kt
@@ -22,19 +22,20 @@ import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import org.onebusaway.android.region.Region
 import org.onebusaway.android.region.RegionRepository
 import org.onebusaway.android.region.RegionState
 
 /**
- * The forced-choice region picker as a self-contained reactive feature (mirrors the other
- * `regionRepo`-observing home VMs, e.g. [org.onebusaway.android.ui.home.widealert.WideAlertViewModel]):
- * region resolution lives entirely in [RegionRepository], which raises [RegionState.NeedsManualChoice]
- * whenever no region can be auto-selected. This exposes that as the [picker] list and resolves it via
- * [choose] — so the picker shows regardless of which screen triggered the refresh (it's rendered at the
- * activity root), rather than being a HomeViewModel/HomeUiState concern.
+ * The forced-choice region picker (and its catastrophic-failure sibling) as a self-contained reactive
+ * feature (mirrors the other `regionRepo`-observing home VMs, e.g.
+ * [org.onebusaway.android.ui.home.widealert.WideAlertViewModel]): region resolution lives entirely in
+ * [RegionRepository], which raises [RegionState.NeedsManualChoice] whenever no region can be auto-selected
+ * and [RegionState.Failed] when region info couldn't be loaded at all. This exposes the former as the
+ * [picker] list (resolved via [choose]) and the latter as [failed] (retried via [retry]) — so both show
+ * regardless of which screen triggered the refresh (they're rendered at the activity root), rather than
+ * being a HomeViewModel/HomeUiState concern.
  */
 @HiltViewModel
 class RegionPickerViewModel @Inject constructor(
@@ -48,16 +49,29 @@ class RegionPickerViewModel @Inject constructor(
     private val _picker = MutableStateFlow<List<Region>?>(null)
     val picker: StateFlow<List<Region>?> = _picker.asStateFlow()
 
+    // Whether region info couldn't be loaded at all (catastrophic failure) — drives the retryable
+    // "couldn't load regions" affordance. A resolving/active/manual-choice transition clears it.
+    private val _failed = MutableStateFlow(false)
+    val failed: StateFlow<Boolean> = _failed.asStateFlow()
+
     init {
+        // One collector drives both projections so the picker and the failure affordance can never
+        // disagree about the current state.
         viewModelScope.launch {
-            regionRepo.state
-                .map { (it as? RegionState.NeedsManualChoice)?.regions }
-                .collect { _picker.value = it }
+            regionRepo.state.collect { state ->
+                _picker.value = (state as? RegionState.NeedsManualChoice)?.regions
+                _failed.value = state is RegionState.Failed
+            }
         }
     }
 
     /** The user picked [region]: the repository applies it, which drives [picker] back to null. */
     fun choose(region: Region) {
         viewModelScope.launch { regionRepo.choose(region) }
+    }
+
+    /** Re-attempt resolution after a [failed] load; a success drives [failed] back to false. */
+    fun retry() {
+        viewModelScope.launch { regionRepo.refresh() }
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/nav/MapReveal.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/nav/MapReveal.kt
@@ -15,6 +15,7 @@
  */
 package org.onebusaway.android.ui.nav
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.NavController
 
 /**
@@ -59,4 +60,27 @@ fun NavController.revealStopOnMap(stopId: String, lat: Double, lon: Double) {
         set(RESULT_MAP_STOP_LON, lon)
     }
     popBackStack(NavRoutes.HOME, false)
+}
+
+/** A complete stop reveal read back off the HOME [SavedStateHandle] — the typed counterpart of the
+ *  three [RESULT_MAP_STOP_ID]/[RESULT_MAP_STOP_LAT]/[RESULT_MAP_STOP_LON] keys [revealStopOnMap] writes. */
+data class StopReveal(val stopId: String, val lat: Double, val lon: Double)
+
+/**
+ * Reads and consumes a pending stop reveal from the HOME [SavedStateHandle] — the symmetric typed *read*
+ * for [revealStopOnMap], keeping the `RESULT_MAP_STOP_*` keys and their `Double` types in this one file
+ * rather than re-naming them in the consumer. All three keys are cleared together regardless of
+ * completeness (so a stale lat/lon pair can't linger past the reveal); returns null when no stop id is
+ * present, or — the corrupted/half-restored case the producer never writes — an id without both
+ * coordinates.
+ */
+fun SavedStateHandle.consumeStopReveal(): StopReveal? {
+    val stopId = get<String>(RESULT_MAP_STOP_ID)
+    val lat = get<Double>(RESULT_MAP_STOP_LAT)
+    val lon = get<Double>(RESULT_MAP_STOP_LON)
+    set(RESULT_MAP_STOP_ID, null)
+    set(RESULT_MAP_STOP_LAT, null)
+    set(RESULT_MAP_STOP_LON, null)
+    if (stopId == null || lat == null || lon == null) return null
+    return StopReveal(stopId, lat, lon)
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/nav/NavRoutes.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/nav/NavRoutes.kt
@@ -35,7 +35,15 @@ data class ReminderEditorArgs(
     val stopSequence: Int = 0,
     val serviceDate: Long = 0L,
     val vehicleId: String? = null,
-)
+) {
+    init {
+        // Fail fast at this construction site (the arrival "set reminder" path) rather than letting a
+        // blank id surface later as an unresolvable route/DB lookup in the editor. (The edit-existing path
+        // builds the route from raw string nav-args and doesn't go through this constructor.)
+        require(tripId.isNotBlank()) { "tripId must not be blank" }
+        require(stopId.isNotBlank()) { "stopId must not be blank" }
+    }
+}
 
 /**
  * Central registry of Navigation-Compose route ids and nav-arg keys. The single

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/nightlight/NightLightLauncher.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/nightlight/NightLightLauncher.kt
@@ -17,8 +17,8 @@
 package org.onebusaway.android.ui.nightlight
 
 import android.content.Context
-import org.onebusaway.android.ui.HomeActivity
 import org.onebusaway.android.ui.nav.NavRoutes
+import org.onebusaway.android.ui.startHomeActivity
 
 /**
  * Launches the night-light flashing screen.
@@ -26,12 +26,12 @@ import org.onebusaway.android.ui.nav.NavRoutes
  * The screen is a NavHost destination ([NightLightRoute]) hosted by HomeActivity; this is no longer an
  * Activity but a launcher facade. The frozen `NightLightActivity` component name is kept alive as an
  * activity-alias → HomeActivity (for old pinned launcher shortcuts). This [start] is the standalone-host
- * fallback (it re-enters HomeActivity with the route via [HomeActivity.navIntent]); in-app callers that
+ * fallback (it re-enters HomeActivity with the route via [startHomeActivity]); in-app callers that
  * already hold a NavController navigate it directly instead.
  */
 object NightLightLauncher {
 
     fun start(context: Context) {
-        context.startActivity(HomeActivity.navIntent(context, NavRoutes.NIGHT_LIGHT))
+        context.startHomeActivity(NavRoutes.NIGHT_LIGHT)
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/settings/AdvancedSettingsViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/settings/AdvancedSettingsViewModel.kt
@@ -25,7 +25,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
@@ -189,8 +188,12 @@ internal suspend fun resetOtpVersionOnRegionChange(
     when (status) {
         is RegionStatus.Changed -> resetOtpVersion()
         is RegionStatus.NeedsManualSelection -> {
-            state.filterIsInstance<RegionState.Active>().first()
-            resetOtpVersion()
+            // Await a terminal resolution rather than only [RegionState.Active]: the forced picker is
+            // non-dismissible so the user's pick normally resolves it, but a retried refresh that fails
+            // transitions to [RegionState.Failed] instead — waiting for Active alone would suspend forever.
+            // Reset only when the region actually became active (a Failed resolution left it unchanged).
+            val resolved = state.first { it is RegionState.Active || it is RegionState.Failed }
+            if (resolved is RegionState.Active) resetOtpVersion()
         }
         RegionStatus.Unchanged, RegionStatus.Skipped, RegionStatus.Failed, is RegionStatus.Fixed -> Unit
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripinfo/TripInfoLauncher.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripinfo/TripInfoLauncher.kt
@@ -19,9 +19,9 @@ package org.onebusaway.android.ui.tripinfo
 import android.content.Context
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import org.onebusaway.android.R
-import org.onebusaway.android.ui.HomeActivity
 import org.onebusaway.android.ui.nav.NavRoutes
 import org.onebusaway.android.ui.nav.ReminderEditorArgs
+import org.onebusaway.android.ui.startHomeActivity
 
 /**
  * Launches the trip-reminder editor (create or edit a trip arrival reminder).
@@ -29,7 +29,7 @@ import org.onebusaway.android.ui.nav.ReminderEditorArgs
  * The editor is a NavHost destination hosted by HomeActivity; this is no longer an Activity but a launcher
  * facade. The edit path carries only the trip/stop ids; the arrivals "set reminder" path also passes the
  * full trip context so a brand-new reminder needs no DB round-trip. This [start] is the standalone-host
- * fallback (it re-enters HomeActivity with the route via [HomeActivity.navIntent], which the translator
+ * fallback (it re-enters HomeActivity with the route via [startHomeActivity], which the translator
  * turns into the [NavRoutes.TRIP_INFO] route); in-app callers that already hold a NavController navigate the
  * route directly instead.
  */
@@ -37,7 +37,7 @@ object TripInfoLauncher {
 
     /** Re-enters HomeActivity at the [NavRoutes.TRIP_INFO] reminder editor for [args]. */
     fun start(context: Context, args: ReminderEditorArgs) {
-        context.startActivity(HomeActivity.navIntent(context, NavRoutes.tripInfo(args)))
+        context.startHomeActivity(NavRoutes.tripInfo(args))
     }
 }
 

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -514,6 +514,8 @@
     <string name="region_selected_auto">selected automatically</string>
     <string name="region_selected_manually">selected manually</string>
     <string name="region_region_found">Found %1$s region</string>
+    <string name="region_load_failed_title">Couldn\'t load regions</string>
+    <string name="region_load_failed_message">Check your connection and try again.</string>
 
     <!--  Bug report -->
     <!-- Note: %1$s is replaced with app_name for white-label support -->

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/RegionPickerViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/RegionPickerViewModelTest.kt
@@ -19,7 +19,9 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.onebusaway.android.region.FakeRegionRepository
@@ -29,8 +31,9 @@ import org.onebusaway.android.testing.MainDispatcherRule
 
 /**
  * Unit tests for [RegionPickerViewModel]: it exposes the repository's [RegionState.NeedsManualChoice] as the
- * [RegionPickerViewModel.picker] list and resolves it via [RegionPickerViewModel.choose] — the forced picker
- * is now driven entirely off the repository, not HomeViewModel/HomeUiState.
+ * [RegionPickerViewModel.picker] list (resolved via [RegionPickerViewModel.choose]) and [RegionState.Failed]
+ * as [RegionPickerViewModel.failed] (retried via [RegionPickerViewModel.retry]) — the forced picker and its
+ * failure sibling are now driven entirely off the repository, not HomeViewModel/HomeUiState.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class RegionPickerViewModelTest {
@@ -70,5 +73,53 @@ class RegionPickerViewModelTest {
         // choose() drives the repository to Active(chosen), so the picker reactively returns to null.
         assertEquals(listOf(chosen), repo.chosen)
         assertNull(vm.picker.value)
+    }
+
+    @Test
+    fun `a resolving transition clears a shown picker`() = runTest {
+        val repo = FakeRegionRepository().apply {
+            emitState(RegionState.NeedsManualChoice(listOf(region(1))))
+        }
+        val vm = RegionPickerViewModel(repo)
+        advanceUntilIdle()
+        assertEquals(listOf(region(1)), vm.picker.value)
+
+        // A subsequent refresh (e.g. the user retried) re-enters Resolving — the picker must clear.
+        repo.emitState(RegionState.Resolving)
+        advanceUntilIdle()
+        assertNull(vm.picker.value)
+        assertFalse(vm.failed.value)
+    }
+
+    @Test
+    fun `a failed load clears the picker and raises the failure flag`() = runTest {
+        val repo = FakeRegionRepository().apply {
+            emitState(RegionState.NeedsManualChoice(listOf(region(1))))
+        }
+        val vm = RegionPickerViewModel(repo)
+        advanceUntilIdle()
+
+        repo.emitState(RegionState.Failed)
+        advanceUntilIdle()
+
+        assertNull(vm.picker.value)
+        assertTrue(vm.failed.value)
+    }
+
+    @Test
+    fun `retry re-attempts resolution and a success clears the failure flag`() = runTest {
+        val repo = FakeRegionRepository().apply { emitState(RegionState.Failed) }
+        val vm = RegionPickerViewModel(repo)
+        advanceUntilIdle()
+        assertTrue(vm.failed.value)
+
+        // A successful retry drives the repository back to Active, so the failure flag reactively clears.
+        repo.refreshResult = org.onebusaway.android.region.RegionStatus.Changed(region(1))
+        vm.retry()
+        repo.emit(region(1))
+        advanceUntilIdle()
+
+        assertEquals(1, repo.refreshCount)
+        assertFalse(vm.failed.value)
     }
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/nav/MapRevealTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/nav/MapRevealTest.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.nav
+
+import androidx.lifecycle.SavedStateHandle
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Unit tests for [SavedStateHandle.consumeStopReveal] — the typed read + atomic consume for the
+ * `RESULT_MAP_STOP_*` keys [NavController.revealStopOnMap] writes. Verifies the complete-reveal read, the
+ * corrupted/partial case ([StopReveal] dropped), and that all three keys are always cleared.
+ */
+class MapRevealTest {
+
+    @Test
+    fun `reads a complete stop reveal and clears all three keys`() {
+        val handle = SavedStateHandle(
+            mapOf(
+                RESULT_MAP_STOP_ID to "stop_1",
+                RESULT_MAP_STOP_LAT to 47.6,
+                RESULT_MAP_STOP_LON to -122.3,
+            )
+        )
+
+        val reveal = handle.consumeStopReveal()
+
+        assertEquals(StopReveal("stop_1", 47.6, -122.3), reveal)
+        assertNull(handle.get<String>(RESULT_MAP_STOP_ID))
+        assertNull(handle.get<Double>(RESULT_MAP_STOP_LAT))
+        assertNull(handle.get<Double>(RESULT_MAP_STOP_LON))
+    }
+
+    @Test
+    fun `drops a partial reveal but still consumes the keys`() {
+        // The corrupted / half-restored case: a stop id without its coordinates.
+        val handle = SavedStateHandle(mapOf(RESULT_MAP_STOP_ID to "stop_1"))
+
+        val reveal = handle.consumeStopReveal()
+
+        assertNull(reveal)
+        assertNull(handle.get<String>(RESULT_MAP_STOP_ID))
+    }
+
+    @Test
+    fun `returns null when nothing was staged`() {
+        assertNull(SavedStateHandle().consumeStopReveal())
+    }
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/nav/ReminderEditorArgsTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/nav/ReminderEditorArgsTest.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.nav
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+/** Unit tests for [ReminderEditorArgs]'s required-id invariant. */
+class ReminderEditorArgsTest {
+
+    @Test
+    fun `accepts non-blank required ids`() {
+        val args = ReminderEditorArgs(tripId = "trip_1", stopId = "stop_1")
+        assertEquals("trip_1", args.tripId)
+        assertEquals("stop_1", args.stopId)
+    }
+
+    @Test
+    fun `rejects a blank trip id`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            ReminderEditorArgs(tripId = "", stopId = "stop_1")
+        }
+    }
+
+    @Test
+    fun `rejects a blank stop id`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            ReminderEditorArgs(tripId = "trip_1", stopId = "   ")
+        }
+    }
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/settings/RegionOtpResetTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/settings/RegionOtpResetTest.kt
@@ -78,4 +78,25 @@ class RegionOtpResetTest {
         assertTrue("resets once the region becomes Active", reset)
         job.cancel()
     }
+
+    @Test
+    fun `a forced manual selection that fails resolves without resetting`() = runTest {
+        val regions = listOf(region(1), region(2))
+        val state = MutableStateFlow<RegionState>(RegionState.NeedsManualChoice(regions))
+        var reset = false
+
+        val job = launch {
+            resetOtpVersionOnRegionChange(RegionStatus.NeedsManualSelection(regions), state) { reset = true }
+        }
+        advanceUntilIdle()
+        assertFalse("must not reset before the pick resolves", reset)
+
+        // A retried refresh fails instead of the user picking — the await must terminate (not hang) on
+        // Failed, and leave the OTP version untouched since no region became active.
+        state.value = RegionState.Failed
+        advanceUntilIdle()
+        assertFalse("a Failed resolution leaves the OTP version untouched", reset)
+        assertTrue("the await must terminate on Failed rather than suspend forever", job.isCompleted)
+        job.cancel()
+    }
 }


### PR DESCRIPTION
Addresses the non-blocking follow-ups tracked in #1602 (identified during review of #1584).

## 1. Surface `RegionState.Failed` to the user
A catastrophic region load (no network, no cache, server unreachable) previously resolved to `RegionState.Failed` but rendered nowhere.
- `DefaultRegionRepository.refresh()` now logs `Log.e` + a Crashlytics non-fatal at the `holder.failed()` site (the `region/` and `ui/home/` packages had no logging).
- `RegionPickerViewModel` exposes a `failed` flow + `retry()` alongside the existing picker, driven by a single `state` collector so the two projections can never disagree.
- `RegionPickerHost` renders a dismissible, retryable **"Couldn't load regions — check your connection"** dialog. It's dismissible (unlike the forced picker) since a cached region may still let the app function.

## 2. Log the dropped partial stop-reveal
`HomeNavHost`'s stop-reveal effect now records a `Log.w` + non-fatal when `STOP_ID` is present but `lat`/`lon` are missing — only reachable on a corrupted/half-restored `SavedStateHandle`, so it makes the latent path findable without firing on legitimate reveals.

## 3. Bound the deferred OTP-reset await
`resetOtpVersionOnRegionChange`'s `NeedsManualSelection` branch awaited `state.filterIsInstance<RegionState.Active>().first()`, which would suspend forever if a refresh transitioned to `Failed` instead of `Active`. It now awaits a terminal state (`Active` **or** `Failed`) and resets only on `Active`.

## 4. Polish
- `MapReveal.kt`: added a symmetric typed read helper `SavedStateHandle.consumeStopReveal(): StopReveal?` so the `RESULT_MAP_STOP_*` keys + `Double` types live in one file; `HomeNavHost` now uses it.
- `TripInfoLauncher.start` / `NightLightLauncher.start`: add `FLAG_ACTIVITY_NEW_TASK` when launched from a non-Activity context (safe today; robust for service/receiver callers).
- `ReminderEditorArgs`: `require(tripId.isNotBlank())` / `require(stopId.isNotBlank())`.
- `HomeDestinationDeps` KDoc updated (`callbacks` → `activityActions`).

## Tests
Added JVM unit tests for the picker failure/retry path (`RegionPickerViewModelTest`), the bounded OTP await on `Failed` (`RegionOtpResetTest`), `consumeStopReveal` (`MapRevealTest`), and the `ReminderEditorArgs` invariant (`ReminderEditorArgsTest`). All pass.

Refs #1602, #1584, #1579.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a retryable region-loading failure dialog with clear guidance.
  * Improved navigation by consistently re-entering the home screen from key entry points.

* **Bug Fixes**
  * Handle partially restored stop reveal data more safely (no silent consumption).
  * Prevent region-dependent flows from hanging when region loading fails.
  * Validate reminder details earlier; show an error toast instead of launching with invalid values.

* **Chores**
  * Added/updated unit tests for region retry, failure transitions, map reveal handling, and reminder validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->