### PR TITLE
Filter "show vehicles on map" to the stop-relevant direction

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/extrapolation/test/ExtrapolatedVehiclesTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/extrapolation/test/ExtrapolatedVehiclesTest.kt
@@ -62,14 +62,14 @@ class ExtrapolatedVehiclesTest {
     fun skipsCanceledMissingRefAndPositionlessVehiclesWithoutCrashing() {
         // route_1 + route_2 requested: only trip_A and trip_B survive; the canceled, ref-less, and
         // positionless trips are dropped rather than throwing.
-        val vehicles = extrapolatedVehicles(response().asRouteTrips(),setOf("route_1", "route_2"), nowMs = 1_000_000L, noState)
+        val vehicles = extrapolatedVehicles(response().asRouteTrips(),setOf("route_1", "route_2"), nowMs = 1_000_000L, lookupState = noState)
 
         assertEquals(listOf("trip_A", "trip_B"), vehicles.map { it.status.activeTripId })
     }
 
     @Test
     fun placesVehicleAtLastKnownLocationAndReportsFixTimeWhenNoState() {
-        val vehicles = extrapolatedVehicles(response().asRouteTrips(),setOf("route_1"), nowMs = 1_000_000L, noState)
+        val vehicles = extrapolatedVehicles(response().asRouteTrips(),setOf("route_1"), nowMs = 1_000_000L, lookupState = noState)
 
         assertEquals(1, vehicles.size)
         val vehicle = vehicles[0]
@@ -85,7 +85,7 @@ class ExtrapolatedVehiclesTest {
 
     @Test
     fun fallsBackToPositionWhenNoLastKnownLocation() {
-        val vehicles = extrapolatedVehicles(response().asRouteTrips(),setOf("route_2"), nowMs = 1_000_000L, noState)
+        val vehicles = extrapolatedVehicles(response().asRouteTrips(),setOf("route_2"), nowMs = 1_000_000L, lookupState = noState)
 
         assertEquals(1, vehicles.size)
         val vehicle = vehicles[0]
@@ -97,9 +97,40 @@ class ExtrapolatedVehiclesTest {
     @Test
     fun filtersToRequestedRoutesOnly() {
         // route_3 serves none of the trips.
-        assertTrue(extrapolatedVehicles(response().asRouteTrips(),setOf("route_3"), nowMs = 1_000_000L, noState).isEmpty())
+        assertTrue(extrapolatedVehicles(response().asRouteTrips(),setOf("route_3"), nowMs = 1_000_000L, lookupState = noState).isEmpty())
         // Empty request -> nothing.
-        assertTrue(extrapolatedVehicles(response().asRouteTrips(),emptySet(), nowMs = 1_000_000L, noState).isEmpty())
+        assertTrue(extrapolatedVehicles(response().asRouteTrips(),emptySet(), nowMs = 1_000_000L, lookupState = noState).isEmpty())
+    }
+
+    // A trips-for-route response with two vehicles on route_1 heading opposite directions (GTFS
+    // directionId 0 vs 1) — the "show vehicles on map" direction filter's fixture.
+    private fun directionResponse(): ObaEnvelope<ListWithReferences<TripDetailsEntry>> =
+        Resources.read(getTargetContext(), Resources.getTestUri("trips_for_route_direction_filter"))
+            .use { json.decodeFromString(it.readText()) }
+
+    @Test
+    fun keepsOnlyTheRequestedDirectionWhenDirectionIdGiven() {
+        val trips = directionResponse().asRouteTrips()
+        // directionId 0 -> only the outbound vehicle.
+        assertEquals(
+            listOf("trip_out"),
+            extrapolatedVehicles(trips, setOf("route_1"), nowMs = 1_000_000L, directionId = 0, lookupState = noState)
+                .map { it.status.activeTripId }
+        )
+        // directionId 1 -> only the inbound vehicle (the opposite-direction bus the old view showed).
+        assertEquals(
+            listOf("trip_in"),
+            extrapolatedVehicles(trips, setOf("route_1"), nowMs = 1_000_000L, directionId = 1, lookupState = noState)
+                .map { it.status.activeTripId }
+        )
+    }
+
+    @Test
+    fun keepsBothDirectionsWhenDirectionIdNull() {
+        val vehicles = extrapolatedVehicles(
+            directionResponse().asRouteTrips(), setOf("route_1"), nowMs = 1_000_000L, lookupState = noState
+        )
+        assertEquals(listOf("trip_out", "trip_in"), vehicles.map { it.status.activeTripId })
     }
 
     @Test
@@ -110,7 +141,7 @@ class ExtrapolatedVehiclesTest {
             if (tripId == "trip_A") TripState("trip_A", anchorLocalTimeMs = 999_000L) else null
         }
 
-        val vehicle = extrapolatedVehicles(response().asRouteTrips(),setOf("route_1"), nowMs = 1_000_000L, anchored).single()
+        val vehicle = extrapolatedVehicles(response().asRouteTrips(),setOf("route_1"), nowMs = 1_000_000L, lookupState = anchored).single()
 
         assertEquals(999_000L, vehicle.fixTimeMs)
         assertEquals(47.20, vehicle.point.latitude, 1e-6)

--- a/onebusaway-android/src/androidTest/res/raw/trips_for_route_direction_filter.json
+++ b/onebusaway-android/src/androidTest/res/raw/trips_for_route_direction_filter.json
@@ -1,0 +1,42 @@
+{
+  "code": 200,
+  "currentTime": 1444073094612,
+  "text": "OK",
+  "version": 2,
+  "data": {
+    "limitExceeded": false,
+    "outOfRange": false,
+    "list": [
+      {
+        "tripId": "trip_out",
+        "serviceDate": 1444017600000,
+        "status": {
+          "activeTripId": "trip_out",
+          "lastUpdateTime": 1000,
+          "status": "default",
+          "position": { "lat": 47.10, "lon": -122.10 }
+        }
+      },
+      {
+        "tripId": "trip_in",
+        "serviceDate": 1444017600000,
+        "status": {
+          "activeTripId": "trip_in",
+          "lastUpdateTime": 2000,
+          "status": "default",
+          "position": { "lat": 47.20, "lon": -122.20 }
+        }
+      }
+    ],
+    "references": {
+      "agencies": [],
+      "routes": [],
+      "situations": [],
+      "stops": [],
+      "trips": [
+        { "id": "trip_out", "routeId": "route_1", "directionId": "0" },
+        { "id": "trip_in", "routeId": "route_1", "directionId": "1" }
+      ]
+    }
+  }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/contract/ObaApiModels.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/contract/ObaApiModels.kt
@@ -173,9 +173,13 @@ data class StopGrouping(
     val stopGroups: List<StopGroup> = emptyList(),
 )
 
-/** One directional group: a display [name] and the ordered [stopIds] it contains. */
+/**
+ * One directional group: its [id] (the GTFS direction id, "0"/"1", for a `type: "direction"`
+ * grouping), a display [name], and the ordered [stopIds] it contains.
+ */
 @Serializable
 data class StopGroup(
+    val id: String? = null,
     val name: StopGroupName = StopGroupName(),
     val stopIds: List<String> = emptyList(),
 ) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/data/MapDataSource.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/data/MapDataSource.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.onebusaway.android.models.NearbyStops
 import org.onebusaway.android.models.RouteMapData
+import org.onebusaway.android.models.RouteMapStop
 import org.onebusaway.android.util.PolylineDecoder
 
 /**
@@ -68,10 +69,22 @@ class DefaultMapDataSource @Inject constructor(
     override suspend fun routeMap(routeId: String): Result<RouteMapData?> = api.callOrNull { service ->
         val data = service.stopsForRoute(routeId, includePolylines = true).requireData()
         val route = data.references.route(routeId)?.let(::DtoRoute)
+        // Invert the direction stop groups (type "direction") into a stop id -> direction ids map, so
+        // each stop can carry its own direction. Only numeric group ids are kept — they're what a
+        // vehicle's trip directionId matches; a stop listed under two groups gets both.
+        val directionsByStop = mutableMapOf<String, MutableSet<Int>>()
+        data.entry.stopGroupings.forEach { grouping ->
+            grouping.stopGroups.forEach { group ->
+                group.id?.toIntOrNull()?.let { dir ->
+                    group.stopIds.forEach { directionsByStop.getOrPut(it) { mutableSetOf() }.add(dir) }
+                }
+            }
+        }
         RouteMapData(
             route = route,
             agencyName = route?.agencyId?.let { data.references.agency(it)?.name },
-            stops = data.references.stops.map(::DtoStop),
+            stops = data.references.stops.map(::DtoStop)
+                .map { RouteMapStop(it, directionsByStop[it.id].orEmpty()) },
             routes = data.references.routes.map(::DtoRoute),
             // Decoding the route's shape polylines is the one bit of non-trivial CPU work in this
             // layer; offload just it (the Retrofit calls are already main-safe, like the other sources).

--- a/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/TripExtrapolationBuilder.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/TripExtrapolationBuilder.kt
@@ -85,6 +85,10 @@ private fun extrapolatedVehicleProjection(state: TripState, nowMs: Long): Vehicl
  * pure function the route controller's vehicle sampler calls each display frame (and that unit tests
  * can call directly without Android).
  *
+ * When [directionId] is non-null, only vehicles whose currently-served trip runs that GTFS direction
+ * are kept — the "show vehicles on map" filter that drops the opposite-direction buses. Null keeps
+ * both directions (the whole-route view).
+ *
  * Each vehicle is dead-reckoned forward from its last fix via [extrapolatedVehicleProjection] when the
  * trip's shape is known, else placed at the reported last-known/position point. [ExtrapolatedVehicle.fixTimeMs]
  * is the store's anchor instant (constant between fixes) when extrapolating, else the reported update
@@ -94,12 +98,14 @@ fun extrapolatedVehicles(
     routeTrips: RouteTrips,
     routeIds: Set<String>,
     nowMs: Long,
+    directionId: Int? = null,
     lookupState: (String?) -> TripState?,
 ): List<ExtrapolatedVehicle> =
     routeTrips.trips.mapNotNull { trip ->
         val status = trip.status ?: return@mapNotNull null
-        val activeRoute = routeTrips.trip(status.activeTripId)?.routeId ?: return@mapNotNull null
-        if (activeRoute !in routeIds || Status.CANCELED == status.status) return@mapNotNull null
+        val activeTrip = routeTrips.trip(status.activeTripId) ?: return@mapNotNull null
+        if (activeTrip.routeId !in routeIds || Status.CANCELED == status.status) return@mapNotNull null
+        if (directionId != null && activeTrip.directionId != directionId) return@mapNotNull null
         val state = lookupState(status.activeTripId)
         val projection = state?.let { extrapolatedVehicleProjection(it, nowMs) }
         val point = projection?.point

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapParams.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapParams.java
@@ -26,6 +26,9 @@ public class MapParams {
 
     public static final String ROUTE_ID = ".RouteId";
 
+    // The stop a "show vehicles on map" launch anchored to, so route mode restores its direction filter.
+    public static final String ROUTE_DIRECTION_STOP_ID = ".RouteDirectionStopId";
+
     public static final String CENTER_LAT = ".MapCenterLat";
 
     public static final String CENTER_LON = ".MapCenterLon";

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
@@ -236,19 +236,21 @@ class MapViewModel @Inject constructor(
      * restore). Callers ([toRoute] and the restore in `init`) only ever pass a route different from the
      * current one — re-selecting the active route is handled (re-framed) by [toRoute].
      */
-    private fun enterRoute(routeId: String, zoomToRoute: Boolean) {
+    private fun enterRoute(routeId: String, zoomToRoute: Boolean, directionStopId: String?) {
         leaveCurrentView()
-        persistRoute(routeId)
-        routeController.start(routeId, zoomToRoute)
+        persistRoute(routeId, directionStopId)
+        routeController.start(routeId, zoomToRoute, directionStopId)
         bikeController.start(directions = false, selectedBikeStationIds = null)
     }
 
     // Persist which route (if any) to restore across process death — null means nearby stops. This is
     // the whole "which view" state (the route controller is the single live source of truth), so there's
-    // no separate mode to save. The transient trip-focus view deliberately doesn't touch this, so a
-    // back-press restores the prior view.
-    private fun persistRoute(routeId: String?) {
+    // no separate mode to save. [directionStopId] rides along so a restored route keeps its direction
+    // filter. The transient trip-focus view deliberately doesn't touch this, so a back-press restores
+    // the prior view.
+    private fun persistRoute(routeId: String?, directionStopId: String? = null) {
         savedStateHandle[MapParams.ROUTE_ID] = routeId
+        savedStateHandle[MapParams.ROUTE_DIRECTION_STOP_ID] = directionStopId
     }
 
     /**
@@ -308,17 +310,21 @@ class MapViewModel @Inject constructor(
     // ----- "Show route on map" / leave route mode (replaces ShowRoute / ExitRouteMode commands) -----
 
     /**
-     * Focus the map on [routeId] — the single entry every "show route on map" caller funnels through (the
-     * recent/starred lists, route search, the arrivals "show vehicles on map", RouteInfo). Enters route
-     * mode (loading its shape, stops, and live vehicles) and frames the route's bounding box. Re-frames
-     * even when the map is already parked on [routeId]: re-tapping it in the recent-routes list (the routes
-     * you most recently viewed) snaps the camera back to the route's extent instead of no-op'ing.
+     * Focus the map on [request]'s route — the single entry every "show route on map" caller funnels
+     * through (the recent/starred lists, route search, the arrivals "show vehicles on map", RouteInfo).
+     * Enters route mode (loading its shape, stops, and live vehicles) and frames the route's bounding
+     * box. Re-frames even when the map is already parked on that route + direction: re-tapping it in the
+     * recent-routes list snaps the camera back to the route's extent instead of no-op'ing.
      */
-    fun toRoute(routeId: String) {
-        if (routeController.routeId == routeId) {
+    fun toRoute(request: ShowRouteRequest) {
+        // Same route AND same direction anchor: just reframe (the recent-routes re-tap). A different
+        // route, or the same route from a different-direction stop, re-enters with the new filter.
+        if (routeController.routeId == request.routeId &&
+            routeController.directionStopId == request.directionStopId
+        ) {
             mapHost.frameRoute()
         } else {
-            enterRoute(routeId, zoomToRoute = true)
+            enterRoute(request.routeId, zoomToRoute = true, directionStopId = request.directionStopId)
         }
     }
 
@@ -408,7 +414,11 @@ class MapViewModel @Inject constructor(
             // ZOOM_TO_ROUTE is a launching-intent framing flag (consumed once); [persistRoute]
             // deliberately doesn't write it, so a process-death restore keeps the saved camera rather
             // than re-framing the route.
-            enterRoute(restoreRouteId, zoomToRoute = savedStateHandle[MapParams.ZOOM_TO_ROUTE] ?: false)
+            enterRoute(
+                restoreRouteId,
+                zoomToRoute = savedStateHandle[MapParams.ZOOM_TO_ROUTE] ?: false,
+                directionStopId = savedStateHandle[MapParams.ROUTE_DIRECTION_STOP_ID],
+            )
         } else {
             showNearbyStops()
         }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
@@ -77,6 +77,21 @@ class RouteMapController(
     var routeId: String? = null
         private set
 
+    // The stop the "show vehicles on map" launch anchored to (null for a whole-route launch). Set in
+    // start(); resolved against the loaded route's direction grouping in onRouteLoaded to the
+    // directionFilter below. Exposed so a re-tap that keeps the route but changes the direction anchor
+    // re-enters (rather than just reframing).
+    var directionStopId: String? = null
+        private set
+
+    // What direction the vehicle layer should show — the single source of truth the per-frame sampler
+    // reads (so it's a field, not a captured value; the sampler is installed in start() before the route
+    // loads). [DirectionState.Pending] holds the layer back while a direction-anchored launch waits for
+    // the (slower) stops-for-route load — otherwise every vehicle would flash for those seconds and then
+    // the opposite direction would cull. [DirectionState.Resolved] carries the filter to apply (null =
+    // both directions). One value, not a filter plus a "resolved yet?" boolean, so the two can't disagree.
+    private var directionState: DirectionState = DirectionState.Resolved(null)
+
     /** Whether a route is currently shown (drives the home map's route-header focus bias). */
     val isActive: Boolean get() = routeId != null
 
@@ -93,22 +108,34 @@ class RouteMapController(
 
     /**
      * Show route [routeId]: load the route + header and start the vehicle poll. [zoomToRoute] frames
-     * the shape once it loads (consumed once).
+     * the shape once it loads (consumed once). [directionStopId], when non-null, narrows the overlay to
+     * the single direction that serves that stop (the arrivals "show vehicles on map" launch); null
+     * shows the whole route.
      */
-    fun start(routeId: String, zoomToRoute: Boolean) {
+    fun start(routeId: String, zoomToRoute: Boolean, directionStopId: String? = null) {
         this.routeId = routeId
+        this.directionStopId = directionStopId
+        // A whole-route launch has no direction to wait for, so its vehicles show as soon as they poll;
+        // a direction-anchored launch stays Pending until the route load resolves the filter (below).
+        this.directionState =
+            if (directionStopId == null) DirectionState.Resolved(null) else DirectionState.Pending
         _loadedRoute.value = LoadedRoute.Loading
         host.setProgress(true)
         // The live vehicle layer: the renderer pulls a frame from this sampler each display frame,
         // dead-reckoning every vehicle in the latest poll forward to the frame's clock (the icon
         // decision lives here, not in the producer). Yields nothing until the first poll lands. The
-        // route-id filter set is built once here, not per frame, since it's constant for this route.
+        // route-id filter set is built once here, not per frame, since it's constant for this route;
+        // directionState is read live since it's resolved only once the route loads.
         val routeIds = setOf(routeId)
         renderState.setVehiclesSampler { nowMs ->
+            // Pending holds the layer back until the direction is known, so a direction launch never
+            // flashes the opposite-direction vehicles before the (slower) route load lands to cull them.
+            val resolved = directionState as? DirectionState.Resolved ?: return@setVehiclesSampler null
             latestPoll?.let { poll ->
                 MapVehicles(
                     markers = extrapolatedVehicles(
-                        poll.response, routeIds, nowMs, tripObservationRepository::lookupTripState
+                        poll.response, routeIds, nowMs, resolved.directionId,
+                        tripObservationRepository::lookupTripState,
                     ).map { it.toMarker() },
                     response = poll.response,
                 )
@@ -125,6 +152,8 @@ class RouteMapController(
         routeJob = null
         vehicleJob = null
         routeId = null
+        directionStopId = null
+        directionState = DirectionState.Resolved(null)
         latestPoll = null
         renderState.clearRoutePolylines()
         renderState.setVehiclesSampler(null)
@@ -148,7 +177,9 @@ class RouteMapController(
         val id = routeId ?: return
         routeJob?.cancel()
         routeJob = scope.launch {
-            val result = routeRepository.getRoute(id)
+            // The repository narrows the stops (and the vehicle direction id) to directionStopId's
+            // direction when set; a whole-route launch passes null and gets the full route back.
+            val result = routeRepository.getRoute(id, directionStopId)
             // Clear the spinner once the load resolves — before dispatching, so it's cleared on the
             // error path too (mirrors StopsMapController). A cancelled load never reaches here; the
             // view transition that cancelled it clears progress via leaveCurrentView().
@@ -158,6 +189,10 @@ class RouteMapController(
     }
 
     private fun onRouteLoaded(result: Result<RouteMap?>, zoomToRoute: Boolean) {
+        // The route load has resolved (success or failure), so release the vehicle layer the sampler
+        // held back in direction mode. Default to Resolved(null) here so an error path below falls back
+        // to showing vehicles unfiltered rather than hidden forever; the success path narrows it.
+        directionState = DirectionState.Resolved(null)
         val routeMap = result.getOrElse {
             MapUtils.showMapError((it as? ObaApiException)?.code ?: ObaApi.OBA_IO_EXCEPTION)
             return
@@ -173,6 +208,9 @@ class RouteMapController(
         renderState.setRoutePolylines(
             routeMap.polylines.map { points -> RoutePolyline(route.color, points) }
         )
+        // The repository already narrowed the stops to the stop-relevant direction (whole route when the
+        // launch had no anchor); its resolved direction id is what the vehicle sampler filters by.
+        directionState = DirectionState.Resolved(routeMap.directionId)
         stopsController.showStops(routeMap.stops, routeMap.routes)
         if (zoomToRoute) {
             host.frameRoute()
@@ -221,6 +259,18 @@ class RouteMapController(
 
 /** The latest trips-for-route [response] and the device clock ([loadNanos]) when it landed. */
 private data class VehiclePoll(val response: RouteTrips, val loadNanos: Long)
+
+/**
+ * What the vehicle layer should show while in route mode — the single value the per-frame sampler reads
+ * to decide whether (and how) to draw vehicles, so a filter and a "resolved yet?" flag can't disagree.
+ */
+private sealed interface DirectionState {
+    /** A direction-anchored launch is still waiting for the route load; the sampler draws nothing yet. */
+    data object Pending : DirectionState
+
+    /** The direction is known: keep only [directionId] (null = both directions / whole route). */
+    data class Resolved(val directionId: Int?) : DirectionState
+}
 
 /**
  * The raw route-load state [RouteMapController] publishes (null when not in route mode); [MapViewModel]

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapRepository.kt
@@ -20,44 +20,76 @@ import org.onebusaway.android.api.data.MapDataSource
 import javax.inject.Inject
 import org.onebusaway.android.models.ObaRoute
 import org.onebusaway.android.models.ObaStop
+import org.onebusaway.android.models.RouteMapStop
 import org.onebusaway.android.map.render.GeoPoint
 
-/** A route's stops, the serving routes (for stop-marker icons), the route + agency name, and its shape. */
+/**
+ * A route's stops (narrowed to a single direction when the load was direction-focused), the serving
+ * routes (for stop-marker icons), the route + agency name, its shape, and the resolved [directionId]
+ * the vehicle layer keeps (null = both directions / whole route).
+ */
 data class RouteMap(
     val route: ObaRoute?,
     val agencyName: String?,
     val stops: List<ObaStop>,
     val routes: List<ObaRoute>,
     val polylines: List<List<GeoPoint>>,
+    val directionId: Int?,
 )
 
 /**
  * Loads a route's stops + shapes (one-shot, stops-for-route with polylines) for the route/stop
  * overlays, via the io.client [MapDataSource]. Turns the source's [android.location.Location] shape
- * points into the render [GeoPoint]s the overlay consumes. (Route-mode real-time vehicles are polled
- * via the trip-observation repository's `routeVehiclesStream`.)
+ * points into the render [GeoPoint]s the overlay consumes, and — when the caller passes a
+ * `directionStopId` — narrows the stops to that stop's direction. (Route-mode real-time vehicles are
+ * polled via the trip-observation repository's `routeVehiclesStream`.)
  */
 interface RouteMapRepository {
-    /** @return the route's stops/shape, or `success(null)` when there is no API endpoint. */
-    suspend fun getRoute(routeId: String): Result<RouteMap?>
+    /**
+     * @param directionStopId when non-null, narrow the returned stops (and [RouteMap.directionId]) to
+     *   the single direction serving that stop; null (or an ambiguous stop) returns the whole route.
+     * @return the route's stops/shape, or `success(null)` when there is no API endpoint.
+     */
+    suspend fun getRoute(routeId: String, directionStopId: String? = null): Result<RouteMap?>
 }
 
 class DefaultRouteMapRepository @Inject constructor(
     private val mapDataSource: MapDataSource,
 ) : RouteMapRepository {
 
-    override suspend fun getRoute(routeId: String): Result<RouteMap?> =
+    override suspend fun getRoute(routeId: String, directionStopId: String?): Result<RouteMap?> =
         mapDataSource.routeMap(routeId).map { data ->
             data?.let {
+                val focus = it.stops.focusDirection(directionStopId)
                 RouteMap(
                     route = it.route,
                     agencyName = it.agencyName,
-                    stops = it.stops,
+                    stops = focus.stops,
                     routes = it.routes,
                     polylines = it.polylines.map { line ->
                         line.map { p -> GeoPoint(p.latitude, p.longitude) }
                     },
+                    directionId = focus.directionId,
                 )
             }
         }
+}
+
+/** The direction-narrowed [stops] plus the resolved vehicle [directionId] (null = show all). */
+internal data class DirectionFocus(val stops: List<ObaStop>, val directionId: Int?)
+
+/**
+ * Narrows a route's [RouteMapStop]s to the single direction serving [anchorStopId] — the stop a
+ * "show vehicles on map" launch anchored to. Returns the whole route (all stops, null [directionId])
+ * when there's no anchor, the anchor isn't among the stops, or its direction is ambiguous (it belongs
+ * to zero or several direction groups — e.g. an ungrouped or shared/loop stop). When the anchor sits
+ * in exactly one direction, the stops are filtered to that direction (shared stops that also serve it
+ * included) and its id returned as the vehicle filter. Pure; unit-tested.
+ */
+internal fun List<RouteMapStop>.focusDirection(anchorStopId: String?): DirectionFocus {
+    val allStops = map { it.stop }
+    if (anchorStopId == null) return DirectionFocus(allStops, null)
+    val target = firstOrNull { it.stop.id == anchorStopId }?.directionIds?.singleOrNull()
+        ?: return DirectionFocus(allStops, null)
+    return DirectionFocus(filter { target in it.directionIds }.map { it.stop }, target)
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/ShowRouteRequest.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/ShowRouteRequest.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.map
+
+/**
+ * The intent to show a route on the map — the single payload every "show route on map" launcher builds
+ * and both UI transports carry opaquely (the navigation reveal in `MapReveal` and the home
+ * `MapDirective.ShowRoute`), unwrapped once at [MapViewModel.toRoute]. Bundling the parameters here
+ * (rather than threading them one-by-one through the callback + directive + reveal hops) keeps adding a
+ * new "show route on map" parameter a change to this one type instead of every layer in between.
+ *
+ * @property routeId the route to show.
+ * @property directionStopId when non-null (the arrivals "show vehicles on map" launch), the stop whose
+ *   direction the map narrows to; null shows the whole route.
+ */
+data class ShowRouteRequest(
+    val routeId: String,
+    val directionStopId: String? = null,
+)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/models/MapData.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/models/MapData.kt
@@ -28,12 +28,23 @@ data class NearbyStops(
 /**
  * A route's stops, the serving routes (for stop-marker icons), the route + agency name, and its
  * decoded shape. Polylines are [Location] points (the neutral geo type); the map layer turns them
- * into its render `GeoPoint`s.
+ * into its render `GeoPoint`s. Each [RouteMapStop] carries the direction(s) it serves, so the overlay
+ * can be narrowed to a single stop-relevant direction without a separate id index.
  */
 data class RouteMapData(
     val route: ObaRoute?,
     val agencyName: String?,
-    val stops: List<ObaStop>,
+    val stops: List<RouteMapStop>,
     val routes: List<ObaRoute>,
     val polylines: List<List<Location>>,
+)
+
+/**
+ * A [stop] as it appears on a route, tagged with the GTFS [directionIds] whose stop groups list it —
+ * usually a single direction, a two-element set for a stop shared between both directions, and empty
+ * when the route has no (numeric) direction grouping.
+ */
+data class RouteMapStop(
+    val stop: ObaStop,
+    val directionIds: Set<Int>,
 )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalActionHandlers.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalActionHandlers.kt
@@ -15,6 +15,7 @@
  */
 package org.onebusaway.android.ui.arrivals
 
+import org.onebusaway.android.map.ShowRouteRequest
 import org.onebusaway.android.ui.tripinfo.TripInfoLauncher
 import org.onebusaway.android.ui.tripdetails.TripDetailsLauncher
 import org.onebusaway.android.ui.arrivals.dialogs.RouteFavoriteHost
@@ -39,7 +40,8 @@ fun createArrivalActionHandler(
     activity: AppCompatActivity,
     viewModel: ArrivalsViewModel,
     currentContent: () -> ArrivalsUiState.Content?,
-    onShowRouteOnMap: (routeId: String) -> Unit,
+    // Carries the arrival's stop in the request, so route mode can narrow to the stop-relevant direction.
+    onShowRouteOnMap: (ShowRouteRequest) -> Unit,
     // How to show the alert hide/undo snackbar — supplied by the host so the dialog isn't tied to a
     // specific View (the standalone activity anchors to its root; Compose hosts use a SnackbarHost).
     showUndoSnackbar: (messageRes: Int, actionRes: Int?, onAction: (() -> Unit)?) -> Unit,
@@ -67,7 +69,8 @@ fun createArrivalActionHandler(
 
     override fun onShowVehiclesOnMap(arrival: ArrivalInfo) {
         DBUtil.addRouteToDB(activity, arrival)
-        onShowRouteOnMap(arrival.routeId)
+        // Pass the arrival's stop so route mode shows only the direction (stops + vehicles) serving it.
+        onShowRouteOnMap(ShowRouteRequest(arrival.routeId, arrival.stopId))
     }
 
     override fun onShowTripStatus(arrival: ArrivalInfo) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsDestinations.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsDestinations.kt
@@ -112,9 +112,7 @@ fun NavGraphBuilder.arrivalsGraph(navController: NavHostController) {
                 activity = activity,
                 viewModel = arrivalsVm,
                 currentContent = { arrivalsVm.state.value as? ArrivalsUiState.Content },
-                onShowRouteOnMap = { routeId ->
-                    navController.revealRouteOnMap(routeId)
-                },
+                onShowRouteOnMap = { request -> navController.revealRouteOnMap(request) },
                 showUndoSnackbar = { messageRes, actionRes, onAction ->
                     scope.launch {
                         val result = snackbarHostState.showSnackbar(

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeNavHost.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeNavHost.kt
@@ -73,6 +73,7 @@ import org.onebusaway.android.ui.nav.IntentRouteMapper
 import org.onebusaway.android.ui.nav.NavHelp
 import org.onebusaway.android.ui.nav.NavRoutes
 import org.onebusaway.android.ui.nav.RESULT_MAP_ROUTE_ID
+import org.onebusaway.android.ui.nav.consumeRouteReveal
 import org.onebusaway.android.ui.nav.RESULT_MAP_STOP_ID
 import org.onebusaway.android.ui.nav.consumeStopReveal
 import org.onebusaway.android.ui.nav.navigateFromHome
@@ -130,10 +131,11 @@ fun HomeNavHost(
             val revealStopId by handle.getStateFlow<String?>(RESULT_MAP_STOP_ID, null)
                 .collectAsStateWithLifecycle()
             LaunchedEffect(revealRouteId) {
-                revealRouteId?.let { routeId ->
-                    home.mapViewModel.toRoute(routeId)
-                    handle[RESULT_MAP_ROUTE_ID] = null
-                }
+                if (revealRouteId == null) return@LaunchedEffect
+                // Read + consume the route id and its optional direction anchor atomically via the typed
+                // helper (which owns both key names), mirroring the stop branch below.
+                val request = handle.consumeRouteReveal() ?: return@LaunchedEffect
+                home.mapViewModel.toRoute(request)
             }
             LaunchedEffect(revealStopId) {
                 if (revealStopId == null) return@LaunchedEffect

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -62,6 +62,7 @@ import org.onebusaway.android.ui.arrivals.ArrivalsLoaded
 import org.onebusaway.android.ui.nav.ReminderEditorArgs
 import org.onebusaway.android.map.RouteHeader
 import org.onebusaway.android.map.MapViewModel
+import org.onebusaway.android.map.ShowRouteRequest
 import org.onebusaway.android.ui.arrivals.ArrivalsViewModel
 import org.onebusaway.android.ui.compose.navigationBarBottomPadding
 import org.onebusaway.android.ui.compose.rememberSheetExpandProgress
@@ -138,7 +139,7 @@ class HomeActivityActions(
     val onSheetSettled: (ArrivalsSheetState, Int) -> Unit,
     val onClearFocus: () -> Unit,
     val onArrivalsLoaded: (ArrivalsLoaded) -> Unit,
-    val onShowRouteOnMap: (String) -> Unit,
+    val onShowRouteOnMap: (ShowRouteRequest) -> Unit,
     val onToggleSheet: () -> Unit,
     val onCancelRouteMode: () -> Unit,
 )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
@@ -21,6 +21,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+import org.onebusaway.android.map.ShowRouteRequest
 import org.onebusaway.android.region.Region
 import org.onebusaway.android.models.ObaRoute
 import org.onebusaway.android.models.ObaStop
@@ -242,10 +243,13 @@ class HomeViewModel @Inject constructor(
         emitMapDirective(MapDirective.FocusStop(stop, routes, settledSheet == ArrivalsSheetState.Expanded))
     }
 
-    /** "Show vehicles on map" — collapse the sheet (screen), then switch the map to route mode. */
-    fun requestShowRouteOnMap(routeId: String) {
+    /**
+     * "Show vehicles on map" — collapse the sheet (screen), then switch the map to route mode. The
+     * [request] carries the route and (for the arrivals-row launch) the direction stop to focus on.
+     */
+    fun requestShowRouteOnMap(request: ShowRouteRequest) {
         emit(SheetCommand.CollapseSheet)
-        emitMapDirective(MapDirective.ShowRoute(routeId))
+        emitMapDirective(MapDirective.ShowRoute(request))
     }
 
     /**
@@ -392,8 +396,8 @@ sealed interface MapDirective {
     /** Animate the camera to recenter on the currently focused stop (sheet expanded). */
     data class RecenterOnFocusedStop(val lat: Double, val lon: Double) : MapDirective
 
-    /** Enter route mode for the given route (the "show vehicles on map" action). */
-    data class ShowRoute(val routeId: String) : MapDirective
+    /** Enter route mode for [request]'s route (the "show vehicles on map" action). */
+    data class ShowRoute(val request: ShowRouteRequest) : MapDirective
 
     /** Clear the map's render focus (back-press from a peeking arrivals sheet). */
     object ClearFocus : MapDirective

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/arrivals/ArrivalsSheetHost.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/arrivals/ArrivalsSheetHost.kt
@@ -34,6 +34,7 @@ import androidx.lifecycle.viewmodel.viewModelFactory
 import kotlinx.coroutines.flow.first
 import org.onebusaway.android.R
 import org.onebusaway.android.app.di.PreferencesEntryPoint
+import org.onebusaway.android.map.ShowRouteRequest
 import org.onebusaway.android.preferences.PreferencesRepository
 import org.onebusaway.android.ui.arrivals.ArrivalsLoaded
 import org.onebusaway.android.ui.arrivals.components.ArrivalsPanel
@@ -73,7 +74,7 @@ internal fun ArrivalsSheetHost(
     expandProgress: () -> Float,
     arrivalsViewModelFactory: ArrivalsViewModel.Factory,
     onArrivalsLoaded: (ArrivalsLoaded) -> Unit,
-    onShowRouteOnMap: (String) -> Unit,
+    onShowRouteOnMap: (ShowRouteRequest) -> Unit,
     onShowTrip: (tripId: String, stopId: String) -> Unit,
     onEditReminder: (args: ReminderEditorArgs) -> Unit,
     onToggleSheet: () -> Unit,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
@@ -190,7 +190,7 @@ fun MapFeature(
             when (directive) {
                 is MapDirective.RecenterOnFocusedStop ->
                     mapViewModel.recenterOnFocusedStop(directive.lat, directive.lon)
-                is MapDirective.ShowRoute -> mapViewModel.toRoute(directive.routeId)
+                is MapDirective.ShowRoute -> mapViewModel.toRoute(directive.request)
                 MapDirective.ClearFocus -> mapViewModel.clearFocus()
                 is MapDirective.FocusStop ->
                     mapViewModel.focusStop(directive.stop, directive.routes, directive.overlayExpanded)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/nav/MapReveal.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/nav/MapReveal.kt
@@ -17,6 +17,7 @@ package org.onebusaway.android.ui.nav
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.NavController
+import org.onebusaway.android.map.ShowRouteRequest
 
 /**
  * Navigate to an in-app [route], popping up to HOME and de-duping the top — the single navigation
@@ -42,14 +43,37 @@ fun NavController.navigateFromHome(route: String) =
  * HOME is the NavHost start destination, so it is always on the back stack and [getBackStackEntry] is safe.
  */
 const val RESULT_MAP_ROUTE_ID = "mapReveal.routeId"
+const val RESULT_MAP_ROUTE_DIRECTION_STOP_ID = "mapReveal.routeDirectionStopId"
 const val RESULT_MAP_STOP_ID = "mapReveal.stopId"
 const val RESULT_MAP_STOP_LAT = "mapReveal.stopLat"
 const val RESULT_MAP_STOP_LON = "mapReveal.stopLon"
 
-/** Reveal the map in route mode for [routeId], popping back to HOME. */
-fun NavController.revealRouteOnMap(routeId: String) {
-    getBackStackEntry(NavRoutes.HOME).savedStateHandle[RESULT_MAP_ROUTE_ID] = routeId
+/**
+ * Reveal the map in route mode for [request], popping back to HOME. The [ShowRouteRequest] is serialized
+ * to the `RESULT_MAP_ROUTE_*` keys and read back by [consumeRouteReveal] — the one place field names live.
+ */
+fun NavController.revealRouteOnMap(request: ShowRouteRequest) {
+    val handle = getBackStackEntry(NavRoutes.HOME).savedStateHandle
+    handle[RESULT_MAP_ROUTE_ID] = request.routeId
+    handle[RESULT_MAP_ROUTE_DIRECTION_STOP_ID] = request.directionStopId
     popBackStack(NavRoutes.HOME, /* inclusive = */ false)
+}
+
+/** Reveal the whole route [routeId] on the map (no direction focus) — the plain-route launchers. */
+fun NavController.revealRouteOnMap(routeId: String) = revealRouteOnMap(ShowRouteRequest(routeId))
+
+/**
+ * Reads and consumes a pending route reveal from the HOME [SavedStateHandle] — the symmetric typed
+ * *read* for [revealRouteOnMap], keeping the `RESULT_MAP_ROUTE_*` key names in this one file rather
+ * than re-reading them in the consumer. The keys are cleared together (so a stale direction anchor
+ * can't linger past the reveal); returns null when no route id is present.
+ */
+fun SavedStateHandle.consumeRouteReveal(): ShowRouteRequest? {
+    val routeId = get<String>(RESULT_MAP_ROUTE_ID)
+    val directionStopId = get<String>(RESULT_MAP_ROUTE_DIRECTION_STOP_ID)
+    set(RESULT_MAP_ROUTE_ID, null)
+    set(RESULT_MAP_ROUTE_DIRECTION_STOP_ID, null)
+    return routeId?.let { ShowRouteRequest(it, directionStopId) }
 }
 
 /** Reveal the map focused on [stopId] at [lat]/[lon], popping back to HOME. */

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteDirectionFocusTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteDirectionFocusTest.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.map
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.onebusaway.android.api.adapters.ObaStopElement
+import org.onebusaway.android.models.RouteMapStop
+
+/** [focusDirection] — the pure "narrow a route to the stop-relevant direction" repository helper. */
+class RouteDirectionFocusTest {
+
+    private fun stop(id: String, vararg directions: Int) =
+        RouteMapStop(ObaStopElement(id = id), directions.toSet())
+
+    // Outbound (direction 0) serves a/b, inbound (direction 1) serves c/d.
+    private val stops = listOf(stop("a", 0), stop("b", 0), stop("c", 1), stop("d", 1))
+
+    @Test
+    fun nullAnchorKeepsWholeRoute() {
+        val focus = stops.focusDirection(anchorStopId = null)
+        assertEquals(listOf("a", "b", "c", "d"), focus.stops.map { it.id })
+        assertNull(focus.directionId)
+    }
+
+    @Test
+    fun anchorInOneDirectionFiltersStopsAndResolvesId() {
+        val focus = stops.focusDirection(anchorStopId = "c")
+        assertEquals(listOf("c", "d"), focus.stops.map { it.id })
+        assertEquals(1, focus.directionId)
+    }
+
+    @Test
+    fun filteredStopsPreserveSourceOrder() {
+        // A source order of d before c must survive the filter to direction 1.
+        val reordered = listOf(stop("d", 1), stop("c", 1), stop("a", 0))
+        assertEquals(listOf("d", "c"), reordered.focusDirection("c").stops.map { it.id })
+    }
+
+    @Test
+    fun sharedStopInTargetDirectionIsIncluded() {
+        // A stop serving both directions shows for the tapped one (not dropped).
+        val withShared = stops + stop("s", 0, 1)
+        val focus = withShared.focusDirection(anchorStopId = "a")
+        assertEquals(listOf("a", "b", "s"), focus.stops.map { it.id })
+        assertEquals(0, focus.directionId)
+    }
+
+    @Test
+    fun ambiguousSharedAnchorKeepsWholeRoute() {
+        // Anchoring on a stop that serves both directions is ambiguous -> whole route.
+        val withShared = stops + stop("s", 0, 1)
+        val focus = withShared.focusDirection(anchorStopId = "s")
+        assertEquals(5, focus.stops.size)
+        assertNull(focus.directionId)
+    }
+
+    @Test
+    fun anchorNotAmongStopsKeepsWholeRoute() {
+        val focus = stops.focusDirection(anchorStopId = "zzz")
+        assertEquals(4, focus.stops.size)
+        assertNull(focus.directionId)
+    }
+
+    @Test
+    fun ungroupedAnchorKeepsWholeRoute() {
+        // A stop with no direction membership (route without a numeric direction grouping) -> whole route.
+        val withUngrouped = stops + stop("u")
+        val focus = withUngrouped.focusDirection(anchorStopId = "u")
+        assertEquals(5, focus.stops.size)
+        assertNull(focus.directionId)
+    }
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
@@ -28,6 +28,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.onebusaway.android.location.FakeLocationRepository
+import org.onebusaway.android.map.ShowRouteRequest
 import org.onebusaway.android.region.FakeRegionRepository
 import org.onebusaway.android.region.RegionStatus
 import org.onebusaway.android.region.region
@@ -50,7 +51,7 @@ private class MapDirectiveRecorder(private val vm: HomeViewModel) {
     val sent = mutableListOf<MapDirective>()
 
     val recenters get() = sent.filterIsInstance<MapDirective.RecenterOnFocusedStop>().map { it.lat to it.lon }
-    val routesShown get() = sent.filterIsInstance<MapDirective.ShowRoute>().map { it.routeId }
+    val routesShown get() = sent.filterIsInstance<MapDirective.ShowRoute>().map { it.request.routeId }
     val clearFocusCount get() = sent.count { it is MapDirective.ClearFocus }
     val focusStops get() = sent.filterIsInstance<MapDirective.FocusStop>()
     val lastBottomPadding get() = vm.mapBottomPadding.value
@@ -269,7 +270,7 @@ class HomeViewModelTest {
         val eventJob = launch { vm.sheetCommands.collect { events.add(it) } }
         advanceUntilIdle()
 
-        vm.requestShowRouteOnMap("42")
+        vm.requestShowRouteOnMap(ShowRouteRequest("42"))
         advanceUntilIdle()
 
         assertEquals(listOf<SheetCommand>(SheetCommand.CollapseSheet), events)


### PR DESCRIPTION
## Summary

Tapping **Show vehicles on map** from a stop's arrival row put the map into route mode showing the *whole* route: every live vehicle (including opposite-direction buses that had already passed the stop) and every stop across all direction variants. Since the user tapped an arrival at a specific stop, only that stop's direction is relevant.

Now the map shows only the stops and vehicles heading in the **stop-relevant direction**. Every other "show route on map" entry point (My Routes, route search, RouteInfo's map button) is unchanged — they still show the whole route.

## How it works

- The tapped stop id is threaded through the existing "show route on map" path as an optional `directionStopId` (default `null`, so the other launchers are untouched).
- `stops-for-route` groups stops by direction, each group carrying the GTFS direction id (`"0"`/`"1"`), so the map data source tags each stop with the direction(s) it serves (`RouteMapStop.directionIds`).
- `RouteMapRepository` narrows the stops to the tapped stop's direction and resolves the direction id; the vehicle sampler filters live vehicles to trips with that `directionId`.
- An **ambiguous** stop (in zero or several direction groups — e.g. a shared/loop stop) falls back to the whole route.

## No flash-then-cull

The vehicle poll (trips-for-route) lands before the slower stops-for-route load that resolves the direction. To avoid flashing all vehicles and then culling the opposite direction, the controller holds the vehicle layer back in a direction launch until the load resolves (`DirectionState.Pending → Resolved`), so vehicles appear already-filtered alongside the stops. Whole-route launches are unaffected (vehicles show as soon as they poll).

## Notes

- The route reveal gained a typed `RouteReveal` / `consumeRouteReveal` helper mirroring the sibling stop reveal.
- Direction membership lives on the stop and the narrowing is a repository concern; the render controller just draws what it's handed.

## Testing

- `RouteDirectionFocusTest` (JVM) — 7 cases covering the direction focus, including the shared-stop and ambiguous-anchor fallbacks.
- `ExtrapolatedVehiclesTest` — added direction-filter cases with a new fixture.
- Built and manually exercised on device (Pixel 7 Pro).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Map route display now preserves direction when launched from a specific stop, so vehicles and stops can stay aligned to the selected direction.
  * Route reveals now carry both route and direction-stop context across navigation and app restarts.
  * Route maps can now show direction-specific stop grouping information.

* **Bug Fixes**
  * Fixed route and vehicle views so direction-filtered launches no longer lose their selected direction after switching screens or restoring state.
  * Improved empty-route handling in route filtering checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->