### PR TITLE
Finish DI (analytics slice): own Plausible/Umami in an injected AnalyticsProvider (#1624)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/analytics/AnalyticsProvider.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/analytics/AnalyticsProvider.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.analytics
+
+import android.content.Context
+import com.onebusaway.plausible.android.Plausible
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.net.URI
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import org.onebusaway.android.app.di.AppScope
+import org.onebusaway.android.region.Region
+import org.onebusaway.android.region.RegionRepository
+
+/**
+ * Owns the region-derived analytics emitters — the [Plausible] and [UmamiAnalytics] instances — as an
+ * injected app-singleton, replacing the `Application.getPlausibleInstance()` / `getUmamiInstance()`
+ * service-locator reads. Both emitters point at the *current* region's analytics servers, so they are
+ * rebuilt reactively whenever the [RegionRepository] region changes (the same "everything that cares
+ * observes the region flow" form as [org.onebusaway.android.region.RegionSubsystems]).
+ *
+ * Injectable consumers inject this directly; the context-less static / Java call sites reach it via
+ * [org.onebusaway.android.app.di.AnalyticsEntryPoint].
+ */
+@Singleton
+class AnalyticsProvider @Inject constructor(
+    @ApplicationContext private val context: Context,
+    regionRepository: RegionRepository,
+    @AppScope scope: CoroutineScope,
+) {
+
+    /** The Plausible emitter for the current region, or null when the region has no Plausible server. */
+    @Volatile
+    var plausible: Plausible? = null
+        private set
+
+    /** The Umami emitter for the current region, or null when the region has no Umami config. */
+    @Volatile
+    var umami: UmamiAnalytics? = null
+        private set
+
+    init {
+        // Seed synchronously from the current region so the emitters are ready the moment the provider
+        // is first injected — the region collector below runs on the @AppScope (IO) dispatcher, so it
+        // would otherwise leave a null window on first use. The collector re-applies the current value
+        // once on subscription (a harmless rebuild) and thereafter tracks region changes.
+        rebuild(regionRepository.region.value)
+        scope.launch {
+            regionRepository.region.collect { rebuild(it) }
+        }
+    }
+
+    private fun rebuild(region: Region?) {
+        plausible = buildPlausible(region)
+        umami = buildUmami(region)
+    }
+
+    private fun buildPlausible(region: Region?): Plausible? {
+        if (region?.obaBaseUrl == null || region.plausibleAnalyticsServerUrl == null) return null
+        // Fire-and-forget telemetry must never throw on a malformed URL (this runs in a long-lived
+        // region collector); a bad host just disables Plausible for that region.
+        val domain = hostOf(region.obaBaseUrl) ?: return null
+        return Plausible(context, domain, region.plausibleAnalyticsServerUrl)
+    }
+
+    private fun buildUmami(region: Region?): UmamiAnalytics? {
+        if (region?.obaBaseUrl == null ||
+            region.umamiAnalyticsUrl == null ||
+            region.umamiAnalyticsId == null
+        ) {
+            return null
+        }
+        val host = hostOf(region.obaBaseUrl) ?: return null
+        return UmamiAnalytics(region.umamiAnalyticsUrl, region.umamiAnalyticsId, host)
+    }
+
+    private fun hostOf(url: String): String? = try {
+        URI(url).host
+    } catch (e: Exception) {
+        null
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/analytics/ObaAnalytics.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/analytics/ObaAnalytics.kt
@@ -21,6 +21,7 @@ import com.google.firebase.analytics.FirebaseAnalytics
 import com.onebusaway.plausible.android.Plausible
 import org.onebusaway.android.R
 import org.onebusaway.android.app.Application
+import org.onebusaway.android.app.di.AnalyticsEntryPoint
 import org.onebusaway.android.util.PreferenceUtils
 
 /**
@@ -230,7 +231,10 @@ object ObaAnalytics {
 
     private fun string(resId: Int): String = Application.get().getString(resId)
 
-    private fun umami(): UmamiAnalytics? = Application.get().umamiInstance
+    // The Umami emitter now lives on the injected AnalyticsProvider. ObaAnalytics is a context-less
+    // static orchestrator, so it resolves the provider through the EntryPoint using the Application only
+    // as a graph handle (a benign context reach) rather than reading app-global analytics *state* off it.
+    private fun umami(): UmamiAnalytics? = AnalyticsEntryPoint.get(Application.get()).umami
 
     private fun Boolean.toYesNo(): String = if (this) "YES" else "NO"
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/analytics/ObaAnalytics.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/analytics/ObaAnalytics.kt
@@ -154,7 +154,7 @@ object ObaAnalytics {
 
     /** Sets the current region as a Firebase user property and on the Umami emitter. */
     @JvmStatic
-    fun setRegion(plausible: Plausible?, analytics: FirebaseAnalytics, regionName: String?) {
+    fun setRegion(analytics: FirebaseAnalytics, regionName: String?) {
         if (!isAnalyticsActive()) return
         analytics.setUserProperty(string(R.string.analytics_label_region_name), regionName)
         umami()?.setRegionName(regionName)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/app/Application.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/app/Application.java
@@ -97,9 +97,10 @@ public class Application extends android.app.Application {
         // starts empty and fills from setLastKnownLocation (listener updates) / its lazy provider poll.
         // The legacy setCurrentRegion / setLastKnownLocation writers reach them via their EntryPoints.
         // So nothing to construct here.
-        // The region-derived subsystems (Plausible, Open311) observe the region flow (A7) — this
+        // The region-derived Open311 endpoints observe the region flow (A7) via RegionSubsystems — this
         // performs their initial init (the StateFlow replays the repo's seeded region) and re-inits on
-        // change, replacing the former explicit initOpen311(getCurrentRegion()) call.
+        // change, replacing the former explicit initOpen311(getCurrentRegion()) call. The Plausible/Umami
+        // analytics emitters observe the same flow independently, from AnalyticsProvider.
         RegionSubsystems.observe(this);
 
         reportAnalytics();
@@ -234,7 +235,8 @@ public class Application extends android.app.Application {
 
     public synchronized void setCurrentRegion(Region region, boolean regionChanged) {
         // The canonical region write lives in RegionRepository as of A7; the region-derived subsystems
-        // (Plausible, Umami, Open311) re-init reactively via RegionSubsystems observing the published flow.
+        // re-init reactively by observing the published flow — Open311 via RegionSubsystems, the
+        // Plausible/Umami analytics emitters via AnalyticsProvider.
         RegionEntryPoint.get(this).applyRegion(region, regionChanged);
     }
 
@@ -430,10 +432,10 @@ public class Application extends android.app.Application {
     private void reportAnalytics() {
         mFirebaseAnalytics = FirebaseAnalytics.getInstance(this);
         // The Plausible/Umami emitters are owned + built reactively by AnalyticsProvider; here we only set
-        // the initial Firebase/Umami region label. setRegion resolves the Umami emitter through the
-        // provider itself, so it needs no Plausible instance (its first arg is unused).
+        // the initial Firebase/Umami region label via setRegion (which resolves the Umami emitter through
+        // the provider itself).
         if (getCustomApiUrl() == null && getCurrentRegion() != null) {
-            ObaAnalytics.setRegion(null, mFirebaseAnalytics, getCurrentRegion().getName());
+            ObaAnalytics.setRegion(mFirebaseAnalytics, getCurrentRegion().getName());
         } else if (getCustomApiUrl() != null) {
             String customUrl;
             try {
@@ -444,7 +446,7 @@ public class Application extends android.app.Application {
             } catch (Exception e) {
                 customUrl = getString(R.string.analytics_label_custom_url);
             }
-            ObaAnalytics.setRegion(null, mFirebaseAnalytics, customUrl);
+            ObaAnalytics.setRegion(mFirebaseAnalytics, customUrl);
         }
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/app/Application.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/app/Application.java
@@ -29,8 +29,6 @@ import android.util.Log;
 import com.google.firebase.analytics.FirebaseAnalytics;
 import com.google.firebase.messaging.FirebaseMessaging;
 
-import com.onebusaway.plausible.android.Plausible;
-
 import org.onebusaway.android.BuildConfig;
 import org.onebusaway.android.R;
 import org.onebusaway.android.donations.DonationsManager;
@@ -46,8 +44,6 @@ import org.onebusaway.android.util.PreferenceUtils;
 import org.onebusaway.android.util.ThemeUtils;
 import org.onebusaway.android.widealerts.GtfsAlerts;
 
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.security.MessageDigest;
 import java.util.UUID;
 
@@ -83,10 +79,6 @@ public class Application extends android.app.Application {
 
     private FirebaseAnalytics mFirebaseAnalytics;
 
-    private Plausible mPlausible;
-
-    private org.onebusaway.android.analytics.UmamiAnalytics mUmami;
-
     @Override
     public void onCreate() {
         super.onCreate();
@@ -118,7 +110,7 @@ public class Application extends android.app.Application {
 
         initFirebaseMessaging();
 
-        mDonationsManager = new DonationsManager(mFirebaseAnalytics, getResources(), getAppLaunchCount());
+        mDonationsManager = new DonationsManager(getApplicationContext(), mFirebaseAnalytics, getResources(), getAppLaunchCount());
 
         mGtfsAlerts = new GtfsAlerts(getApplicationContext());
     }
@@ -247,72 +239,14 @@ public class Application extends android.app.Application {
     }
 
     /**
-     * Re-initializes the region-*derived* subsystems — the Plausible/Umami analytics instances and the
-     * Open311 reporting endpoints — for [region]. Driven reactively by
+     * Re-initializes the region-*derived* Open311 reporting endpoints for [region]. Driven reactively by
      * {@link org.onebusaway.android.region.RegionSubsystems}, which observes the region flow (A7), rather
-     * than poked imperatively by a region write transaction.
+     * than poked imperatively by a region write transaction. The Plausible/Umami analytics emitters are
+     * likewise region-derived, but they are owned + rebuilt by
+     * {@link org.onebusaway.android.analytics.AnalyticsProvider} (which observes the same flow).
      */
     public void onRegionChanged(Region region) {
-        buildPlausibleInstance(region);
-        buildUmamiInstance(region);
         initOpen311(region);
-    }
-
-    /**
-     * Return Plausible instance for the application
-     * @return Plausible instance
-     */
-    public Plausible getPlausibleInstance() {
-        if(mPlausible == null) {
-            buildPlausibleInstance(getCurrentRegion());
-        }
-        return mPlausible;
-    }
-
-    /**
-     * Build the Plausible instance for the application
-     * Include the domain and the plausible server url for the current region
-     * @param region
-     */
-    private void buildPlausibleInstance(Region region) {
-        mPlausible = null;
-        if (region == null || region.getObaBaseUrl() == null || region.getPlausibleAnalyticsServerUrl() == null) return;
-        String domain;
-        try {
-            domain = new URI(region.getObaBaseUrl()).getHost();
-        } catch (URISyntaxException e) {
-            throw new RuntimeException(e);
-        }
-        mPlausible = new Plausible(this, domain, region.getPlausibleAnalyticsServerUrl());
-    }
-
-    public org.onebusaway.android.analytics.UmamiAnalytics getUmamiInstance() {
-        if (mUmami == null) {
-            buildUmamiInstance(getCurrentRegion());
-        }
-        return mUmami;
-    }
-
-    private void buildUmamiInstance(Region region) {
-        mUmami = null;
-        if (region == null
-                || region.getObaBaseUrl() == null
-                || region.getUmamiAnalyticsUrl() == null
-                || region.getUmamiAnalyticsId() == null) {
-            return;
-        }
-        String host;
-        try {
-            host = new URI(region.getObaBaseUrl()).getHost();
-        } catch (URISyntaxException e) {
-            // Fire-and-forget telemetry must never throw on a malformed URL.
-            return;
-        }
-        if (host == null) {
-            return;
-        }
-        mUmami = new org.onebusaway.android.analytics.UmamiAnalytics(
-                region.getUmamiAnalyticsUrl(), region.getUmamiAnalyticsId(), host);
     }
 
 
@@ -495,22 +429,22 @@ public class Application extends android.app.Application {
 
     private void reportAnalytics() {
         mFirebaseAnalytics = FirebaseAnalytics.getInstance(this);
+        // The Plausible/Umami emitters are owned + built reactively by AnalyticsProvider; here we only set
+        // the initial Firebase/Umami region label. setRegion resolves the Umami emitter through the
+        // provider itself, so it needs no Plausible instance (its first arg is unused).
         if (getCustomApiUrl() == null && getCurrentRegion() != null) {
-            buildPlausibleInstance(getCurrentRegion());
-            buildUmamiInstance(getCurrentRegion());
-            ObaAnalytics.setRegion(mPlausible, mFirebaseAnalytics, getCurrentRegion().getName());
-        } else if (Application.get().getCustomApiUrl() != null) {
-            String customUrl = null;
-            MessageDigest digest = null;
+            ObaAnalytics.setRegion(null, mFirebaseAnalytics, getCurrentRegion().getName());
+        } else if (getCustomApiUrl() != null) {
+            String customUrl;
             try {
-                digest = MessageDigest.getInstance("SHA-1");
+                MessageDigest digest = MessageDigest.getInstance("SHA-1");
                 digest.update(getCustomApiUrl().getBytes(StandardCharsets.UTF_8));
                 customUrl = getString(R.string.analytics_label_custom_url) +
                         ": " + getHex(digest.digest());
             } catch (Exception e) {
-                customUrl = Application.get().getString(R.string.analytics_label_custom_url);
+                customUrl = getString(R.string.analytics_label_custom_url);
             }
-            ObaAnalytics.setRegion(mPlausible, mFirebaseAnalytics, customUrl);
+            ObaAnalytics.setRegion(null, mFirebaseAnalytics, customUrl);
         }
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/app/di/AnalyticsEntryPoint.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/app/di/AnalyticsEntryPoint.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.app.di
+
+import android.content.Context
+import dagger.hilt.EntryPoint
+import dagger.hilt.InstallIn
+import dagger.hilt.android.EntryPointAccessors
+import dagger.hilt.components.SingletonComponent
+import org.onebusaway.android.analytics.AnalyticsProvider
+
+/**
+ * A Hilt [EntryPoint] that lets code which can't be constructor- or field-injected — the static
+ * `ObaAnalytics` orchestrator, static Java utilities, composable helpers without a ViewModel — reach
+ * the [AnalyticsProvider] seam (and thus the current region's Plausible/Umami emitters) instead of
+ * `Application.get().getPlausibleInstance()` / `getUmamiInstance()`. It needs a [Context] only to
+ * resolve the singleton graph; the returned provider is the same app-singleton every injected consumer
+ * shares.
+ *
+ * Use it only where injection genuinely isn't available — Hilt-reachable classes (Activities,
+ * Fragments, Services, ViewModels, Workers) should inject [AnalyticsProvider] directly.
+ */
+@EntryPoint
+@InstallIn(SingletonComponent::class)
+interface AnalyticsEntryPoint {
+
+    fun analyticsProvider(): AnalyticsProvider
+
+    companion object {
+        /** Resolves the [AnalyticsProvider] from any [context] (its application is used). */
+        @JvmStatic
+        fun get(context: Context): AnalyticsProvider =
+            EntryPointAccessors.fromApplication(context, AnalyticsEntryPoint::class.java)
+                .analyticsProvider()
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/backup/BackupUtils.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/backup/BackupUtils.java
@@ -28,7 +28,7 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.firebase.analytics.FirebaseAnalytics;
 
 import org.onebusaway.android.R;
-import org.onebusaway.android.app.Application;
+import org.onebusaway.android.app.di.AnalyticsEntryPoint;
 import org.onebusaway.android.analytics.ObaAnalytics;
 import org.onebusaway.android.analytics.PlausibleAnalytics;
 
@@ -70,8 +70,7 @@ public class BackupUtils {
     static private void doRestore(Context activityContext, Uri uri, Runnable onRestored) {
         final Context context = activityContext.getApplicationContext();
         ObaAnalytics.reportUiEvent(FirebaseAnalytics.getInstance(activityContext),
-                // TODO(D4): plausible is region-mutable; inject a Provider
-                Application.get().getPlausibleInstance(),
+                AnalyticsEntryPoint.get(context).getPlausible(),
                 PlausibleAnalytics.REPORT_BACKUP_EVENT_URL,
                 context.getString(R.string.analytics_label_button_press_restore_preference),
                 null);
@@ -126,8 +125,7 @@ public class BackupUtils {
     public static void save(Context activityContext,Uri uri) {
         Context context = activityContext.getApplicationContext();
         ObaAnalytics.reportUiEvent(FirebaseAnalytics.getInstance(activityContext),
-                // TODO(D4): plausible is region-mutable; inject a Provider
-                Application.get().getPlausibleInstance(),
+                AnalyticsEntryPoint.get(context).getPlausible(),
                 PlausibleAnalytics.REPORT_BACKUP_EVENT_URL,
                 context.getString(R.string.analytics_label_button_press_save_preference),
                 null);

--- a/onebusaway-android/src/main/java/org/onebusaway/android/donations/DonationsManager.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/donations/DonationsManager.java
@@ -3,12 +3,13 @@ package org.onebusaway.android.donations;
 import com.google.firebase.analytics.FirebaseAnalytics;
 
 import org.onebusaway.android.R;
-import org.onebusaway.android.app.Application;
+import org.onebusaway.android.app.di.AnalyticsEntryPoint;
 import org.onebusaway.android.analytics.ObaAnalytics;
 import org.onebusaway.android.analytics.PlausibleAnalytics;
 import org.onebusaway.android.util.BuildFlavorUtils;
 import org.onebusaway.android.util.PreferenceUtils;
 
+import android.content.Context;
 import android.content.Intent;
 import android.content.res.Resources;
 import android.net.Uri;
@@ -19,10 +20,19 @@ public class DonationsManager {
     private Resources mResources;
     private int mAppLaunchCount;
 
+    // Application context, kept only to resolve the AnalyticsProvider (for the region-derived Plausible
+    // emitter) lazily at event time. Resolving it lazily — rather than injecting AnalyticsProvider into
+    // this constructor — matters because DonationsManager is built eagerly in Application.onCreate, and
+    // AnalyticsProvider pulls in the RegionRepository, which is deliberately constructed lazily
+    // post-onCreate to avoid the region-init ordering hazard.
+    private final Context mContext;
+
     public DonationsManager(
+            Context context,
             FirebaseAnalytics firebaseAnalytics,
             Resources resources,
             int appLaunchCount) {
+        this.mContext = context;
         this.mAnalytics = firebaseAnalytics;
         this.mResources = resources;
         this.mAppLaunchCount = appLaunchCount;
@@ -37,7 +47,7 @@ public class DonationsManager {
      * @param state the state or variant of the UI item, or null if the item doesn't have a state or variant
      */
     private void reportUIEvent(Integer resourceID, String state) {
-        ObaAnalytics.reportUiEvent(mAnalytics, Application.get().getPlausibleInstance(), PlausibleAnalytics.REPORT_DONATE_EVENT_URL, mResources.getString(resourceID), state);
+        ObaAnalytics.reportUiEvent(mAnalytics, AnalyticsEntryPoint.get(mContext).getPlausible(), PlausibleAnalytics.REPORT_DONATE_EVENT_URL, mResources.getString(resourceID), state);
     }
 
     // endregion

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapNavigation.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapNavigation.kt
@@ -19,6 +19,7 @@ import android.content.Context
 import com.google.firebase.analytics.FirebaseAnalytics
 import org.onebusaway.android.R
 import org.onebusaway.android.app.Application
+import org.onebusaway.android.app.di.AnalyticsEntryPoint
 import org.onebusaway.android.analytics.ObaAnalytics
 import org.onebusaway.android.analytics.PlausibleAnalytics
 import org.onebusaway.android.models.ObaTripStatus
@@ -58,7 +59,7 @@ object MapNavigation {
         }
         ObaAnalytics.reportUiEvent(
             FirebaseAnalytics.getInstance(context),
-            app.plausibleInstance,
+            AnalyticsEntryPoint.get(context).plausible,
             PlausibleAnalytics.REPORT_BIKE_EVENT_URL,
             context.getString(
                 if (station.isFloatingBike) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/nav/NavigationService.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/nav/NavigationService.kt
@@ -44,6 +44,7 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import org.apache.commons.io.FileUtils
 import org.onebusaway.android.R
+import org.onebusaway.android.analytics.AnalyticsProvider
 import org.onebusaway.android.app.Application
 import org.onebusaway.android.app.di.LocationEntryPoint
 import org.onebusaway.android.analytics.ObaAnalytics
@@ -83,6 +84,7 @@ class NavigationService : Service() {
     @Inject lateinit var navStopDao: NavStopDao
     @Inject lateinit var stopDao: StopDao
     @Inject lateinit var importGate: ImportGate
+    @Inject lateinit var analyticsProvider: AnalyticsProvider
 
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
     private var navJob: Job? = null
@@ -246,7 +248,7 @@ class NavigationService : Service() {
                 finishedTime = System.currentTimeMillis()
             } else if (System.currentTimeMillis() - finishedTime >= 30000) {
                 ObaAnalytics.reportUiEvent(
-                    firebaseAnalytics, Application.get().plausibleInstance,
+                    firebaseAnalytics, analyticsProvider.plausible,
                     PlausibleAnalytics.REPORT_DESTINATION_REMINDER_EVENT_URL,
                     getString(R.string.analytics_label_destination_reminder),
                     getString(R.string.analytics_label_destination_reminder_variant_ended)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/nav/NavigationServiceProvider.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/nav/NavigationServiceProvider.java
@@ -21,6 +21,7 @@ import com.google.firebase.analytics.FirebaseAnalytics;
 
 import org.onebusaway.android.R;
 import org.onebusaway.android.app.Application;
+import org.onebusaway.android.app.di.AnalyticsEntryPoint;
 import org.onebusaway.android.analytics.ObaAnalytics;
 import org.onebusaway.android.analytics.PlausibleAnalytics;
 import org.onebusaway.android.nav.model.Path;
@@ -503,7 +504,7 @@ public class NavigationServiceProvider implements TextToSpeech.OnInitListener {
                     if (proximityEvent(EVENT_TYPE_GET_READY, ALERT_STATE_NONE)) {
                         mNavProvider.updateUi(EVENT_TYPE_GET_READY);
                         Log.d(TAG, "-----Get ready!");
-                        ObaAnalytics.reportUiEvent(mFirebaseAnalytics, Application.get().getPlausibleInstance(), PlausibleAnalytics.REPORT_DESTINATION_REMINDER_EVENT_URL, Application.get().getString(R.string.analytics_label_destination_reminder), Application.get().getString(R.string.analytics_label_destination_reminder_variant_get_ready));
+                        ObaAnalytics.reportUiEvent(mFirebaseAnalytics, AnalyticsEntryPoint.get(Application.get()).getPlausible(), PlausibleAnalytics.REPORT_DESTINATION_REMINDER_EVENT_URL, Application.get().getString(R.string.analytics_label_destination_reminder), Application.get().getString(R.string.analytics_label_destination_reminder_variant_get_ready));
                         return EVENT_TYPE_GET_READY; //Get ready alert played
                     }
                 }
@@ -513,7 +514,7 @@ public class NavigationServiceProvider implements TextToSpeech.OnInitListener {
                     if (proximityEvent(EVENT_TYPE_PULL_CORD, ALERT_STATE_SHOWN_TO_RIDER)) {
                         mNavProvider.updateUi(EVENT_TYPE_PULL_CORD);
                         Log.d(TAG, "-----Get off the bus!");
-                        ObaAnalytics.reportUiEvent(mFirebaseAnalytics, Application.get().getPlausibleInstance(), PlausibleAnalytics.REPORT_DESTINATION_REMINDER_EVENT_URL, Application.get().getString(R.string.analytics_label_destination_reminder), Application.get().getString(R.string.analytics_label_destination_reminder_variant_exit_at_next_stop));
+                        ObaAnalytics.reportUiEvent(mFirebaseAnalytics, AnalyticsEntryPoint.get(Application.get()).getPlausible(), PlausibleAnalytics.REPORT_DESTINATION_REMINDER_EVENT_URL, Application.get().getString(R.string.analytics_label_destination_reminder), Application.get().getString(R.string.analytics_label_destination_reminder_variant_exit_at_next_stop));
                         return EVENT_TYPE_PULL_CORD; // Get off bus alert played
                     }
                 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/region/RegionSubsystems.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/region/RegionSubsystems.kt
@@ -23,12 +23,14 @@ import org.onebusaway.android.app.Application
 import org.onebusaway.android.app.di.RegionEntryPoint
 
 /**
- * Wires the region-*derived* `Application` subsystems — Plausible analytics + Open311 reporting — to the
- * [RegionRepository] region flow. Instead of the old region write transaction
- * imperatively rebuilding them, they re-initialize whenever the observed region changes — the §1.2
- * "everything that cares observes it" form. The `StateFlow` replays its seeded value immediately
- * (`Main.immediate`), so this also performs the initial init, subsuming the former onCreate
- * `initOpen311(currentRegion)` call.
+ * Wires the region-*derived* Open311 reporting endpoints to the [RegionRepository] region flow. Instead
+ * of the old region write transaction imperatively rebuilding them, they re-initialize whenever the
+ * observed region changes — the §1.2 "everything that cares observes it" form. The `StateFlow` replays
+ * its seeded value immediately (`Main.immediate`), so this also performs the initial init, subsuming the
+ * former onCreate `initOpen311(currentRegion)` call.
+ *
+ * The other region-derived subsystem — the Plausible/Umami analytics emitters — observes the same region
+ * flow independently, from [org.onebusaway.android.analytics.AnalyticsProvider].
  *
  * Started once from `Application.onCreate` (after `initObaRegion`, so the repo seeds from the region
  * already loaded). The collector runs for the process lifetime — an app-global subscription.

--- a/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/CustomerServiceDestination.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/CustomerServiceDestination.kt
@@ -23,7 +23,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import com.google.firebase.analytics.FirebaseAnalytics
 import org.onebusaway.android.R
-import org.onebusaway.android.app.Application
+import org.onebusaway.android.app.di.AnalyticsEntryPoint
 import org.onebusaway.android.analytics.ObaAnalytics
 import org.onebusaway.android.analytics.PlausibleAnalytics
 import org.onebusaway.android.report.ReportContext
@@ -44,7 +44,7 @@ fun CustomerServiceDestination(navController: NavController, reportContext: Repo
     fun reportContactEvent(agencyName: String, labelRes: Int) {
         ObaAnalytics.reportUiEvent(
             firebaseAnalytics,
-            Application.get().plausibleInstance,
+            AnalyticsEntryPoint.get(activity).plausible,
             PlausibleAnalytics.REPORT_MORE_EVENT_URL,
             agencyName + "_" + activity.getString(R.string.analytics_customer_service),
             activity.getString(labelRes)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/InfrastructureIssueScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/InfrastructureIssueScreen.kt
@@ -84,7 +84,7 @@ import com.google.firebase.analytics.FirebaseAnalytics
 import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
-import org.onebusaway.android.app.Application
+import org.onebusaway.android.app.di.AnalyticsEntryPoint
 import org.onebusaway.android.app.di.ArrivalsViewModelFactoryEntryPoint
 import org.onebusaway.android.app.di.LocationEntryPoint
 import org.onebusaway.android.app.di.NetworkEntryPoint
@@ -508,7 +508,7 @@ private fun reportProblemAnalytics(context: Context, kind: ProblemKind) {
     val isTrip = kind == ProblemKind.TRIP
     ObaAnalytics.reportUiEvent(
         FirebaseAnalytics.getInstance(context),
-        Application.get().plausibleInstance,
+        AnalyticsEntryPoint.get(context).plausible,
         if (isTrip) {
             PlausibleAnalytics.REPORT_VEHICLE_PROBLEM_EVENT_URL
         } else {
@@ -612,7 +612,7 @@ private fun Open311FormInline(
             (target.category.raw as? Service)?.let { service ->
                 ObaAnalytics.reportUiEvent(
                     firebaseAnalytics,
-                    Application.get().plausibleInstance,
+                    AnalyticsEntryPoint.get(context).plausible,
                     PlausibleAnalytics.REPORT_OPEN311_SERVER_EVENT_URL,
                     resources.getString(R.string.analytics_problem),
                     service.service_name,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/ReportLauncher.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/ReportLauncher.kt
@@ -36,7 +36,7 @@ import androidx.navigation.NavController
 import com.google.firebase.analytics.FirebaseAnalytics
 import org.onebusaway.android.BuildConfig
 import org.onebusaway.android.R
-import org.onebusaway.android.app.Application
+import org.onebusaway.android.app.di.AnalyticsEntryPoint
 import org.onebusaway.android.app.di.LocationEntryPoint
 import org.onebusaway.android.app.di.RegionEntryPoint
 import org.onebusaway.android.analytics.ObaAnalytics
@@ -240,7 +240,7 @@ private fun reportEvent(
 ) {
     ObaAnalytics.reportUiEvent(
         firebaseAnalytics,
-        Application.get().plausibleInstance,
+        AnalyticsEntryPoint.get(activity).plausible,
         eventUrl,
         activity.getString(R.string.analytics_problem),
         activity.getString(labelRes)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsRepository.kt
@@ -35,7 +35,7 @@ import org.onebusaway.android.analytics.ObaAnalytics
 import org.onebusaway.android.analytics.PlausibleAnalytics
 import org.onebusaway.android.api.ObaApi
 import org.onebusaway.android.api.ObaApiException
-import org.onebusaway.android.app.Application
+import org.onebusaway.android.analytics.AnalyticsProvider
 import org.onebusaway.android.database.oba.ImportGate
 import org.onebusaway.android.database.oba.RouteDao
 import org.onebusaway.android.database.oba.RouteHeadsignFavoriteDao
@@ -241,7 +241,8 @@ class DefaultArrivalsRepository @Inject constructor(
     private val routeDao: RouteDao,
     private val routeHeadsignFavoriteDao: RouteHeadsignFavoriteDao,
     private val importGate: ImportGate,
-    private val preferences: PreferencesRepository
+    private val preferences: PreferencesRepository,
+    private val analyticsProvider: AnalyticsProvider,
 ) : ArrivalsRepository {
 
     /** The last good snapshot paired with the monotonic device time it was received, so the
@@ -455,7 +456,7 @@ class DefaultArrivalsRepository @Inject constructor(
         val param = "${routeId}_$headsign for ${stopId ?: "all stops"}"
         ObaAnalytics.reportUiEvent(
             FirebaseAnalytics.getInstance(context),
-            Application.get().plausibleInstance,
+            analyticsProvider.plausible,
             PlausibleAnalytics.REPORT_BOOKMARK_EVENT_URL,
             event,
             param,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeNavHost.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeNavHost.kt
@@ -49,7 +49,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import org.onebusaway.android.R
-import org.onebusaway.android.app.Application
+import org.onebusaway.android.app.di.AnalyticsEntryPoint
 import org.onebusaway.android.app.di.PreferencesEntryPoint
 import org.onebusaway.android.analytics.ObaAnalytics
 import org.onebusaway.android.analytics.PlausibleAnalytics
@@ -303,7 +303,7 @@ internal fun HomeAnalyticsEffect(analyticsEvents: SharedFlow<HomeAnalyticsEvent>
     LaunchedEffect(analyticsEvents) {
         analyticsEvents.collect { event ->
             val firebase = FirebaseAnalytics.getInstance(context)
-            val plausible = Application.get().plausibleInstance
+            val plausible = AnalyticsEntryPoint.get(context).plausible
             when (event) {
                 is HomeAnalyticsEvent.RegionSelected ->
                     ObaAnalytics.setRegion(plausible, firebase, event.regionName)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeNavHost.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeNavHost.kt
@@ -306,7 +306,7 @@ internal fun HomeAnalyticsEffect(analyticsEvents: SharedFlow<HomeAnalyticsEvent>
             val plausible = AnalyticsEntryPoint.get(context).plausible
             when (event) {
                 is HomeAnalyticsEvent.RegionSelected ->
-                    ObaAnalytics.setRegion(plausible, firebase, event.regionName)
+                    ObaAnalytics.setRegion(firebase, event.regionName)
                 is HomeAnalyticsEvent.MenuItem ->
                     ObaAnalytics.reportUiEvent(
                         firebase, plausible, PlausibleAnalytics.REPORT_MENU_EVENT_URL,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
@@ -60,6 +60,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.google.firebase.analytics.FirebaseAnalytics
 import org.onebusaway.android.R
 import org.onebusaway.android.app.Application
+import org.onebusaway.android.app.di.AnalyticsEntryPoint
 import org.onebusaway.android.analytics.ObaAnalytics
 import org.onebusaway.android.analytics.PlausibleAnalytics
 import org.onebusaway.android.models.ObaStop
@@ -129,7 +130,7 @@ fun MapFeature(
                 )
                 ObaAnalytics.reportUiEvent(
                     firebaseAnalytics,
-                    Application.get().plausibleInstance,
+                    AnalyticsEntryPoint.get(context).plausible,
                     PlausibleAnalytics.REPORT_MAP_EVENT_URL,
                     resources.getString(R.string.analytics_label_button_press_map_icon),
                     null,
@@ -149,7 +150,7 @@ fun MapFeature(
                 }
                 ObaAnalytics.reportUiEvent(
                     firebaseAnalytics,
-                    Application.get().plausibleInstance,
+                    AnalyticsEntryPoint.get(context).plausible,
                     PlausibleAnalytics.REPORT_BIKE_EVENT_URL,
                     resources.getString(
                         if (station.isFloatingBike) {
@@ -328,7 +329,7 @@ fun MapFeature(
             mapViewModel.requestMyLocation(useDefaultZoom = true, animate = true)
             ObaAnalytics.reportUiEvent(
                 firebaseAnalytics,
-                Application.get().plausibleInstance,
+                AnalyticsEntryPoint.get(context).plausible,
                 PlausibleAnalytics.REPORT_MAP_EVENT_URL,
                 resources.getString(R.string.analytics_label_button_press_location),
                 null,
@@ -343,7 +344,7 @@ fun MapFeature(
             mapViewModel.setBikeshareLayerVisible(!active, persist = true)
             ObaAnalytics.reportUiEvent(
                 firebaseAnalytics,
-                Application.get().plausibleInstance,
+                AnalyticsEntryPoint.get(context).plausible,
                 PlausibleAnalytics.REPORT_MAP_EVENT_URL,
                 resources.getString(R.string.analytics_layer_bikeshare),
                 resources.getString(

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/nav/ExtraDestinations.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/nav/ExtraDestinations.kt
@@ -28,6 +28,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
 import com.google.firebase.analytics.FirebaseAnalytics
 import org.onebusaway.android.app.Application
+import org.onebusaway.android.app.di.AnalyticsEntryPoint
 import org.onebusaway.android.analytics.ObaAnalytics
 import org.onebusaway.android.ui.compose.findActivity
 import org.onebusaway.android.ui.nav.revealRouteOnMap
@@ -113,7 +114,7 @@ fun NavGraphBuilder.extraDestinations(navController: NavHostController) {
         val searchVm: SearchResultsViewModel = hiltViewModel()
         LaunchedEffect(query) {
             ObaAnalytics.reportSearchEvent(
-                Application.get().plausibleInstance, firebaseAnalytics, query
+                AnalyticsEntryPoint.get(activity).plausible, firebaseAnalytics, query
             )
             searchVm.search(query)
         }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/regions/RegionsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/regions/RegionsRepository.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.onebusaway.android.R
 import org.onebusaway.android.app.Application
+import org.onebusaway.android.analytics.AnalyticsProvider
 import org.onebusaway.android.analytics.ObaAnalytics
 import org.onebusaway.android.analytics.PlausibleAnalytics
 import org.onebusaway.android.region.Region
@@ -78,6 +79,7 @@ class DefaultRegionsRepository @Inject constructor(
     private val regionRepository: RegionRepository,
     private val regionCache: RegionCache,
     private val locationRepository: LocationRepository,
+    private val analyticsProvider: AnalyticsProvider,
 ) : RegionsRepository {
 
     // Domain objects from the last successful load, so selectRegion(id) can resolve the Region
@@ -128,7 +130,7 @@ class DefaultRegionsRepository @Inject constructor(
 
         ObaAnalytics.reportUiEvent(
             FirebaseAnalytics.getInstance(context),
-            Application.get().plausibleInstance,
+            analyticsProvider.plausible,
             PlausibleAnalytics.REPORT_REGION_EVENT_URL,
             context.getString(R.string.region_selected_manually),
             region.name

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/settings/SettingsAnalytics.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/settings/SettingsAnalytics.kt
@@ -18,7 +18,7 @@ package org.onebusaway.android.ui.settings
 import android.content.Context
 import androidx.annotation.StringRes
 import com.google.firebase.analytics.FirebaseAnalytics
-import org.onebusaway.android.app.Application
+import org.onebusaway.android.app.di.AnalyticsEntryPoint
 import org.onebusaway.android.analytics.ObaAnalytics
 import org.onebusaway.android.analytics.PlausibleAnalytics
 
@@ -26,7 +26,7 @@ import org.onebusaway.android.analytics.PlausibleAnalytics
 internal fun reportPreferencesEvent(context: Context, @StringRes labelRes: Int) {
     ObaAnalytics.reportUiEvent(
         FirebaseAnalytics.getInstance(context),
-        Application.get().plausibleInstance,
+        AnalyticsEntryPoint.get(context).plausible,
         PlausibleAnalytics.REPORT_PREFERENCES_EVENT_URL,
         context.getString(labelRes),
         null,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripdetails/DestinationReminder.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripdetails/DestinationReminder.kt
@@ -51,7 +51,7 @@ import com.google.android.gms.location.LocationSettingsStatusCodes
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.firebase.analytics.FirebaseAnalytics
 import org.onebusaway.android.R
-import org.onebusaway.android.app.Application
+import org.onebusaway.android.app.di.AnalyticsEntryPoint
 import org.onebusaway.android.analytics.ObaAnalytics
 import org.onebusaway.android.analytics.PlausibleAnalytics
 import org.onebusaway.android.nav.NavigationService
@@ -169,7 +169,7 @@ internal fun rememberDestinationReminderAction(
             destinationReminderBetaDialog()
         }
         ObaAnalytics.reportUiEvent(
-            FirebaseAnalytics.getInstance(context), Application.get().plausibleInstance,
+            FirebaseAnalytics.getInstance(context), AnalyticsEntryPoint.get(context).plausible,
             PlausibleAnalytics.REPORT_DESTINATION_REMINDER_EVENT_URL,
             resources.getString(R.string.analytics_label_destination_reminder),
             resources.getString(R.string.analytics_label_destination_reminder_variant_started)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanScreen.kt
@@ -76,6 +76,7 @@ import java.util.TimeZone
 import kotlinx.coroutines.launch
 import org.onebusaway.android.R
 import org.onebusaway.android.app.Application
+import org.onebusaway.android.app.di.AnalyticsEntryPoint
 import org.onebusaway.android.app.di.LocationEntryPoint
 import org.onebusaway.android.app.di.RegionEntryPoint
 import org.onebusaway.android.directions.util.ConversionUtils
@@ -569,7 +570,7 @@ private fun reportProblem(
     val locationString = location?.let { LocationUtils.printLocationDetails(it) }
     ExternalIntents.sendEmail(activity, email, locationString, null, true)
     ObaAnalytics.reportUiEvent(
-        firebaseAnalytics, Application.get().plausibleInstance,
+        firebaseAnalytics, AnalyticsEntryPoint.get(activity).plausible,
         PlausibleAnalytics.REPORT_TRIP_PLANNER_EVENT_URL,
         activity.getString(R.string.analytics_label_app_feedback_otp), null
     )
@@ -580,7 +581,7 @@ private fun reportPlanAnalytics(
     firebaseAnalytics: FirebaseAnalytics
 ) {
     ObaAnalytics.reportUiEvent(
-        firebaseAnalytics, Application.get().plausibleInstance,
+        firebaseAnalytics, AnalyticsEntryPoint.get(activity).plausible,
         PlausibleAnalytics.REPORT_TRIP_PLANNER_EVENT_URL,
         activity.getString(R.string.analytics_label_trip_plan), null
     )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/ExternalIntents.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/ExternalIntents.kt
@@ -33,6 +33,7 @@ import com.google.firebase.analytics.FirebaseAnalytics
 
 import org.onebusaway.android.R
 import org.onebusaway.android.app.Application
+import org.onebusaway.android.app.di.AnalyticsEntryPoint
 import org.onebusaway.android.analytics.ObaAnalytics
 import org.onebusaway.android.analytics.PlausibleAnalytics
 import org.onebusaway.android.region.Region
@@ -288,7 +289,7 @@ object ExternalIntents {
             activity.startActivity(intent)
             ObaAnalytics.reportUiEvent(
                 FirebaseAnalytics.getInstance(activity),
-                Application.get().plausibleInstance,
+                AnalyticsEntryPoint.get(activity).plausible,
                 PlausibleAnalytics.REPORT_FARE_PAYMENT_EVENT_URL,
                 Application.get().getString(R.string.analytics_label_button_fare_payment),
                 Application.get().getString(R.string.analytics_label_open_app)
@@ -300,7 +301,7 @@ object ExternalIntents {
             activity.startActivity(intent)
             ObaAnalytics.reportUiEvent(
                 FirebaseAnalytics.getInstance(activity),
-                Application.get().plausibleInstance,
+                AnalyticsEntryPoint.get(activity).plausible,
                 PlausibleAnalytics.REPORT_FARE_PAYMENT_EVENT_URL,
                 Application.get().getString(R.string.analytics_label_button_fare_payment),
                 Application.get().getString(R.string.analytics_label_download_app)
@@ -323,7 +324,7 @@ object ExternalIntents {
             context.startActivity(intent)
             ObaAnalytics.reportUiEvent(
                 FirebaseAnalytics.getInstance(context),
-                Application.get().plausibleInstance,
+                AnalyticsEntryPoint.get(context).plausible,
                 PlausibleAnalytics.REPORT_FARE_PAYMENT_EVENT_URL,
                 Application.get().getString(R.string.analytics_label_button_bike_share),
                 Application.get().getString(R.string.analytics_label_open_app)
@@ -335,7 +336,7 @@ object ExternalIntents {
             context.startActivity(intent)
             ObaAnalytics.reportUiEvent(
                 FirebaseAnalytics.getInstance(context),
-                Application.get().plausibleInstance,
+                AnalyticsEntryPoint.get(context).plausible,
                 PlausibleAnalytics.REPORT_FARE_PAYMENT_EVENT_URL,
                 Application.get().getString(R.string.analytics_label_button_bike_share),
                 Application.get().getString(R.string.analytics_label_download_app)

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/DonationViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/DonationViewModelTest.kt
@@ -42,7 +42,7 @@ class DonationViewModelTest {
 
     // These tests cover only the dialog/effect logic, which never calls the DonationsManager, so a
     // bare instance (its Android collaborators are never touched) is enough to satisfy the constructor.
-    private fun donationViewModel() = DonationViewModel(DonationsManager(null, null, 0))
+    private fun donationViewModel() = DonationViewModel(DonationsManager(null, null, null, 0))
 
     @Test
     fun `close requests the dismiss confirmation, cancel clears it`() = runTest {


### PR DESCRIPTION
Part of #1624 — finishing the DI campaign by eliminating the `Application.get()` static service-locator. This is the **analytics slice**, the largest and only one that needed new infrastructure. Independent of the region/config PRs; all branch from `main`.

## The problem

~26 call sites threaded `Application.get().plausibleInstance` in as a parameter, and `ObaAnalytics` reached `Application.get().umamiInstance` internally — because `ObaAnalytics` is a context-less static orchestrator with no DI seam. The Plausible/Umami emitters are **region-derived** app-global state living on `Application`.

## What changed

**New `AnalyticsProvider`** (`@Singleton @Inject`): owns the Plausible + Umami instances, rebuilt reactively whenever the `RegionRepository` region changes — the same "everything that cares observes the region flow" form as `RegionSubsystems`. It seeds synchronously from the current region in `init` (the `@AppScope` collector runs on IO, so a lazy-only collector would leave a null window on first use). Fire-and-forget: a malformed region URL disables that emitter rather than throwing inside the long-lived collector.

**New `AnalyticsEntryPoint`**: the seam for the context-less static (`ObaAnalytics`) and Java call sites, mirroring `RegionEntryPoint`/`LocationEntryPoint`.

**Call sites (26)** follow the codebase's established pattern:
- Injectable classes inject `AnalyticsProvider` (`ArrivalsRepository`, `RegionsRepository`, `NavigationService`).
- Composables / free functions / objects / Java-with-a-Context resolve it via `AnalyticsEntryPoint.get(context)`.
- `DonationsManager` gains a `Context` field and resolves the provider **lazily** at event time — it's built eagerly in `Application.onCreate`, so constructor-injecting `AnalyticsProvider` (which pulls in the deliberately-lazy `RegionRepository`) would risk the region-init ordering hazard.

**`Application`**: deletes `mPlausible`/`mUmami` + the four `get*/build*Instance` methods; `onRegionChanged` now only re-inits Open311; `reportAnalytics` only sets the initial Firebase/Umami region label (the emitters build reactively).

**`ObaAnalytics.umami()`** now reads `AnalyticsProvider` via the EntryPoint rather than app-global state. As a context-less static it keeps `Application.get()` only as a *graph handle* (the benign context category the issue carves out, like its existing `string()` helper).

## Behavior

No user-facing change — best-effort telemetry, structurally rehomed. The initial region label and reactive region-change rebuild are both preserved. Builds clean on `obaGoogleDebug`; the full JVM unit suite passes (`DonationViewModelTest` updated for the new `DonationsManager` constructor arg).

## Note on remaining work

`ObaAnalytics.string()` and a few Firebase/notification context grabs still call `Application.get()` for a Context (the issue's explicitly-lower-priority "benign context" bucket). The deferred **legacy directions cluster** (`isBikeshareEnabled`/`TripRequest`, see the config-slice PR) is unrelated to analytics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved analytics tracking across the app, including region changes and common actions like navigation, reporting, settings, donations, maps, search, and external app launches.
  * Made analytics more reliable during app startup and when switching regions, including safer handling for malformed region links/URLs.
* **Documentation**
  * Clarified how region-based analytics and Open311 reporting are initialized and updated.
* **Tests**
  * Updated analytics-related test setup to match the current donations manager signature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->