### PR TITLE
[codex] Remove travel-behavior residue

### DIFF
--- a/onebusaway-android/flavors/agencyX.gradle
+++ b/onebusaway-android/flavors/agencyX.gradle
@@ -40,8 +40,6 @@ android.productFlavors {
         buildConfigField "String", "FIXED_REGION_PAYMENT_ANDROID_APP_ID", "null"
         buildConfigField "String", "FIXED_REGION_PAYMENT_WARNING_TITLE", "null"
         buildConfigField "String", "FIXED_REGION_PAYMENT_WARNING_BODY", "null"
-        buildConfigField "boolean", "FIXED_REGION_TRAVEL_BEHAVIOR_DATA_COLLECTION", "false"
-        buildConfigField "boolean", "FIXED_REGION_ENROLL_PARTICIPANTS_IN_STUDY", "false"
         buildConfigField "String", "FIXED_REGION_SIDECAR_BASE_URL", "null"
         buildConfigField "String", "FIXED_REGION_PLAUSIBLE_ANALYTICS_SERVER_URL", "null"
     }

--- a/onebusaway-android/flavors/agencyY.gradle
+++ b/onebusaway-android/flavors/agencyY.gradle
@@ -45,8 +45,6 @@ android.productFlavors {
         buildConfigField "String", "FIXED_REGION_PAYMENT_ANDROID_APP_ID", "\"co.bytemark.hart\""
         buildConfigField "String", "FIXED_REGION_PAYMENT_WARNING_TITLE", "null"
         buildConfigField "String", "FIXED_REGION_PAYMENT_WARNING_BODY", "null"
-        buildConfigField "boolean", "FIXED_REGION_TRAVEL_BEHAVIOR_DATA_COLLECTION", "false"
-        buildConfigField "boolean", "FIXED_REGION_ENROLL_PARTICIPANTS_IN_STUDY", "false"
         buildConfigField "String", "FIXED_REGION_SIDECAR_BASE_URL", "null"
         buildConfigField "String", "FIXED_REGION_PLAUSIBLE_ANALYTICS_SERVER_URL", "null"
     }

--- a/onebusaway-android/flavors/kiedybus.gradle
+++ b/onebusaway-android/flavors/kiedybus.gradle
@@ -40,8 +40,6 @@ android.productFlavors {
         buildConfigField "String", "FIXED_REGION_PAYMENT_ANDROID_APP_ID", "null"
         buildConfigField "String", "FIXED_REGION_PAYMENT_WARNING_TITLE", "null"
         buildConfigField "String", "FIXED_REGION_PAYMENT_WARNING_BODY", "null"
-        buildConfigField "boolean", "FIXED_REGION_TRAVEL_BEHAVIOR_DATA_COLLECTION", "false"
-        buildConfigField "boolean", "FIXED_REGION_ENROLL_PARTICIPANTS_IN_STUDY", "false"
         buildConfigField "String", "FIXED_REGION_SIDECAR_BASE_URL", "null"
         buildConfigField "String", "FIXED_REGION_PLAUSIBLE_ANALYTICS_SERVER_URL", "null"
     }

--- a/onebusaway-android/flavors/oba.gradle
+++ b/onebusaway-android/flavors/oba.gradle
@@ -40,8 +40,6 @@ android.productFlavors {
         buildConfigField "String", "FIXED_REGION_PAYMENT_ANDROID_APP_ID", "null"
         buildConfigField "String", "FIXED_REGION_PAYMENT_WARNING_TITLE", "null"
         buildConfigField "String", "FIXED_REGION_PAYMENT_WARNING_BODY", "null"
-        buildConfigField "boolean", "FIXED_REGION_TRAVEL_BEHAVIOR_DATA_COLLECTION", "false"
-        buildConfigField "boolean", "FIXED_REGION_ENROLL_PARTICIPANTS_IN_STUDY", "false"
         buildConfigField "String", "FIXED_REGION_SIDECAR_BASE_URL", "\"https://onebusaway.co\""
         buildConfigField "String", "FIXED_REGION_PLAUSIBLE_ANALYTICS_SERVER_URL", "null"
     }

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/mock/MockRegion.java
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/mock/MockRegion.java
@@ -93,8 +93,6 @@ public class MockRegion {
                 "co.bytemark.hart",
                 null,
                 null,
-                false,
-                false,
                 "https://onebusaway.co",
                 null,
                 null);   // UmamiAnalyticsConfig — disabled in test regions
