### PR TITLE
Finish DI (region slice): retire Application.get().currentRegion reads (#1624)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/app/Application.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/app/Application.java
@@ -317,30 +317,6 @@ public class Application extends android.app.Application {
 
 
     /**
-     * Gets the date at which the region information was last updated, in the number of
-     * milliseconds
-     * since January 1, 1970, 00:00:00 GMT
-     * Default value is 0 if the region info has never been updated.
-     *
-     * @return the date at which the region information was last updated, in the number of
-     * milliseconds since January 1, 1970, 00:00:00 GMT.  Default value is 0 if the region info has
-     * never been updated.
-     */
-    public long getLastRegionUpdateDate() {
-        return PreferenceUtils.getLong(getString(R.string.preference_key_last_region_update), 0);
-    }
-
-    /**
-     * Sets the date at which the region information was last updated
-     *
-     * @param date the date at which the region information was last updated, in the number of
-     *             milliseconds since January 1, 1970, 00:00:00 GMT
-     */
-    public void setLastRegionUpdateDate(long date) {
-        PreferenceUtils.saveLong(getString(R.string.preference_key_last_region_update), date);
-    }
-
-    /**
      * Returns the custom URL if the user has set a custom API URL manually via Preferences, or
      * null
      * if it has not been set

--- a/onebusaway-android/src/main/java/org/onebusaway/android/region/RegionCache.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/region/RegionCache.kt
@@ -19,9 +19,10 @@ import android.content.Context
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import javax.inject.Singleton
-import org.onebusaway.android.app.Application
+import org.onebusaway.android.R
 import org.onebusaway.android.database.oba.ImportGate
 import org.onebusaway.android.database.oba.RegionDao
+import org.onebusaway.android.preferences.PreferencesRepository
 import org.onebusaway.android.util.RegionUtils
 
 /**
@@ -36,6 +37,7 @@ class RegionCache @Inject constructor(
     @ApplicationContext private val context: Context,
     private val regionDao: RegionDao,
     private val importGate: ImportGate,
+    private val prefs: PreferencesRepository,
 ) {
 
     /** The cached regions, or an empty list when the cache is empty. */
@@ -82,7 +84,7 @@ class RegionCache @Inject constructor(
             // load regions") instead of falling through to save([]), which would wipe the cache.
             if (results.isNullOrEmpty()) return null
         } else {
-            Application.get().setLastRegionUpdateDate(System.currentTimeMillis())
+            prefs.setLong(R.string.preference_key_last_region_update, System.currentTimeMillis())
         }
 
         save(results)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/regions/RegionsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/regions/RegionsRepository.kt
@@ -96,7 +96,7 @@ class DefaultRegionsRepository @Inject constructor(
             regionsById = usable.associateBy { it.id }
 
             val location = locationRepository.lastKnownLocation()
-            val currentRegionId = Application.get().currentRegion?.id
+            val currentRegionId = regionRepository.currentRegion()?.id
             val items = usable.map { region ->
                 RegionItem(
                     id = region.id,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/settings/SettingsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/settings/SettingsScreen.kt
@@ -42,7 +42,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import org.onebusaway.android.R
-import org.onebusaway.android.app.Application
+import org.onebusaway.android.app.di.RegionEntryPoint
 import org.onebusaway.android.ui.compose.components.ObaTopAppBar
 import org.onebusaway.android.ui.compose.findActivity
 import org.onebusaway.android.ui.settings.components.ClickPreferenceItem
@@ -115,7 +115,7 @@ fun SettingsRoute(
     // EXTRA_SHOW_CHECK_REGION_DIALOG extra.
     LaunchedEffect(Unit) {
         if (activity.intent.getBooleanExtra(HomeActivity.EXTRA_SHOW_CHECK_REGION_DIALOG, false)) {
-            Application.get().currentRegion?.let { region ->
+            RegionEntryPoint.get(activity).currentRegion()?.let { region ->
                 MaterialAlertDialogBuilder(activity)
                     .setTitle(activity.getString(R.string.preference_region_dialog_title))
                     .setMessage(

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/ExternalIntents.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/ExternalIntents.kt
@@ -33,6 +33,7 @@ import com.google.firebase.analytics.FirebaseAnalytics
 
 import org.onebusaway.android.R
 import org.onebusaway.android.app.Application
+import org.onebusaway.android.app.di.RegionEntryPoint
 import org.onebusaway.android.analytics.ObaAnalytics
 import org.onebusaway.android.analytics.PlausibleAnalytics
 import org.onebusaway.android.region.Region
@@ -252,7 +253,7 @@ object ExternalIntents {
      * @return the region whose payment warning must be shown first, or null if already handled
      */
     fun payFareOrWarningRegion(activity: Activity): Region? {
-        val region = Application.get().currentRegion
+        val region = RegionEntryPoint.get(activity).currentRegion()
         if (region == null) {
             // If a custom API URL is set (i.e., no region), then no op
             return null

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/ObaRequestErrors.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/ObaRequestErrors.kt
@@ -23,7 +23,7 @@ import android.provider.Settings
 
 import java.net.HttpURLConnection
 import org.onebusaway.android.R
-import org.onebusaway.android.app.Application
+import org.onebusaway.android.app.di.RegionEntryPoint
 import org.onebusaway.android.api.ObaApi
 
 /**
@@ -44,7 +44,7 @@ object ObaRequestErrors {
             HttpURLConnection.HTTP_INTERNAL_ERROR ->
                 context.getString(R.string.internal_error)
             HttpURLConnection.HTTP_NOT_FOUND -> {
-                val r = Application.get().currentRegion
+                val r = RegionEntryPoint.get(context).currentRegion()
                 if (r != null) {
                     context.getString(R.string.route_not_found_error_with_region_name, r.name)
                 } else {
@@ -73,7 +73,7 @@ object ObaRequestErrors {
             HttpURLConnection.HTTP_INTERNAL_ERROR ->
                 context.getString(R.string.internal_error)
             HttpURLConnection.HTTP_NOT_FOUND -> {
-                val r = Application.get().currentRegion
+                val r = RegionEntryPoint.get(context).currentRegion()
                 if (r != null) {
                     context.getString(R.string.stop_not_found_error_with_region_name, r.name)
                 } else {


### PR DESCRIPTION
Part of #1624 — finishing the DI campaign by eliminating the `Application.get()` static service-locator. This is the **region slice** (the issue's recommended first slice).

## What changed

Routes the app-global current-region reads that still went through the `Application` singleton to the injected `RegionRepository` seam:

- **ObaRequestErrors**, **ExternalIntents.payFareOrWarningRegion**, **SettingsScreen** — read via `RegionEntryPoint.get(context).currentRegion()` (these are a stateless object / a composable — the sanctioned EntryPoint path for non-injectable call sites).
- **DefaultRegionsRepository** — use the already-injected `regionRepository`.
- **RegionCache** — the last-region-update timestamp is a *preference*, not region state, so inject `PreferencesRepository` and write it there. This makes `Application.get/setLastRegionUpdateDate` dead, so they're deleted.

## Deliberately out of scope

The two cross-cutting region **+ config** statics — `RegionUtils.getObaRegionName()` and `Application.isBikeshareEnabled()` — also read `customApiUrl` / `customOtpApiUrl`. They're left for the **config slice** so they can be de-static-ified in one pass rather than half-migrated here.

## Behavior

No user-facing behavior change — a pure structural/DI refactor. `RegionRepository` mirrors the exact value the `Application` locator returned (established during Campaign A). Compiles clean on `obaGoogleDebug`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how the app determines the active region in several screens and dialogs, so region-specific messages and actions are more consistent.
  * Fixed region-based payment warnings and “not found” error messages to use the currently selected region.
  * Region lists now more reliably mark the current region.
  * Region data updates continue to be tracked properly after successful refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->