### PR TITLE
Make ObaAnalytics an injectable @Singleton orchestrator (#1631)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/analytics/ObaAnalytics.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/analytics/ObaAnalytics.kt
@@ -15,26 +15,34 @@
  */
 package org.onebusaway.android.analytics
 
+import android.content.Context
 import android.location.Location
 import android.os.Bundle
 import com.google.firebase.analytics.FirebaseAnalytics
-import com.onebusaway.plausible.android.Plausible
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
 import org.onebusaway.android.R
-import org.onebusaway.android.app.Application
-import org.onebusaway.android.app.di.AnalyticsEntryPoint
-import org.onebusaway.android.util.PreferenceUtils
+import org.onebusaway.android.preferences.PreferencesRepository
 
 /**
  * Analytics orchestrator for the app: fans each tracked event out to Firebase, Plausible
- * ([PlausibleAnalytics]) and Umami ([UmamiAnalyticsReporter]). Exposed as `@JvmStatic` methods so the
- * many Java + Kotlin call sites keep calling `ObaAnalytics.xxx(...)` unchanged.
+ * ([PlausibleAnalytics]) and Umami ([UmamiAnalyticsReporter]). An injected app-singleton — it holds the
+ * Firebase emitter, the region-derived [AnalyticsProvider] (Plausible/Umami), and the analytics-enabled
+ * preference itself, so call sites just call `obaAnalytics.reportXxx(...)` instead of threading a
+ * `FirebaseAnalytics` + `Plausible` in. Injectable classes inject it directly; the context-less static /
+ * Java / composable call sites reach it via [org.onebusaway.android.app.di.AnalyticsEntryPoint].
  *
  * @author Cagri Cetin, Sean Barbeau
  */
-object ObaAnalytics {
+@Singleton
+class ObaAnalytics @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val analyticsProvider: AnalyticsProvider,
+    private val preferences: PreferencesRepository,
+) {
 
-    /** A device fix is only accurate enough to bucket stop distance when below this (meters). */
-    private const val LOCATION_ACCURACY_THRESHOLD = 50f
+    private val firebase: FirebaseAnalytics = FirebaseAnalytics.getInstance(context)
 
     /** Distance buckets reported when a stop is tapped. */
     enum class ObaStopDistance(private val label: String, val distanceInMeters: Int) {
@@ -63,22 +71,15 @@ object ObaAnalytics {
      * @param id ID of the UI element
      * @param state the state/variant of the UI item, or null if it has none
      */
-    @JvmStatic
-    fun reportUiEvent(
-        analytics: FirebaseAnalytics,
-        plausible: Plausible?,
-        pageUrl: String,
-        id: String,
-        state: String?,
-    ) {
+    fun reportUiEvent(pageUrl: String, id: String, state: String?) {
         if (!isAnalyticsActive()) return
         val bundle = Bundle().apply {
             putString(FirebaseAnalytics.Param.ITEM_ID, id)
             if (!state.isNullOrEmpty()) putString(FirebaseAnalytics.Param.ITEM_VARIANT, state)
         }
-        analytics.logEvent(FirebaseAnalytics.Event.SELECT_CONTENT, bundle)
-        PlausibleAnalytics.reportUiEvent(plausible, pageUrl, id, state)
-        UmamiAnalyticsReporter.reportUiEvent(umami(), pageUrl, id, state)
+        firebase.logEvent(FirebaseAnalytics.Event.SELECT_CONTENT, bundle)
+        PlausibleAnalytics.reportUiEvent(analyticsProvider.plausible, pageUrl, id, state)
+        UmamiAnalyticsReporter.reportUiEvent(analyticsProvider.umami, pageUrl, id, state)
     }
 
     /**
@@ -86,13 +87,12 @@ object ObaAnalytics {
      *
      * @param signUpMethod sign-up method of the login, or null if unknown
      */
-    @JvmStatic
-    fun reportLoginEvent(analytics: FirebaseAnalytics, signUpMethod: String?) {
+    fun reportLoginEvent(signUpMethod: String?) {
         if (!isAnalyticsActive()) return
         val bundle = signUpMethod?.takeIf { it.isNotEmpty() }?.let {
             Bundle().apply { putString(FirebaseAnalytics.Param.METHOD, it) }
         }
-        analytics.logEvent(FirebaseAnalytics.Event.LOGIN, bundle)
+        firebase.logEvent(FirebaseAnalytics.Event.LOGIN, bundle)
     }
 
     /**
@@ -100,16 +100,15 @@ object ObaAnalytics {
      *
      * @param searchTerm search term used, or null if unknown
      */
-    @JvmStatic
-    fun reportSearchEvent(plausible: Plausible?, analytics: FirebaseAnalytics, searchTerm: String?) {
+    fun reportSearchEvent(searchTerm: String?) {
         if (!isAnalyticsActive()) return
         val bundle = searchTerm?.takeIf { it.isNotEmpty() }?.let {
             Bundle().apply { putString(FirebaseAnalytics.Param.SEARCH_TERM, it) }
         }
-        analytics.logEvent(FirebaseAnalytics.Event.SEARCH, bundle)
+        firebase.logEvent(FirebaseAnalytics.Event.SEARCH, bundle)
         searchTerm?.let {
-            PlausibleAnalytics.reportSearchEvent(plausible, it)
-            UmamiAnalyticsReporter.reportSearchEvent(umami(), it)
+            PlausibleAnalytics.reportSearchEvent(analyticsProvider.plausible, it)
+            UmamiAnalyticsReporter.reportSearchEvent(analyticsProvider.umami, it)
         }
     }
 
@@ -117,10 +116,7 @@ object ObaAnalytics {
      * Reports the user viewing a stop, bucketing the distance between the device and the stop (only
      * when the device fix is accurate enough — under [LOCATION_ACCURACY_THRESHOLD]).
      */
-    @JvmStatic
     fun reportViewStopEvent(
-        plausible: Plausible?,
-        analytics: FirebaseAnalytics,
         stopId: String,
         stopName: String?,
         myLocation: Location?,
@@ -129,13 +125,11 @@ object ObaAnalytics {
         if (!isAnalyticsActive() || myLocation == null) return
         if (myLocation.accuracy < LOCATION_ACCURACY_THRESHOLD) {
             val stopDistance = ObaStopDistance.forDistance(myLocation.distanceTo(stopLocation))
-            reportViewStopEvent(plausible, analytics, stopId, stopName, stopDistance.toString())
+            reportViewStopEvent(stopId, stopName, stopDistance.toString())
         }
     }
 
     private fun reportViewStopEvent(
-        plausible: Plausible?,
-        analytics: FirebaseAnalytics,
         stopId: String,
         stopName: String?,
         proximityToStopCategory: String,
@@ -147,51 +141,46 @@ object ObaAnalytics {
             putString(FirebaseAnalytics.Param.ITEM_CATEGORY, string(R.string.analytics_label_stop_category))
             putString(FirebaseAnalytics.Param.LOCATION_ID, proximityToStopCategory)
         }
-        analytics.logEvent(FirebaseAnalytics.Event.VIEW_ITEM, bundle)
-        PlausibleAnalytics.reportViewStopEvent(plausible, stopId, proximityToStopCategory)
-        UmamiAnalyticsReporter.reportViewStopEvent(umami(), stopId, proximityToStopCategory)
+        firebase.logEvent(FirebaseAnalytics.Event.VIEW_ITEM, bundle)
+        PlausibleAnalytics.reportViewStopEvent(analyticsProvider.plausible, stopId, proximityToStopCategory)
+        UmamiAnalyticsReporter.reportViewStopEvent(analyticsProvider.umami, stopId, proximityToStopCategory)
     }
 
     /** Sets the current region as a Firebase user property and on the Umami emitter. */
-    @JvmStatic
-    fun setRegion(analytics: FirebaseAnalytics, regionName: String?) {
+    fun setRegion(regionName: String?) {
         if (!isAnalyticsActive()) return
-        analytics.setUserProperty(string(R.string.analytics_label_region_name), regionName)
-        umami()?.setRegionName(regionName)
+        firebase.setUserProperty(string(R.string.analytics_label_region_name), regionName)
+        analyticsProvider.umami?.setRegionName(regionName)
     }
 
     /** Records (and toggles Firebase collection for) the send-anonymous-usage-data preference. */
-    @JvmStatic
-    fun setSendAnonymousData(analytics: FirebaseAnalytics, isAnalyticsActive: Boolean) {
-        analytics.setUserProperty(
+    fun setSendAnonymousData(isAnalyticsActive: Boolean) {
+        firebase.setUserProperty(
             string(R.string.analytics_label_analytics_property),
             isAnalyticsActive.toYesNo(),
         )
-        analytics.setAnalyticsCollectionEnabled(isAnalyticsActive)
+        firebase.setAnalyticsCollectionEnabled(isAnalyticsActive)
     }
 
     /** Records the left-handed-mode preference as a Firebase user property. */
-    @JvmStatic
-    fun setLeftHanded(analytics: FirebaseAnalytics, isLeftHanded: Boolean) {
+    fun setLeftHanded(isLeftHanded: Boolean) {
         if (!isAnalyticsActive()) return
-        analytics.setUserProperty(string(R.string.analytics_label_left_hand_property), isLeftHanded.toYesNo())
+        firebase.setUserProperty(string(R.string.analytics_label_left_hand_property), isLeftHanded.toYesNo())
     }
 
     /** Records the hide-departed-vehicles preference as a Firebase user property. */
-    @JvmStatic
-    fun setShowDepartedVehicles(analytics: FirebaseAnalytics, showDepartedVehicles: Boolean) {
+    fun setShowDepartedVehicles(showDepartedVehicles: Boolean) {
         if (!isAnalyticsActive()) return
-        analytics.setUserProperty(
+        firebase.setUserProperty(
             string(R.string.analytics_label_show_departed_vehicles_property),
             showDepartedVehicles.toYesNo(),
         )
     }
 
     /** Records whether the device has touch exploration (accessibility) enabled. */
-    @JvmStatic
-    fun setAccessibility(analytics: FirebaseAnalytics, isAccessibilityActive: Boolean) {
+    fun setAccessibility(isAccessibilityActive: Boolean) {
         if (!isAnalyticsActive()) return
-        analytics.setUserProperty(string(R.string.analytics_accessibility), isAccessibilityActive.toYesNo())
+        firebase.setUserProperty(string(R.string.analytics_accessibility), isAccessibilityActive.toYesNo())
     }
 
     /**
@@ -201,9 +190,7 @@ object ObaAnalytics {
      * @param feedbackText free-text feedback, or null if none was entered
      * @param fileName name of the uploaded trip-data file, or null if nothing was uploaded
      */
-    @JvmStatic
     fun reportDestinationReminderFeedback(
-        analytics: FirebaseAnalytics,
         wasGoodReminder: Boolean,
         feedbackText: String?,
         fileName: String?,
@@ -222,19 +209,19 @@ object ObaAnalytics {
             if (!feedbackText.isNullOrEmpty()) putString(FirebaseAnalytics.Param.CONTENT, feedbackText)
             if (!fileName.isNullOrEmpty()) putString(FirebaseAnalytics.Param.LOCATION_ID, fileName)
         }
-        analytics.logEvent(FirebaseAnalytics.Event.SELECT_CONTENT, bundle)
+        firebase.logEvent(FirebaseAnalytics.Event.SELECT_CONTENT, bundle)
     }
 
     /** Whether the user has left analytics collection enabled in settings. */
     private fun isAnalyticsActive(): Boolean =
-        PreferenceUtils.getBoolean(string(R.string.preferences_key_analytics), true)
+        preferences.getBoolean(R.string.preferences_key_analytics, true)
 
-    private fun string(resId: Int): String = Application.get().getString(resId)
-
-    // The Umami emitter now lives on the injected AnalyticsProvider. ObaAnalytics is a context-less
-    // static orchestrator, so it resolves the provider through the EntryPoint using the Application only
-    // as a graph handle (a benign context reach) rather than reading app-global analytics *state* off it.
-    private fun umami(): UmamiAnalytics? = AnalyticsEntryPoint.get(Application.get()).umami
+    private fun string(resId: Int): String = context.getString(resId)
 
     private fun Boolean.toYesNo(): String = if (this) "YES" else "NO"
+
+    private companion object {
+        /** A device fix is only accurate enough to bucket stop distance when below this (meters). */
+        const val LOCATION_ACCURACY_THRESHOLD = 50f
+    }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/app/Application.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/app/Application.java
@@ -26,13 +26,12 @@ import android.os.PowerManager;
 import android.text.TextUtils;
 import android.util.Log;
 
-import com.google.firebase.analytics.FirebaseAnalytics;
 import com.google.firebase.messaging.FirebaseMessaging;
 
 import org.onebusaway.android.BuildConfig;
 import org.onebusaway.android.R;
 import org.onebusaway.android.donations.DonationsManager;
-import org.onebusaway.android.analytics.ObaAnalytics;
+import org.onebusaway.android.app.di.AnalyticsEntryPoint;
 import org.onebusaway.android.api.ObaApi;
 import org.onebusaway.android.region.Region;
 import org.onebusaway.android.app.di.LocationEntryPoint;
@@ -77,7 +76,6 @@ public class Application extends android.app.Application {
     // itself lives in the reactive LocationRepository singleton.)
     static GeomagneticField mGeomagneticField = null;
 
-    private FirebaseAnalytics mFirebaseAnalytics;
 
     @Override
     public void onCreate() {
@@ -111,7 +109,7 @@ public class Application extends android.app.Application {
 
         initFirebaseMessaging();
 
-        mDonationsManager = new DonationsManager(getApplicationContext(), mFirebaseAnalytics, getResources(), getAppLaunchCount());
+        mDonationsManager = new DonationsManager(getApplicationContext(), getResources(), getAppLaunchCount());
 
         mGtfsAlerts = new GtfsAlerts(getApplicationContext());
     }
@@ -406,12 +404,11 @@ public class Application extends android.app.Application {
     }
 
     private void reportAnalytics() {
-        mFirebaseAnalytics = FirebaseAnalytics.getInstance(this);
         // The Plausible/Umami emitters are owned + built reactively by AnalyticsProvider; here we only set
         // the initial Firebase/Umami region label via setRegion (which resolves the Umami emitter through
         // the provider itself).
         if (getCustomApiUrl() == null && getCurrentRegion() != null) {
-            ObaAnalytics.setRegion(mFirebaseAnalytics, getCurrentRegion().getName());
+            AnalyticsEntryPoint.get(this).setRegion(getCurrentRegion().getName());
         } else if (getCustomApiUrl() != null) {
             String customUrl;
             try {
@@ -422,7 +419,7 @@ public class Application extends android.app.Application {
             } catch (Exception e) {
                 customUrl = getString(R.string.analytics_label_custom_url);
             }
-            ObaAnalytics.setRegion(mFirebaseAnalytics, customUrl);
+            AnalyticsEntryPoint.get(this).setRegion(customUrl);
         }
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/app/di/AnalyticsEntryPoint.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/app/di/AnalyticsEntryPoint.kt
@@ -20,30 +20,29 @@ import dagger.hilt.EntryPoint
 import dagger.hilt.InstallIn
 import dagger.hilt.android.EntryPointAccessors
 import dagger.hilt.components.SingletonComponent
-import org.onebusaway.android.analytics.AnalyticsProvider
+import org.onebusaway.android.analytics.ObaAnalytics
 
 /**
- * A Hilt [EntryPoint] that lets code which can't be constructor- or field-injected — the static
- * `ObaAnalytics` orchestrator, static Java utilities, composable helpers without a ViewModel — reach
- * the [AnalyticsProvider] seam (and thus the current region's Plausible/Umami emitters) instead of
- * `Application.get().getPlausibleInstance()` / `getUmamiInstance()`. It needs a [Context] only to
- * resolve the singleton graph; the returned provider is the same app-singleton every injected consumer
- * shares.
+ * A Hilt [EntryPoint] that lets code which can't be constructor- or field-injected — static Java
+ * utilities, composable helpers without a ViewModel — reach the injected [ObaAnalytics] orchestrator.
+ * It needs a [Context] only to resolve the singleton graph; the returned orchestrator is the same
+ * app-singleton every injected consumer shares (and holds the Firebase + Plausible/Umami emitters, so
+ * callers no longer thread those in).
  *
  * Use it only where injection genuinely isn't available — Hilt-reachable classes (Activities,
- * Fragments, Services, ViewModels, Workers) should inject [AnalyticsProvider] directly.
+ * Fragments, Services, ViewModels, Workers) should inject [ObaAnalytics] directly.
  */
 @EntryPoint
 @InstallIn(SingletonComponent::class)
 interface AnalyticsEntryPoint {
 
-    fun analyticsProvider(): AnalyticsProvider
+    fun obaAnalytics(): ObaAnalytics
 
     companion object {
-        /** Resolves the [AnalyticsProvider] from any [context] (its application is used). */
+        /** Resolves the [ObaAnalytics] orchestrator from any [context] (its application is used). */
         @JvmStatic
-        fun get(context: Context): AnalyticsProvider =
+        fun get(context: Context): ObaAnalytics =
             EntryPointAccessors.fromApplication(context, AnalyticsEntryPoint::class.java)
-                .analyticsProvider()
+                .obaAnalytics()
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/backup/BackupUtils.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/backup/BackupUtils.java
@@ -25,11 +25,9 @@ import android.util.Log;
 import android.widget.Toast;
 
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
-import com.google.firebase.analytics.FirebaseAnalytics;
 
 import org.onebusaway.android.R;
 import org.onebusaway.android.app.di.AnalyticsEntryPoint;
-import org.onebusaway.android.analytics.ObaAnalytics;
 import org.onebusaway.android.analytics.PlausibleAnalytics;
 
 import java.io.IOException;
@@ -69,8 +67,7 @@ public class BackupUtils {
      */
     static private void doRestore(Context activityContext, Uri uri, Runnable onRestored) {
         final Context context = activityContext.getApplicationContext();
-        ObaAnalytics.reportUiEvent(FirebaseAnalytics.getInstance(activityContext),
-                AnalyticsEntryPoint.get(context).getPlausible(),
+        AnalyticsEntryPoint.get(context).reportUiEvent(
                 PlausibleAnalytics.REPORT_BACKUP_EVENT_URL,
                 context.getString(R.string.analytics_label_button_press_restore_preference),
                 null);
@@ -124,8 +121,7 @@ public class BackupUtils {
      */
     public static void save(Context activityContext,Uri uri) {
         Context context = activityContext.getApplicationContext();
-        ObaAnalytics.reportUiEvent(FirebaseAnalytics.getInstance(activityContext),
-                AnalyticsEntryPoint.get(context).getPlausible(),
+        AnalyticsEntryPoint.get(context).reportUiEvent(
                 PlausibleAnalytics.REPORT_BACKUP_EVENT_URL,
                 context.getString(R.string.analytics_label_button_press_save_preference),
                 null);

--- a/onebusaway-android/src/main/java/org/onebusaway/android/donations/DonationsManager.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/donations/DonationsManager.java
@@ -1,10 +1,7 @@
 package org.onebusaway.android.donations;
 
-import com.google.firebase.analytics.FirebaseAnalytics;
-
 import org.onebusaway.android.R;
 import org.onebusaway.android.app.di.AnalyticsEntryPoint;
-import org.onebusaway.android.analytics.ObaAnalytics;
 import org.onebusaway.android.analytics.PlausibleAnalytics;
 import org.onebusaway.android.util.BuildFlavorUtils;
 import org.onebusaway.android.util.PreferenceUtils;
@@ -29,25 +26,22 @@ public class DonationsManager {
 
     public DonationsManager(
             Context context,
-            FirebaseAnalytics firebaseAnalytics,
             Resources resources,
             int appLaunchCount) {
         this.mContext = context;
-        this.mAnalytics = firebaseAnalytics;
         this.mResources = resources;
         this.mAppLaunchCount = appLaunchCount;
     }
 
     // region Analytics
 
-    private FirebaseAnalytics mAnalytics;
     /**
      * Reports UI events using Firebase
      * @param resourceID ID of the UI element to report
      * @param state the state or variant of the UI item, or null if the item doesn't have a state or variant
      */
     private void reportUIEvent(Integer resourceID, String state) {
-        ObaAnalytics.reportUiEvent(mAnalytics, AnalyticsEntryPoint.get(mContext).getPlausible(), PlausibleAnalytics.REPORT_DONATE_EVENT_URL, mResources.getString(resourceID), state);
+        AnalyticsEntryPoint.get(mContext).reportUiEvent(PlausibleAnalytics.REPORT_DONATE_EVENT_URL, mResources.getString(resourceID), state);
     }
 
     // endregion

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapNavigation.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapNavigation.kt
@@ -16,11 +16,9 @@
 package org.onebusaway.android.map
 
 import android.content.Context
-import com.google.firebase.analytics.FirebaseAnalytics
 import org.onebusaway.android.R
 import org.onebusaway.android.app.Application
 import org.onebusaway.android.app.di.AnalyticsEntryPoint
-import org.onebusaway.android.analytics.ObaAnalytics
 import org.onebusaway.android.analytics.PlausibleAnalytics
 import org.onebusaway.android.models.ObaTripStatus
 import org.onebusaway.android.ui.tripdetails.TripDetailsLauncher
@@ -57,9 +55,7 @@ object MapNavigation {
         if (region.id != RegionUtils.TAMPA_REGION_ID.toLong()) {
             return
         }
-        ObaAnalytics.reportUiEvent(
-            FirebaseAnalytics.getInstance(context),
-            AnalyticsEntryPoint.get(context).plausible,
+        AnalyticsEntryPoint.get(context).reportUiEvent(
             PlausibleAnalytics.REPORT_BIKE_EVENT_URL,
             context.getString(
                 if (station.isFloatingBike) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/nav/FeedbackReceiver.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/nav/FeedbackReceiver.java
@@ -22,13 +22,12 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.util.Log;
 
-import com.google.firebase.analytics.FirebaseAnalytics;
 
 import org.apache.commons.io.FileUtils;
 import org.onebusaway.android.BuildConfig;
 import org.onebusaway.android.R;
 import org.onebusaway.android.app.Application;
-import org.onebusaway.android.analytics.ObaAnalytics;
+import org.onebusaway.android.app.di.AnalyticsEntryPoint;
 import org.onebusaway.android.util.PreferenceUtils;
 
 import java.io.File;
@@ -56,13 +55,11 @@ public class FeedbackReceiver extends BroadcastReceiver {
     public static final int FEEDBACK_NO = 1;
     public static final int FEEDBACK_YES = 2;
 
-    private FirebaseAnalytics mFirebaseAnalytics;
 
     @Override
     public void onReceive(Context context, Intent intent) {
         Log.d(TAG, "onReceive");
 
-        mFirebaseAnalytics = FirebaseAnalytics.getInstance(context);
 
         int notifyId = intent.getIntExtra(NOTIFICATION_ID,
                 NavigationServiceProvider.NOTIFICATION_ID + 1);
@@ -184,7 +181,7 @@ public class FeedbackReceiver extends BroadcastReceiver {
         } else {
             wasGoodReminder = false;
         }
-        ObaAnalytics.reportDestinationReminderFeedback(mFirebaseAnalytics, wasGoodReminder
+        AnalyticsEntryPoint.get(Application.get()).reportDestinationReminderFeedback(wasGoodReminder
                 , ((!isEmpty(feedbackText)) ? feedbackText : null), null);
         Log.d(TAG, "User feedback logged to Firebase Analytics :: wasGoodReminder - "
                 + wasGoodReminder + ", feedbackText - " + ((!isEmpty(feedbackText)) ? feedbackText : null));

--- a/onebusaway-android/src/main/java/org/onebusaway/android/nav/NavigationService.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/nav/NavigationService.kt
@@ -31,7 +31,6 @@ import androidx.core.app.NotificationCompat
 import androidx.core.app.RemoteInput
 import androidx.work.PeriodicWorkRequest
 import androidx.work.WorkManager
-import com.google.firebase.analytics.FirebaseAnalytics
 import com.google.firebase.auth.FirebaseAuth
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -44,7 +43,6 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import org.apache.commons.io.FileUtils
 import org.onebusaway.android.R
-import org.onebusaway.android.analytics.AnalyticsProvider
 import org.onebusaway.android.app.Application
 import org.onebusaway.android.app.di.LocationEntryPoint
 import org.onebusaway.android.analytics.ObaAnalytics
@@ -84,7 +82,7 @@ class NavigationService : Service() {
     @Inject lateinit var navStopDao: NavStopDao
     @Inject lateinit var stopDao: StopDao
     @Inject lateinit var importGate: ImportGate
-    @Inject lateinit var analyticsProvider: AnalyticsProvider
+    @Inject lateinit var obaAnalytics: ObaAnalytics
 
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
     private var navJob: Job? = null
@@ -102,11 +100,8 @@ class NavigationService : Service() {
 
     private var finishedTime: Long = 0
 
-    private lateinit var firebaseAnalytics: FirebaseAnalytics
-
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         Log.d(TAG, "Starting Service")
-        firebaseAnalytics = FirebaseAnalytics.getInstance(this)
         val currentTime = System.currentTimeMillis()
         // The nav-stop read/write is now Room-backed (suspend), so the setup runs on the service scope
         // after the one-time import gate. Dispatchers.Main.immediate keeps startForeground on the main
@@ -247,8 +242,7 @@ class NavigationService : Service() {
             if (finishedTime == 0L) {
                 finishedTime = System.currentTimeMillis()
             } else if (System.currentTimeMillis() - finishedTime >= 30000) {
-                ObaAnalytics.reportUiEvent(
-                    firebaseAnalytics, analyticsProvider.plausible,
+                obaAnalytics.reportUiEvent(
                     PlausibleAnalytics.REPORT_DESTINATION_REMINDER_EVENT_URL,
                     getString(R.string.analytics_label_destination_reminder),
                     getString(R.string.analytics_label_destination_reminder_variant_ended)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/nav/NavigationServiceProvider.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/nav/NavigationServiceProvider.java
@@ -17,12 +17,10 @@ package org.onebusaway.android.nav;
 
 import static android.app.PendingIntent.*;
 
-import com.google.firebase.analytics.FirebaseAnalytics;
 
 import org.onebusaway.android.R;
 import org.onebusaway.android.app.Application;
 import org.onebusaway.android.app.di.AnalyticsEntryPoint;
-import org.onebusaway.android.analytics.ObaAnalytics;
 import org.onebusaway.android.analytics.PlausibleAnalytics;
 import org.onebusaway.android.nav.model.Path;
 import org.onebusaway.android.nav.model.PathLink;
@@ -99,11 +97,9 @@ public class NavigationServiceProvider implements TextToSpeech.OnInitListener {
     private String mTripId;             // Trip ID
     private String mStopId;             // Stop ID
 
-    private FirebaseAnalytics mFirebaseAnalytics;
 
     public NavigationServiceProvider(String tripId, String stopId) {
         Log.d(TAG, "Creating NavigationServiceProvider...");
-        mFirebaseAnalytics = FirebaseAnalytics.getInstance(Application.get().getApplicationContext());
         if (mTTS == null) {
             mTTS = new TextToSpeech(Application.get().getApplicationContext(), this);
         }
@@ -114,7 +110,6 @@ public class NavigationServiceProvider implements TextToSpeech.OnInitListener {
 
     public NavigationServiceProvider(String tripId, String stopId, int flag) {
         Log.d(TAG, "Creating NavigationServiceProvider...");
-        mFirebaseAnalytics = FirebaseAnalytics.getInstance(Application.get().getApplicationContext());
         mResuming = flag == 1;
         if (mTTS == null) {
             mTTS = new TextToSpeech(Application.get().getApplicationContext(), this);
@@ -504,7 +499,7 @@ public class NavigationServiceProvider implements TextToSpeech.OnInitListener {
                     if (proximityEvent(EVENT_TYPE_GET_READY, ALERT_STATE_NONE)) {
                         mNavProvider.updateUi(EVENT_TYPE_GET_READY);
                         Log.d(TAG, "-----Get ready!");
-                        ObaAnalytics.reportUiEvent(mFirebaseAnalytics, AnalyticsEntryPoint.get(Application.get()).getPlausible(), PlausibleAnalytics.REPORT_DESTINATION_REMINDER_EVENT_URL, Application.get().getString(R.string.analytics_label_destination_reminder), Application.get().getString(R.string.analytics_label_destination_reminder_variant_get_ready));
+                        AnalyticsEntryPoint.get(Application.get()).reportUiEvent(PlausibleAnalytics.REPORT_DESTINATION_REMINDER_EVENT_URL, Application.get().getString(R.string.analytics_label_destination_reminder), Application.get().getString(R.string.analytics_label_destination_reminder_variant_get_ready));
                         return EVENT_TYPE_GET_READY; //Get ready alert played
                     }
                 }
@@ -514,7 +509,7 @@ public class NavigationServiceProvider implements TextToSpeech.OnInitListener {
                     if (proximityEvent(EVENT_TYPE_PULL_CORD, ALERT_STATE_SHOWN_TO_RIDER)) {
                         mNavProvider.updateUi(EVENT_TYPE_PULL_CORD);
                         Log.d(TAG, "-----Get off the bus!");
-                        ObaAnalytics.reportUiEvent(mFirebaseAnalytics, AnalyticsEntryPoint.get(Application.get()).getPlausible(), PlausibleAnalytics.REPORT_DESTINATION_REMINDER_EVENT_URL, Application.get().getString(R.string.analytics_label_destination_reminder), Application.get().getString(R.string.analytics_label_destination_reminder_variant_exit_at_next_stop));
+                        AnalyticsEntryPoint.get(Application.get()).reportUiEvent(PlausibleAnalytics.REPORT_DESTINATION_REMINDER_EVENT_URL, Application.get().getString(R.string.analytics_label_destination_reminder), Application.get().getString(R.string.analytics_label_destination_reminder_variant_exit_at_next_stop));
                         return EVENT_TYPE_PULL_CORD; // Get off bus alert played
                     }
                 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/nav/NavigationUploadWorker.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/nav/NavigationUploadWorker.java
@@ -21,7 +21,6 @@ import android.util.Log;
 
 import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.OnSuccessListener;
-import com.google.firebase.analytics.FirebaseAnalytics;
 import com.google.firebase.storage.FirebaseStorage;
 import com.google.firebase.storage.StorageMetadata;
 import com.google.firebase.storage.StorageReference;
@@ -29,7 +28,7 @@ import com.google.firebase.storage.UploadTask;
 
 import org.onebusaway.android.R;
 import org.onebusaway.android.app.Application;
-import org.onebusaway.android.analytics.ObaAnalytics;
+import org.onebusaway.android.app.di.AnalyticsEntryPoint;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -47,11 +46,9 @@ public class NavigationUploadWorker extends Worker {
 
     public static final String TAG = "NavigationUploadWorker";
 
-    private FirebaseAnalytics mFirebaseAnalytics;
 
     public NavigationUploadWorker(@NonNull Context context, @NonNull WorkerParameters workerParams) {
         super(context, workerParams);
-        mFirebaseAnalytics = FirebaseAnalytics.getInstance(context);
     }
 
     @NonNull
@@ -128,7 +125,7 @@ public class NavigationUploadWorker extends Worker {
         } else {
             wasGoodReminder = false;
         }
-        ObaAnalytics.reportDestinationReminderFeedback(mFirebaseAnalytics, wasGoodReminder
+        AnalyticsEntryPoint.get(Application.get()).reportDestinationReminderFeedback(wasGoodReminder
                 , ((!isEmpty(feedbackText)) ? feedbackText : null), fileName);
         Log.d(TAG, "User feedback logged to Firebase Analytics :: wasGoodReminder - "
                 + wasGoodReminder + ", feedbackText - " + ((!isEmpty(feedbackText)) ? feedbackText : null) + ", filename - " + fileName);

--- a/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/CustomerServiceDestination.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/CustomerServiceDestination.kt
@@ -21,10 +21,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
-import com.google.firebase.analytics.FirebaseAnalytics
 import org.onebusaway.android.R
 import org.onebusaway.android.app.di.AnalyticsEntryPoint
-import org.onebusaway.android.analytics.ObaAnalytics
 import org.onebusaway.android.analytics.PlausibleAnalytics
 import org.onebusaway.android.report.ReportContext
 import org.onebusaway.android.ui.compose.findActivity
@@ -39,12 +37,9 @@ import org.onebusaway.android.util.ExternalIntents
 @Composable
 fun CustomerServiceDestination(navController: NavController, reportContext: ReportContext) {
     val activity = LocalContext.current.findActivity()
-    val firebaseAnalytics = remember { FirebaseAnalytics.getInstance(activity) }
 
     fun reportContactEvent(agencyName: String, labelRes: Int) {
-        ObaAnalytics.reportUiEvent(
-            firebaseAnalytics,
-            AnalyticsEntryPoint.get(activity).plausible,
+        AnalyticsEntryPoint.get(activity).reportUiEvent(
             PlausibleAnalytics.REPORT_MORE_EVENT_URL,
             agencyName + "_" + activity.getString(R.string.analytics_customer_service),
             activity.getString(labelRes)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/InfrastructureIssueScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/InfrastructureIssueScreen.kt
@@ -80,7 +80,6 @@ import android.content.Context
 import android.net.Uri
 import android.util.Log
 import android.widget.Toast
-import com.google.firebase.analytics.FirebaseAnalytics
 import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
@@ -88,7 +87,6 @@ import org.onebusaway.android.app.di.AnalyticsEntryPoint
 import org.onebusaway.android.app.di.ArrivalsViewModelFactoryEntryPoint
 import org.onebusaway.android.app.di.LocationEntryPoint
 import org.onebusaway.android.app.di.NetworkEntryPoint
-import org.onebusaway.android.analytics.ObaAnalytics
 import org.onebusaway.android.analytics.PlausibleAnalytics
 import org.onebusaway.android.report.ReportContext
 import org.onebusaway.android.report.TripReportContext
@@ -506,9 +504,7 @@ private fun createProblemReportViewModel(
 /** Port of ProblemReportFragment.reportAnalytics — the stop/trip problem Plausible event. */
 private fun reportProblemAnalytics(context: Context, kind: ProblemKind) {
     val isTrip = kind == ProblemKind.TRIP
-    ObaAnalytics.reportUiEvent(
-        FirebaseAnalytics.getInstance(context),
-        AnalyticsEntryPoint.get(context).plausible,
+    AnalyticsEntryPoint.get(context).reportUiEvent(
         if (isTrip) {
             PlausibleAnalytics.REPORT_VEHICLE_PROBLEM_EVENT_URL
         } else {
@@ -605,14 +601,11 @@ private fun Open311FormInline(
 
     // Publish the send action to the app bar while shown; clear it (and the spinner) on leave. Port of
     // onSend: submit + the Open311 server analytics event.
-    val firebaseAnalytics = remember { FirebaseAnalytics.getInstance(context) }
     DisposableEffect(vm) {
         onSubmit {
             vm.submit()
             (target.category.raw as? Service)?.let { service ->
-                ObaAnalytics.reportUiEvent(
-                    firebaseAnalytics,
-                    AnalyticsEntryPoint.get(context).plausible,
+                AnalyticsEntryPoint.get(context).reportUiEvent(
                     PlausibleAnalytics.REPORT_OPEN311_SERVER_EVENT_URL,
                     resources.getString(R.string.analytics_problem),
                     service.service_name,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/ReportLauncher.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/ReportLauncher.kt
@@ -33,13 +33,11 @@ import androidx.compose.ui.window.DialogProperties
 import androidx.appcompat.app.AppCompatActivity
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
-import com.google.firebase.analytics.FirebaseAnalytics
 import org.onebusaway.android.BuildConfig
 import org.onebusaway.android.R
 import org.onebusaway.android.app.di.AnalyticsEntryPoint
 import org.onebusaway.android.app.di.LocationEntryPoint
 import org.onebusaway.android.app.di.RegionEntryPoint
-import org.onebusaway.android.analytics.ObaAnalytics
 import org.onebusaway.android.analytics.PlausibleAnalytics
 import org.onebusaway.android.region.Region
 import org.onebusaway.android.report.ReportContext
@@ -116,7 +114,6 @@ object ReportLauncher {
 @Composable
 fun ReportDestination(navController: NavController, reportContext: ReportContext) {
     val activity = LocalContext.current.findActivity()
-    val firebaseAnalytics = remember { FirebaseAnalytics.getInstance(activity) }
 
     // Whether the region needs validating: false → show the type list straight away. Computed once.
     val needsValidation = remember { showValidateRegionDialog(activity) }
@@ -160,7 +157,7 @@ fun ReportDestination(navController: NavController, reportContext: ReportContext
             viewModel = hiltViewModel(),
             onBack = { navController.popBackStack() },
             onActionSelected = { action ->
-                onReportActionSelected(activity, firebaseAnalytics, navController, action, reportContext)
+                onReportActionSelected(activity, navController, action, reportContext)
             }
         )
     }
@@ -168,7 +165,6 @@ fun ReportDestination(navController: NavController, reportContext: ReportContext
 
 private fun onReportActionSelected(
     activity: AppCompatActivity,
-    firebaseAnalytics: FirebaseAnalytics,
     navController: NavController,
     action: ReportAction,
     reportContext: ReportContext
@@ -180,7 +176,7 @@ private fun onReportActionSelected(
         ReportAction.CUSTOMER_SERVICE -> {
             navController.navigate(NavRoutes.customerService(encodedContext))
             reportEvent(
-                activity, firebaseAnalytics,
+                activity,
                 PlausibleAnalytics.REPORT_MORE_EVENT_URL, R.string.analytics_label_customer_service
             )
         }
@@ -192,7 +188,7 @@ private fun onReportActionSelected(
                 )
             )
             reportEvent(
-                activity, firebaseAnalytics,
+                activity,
                 PlausibleAnalytics.REPORT_STOP_PROBLEM_EVENT_URL, R.string.analytics_label_stop_problem
             )
         }
@@ -204,28 +200,27 @@ private fun onReportActionSelected(
                 )
             )
             reportEvent(
-                activity, firebaseAnalytics,
+                activity,
                 PlausibleAnalytics.REPORT_VEHICLE_PROBLEM_EVENT_URL, R.string.analytics_label_trip_problem
             )
         }
 
-        ReportAction.APP_FEEDBACK -> sendAppFeedback(activity, firebaseAnalytics, reportContext.locationString)
+        ReportAction.APP_FEEDBACK -> sendAppFeedback(activity, reportContext.locationString)
     }
 }
 
 private fun sendAppFeedback(
     activity: AppCompatActivity,
-    firebaseAnalytics: FirebaseAnalytics,
     locationString: String?
 ) {
     ExternalIntents.sendEmail(activity, activity.getString(R.string.ri_app_feedback_email), locationString)
     reportEvent(
-        activity, firebaseAnalytics,
+        activity,
         PlausibleAnalytics.REPORT_MORE_EVENT_URL, R.string.analytics_label_app_feedback
     )
     if (locationString == null) {
         reportEvent(
-            activity, firebaseAnalytics,
+            activity,
             PlausibleAnalytics.REPORT_VEHICLE_PROBLEM_EVENT_URL,
             R.string.analytics_label_app_feedback_without_location
         )
@@ -234,13 +229,10 @@ private fun sendAppFeedback(
 
 private fun reportEvent(
     activity: AppCompatActivity,
-    firebaseAnalytics: FirebaseAnalytics,
     eventUrl: String,
     labelRes: Int
 ) {
-    ObaAnalytics.reportUiEvent(
-        firebaseAnalytics,
-        AnalyticsEntryPoint.get(activity).plausible,
+    AnalyticsEntryPoint.get(activity).reportUiEvent(
         eventUrl,
         activity.getString(R.string.analytics_problem),
         activity.getString(labelRes)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsRepository.kt
@@ -21,7 +21,6 @@ import org.onebusaway.android.api.data.RouteDataSource
 
 import android.content.Context
 import android.os.SystemClock
-import com.google.firebase.analytics.FirebaseAnalytics
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.io.IOException
 import javax.inject.Inject
@@ -35,7 +34,6 @@ import org.onebusaway.android.analytics.ObaAnalytics
 import org.onebusaway.android.analytics.PlausibleAnalytics
 import org.onebusaway.android.api.ObaApi
 import org.onebusaway.android.api.ObaApiException
-import org.onebusaway.android.analytics.AnalyticsProvider
 import org.onebusaway.android.database.oba.ImportGate
 import org.onebusaway.android.database.oba.RouteDao
 import org.onebusaway.android.database.oba.RouteHeadsignFavoriteDao
@@ -242,7 +240,7 @@ class DefaultArrivalsRepository @Inject constructor(
     private val routeHeadsignFavoriteDao: RouteHeadsignFavoriteDao,
     private val importGate: ImportGate,
     private val preferences: PreferencesRepository,
-    private val analyticsProvider: AnalyticsProvider,
+    private val obaAnalytics: ObaAnalytics,
 ) : ArrivalsRepository {
 
     /** The last good snapshot paired with the monotonic device time it was received, so the
@@ -454,9 +452,7 @@ class DefaultArrivalsRepository @Inject constructor(
             if (favorite) R.string.analytics_label_star_route else R.string.analytics_label_unstar_route
         )
         val param = "${routeId}_$headsign for ${stopId ?: "all stops"}"
-        ObaAnalytics.reportUiEvent(
-            FirebaseAnalytics.getInstance(context),
-            analyticsProvider.plausible,
+        obaAnalytics.reportUiEvent(
             PlausibleAnalytics.REPORT_BOOKMARK_EVENT_URL,
             event,
             param,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/feedback/Feedback.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/feedback/Feedback.kt
@@ -51,13 +51,12 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.work.PeriodicWorkRequest
 import androidx.work.WorkManager
-import com.google.firebase.analytics.FirebaseAnalytics
 import java.io.File
 import java.io.IOException
 import java.util.concurrent.TimeUnit
 import org.apache.commons.io.FileUtils
 import org.onebusaway.android.R
-import org.onebusaway.android.analytics.ObaAnalytics
+import org.onebusaway.android.app.di.AnalyticsEntryPoint
 import org.onebusaway.android.nav.NavigationService
 import org.onebusaway.android.nav.NavigationUploadWorker
 import org.onebusaway.android.preferences.PreferencesRepository
@@ -178,8 +177,8 @@ class FeedbackSubmitter(
     }
 
     private fun logFeedback(liked: Boolean, feedbackText: String) {
-        ObaAnalytics.reportDestinationReminderFeedback(
-            FirebaseAnalytics.getInstance(context), liked, feedbackText.ifEmpty { null }, null
+        AnalyticsEntryPoint.get(context).reportDestinationReminderFeedback(
+            liked, feedbackText.ifEmpty { null }, null
         )
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeNavHost.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeNavHost.kt
@@ -43,7 +43,6 @@ import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
-import com.google.firebase.analytics.FirebaseAnalytics
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharedFlow
@@ -284,10 +283,7 @@ internal fun AccessibilityAnalyticsEffect() {
     val context = LocalContext.current
     LifecycleEventEffect(Lifecycle.Event.ON_START) {
         val am = context.getSystemService(Context.ACCESSIBILITY_SERVICE) as AccessibilityManager
-        ObaAnalytics.setAccessibility(
-            FirebaseAnalytics.getInstance(context),
-            am.isTouchExplorationEnabled,
-        )
+        AnalyticsEntryPoint.get(context).setAccessibility(am.isTouchExplorationEnabled)
     }
 }
 
@@ -302,14 +298,13 @@ internal fun HomeAnalyticsEffect(analyticsEvents: SharedFlow<HomeAnalyticsEvent>
     val resources = LocalResources.current
     LaunchedEffect(analyticsEvents) {
         analyticsEvents.collect { event ->
-            val firebase = FirebaseAnalytics.getInstance(context)
-            val plausible = AnalyticsEntryPoint.get(context).plausible
+            val analytics = AnalyticsEntryPoint.get(context)
             when (event) {
                 is HomeAnalyticsEvent.RegionSelected ->
-                    ObaAnalytics.setRegion(firebase, event.regionName)
+                    analytics.setRegion(event.regionName)
                 is HomeAnalyticsEvent.MenuItem ->
-                    ObaAnalytics.reportUiEvent(
-                        firebase, plausible, PlausibleAnalytics.REPORT_MENU_EVENT_URL,
+                    analytics.reportUiEvent(
+                        PlausibleAnalytics.REPORT_MENU_EVENT_URL,
                         resources.getString(event.labelRes), null,
                     )
             }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
@@ -57,11 +57,9 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.google.firebase.analytics.FirebaseAnalytics
 import org.onebusaway.android.R
 import org.onebusaway.android.app.Application
 import org.onebusaway.android.app.di.AnalyticsEntryPoint
-import org.onebusaway.android.analytics.ObaAnalytics
 import org.onebusaway.android.analytics.PlausibleAnalytics
 import org.onebusaway.android.models.ObaStop
 import org.onebusaway.android.models.ObaTripStatus
@@ -103,7 +101,6 @@ fun MapFeature(
 ) {
     val context = LocalContext.current
     val resources = LocalResources.current
-    val firebaseAnalytics = remember { FirebaseAnalytics.getInstance(context) }
 
     // Compose-native permission launcher: deliver the result to the map view model (blue dot) + the
     // home view model (the deferred first-launch region check).
@@ -116,7 +113,7 @@ fun MapFeature(
         homeViewModel.onLocationPermissionResult()
     }
 
-    val callbacks = remember(mapViewModel, homeViewModel, firebaseAnalytics) {
+    val callbacks = remember(mapViewModel, homeViewModel) {
         object : ObaMapCallbacks {
             override fun onStopClick(stop: ObaStop) {
                 mapViewModel.onStopTapped(stop)
@@ -128,9 +125,7 @@ fun MapFeature(
                 homeViewModel.onStopFocused(
                     FocusedStop(stop.id, stop.name, stop.stopCode, stop.latitude, stop.longitude)
                 )
-                ObaAnalytics.reportUiEvent(
-                    firebaseAnalytics,
-                    AnalyticsEntryPoint.get(context).plausible,
+                AnalyticsEntryPoint.get(context).reportUiEvent(
                     PlausibleAnalytics.REPORT_MAP_EVENT_URL,
                     resources.getString(R.string.analytics_label_button_press_map_icon),
                     null,
@@ -148,9 +143,7 @@ fun MapFeature(
                 if (bikeId == null || !bikeId.equals(station.id, ignoreCase = true)) {
                     homeViewModel.onBikeStationFocused(station.id)
                 }
-                ObaAnalytics.reportUiEvent(
-                    firebaseAnalytics,
-                    AnalyticsEntryPoint.get(context).plausible,
+                AnalyticsEntryPoint.get(context).reportUiEvent(
                     PlausibleAnalytics.REPORT_BIKE_EVENT_URL,
                     resources.getString(
                         if (station.isFloatingBike) {
@@ -327,9 +320,7 @@ fun MapFeature(
             )
             PreferenceUtils.setUserDeniedLocationPermissions(false)
             mapViewModel.requestMyLocation(useDefaultZoom = true, animate = true)
-            ObaAnalytics.reportUiEvent(
-                firebaseAnalytics,
-                AnalyticsEntryPoint.get(context).plausible,
+            AnalyticsEntryPoint.get(context).reportUiEvent(
                 PlausibleAnalytics.REPORT_MAP_EVENT_URL,
                 resources.getString(R.string.analytics_label_button_press_location),
                 null,
@@ -342,9 +333,7 @@ fun MapFeature(
             // Persist the toggled state (DataStore) + drive the bike loader. MapChromeViewModel observes
             // the visibility pref reactively, so the bikeshare-active tint updates without a host push.
             mapViewModel.setBikeshareLayerVisible(!active, persist = true)
-            ObaAnalytics.reportUiEvent(
-                firebaseAnalytics,
-                AnalyticsEntryPoint.get(context).plausible,
+            AnalyticsEntryPoint.get(context).reportUiEvent(
                 PlausibleAnalytics.REPORT_MAP_EVENT_URL,
                 resources.getString(R.string.analytics_layer_bikeshare),
                 resources.getString(

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/nav/ExtraDestinations.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/nav/ExtraDestinations.kt
@@ -26,10 +26,8 @@ import androidx.navigation.NavHostController
 import androidx.navigation.NavType
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
-import com.google.firebase.analytics.FirebaseAnalytics
 import org.onebusaway.android.app.Application
 import org.onebusaway.android.app.di.AnalyticsEntryPoint
-import org.onebusaway.android.analytics.ObaAnalytics
 import org.onebusaway.android.ui.compose.findActivity
 import org.onebusaway.android.ui.nav.revealRouteOnMap
 import org.onebusaway.android.ui.nav.revealStopOnMap
@@ -109,13 +107,10 @@ fun NavGraphBuilder.extraDestinations(navController: NavHostController) {
         val activity = LocalContext.current.findActivity()
         // The Firebase analytics process-singleton, fetched from the Context like everywhere else
         // (MapFeature/TripPlanScreen) rather than reaching into the host for it.
-        val firebaseAnalytics = remember { FirebaseAnalytics.getInstance(activity) }
         val query = backStackEntry.arguments?.getString(NavRoutes.ARG_QUERY).orEmpty()
         val searchVm: SearchResultsViewModel = hiltViewModel()
         LaunchedEffect(query) {
-            ObaAnalytics.reportSearchEvent(
-                AnalyticsEntryPoint.get(activity).plausible, firebaseAnalytics, query
-            )
+            AnalyticsEntryPoint.get(activity).reportSearchEvent(query)
             searchVm.search(query)
         }
         ObaTheme {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/regions/RegionsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/regions/RegionsRepository.kt
@@ -16,14 +16,12 @@
 package org.onebusaway.android.ui.regions
 
 import android.content.Context
-import com.google.firebase.analytics.FirebaseAnalytics
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.io.IOException
 import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.onebusaway.android.R
-import org.onebusaway.android.analytics.AnalyticsProvider
 import org.onebusaway.android.analytics.ObaAnalytics
 import org.onebusaway.android.analytics.PlausibleAnalytics
 import org.onebusaway.android.region.Region
@@ -78,7 +76,7 @@ class DefaultRegionsRepository @Inject constructor(
     private val regionRepository: RegionRepository,
     private val regionCache: RegionCache,
     private val locationRepository: LocationRepository,
-    private val analyticsProvider: AnalyticsProvider,
+    private val obaAnalytics: ObaAnalytics,
 ) : RegionsRepository {
 
     // Domain objects from the last successful load, so selectRegion(id) can resolve the Region
@@ -127,9 +125,7 @@ class DefaultRegionsRepository @Inject constructor(
             prefs.setBoolean(R.string.preference_key_auto_select_region, false)
         }
 
-        ObaAnalytics.reportUiEvent(
-            FirebaseAnalytics.getInstance(context),
-            analyticsProvider.plausible,
+        obaAnalytics.reportUiEvent(
             PlausibleAnalytics.REPORT_REGION_EVENT_URL,
             context.getString(R.string.region_selected_manually),
             region.name

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/settings/SettingsAnalytics.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/settings/SettingsAnalytics.kt
@@ -17,16 +17,12 @@ package org.onebusaway.android.ui.settings
 
 import android.content.Context
 import androidx.annotation.StringRes
-import com.google.firebase.analytics.FirebaseAnalytics
 import org.onebusaway.android.app.di.AnalyticsEntryPoint
-import org.onebusaway.android.analytics.ObaAnalytics
 import org.onebusaway.android.analytics.PlausibleAnalytics
 
 /** Reports a settings UI event (label [labelRes]) to the preferences analytics page. */
 internal fun reportPreferencesEvent(context: Context, @StringRes labelRes: Int) {
-    ObaAnalytics.reportUiEvent(
-        FirebaseAnalytics.getInstance(context),
-        AnalyticsEntryPoint.get(context).plausible,
+    AnalyticsEntryPoint.get(context).reportUiEvent(
         PlausibleAnalytics.REPORT_PREFERENCES_EVENT_URL,
         context.getString(labelRes),
         null,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/settings/SettingsViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/settings/SettingsViewModel.kt
@@ -19,7 +19,6 @@ import android.content.Context
 import android.os.Build
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.google.firebase.analytics.FirebaseAnalytics
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
@@ -65,6 +64,7 @@ class SettingsViewModel @Inject constructor(
     private val regionRepository: RegionRepository,
     private val serviceAlertDao: ServiceAlertDao,
     private val importGate: ImportGate,
+    private val obaAnalytics: ObaAnalytics,
 ) : ViewModel() {
 
     private val env = SettingsEnvironment(
@@ -72,8 +72,6 @@ class SettingsViewModel @Inject constructor(
         sdkInt = Build.VERSION.SDK_INT,
         isObaFlavor = BuildFlavorUtils.isOBABuildFlavor(),
     )
-
-    private val firebaseAnalytics: FirebaseAnalytics by lazy { FirebaseAnalytics.getInstance(context) }
 
     val state: StateFlow<SettingsUiState> =
         combine(prefs.observeChanges(), regionRepository.region) { _, region -> compute(region) }
@@ -138,7 +136,7 @@ class SettingsViewModel @Inject constructor(
 
     fun onShowNegativeArrivalsChanged(value: Boolean) {
         prefs.setBoolean(R.string.preference_key_show_negative_arrivals, value)
-        ObaAnalytics.setShowDepartedVehicles(firebaseAnalytics, value)
+        obaAnalytics.setShowDepartedVehicles(value)
     }
 
     fun onHideAlertsChanged(value: Boolean) {
@@ -168,7 +166,7 @@ class SettingsViewModel @Inject constructor(
 
     fun onLeftHandModeChanged(value: Boolean) {
         prefs.setBoolean(R.string.preference_key_left_hand_mode, value)
-        ObaAnalytics.setLeftHanded(firebaseAnalytics, value)
+        obaAnalytics.setLeftHanded(value)
     }
 
     fun onShowHeaderArrivalsChanged(value: Boolean) =
@@ -182,7 +180,7 @@ class SettingsViewModel @Inject constructor(
 
     fun onAnalyticsChanged(value: Boolean) {
         prefs.setBoolean(R.string.preferences_key_analytics, value)
-        ObaAnalytics.setSendAnonymousData(firebaseAnalytics, value)
+        obaAnalytics.setSendAnonymousData(value)
     }
 
     fun onShareDestinationLogsChanged(value: Boolean) =

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripdetails/DestinationReminder.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripdetails/DestinationReminder.kt
@@ -49,10 +49,8 @@ import com.google.android.gms.location.LocationServices
 import com.google.android.gms.location.LocationSettingsRequest
 import com.google.android.gms.location.LocationSettingsStatusCodes
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
-import com.google.firebase.analytics.FirebaseAnalytics
 import org.onebusaway.android.R
 import org.onebusaway.android.app.di.AnalyticsEntryPoint
-import org.onebusaway.android.analytics.ObaAnalytics
 import org.onebusaway.android.analytics.PlausibleAnalytics
 import org.onebusaway.android.nav.NavigationService
 import org.onebusaway.android.preferences.PreferencesRepository
@@ -168,8 +166,7 @@ internal fun rememberDestinationReminderAction(
         if (!prefsRepository.getBoolean(R.string.preference_key_never_show_destination_reminder_beta_dialog, false)) {
             destinationReminderBetaDialog()
         }
-        ObaAnalytics.reportUiEvent(
-            FirebaseAnalytics.getInstance(context), AnalyticsEntryPoint.get(context).plausible,
+        AnalyticsEntryPoint.get(context).reportUiEvent(
             PlausibleAnalytics.REPORT_DESTINATION_REMINDER_EVENT_URL,
             resources.getString(R.string.analytics_label_destination_reminder),
             resources.getString(R.string.analytics_label_destination_reminder_variant_started)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanScreen.kt
@@ -70,7 +70,6 @@ import com.google.android.material.datepicker.MaterialDatePicker
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.timepicker.MaterialTimePicker
 import com.google.android.material.timepicker.TimeFormat
-import com.google.firebase.analytics.FirebaseAnalytics
 import java.util.Calendar
 import java.util.TimeZone
 import kotlinx.coroutines.launch
@@ -83,7 +82,6 @@ import org.onebusaway.android.directions.util.ConversionUtils
 import org.onebusaway.android.directions.util.CustomAddress
 import org.onebusaway.android.directions.util.OTPConstants
 import org.onebusaway.android.directions.util.TripRequestBuilder
-import org.onebusaway.android.analytics.ObaAnalytics
 import org.onebusaway.android.analytics.PlausibleAnalytics
 import org.onebusaway.android.region.RegionRepository
 import org.onebusaway.android.ui.compose.components.ObaTopAppBar
@@ -110,7 +108,6 @@ fun TripPlanDestination(navController: NavHostController, onBack: () -> Unit) {
     val activity = LocalContext.current.findActivity()
 
     // Built once for the lifetime of this destination (analytics + region email for "report problem").
-    val firebaseAnalytics = remember { FirebaseAnalytics.getInstance(activity) }
     // HomeActivity doesn't inject RegionRepository; reach the shared singleton via the EntryPoint.
     val regionRepository = remember { RegionEntryPoint.get(activity) }
 
@@ -177,9 +174,9 @@ fun TripPlanDestination(navController: NavHostController, onBack: () -> Unit) {
     LaunchedEffect(viewModel) {
         viewModel.planState.collect { state ->
             when (state) {
-                is PlanResult.Loading -> reportPlanAnalytics(activity, firebaseAnalytics)
+                is PlanResult.Loading -> reportPlanAnalytics(activity)
                 is PlanResult.Error -> {
-                    showFeedbackDialog(activity, firebaseAnalytics, regionRepository, state.message)
+                    showFeedbackDialog(activity, regionRepository, state.message)
                     viewModel.clearPlanResult()
                 }
                 else -> {}
@@ -209,7 +206,7 @@ fun TripPlanDestination(navController: NavHostController, onBack: () -> Unit) {
         onFromPickOnMap = { launchMapPicker("from", viewModel.formState.value.from) },
         onToPickOnMap = { launchMapPicker("to", viewModel.formState.value.to) },
         onAdvancedSettings = { showAdvanced = true },
-        onReportProblem = { reportProblem(activity, firebaseAnalytics, regionRepository) }
+        onReportProblem = { reportProblem(activity, regionRepository) }
     )
 
     if (showAdvanced) {
@@ -541,7 +538,6 @@ private fun AdvancedSettingsDialog(
 
 private fun showFeedbackDialog(
     activity: AppCompatActivity,
-    firebaseAnalytics: FirebaseAnalytics,
     regionRepository: RegionRepository,
     message: String
 ) {
@@ -550,14 +546,13 @@ private fun showFeedbackDialog(
         .setMessage(message)
         .setPositiveButton(android.R.string.ok, null)
         .setNegativeButton(R.string.report_problem_report) { _, _ ->
-            reportProblem(activity, firebaseAnalytics, regionRepository)
+            reportProblem(activity, regionRepository)
         }
         .show()
 }
 
 private fun reportProblem(
     activity: AppCompatActivity,
-    firebaseAnalytics: FirebaseAnalytics,
     regionRepository: RegionRepository
 ) {
     val email = regionRepository.region.value?.otpContactEmail
@@ -569,19 +564,16 @@ private fun reportProblem(
     val location = LocationEntryPoint.get(activity.applicationContext).lastKnownLocation()
     val locationString = location?.let { LocationUtils.printLocationDetails(it) }
     ExternalIntents.sendEmail(activity, email, locationString, null, true)
-    ObaAnalytics.reportUiEvent(
-        firebaseAnalytics, AnalyticsEntryPoint.get(activity).plausible,
+    AnalyticsEntryPoint.get(activity).reportUiEvent(
         PlausibleAnalytics.REPORT_TRIP_PLANNER_EVENT_URL,
         activity.getString(R.string.analytics_label_app_feedback_otp), null
     )
 }
 
 private fun reportPlanAnalytics(
-    activity: AppCompatActivity,
-    firebaseAnalytics: FirebaseAnalytics
+    activity: AppCompatActivity
 ) {
-    ObaAnalytics.reportUiEvent(
-        firebaseAnalytics, AnalyticsEntryPoint.get(activity).plausible,
+    AnalyticsEntryPoint.get(activity).reportUiEvent(
         PlausibleAnalytics.REPORT_TRIP_PLANNER_EVENT_URL,
         activity.getString(R.string.analytics_label_trip_plan), null
     )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/ExternalIntents.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/ExternalIntents.kt
@@ -29,13 +29,11 @@ import android.text.TextUtils
 import android.widget.Toast
 
 import com.google.android.gms.common.GoogleApiAvailability
-import com.google.firebase.analytics.FirebaseAnalytics
 
 import org.onebusaway.android.R
 import org.onebusaway.android.app.Application
 import org.onebusaway.android.app.di.AnalyticsEntryPoint
 import org.onebusaway.android.app.di.RegionEntryPoint
-import org.onebusaway.android.analytics.ObaAnalytics
 import org.onebusaway.android.analytics.PlausibleAnalytics
 import org.onebusaway.android.region.Region
 
@@ -288,9 +286,7 @@ object ExternalIntents {
             // Launch installed app
             intent.addCategory(Intent.CATEGORY_LAUNCHER)
             activity.startActivity(intent)
-            ObaAnalytics.reportUiEvent(
-                FirebaseAnalytics.getInstance(activity),
-                AnalyticsEntryPoint.get(activity).plausible,
+            AnalyticsEntryPoint.get(activity).reportUiEvent(
                 PlausibleAnalytics.REPORT_FARE_PAYMENT_EVENT_URL,
                 Application.get().getString(R.string.analytics_label_button_fare_payment),
                 Application.get().getString(R.string.analytics_label_open_app)
@@ -300,9 +296,7 @@ object ExternalIntents {
             intent = Intent(Intent.ACTION_VIEW)
             intent.setData(Uri.parse(Application.get().getString(R.string.google_play_listing_prefix, paymentAndroidAppId)))
             activity.startActivity(intent)
-            ObaAnalytics.reportUiEvent(
-                FirebaseAnalytics.getInstance(activity),
-                AnalyticsEntryPoint.get(activity).plausible,
+            AnalyticsEntryPoint.get(activity).reportUiEvent(
                 PlausibleAnalytics.REPORT_FARE_PAYMENT_EVENT_URL,
                 Application.get().getString(R.string.analytics_label_button_fare_payment),
                 Application.get().getString(R.string.analytics_label_download_app)
@@ -323,9 +317,7 @@ object ExternalIntents {
             // Launch installed app
             intent.addCategory(Intent.CATEGORY_LAUNCHER)
             context.startActivity(intent)
-            ObaAnalytics.reportUiEvent(
-                FirebaseAnalytics.getInstance(context),
-                AnalyticsEntryPoint.get(context).plausible,
+            AnalyticsEntryPoint.get(context).reportUiEvent(
                 PlausibleAnalytics.REPORT_FARE_PAYMENT_EVENT_URL,
                 Application.get().getString(R.string.analytics_label_button_bike_share),
                 Application.get().getString(R.string.analytics_label_open_app)
@@ -335,9 +327,7 @@ object ExternalIntents {
             intent = Intent(Intent.ACTION_VIEW)
             intent.setData(Uri.parse(Application.get().getString(R.string.google_play_listing_prefix, context.getString(R.string.hopr_android_app_id))))
             context.startActivity(intent)
-            ObaAnalytics.reportUiEvent(
-                FirebaseAnalytics.getInstance(context),
-                AnalyticsEntryPoint.get(context).plausible,
+            AnalyticsEntryPoint.get(context).reportUiEvent(
                 PlausibleAnalytics.REPORT_FARE_PAYMENT_EVENT_URL,
                 Application.get().getString(R.string.analytics_label_button_bike_share),
                 Application.get().getString(R.string.analytics_label_download_app)

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/DonationViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/DonationViewModelTest.kt
@@ -42,7 +42,7 @@ class DonationViewModelTest {
 
     // These tests cover only the dialog/effect logic, which never calls the DonationsManager, so a
     // bare instance (its Android collaborators are never touched) is enough to satisfy the constructor.
-    private fun donationViewModel() = DonationViewModel(DonationsManager(null, null, null, 0))
+    private fun donationViewModel() = DonationViewModel(DonationsManager(null, null, 0))
 
     @Test
     fun `close requests the dismiss confirmation, cancel clears it`() = runTest {


### PR DESCRIPTION
Part of #1631 — the core piece: retire `ObaAnalytics` as a static service-locator. It's now an injected `@Singleton` orchestrator that holds the Firebase emitter, the region-derived `AnalyticsProvider` (Plausible/Umami), and the analytics-enabled preference — so the ~38 call sites drop the threaded `FirebaseAnalytics` + `Plausible` arguments and just call `obaAnalytics.reportXxx(...)`.

## What changed

- **`ObaAnalytics`**: `object` → `@Singleton class @Inject(@ApplicationContext, AnalyticsProvider, PreferencesRepository)`. It builds its own `FirebaseAnalytics` from the context; `isAnalyticsActive()` reads the injected `PreferencesRepository`. Every method loses its `FirebaseAnalytics`/`Plausible` parameters.
- **`AnalyticsEntryPoint`** now exposes `ObaAnalytics` (was `AnalyticsProvider`); `AnalyticsProvider` is injected only into `ObaAnalytics` now.
- **Injectable consumers** (`ArrivalsRepository`, `RegionsRepository`, `NavigationService`, `SettingsViewModel`) constructor/field-inject `ObaAnalytics`.
- **Composables / objects / free functions / Java** (`MapFeature`, `TripPlanScreen`, `HomeNavHost`, `report/*`, `ExternalIntents`, `MapNavigation`, `DonationsManager`, `BackupUtils`, `NavigationServiceProvider`, `FeedbackReceiver`, `NavigationUploadWorker`, `Application`) reach it via `AnalyticsEntryPoint.get(context)`.
- Removes the now-dead `FirebaseAnalytics` threading throughout (locals, params, the `Application`/`DonationsManager` field) — **net −125 lines**.

## Behavior

No user-facing change — best-effort telemetry with the same Firebase/Plausible/Umami fan-out; `isAnalyticsActive()` reads the same DataStore-backed pref (`PreferenceUtils` and the injected `PreferencesRepository` share one store). Builds clean on `obaGoogleDebug`; unit **and** androidTest sources compile; full JVM suite passes (`DonationViewModelTest` updated for the slimmed `DonationsManager` ctor).

## Scope note

This is #1631's headline (make the static orchestrator injectable). The remaining part of #1631 — the ~67 benign `Application.get().getString/getResources` context reaches (Compose→`stringResource`/`LocalContext` sweep) — is independent and can follow separately. The `AnalyticsEntryPoint.get(Application.get())` handles in the context-less Java statics (`NavigationServiceProvider`, `FeedbackReceiver`, `NavigationUploadWorker`) remain a benign context resolution, not app-global state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app analytics handling across settings, search, map, navigation, trip planning, feedback, and donations.
  * Kept event tracking consistent for actions like region selection, accessibility changes, report submissions, and external app launches.
  * Reduced duplicate setup so analytics-related interactions should behave more reliably throughout the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->