@@ -136,8 +134,6 @@ public class MockRegion {
                 null,
                 null,
                 null,
-                false,
-                false,
                 "https://onebusaway.co",
                 null,
                 null);   // UmamiAnalyticsConfig — disabled in test regions
@@ -179,8 +175,6 @@ public class MockRegion {
                 "co.bytemark.hart",
                 null,
                 null,
-                false,
-                false,
                 "https://onebusaway.co",
                 null,
                 null);   // UmamiAnalyticsConfig — disabled in test regions
@@ -222,8 +216,6 @@ public class MockRegion {
                 "co.bytemark.hart",
                 null,
                 null,
-                false,
-                false,
                 "https://onebusaway.co",
                 null,
                 null);   // UmamiAnalyticsConfig — disabled in test regions
@@ -265,8 +257,6 @@ public class MockRegion {
                 "co.bytemark.hart",
                 null,
                 null,
-                false,
-                false,
                 "https://onebusaway.co",
                 null,
                 null);   // UmamiAnalyticsConfig — disabled in test regions
@@ -308,8 +298,6 @@ public class MockRegion {
                 "co.bytemark.hart",
                 null,
                 null,
-                false,
-                false,
                 "https://onebusaway.co",
                 null,
                 null);   // UmamiAnalyticsConfig — disabled in test regions
@@ -349,8 +337,6 @@ public class MockRegion {
                 "co.bytemark.hart",
                 null,
                 null,
-                false,
-                false,
                 "https://onebusaway.co",
                 null,
                 null);   // UmamiAnalyticsConfig — disabled in test regions
@@ -390,8 +376,6 @@ public class MockRegion {
                 "co.bytemark.hart",
                 null,
                 null,
-                false,
-                false,
                 "https://onebusaway.co",
                 null,
                 null);   // UmamiAnalyticsConfig — disabled in test regions

--- a/onebusaway-android/src/main/AndroidManifest.xml
+++ b/onebusaway-android/src/main/AndroidManifest.xml
@@ -37,13 +37,6 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
 
