### PR TITLE
Finish DI (config slice): retire Application.get() OTP/API config-flag reads (#1624)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/bike/BikeStationsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/bike/BikeStationsRepository.kt
@@ -18,7 +18,6 @@ package org.onebusaway.android.map.bike
 import javax.inject.Inject
 import android.location.Location
 import org.onebusaway.android.R
-import org.onebusaway.android.app.Application
 import org.onebusaway.android.api.contract.BikeWebService
 import org.onebusaway.android.api.contract.toBikeRentalStations
 import org.onebusaway.android.preferences.PreferencesRepository
@@ -53,13 +52,13 @@ class DefaultBikeStationsRepository @Inject constructor(
         // /routers/default (e.g. Puget Sound), so blindly prepending it doubles the path. Try the
         // recorded structure first, then fall back to the old one and record it (shared with trip
         // planning via the same flag, reset on region change).
-        val useOld = Application.get().useOldOtpApiUrlVersion
+        val useOld = prefs.getBoolean(R.string.preference_key_otp_api_url_version, false)
         try {
             fetch(base, useOld, southWest, northEast)
         } catch (e: Exception) {
             if (useOld) throw e
             fetch(base, useOldUrlStructure = true, southWest, northEast)
-                .also { Application.get().useOldOtpApiUrlVersion = true }
+                .also { prefs.setBoolean(R.string.preference_key_otp_api_url_version, true) }
         }
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/drawer/NavItemsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/drawer/NavItemsRepository.kt
@@ -17,7 +17,8 @@ package org.onebusaway.android.ui.home.drawer
 
 import android.text.TextUtils
 import javax.inject.Inject
-import org.onebusaway.android.app.Application
+import org.onebusaway.android.R
+import org.onebusaway.android.preferences.PreferencesRepository
 import org.onebusaway.android.region.RegionRepository
 import org.onebusaway.android.util.ReminderUtils
 
@@ -46,6 +47,7 @@ interface NavItemsRepository {
  */
 class DefaultNavItemsRepository @Inject constructor(
     private val regionRepository: RegionRepository,
+    private val prefs: PreferencesRepository,
 ) : NavItemsRepository {
 
     override fun availability(): NavItemAvailability {
@@ -54,7 +56,8 @@ class DefaultNavItemsRepository @Inject constructor(
             showReminders = ReminderUtils.shouldShowReminders(),
             planTripAvailable = region != null &&
                 (!TextUtils.isEmpty(region.otpBaseUrl) ||
-                    !TextUtils.isEmpty(Application.get().customOtpApiUrl)),
+                    !TextUtils.isEmpty(
+                        prefs.getString(R.string.preference_key_otp_api_url, null))),
             payFareAvailable = region != null && !TextUtils.isEmpty(region.paymentAndroidAppId),
         )
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/settings/AdvancedSettingsViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/settings/AdvancedSettingsViewModel.kt
@@ -62,7 +62,7 @@ class AdvancedSettingsViewModel @Inject constructor(
 
     init {
         // The old fragment reset this on every (re)display of the advanced screen.
-        Application.get().setUseOldOtpApiUrlVersion(false)
+        prefs.setBoolean(R.string.preference_key_otp_api_url_version, false)
     }
 
     val state: StateFlow<AdvancedSettingsUiState> =

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanRepository.kt
@@ -28,7 +28,6 @@ import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.onebusaway.android.R
-import org.onebusaway.android.app.Application
 import org.onebusaway.android.directions.util.CustomAddress
 import org.onebusaway.android.directions.util.JacksonConfig
 import org.onebusaway.android.directions.util.TripRequestBuilder
@@ -37,6 +36,7 @@ import org.opentripplanner.api.ws.Message
 import org.opentripplanner.api.ws.Request
 import org.opentripplanner.api.ws.Response
 import org.opentripplanner.routing.core.TraverseMode
+import org.onebusaway.android.preferences.PreferencesRepository
 
 /** Plans a trip against the region's OpenTripPlanner server. */
 interface TripPlanRepository {
@@ -50,7 +50,8 @@ interface TripPlanRepository {
  * messages (ported from TripPlanActivity.getErrorMessage) and surfaced as [Result.failure].
  */
 class DefaultTripPlanRepository @Inject constructor(
-    @ApplicationContext private val context: Context
+    @ApplicationContext private val context: Context,
+    private val prefs: PreferencesRepository,
 ) : TripPlanRepository {
 
     override suspend fun plan(params: TripPlanParams): Result<List<Itinerary>> =
@@ -70,7 +71,11 @@ class DefaultTripPlanRepository @Inject constructor(
                 val baseUrl = builder.formattedOtpBaseUrl
                     ?: throw IOException(context.getString(R.string.tripplanner_no_server_selected_error))
 
-                val response = requestPlan(request, baseUrl, Application.get().useOldOtpApiUrlVersion)
+                val response = requestPlan(
+                    request,
+                    baseUrl,
+                    prefs.getBoolean(R.string.preference_key_otp_api_url_version, false),
+                )
                 val itineraries = response.plan?.itinerary
                 if (itineraries.isNullOrEmpty()) {
                     throw IOException(errorMessage(response.error?.id ?: -1))
@@ -126,7 +131,7 @@ class DefaultTripPlanRepository @Inject constructor(
             }
             val response: Response = JacksonConfig.getObjectReaderInstance().readValue(connection.inputStream)
             if (useOldUrlStructure) {
-                Application.get().useOldOtpApiUrlVersion = true
+                prefs.setBoolean(R.string.preference_key_otp_api_url_version, true)
             }
             return response
         } catch (e: SocketTimeoutException) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/ExternalIntents.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/ExternalIntents.kt
@@ -77,7 +77,7 @@ object ExternalIntents {
         context: Context, email: String, location: String?,
         tripPlanUrl: String?, tripPlanFail: Boolean
     ) {
-        val obaRegionName = RegionUtils.getObaRegionName()
+        val obaRegionName = RegionUtils.getObaRegionName(context)
         val autoRegion = PreferenceUtils
             .getBoolean(context.getString(R.string.preference_key_auto_select_region), true)
         val regionSelectionMethod: String

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/RegionUtils.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/RegionUtils.java
@@ -20,6 +20,8 @@ package org.onebusaway.android.util;
 import org.onebusaway.android.BuildConfig;
 import org.onebusaway.android.R;
 import org.onebusaway.android.app.Application;
+import org.onebusaway.android.app.di.PreferencesEntryPoint;
+import org.onebusaway.android.app.di.RegionEntryPoint;
 import org.onebusaway.android.api.bridge.RegionsClient;
 import org.onebusaway.android.region.Region;
 
@@ -121,26 +123,30 @@ public class RegionUtils {
      *
      * @return regionName
      */
-    public static String getObaRegionName() {
+    public static String getObaRegionName(Context context) {
         String regionName = null;
-        Region region = Application.get().getCurrentRegion();
+        Region region = RegionEntryPoint.get(context).currentRegion();
         if (region != null && region.getName() != null) {
             regionName = region.getName();
-        } else if (Application.get().getCustomApiUrl() != null) {
-            regionName = createHashCode(Application.get().getCustomApiUrl().getBytes());
+        } else {
+            String customApiUrl = PreferencesEntryPoint.get(context)
+                    .getString(context.getString(R.string.preference_key_oba_api_url), (String) null);
+            if (customApiUrl != null) {
+                regionName = createHashCode(context, customApiUrl.getBytes());
+            }
         }
         return regionName;
     }
 
-    private static String createHashCode(byte[] bytes) {
+    private static String createHashCode(Context context, byte[] bytes) {
         MessageDigest digest;
         try {
             digest = MessageDigest.getInstance("SHA-1");
             digest.update(bytes);
-            return Application.get().getString(R.string.analytics_label_custom_url) +
+            return context.getString(R.string.analytics_label_custom_url) +
                     ": " + Application.getHex(digest.digest());
         } catch (Exception e) {
-            return Application.get().getString(R.string.analytics_label_custom_url);
+            return context.getString(R.string.analytics_label_custom_url);
         }
     }
 


### PR DESCRIPTION
Part of #1624 — finishing the DI campaign by eliminating the `Application.get()` static service-locator. This is the **config slice** (OTP/API URL flags). Independent of the region-slice PR; both branch from `main`.

## What changed

Routes the OTP/API URL config flags that still went through the `Application` singleton to the injected `PreferencesRepository` seam:

- **TripPlanRepository** — inject `PreferencesRepository`; read/write the `otp_api_url_version` flag there instead of `Application.useOldOtpApiUrlVersion`.
- **BikeStationsRepository** — use the already-injected `prefs` for the same flag.
- **NavItemsRepository** — inject `PreferencesRepository` for the custom OTP URL read.
- **AdvancedSettingsViewModel** — reset `otp_api_url_version` via the already-injected `prefs` (the VM already uses this exact key elsewhere).
- **RegionUtils.getObaRegionName** — take a `Context` and read region + custom OBA URL via `RegionEntryPoint` / `PreferencesEntryPoint`; its one caller (`ExternalIntents`) passes its context. Also drops the benign `Application.getString` reaches in `createHashCode`.

## Deliberately out of scope

The legacy **directions cluster** — `TripRequest`, `TripRequestBuilder`, and `Application.isBikeshareEnabled()`. These are coupled through the Context-less `TripRequestBuilder` (constructed by `execute()` with a null `Activity` from `RealtimeService`), so de-static-ifying them cleanly requires the builder to carry a `Context`/region — a distinct, more invasive slice best done on its own.

## Behavior

No user-facing behavior change. `PreferenceUtils` and `PreferencesRepository` share the same DataStore behind `PreferencesEntryPoint`, so reads/writes stay consistent. Compiles clean on `obaGoogleDebug`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved trip planning reliability by keeping the app’s API URL setting consistent across retries and settings changes.
  * Fixed region/name handling for email sharing so it uses the current app context and custom API URL more reliably.
  * Updated trip-planning availability checks to reflect the saved app preferences, helping the app show the right options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->