### PR TITLE
refactor: extract duplicated inDarkMode() helper to ThemeUtils

### DIFF
--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleComposeAdapter.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleComposeAdapter.kt
@@ -17,9 +17,7 @@ package org.onebusaway.android.map.googlemapsv2.compose
 
 import android.annotation.SuppressLint
 import android.content.Context
-import android.content.res.Configuration
 import android.view.ViewGroup
-import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -65,6 +63,7 @@ import org.onebusaway.android.map.render.MapProjector
 import org.onebusaway.android.map.render.ScreenOffset
 import org.onebusaway.android.ui.compose.findActivity
 import org.onebusaway.android.util.PermissionUtils
+import org.onebusaway.android.util.ThemeUtils
 
 /**
  * The dynamic-layer redraw interval: ~20Hz, the proven upstream cadence. Downsampling from the display
@@ -376,7 +375,7 @@ private fun applyMyLocation(map: GoogleMap, context: Context, enabled: Boolean) 
 
 /** The map style for the current night-mode state: the dark theme, or POI removal in light mode. */
 private fun resolveMapStyle(context: Context): MapStyleOptions =
-    if (isInDarkMode(context)) {
+    if (ThemeUtils.isInDarkMode(context)) {
         MapStyleOptions.loadRawResourceStyle(context, R.raw.dark_map)
     } else {
         // Light mode: just hide POIs (ported from GoogleMapHost.onMapReady).
@@ -384,16 +383,3 @@ private fun resolveMapStyle(context: Context): MapStyleOptions =
             "[{\"featureType\":\"poi\",\"elementType\":\"all\",\"stylers\":[{\"visibility\":\"off\"}]}]"
         )
     }
-
-/** Mirrors the former GoogleMapHost.inDarkMode: app night-mode override, else the system config. */
-private fun isInDarkMode(context: Context): Boolean {
-    val mode = AppCompatDelegate.getDefaultNightMode()
-    if (mode == AppCompatDelegate.MODE_NIGHT_YES) {
-        return true
-    }
-    if (mode == AppCompatDelegate.MODE_NIGHT_NO) {
-        return false
-    }
-    return (context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK) ==
-        Configuration.UI_MODE_NIGHT_YES
-}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/ThemeUtils.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/ThemeUtils.kt
@@ -16,6 +16,8 @@
  */
 package org.onebusaway.android.util
 
+import android.content.Context
+import android.content.res.Configuration
 import androidx.appcompat.app.AppCompatDelegate
 import org.onebusaway.android.R
 import org.onebusaway.android.app.Application
@@ -48,5 +50,22 @@ object ThemeUtils {
             else -> return
         }
         AppCompatDelegate.setDefaultNightMode(mode)
+    }
+
+    /**
+     * Returns true if the app is currently in dark mode: the AppCompat night-mode
+     * override takes precedence, otherwise the system UI configuration decides.
+     */
+    @JvmStatic
+    fun isInDarkMode(context: Context): Boolean {
+        val mode = AppCompatDelegate.getDefaultNightMode()
+        if (mode == AppCompatDelegate.MODE_NIGHT_YES) {
+            return true
+        }
+        if (mode == AppCompatDelegate.MODE_NIGHT_NO) {
+            return false
+        }
+        return (context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK) ==
+            Configuration.UI_MODE_NIGHT_YES
     }
 }

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreComposeAdapter.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreComposeAdapter.kt
@@ -19,9 +19,7 @@ import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Context
 import android.content.ContextWrapper
-import android.content.res.Configuration
 import android.view.ViewGroup
-import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -59,6 +57,7 @@ import org.onebusaway.android.map.maplibre.MapLibreRenderer
 import org.onebusaway.android.map.render.CameraSnapshot
 import org.onebusaway.android.map.render.GeoPoint
 import org.onebusaway.android.util.PermissionUtils
+import org.onebusaway.android.util.ThemeUtils
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
@@ -139,7 +138,7 @@ class MapLibreComposeAdapter : ObaComposeMapAdapter {
                         .build()
                 }
                 map.uiSettings.isCompassEnabled = false
-                val styleUrl = if (isInDarkMode(context)) STYLE_URL_DARK else STYLE_URL_LIGHT
+                val styleUrl = if (ThemeUtils.isInDarkMode(context)) STYLE_URL_DARK else STYLE_URL_LIGHT
                 map.setStyle(Style.Builder().fromUri(styleUrl)) { style ->
                     loadedStyle = style
                     val r = MapLibreRenderer(map, context, renderState)
@@ -315,19 +314,6 @@ private fun enableLocationComponent(map: MapLibreMap, style: Style, context: Con
         component.renderMode = RenderMode.COMPASS
     }
     component.isLocationComponentEnabled = true
-}
-
-/** Mirrors the former MapLibreMapHost.inDarkMode: app night-mode override, else the system config. */
-private fun isInDarkMode(context: Context): Boolean {
-    val mode = AppCompatDelegate.getDefaultNightMode()
-    if (mode == AppCompatDelegate.MODE_NIGHT_YES) {
-        return true
-    }
-    if (mode == AppCompatDelegate.MODE_NIGHT_NO) {
-        return false
-    }
-    return (context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK) ==
-        Configuration.UI_MODE_NIGHT_YES
 }
 
 private fun Context.findActivity(): Activity {


### PR DESCRIPTION
Supersedes #1545 (by @amanjn38), rebased onto current `main`.

### Why a new PR
#1545 branched off `main` in March and set out to extract a duplicated `inDarkMode()` helper. Since then the modernization campaign landed and **deleted all three files that PR touched** (`BaseMapFragment.java`, `MapLibreMapFragment.java`, `UIUtils.java`), so it can only ever conflict (modify/delete) — a normal merge is impossible.

Ironically, that same campaign **re-introduced the exact duplication** the original PR aimed to remove: a byte-for-byte identical private `isInDarkMode(context)` now lives in both `GoogleComposeAdapter.kt` and `MapLibreComposeAdapter.kt`. The original intent is still valid; only the target files moved.

### What this does
- Hoists a single `ThemeUtils.isInDarkMode(context)` into the existing `ThemeUtils` object (`util/`).
- Points both Compose map adapters at it, dropping the now-unused `AppCompatDelegate` / `Configuration` imports.

Behavior is unchanged (identical logic, just deduplicated).

### Verification
`obaGoogleDebug` and `obaMaplibreDebug` both compile clean.

Credit to @amanjn38 for the original refactor in #1545.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved map appearance handling to better match the app’s current light or dark theme.
  * Map views now consistently choose the appropriate style based on the active display mode.

* **Bug Fixes**
  * Fixed theme detection so map styling follows the app’s dark mode settings more reliably across map views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->