-    <!-- Permission request for activity recognition and background location is disabled because the related feature has been turned off.
-    See issue #1240 for more details: https://github.com/OneBusAway/onebusaway-android/issues/1240-->
-    <!-- ACTIVITY_RECOGNITION API 28 and lower -->
-<!--    <uses-permission android:name="com.google.android.gms.permission.ACTIVITY_RECOGNITION" />-->
-<!--    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />-->
-    <!-- ACTIVITY_RECOGNITION API 29 and higher -->
-<!--    <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION" />-->
     <!--To enable checkBatteryOptimizations feature, also uncomment checkBatteryOptimizations() in
     the HomeActivity's onCreate() method-->
     <!--<uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS"/>-->

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/adapters/RegionAdapters.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/adapters/RegionAdapters.kt
@@ -50,8 +50,6 @@ fun RegionDto.toObaRegion(): Region = Region(
     paymentAndroidAppId,
     paymentWarningTitle,
     paymentWarningBody,
-    travelBehaviorDataCollectionEnabled,
-    enrollParticipantsInStudy,
     sidecarBaseUrl,
     plausibleAnalyticsServerUrl,
     // Match getRegionsFromProvider: only build a config when something is actually set.

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/contract/ObaApiModels.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/contract/ObaApiModels.kt
@@ -439,8 +439,6 @@ data class RegionDto(
     val paymentAndroidAppId: String? = null,
     val paymentWarningTitle: String? = null,
     val paymentWarningBody: String? = null,
-    val travelBehaviorDataCollectionEnabled: Boolean = false,
-    val enrollParticipantsInStudy: Boolean = false,
 )
 
 /** One bounding box of a region (center [lat]/[lon] and its [latSpan]/[lonSpan]). */

--- a/onebusaway-android/src/main/java/org/onebusaway/android/provider/ObaContract.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/provider/ObaContract.java
@@ -530,9 +530,6 @@ public final class ObaContract {
          */
         public static final String PAYMENT_WARNING_BODY = "payment_warning_body";
 
-        public static final String TRAVEL_BEHAVIOR_DATA_COLLECTION = "travel_behavior_data_collection";
-
-        public static final String ENROLL_PARTICIPANTS_IN_STUDY = "enroll_participants_in_study";
     }
 
     protected interface RegionBoundsColumns {
@@ -1426,8 +1423,6 @@ public final class ObaContract {
                     PAYMENT_ANDROID_APP_ID,
                     PAYMENT_WARNING_TITLE,
                     PAYMENT_WARNING_BODY,
-                    TRAVEL_BEHAVIOR_DATA_COLLECTION,
-                    ENROLL_PARTICIPANTS_IN_STUDY,
                     SIDECAR_BASE_URL,
                     PLAUSIBLE_ANALYTICS_SERVER_URL,
                     UMAMI_ANALYTICS_URL,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/provider/ObaProvider.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/provider/ObaProvider.java
@@ -302,9 +302,9 @@ public class ObaProvider extends ContentProvider {
 
             if (oldVersion == 29) {
                 db.execSQL("ALTER TABLE " + ObaContract.Regions.PATH +
-                        " ADD COLUMN " + ObaContract.Regions.TRAVEL_BEHAVIOR_DATA_COLLECTION + " INTEGER");
+                        " ADD COLUMN travel_behavior_data_collection INTEGER");
                 db.execSQL("ALTER TABLE " + ObaContract.Regions.PATH +
-                        " ADD COLUMN " + ObaContract.Regions.ENROLL_PARTICIPANTS_IN_STUDY + " INTEGER");
+                        " ADD COLUMN enroll_participants_in_study INTEGER");
                 ++oldVersion;
             }
 
@@ -610,11 +610,6 @@ public class ObaProvider extends ContentProvider {
                 .put(ObaContract.Regions.PAYMENT_WARNING_TITLE, ObaContract.Regions.PAYMENT_WARNING_TITLE);
         sRegionsProjectionMap
                 .put(ObaContract.Regions.PAYMENT_WARNING_BODY, ObaContract.Regions.PAYMENT_WARNING_BODY);
-        sRegionsProjectionMap
-                .put(ObaContract.Regions.TRAVEL_BEHAVIOR_DATA_COLLECTION, ObaContract.Regions.TRAVEL_BEHAVIOR_DATA_COLLECTION);
-        sRegionsProjectionMap
-                .put(ObaContract.Regions.ENROLL_PARTICIPANTS_IN_STUDY, ObaContract.Regions.ENROLL_PARTICIPANTS_IN_STUDY);
-
         sRegionBoundsProjectionMap = new HashMap<String, String>();
         sRegionBoundsProjectionMap.put(ObaContract.RegionBounds._ID, ObaContract.RegionBounds._ID);
         sRegionBoundsProjectionMap

--- a/onebusaway-android/src/main/java/org/onebusaway/android/region/Region.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/region/Region.kt
@@ -48,8 +48,6 @@ data class Region(
     val paymentAndroidAppId: String? = null,
     val paymentWarningTitle: String? = null,
     val paymentWarningBody: String? = null,
-    val isTravelBehaviorDataCollectionEnabled: Boolean = false,
-    val isEnrollParticipantsInStudy: Boolean = false,
     val sidecarBaseUrl: String? = "",
     val plausibleAnalyticsServerUrl: String? = "",
     val umamiAnalytics: UmamiAnalyticsConfig? = null,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/region/RegionCursor.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/region/RegionCursor.kt
@@ -32,8 +32,8 @@ object RegionCursor {
         bounds: Array<Region.Bounds>?,
         open311Servers: Array<Region.Open311Server>?,
     ): Region {
-        val umamiUrl = c.getString(23)
-        val umamiId = c.getString(24)
+        val umamiUrl = c.getString(21)
+        val umamiId = c.getString(22)
         val umami = if (umamiUrl != null || umamiId != null) {
             Region.UmamiAnalyticsConfig(umamiUrl, umamiId)
         } else {
@@ -62,10 +62,8 @@ object RegionCursor {
             paymentAndroidAppId = c.getString(16),
             paymentWarningTitle = c.getString(17),
             paymentWarningBody = c.getString(18),
-            isTravelBehaviorDataCollectionEnabled = c.getInt(19) > 0,
-            isEnrollParticipantsInStudy = c.getInt(20) > 0,
-            sidecarBaseUrl = c.getString(21),
-            plausibleAnalyticsServerUrl = c.getString(22),
+            sidecarBaseUrl = c.getString(19),
+            plausibleAnalyticsServerUrl = c.getString(20),
             umamiAnalytics = umami,
         )
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/RegionUtils.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/RegionUtils.java
@@ -415,8 +415,6 @@ public class RegionUtils {
                     ObaContract.Regions.PAYMENT_ANDROID_APP_ID,
                     ObaContract.Regions.PAYMENT_WARNING_TITLE,
                     ObaContract.Regions.PAYMENT_WARNING_BODY,
-                    ObaContract.Regions.TRAVEL_BEHAVIOR_DATA_COLLECTION,
-                    ObaContract.Regions.ENROLL_PARTICIPANTS_IN_STUDY,
                     ObaContract.Regions.SIDECAR_BASE_URL,
                     ObaContract.Regions.PLAUSIBLE_ANALYTICS_SERVER_URL,
                     ObaContract.Regions.UMAMI_ANALYTICS_URL,
@@ -630,8 +628,6 @@ public class RegionUtils {
                 BuildConfig.FIXED_REGION_PAYMENT_ANDROID_APP_ID,
                 BuildConfig.FIXED_REGION_PAYMENT_WARNING_TITLE,
                 BuildConfig.FIXED_REGION_PAYMENT_WARNING_BODY,
-                BuildConfig.FIXED_REGION_TRAVEL_BEHAVIOR_DATA_COLLECTION,
-                BuildConfig.FIXED_REGION_ENROLL_PARTICIPANTS_IN_STUDY,
                 BuildConfig.FIXED_REGION_SIDECAR_BASE_URL,
                 BuildConfig.FIXED_REGION_PLAUSIBLE_ANALYTICS_SERVER_URL,
                 null);   // No Umami config for the fixed-region build flavor
@@ -709,10 +705,6 @@ public class RegionUtils {
         values.put(ObaContract.Regions.PAYMENT_ANDROID_APP_ID, region.getPaymentAndroidAppId());
         values.put(ObaContract.Regions.PAYMENT_WARNING_TITLE, region.getPaymentWarningTitle());
         values.put(ObaContract.Regions.PAYMENT_WARNING_BODY, region.getPaymentWarningBody());
-        values.put(ObaContract.Regions.TRAVEL_BEHAVIOR_DATA_COLLECTION,
-                region.isTravelBehaviorDataCollectionEnabled() ? 1 : 0);
-        values.put(ObaContract.Regions.ENROLL_PARTICIPANTS_IN_STUDY,
-                region.isEnrollParticipantsInStudy() ? 1 : 0);
         values.put(ObaContract.Regions.SIDECAR_BASE_URL, region.getSidecarBaseUrl());
         values.put(ObaContract.Regions.PLAUSIBLE_ANALYTICS_SERVER_URL, region.getPlausibleAnalyticsServerUrl());
         values.put(ObaContract.Regions.UMAMI_ANALYTICS_URL, region.getUmamiAnalyticsUrl());

--- a/onebusaway-android/src/main/res/raw/regions_v3.json
+++ b/onebusaway-android/src/main/res/raw/regions_v3.json
@@ -51,9 +51,7 @@
         "paymentWarningTitle": null,
         "paymentWarningBody": null,
         "paymentiOSAppStoreIdentifier": "1487465395",
-        "paymentiOSAppUrlScheme": "fb313213768708402HART",
-        "travelBehaviorDataCollectionEnabled": false,
-        "enrollParticipantsInStudy": false
+        "paymentiOSAppUrlScheme": "fb313213768708402HART"
       },
       {
         "id": 1,
@@ -138,9 +136,7 @@
         "paymentWarningTitle": "Check before you buy!",
         "paymentWarningBody": "The mobile fare payment app for Puget Sound does not support all transit service shown in OneBusAway. Please check that a ticket is eligible for your agency and route before you purchase!",
         "paymentiOSAppStoreIdentifier": "1131345078",
-        "paymentiOSAppUrlScheme": "co.bytemark.tgt",
-        "travelBehaviorDataCollectionEnabled": false,
-        "enrollParticipantsInStudy": false
+        "paymentiOSAppUrlScheme": "co.bytemark.tgt"
       },
       {
         "id": 2,
@@ -183,9 +179,7 @@
         "paymentWarningTitle": null,
         "paymentWarningBody": null,
         "paymentiOSAppStoreIdentifier": null,
-        "paymentiOSAppUrlScheme": null,
-        "travelBehaviorDataCollectionEnabled": false,
-        "enrollParticipantsInStudy": false
+        "paymentiOSAppUrlScheme": null
       },
       {
         "id": 4,
@@ -222,9 +216,7 @@
         "paymentWarningTitle": null,
         "paymentWarningBody": null,
         "paymentiOSAppStoreIdentifier": null,
-        "paymentiOSAppUrlScheme": null,
-        "travelBehaviorDataCollectionEnabled": false,
-        "enrollParticipantsInStudy": false
+        "paymentiOSAppUrlScheme": null
       },
       {
         "id": 11,
@@ -273,9 +265,7 @@
         "paymentWarningTitle": null,
         "paymentWarningBody": null,
         "paymentiOSAppStoreIdentifier": "1577230742",
-        "paymentiOSAppUrlScheme": "org.sdmts.pronto",
-        "travelBehaviorDataCollectionEnabled": false,
-        "enrollParticipantsInStudy": false
+        "paymentiOSAppUrlScheme": "org.sdmts.pronto"
       },
       {
         "id": 15,
@@ -360,9 +350,7 @@
         "paymentWarningTitle": null,
         "paymentWarningBody": null,
         "paymentiOSAppStoreIdentifier": null,
-        "paymentiOSAppUrlScheme": null,
-        "travelBehaviorDataCollectionEnabled": false,
-        "enrollParticipantsInStudy": false
+        "paymentiOSAppUrlScheme": null
       },
       {
         "id": 16,
@@ -399,9 +387,7 @@
         "paymentWarningTitle": null,
         "paymentWarningBody": null,
         "paymentiOSAppStoreIdentifier": null,
-        "paymentiOSAppUrlScheme": null,
-        "travelBehaviorDataCollectionEnabled": false,
-        "enrollParticipantsInStudy": false
+        "paymentiOSAppUrlScheme": null
       }
     ]
   }

--- a/onebusaway-android/src/main/res/values/donottranslate.xml
+++ b/onebusaway-android/src/main/res/values/donottranslate.xml
@@ -168,9 +168,6 @@
     <string name="analytics_label_download_app">download_app</string>
     <string name="analytics_label_open_app">open_app</string>
 
-    <!-- Analytics for travel behavior data collection -->
-
-
     <!-- General strings -->
     <string name="https_prefix">https://</string>
 

--- a/onebusaway-android/src/test/java/org/onebusaway/android/region/RegionTestFixtures.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/region/RegionTestFixtures.kt
@@ -81,8 +81,6 @@ internal fun region(
         null,          // paymentAndroidAppId
         null,          // paymentWarningTitle
         null,          // paymentWarningBody
-        false,         // travelBehaviorDataCollectionEnabled
-        false,         // enrollParticipantsInStudy
         null,          // sidecarBaseUrl
         null,          // plausibleAnalyticsServerUrl
         null           // umamiAnalytics (UmamiAnalyticsConfig)


### PR DESCRIPTION
## Summary

Closes #1573.

Removes the remaining references to the retired travel-behavior feature after the subsystem deletion:

- drops the old region flags from the domain model, API DTO, adapter, provider projections, and fixed-region BuildConfig setup
- removes stale manifest/resource comments and bundled regions JSON fields
- updates test fixtures for the shorter Region constructor

The legacy database migration still adds the historical column names with string literals so older installs can continue upgrading cleanly.

## Validation

- ./gradlew :onebusaway-android:compileObaGoogleDebugSources :onebusaway-android:compileObaGoogleDebugAndroidTestSources
- ./gradlew :onebusaway-android:compileAgencyYGoogleDebugSources
- jq empty onebusaway-android/src/main/res/raw/regions_v3.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated region configuration data to include additional payment and analytics settings.

* **Bug Fixes**
  * Removed obsolete region fields from app configuration and data handling.
  * Aligned region loading, storage, and test data with the updated configuration format.
  * Cleaned up unused manifest and resource comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->