### PR TITLE
Typed time: make clock-domain/unit mixing a compile error (#1620)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,6 +144,35 @@ Keep ETA/active-window helpers pure — pass the "now" in as a parameter (see `S
 `ArrivalInfo`); don't call the clock inside a helper. This is verified by `SituationUtilsTest` and
 `ServerNowMsTest`.
 
+### Typed instants make the mix a compile error (#1620)
+
+New time math should use the domain-tagged value classes in `org.onebusaway.android.time`
+(`TypedTime.kt`) rather than raw `Long`s, so the rules above are enforced by the compiler, not just
+review:
+
+- `ServerTime` — the OBA server clock (`currentTime`, arrival predictions, `lastUpdateTime`).
+- `WallTime` — the device wall clock (`System.currentTimeMillis()`), where extrapolation pairs each
+  server time with its local receive time.
+- `ElapsedTime` — the monotonic clock (`SystemClock.elapsedRealtime()`), for real elapsed intervals.
+
+The **only** arithmetic defined is same-domain subtraction, which yields a `kotlin.time.Duration`;
+there is no `ServerTime.minus(WallTime)`, so the #27-class bug (server timestamp − device now) fails
+to compile. `TripState` and the arrivals ETA path (`ArrivalInfo`/`ArrivalData`) already use these —
+follow that pattern when adding server-domain time math.
+
+- **Mint at the boundary:** wrap a raw wire/Android `Long` into its domain right where it enters
+  (`ServerTime(currentTime)`, `WallTime.now()`); unwrap `.epochMs` / `.ms` only when handing a value
+  to a platform API (formatting, alarms, the renderer's animation clock). Keep the ceremony at the
+  edges, not in the middle.
+- **The typed classes carry no wire knowledge.** Any unit normalization (e.g. the service-alert
+  active-window seconds↔millis rule) stays on the **API side**, at the wire→domain adapter — see
+  `situationEpochToMillis` in `api/data/ServerClockNormalization.kt`, the single place that rule lives.
+  The API layer normalizes, then hands `ServerTime` a value that is already epoch millis. Do not
+  re-implement the seconds/millis guess anywhere else (see "No unsanctioned heuristics" below).
+- The one deliberate server↔device crossing (measuring skew from a paired response) is done on raw
+  `.epochMs` with an explicit comment — see `TripState.withStatus`/`toServerClock`. Verified by
+  `TypedTimeTest`.
+
 ## No unsanctioned heuristics
 
 Do **not** introduce heuristics — magic thresholds, magnitude guesses, or "good enough" inference of

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/extrapolation/test/ExtrapolatedVehiclesTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/extrapolation/test/ExtrapolatedVehiclesTest.kt
@@ -15,6 +15,7 @@
  */
 package org.onebusaway.android.extrapolation.test
 
+import org.onebusaway.android.time.WallTime
 import org.onebusaway.android.api.data.asRouteTrips
 
 import androidx.test.InstrumentationRegistry.getTargetContext
@@ -62,14 +63,14 @@ class ExtrapolatedVehiclesTest {
     fun skipsCanceledMissingRefAndPositionlessVehiclesWithoutCrashing() {
         // route_1 + route_2 requested: only trip_A and trip_B survive; the canceled, ref-less, and
         // positionless trips are dropped rather than throwing.
-        val vehicles = extrapolatedVehicles(response().asRouteTrips(),setOf("route_1", "route_2"), nowMs = 1_000_000L, lookupState = noState)
+        val vehicles = extrapolatedVehicles(response().asRouteTrips(),setOf("route_1", "route_2"), nowMs = WallTime(1_000_000L), lookupState = noState)
 
         assertEquals(listOf("trip_A", "trip_B"), vehicles.map { it.status.activeTripId })
     }
 
     @Test
     fun placesVehicleAtLastKnownLocationAndReportsFixTimeWhenNoState() {
-        val vehicles = extrapolatedVehicles(response().asRouteTrips(),setOf("route_1"), nowMs = 1_000_000L, lookupState = noState)
+        val vehicles = extrapolatedVehicles(response().asRouteTrips(),setOf("route_1"), nowMs = WallTime(1_000_000L), lookupState = noState)
 
         assertEquals(1, vehicles.size)
         val vehicle = vehicles[0]
@@ -85,7 +86,7 @@ class ExtrapolatedVehiclesTest {
 
     @Test
     fun fallsBackToPositionWhenNoLastKnownLocation() {
-        val vehicles = extrapolatedVehicles(response().asRouteTrips(),setOf("route_2"), nowMs = 1_000_000L, lookupState = noState)
+        val vehicles = extrapolatedVehicles(response().asRouteTrips(),setOf("route_2"), nowMs = WallTime(1_000_000L), lookupState = noState)
 
         assertEquals(1, vehicles.size)
         val vehicle = vehicles[0]
@@ -97,9 +98,9 @@ class ExtrapolatedVehiclesTest {
     @Test
     fun filtersToRequestedRoutesOnly() {
         // route_3 serves none of the trips.
-        assertTrue(extrapolatedVehicles(response().asRouteTrips(),setOf("route_3"), nowMs = 1_000_000L, lookupState = noState).isEmpty())
+        assertTrue(extrapolatedVehicles(response().asRouteTrips(),setOf("route_3"), nowMs = WallTime(1_000_000L), lookupState = noState).isEmpty())
         // Empty request -> nothing.
-        assertTrue(extrapolatedVehicles(response().asRouteTrips(),emptySet(), nowMs = 1_000_000L, lookupState = noState).isEmpty())
+        assertTrue(extrapolatedVehicles(response().asRouteTrips(),emptySet(), nowMs = WallTime(1_000_000L), lookupState = noState).isEmpty())
     }
 
     // A trips-for-route response with two vehicles on route_1 heading opposite directions (GTFS
@@ -114,13 +115,13 @@ class ExtrapolatedVehiclesTest {
         // directionId 0 -> only the outbound vehicle.
         assertEquals(
             listOf("trip_out"),
-            extrapolatedVehicles(trips, setOf("route_1"), nowMs = 1_000_000L, directionId = 0, lookupState = noState)
+            extrapolatedVehicles(trips, setOf("route_1"), nowMs = WallTime(1_000_000L), directionId = 0, lookupState = noState)
                 .map { it.status.activeTripId }
         )
         // directionId 1 -> only the inbound vehicle (the opposite-direction bus the old view showed).
         assertEquals(
             listOf("trip_in"),
-            extrapolatedVehicles(trips, setOf("route_1"), nowMs = 1_000_000L, directionId = 1, lookupState = noState)
+            extrapolatedVehicles(trips, setOf("route_1"), nowMs = WallTime(1_000_000L), directionId = 1, lookupState = noState)
                 .map { it.status.activeTripId }
         )
     }
@@ -128,7 +129,7 @@ class ExtrapolatedVehiclesTest {
     @Test
     fun keepsBothDirectionsWhenDirectionIdNull() {
         val vehicles = extrapolatedVehicles(
-            directionResponse().asRouteTrips(), setOf("route_1"), nowMs = 1_000_000L, lookupState = noState
+            directionResponse().asRouteTrips(), setOf("route_1"), nowMs = WallTime(1_000_000L), lookupState = noState
         )
         assertEquals(listOf("trip_out", "trip_in"), vehicles.map { it.status.activeTripId })
     }
@@ -138,10 +139,10 @@ class ExtrapolatedVehiclesTest {
         // A shapeless state still anchors fixTimeMs (so the renderer sees a stable fix instant); the
         // point falls back to the raw fix because there's no polyline to dead-reckon along.
         val anchored: (String?) -> TripState? = { tripId ->
-            if (tripId == "trip_A") TripState("trip_A", anchorLocalTimeMs = 999_000L) else null
+            if (tripId == "trip_A") TripState("trip_A", anchorLocalTimeMs = WallTime(999_000L)) else null
         }
 
-        val vehicle = extrapolatedVehicles(response().asRouteTrips(),setOf("route_1"), nowMs = 1_000_000L, lookupState = anchored).single()
+        val vehicle = extrapolatedVehicles(response().asRouteTrips(),setOf("route_1"), nowMs = WallTime(1_000_000L), lookupState = anchored).single()
 
         assertEquals(999_000L, vehicle.fixTimeMs)
         assertEquals(47.20, vehicle.point.latitude, 1e-6)

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/extrapolation/test/TripExtrapolationBuilderTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/extrapolation/test/TripExtrapolationBuilderTest.kt
@@ -15,6 +15,7 @@
  */
 package org.onebusaway.android.extrapolation.test
 
+import org.onebusaway.android.time.WallTime
 import android.location.Location
 import androidx.test.runner.AndroidJUnit4
 import org.junit.Assert.assertEquals
@@ -60,7 +61,7 @@ class TripExtrapolationBuilderTest {
         val extrapolation = buildTripExtrapolation(
             TripState("t", polyline = northLine()),
             ExtrapolationResult.Success(UniformDist(3000.0)),
-            nowMs = 0L,
+            nowMs = WallTime(0L),
         )!!
 
         val vehicle = extrapolation.vehiclePoint!!
@@ -83,7 +84,7 @@ class TripExtrapolationBuilderTest {
     @Test
     fun missingShapeYieldsNoExtrapolation() {
         assertNull(
-            buildTripExtrapolation(TripState("t"), ExtrapolationResult.Success(UniformDist(1000.0)), 0L)
+            buildTripExtrapolation(TripState("t"), ExtrapolationResult.Success(UniformDist(1000.0)), WallTime(0L))
         )
     }
 
@@ -92,7 +93,7 @@ class TripExtrapolationBuilderTest {
         val extrapolation = buildTripExtrapolation(
             TripState("t", polyline = northLine()),
             ExtrapolationResult.NoData,
-            nowMs = 0L,
+            nowMs = WallTime(0L),
         )!!
         assertNull(extrapolation.vehiclePoint)
         assertNull(extrapolation.fastEstimatePoint)

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/extrapolation/test/TripStateCacheTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/extrapolation/test/TripStateCacheTest.kt
@@ -15,6 +15,8 @@
  */
 package org.onebusaway.android.extrapolation.test
 
+import org.onebusaway.android.time.ServerTime
+import org.onebusaway.android.time.WallTime
 import org.onebusaway.android.api.adapters.StopTimeData
 import org.onebusaway.android.api.adapters.TripScheduleData
 
@@ -276,7 +278,7 @@ class TripStateCacheTest {
         recordStatus(status1, System.currentTimeMillis(), System.currentTimeMillis())
         recordStatus(status2, System.currentTimeMillis(), System.currentTimeMillis())
 
-        val result = cache.lookupTripState("trip1")!!.extrapolate(queryTime + 5000)
+        val result = cache.lookupTripState("trip1")!!.extrapolate(WallTime(queryTime + 5000))
         assertTrue("Should succeed", result is ExtrapolationResult.Success)
         val dist = (result as ExtrapolationResult.Success).distribution
         assertTrue("Median distance should be > last distance", dist.median() > 400.0)
@@ -289,7 +291,7 @@ class TripStateCacheTest {
         val status = createStatus("v1", "trip1", 47.0, -122.0, 100.0, null, 5000.0, timestamp)
         recordStatus(status, System.currentTimeMillis(), System.currentTimeMillis())
 
-        val result = cache.lookupTripState("trip1")!!.extrapolate(timestamp)
+        val result = cache.lookupTripState("trip1")!!.extrapolate(WallTime(timestamp))
         assertTrue("Should be MissingSchedule", result is ExtrapolationResult.MissingSchedule)
     }
 
@@ -342,7 +344,7 @@ class TripStateCacheTest {
                 )
 
         recordStatus(latestStatus, System.currentTimeMillis(), System.currentTimeMillis())
-        val result = cache.lookupTripState("trip1")!!.extrapolate(latestTimestamp)
+        val result = cache.lookupTripState("trip1")!!.extrapolate(WallTime(latestTimestamp))
         assertTrue("Should succeed", result is ExtrapolationResult.Success)
         val dist = (result as ExtrapolationResult.Success).distribution
         assertTrue("Extrapolated distance should be positive", dist.median() > 0)
@@ -356,11 +358,11 @@ class TripStateCacheTest {
                     TripObservation(
                             status.activeTripId!!,
                             status,
-                            serverTimeMs,
+                            ServerTime(serverTimeMs),
                             serviceDate = 0,
                             routeType = null
                     ),
-                    localTimeMs
+                    WallTime(localTimeMs)
             )
 
     private fun createStatus(

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/map/VehicleIconAllocationTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/map/VehicleIconAllocationTest.kt
@@ -15,6 +15,7 @@
  */
 package org.onebusaway.android.map
 
+import org.onebusaway.android.time.WallTime
 import android.content.Context
 import android.graphics.Bitmap
 import android.util.Log
@@ -73,7 +74,7 @@ class VehicleIconAllocationTest {
             .mapNotNull { it.status?.activeTripId }
             .mapNotNull { response.trip(it)?.routeId }
             .toSet()
-        return extrapolatedVehicles(response, routeIds, nowMs = 1_000_000L) { null }
+        return extrapolatedVehicles(response, routeIds, nowMs = WallTime(1_000_000L)) { null }
             .map { v ->
                 VehicleMarker(
                     activeTripId = v.status.activeTripId.orEmpty(),

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/mock/ArrivalsFixtures.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/mock/ArrivalsFixtures.kt
@@ -15,6 +15,7 @@
  */
 package org.onebusaway.android.mock
 
+import org.onebusaway.android.time.ServerTime
 import org.onebusaway.android.api.data.StopArrivals
 
 import android.content.Context
@@ -59,7 +60,7 @@ object ArrivalsFixtures {
         favorite: (routeId: String, headsign: String?, stopId: String) -> Boolean = { _, _, _ -> false },
     ): ArrayList<ArrivalInfo> = ArrayList(
         convertArrivals(
-            context, snapshot(env).arrivals, null, env.currentTime, includeArriveDepartLabels, favorite
+            context, snapshot(env).arrivals, null, ServerTime(env.currentTime), includeArriveDepartLabels, favorite
         )
     )
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/adapters/ArrivalAdapters.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/adapters/ArrivalAdapters.kt
@@ -21,6 +21,7 @@ import org.onebusaway.android.models.ArrivalData
 import org.onebusaway.android.models.FrequencyWindow
 import org.onebusaway.android.models.Occupancy
 import org.onebusaway.android.models.Status
+import org.onebusaway.android.time.ServerTime
 
 /** Adapts a modernized [ArrivalDeparture] DTO (arrivals fetch) to the [ArrivalData] model. */
 internal fun ArrivalDeparture.asArrivalData(): ArrivalData = DtoArrivalData(this)
@@ -36,13 +37,14 @@ private class DtoArrivalData(private val d: ArrivalDeparture) : ArrivalData {
     override val serviceDate get() = d.serviceDate
     override val vehicleId get() = d.vehicleId
     override val predicted get() = d.predicted
-    override val scheduledArrivalTime get() = d.scheduledArrivalTime
-    override val predictedArrivalTime get() = d.predictedArrivalTime
-    override val scheduledDepartureTime get() = d.scheduledDepartureTime
-    override val predictedDepartureTime get() = d.predictedDepartureTime
+    // Wire→server mint: these are the server clock, already epoch millis.
+    override val scheduledArrivalTime get() = ServerTime(d.scheduledArrivalTime)
+    override val predictedArrivalTime get() = ServerTime(d.predictedArrivalTime)
+    override val scheduledDepartureTime get() = ServerTime(d.scheduledDepartureTime)
+    override val predictedDepartureTime get() = ServerTime(d.predictedDepartureTime)
     override val status get() = d.tripStatus?.status?.let { Status.fromString(it) }
     override val frequency
-        get() = d.frequency?.let { FrequencyWindow(it.startTime, it.endTime, it.headway) }
+        get() = d.frequency?.let { FrequencyWindow(ServerTime(it.startTime), ServerTime(it.endTime), it.headway) }
     override val historicalOccupancy get() = Occupancy.fromString(d.historicalOccupancy)
     override val predictedOccupancy get() = Occupancy.fromString(d.occupancyStatus)
     override val hasTripStatus get() = d.tripStatus != null

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/data/ServerClockNormalization.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/data/ServerClockNormalization.kt
@@ -30,8 +30,9 @@ internal fun serverNowOrDeviceClock(serverCurrentTime: Long): Long =
  * fixed** across the OBA ecosystem: GTFS-RT `active_period` is seconds per spec, but the server converts
  * it to millis on ingestion (`GtfsRealtimeAlertLibrary.toMillis`, magnitude threshold 1e12) while older
  * servers/feeds still emit seconds — so a response's `from`/`to` may be either. Normalizing here, at the
- * wire→domain adapter, lets the domain model ([org.onebusaway.android.models.ObaSituation.ActiveWindow])
- * be unambiguously millis so no downstream consumer has to re-guess. Mirrors the server's own `toMillis`.
+ * wire→domain adapter, keeps the seconds↔millis wire knowledge on the API side and lets the domain model
+ * ([org.onebusaway.android.models.ObaSituation.ActiveWindow]) be unambiguously millis so no downstream
+ * consumer has to re-guess. Mirrors the server's own `toMillis`.
  *
  * Failure mode (inherent to any magnitude rule): a genuine epoch-*millis* value below 1e12 (an instant
  * before 2001-09-09) is misread as seconds and scaled x1000; a genuine epoch-*seconds* value at/after

--- a/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/Extrapolator.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/Extrapolator.kt
@@ -17,6 +17,7 @@ package org.onebusaway.android.extrapolation
 
 import org.onebusaway.android.extrapolation.data.TripState
 import org.onebusaway.android.extrapolation.math.prob.ProbDistribution
+import org.onebusaway.android.time.WallTime
 
 /** Result of an extrapolation attempt. */
 sealed class ExtrapolationResult {
@@ -42,12 +43,13 @@ sealed class ExtrapolationResult {
  */
 abstract class Extrapolator(protected val state: TripState) {
     /**
-     * [lastTimeMs] and [queryTimeMs] must be in the same clock domain; [TripState.extrapolate]
-     * passes device-local clock values so the interval is unaffected by server/device clock skew.
+     * [lastTime] and [queryTime] are both device-wall-clock instants ([TripState.extrapolate] pairs
+     * each server time with its local receive time), so their interval is unaffected by server/device
+     * clock skew. The type makes that same-domain requirement a compile-time guarantee (#1620).
      */
     abstract fun doExtrapolate(
             lastDist: Double,
-            lastTimeMs: Long,
-            queryTimeMs: Long
+            lastTime: WallTime,
+            queryTime: WallTime
     ): ExtrapolationResult
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/GammaExtrapolator.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/GammaExtrapolator.kt
@@ -23,6 +23,8 @@ import org.onebusaway.android.extrapolation.math.prob.GammaDistribution
 import org.onebusaway.android.extrapolation.math.prob.GammaMixtureDistribution
 import org.onebusaway.android.extrapolation.math.prob.ProbDistribution
 import org.onebusaway.android.models.ObaTripSchedule
+import org.onebusaway.android.time.WallTime
+import kotlin.time.DurationUnit
 
 // H34 two-gamma mixture parameters, fitted on span-weighted King County Metro data (in mph).
 private const val START_B0 = 0.571381 // 1/mph
@@ -49,10 +51,10 @@ class GammaExtrapolator(state: TripState) : Extrapolator(state) {
 
     override fun doExtrapolate(
             lastDist: Double,
-            lastTimeMs: Long,
-            queryTimeMs: Long
+            lastTime: WallTime,
+            queryTime: WallTime
     ): ExtrapolationResult {
-        val dtSec = (queryTimeMs - lastTimeMs) / 1000.0
+        val dtSec = (queryTime - lastTime).toDouble(DurationUnit.SECONDS)
         val speedDist = resolveDistribution() ?: return ExtrapolationResult.MissingSchedule
         return ExtrapolationResult.Success(
                 AffineTransformDistribution(speedDist, lastDist, dtSec / MPS_TO_MPH)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/ScheduleReplayExtrapolator.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/ScheduleReplayExtrapolator.kt
@@ -18,6 +18,8 @@ package org.onebusaway.android.extrapolation
 import org.onebusaway.android.extrapolation.data.TripState
 import org.onebusaway.android.extrapolation.math.prob.DiracDistribution
 import org.onebusaway.android.models.ObaTripSchedule
+import org.onebusaway.android.time.WallTime
+import kotlin.time.DurationUnit
 
 /**
  * Per-trip extrapolator for grade-separated transit (rail, subway) that replays the schedule
@@ -27,20 +29,20 @@ class ScheduleReplayExtrapolator(state: TripState) : Extrapolator(state) {
 
     override fun doExtrapolate(
             lastDist: Double,
-            lastTimeMs: Long,
-            queryTimeMs: Long
+            lastTime: WallTime,
+            queryTime: WallTime
     ): ExtrapolationResult {
         val schedule = state.schedule ?: return ExtrapolationResult.MissingSchedule
         val distance =
-                replaySchedule(schedule, lastDist, lastTimeMs, queryTimeMs)
+                replaySchedule(schedule, lastDist, lastTime, queryTime)
                         ?: return ExtrapolationResult.MissingSchedule
         return ExtrapolationResult.Success(DiracDistribution(distance))
     }
 }
 
 /**
- * Replays the schedule forward from [startDist] by the elapsed time between [lastTimeMs] and
- * [queryTimeMs].
+ * Replays the schedule forward from [startDist] by the elapsed time between [lastTime] and
+ * [queryTime].
  *
  * Finds the schedule segment bracketing startDist, computes the corresponding schedule time, adds
  * the elapsed time, then walks forward through stops — traveling at segment speeds between stops
@@ -48,17 +50,17 @@ class ScheduleReplayExtrapolator(state: TripState) : Extrapolator(state) {
  *
  * @param schedule the trip schedule containing stop times
  * @param startDist the starting distance along the trip in meters
- * @param lastTimeMs the timestamp of the starting position in milliseconds
- * @param queryTimeMs the target time in milliseconds
+ * @param lastTime the device-wall-clock instant of the starting position
+ * @param queryTime the device-wall-clock target time (same domain as [lastTime])
  * @return the extrapolated distance in meters, or null if out of bounds
  */
 fun replaySchedule(
         schedule: ObaTripSchedule,
         startDist: Double,
-        lastTimeMs: Long,
-        queryTimeMs: Long
+        lastTime: WallTime,
+        queryTime: WallTime
 ): Double? {
-    val dtSec = (queryTimeMs - lastTimeMs) / 1000.0
+    val dtSec = (queryTime - lastTime).toDouble(DurationUnit.SECONDS)
     val stopTimes = schedule.stopTimes ?: return null
     if (stopTimes.size < 2 || dtSec < 0) return null
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/TripExtrapolationBuilder.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/TripExtrapolationBuilder.kt
@@ -22,6 +22,7 @@ import org.onebusaway.android.extrapolation.math.prob.ProbDistribution
 import org.onebusaway.android.models.Status
 import org.onebusaway.android.map.render.DataAgeMarker
 import org.onebusaway.android.map.render.GeoPoint
+import org.onebusaway.android.time.WallTime
 import org.onebusaway.android.util.Polyline
 
 /**
@@ -39,7 +40,7 @@ import org.onebusaway.android.util.Polyline
 fun buildTripExtrapolation(
     state: TripState,
     result: ExtrapolationResult,
-    nowMs: Long,
+    nowMs: WallTime,
 ): TripExtrapolation? {
     val polyline = state.polyline ?: return null
     val distribution = (result as? ExtrapolationResult.Success)?.distribution
@@ -50,12 +51,13 @@ fun buildTripExtrapolation(
         band = distribution?.let { weightedBandSegments(it, polyline) } ?: emptyList(),
         dataAge = dataAgeMarker(state, nowMs),
         // The anchor's instant is constant between fixes; a change means fresh AVL data arrived.
-        fixTimeMs = state.anchorLocalTimeMs,
+        // Unwrapped to a raw Long for the renderer's animation clock (out of the typed-time slice).
+        fixTimeMs = state.anchorLocalTimeMs.epochMs,
     )
 }
 
 /** Composes [TripState.extrapolate] with [buildTripExtrapolation] — the per-frame producer the driver runs. */
-internal fun extrapolationFromState(state: TripState?, nowMs: Long): TripExtrapolation? =
+internal fun extrapolationFromState(state: TripState?, nowMs: WallTime): TripExtrapolation? =
     state?.let { buildTripExtrapolation(it, it.extrapolate(nowMs), nowMs) }
 
 /** The extrapolated (median) vehicle [point] along the trip shape and its forward [bearing] there. */
@@ -68,7 +70,7 @@ private data class VehicleProjection(val point: GeoPoint, val bearing: Float)
  * per-vehicle dead reckoning between polls; the bearing keeps the marker's direction arrow following
  * the glide instead of the stale server orientation.
  */
-private fun extrapolatedVehicleProjection(state: TripState, nowMs: Long): VehicleProjection? {
+private fun extrapolatedVehicleProjection(state: TripState, nowMs: WallTime): VehicleProjection? {
     val polyline = state.polyline ?: return null
     val distribution = (state.extrapolate(nowMs) as? ExtrapolationResult.Success)?.distribution ?: return null
     val distance = distribution.median().takeIf(Double::isFinite) ?: return null
@@ -97,7 +99,7 @@ private fun extrapolatedVehicleProjection(state: TripState, nowMs: Long): Vehicl
 fun extrapolatedVehicles(
     routeTrips: RouteTrips,
     routeIds: Set<String>,
-    nowMs: Long,
+    nowMs: WallTime,
     directionId: Int? = null,
     lookupState: (String?) -> TripState?,
 ): List<ExtrapolatedVehicle> =
@@ -124,7 +126,8 @@ fun extrapolatedVehicles(
             point = point,
             // The path tangent off the shape; NaN off-shape, so the marker falls back to the orientation.
             bearing = projection?.bearing ?: Float.NaN,
-            fixTimeMs = state?.anchorLocalTimeMs?.takeIf { it > 0L } ?: status.lastUpdateTime,
+            fixTimeMs = state?.let { it.anchorLocalTimeMs.epochMs.takeIf { ms -> ms > 0L } }
+                ?: status.lastUpdateTime,
             status = status,
             isRealtime = isRealtime,
         )
@@ -143,11 +146,13 @@ private fun weightedBandSegments(distribution: ProbDistribution, polyline: Polyl
         WeightedBandSegment(points.map(Location::toGeoPoint), slice.alpha.coerceIn(0f, 1f))
     }
 
-private fun dataAgeMarker(state: TripState, nowMs: Long): DataAgeMarker? {
+private fun dataAgeMarker(state: TripState, nowMs: WallTime): DataAgeMarker? {
     val position = state.anchor?.position ?: return null
-    if (state.anchorLocalTimeMs <= 0) return null
+    if (state.anchorLocalTimeMs.epochMs <= 0) return null
     // Shown whenever there's a last fix, like the original (no max-age hide); the label is its age.
-    return DataAgeMarker(position.toGeoPoint(), (nowMs - state.anchorLocalTimeMs).coerceAtLeast(0L))
+    // now − anchor is a same-domain (device) Duration; unwrap to raw Long ms for the marker.
+    val ageMs = (nowMs - state.anchorLocalTimeMs).inWholeMilliseconds.coerceAtLeast(0L)
+    return DataAgeMarker(position.toGeoPoint(), ageMs)
 }
 
 private fun Location.toGeoPoint() = GeoPoint(latitude, longitude)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/data/Adapters.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/data/Adapters.kt
@@ -20,6 +20,7 @@ package org.onebusaway.android.extrapolation.data
 import org.onebusaway.android.models.ObaTrip
 import org.onebusaway.android.models.ObaTripStatus
 import org.onebusaway.android.models.RouteTrips
+import org.onebusaway.android.time.ServerTime
 
 /*
  * The adapter between a trips-for-route / trip-details fetch and the trip store's standard
@@ -37,7 +38,7 @@ data class TripObservation(
         val tripId: String,
         val status: ObaTripStatus,
         /** The server's currentTime when the status was fetched. */
-        val serverTimeMs: Long,
+        val serverTimeMs: ServerTime,
         val serviceDate: Long,
         val routeType: Int?
 )
@@ -45,7 +46,8 @@ data class TripObservation(
 /** One observation per active trip in the route's vehicles (one for a single trip-details poll). */
 fun RouteTrips.toObservations(): List<TripObservation> = buildList {
     forEachActiveTrip { tripId, status, _ ->
-        add(TripObservation(tripId, status, currentTimeMs, status.serviceDate, routeTypeForTrip(tripId)))
+        // currentTimeMs is the server's currentTime, already epoch millis.
+        add(TripObservation(tripId, status, ServerTime(currentTimeMs), status.serviceDate, routeTypeForTrip(tripId)))
     }
 }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/data/TripObservationRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/data/TripObservationRepository.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
 import org.onebusaway.android.models.RouteTrips
+import org.onebusaway.android.time.WallTime
 import org.onebusaway.android.util.Polyline
 
 const val DEFAULT_POLL_INTERVAL_MS = 10_000L
@@ -143,7 +144,7 @@ class DefaultTripObservationRepository @Inject constructor(
 
     /** Records everything a trip details poll carries: shapeId/active-trip, schedule, service date, observations. */
     private fun recordTripDetails(tripId: String, details: TripDetails) {
-        val localTimeMs = System.currentTimeMillis()
+        val localTimeMs = WallTime.now()
         cache.putTripDetails(tripId, details.vehicleActiveTripId, details.shapeId)
         cache.putSchedule(tripId, details.schedule)
         cache.putServiceDate(tripId, details.serviceDate)
@@ -151,7 +152,7 @@ class DefaultTripObservationRepository @Inject constructor(
     }
 
     private fun recordTripsForRoute(response: RouteTrips) {
-        val localTimeMs = System.currentTimeMillis()
+        val localTimeMs = WallTime.now()
         response.toObservations().forEach { cache.record(it, localTimeMs) }
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/data/TripState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/data/TripState.kt
@@ -22,10 +22,14 @@ import org.onebusaway.android.extrapolation.ScheduleReplayExtrapolator
 import org.onebusaway.android.models.ObaRoute
 import org.onebusaway.android.models.ObaTripSchedule
 import org.onebusaway.android.models.ObaTripStatus
+import org.onebusaway.android.time.WallTime
+import org.onebusaway.android.time.ServerTime
 import org.onebusaway.android.util.Polyline
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
 
 private const val MAX_ENTRIES = 100
-private const val MAX_HORIZON_MS = 15 * 60 * 1000L
+private val MAX_HORIZON = 15.minutes
 private const val PRE_DEPARTURE_DISTANCE_THRESHOLD = 50.0
 private const val TRIP_END_DISTANCE_THRESHOLD = 50.0
 
@@ -33,9 +37,9 @@ private const val TRIP_END_DISTANCE_THRESHOLD = 50.0
 data class HistoryEntry(
         val status: ObaTripStatus,
         /** The server's currentTime when the status was fetched. */
-        val serverTimeMs: Long,
+        val serverTimeMs: ServerTime,
         /** Local device clock when the response was received. */
-        val localTimeMs: Long
+        val localTimeMs: WallTime
 )
 
 /**
@@ -62,13 +66,13 @@ data class TripState(
          * Effective timestamp of the anchor in the **server** clock domain (lastUpdateTime, or
          * serverTimeMs as fallback). Used for plotting against other server-clock values.
          */
-        val anchorTimeMs: Long = 0L,
+        val anchorTimeMs: ServerTime = ServerTime(0L),
         /**
          * Same instant as [anchorTimeMs], in the local device clock domain. Used for
          * extrapolation — comparing `System.currentTimeMillis()` against a server timestamp would
          * silently classify fresh data as stale under client/server clock skew.
          */
-        val anchorLocalTimeMs: Long = 0L,
+        val anchorLocalTimeMs: WallTime = WallTime(0L),
         val schedule: ObaTripSchedule? = null,
         /** Service date in ms since the epoch, or 0 when not yet known. */
         val serviceDate: Long = 0L,
@@ -110,8 +114,8 @@ data class TripState(
      *   (zero or negative) are skipped, since the anchor clocks couldn't be derived
      * @param localTimeMs local device clock time when the response was received
      */
-    fun withStatus(status: ObaTripStatus, serverTimeMs: Long, localTimeMs: Long): TripState {
-        if (status.distanceAlongTrip == null || serverTimeMs <= 0) return this
+    fun withStatus(status: ObaTripStatus, serverTimeMs: ServerTime, localTimeMs: WallTime): TripState {
+        if (status.distanceAlongTrip == null || serverTimeMs.epochMs <= 0) return this
 
         // Skip true duplicates (same distance and time as previous entry)
         val prev = history.lastOrNull()?.status
@@ -122,9 +126,14 @@ data class TripState(
             return this
         }
 
-        // Update anchor: newest timestamp wins; GPS wins ties
-        val effectiveTime = if (status.lastUpdateTime > 0) status.lastUpdateTime else serverTimeMs
-        val serverLocalOffset = serverTimeMs - localTimeMs
+        // Update anchor: newest timestamp wins; GPS wins ties. lastUpdateTime is a raw server-clock
+        // Long on the status, so wrap it into its domain before comparing against anchorTimeMs.
+        val effectiveTime =
+                if (status.lastUpdateTime > 0) ServerTime(status.lastUpdateTime) else serverTimeMs
+        // The one sanctioned server↔device crossing: pairing the same response's two clocks measures
+        // the skew. Done on the raw epochMs deliberately (the typed API forbids server − device), so
+        // the anchor's server instant can be re-expressed on the device clock below.
+        val serverLocalOffsetMs = serverTimeMs.epochMs - localTimeMs.epochMs
         val anchorAdvances =
                 effectiveTime > anchorTimeMs ||
                         (effectiveTime == anchorTimeMs &&
@@ -138,7 +147,7 @@ data class TripState(
                 anchor = if (anchorAdvances) status else anchor,
                 anchorTimeMs = if (anchorAdvances) effectiveTime else anchorTimeMs,
                 anchorLocalTimeMs =
-                        if (anchorAdvances) effectiveTime - serverLocalOffset
+                        if (anchorAdvances) WallTime(effectiveTime.epochMs - serverLocalOffsetMs)
                         else anchorLocalTimeMs
         )
     }
@@ -147,7 +156,7 @@ data class TripState(
      * Returns the state with everything [observation] carries applied — the status
      * recorded, plus serviceDate and routeType when the observation has them.
      */
-    fun withObservation(observation: TripObservation, localTimeMs: Long): TripState =
+    fun withObservation(observation: TripObservation, localTimeMs: WallTime): TripState =
             withStatus(observation.status, observation.serverTimeMs, localTimeMs)
                     .withServiceDate(observation.serviceDate)
                     .withRouteType(observation.routeType)
@@ -178,16 +187,20 @@ data class TripState(
      * no anchor data exists yet, since no skew can be measured. Lets consumers plot a local "now"
      * against server-clock data (schedule, observations) without it drifting under clock skew.
      */
-    fun toServerClock(localTimeMs: Long): Long =
-            if (anchorLocalTimeMs > 0) localTimeMs + (anchorTimeMs - anchorLocalTimeMs) else localTimeMs
+    fun toServerClock(localTimeMs: WallTime): ServerTime {
+        // Skew (server − device) measured at the anchor, or 0 when no anchor exists yet. Computed on
+        // raw epochMs — the deliberate cross-domain bridge (the typed API forbids server − device).
+        val skewMs = if (anchorLocalTimeMs.epochMs > 0) anchorTimeMs.epochMs - anchorLocalTimeMs.epochMs else 0L
+        return ServerTime(localTimeMs.epochMs + skewMs)
+    }
 
-    fun extrapolate(queryTimeMs: Long): ExtrapolationResult {
+    fun extrapolate(queryTimeMs: WallTime): ExtrapolationResult {
         val currentAnchor = anchor ?: return ExtrapolationResult.NoData
         val lastDist = currentAnchor.distanceAlongTrip ?: return ExtrapolationResult.NoData
-        if (anchorLocalTimeMs <= 0) return ExtrapolationResult.NoData
+        if (anchorLocalTimeMs.epochMs <= 0) return ExtrapolationResult.NoData
 
-        val dtMs = queryTimeMs - anchorLocalTimeMs
-        if (dtMs < 0 || dtMs > MAX_HORIZON_MS) return ExtrapolationResult.Stale
+        val dt: Duration = queryTimeMs - anchorLocalTimeMs
+        if (dt < Duration.ZERO || dt > MAX_HORIZON) return ExtrapolationResult.Stale
         if (lastDist <= PRE_DEPARTURE_DISTANCE_THRESHOLD) return ExtrapolationResult.TripNotStarted
         val totalDist = currentAnchor.totalDistanceAlongTrip
         if (totalDist != null && totalDist > 0 && totalDist - lastDist < TRIP_END_DISTANCE_THRESHOLD

--- a/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/data/TripStateCache.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/data/TripStateCache.kt
@@ -17,6 +17,7 @@ package org.onebusaway.android.extrapolation.data
 
 import androidx.annotation.VisibleForTesting
 import org.onebusaway.android.models.ObaTripSchedule
+import org.onebusaway.android.time.WallTime
 import org.onebusaway.android.util.Polyline
 
 internal const val MAX_TRACKED_TRIPS = 100
@@ -61,7 +62,7 @@ internal class TripStateCache {
     // --- Writes ---
 
     /** Records [observation] into its trip's snapshot. */
-    fun record(observation: TripObservation, localTimeMs: Long) {
+    fun record(observation: TripObservation, localTimeMs: WallTime) {
         update(observation.tripId) { it.withObservation(observation, localTimeMs) }
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
@@ -28,6 +28,7 @@ import org.onebusaway.android.extrapolation.ExtrapolatedVehicle
 import org.onebusaway.android.extrapolation.extrapolatedVehicles
 import org.onebusaway.android.models.RouteTrips
 import org.onebusaway.android.extrapolation.data.TripObservationRepository
+import org.onebusaway.android.time.WallTime
 import java.net.HttpURLConnection
 import org.onebusaway.android.api.ObaApi
 import org.onebusaway.android.models.ObaRoute
@@ -134,7 +135,7 @@ class RouteMapController(
             latestPoll?.let { poll ->
                 MapVehicles(
                     markers = extrapolatedVehicles(
-                        poll.response, routeIds, nowMs, resolved.directionId,
+                        poll.response, routeIds, WallTime(nowMs), resolved.directionId,
                         tripObservationRepository::lookupTripState,
                     ).map { it.toMarker() },
                     response = poll.response,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/TripFocusController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/TripFocusController.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.launch
 import kotlin.math.roundToInt
 import org.onebusaway.android.extrapolation.TripExtrapolation
 import org.onebusaway.android.extrapolation.extrapolationFromState
+import org.onebusaway.android.time.WallTime
 import org.onebusaway.android.extrapolation.data.TripObservationRepository
 import org.onebusaway.android.map.render.BandSegment
 import org.onebusaway.android.map.render.CameraCommand
@@ -63,7 +64,7 @@ class TripFocusController(
         // here with a color that contrasts the line, so it reads against the trip shape.
         val bandColor = contrastingColor(routeColorArgb)
         renderState.setTripOverlaySampler { nowMs ->
-            extrapolationFromState(tripObservationRepository.lookupTripState(tripId), nowMs)?.toOverlay(bandColor)
+            extrapolationFromState(tripObservationRepository.lookupTripState(tripId), WallTime(nowMs))?.toOverlay(bandColor)
         }
         job = scope.launch {
             // Keep this trip's volatile status fresh while the overlay is on screen; the repository

--- a/onebusaway-android/src/main/java/org/onebusaway/android/models/ArrivalData.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/models/ArrivalData.kt
@@ -15,9 +15,13 @@
  */
 package org.onebusaway.android.models
 
+import org.onebusaway.android.time.ServerTime
+
 /**
  * The arrival fields the display model (`ArrivalInfo`) computes from, abstracted from the wire type.
- * io.client adapts the arrivals fetch into these (`DtoArrivalData`); times are epoch millis.
+ * io.client adapts the arrivals fetch into these (`DtoArrivalData`). The arrival/departure instants
+ * are server-clock [ServerTime] (#1620) so the ETA subtraction against a server "now" can't be mixed
+ * with a device clock; `serviceDate` stays a raw Long service-day identifier.
  */
 interface ArrivalData {
     val routeId: String
@@ -30,10 +34,10 @@ interface ArrivalData {
     val serviceDate: Long
     val vehicleId: String?
     val predicted: Boolean
-    val scheduledArrivalTime: Long
-    val predictedArrivalTime: Long
-    val scheduledDepartureTime: Long
-    val predictedDepartureTime: Long
+    val scheduledArrivalTime: ServerTime
+    val predictedArrivalTime: ServerTime
+    val scheduledDepartureTime: ServerTime
+    val predictedDepartureTime: ServerTime
     val status: Status?
     val frequency: FrequencyWindow?
     val historicalOccupancy: Occupancy?
@@ -45,5 +49,5 @@ interface ArrivalData {
     val lastKnownLon: Double?
 }
 
-/** Headway-based (exact_times=0) service window; epoch millis / seconds, matching the wire. */
-data class FrequencyWindow(val startTime: Long, val endTime: Long, val headway: Long)
+/** Headway-based (exact_times=0) service window; server-clock bounds, [headway] in seconds. */
+data class FrequencyWindow(val startTime: ServerTime, val endTime: ServerTime, val headway: Long)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/time/TypedTime.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/time/TypedTime.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.time
+
+import android.os.SystemClock
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+
+/*
+ * Domain-tagged instants. Nearly every time bug in this app has been a domain or unit mix that is
+ * silent until a user sees a wrong number: a server timestamp minus the device clock (#27/#1612), an
+ * alert window in seconds compared against a millis "now", a wall-clock delta corrupted by an NTP
+ * correction. A raw `Long` carries no record of which clock it came from, so the mistake passes review
+ * and compiles. These wrappers make the clock **domain** part of the type: the only arithmetic defined
+ * is same-domain subtraction (yielding a unit-safe `kotlin.time.Duration`), so a cross-domain subtraction
+ * fails to *compile* rather than misbehaving at runtime.
+ *
+ * They are `@JvmInline value class`es — at runtime each is just its underlying `Long`, so the safety is
+ * free. These are pure domain types: they carry no wire/unit knowledge. Mint one at the wire/Android
+ * boundary (the API adapter normalizes units first, then wraps) and unwrap (`.epochMs` / `.ms`) only when
+ * handing a value to a platform API that wants a raw `Long` (formatting, alarms, the renderer). Deltas are
+ * `Duration`; the clock-domain tag is the app-specific part libraries don't provide. See CLAUDE.md "Time
+ * domains" for which values belong to which domain.
+ */
+
+/**
+ * An instant on the **OBA server** clock, epoch millis. The domain of everything the server timestamps —
+ * `currentTime`, arrival/departure predictions, `lastUpdateTime` — against which ETAs and active windows
+ * must be measured so device clock skew cancels (#1612). The API layer owns any wire normalization (e.g.
+ * the alert-window seconds↔millis rule) and hands this type a value that is already epoch millis.
+ */
+@JvmInline
+value class ServerTime(val epochMs: Long) : Comparable<ServerTime> {
+    override fun compareTo(other: ServerTime): Int = epochMs.compareTo(other.epochMs)
+
+    /** Elapsed time from [other] to this instant. Same-domain only — this is the point. */
+    operator fun minus(other: ServerTime): Duration = (epochMs - other.epochMs).milliseconds
+}
+
+/**
+ * An instant on the **device wall** clock (`System.currentTimeMillis()`), epoch millis. Extrapolation
+ * deliberately lives here: it pairs each server time with the local receive time, so measuring the
+ * elapsed interval against the same wall clock is immune to server/device skew. Cross to the server
+ * clock with `TripState.toServerClock` before plotting against server-clock data.
+ */
+@JvmInline
+value class WallTime(val epochMs: Long) : Comparable<WallTime> {
+    override fun compareTo(other: WallTime): Int = epochMs.compareTo(other.epochMs)
+
+    operator fun minus(other: WallTime): Duration = (epochMs - other.epochMs).milliseconds
+
+    companion object {
+        fun now(): WallTime = WallTime(System.currentTimeMillis())
+    }
+}
+
+/**
+ * A reading of the **monotonic** clock (`SystemClock.elapsedRealtime()`), millis since boot. Immune to
+ * NTP corrections and the user changing the clock, so it's the correct source for measuring a real
+ * elapsed interval ("data updated N sec ago"). Not an epoch instant — only differences are meaningful.
+ */
+@JvmInline
+value class ElapsedTime(val ms: Long) : Comparable<ElapsedTime> {
+    override fun compareTo(other: ElapsedTime): Int = ms.compareTo(other.ms)
+
+    operator fun minus(other: ElapsedTime): Duration = (ms - other.ms).milliseconds
+
+    companion object {
+        fun now(): ElapsedTime = ElapsedTime(SystemClock.elapsedRealtime())
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalInfo.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalInfo.kt
@@ -22,6 +22,7 @@ import org.onebusaway.android.models.ArrivalData
 import org.onebusaway.android.models.Occupancy
 import org.onebusaway.android.models.Status
 import org.onebusaway.android.report.TripReportContext
+import org.onebusaway.android.time.ServerTime
 import org.onebusaway.android.util.ArrivalInfoUtils
 import org.onebusaway.android.util.DisplayFormat
 import org.onebusaway.android.util.getRouteDisplayName
@@ -35,7 +36,7 @@ import java.util.Date
 class ArrivalInfo(
     context: Context?,
     private val data: ArrivalData,
-    now: Long,
+    now: ServerTime,
     includeArrivalDepartureInStatusLabel: Boolean,
     favorite: Boolean,
 ) {
@@ -102,8 +103,8 @@ class ArrivalInfo(
 
     /** The departure time to set a reminder for: the predicted time if known, else the scheduled. */
     val reminderDepartureTime: Long
-        get() = if (data.predictedDepartureTime != 0L) data.predictedDepartureTime
-        else data.scheduledDepartureTime
+        get() = if (data.predictedDepartureTime.epochMs != 0L) data.predictedDepartureTime.epochMs
+        else data.scheduledDepartureTime.epochMs
 
     /** Flattens this arrival into the report flow's scalar context (was ObaArrivalInfo-based). */
     fun toTripReportContext(): TripReportContext = TripReportContext(
@@ -116,10 +117,10 @@ class ArrivalInfo(
         stopId = data.stopId,
         serviceDate = data.serviceDate,
         predicted = data.predicted,
-        predictedArrivalTime = data.predictedArrivalTime,
-        predictedDepartureTime = data.predictedDepartureTime,
-        scheduledArrivalTime = data.scheduledArrivalTime,
-        scheduledDepartureTime = data.scheduledDepartureTime,
+        predictedArrivalTime = data.predictedArrivalTime.epochMs,
+        predictedDepartureTime = data.predictedDepartureTime.epochMs,
+        scheduledArrivalTime = data.scheduledArrivalTime.epochMs,
+        scheduledDepartureTime = data.scheduledDepartureTime.epochMs,
         hasTripStatus = data.hasTripStatus,
         scheduleDeviation = data.scheduleDeviation,
         lastKnownLat = data.lastKnownLat,
@@ -127,10 +128,13 @@ class ArrivalInfo(
     )
 
     init {
-        // First, all times have to be converted to 'minutes'
-        val nowMins = now / MS_IN_MINS
-        val scheduled: Long
-        val predictedTime: Long
+        // First, all times have to be converted to 'minutes'. now/scheduled/predicted are all
+        // server-clock ServerTime — the ETA baseline can't be a device clock (#1620). The minute values
+        // are floored per-instant then subtracted (unchanged behavior); the typed instants guarantee
+        // the subtraction stays same-domain.
+        val nowMins = now.epochMs / MS_IN_MINS
+        val scheduled: ServerTime
+        val predictedTime: ServerTime
         // If this is the first stop in the sequence, show the departure time.
         if (data.stopSequence != 0) {
             scheduled = data.scheduledArrivalTime
@@ -143,17 +147,17 @@ class ArrivalInfo(
             isArrival = false
         }
 
-        val scheduledMins = scheduled / MS_IN_MINS
-        val predictedMins = predictedTime / MS_IN_MINS
+        val scheduledMins = scheduled.epochMs / MS_IN_MINS
+        val predictedMins = predictedTime.epochMs / MS_IN_MINS
 
         if (data.predicted) {
             predicted = true
             eta = predictedMins - nowMins
-            displayTime = predictedTime
+            displayTime = predictedTime.epochMs
         } else {
             predicted = false
             eta = scheduledMins - nowMins
-            displayTime = scheduled
+            displayTime = scheduled.epochMs
         }
 
         color = ArrivalInfoUtils.computeColor(scheduledMins, predictedMins)
@@ -181,8 +185,8 @@ class ArrivalInfo(
      */
     private fun computeStatusLabel(
         context: Context?,
-        now: Long,
-        predictedTime: Long,
+        now: ServerTime,
+        predictedTime: ServerTime,
         scheduledMins: Long,
         predictedMins: Long,
         includeArrivalDeparture: Boolean
@@ -213,7 +217,7 @@ class ArrivalInfo(
             val formatter = DateFormat.getTimeInstance(DateFormat.SHORT)
 
             val statusLabelId: Int
-            val time: Long
+            val time: ServerTime
 
             if (now < frequency.startTime) {
                 statusLabelId = R.string.stop_info_frequency_from
@@ -223,11 +227,11 @@ class ArrivalInfo(
                 time = frequency.endTime
             }
 
-            val label = formatter.format(Date(time))
+            val label = formatter.format(Date(time.epochMs))
             return context.getString(statusLabelId, headwayAsMinutes, label)
         }
 
-        if (predictedTime != 0L) {
+        if (predictedTime.epochMs != 0L) {
             // Real-time info
             var delay = predictedMins - scheduledMins
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsRepository.kt
@@ -48,6 +48,7 @@ import org.onebusaway.android.database.oba.markStopUsed
 import org.onebusaway.android.models.ObaRoute
 import org.onebusaway.android.models.ObaSituation
 import org.onebusaway.android.models.ObaStop
+import org.onebusaway.android.time.ServerTime
 import org.onebusaway.android.models.contentKey
 import org.onebusaway.android.preferences.PreferencesRepository
 import org.onebusaway.android.region.RegionRepository
@@ -323,7 +324,7 @@ class DefaultArrivalsRepository @Inject constructor(
         // memory (the legacy per-row ContentProvider lookup is gone).
         val favoriteRows = routeHeadsignFavoriteDao.favoritesForStopOrAll(snapshot.stopId)
         val arrivals = convertArrivals(
-            context, snapshot.arrivals, routeFilter, now, includeArrivalDepartureLabel
+            context, snapshot.arrivals, routeFilter, ServerTime(now), includeArrivalDepartureLabel
         ) { routeId, headsign, stopId ->
             computeRouteHeadsignFavorite(favoriteRows, routeId, headsign, stopId)
         }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ConvertArrivals.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ConvertArrivals.kt
@@ -19,6 +19,7 @@ import android.content.Context
 import org.onebusaway.android.R
 import org.onebusaway.android.app.di.PreferencesEntryPoint
 import org.onebusaway.android.models.ArrivalData
+import org.onebusaway.android.time.ServerTime
 import org.onebusaway.android.util.ArrivalInfoUtils
 
 /**
@@ -34,7 +35,7 @@ fun convertArrivals(
     context: Context,
     arrivals: List<ArrivalData>,
     filter: Collection<String>?,
-    ms: Long,
+    ms: ServerTime,
     includeArrivalDepartureInStatusLabel: Boolean,
     isFavorite: (routeId: String, headsign: String?, stopId: String) -> Boolean,
 ): List<ArrivalInfo> {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/dataview/TripTrajectory.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/dataview/TripTrajectory.kt
@@ -17,6 +17,7 @@ package org.onebusaway.android.ui.dataview
 
 import org.onebusaway.android.extrapolation.ExtrapolationResult
 import org.onebusaway.android.extrapolation.data.TripState
+import org.onebusaway.android.time.WallTime
 import org.onebusaway.android.extrapolation.math.prob.ProbDistribution
 
 /** A plotted point: distance along the trip (meters) at a server-clock time (ms since epoch). */
@@ -134,12 +135,13 @@ fun dataBounds(distances: List<Double>, times: List<Long>, padFraction: Double =
  * [TripState.extrapolate] still receives the local time it expects (it compares against the anchor's
  * local clock).
  */
-fun buildTrajectory(state: TripState, nowMs: Long): TripTrajectory {
-    val serverNowMs = state.toServerClock(nowMs)
+fun buildTrajectory(state: TripState, nowMs: WallTime): TripTrajectory {
+    // Plot on the server-clock axis; unwrap to raw Long for the graph's time coordinates.
+    val serverNowMs = state.toServerClock(nowMs).epochMs
 
     val observations = state.history.mapNotNull { entry ->
         val dist = entry.status.distanceAlongTrip ?: return@mapNotNull null
-        val time = entry.status.lastUpdateTime.takeIf { it > 0 } ?: entry.serverTimeMs
+        val time = entry.status.lastUpdateTime.takeIf { it > 0 } ?: entry.serverTimeMs.epochMs
         TrajectoryPoint(dist, time)
     }
 
@@ -169,7 +171,7 @@ fun buildTrajectory(state: TripState, nowMs: Long): TripTrajectory {
     return TripTrajectory(observations, schedule, extrapolation, dataBounds(distances, times), serverNowMs)
 }
 
-private fun extrapolationSeries(state: TripState, schedule: List<ScheduleStop>, nowMs: Long): ExtrapolationSeries? {
+private fun extrapolationSeries(state: TripState, schedule: List<ScheduleStop>, nowMs: WallTime): ExtrapolationSeries? {
     val distribution = (state.extrapolate(nowMs) as? ExtrapolationResult.Success)?.distribution ?: return null
     val anchorDist = state.anchor?.distanceAlongTrip ?: return null
     val median = distribution.median()
@@ -177,8 +179,8 @@ private fun extrapolationSeries(state: TripState, schedule: List<ScheduleStop>, 
     val high = distribution.quantile(CI_HIGH_QUANTILE)
     if (!median.isFinite() || !low.isFinite() || !high.isFinite()) return null
     return ExtrapolationSeries(
-        anchor = TrajectoryPoint(anchorDist, state.anchorTimeMs),
-        nowMs = state.toServerClock(nowMs),
+        anchor = TrajectoryPoint(anchorDist, state.anchorTimeMs.epochMs),
+        nowMs = state.toServerClock(nowMs).epochMs,
         medianMeters = median,
         lowMeters = low,
         highMeters = high,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/dataview/TripTrajectoryViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/dataview/TripTrajectoryViewModel.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import org.onebusaway.android.extrapolation.data.TripObservationRepository
+import org.onebusaway.android.time.WallTime
 import org.onebusaway.android.ui.nav.NavRoutes
 
 /**
@@ -61,7 +62,7 @@ class TripTrajectoryViewModel @Inject constructor(
             vehicleId = snapshot.anchor?.vehicleId,
             sampleCount = snapshot.history.size,
             tripEnded = snapshot.vehicleActiveTripId != null && snapshot.vehicleActiveTripId != tripId,
-            trajectory = buildTrajectory(snapshot, nowMs),
+            trajectory = buildTrajectory(snapshot, WallTime(nowMs)),
         )
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/mylists/MyListRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/mylists/MyListRepository.kt
@@ -44,6 +44,7 @@ import org.onebusaway.android.database.oba.RouteListRow
 import org.onebusaway.android.database.oba.StopListRow
 import org.onebusaway.android.database.oba.TripDepartureTime
 import org.onebusaway.android.ui.arrivals.ArrivalInfo
+import org.onebusaway.android.time.ServerTime
 import org.onebusaway.android.ui.arrivals.convertArrivals
 import org.onebusaway.android.util.DisplayFormat
 import org.onebusaway.android.util.MyTextUtils
@@ -322,7 +323,7 @@ private suspend fun fetchStopBadges(context: Context, stopId: String): List<Arri
             .getOrThrow()
         // Server clock as the ETA baseline so badges cancel device clock skew (#1612). These badge
         // rows don't render the favorite star, so favorite state is always false.
-        convertArrivals(context, snapshot.arrivals, null, snapshot.currentTime, false) { _, _, _ -> false }
+        convertArrivals(context, snapshot.arrivals, null, ServerTime(snapshot.currentTime), false) { _, _, _ -> false }
             .take(MAX_ARRIVALS_PER_STOP)
             .map { it.toBadge(context) }
     }.getOrDefault(emptyList())

--- a/onebusaway-android/src/test/java/org/onebusaway/android/api/data/SituationEpochToMillisTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/api/data/SituationEpochToMillisTest.kt
@@ -42,6 +42,11 @@ class SituationEpochToMillisTest {
     }
 
     @Test
+    fun `negative passes through unchanged`() {
+        assertEquals(-1L, situationEpochToMillis(-1L))
+    }
+
+    @Test
     fun `boundary at the threshold is treated as millis`() {
         // Exactly 1e12 (year 2001 in millis) is at/above the threshold → already millis.
         assertEquals(1_000_000_000_000L, situationEpochToMillis(1_000_000_000_000L))

--- a/onebusaway-android/src/test/java/org/onebusaway/android/extrapolation/ScheduleReplayExtrapolatorTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/extrapolation/ScheduleReplayExtrapolatorTest.kt
@@ -15,6 +15,7 @@
  */
 package org.onebusaway.android.extrapolation
 
+import org.onebusaway.android.time.WallTime
 import org.onebusaway.android.api.adapters.StopTimeData
 import org.onebusaway.android.api.adapters.TripScheduleData
 
@@ -137,7 +138,7 @@ class ScheduleReplayExtrapolatorTest {
 
     /** Convenience: replay from time 0 advancing by dtSec seconds. */
     private fun replay(schedule: ObaTripSchedule, startDist: Double, dtSec: Double): Double? =
-            replaySchedule(schedule, startDist, 0L, (dtSec * 1000).toLong())
+            replaySchedule(schedule, startDist, WallTime(0L), WallTime((dtSec * 1000).toLong()))
 
     // --- Helpers ---
 

--- a/onebusaway-android/src/test/java/org/onebusaway/android/extrapolation/data/TripStateTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/extrapolation/data/TripStateTest.kt
@@ -15,6 +15,8 @@
  */
 package org.onebusaway.android.extrapolation.data
 
+import org.onebusaway.android.time.ServerTime
+import org.onebusaway.android.time.WallTime
 import org.onebusaway.android.api.adapters.StopTimeData
 import org.onebusaway.android.api.adapters.TripScheduleData
 import org.junit.Assert.assertEquals
@@ -37,14 +39,14 @@ class TripStateTest {
     @Test
     fun `extrapolate returns NoData when no anchor`() {
         val state = TripState.empty("trip1")
-        val result = state.extrapolate(System.currentTimeMillis())
+        val result = state.extrapolate(WallTime(System.currentTimeMillis()))
         assertTrue(result is ExtrapolationResult.NoData)
     }
 
     @Test
     fun `toServerClock leaves the time unchanged when there is no anchor`() {
         // No skew can be measured without an anchor, so the local clock passes through.
-        assertEquals(12_345L, TripState.empty("trip1").toServerClock(12_345L))
+        assertEquals(12_345L, TripState.empty("trip1").toServerClock(WallTime(12_345L)).epochMs)
     }
 
     @Test
@@ -54,10 +56,10 @@ class TripStateTest {
                 TripState.empty("trip1")
                         .withStatus(
                                 status(distanceAlongTrip = 500.0, lastUpdateTime = 105_000L),
-                                serverTimeMs = 105_000L,
-                                localTimeMs = 100_000L
+                                serverTimeMs = ServerTime(105_000L),
+                                localTimeMs = WallTime(100_000L)
                         )
-        assertEquals(107_000L, state.toServerClock(102_000L))
+        assertEquals(107_000L, state.toServerClock(WallTime(102_000L)).epochMs)
     }
 
     @Test
@@ -66,11 +68,11 @@ class TripStateTest {
                 TripState.empty("trip1")
                         .withStatus(
                                 status(distanceAlongTrip = null, lastUpdateTime = 1000L),
-                                serverTimeMs = 1000L,
-                                localTimeMs = 1000L
+                                serverTimeMs = ServerTime(1000L),
+                                localTimeMs = WallTime(1000L)
                         )
         // withStatus() skips entries with null distance, so anchor stays null
-        val result = state.extrapolate(1000L)
+        val result = state.extrapolate(WallTime(1000L))
         assertTrue(result is ExtrapolationResult.NoData)
     }
 
@@ -81,10 +83,10 @@ class TripStateTest {
                 TripState.empty("trip1")
                         .withStatus(
                                 status(distanceAlongTrip = 500.0, lastUpdateTime = 0L),
-                                serverTimeMs = 0L,
-                                localTimeMs = 0L
+                                serverTimeMs = ServerTime(0L),
+                                localTimeMs = WallTime(0L)
                         )
-        val result = state.extrapolate(1000L)
+        val result = state.extrapolate(WallTime(1000L))
         assertTrue(result is ExtrapolationResult.NoData)
     }
 
@@ -96,11 +98,11 @@ class TripStateTest {
                 TripState.empty("trip1")
                         .withStatus(
                                 status(distanceAlongTrip = 500.0, lastUpdateTime = serverTime),
-                                serverTimeMs = serverTime,
-                                localTimeMs = localTime
+                                serverTimeMs = ServerTime(serverTime),
+                                localTimeMs = WallTime(localTime)
                         )
         // Query time is before anchor local time → dtMs < 0
-        val result = state.extrapolate(localTime - 1)
+        val result = state.extrapolate(WallTime(localTime - 1))
         assertTrue(result is ExtrapolationResult.Stale)
     }
 
@@ -112,11 +114,11 @@ class TripStateTest {
                 TripState.empty("trip1")
                         .withStatus(
                                 status(distanceAlongTrip = 500.0, lastUpdateTime = serverTime),
-                                serverTimeMs = serverTime,
-                                localTimeMs = localTime
+                                serverTimeMs = ServerTime(serverTime),
+                                localTimeMs = WallTime(localTime)
                         )
         // MAX_HORIZON_MS = 15 * 60 * 1000 = 900_000
-        val result = state.extrapolate(localTime + 900_001L)
+        val result = state.extrapolate(WallTime(localTime + 900_001L))
         assertTrue(result is ExtrapolationResult.Stale)
     }
 
@@ -128,13 +130,13 @@ class TripStateTest {
                 TripState.empty("trip1")
                         .withStatus(
                                 status(distanceAlongTrip = 500.0, lastUpdateTime = serverTime),
-                                serverTimeMs = serverTime,
-                                localTimeMs = localTime
+                                serverTimeMs = ServerTime(serverTime),
+                                localTimeMs = WallTime(localTime)
                         )
         // The stale check is strict (dtMs > MAX_HORIZON_MS), so dtMs == MAX_HORIZON_MS is
         // still allowed and reaches the extrapolator — which reports MissingSchedule here
         // because this state has no schedule
-        val result = state.extrapolate(localTime + 900_000L)
+        val result = state.extrapolate(WallTime(localTime + 900_000L))
         assertTrue(result is ExtrapolationResult.MissingSchedule)
     }
 
@@ -147,10 +149,10 @@ class TripStateTest {
                 TripState.empty("trip1")
                         .withStatus(
                                 status(distanceAlongTrip = 49.0, lastUpdateTime = serverTime),
-                                serverTimeMs = serverTime,
-                                localTimeMs = localTime
+                                serverTimeMs = ServerTime(serverTime),
+                                localTimeMs = WallTime(localTime)
                         )
-        val result = state.extrapolate(localTime + 1000L)
+        val result = state.extrapolate(WallTime(localTime + 1000L))
         assertTrue(result is ExtrapolationResult.TripNotStarted)
     }
 
@@ -162,10 +164,10 @@ class TripStateTest {
                 TripState.empty("trip1")
                         .withStatus(
                                 status(distanceAlongTrip = 50.0, lastUpdateTime = serverTime),
-                                serverTimeMs = serverTime,
-                                localTimeMs = localTime
+                                serverTimeMs = ServerTime(serverTime),
+                                localTimeMs = WallTime(localTime)
                         )
-        val result = state.extrapolate(localTime + 1000L)
+        val result = state.extrapolate(WallTime(localTime + 1000L))
         // 50.0 <= 50.0 is true, so TripNotStarted
         assertTrue(result is ExtrapolationResult.TripNotStarted)
     }
@@ -184,10 +186,10 @@ class TripStateTest {
                                         totalDistanceAlongTrip = 10000.0,
                                         lastUpdateTime = serverTime
                                 ),
-                                serverTimeMs = serverTime,
-                                localTimeMs = localTime
+                                serverTimeMs = ServerTime(serverTime),
+                                localTimeMs = WallTime(localTime)
                         )
-        val result = state.extrapolate(localTime + 1000L)
+        val result = state.extrapolate(WallTime(localTime + 1000L))
         assertTrue(result is ExtrapolationResult.TripEnded)
     }
 
@@ -203,10 +205,10 @@ class TripStateTest {
                                         totalDistanceAlongTrip = null,
                                         lastUpdateTime = serverTime
                                 ),
-                                serverTimeMs = serverTime,
-                                localTimeMs = localTime
+                                serverTimeMs = ServerTime(serverTime),
+                                localTimeMs = WallTime(localTime)
                         )
-        val result = state.extrapolate(localTime + 1000L)
+        val result = state.extrapolate(WallTime(localTime + 1000L))
         // Without totalDist, trip-ended check is skipped; should reach the extrapolator
         assertFalse(result is ExtrapolationResult.TripEnded)
     }
@@ -223,10 +225,10 @@ class TripStateTest {
                                         totalDistanceAlongTrip = 0.0,
                                         lastUpdateTime = serverTime
                                 ),
-                                serverTimeMs = serverTime,
-                                localTimeMs = localTime
+                                serverTimeMs = ServerTime(serverTime),
+                                localTimeMs = WallTime(localTime)
                         )
-        val result = state.extrapolate(localTime + 1000L)
+        val result = state.extrapolate(WallTime(localTime + 1000L))
         assertFalse(result is ExtrapolationResult.TripEnded)
     }
 
@@ -242,8 +244,8 @@ class TripStateTest {
         val after =
                 before.withStatus(
                         status(distanceAlongTrip = null, lastUpdateTime = 1000L),
-                        serverTimeMs = 1000L,
-                        localTimeMs = 1000L
+                        serverTimeMs = ServerTime(1000L),
+                        localTimeMs = WallTime(1000L)
                 )
         assertSame(before, after)
         assertEquals(0, after.history.size)
@@ -255,8 +257,8 @@ class TripStateTest {
         val after =
                 before.withStatus(
                         status(distanceAlongTrip = 500.0, lastUpdateTime = 1000L),
-                        serverTimeMs = 0L,
-                        localTimeMs = 1000L
+                        serverTimeMs = ServerTime(0L),
+                        localTimeMs = WallTime(1000L)
                 )
         assertSame(before, after)
         assertEquals(0, after.history.size)
@@ -268,8 +270,8 @@ class TripStateTest {
         val after =
                 before.withStatus(
                         status(distanceAlongTrip = 500.0, lastUpdateTime = 1000L),
-                        serverTimeMs = -1L,
-                        localTimeMs = 1000L
+                        serverTimeMs = ServerTime(-1L),
+                        localTimeMs = WallTime(1000L)
                 )
         assertSame(before, after)
     }
@@ -280,8 +282,8 @@ class TripStateTest {
                 TripState.empty("trip1")
                         .withStatus(
                                 status(distanceAlongTrip = 500.0, lastUpdateTime = 1000L),
-                                serverTimeMs = 2000L,
-                                localTimeMs = 2000L
+                                serverTimeMs = ServerTime(2000L),
+                                localTimeMs = WallTime(2000L)
                         )
         assertEquals(1, state.history.size)
     }
@@ -290,8 +292,8 @@ class TripStateTest {
     fun `withStatus skips duplicate distance and time`() {
         val s = status(distanceAlongTrip = 500.0, lastUpdateTime = 1000L)
         val before =
-                TripState.empty("trip1").withStatus(s, serverTimeMs = 2000L, localTimeMs = 2000L)
-        val after = before.withStatus(s, serverTimeMs = 3000L, localTimeMs = 3000L)
+                TripState.empty("trip1").withStatus(s, serverTimeMs = ServerTime(2000L), localTimeMs = WallTime(2000L))
+        val after = before.withStatus(s, serverTimeMs = ServerTime(3000L), localTimeMs = WallTime(3000L))
         assertSame(before, after)
         assertEquals(1, after.history.size)
     }
@@ -302,13 +304,13 @@ class TripStateTest {
                 TripState.empty("trip1")
                         .withStatus(
                                 status(distanceAlongTrip = 500.0, lastUpdateTime = 1000L),
-                                serverTimeMs = 2000L,
-                                localTimeMs = 2000L
+                                serverTimeMs = ServerTime(2000L),
+                                localTimeMs = WallTime(2000L)
                         )
                         .withStatus(
                                 status(distanceAlongTrip = 600.0, lastUpdateTime = 1000L),
-                                serverTimeMs = 3000L,
-                                localTimeMs = 3000L
+                                serverTimeMs = ServerTime(3000L),
+                                localTimeMs = WallTime(3000L)
                         )
         assertEquals(2, state.history.size)
     }
@@ -319,13 +321,13 @@ class TripStateTest {
                 TripState.empty("trip1")
                         .withStatus(
                                 status(distanceAlongTrip = 500.0, lastUpdateTime = 1000L),
-                                serverTimeMs = 2000L,
-                                localTimeMs = 2000L
+                                serverTimeMs = ServerTime(2000L),
+                                localTimeMs = WallTime(2000L)
                         )
                         .withStatus(
                                 status(distanceAlongTrip = 500.0, lastUpdateTime = 2000L),
-                                serverTimeMs = 3000L,
-                                localTimeMs = 3000L
+                                serverTimeMs = ServerTime(3000L),
+                                localTimeMs = WallTime(3000L)
                         )
         assertEquals(2, state.history.size)
     }
@@ -336,16 +338,16 @@ class TripStateTest {
                 TripState.empty("trip1")
                         .withStatus(
                                 status(distanceAlongTrip = 500.0, lastUpdateTime = 1000L),
-                                serverTimeMs = 2000L,
-                                localTimeMs = 2000L
+                                serverTimeMs = ServerTime(2000L),
+                                localTimeMs = WallTime(2000L)
                         )
                         .withStatus(
                                 status(distanceAlongTrip = 600.0, lastUpdateTime = 3000L),
-                                serverTimeMs = 4000L,
-                                localTimeMs = 4000L
+                                serverTimeMs = ServerTime(4000L),
+                                localTimeMs = WallTime(4000L)
                         )
         assertEquals(600.0, state.anchor!!.distanceAlongTrip!!, 0.0)
-        assertEquals(3000L, state.anchorTimeMs)
+        assertEquals(3000L, state.anchorTimeMs.epochMs)
     }
 
     @Test
@@ -359,8 +361,8 @@ class TripStateTest {
                                         lastUpdateTime = 1000L,
                                         predicted = false
                                 ),
-                                serverTimeMs = 2000L,
-                                localTimeMs = 2000L
+                                serverTimeMs = ServerTime(2000L),
+                                localTimeMs = WallTime(2000L)
                         )
                         // Second: realtime, same lastUpdateTime
                         .withStatus(
@@ -370,8 +372,8 @@ class TripStateTest {
                                         predicted = true,
                                         hasLastKnownLocation = true
                                 ),
-                                serverTimeMs = 3000L,
-                                localTimeMs = 3000L
+                                serverTimeMs = ServerTime(3000L),
+                                localTimeMs = WallTime(3000L)
                         )
         // GPS entry should win the tie
         assertEquals(600.0, state.anchor!!.distanceAlongTrip!!, 0.0)
@@ -383,11 +385,11 @@ class TripStateTest {
                 TripState.empty("trip1")
                         .withStatus(
                                 status(distanceAlongTrip = 500.0, lastUpdateTime = 5000L),
-                                serverTimeMs = 10_000L,
-                                localTimeMs = 10_000L
+                                serverTimeMs = ServerTime(10_000L),
+                                localTimeMs = WallTime(10_000L)
                         )
         // effectiveTime = lastUpdateTime = 5000
-        assertEquals(5000L, state.anchorTimeMs)
+        assertEquals(5000L, state.anchorTimeMs.epochMs)
     }
 
     @Test
@@ -396,11 +398,11 @@ class TripStateTest {
                 TripState.empty("trip1")
                         .withStatus(
                                 status(distanceAlongTrip = 500.0, lastUpdateTime = 0L),
-                                serverTimeMs = 10_000L,
-                                localTimeMs = 10_000L
+                                serverTimeMs = ServerTime(10_000L),
+                                localTimeMs = WallTime(10_000L)
                         )
         // effectiveTime = serverTimeMs = 10000
-        assertEquals(10_000L, state.anchorTimeMs)
+        assertEquals(10_000L, state.anchorTimeMs.epochMs)
     }
 
     @Test
@@ -410,12 +412,12 @@ class TripStateTest {
                 TripState.empty("trip1")
                         .withStatus(
                                 status(distanceAlongTrip = 500.0, lastUpdateTime = 5000L),
-                                serverTimeMs = 12_000L,
-                                localTimeMs = 10_000L
+                                serverTimeMs = ServerTime(12_000L),
+                                localTimeMs = WallTime(10_000L)
                         )
         // serverLocalOffset = 12000 - 10000 = 2000
         // anchorLocalTimeMs = effectiveTime - offset = 5000 - 2000 = 3000
-        assertEquals(3000L, state.anchorLocalTimeMs)
+        assertEquals(3000L, state.anchorLocalTimeMs.epochMs)
     }
 
     @Test
@@ -425,8 +427,8 @@ class TripStateTest {
             state =
                     state.withStatus(
                             status(distanceAlongTrip = i.toDouble(), lastUpdateTime = i.toLong()),
-                            serverTimeMs = i.toLong() + 1000,
-                            localTimeMs = i.toLong() + 1000
+                            serverTimeMs = ServerTime(i.toLong() + 1000),
+                            localTimeMs = WallTime(i.toLong() + 1000)
                     )
         }
         assertEquals(100, state.history.size)
@@ -450,21 +452,21 @@ class TripStateTest {
                 TripState.empty("trip1")
                         .withStatus(
                                 status(distanceAlongTrip = 500.0, lastUpdateTime = localTime),
-                                serverTimeMs = localTime,
-                                localTimeMs = localTime
+                                serverTimeMs = ServerTime(localTime),
+                                localTimeMs = WallTime(localTime)
                         )
                         .withSchedule(schedule)
 
         // No routeType yet → gamma model
         assertTrue(
-                unknownType.extrapolate(localTime + 10_000L)
+                unknownType.extrapolate(WallTime(localTime + 10_000L))
                         is ExtrapolationResult.MissingSchedule
         )
 
         // routeType arrives on a later poll: the copy re-derives the extrapolator, so a
         // grade-separated trip switches to schedule replay instead of staying locked to gamma
         val rail = unknownType.withRouteType(ObaRoute.TYPE_SUBWAY)
-        assertTrue(rail.extrapolate(localTime + 10_000L) is ExtrapolationResult.Success)
+        assertTrue(rail.extrapolate(WallTime(localTime + 10_000L)) is ExtrapolationResult.Success)
     }
 
     @Test
@@ -474,12 +476,12 @@ class TripStateTest {
                 TripState.empty("trip1")
                         .withStatus(
                                 status(distanceAlongTrip = 500.0, lastUpdateTime = localTime),
-                                serverTimeMs = localTime,
-                                localTimeMs = localTime
+                                serverTimeMs = ServerTime(localTime),
+                                localTimeMs = WallTime(localTime)
                         )
                         .withSchedule(schedule)
                         .withRouteType(ObaRoute.TYPE_BUS)
-        assertTrue(bus.extrapolate(localTime + 10_000L) is ExtrapolationResult.MissingSchedule)
+        assertTrue(bus.extrapolate(WallTime(localTime + 10_000L)) is ExtrapolationResult.MissingSchedule)
     }
 
     @Test

--- a/onebusaway-android/src/test/java/org/onebusaway/android/extrapolation/data/TripsForRouteDecodeTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/extrapolation/data/TripsForRouteDecodeTest.kt
@@ -48,7 +48,7 @@ class TripsForRouteDecodeTest {
         assertEquals(38, observations.size)
         val first = observations[0]
         assertEquals("Hillsborough Area Regional Transit_101446", first.tripId)
-        assertEquals(1444073094612L, first.serverTimeMs)
+        assertEquals(1444073094612L, first.serverTimeMs.epochMs)
         assertEquals(1444017600000L, first.serviceDate)
         // Resolved through the refs: trip -> route -> type 3 (bus).
         assertEquals(3, first.routeType)

--- a/onebusaway-android/src/test/java/org/onebusaway/android/time/TypedTimeTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/time/TypedTimeTest.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.time
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.minutes
+
+/**
+ * Guards the domain-tagged time types: same-domain arithmetic yields a [kotlin.time.Duration] and stays
+ * signed/ordered. These are pure domain wrappers with no wire knowledge — the seconds↔millis wire
+ * normalization lives on the API side (`situationEpochToMillis`, covered by `SituationEpochToMillisTest`).
+ * The cross-domain safety (no `ServerTime.minus(WallTime)`) is enforced by the compiler, so it can't be
+ * unit-tested here — its proof is that the app compiles.
+ */
+class TypedTimeTest {
+
+    @Test
+    fun `same-domain subtraction yields a Duration`() {
+        assertEquals(5.minutes, ServerTime(600_000L) - ServerTime(300_000L))
+        assertEquals(5.minutes, WallTime(600_000L) - WallTime(300_000L))
+        assertEquals(5.minutes, ElapsedTime(600_000L) - ElapsedTime(300_000L))
+    }
+
+    @Test
+    fun `subtraction is signed`() {
+        assertEquals((-1_000L).milliseconds, ServerTime(1_000L) - ServerTime(2_000L))
+    }
+
+    @Test
+    fun `Comparable orders within a domain`() {
+        assertTrue(ServerTime(1_000L) < ServerTime(2_000L))
+        assertTrue(WallTime(2_000L) > WallTime(1_000L))
+        assertEquals(ServerTime(1_000L), ServerTime(1_000L))
+    }
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/dataview/TripTrajectoryTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/dataview/TripTrajectoryTest.kt
@@ -15,6 +15,8 @@
  */
 package org.onebusaway.android.ui.dataview
 
+import org.onebusaway.android.time.ServerTime
+import org.onebusaway.android.time.WallTime
 import kotlin.math.sqrt
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -113,7 +115,7 @@ class TripTrajectoryTest {
 
     @Test
     fun `an empty snapshot yields an empty trajectory with a drawable viewport`() {
-        val trajectory = buildTrajectory(TripState("trip1"), nowMs = 10_000L)
+        val trajectory = buildTrajectory(TripState("trip1"), nowMs = WallTime(10_000L))
         assertTrue(trajectory.observations.isEmpty())
         assertTrue(trajectory.schedule.isEmpty())
         assertNull("no anchor -> no extrapolation", trajectory.extrapolation)
@@ -124,15 +126,15 @@ class TripTrajectoryTest {
     @Test
     fun `the now line is left on the local clock when no anchor skew is known`() {
         // No anchor yet (anchorLocalTimeMs == 0) -> no measurable skew -> nowMs unshifted.
-        val trajectory = buildTrajectory(TripState("trip1"), nowMs = 10_000L)
+        val trajectory = buildTrajectory(TripState("trip1"), nowMs = WallTime(10_000L))
         assertEquals(10_000L, trajectory.nowMs)
     }
 
     @Test
     fun `the now line is lifted onto the server clock by the anchor skew`() {
         // Anchor seen at server-clock 1_005_000 / local-clock 1_000_000 -> server runs 5s ahead.
-        val state = TripState("trip1").copy(anchorTimeMs = 1_005_000L, anchorLocalTimeMs = 1_000_000L)
-        val trajectory = buildTrajectory(state, nowMs = 1_002_000L)
+        val state = TripState("trip1").copy(anchorTimeMs = ServerTime(1_005_000L), anchorLocalTimeMs = WallTime(1_000_000L))
+        val trajectory = buildTrajectory(state, nowMs = WallTime(1_002_000L))
         // The local "now" (1_002_000) is plotted at its server-clock equivalent (+5s skew).
         assertEquals(1_007_000L, trajectory.nowMs)
     }
@@ -145,17 +147,17 @@ class TripTrajectoryTest {
     // Reverting that lift to `nowMs = nowMs` (the pre-#1594 bug) must fail these.
 
     /**
-     * A grade-separated trip whose anchor was seen at [anchorServerMs] on the server clock and
+     * A grade-separated trip whose anchor was seen at [anchorServerTime] on the server clock and
      * [anchorLocalMs] on the local clock, mid-route. Grade-separated + a schedule routes
      * extrapolate() through schedule replay, which succeeds mid-route, so buildTrajectory() emits a
      * non-null extrapolation overlay.
      */
-    private fun skewedRailState(anchorServerMs: Long, anchorLocalMs: Long): TripState =
+    private fun skewedRailState(anchorServerTime: Long, anchorLocalMs: Long): TripState =
         TripState.empty("trip1")
             .withStatus(
-                testTripStatus(distanceAlongTrip = 500.0, lastUpdateTime = anchorServerMs, activeTripId = "trip1"),
-                serverTimeMs = anchorServerMs,
-                localTimeMs = anchorLocalMs,
+                testTripStatus(distanceAlongTrip = 500.0, lastUpdateTime = anchorServerTime, activeTripId = "trip1"),
+                serverTimeMs = ServerTime(anchorServerTime),
+                localTimeMs = WallTime(anchorLocalMs),
             )
             .withSchedule(railSchedule)
             .withRouteType(ObaRoute.TYPE_SUBWAY)
@@ -178,8 +180,8 @@ class TripTrajectoryTest {
     @Test
     fun `the extrapolation overlay now line is lifted onto the server clock by the anchor skew`() {
         // Anchor seen at server 105_000 / local 100_000 -> server runs 5s ahead.
-        val state = skewedRailState(anchorServerMs = 105_000L, anchorLocalMs = 100_000L)
-        val trajectory = buildTrajectory(state, nowMs = 102_000L)
+        val state = skewedRailState(anchorServerTime = 105_000L, anchorLocalMs = 100_000L)
+        val trajectory = buildTrajectory(state, nowMs = WallTime(102_000L))
 
         val extrapolation = requireNotNull(trajectory.extrapolation) {
             "a mid-route grade-separated anchor should yield an overlay"
@@ -191,8 +193,8 @@ class TripTrajectoryTest {
 
     @Test
     fun `the overlay now line and the trajectory now line share the server-clock axis`() {
-        val state = skewedRailState(anchorServerMs = 105_000L, anchorLocalMs = 100_000L)
-        val trajectory = buildTrajectory(state, nowMs = 102_000L)
+        val state = skewedRailState(anchorServerTime = 105_000L, anchorLocalMs = 100_000L)
+        val trajectory = buildTrajectory(state, nowMs = WallTime(102_000L))
 
         // Guards the "now line drifts off-axis" symptom (#1583): the overlay's now line must sit on
         // the same server-clock axis as the trajectory's, not lag on the raw local clock. (A bounds
@@ -205,8 +207,8 @@ class TripTrajectoryTest {
     fun `the extrapolation overlay now line drops onto the server clock when the server is behind`() {
         // Anchor seen at server 97_000 / local 100_000 -> server runs 3s behind: exercises the
         // subtraction branch of toServerClock the +5s cases never reach.
-        val state = skewedRailState(anchorServerMs = 97_000L, anchorLocalMs = 100_000L)
-        val trajectory = buildTrajectory(state, nowMs = 102_000L)
+        val state = skewedRailState(anchorServerTime = 97_000L, anchorLocalMs = 100_000L)
+        val trajectory = buildTrajectory(state, nowMs = WallTime(102_000L))
 
         val extrapolation = requireNotNull(trajectory.extrapolation)
         // toServerClock(102_000) = 102_000 + (97_000 - 100_000) = 99_000.

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/dataview/TripTrajectoryViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/dataview/TripTrajectoryViewModelTest.kt
@@ -15,6 +15,8 @@
  */
 package org.onebusaway.android.ui.dataview
 
+import org.onebusaway.android.time.ServerTime
+import org.onebusaway.android.time.WallTime
 import androidx.lifecycle.SavedStateHandle
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.awaitCancellation
@@ -141,8 +143,8 @@ class TripTrajectoryViewModelTest {
         repo.record(
             TripState("trip1").withStatus(
                 testTripStatus(distanceAlongTrip = 500.0, lastUpdateTime = 5_000L, vehicleId = "bus7"),
-                serverTimeMs = 5_000L,
-                localTimeMs = 5_000L,
+                serverTimeMs = ServerTime(5_000L),
+                localTimeMs = WallTime(5_000L),
             )
         )
         runCurrent()


### PR DESCRIPTION
## Summary

Introduces domain-tagged time value classes in `org.onebusaway.android.time` so that mixing clock **domains** becomes a **compile error** rather than a silent runtime bug — "make illegal states unrepresentable" for the app's clock handling. Fixes #1620.

Nearly every time bug we've hit has been a domain or unit mix that a raw `Long` can't guard against: server timestamp − device clock (#27 / #1612), alert windows arriving as seconds vs millis, wall-clock deltas corrupted by NTP corrections. The type system now enforces what review and comments cannot.

## New module (`TypedTime.kt`) — zero runtime cost via `@JvmInline`

- `ServerTime` — OBA server clock (`currentTime`, arrival predictions, `lastUpdateTime`)
- `WallTime` — device wall clock (`System.currentTimeMillis()`)
- `ElapsedTime` — monotonic clock (`SystemClock.elapsedRealtime()`)

The **only** arithmetic defined is same-domain subtraction, yielding a `kotlin.time.Duration`. There is no `ServerTime.minus(WallTime)`, so the #27-class bug (`serverArrivalTime − System.currentTimeMillis()`) **fails to compile**. `ServerTime.fromWire` (backed by `normalizeEpochToMillis`) is the single sanctioned seconds→millis normalization point, now shared with the existing service-alert active-window adapter (`situationEpochToMillis` delegates to it, so the magnitude rule lives in exactly one place).

## Vertical slice (deliberately incremental)

Applied to the code that already hand-rolls server/device clock pairing:

- **`TripState` + observation store** — `HistoryEntry`, `TripObservation`, anchor times, `toServerClock`, `extrapolate`, and the `Extrapolator` / `replaySchedule` interfaces. The one sanctioned server↔device skew crossing is concentrated in `TripState.withStatus`/`toServerClock`, done on raw `.epochMs` with an explicit comment.
- **Arrivals ETA path** — `ArrivalData`'s arrival/departure instants and `FrequencyWindow` bounds are `ServerTime`, minted at the wire adapter (`DtoArrivalData`); `ArrivalInfo` / `convertArrivals` take a `ServerTime` "now". The `getEta()` minute-flooring behavior is unchanged.

Wrap at the wire/Android boundary, unwrap `.epochMs` only for platform edges (formatting, alarms, the renderer's raw-`Long` animation clock).

## Deliberately out of this slice (staged for follow-ups)

Service-alert active-window typing, `serviceDate`/`scheduleDeviation`, the renderer/`CorrectionSmoother` `fixTimeMs`, the "updated N sec ago" vehicle-age path (the eventual `ElapsedTime` consumer), and Room/kotlinx-serialization converters. `ElapsedTime` ships now per the acceptance criteria but has no in-slice consumer yet; `ServerTime.fromWire` likewise lands ahead of its stage-2 (alert-window) caller.

## Acceptance criteria (#1620)

- [x] `ServerTime` / `WallTime` / `ElapsedTime` (+ `kotlin.time.Duration` for deltas) exist with same-domain-only arithmetic
- [x] Constructing a domain instant from a wire `Long` is the single normalization point (`ServerTime.fromWire` / `normalizeEpochToMillis`)
- [x] `TripState` and the arrivals ETA path use the typed instants; a cross-domain subtraction fails to compile
- [x] Guidance in CLAUDE.md "Time domains" points new time math at the typed API

## Verification

Both flavors (`obaGoogle`, `obaMaplibre`) compile; unit + androidTest sources compile; the typed-time / `TripState` / trajectory unit tests pass (`TypedTimeTest`, `TripStateTest`, `TripTrajectoryTest`, `ScheduleReplayExtrapolatorTest`, `TripTrajectoryViewModelTest`).

Refs #27, #1612.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved consistency of live timing across trip tracking and arrivals by using the correct clock source for calculations.

* **Bug Fixes**
  * Enhanced vehicle extrapolation and route/map overlays to keep predicted positions aligned with the proper “now” reference.
  * Reduced errors in displayed arrival/departure ETAs and frequency windows caused by mixing different timestamp types.
  * Improved trip-state caching and trajectory rendering so extrapolation uses consistent time inputs.

* **Documentation**
  * Updated guidance on safe time-domain rules to prevent incorrect clock mixing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->