### PR TITLE
De-static-ify the directions/bikeshare DI cluster (#1630)

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/directions/realtime/RealtimeServiceTest.java
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/directions/realtime/RealtimeServiceTest.java
@@ -81,7 +81,7 @@ public class RealtimeServiceTest {
         Bundle bundle = new Bundle();
         // Set start time to 2 hours in the future (Query window is 1 hour)
         long futureTime = System.currentTimeMillis() + (OTPConstants.REALTIME_SERVICE_QUERY_WINDOW * 2);
-        new TripRequestBuilder(bundle).setDateTime(new Date(futureTime));
+        new TripRequestBuilder(InstrumentationRegistry.getTargetContext(), bundle).setDateTime(new Date(futureTime));
 
         boolean result = mService.rescheduleRealtimeUpdates(bundle);
         assertTrue("Realtime updates should be rescheduled for future trips", result);
@@ -92,7 +92,7 @@ public class RealtimeServiceTest {
         Bundle bundle = new Bundle();
         // Set start time to 30 minutes in the future (within 1 hour window)
         long nearTime = System.currentTimeMillis() + (OTPConstants.REALTIME_SERVICE_QUERY_WINDOW / 2);
-        new TripRequestBuilder(bundle).setDateTime(new Date(nearTime));
+        new TripRequestBuilder(InstrumentationRegistry.getTargetContext(), bundle).setDateTime(new Date(nearTime));
 
         boolean result = mService.rescheduleRealtimeUpdates(bundle);
         assertFalse("Realtime updates should not be rescheduled if trip starts soon", result);
@@ -172,7 +172,7 @@ public class RealtimeServiceTest {
         CustomAddress to = new CustomAddress();
         to.setLatitude(0);
         to.setLongitude(0);
-        new TripRequestBuilder(bundle).setFrom(from).setTo(to).setDateTime(new Date());
+        new TripRequestBuilder(InstrumentationRegistry.getTargetContext(), bundle).setFrom(from).setTo(to).setDateTime(new Date());
 
         // Build a valid itinerary with one transit leg so ItineraryDescription succeeds
         // and we actually reach the NOTIFICATION_TARGET check (not the catch block).

--- a/onebusaway-android/src/main/java/org/onebusaway/android/app/Application.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/app/Application.java
@@ -426,20 +426,6 @@ public class Application extends android.app.Application {
         }
     }
 
-    /**
-     * Method to check whether bikeshare layer is enabled or not.
-     *
-     * @return true if the bikeshare layer is an option that can be toggled on/off
-     */
-    public static boolean isBikeshareEnabled() {
-        // Bike layer is enabled if either the current region
-        // supports it or a custom otp url is set. The custom otp url is used to make the testing
-        // process easier
-        return ((Application.get().getCurrentRegion() != null
-                && Application.get().getCurrentRegion().getSupportsOtpBikeshare())
-                || !TextUtils.isEmpty(Application.get().getCustomOtpApiUrl()));
-    }
-
     private void createNotificationChannels() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             NotificationChannel channel1 = new NotificationChannel(

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/realtime/RealtimeService.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/realtime/RealtimeService.java
@@ -145,7 +145,7 @@ public class RealtimeService extends IntentService {
      */
     boolean rescheduleRealtimeUpdates(Bundle bundle) {
         // Delay if this trip doesn't start for at least an hour
-        Date start = new TripRequestBuilder(bundle).getDateTime();
+        Date start = new TripRequestBuilder(this, bundle).getDateTime();
 
         if (start != null) {
             Date queryStart = new Date(start.getTime() - OTPConstants.REALTIME_SERVICE_QUERY_WINDOW);
@@ -175,7 +175,7 @@ public class RealtimeService extends IntentService {
     }
 
     private void checkForItineraryChange(final Bundle bundle) {
-        TripRequestBuilder builder = TripRequestBuilder.initFromBundleSimple(bundle);
+        TripRequestBuilder builder = TripRequestBuilder.initFromBundleSimple(this, bundle);
         ItineraryDescription desc = getItineraryDescription(bundle);
         Class target = getNotificationTarget(bundle);
         if (target == null) {
@@ -383,7 +383,7 @@ public class RealtimeService extends IntentService {
 
         Bundle extras = new Bundle();
         try {
-            new TripRequestBuilder(params).copyIntoBundleSimple(extras);
+            new TripRequestBuilder(this, params).copyIntoBundleSimple(extras);
         } catch (NullPointerException e) {
             Log.e(TAG, "getSimplifiedBundle: error copying trip params into bundle", e);
             return null;

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/tasks/TripRequest.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/tasks/TripRequest.java
@@ -16,10 +16,12 @@
 
 package org.onebusaway.android.directions.tasks;
 
+import android.content.Context;
 import android.os.AsyncTask;
 import android.util.Log;
 
-import org.onebusaway.android.app.Application;
+import org.onebusaway.android.R;
+import org.onebusaway.android.app.di.PreferencesEntryPoint;
 import org.onebusaway.android.directions.util.JacksonConfig;
 import org.opentripplanner.api.model.TripPlan;
 import org.opentripplanner.api.ws.Message;
@@ -68,8 +70,12 @@ public class TripRequest extends AsyncTask<Request, Integer, Long> {
 
     private Callback mCallback;
 
+    // Application context, used to read/write the OTP-url-version flag through PreferencesEntryPoint.
+    private final Context mContext;
+
     // change Server object to baseUrl string.
-    public TripRequest(String baseUrl, Callback callback) {
+    public TripRequest(Context context, String baseUrl, Callback callback) {
+        mContext = context.getApplicationContext();
         mBaseUrl = baseUrl;
         mCallback = callback;
     }
@@ -87,7 +93,8 @@ public class TripRequest extends AsyncTask<Request, Integer, Long> {
             return null;
         } else {
             String prefix = FOLDER_STRUCTURE_PREFIX_NEW;
-            boolean useOldUrlVersion = Application.get().getUseOldOtpApiUrlVersion();
+            boolean useOldUrlVersion = PreferencesEntryPoint.get(mContext)
+                    .getBoolean(R.string.preference_key_otp_api_url_version, false);
             for (Request req : reqs) {
                 mResponse = requestPlan(req, prefix, mBaseUrl, useOldUrlVersion);
             }
@@ -175,7 +182,8 @@ public class TripRequest extends AsyncTask<Request, Integer, Long> {
 
             if (useOldUrlStructure) {
                 // If the old url structure is successful then cache it
-                Application.get().setUseOldOtpApiUrlVersion(true);
+                PreferencesEntryPoint.get(mContext)
+                        .setBoolean(R.string.preference_key_otp_api_url_version, true);
             }
         } catch (java.net.SocketTimeoutException e) {
             Log.e(TAG, "Timeout fetching JSON or XML: " + e);

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/TripRequestBuilder.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/TripRequestBuilder.java
@@ -291,7 +291,13 @@ public class TripRequestBuilder {
             otpBaseUrl = customOtpApiUrl;
             Log.d(TAG, "Using custom OTP API URL set by user '" + otpBaseUrl + "'.");
         } else {
-            otpBaseUrl = RegionEntryPoint.get(mContext).currentRegion().getOtpBaseUrl();
+            Region region = RegionEntryPoint.get(mContext).currentRegion();
+            // No custom URL and no selected region: return null so the caller (TripRequest /
+            // TripPlanRepository) surfaces a "no server selected" error instead of crashing.
+            if (region == null) {
+                return null;
+            }
+            otpBaseUrl = region.getOtpBaseUrl();
         }
         try {
             // URI.parse() doesn't tell us if the scheme is missing, so use URL() instead (#126)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/TripRequestBuilder.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/TripRequestBuilder.java
@@ -17,14 +17,18 @@
 package org.onebusaway.android.directions.util;
 
 import android.app.Activity;
+import android.content.Context;
 import android.os.Bundle;
 import android.text.TextUtils;
 import android.util.Log;
 
 import org.onebusaway.android.R;
-import org.onebusaway.android.app.Application;
+import org.onebusaway.android.app.di.PreferencesEntryPoint;
+import org.onebusaway.android.app.di.RegionEntryPoint;
 import org.onebusaway.android.directions.tasks.TripRequest;
+import org.onebusaway.android.region.Region;
 import org.onebusaway.android.ui.tripplan.TripModes;
+import org.onebusaway.android.util.BikeshareAvailability;
 import org.onebusaway.android.util.RegionUtils;
 import org.opentripplanner.api.ws.Request;
 import org.opentripplanner.routing.core.OptimizeType;
@@ -66,7 +70,12 @@ public class TripRequestBuilder {
 
     private int mModeId;
 
-    public TripRequestBuilder(Bundle bundle) {
+    // Application context, used to read the region / OTP-config seams (bikeshare availability, the OTP
+    // base URL) that used to be reached through the Application static.
+    private final Context mContext;
+
+    public TripRequestBuilder(Context context, Bundle bundle) {
+        this.mContext = context.getApplicationContext();
         this.mBundle = bundle;
     }
 
@@ -161,10 +170,10 @@ public class TripRequestBuilder {
                 break;
             // Transit & bikeshare
             case TripModes.TRANSIT_AND_BIKE:
-                if (Application.isBikeshareEnabled()) {
+                if (BikeshareAvailability.isEnabled(mContext)) {
                     modes = Arrays.asList(TraverseMode.TRANSIT.toString(),
                             TraverseMode.WALK.toString(),
-                            Application.get().getString(R.string.traverse_mode_bicycle_rent));
+                            mContext.getString(R.string.traverse_mode_bicycle_rent));
                 } else {
                     modes = Arrays.asList(TraverseMode.TRANSIT.toString(), TraverseMode.WALK.toString());
                 }
@@ -177,7 +186,7 @@ public class TripRequestBuilder {
                         TraverseMode.WALK.toString());
                 break;
             case TripModes.BIKESHARE:
-                modes = Arrays.asList(Application.get().getString(R.string.traverse_mode_bicycle_rent));
+                modes = Arrays.asList(mContext.getString(R.string.traverse_mode_bicycle_rent));
                 break;
             default:
                 Log.e(TAG, "Invalid mode set ID");
@@ -192,7 +201,7 @@ public class TripRequestBuilder {
 
     public int getModeSetId() {
         // IF bike mode is selected in the trip plan additional preferences but bikeshare is not enabled use the default mode (TRANSTI)
-        if (TripModes.BIKESHARE == mModeId && !Application.isBikeshareEnabled()) {
+        if (TripModes.BIKESHARE == mModeId && !BikeshareAvailability.isEnabled(mContext)) {
             return TripModes.TRANSIT_ONLY;
         }
         return mModeId;
@@ -216,7 +225,7 @@ public class TripRequestBuilder {
         Request request = buildRequest();
         // TripRequest will accept a null value and give a user-friendly error
         String fmtOtpBaseUrl = getFormattedOtpBaseUrl();
-        TripRequest tripRequest = new TripRequest(fmtOtpBaseUrl, mListener);
+        TripRequest tripRequest = new TripRequest(mContext, fmtOtpBaseUrl, mListener);
         tripRequest.execute(request);
         return tripRequest;
     }
@@ -276,19 +285,20 @@ public class TripRequestBuilder {
      */
     public String getFormattedOtpBaseUrl() {
         String otpBaseUrl;
-        Application app = Application.get();
-        if (!TextUtils.isEmpty(app.getCustomOtpApiUrl())) {
-            otpBaseUrl = app.getCustomOtpApiUrl();
+        String customOtpApiUrl = PreferencesEntryPoint.get(mContext)
+                .getString(mContext.getString(R.string.preference_key_otp_api_url), (String) null);
+        if (!TextUtils.isEmpty(customOtpApiUrl)) {
+            otpBaseUrl = customOtpApiUrl;
             Log.d(TAG, "Using custom OTP API URL set by user '" + otpBaseUrl + "'.");
         } else {
-            otpBaseUrl = app.getCurrentRegion().getOtpBaseUrl();
+            otpBaseUrl = RegionEntryPoint.get(mContext).currentRegion().getOtpBaseUrl();
         }
         try {
             // URI.parse() doesn't tell us if the scheme is missing, so use URL() instead (#126)
             URL url = new URL(otpBaseUrl);
         } catch (MalformedURLException e) {
             // Assume HTTPS scheme, since without a scheme the Uri won't parse the authority
-            otpBaseUrl = app.getString(R.string.https_prefix) + otpBaseUrl;
+            otpBaseUrl = mContext.getString(R.string.https_prefix) + otpBaseUrl;
         }
         return otpBaseUrl != null ? RegionUtils.formatOtpBaseUrl(otpBaseUrl) : null;
     }
@@ -381,7 +391,7 @@ public class TripRequestBuilder {
     /**
      * Initialize from a BaseBundle
      */
-    public static TripRequestBuilder initFromBundleSimple(Bundle bundle) {
+    public static TripRequestBuilder initFromBundleSimple(Context context, Bundle bundle) {
         Bundle target = new Bundle();
         target.putBoolean(ARRIVE_BY, bundle.getBoolean(ARRIVE_BY));
 
@@ -408,7 +418,7 @@ public class TripRequestBuilder {
         target.putString(MODE_SET, bundle.getString(MODE_SET));
         target.putLong(DATE_TIME, bundle.getLong(DATE_TIME));
 
-        return new TripRequestBuilder(target);
+        return new TripRequestBuilder(context, target);
     }
 
     /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/BikeLayerController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/BikeLayerController.kt
@@ -26,7 +26,8 @@ import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.launch
 import org.onebusaway.android.R
-import org.onebusaway.android.app.Application
+import org.onebusaway.android.region.RegionRepository
+import org.onebusaway.android.util.BikeshareAvailability
 import org.onebusaway.android.map.bike.BikeAction
 import org.onebusaway.android.map.bike.BikeStationsRepository
 import org.onebusaway.android.map.bike.bikeAction
@@ -48,6 +49,7 @@ class BikeLayerController(
     private val host: MapHost,
     private val bikeStationsRepository: BikeStationsRepository,
     private val prefsRepository: PreferencesRepository,
+    private val regionRepository: RegionRepository,
     private val scope: CoroutineScope,
 ) {
 
@@ -80,7 +82,11 @@ class BikeLayerController(
             ) { camera, layerVisible -> camera to layerVisible }
                 // collectLatest so a newer viewport cancels an in-flight station load (the old loadJob?.cancel()).
                 .collectLatest { (camera, layerVisible) ->
-                    if (!Application.isBikeshareEnabled()) {
+                    if (!BikeshareAvailability.isEnabled(
+                            regionRepository.currentRegion(),
+                            prefsRepository.getString(R.string.preference_key_otp_api_url, null),
+                        )
+                    ) {
                         return@collectLatest
                     }
                     when (bikeAction(directions, selectedBikeStationIds, layerVisible)) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/DirectionsMapViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/DirectionsMapViewModel.kt
@@ -70,6 +70,7 @@ class DirectionsMapViewModel @Inject constructor(
         host = mapHost,
         bikeStationsRepository = bikeStationsRepository,
         prefsRepository = prefsRepository,
+        regionRepository = regionRepo,
         scope = viewModelScope,
     )
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
@@ -162,6 +162,7 @@ class MapViewModel @Inject constructor(
         host = mapHost,
         bikeStationsRepository = bikeStationsRepository,
         prefsRepository = prefsRepository,
+        regionRepository = regionRepo,
         scope = viewModelScope,
     )
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapChromeViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapChromeViewModel.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.launch
 import org.onebusaway.android.R
 import org.onebusaway.android.preferences.PreferencesRepository
 import org.onebusaway.android.region.RegionRepository
+import org.onebusaway.android.util.BikeshareAvailability
 
 /** The map-chrome visibility gates: which FABs/controls show over the map, derived from prefs + region. */
 data class MapChromeState(
@@ -65,13 +66,10 @@ class MapChromeViewModel @Inject constructor(
                 regionRepo.region,
                 prefsRepo.observeString(R.string.preference_key_otp_api_url, null),
             ) { zoomControls, leftHand, bikeVisible, region, otpUrl ->
-                // Reactive re-derivation of Application.isBikeshareEnabled() for this consumer, so the
-                // gate tracks region + the OTP-URL pref instead of reading the Application static. The
-                // same predicate still lives in Application.isBikeshareEnabled(), LayerUtils, and
-                // MapViewModel's resume sync; converging them onto one shared reactive source is the
-                // deferred LayerUtils TODO(D4) — keep these in sync until then.
-                val bikeshareEnabled =
-                    (region != null && region.supportsOtpBikeshare) || !otpUrl.isNullOrEmpty()
+                // Reactive re-derivation of bikeshare availability for this consumer, tracking region +
+                // the OTP-URL pref. Shares the one predicate ([BikeshareAvailability]) with the trip/layer
+                // call sites, so this stays a live flow while they resolve it per-call from a Context.
+                val bikeshareEnabled = BikeshareAvailability.isEnabled(region, otpUrl)
                 MapChromeState(
                     zoomControls = zoomControls,
                     leftHand = leftHand,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanRepository.kt
@@ -57,7 +57,7 @@ class DefaultTripPlanRepository @Inject constructor(
     override suspend fun plan(params: TripPlanParams): Result<List<Itinerary>> =
         withContext(Dispatchers.IO) {
             runCatching {
-                val builder = TripRequestBuilder(Bundle()).apply {
+                val builder = TripRequestBuilder(context, Bundle()).apply {
                     setFrom(params.from.toCustomAddress())
                     setTo(params.to.toCustomAddress())
                     val calendar = Calendar.getInstance().apply { timeInMillis = params.dateTimeMillis }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanScreen.kt
@@ -15,6 +15,7 @@
  */
 package org.onebusaway.android.ui.tripplan
 
+import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.provider.ContactsContract
@@ -75,7 +76,6 @@ import java.util.Calendar
 import java.util.TimeZone
 import kotlinx.coroutines.launch
 import org.onebusaway.android.R
-import org.onebusaway.android.app.Application
 import org.onebusaway.android.app.di.AnalyticsEntryPoint
 import org.onebusaway.android.app.di.LocationEntryPoint
 import org.onebusaway.android.app.di.RegionEntryPoint
@@ -91,6 +91,7 @@ import org.onebusaway.android.ui.compose.components.SwitchRow
 import org.onebusaway.android.ui.compose.findActivity
 import org.onebusaway.android.ui.nav.NavRoutes
 import org.onebusaway.android.ui.tripresults.TripResults
+import org.onebusaway.android.util.BikeshareAvailability
 import org.onebusaway.android.util.ExternalIntents
 import org.onebusaway.android.util.LocationUtils
 import org.onebusaway.android.util.PreferenceUtils
@@ -192,7 +193,7 @@ fun TripPlanDestination(navController: NavHostController, onBack: () -> Unit) {
     // fresh; read the restore extras off the host intent once. (A notification arriving while already
     // on this destination — singleTop, no recomposition — won't re-restore; acceptable rare edge.)
     LaunchedEffect(Unit) {
-        maybeRestoreFromIntent(viewModel, activity.intent)?.let { activity.setIntent(it) }
+        maybeRestoreFromIntent(viewModel, activity, activity.intent)?.let { activity.setIntent(it) }
     }
 
     var showAdvanced by remember { mutableStateOf(false) }
@@ -436,7 +437,7 @@ private fun AdvancedSettingsDialog(
             labels[i] to TripModes.getTripModeCodeFromSelection(typed.getResourceId(i, 0))
         }
         typed.recycle()
-        if (Application.isBikeshareEnabled()) {
+        if (BikeshareAvailability.isEnabled(activity)) {
             all
         } else {
             all.filter { it.second != TripModes.BIKESHARE && it.second != TripModes.TRANSIT_AND_BIKE }
@@ -593,14 +594,18 @@ private fun reportPlanAnalytics(
  * there was nothing to restore.
  */
 @Suppress("UNCHECKED_CAST", "DEPRECATION")
-private fun maybeRestoreFromIntent(viewModel: TripPlanViewModel, intent: Intent?): Intent? {
+private fun maybeRestoreFromIntent(
+    viewModel: TripPlanViewModel,
+    context: Context,
+    intent: Intent?,
+): Intent? {
     val extras = intent?.extras ?: return null
     if (extras.getSerializable(OTPConstants.INTENT_SOURCE) == null) return null
     val itineraries =
         (extras.getSerializable(OTPConstants.ITINERARIES) as? ArrayList<Itinerary>).orEmpty()
     if (itineraries.isEmpty()) return null
 
-    val builder = TripRequestBuilder.initFromBundleSimple(extras)
+    val builder = TripRequestBuilder.initFromBundleSimple(context, extras)
     viewModel.restoreFrom(
         from = builder.from?.toPlaceItem(),
         to = builder.to?.toPlaceItem(),

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/BikeshareAvailability.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/BikeshareAvailability.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.util
+
+import android.content.Context
+import org.onebusaway.android.R
+import org.onebusaway.android.app.di.PreferencesEntryPoint
+import org.onebusaway.android.app.di.RegionEntryPoint
+import org.onebusaway.android.region.Region
+
+/**
+ * Whether bikeshare is an available trip/layer option — the predicate lifted off the former
+ * `Application.isBikeshareEnabled()` static so it reads the injected region / preferences seams instead
+ * of app-global `Application` state. Bikeshare is available when the current region supports OTP
+ * bikeshare, or when a custom OTP API URL is set (which eases testing against a bikeshare-capable OTP).
+ */
+object BikeshareAvailability {
+
+    /**
+     * Resolves the region + custom OTP URL from [context] (via the DI EntryPoints) for callers that
+     * aren't themselves injectable — static Java utilities, the [TripRequestBuilder], composables.
+     */
+    @JvmStatic
+    fun isEnabled(context: Context): Boolean = isEnabled(
+        RegionEntryPoint.get(context).currentRegion(),
+        PreferencesEntryPoint.get(context)
+            .getString(context.getString(R.string.preference_key_otp_api_url), null),
+    )
+
+    /** Pure predicate for injected consumers that already hold the [region] + [customOtpApiUrl]. */
+    @JvmStatic
+    fun isEnabled(region: Region?, customOtpApiUrl: String?): Boolean =
+        (region != null && region.supportsOtpBikeshare) || !customOtpApiUrl.isNullOrEmpty()
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/LayerUtils.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/LayerUtils.java
@@ -18,7 +18,6 @@ package org.onebusaway.android.util;
 import android.content.Context;
 
 import org.onebusaway.android.R;
-import org.onebusaway.android.app.Application;
 import org.onebusaway.android.app.di.PreferencesEntryPoint;
 
 /**
@@ -34,9 +33,7 @@ public class LayerUtils {
     * @return true if the bikeshare layer is active and visible
      */
     public static boolean isBikeshareLayerVisible(Context context) {
-        // TODO: Application.isBikeshareEnabled() is a separate app-global static still reaching
-        // Application; left as-is for now.
-        return Application.isBikeshareEnabled() && PreferencesEntryPoint.get(context).getBoolean(
+        return BikeshareAvailability.isEnabled(context) && PreferencesEntryPoint.get(context).getBoolean(
                 R.string.preference_key_layer_bikeshare_visible, true);
     }
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/util/BikeshareAvailabilityTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/util/BikeshareAvailabilityTest.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.util
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.onebusaway.android.region.Region
+
+/** JVM unit tests for the pure [BikeshareAvailability.isEnabled] predicate (region + custom OTP URL). */
+class BikeshareAvailabilityTest {
+
+    private fun region(supportsBikeshare: Boolean) = Region(supportsOtpBikeshare = supportsBikeshare)
+
+    @Test
+    fun `enabled when the region supports OTP bikeshare`() {
+        assertTrue(BikeshareAvailability.isEnabled(region(supportsBikeshare = true), null))
+    }
+
+    @Test
+    fun `disabled when the region does not support bikeshare and no custom OTP URL`() {
+        assertFalse(BikeshareAvailability.isEnabled(region(supportsBikeshare = false), null))
+        assertFalse(BikeshareAvailability.isEnabled(region(supportsBikeshare = false), ""))
+    }
+
+    @Test
+    fun `enabled when a custom OTP URL is set, even if the region does not support bikeshare`() {
+        assertTrue(BikeshareAvailability.isEnabled(region(supportsBikeshare = false), "https://otp.example"))
+    }
+
+    @Test
+    fun `custom OTP URL enables bikeshare even with no region`() {
+        assertTrue(BikeshareAvailability.isEnabled(null, "https://otp.example"))
+    }
+
+    @Test
+    fun `disabled with no region and no custom OTP URL`() {
+        assertFalse(BikeshareAvailability.isEnabled(null, null))
+        assertFalse(BikeshareAvailability.isEnabled(null, ""))
+    }
+}


### PR DESCRIPTION
Closes #1630. The final app-global **state** reaches through `Application.get()` from the #1624 campaign — the directions/bikeshare cluster — which were deferred because they're coupled through the **Context-less `TripRequestBuilder`** (built by `execute()` with a null `Activity` from `RealtimeService`).

## What changed

- **New `BikeshareAvailability`** (Kotlin `@JvmStatic object`) holds the single bikeshare predicate, lifted off `Application.isBikeshareEnabled()`:
  - `isEnabled(context)` — resolves region + custom OTP URL via the DI EntryPoints, for non-injectable callers (the builder, static utils, composables).
  - `isEnabled(region, customOtpApiUrl)` — pure overload for injected consumers.
  - `Application.isBikeshareEnabled()` is **deleted**.
- **`TripRequestBuilder`** gains a `Context`: bikeshare mode-set decisions use `BikeshareAvailability`; `getFormattedOtpBaseUrl` reads the region + custom OTP URL via `RegionEntryPoint` / `PreferencesEntryPoint`; `execute()` passes the context to `TripRequest`; `initFromBundleSimple` takes a `Context`. All construction sites updated (`TripPlanRepository`, `RealtimeService` ×3, `TripPlanScreen`'s restore path).
- **`TripRequest`** gains a `Context` and reads/writes the `otp_api_url_version` flag via `PreferencesEntryPoint`.
- Call sites: `TripPlanScreen` + `LayerUtils` call `BikeshareAvailability.isEnabled(context)` (and `LayerUtils`' `TODO` is gone); `BikeLayerController` injects `RegionRepository` and uses the pure overload; `MapChromeViewModel` converges its inline duplicate predicate onto the shared one (retiring the deferred-convergence TODO it documented).

## Verification

No user-facing behavior change (the swaps are value-identical; `getFormattedOtpBaseUrl`'s null-region behavior is preserved). The pure predicate is JVM-unit-tested (`BikeshareAvailabilityTest`). Builds clean on `obaGoogleDebug`; unit **and** androidTest sources compile; full JVM suite passes.

After this, the only remaining `Application.get()` uses are the benign context/resource grabs + the static-orchestrator-injectability tail, both tracked in #1631.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added centralized bikeshare availability logic and consistent enablement across maps and trip-planning options.
* **Bug Fixes**
  * Improved trip request construction for realtime updates and trip planning by ensuring requests are built with the correct runtime context and preferences.
  * Updated bikeshare layer gating so it reliably follows region support and any custom OTP API URL setting.
* **Tests**
  * Added unit tests covering bikeshare availability behavior with/without region and with custom OTP API URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->