### PR TITLE
Fix vehicle map marker rendered "scheduled" for live vehicles

### DIFF
--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleComposeAdapter.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleComposeAdapter.kt
@@ -347,7 +347,7 @@ private fun GoogleInfoWindows.openVehicleWindow(renderer: GoogleMapRenderer, mar
         // want the latest poll at render time rather than a collectAsState that would never recompose here.
         @Suppress("StateFlowValueCalledInComposition")
         val response = renderer.vehicleResponse.value
-        if (live != null && response != null) VehicleInfoWindow(live.status, response)
+        if (live != null && response != null) VehicleInfoWindow(live.status, live.isRealtime, response)
     }
 }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/TripExtrapolation.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/TripExtrapolation.kt
@@ -64,4 +64,8 @@ data class ExtrapolatedVehicle(
     val bearing: Float,
     val fixTimeMs: Long,
     val status: ObaTripStatus,
+    // Live-vs-scheduled, decided at draw time from whatever produced [point] (the extrapolation anchor
+    // when [point] is extrapolated, else the current status), so the icon/info-window can't disagree
+    // with the position the marker is actually drawn at. See #1621.
+    val isRealtime: Boolean,
 )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/TripExtrapolationBuilder.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/TripExtrapolationBuilder.kt
@@ -112,12 +112,21 @@ fun extrapolatedVehicles(
             ?: status.lastKnownLocation?.toGeoPoint()
             ?: status.position?.toGeoPoint()
             ?: return@mapNotNull null
+        // Real-time iff the source of [point] is real-time: an extrapolated point inherits its anchor
+        // fix's flag, a point taken from the current status uses that status'. This keeps the marker
+        // from reading "scheduled" for a vehicle we're actively tracking/extrapolating (#1621).
+        val isRealtime = if (projection != null) {
+            state?.anchor?.isLocationRealtime == true
+        } else {
+            status.isLocationRealtime
+        }
         ExtrapolatedVehicle(
             point = point,
             // The path tangent off the shape; NaN off-shape, so the marker falls back to the orientation.
             bearing = projection?.bearing ?: Float.NaN,
             fixTimeMs = state?.anchorLocalTimeMs?.takeIf { it > 0L } ?: status.lastUpdateTime,
             status = status,
+            isRealtime = isRealtime,
         )
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
@@ -242,15 +242,15 @@ class RouteMapController(
     }
 
     /**
-     * Builds the render [VehicleMarker] from a display-free [ExtrapolatedVehicle], deriving the
-     * live-vs-scheduled flag from the source status (the renderer picks its icon from it).
+     * Builds the render [VehicleMarker] from a display-free [ExtrapolatedVehicle], carrying the
+     * draw-time live-vs-scheduled flag through (the renderer picks its icon from it).
      */
     private fun ExtrapolatedVehicle.toMarker(): VehicleMarker =
         VehicleMarker(
             // Vehicles are only built for trips with a resolvable active id, so this is non-null here.
             activeTripId = status.activeTripId.orEmpty(),
             point = point,
-            isRealtime = status.isLocationRealtime,
+            isRealtime = isRealtime,
             status = status,
             fixTimeMs = fixTimeMs,
             bearing = bearing,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/compose/VehicleInfoWindow.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/compose/VehicleInfoWindow.kt
@@ -65,32 +65,29 @@ import java.util.concurrent.TimeUnit
  * `ComposeView`.
  */
 @Composable
-fun VehicleInfoWindow(status: ObaTripStatus, response: RouteTrips) {
+fun VehicleInfoWindow(status: ObaTripStatus, isRealtime: Boolean, response: RouteTrips) {
     val res = LocalContext.current.resources
     val nowMs = rememberNowMs()
     // The window only opens for an already-rendered vehicle, so its trip/route are in the refs;
     // guard the unreachable null instead of dereferencing (the legacy getTrip/getRoute would NPE).
     val trip = response.trip(status.activeTripId) ?: return
     val route = response.route(trip.routeId) ?: return
-    val realtime = status.isLocationRealtime
     val deviationMin = TimeUnit.SECONDS.toMinutes(status.scheduleDeviation)
 
+    // [isRealtime] is the drawn marker's live-vs-scheduled flag (from the renderer), so the window can't
+    // disagree with the icon; the arrival listings share the scheduled-vs-deviation coloring via ArrivalInfoUtils.
     VehicleInfoWindowContent(
         title = getRouteDisplayName(route) + " " +
             stringResource(R.string.trip_info_separator) + " " +
             MyTextUtils.formatDisplayText(trip.headsign),
-        statusLabel = if (realtime) {
+        statusLabel = if (isRealtime) {
             ArrivalInfoUtils.computeArrivalLabelFromDelay(res, deviationMin)
         } else {
             stringResource(R.string.stop_info_scheduled)
         },
-        statusColor = if (realtime) {
-            colorResource(ArrivalInfoUtils.computeColorFromDeviation(deviationMin))
-        } else {
-            colorResource(R.color.stop_info_scheduled_time)
-        },
-        occupancyDots = if (realtime) occupancyDots(status.occupancyStatus) else 0,
-        lastUpdated = lastUpdatedText(res, realtime, status, nowMs),
+        statusColor = colorResource(ArrivalInfoUtils.statusColor(isRealtime, deviationMin)),
+        occupancyDots = if (isRealtime) occupancyDots(status.occupancyStatus) else 0,
+        lastUpdated = lastUpdatedText(res, isRealtime, status, nowMs),
     )
 }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
@@ -83,7 +83,8 @@ data class GenericMarker(val point: GeoPoint, val hue: Float?)
  * One real-time vehicle marker. [status] is the raw io/elements status (the renderer derives the
  * icon, color, and info-window text from it, paired with the shared [MapVehicles.response]);
  * [activeTripId] is the stable key used for marker identity + animation; [isRealtime] is the
- * populate-time decision (last-known location present + predicted) that selects the live-vs-scheduled icon.
+ * draw-time decision (from whatever produced the drawn point — the extrapolation anchor or the current
+ * status) that selects the live-vs-scheduled icon.
  */
 data class VehicleMarker(
     val activeTripId: String,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/VehicleBitmaps.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/VehicleBitmaps.java
@@ -115,11 +115,8 @@ public final class VehicleBitmaps {
 
     /** The schedule-deviation color (realtime) or the scheduled color — constant between polls. */
     private static int colorResource(VehicleMarker vehicle) {
-        if (vehicle.isRealtime()) {
-            long deviationMin = TimeUnit.SECONDS.toMinutes(vehicle.getStatus().getScheduleDeviation());
-            return ArrivalInfoUtils.computeColorFromDeviation(deviationMin);
-        }
-        return R.color.stop_info_scheduled_time;
+        long deviationMin = TimeUnit.SECONDS.toMinutes(vehicle.getStatus().getScheduleDeviation());
+        return ArrivalInfoUtils.statusColor(vehicle.isRealtime(), deviationMin);
     }
 
     /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/models/ObaTripStatus.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/models/ObaTripStatus.kt
@@ -105,9 +105,19 @@ interface ObaTripStatus {
     val occupancyStatus: Occupancy?
 
     /**
-     * True if the server provided a real-time location for this vehicle — i.e. it has a last-known
-     * location *and* the trip is predicted.
+     * True if the server provided a real-time location for this vehicle — i.e. the trip is predicted
+     * *and* we have a real-time location for it.
+     *
+     * "A location" means either [lastKnownLocation] (a raw GPS fix) or [position] (which, per its own
+     * contract, "is only present if the trip is actively running"). Requiring [lastKnownLocation]
+     * specifically wrongly flagged an actively-running, predicted vehicle as *scheduled* when the feed
+     * populated only [position] — that marker was still drawn (and extrapolated) from [position], and
+     * its arrival listings showed predictions, so styling it scheduled contradicted both. See #1621.
+     *
+     * The arrival listings answer the same "is this real-time?" question with `ObaArrivalInfo.predicted`
+     * (bare [isPredicted], with no location requirement since a list row needs no coordinates); keep the
+     * two in step if the feed's real-time semantics ever change.
      */
     val isLocationRealtime: Boolean
-        get() = lastKnownLocation != null && isPredicted
+        get() = isPredicted && (lastKnownLocation != null || position != null)
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/ArrivalInfoUtils.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/ArrivalInfoUtils.java
@@ -119,12 +119,16 @@ public class ArrivalInfoUtils {
      * or if we don't have real-time info (i.e., scheduled)
      */
     public static int computeColor(final long scheduled, final long predicted) {
-        if (predicted != 0) {
-            return computeColorFromDeviation(predicted - scheduled);
-        } else {
-            // Use scheduled color
-            return R.color.stop_info_scheduled_time;
-        }
+        return statusColor(predicted != 0, predicted - scheduled);
+    }
+
+    /**
+     * The one live-vs-scheduled color choice shared by the map's vehicle markers/info windows and the
+     * arrival-list rows: the schedule-deviation color when real-time, otherwise the scheduled (gray)
+     * color. [deviationMinutes] is ignored when not real-time.
+     */
+    public static int statusColor(final boolean isRealtime, final long deviationMinutes) {
+        return isRealtime ? computeColorFromDeviation(deviationMinutes) : R.color.stop_info_scheduled_time;
     }
 
     /**

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreComposeAdapter.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreComposeAdapter.kt
@@ -251,7 +251,7 @@ private fun wireClicks(
         val response = renderer.vehicleResponse()
         if (vehicle != null && response != null) {
             callbacks.onVehicleClick(vehicle.status) // selects it -> renderer shows the most-recent-data dot
-            infoWindows.open(marker) { VehicleInfoWindow(vehicle.status, response) }
+            infoWindows.open(marker) { VehicleInfoWindow(vehicle.status, vehicle.isRealtime, response) }
             return@setOnMarkerClickListener true
         }
         val bike = renderer.bikeForMarker(marker)

--- a/onebusaway-android/src/test/java/org/onebusaway/android/extrapolation/data/TripStateTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/extrapolation/data/TripStateTest.kt
@@ -368,7 +368,7 @@ class TripStateTest {
                                         distanceAlongTrip = 600.0,
                                         lastUpdateTime = 1000L,
                                         predicted = true,
-                                        hasLocation = true
+                                        hasLastKnownLocation = true
                                 ),
                                 serverTimeMs = 3000L,
                                 localTimeMs = 3000L
@@ -500,14 +500,14 @@ class TripStateTest {
             totalDistanceAlongTrip: Double? = null,
             lastUpdateTime: Long = 0L,
             predicted: Boolean = false,
-            hasLocation: Boolean = false,
+            hasLastKnownLocation: Boolean = false,
             activeTripId: String? = "trip1"
     ): ObaTripStatus = testTripStatus(
             distanceAlongTrip = distanceAlongTrip,
             totalDistanceAlongTrip = totalDistanceAlongTrip,
             lastUpdateTime = lastUpdateTime,
             predicted = predicted,
-            hasLocation = hasLocation,
+            hasLastKnownLocation = hasLastKnownLocation,
             activeTripId = activeTripId
     )
 

--- a/onebusaway-android/src/test/java/org/onebusaway/android/models/ObaTripStatusTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/models/ObaTripStatusTest.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.models
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.onebusaway.android.testing.testTripStatus
+
+/** [ObaTripStatus.isLocationRealtime] — real-time iff predicted AND some real-time location exists. */
+class ObaTripStatusTest {
+
+    @Test
+    fun predictedWithLastKnownLocation_isRealtime() {
+        assertTrue(testTripStatus(predicted = true, hasLastKnownLocation = true).isLocationRealtime)
+    }
+
+    /** The #1621 fix: a predicted, actively-running vehicle with only `position` (feed omits the raw
+     *  last-known fix) is real-time — the marker is drawn from `position`, so it mustn't read scheduled. */
+    @Test
+    fun predictedWithPositionOnly_isRealtime() {
+        assertTrue(testTripStatus(predicted = true, hasPosition = true).isLocationRealtime)
+    }
+
+    @Test
+    fun predictedWithoutAnyLocation_isNotRealtime() {
+        assertFalse(testTripStatus(predicted = true).isLocationRealtime)
+    }
+
+    @Test
+    fun notPredicted_isNotRealtime_evenWithLocation() {
+        assertFalse(testTripStatus(predicted = false, hasLastKnownLocation = true).isLocationRealtime)
+        assertFalse(testTripStatus(predicted = false, hasPosition = true).isLocationRealtime)
+    }
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/testing/TestTripStatus.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/testing/TestTripStatus.kt
@@ -23,8 +23,9 @@ import org.onebusaway.android.models.Status
 /**
  * A minimal [ObaTripStatus] for JVM unit tests. Location-typed accessors return null by default, so
  * the android.location.Location stubs (which throw "Stub!") are never invoked — no Robolectric
- * needed. Pass [hasLocation] = true when a test needs `lastKnownLocation` to be non-null (e.g.
- * to exercise `isLocationRealtime`); the returned sentinel is only ever null-checked, never called.
+ * needed. Pass [hasLastKnownLocation]/[hasPosition] = true when a test needs `lastKnownLocation`/`position` to
+ * be non-null (e.g. to exercise `isLocationRealtime`); the returned sentinel is only ever null-checked,
+ * never called.
  */
 fun testTripStatus(
     distanceAlongTrip: Double? = null,
@@ -33,7 +34,8 @@ fun testTripStatus(
     vehicleId: String? = null,
     activeTripId: String? = null,
     predicted: Boolean = false,
-    hasLocation: Boolean = false,
+    hasLastKnownLocation: Boolean = false,
+    hasPosition: Boolean = false,
 ): ObaTripStatus = TestTripStatus(
     distanceAlongTrip = distanceAlongTrip,
     totalDistanceAlongTrip = totalDistanceAlongTrip,
@@ -41,7 +43,8 @@ fun testTripStatus(
     vehicleId = vehicleId,
     activeTripId = activeTripId,
     predicted = predicted,
-    hasLocation = hasLocation,
+    hasLastKnownLocation = hasLastKnownLocation,
+    hasPosition = hasPosition,
 )
 
 private class TestTripStatus(
@@ -51,7 +54,8 @@ private class TestTripStatus(
     vehicleId: String?,
     activeTripId: String?,
     predicted: Boolean,
-    private val hasLocation: Boolean,
+    private val hasLastKnownLocation: Boolean,
+    private val hasPosition: Boolean,
 ) : ObaTripStatus {
     override val serviceDate: Long = 0L
     override val isPredicted: Boolean = predicted
@@ -59,7 +63,8 @@ private class TestTripStatus(
     override val vehicleId: String? = vehicleId
     override val closestStop: String? = null
     override val closestStopTimeOffset: Long = 0L
-    override val position: Location? = null
+    override val position: Location?
+        get() = if (hasPosition) FAKE_LOCATION else null
     override val activeTripId: String? = activeTripId
     override val distanceAlongTrip: Double? = distanceAlongTrip
     override val scheduledDistanceAlongTrip: Double? = null
@@ -71,7 +76,7 @@ private class TestTripStatus(
     override val status: Status? = null
     override val lastUpdateTime: Long = lastUpdateTime
     override val lastKnownLocation: Location?
-        get() = if (hasLocation) FAKE_LOCATION else null
+        get() = if (hasLastKnownLocation) FAKE_LOCATION else null
     override val lastLocationUpdateTime: Long = 0L
     override val lastKnownDistanceAlongTrip: Double? = null
     override val lastKnownOrientation: Double? = null


### PR DESCRIPTION
Fixes #1621.

## Problem

On the route map, a vehicle marker could render with **scheduled** styling (gray icon, "Scheduled" info-window label) even though the vehicle was being actively tracked — the same route's arrival listings showed real-time predictions, and the marker had a live data-age marker.

## Root cause

Two independent contributors:

1. `ObaTripStatus.isLocationRealtime` was `lastKnownLocation != null && isPredicted`, which ignores `position` — a field that (per its own contract) is "only present if the trip is actively running." A predicted, running vehicle whose feed populated only `position` was flagged scheduled, even though the marker was drawn from that `position`.
2. Each render consumer independently re-derived the flag from the **raw current poll status**, which can differ from the source the marker was actually drawn/extrapolated from.

## Changes

- `isLocationRealtime` now accepts either location: `isPredicted && (lastKnownLocation != null || position != null)`.
- Decide live-vs-scheduled **once at draw time** in `ExtrapolatedVehicle` — from the extrapolation anchor when the point is extrapolated, else the current status — and thread it through `VehicleMarker` and `VehicleInfoWindow`, so the icon and info window can't disagree with the position the marker is drawn at.
- Extract `ArrivalInfoUtils.statusColor(isRealtime, deviationMinutes)` so the marker icon, the info window, and the arrival-list rows share **one** scheduled-vs-deviation color decision (`computeColor` now delegates to it).

## Testing

- New `ObaTripStatusTest` covers `isLocationRealtime` across the location/predicted matrix (including the position-only case).
- `obaGoogleDebug` and `obaMaplibreDebug` compile; full `obaGoogleDebug` unit suite passes.
- Not yet verified on-device.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Vehicle markers and info windows now stay consistent about whether a vehicle is live or scheduled.
  * Real-time status labels, colors, and update timestamps are more accurate for vehicles with live position data.
  * Vehicles with certain real-time data now display the correct live styling instead of appearing scheduled.

* **Tests**
  * Added and updated tests covering real-time status detection and location handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->