### PR TITLE
Benign-context sweep: route Application.get() context reaches to real Contexts (#1631)

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/nav/test/NavigationTest.java
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/nav/test/NavigationTest.java
@@ -947,7 +947,7 @@ public class NavigationTest extends ObaTestCase {
          * @param expectedPullCordIndex the index for when the "Pull the Cord Now" notification is expected
          */
         void runSimulation(int expectedGetReadyIndex, int expectedPullCordIndex) {
-            NavigationServiceProvider provider = new NavigationServiceProvider(mTripId,
+            NavigationServiceProvider provider = new NavigationServiceProvider(getTargetContext(), mTripId,
                     mDestinationId);
             Location prevLocation = null;
             // Use the first location time as the starting time for this PathLink

--- a/onebusaway-android/src/main/java/org/onebusaway/android/analytics/ObaAnalytics.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/analytics/ObaAnalytics.kt
@@ -15,26 +15,34 @@
  */
 package org.onebusaway.android.analytics
 
+import android.content.Context
 import android.location.Location
 import android.os.Bundle
 import com.google.firebase.analytics.FirebaseAnalytics
-import com.onebusaway.plausible.android.Plausible
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
 import org.onebusaway.android.R
-import org.onebusaway.android.app.Application
-import org.onebusaway.android.app.di.AnalyticsEntryPoint
-import org.onebusaway.android.util.PreferenceUtils
+import org.onebusaway.android.preferences.PreferencesRepository
 
 /**
  * Analytics orchestrator for the app: fans each tracked event out to Firebase, Plausible
- * ([PlausibleAnalytics]) and Umami ([UmamiAnalyticsReporter]). Exposed as `@JvmStatic` methods so the
- * many Java + Kotlin call sites keep calling `ObaAnalytics.xxx(...)` unchanged.
+ * ([PlausibleAnalytics]) and Umami ([UmamiAnalyticsReporter]). An injected app-singleton — it holds the
+ * Firebase emitter, the region-derived [AnalyticsProvider] (Plausible/Umami), and the analytics-enabled
+ * preference itself, so call sites just call `obaAnalytics.reportXxx(...)` instead of threading a
+ * `FirebaseAnalytics` + `Plausible` in. Injectable classes inject it directly; the context-less static /
+ * Java / composable call sites reach it via [org.onebusaway.android.app.di.AnalyticsEntryPoint].
  *
  * @author Cagri Cetin, Sean Barbeau
  */
-object ObaAnalytics {
+@Singleton
+class ObaAnalytics @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val analyticsProvider: AnalyticsProvider,
+    private val preferences: PreferencesRepository,
+) {
 
-    /** A device fix is only accurate enough to bucket stop distance when below this (meters). */
-    private const val LOCATION_ACCURACY_THRESHOLD = 50f
+    private val firebase: FirebaseAnalytics = FirebaseAnalytics.getInstance(context)
 
     /** Distance buckets reported when a stop is tapped. */
     enum class ObaStopDistance(private val label: String, val distanceInMeters: Int) {
@@ -63,22 +71,15 @@ object ObaAnalytics {
      * @param id ID of the UI element
      * @param state the state/variant of the UI item, or null if it has none
      */
-    @JvmStatic
-    fun reportUiEvent(
-        analytics: FirebaseAnalytics,
-        plausible: Plausible?,
-        pageUrl: String,
-        id: String,
-        state: String?,
-    ) {
+    fun reportUiEvent(pageUrl: String, id: String, state: String?) {
         if (!isAnalyticsActive()) return
         val bundle = Bundle().apply {
             putString(FirebaseAnalytics.Param.ITEM_ID, id)
             if (!state.isNullOrEmpty()) putString(FirebaseAnalytics.Param.ITEM_VARIANT, state)
         }
-        analytics.logEvent(FirebaseAnalytics.Event.SELECT_CONTENT, bundle)
-        PlausibleAnalytics.reportUiEvent(plausible, pageUrl, id, state)
-        UmamiAnalyticsReporter.reportUiEvent(umami(), pageUrl, id, state)
+        firebase.logEvent(FirebaseAnalytics.Event.SELECT_CONTENT, bundle)
+        PlausibleAnalytics.reportUiEvent(analyticsProvider.plausible, pageUrl, id, state)
+        UmamiAnalyticsReporter.reportUiEvent(analyticsProvider.umami, pageUrl, id, state)
     }
 
     /**
@@ -86,13 +87,12 @@ object ObaAnalytics {
      *
      * @param signUpMethod sign-up method of the login, or null if unknown
      */
-    @JvmStatic
-    fun reportLoginEvent(analytics: FirebaseAnalytics, signUpMethod: String?) {
+    fun reportLoginEvent(signUpMethod: String?) {
         if (!isAnalyticsActive()) return
         val bundle = signUpMethod?.takeIf { it.isNotEmpty() }?.let {
             Bundle().apply { putString(FirebaseAnalytics.Param.METHOD, it) }
         }
-        analytics.logEvent(FirebaseAnalytics.Event.LOGIN, bundle)
+        firebase.logEvent(FirebaseAnalytics.Event.LOGIN, bundle)
     }
 
     /**
@@ -100,16 +100,15 @@ object ObaAnalytics {
      *
      * @param searchTerm search term used, or null if unknown
      */
-    @JvmStatic
-    fun reportSearchEvent(plausible: Plausible?, analytics: FirebaseAnalytics, searchTerm: String?) {
+    fun reportSearchEvent(searchTerm: String?) {
         if (!isAnalyticsActive()) return
         val bundle = searchTerm?.takeIf { it.isNotEmpty() }?.let {
             Bundle().apply { putString(FirebaseAnalytics.Param.SEARCH_TERM, it) }
         }
-        analytics.logEvent(FirebaseAnalytics.Event.SEARCH, bundle)
+        firebase.logEvent(FirebaseAnalytics.Event.SEARCH, bundle)
         searchTerm?.let {
-            PlausibleAnalytics.reportSearchEvent(plausible, it)
-            UmamiAnalyticsReporter.reportSearchEvent(umami(), it)
+            PlausibleAnalytics.reportSearchEvent(analyticsProvider.plausible, it)
+            UmamiAnalyticsReporter.reportSearchEvent(analyticsProvider.umami, it)
         }
     }
 
@@ -117,10 +116,7 @@ object ObaAnalytics {
      * Reports the user viewing a stop, bucketing the distance between the device and the stop (only
      * when the device fix is accurate enough — under [LOCATION_ACCURACY_THRESHOLD]).
      */
-    @JvmStatic
     fun reportViewStopEvent(
-        plausible: Plausible?,
-        analytics: FirebaseAnalytics,
         stopId: String,
         stopName: String?,
         myLocation: Location?,
@@ -129,13 +125,11 @@ object ObaAnalytics {
         if (!isAnalyticsActive() || myLocation == null) return
         if (myLocation.accuracy < LOCATION_ACCURACY_THRESHOLD) {
             val stopDistance = ObaStopDistance.forDistance(myLocation.distanceTo(stopLocation))
-            reportViewStopEvent(plausible, analytics, stopId, stopName, stopDistance.toString())
+            reportViewStopEvent(stopId, stopName, stopDistance.toString())
         }
     }
 
     private fun reportViewStopEvent(
-        plausible: Plausible?,
-        analytics: FirebaseAnalytics,
         stopId: String,
         stopName: String?,
         proximityToStopCategory: String,
@@ -147,51 +141,46 @@ object ObaAnalytics {
             putString(FirebaseAnalytics.Param.ITEM_CATEGORY, string(R.string.analytics_label_stop_category))
             putString(FirebaseAnalytics.Param.LOCATION_ID, proximityToStopCategory)
         }
-        analytics.logEvent(FirebaseAnalytics.Event.VIEW_ITEM, bundle)
-        PlausibleAnalytics.reportViewStopEvent(plausible, stopId, proximityToStopCategory)
-        UmamiAnalyticsReporter.reportViewStopEvent(umami(), stopId, proximityToStopCategory)
+        firebase.logEvent(FirebaseAnalytics.Event.VIEW_ITEM, bundle)
+        PlausibleAnalytics.reportViewStopEvent(analyticsProvider.plausible, stopId, proximityToStopCategory)
+        UmamiAnalyticsReporter.reportViewStopEvent(analyticsProvider.umami, stopId, proximityToStopCategory)
     }
 
     /** Sets the current region as a Firebase user property and on the Umami emitter. */
-    @JvmStatic
-    fun setRegion(analytics: FirebaseAnalytics, regionName: String?) {
+    fun setRegion(regionName: String?) {
         if (!isAnalyticsActive()) return
-        analytics.setUserProperty(string(R.string.analytics_label_region_name), regionName)
-        umami()?.setRegionName(regionName)
+        firebase.setUserProperty(string(R.string.analytics_label_region_name), regionName)
+        analyticsProvider.umami?.setRegionName(regionName)
     }
 
     /** Records (and toggles Firebase collection for) the send-anonymous-usage-data preference. */
-    @JvmStatic
-    fun setSendAnonymousData(analytics: FirebaseAnalytics, isAnalyticsActive: Boolean) {
-        analytics.setUserProperty(
+    fun setSendAnonymousData(isAnalyticsActive: Boolean) {
+        firebase.setUserProperty(
             string(R.string.analytics_label_analytics_property),
             isAnalyticsActive.toYesNo(),
         )
-        analytics.setAnalyticsCollectionEnabled(isAnalyticsActive)
+        firebase.setAnalyticsCollectionEnabled(isAnalyticsActive)
     }
 
     /** Records the left-handed-mode preference as a Firebase user property. */
-    @JvmStatic
-    fun setLeftHanded(analytics: FirebaseAnalytics, isLeftHanded: Boolean) {
+    fun setLeftHanded(isLeftHanded: Boolean) {
         if (!isAnalyticsActive()) return
-        analytics.setUserProperty(string(R.string.analytics_label_left_hand_property), isLeftHanded.toYesNo())
+        firebase.setUserProperty(string(R.string.analytics_label_left_hand_property), isLeftHanded.toYesNo())
     }
 
     /** Records the hide-departed-vehicles preference as a Firebase user property. */
-    @JvmStatic
-    fun setShowDepartedVehicles(analytics: FirebaseAnalytics, showDepartedVehicles: Boolean) {
+    fun setShowDepartedVehicles(showDepartedVehicles: Boolean) {
         if (!isAnalyticsActive()) return
-        analytics.setUserProperty(
+        firebase.setUserProperty(
             string(R.string.analytics_label_show_departed_vehicles_property),
             showDepartedVehicles.toYesNo(),
         )
     }
 
     /** Records whether the device has touch exploration (accessibility) enabled. */
-    @JvmStatic
-    fun setAccessibility(analytics: FirebaseAnalytics, isAccessibilityActive: Boolean) {
+    fun setAccessibility(isAccessibilityActive: Boolean) {
         if (!isAnalyticsActive()) return
-        analytics.setUserProperty(string(R.string.analytics_accessibility), isAccessibilityActive.toYesNo())
+        firebase.setUserProperty(string(R.string.analytics_accessibility), isAccessibilityActive.toYesNo())
     }
 
     /**
@@ -201,9 +190,7 @@ object ObaAnalytics {
      * @param feedbackText free-text feedback, or null if none was entered
      * @param fileName name of the uploaded trip-data file, or null if nothing was uploaded
      */
-    @JvmStatic
     fun reportDestinationReminderFeedback(
-        analytics: FirebaseAnalytics,
         wasGoodReminder: Boolean,
         feedbackText: String?,
         fileName: String?,
@@ -222,19 +209,19 @@ object ObaAnalytics {
             if (!feedbackText.isNullOrEmpty()) putString(FirebaseAnalytics.Param.CONTENT, feedbackText)
             if (!fileName.isNullOrEmpty()) putString(FirebaseAnalytics.Param.LOCATION_ID, fileName)
         }
-        analytics.logEvent(FirebaseAnalytics.Event.SELECT_CONTENT, bundle)
+        firebase.logEvent(FirebaseAnalytics.Event.SELECT_CONTENT, bundle)
     }
 
     /** Whether the user has left analytics collection enabled in settings. */
     private fun isAnalyticsActive(): Boolean =
-        PreferenceUtils.getBoolean(string(R.string.preferences_key_analytics), true)
+        preferences.getBoolean(R.string.preferences_key_analytics, true)
 
-    private fun string(resId: Int): String = Application.get().getString(resId)
-
-    // The Umami emitter now lives on the injected AnalyticsProvider. ObaAnalytics is a context-less
-    // static orchestrator, so it resolves the provider through the EntryPoint using the Application only
-    // as a graph handle (a benign context reach) rather than reading app-global analytics *state* off it.
-    private fun umami(): UmamiAnalytics? = AnalyticsEntryPoint.get(Application.get()).umami
+    private fun string(resId: Int): String = context.getString(resId)
 
     private fun Boolean.toYesNo(): String = if (this) "YES" else "NO"
+
+    private companion object {
+        /** A device fix is only accurate enough to bucket stop distance when below this (meters). */
+        const val LOCATION_ACCURACY_THRESHOLD = 50f
+    }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/analytics/ObaAnalytics.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/analytics/ObaAnalytics.kt
@@ -40,9 +40,8 @@ class ObaAnalytics @Inject constructor(
     @ApplicationContext private val context: Context,
     private val analyticsProvider: AnalyticsProvider,
     private val preferences: PreferencesRepository,
+    private val firebase: FirebaseAnalytics,
 ) {
-
-    private val firebase: FirebaseAnalytics = FirebaseAnalytics.getInstance(context)
 
     /** Distance buckets reported when a stop is tapped. */
     enum class ObaStopDistance(private val label: String, val distanceInMeters: Int) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/app/Application.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/app/Application.java
@@ -26,13 +26,12 @@ import android.os.PowerManager;
 import android.text.TextUtils;
 import android.util.Log;
 
-import com.google.firebase.analytics.FirebaseAnalytics;
 import com.google.firebase.messaging.FirebaseMessaging;
 
 import org.onebusaway.android.BuildConfig;
 import org.onebusaway.android.R;
 import org.onebusaway.android.donations.DonationsManager;
-import org.onebusaway.android.analytics.ObaAnalytics;
+import org.onebusaway.android.app.di.AnalyticsEntryPoint;
 import org.onebusaway.android.api.ObaApi;
 import org.onebusaway.android.region.Region;
 import org.onebusaway.android.app.di.LocationEntryPoint;
@@ -77,7 +76,6 @@ public class Application extends android.app.Application {
     // itself lives in the reactive LocationRepository singleton.)
     static GeomagneticField mGeomagneticField = null;
 
-    private FirebaseAnalytics mFirebaseAnalytics;
 
     @Override
     public void onCreate() {
@@ -111,7 +109,7 @@ public class Application extends android.app.Application {
 
         initFirebaseMessaging();
 
-        mDonationsManager = new DonationsManager(getApplicationContext(), mFirebaseAnalytics, getResources(), getAppLaunchCount());
+        mDonationsManager = new DonationsManager(getApplicationContext(), getResources(), getAppLaunchCount());
 
         mGtfsAlerts = new GtfsAlerts(getApplicationContext());
     }
@@ -406,12 +404,11 @@ public class Application extends android.app.Application {
     }
 
     private void reportAnalytics() {
-        mFirebaseAnalytics = FirebaseAnalytics.getInstance(this);
         // The Plausible/Umami emitters are owned + built reactively by AnalyticsProvider; here we only set
         // the initial Firebase/Umami region label via setRegion (which resolves the Umami emitter through
         // the provider itself).
         if (getCustomApiUrl() == null && getCurrentRegion() != null) {
-            ObaAnalytics.setRegion(mFirebaseAnalytics, getCurrentRegion().getName());
+            AnalyticsEntryPoint.get(this).setRegion(getCurrentRegion().getName());
         } else if (getCustomApiUrl() != null) {
             String customUrl;
             try {
@@ -422,7 +419,7 @@ public class Application extends android.app.Application {
             } catch (Exception e) {
                 customUrl = getString(R.string.analytics_label_custom_url);
             }
-            ObaAnalytics.setRegion(mFirebaseAnalytics, customUrl);
+            AnalyticsEntryPoint.get(this).setRegion(customUrl);
         }
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/app/Application.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/app/Application.java
@@ -139,7 +139,8 @@ public class Application extends android.app.Application {
     }
 
 
-    public static final String APP_LAUNCH_COUNT_KEY = "APP_LAUNCH_COUNT_KEY";
+    // Preserve the original preference-key value so persisted launch counts survive upgrades.
+    public static final String APP_LAUNCH_COUNT_KEY = "appLaunchCountPreferencesKey";
 
     private void incrementAppLaunchCount() {
         int count = PreferenceUtils.getInt(APP_LAUNCH_COUNT_KEY, 0);

--- a/onebusaway-android/src/main/java/org/onebusaway/android/app/Application.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/app/Application.java
@@ -139,16 +139,16 @@ public class Application extends android.app.Application {
     }
 
 
-    private static String appLaunchCountPreferencesKey = "appLaunchCountPreferencesKey";
+    public static final String APP_LAUNCH_COUNT_KEY = "APP_LAUNCH_COUNT_KEY";
 
     private void incrementAppLaunchCount() {
-        int count = PreferenceUtils.getInt(appLaunchCountPreferencesKey, 0);
+        int count = PreferenceUtils.getInt(APP_LAUNCH_COUNT_KEY, 0);
         count += 1;
-        PreferenceUtils.saveInt(appLaunchCountPreferencesKey, count);
+        PreferenceUtils.saveInt(APP_LAUNCH_COUNT_KEY, count);
     }
 
     public int getAppLaunchCount() {
-        return PreferenceUtils.getInt(appLaunchCountPreferencesKey, 0);
+        return PreferenceUtils.getInt(APP_LAUNCH_COUNT_KEY, 0);
     }
 
     /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/app/di/AnalyticsEntryPoint.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/app/di/AnalyticsEntryPoint.kt
@@ -20,30 +20,29 @@ import dagger.hilt.EntryPoint
 import dagger.hilt.InstallIn
 import dagger.hilt.android.EntryPointAccessors
 import dagger.hilt.components.SingletonComponent
-import org.onebusaway.android.analytics.AnalyticsProvider
+import org.onebusaway.android.analytics.ObaAnalytics
 
 /**
- * A Hilt [EntryPoint] that lets code which can't be constructor- or field-injected — the static
- * `ObaAnalytics` orchestrator, static Java utilities, composable helpers without a ViewModel — reach
- * the [AnalyticsProvider] seam (and thus the current region's Plausible/Umami emitters) instead of
- * `Application.get().getPlausibleInstance()` / `getUmamiInstance()`. It needs a [Context] only to
- * resolve the singleton graph; the returned provider is the same app-singleton every injected consumer
- * shares.
+ * A Hilt [EntryPoint] that lets code which can't be constructor- or field-injected — static Java
+ * utilities, composable helpers without a ViewModel — reach the injected [ObaAnalytics] orchestrator.
+ * It needs a [Context] only to resolve the singleton graph; the returned orchestrator is the same
+ * app-singleton every injected consumer shares (and holds the Firebase + Plausible/Umami emitters, so
+ * callers no longer thread those in).
  *
  * Use it only where injection genuinely isn't available — Hilt-reachable classes (Activities,
- * Fragments, Services, ViewModels, Workers) should inject [AnalyticsProvider] directly.
+ * Fragments, Services, ViewModels, Workers) should inject [ObaAnalytics] directly.
  */
 @EntryPoint
 @InstallIn(SingletonComponent::class)
 interface AnalyticsEntryPoint {
 
-    fun analyticsProvider(): AnalyticsProvider
+    fun obaAnalytics(): ObaAnalytics
 
     companion object {
-        /** Resolves the [AnalyticsProvider] from any [context] (its application is used). */
+        /** Resolves the [ObaAnalytics] orchestrator from any [context] (its application is used). */
         @JvmStatic
-        fun get(context: Context): AnalyticsProvider =
+        fun get(context: Context): ObaAnalytics =
             EntryPointAccessors.fromApplication(context, AnalyticsEntryPoint::class.java)
-                .analyticsProvider()
+                .obaAnalytics()
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/app/di/AppModule.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/app/di/AppModule.kt
@@ -22,6 +22,7 @@ import androidx.datastore.preferences.SharedPreferencesMigration
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.preferencesDataStoreFile
+import com.google.firebase.analytics.FirebaseAnalytics
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -84,4 +85,10 @@ object AppModule {
     @Provides
     @Singleton
     fun provideTimeProvider(): TimeProvider = TimeProvider { System.currentTimeMillis() }
+
+    @Provides
+    @Singleton
+    fun provideFirebaseAnalytics(
+        @ApplicationContext context: Context,
+    ): FirebaseAnalytics = FirebaseAnalytics.getInstance(context)
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/backup/BackupUtils.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/backup/BackupUtils.java
@@ -25,11 +25,9 @@ import android.util.Log;
 import android.widget.Toast;
 
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
-import com.google.firebase.analytics.FirebaseAnalytics;
 
 import org.onebusaway.android.R;
 import org.onebusaway.android.app.di.AnalyticsEntryPoint;
-import org.onebusaway.android.analytics.ObaAnalytics;
 import org.onebusaway.android.analytics.PlausibleAnalytics;
 
 import java.io.IOException;
@@ -69,8 +67,7 @@ public class BackupUtils {
      */
     static private void doRestore(Context activityContext, Uri uri, Runnable onRestored) {
         final Context context = activityContext.getApplicationContext();
-        ObaAnalytics.reportUiEvent(FirebaseAnalytics.getInstance(activityContext),
-                AnalyticsEntryPoint.get(context).getPlausible(),
+        AnalyticsEntryPoint.get(context).reportUiEvent(
                 PlausibleAnalytics.REPORT_BACKUP_EVENT_URL,
                 context.getString(R.string.analytics_label_button_press_restore_preference),
                 null);
@@ -124,8 +121,7 @@ public class BackupUtils {
      */
     public static void save(Context activityContext,Uri uri) {
         Context context = activityContext.getApplicationContext();
-        ObaAnalytics.reportUiEvent(FirebaseAnalytics.getInstance(activityContext),
-                AnalyticsEntryPoint.get(context).getPlausible(),
+        AnalyticsEntryPoint.get(context).reportUiEvent(
                 PlausibleAnalytics.REPORT_BACKUP_EVENT_URL,
                 context.getString(R.string.analytics_label_button_press_save_preference),
                 null);

--- a/onebusaway-android/src/main/java/org/onebusaway/android/donations/DonationsManager.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/donations/DonationsManager.java
@@ -1,10 +1,7 @@
 package org.onebusaway.android.donations;
 
-import com.google.firebase.analytics.FirebaseAnalytics;
-
 import org.onebusaway.android.R;
 import org.onebusaway.android.app.di.AnalyticsEntryPoint;
-import org.onebusaway.android.analytics.ObaAnalytics;
 import org.onebusaway.android.analytics.PlausibleAnalytics;
 import org.onebusaway.android.util.BuildFlavorUtils;
 import org.onebusaway.android.util.PreferenceUtils;
@@ -29,25 +26,22 @@ public class DonationsManager {
 
     public DonationsManager(
             Context context,
-            FirebaseAnalytics firebaseAnalytics,
             Resources resources,
             int appLaunchCount) {
         this.mContext = context;
-        this.mAnalytics = firebaseAnalytics;
         this.mResources = resources;
         this.mAppLaunchCount = appLaunchCount;
     }
 
     // region Analytics
 
-    private FirebaseAnalytics mAnalytics;
     /**
      * Reports UI events using Firebase
      * @param resourceID ID of the UI element to report
      * @param state the state or variant of the UI item, or null if the item doesn't have a state or variant
      */
     private void reportUIEvent(Integer resourceID, String state) {
-        ObaAnalytics.reportUiEvent(mAnalytics, AnalyticsEntryPoint.get(mContext).getPlausible(), PlausibleAnalytics.REPORT_DONATE_EVENT_URL, mResources.getString(resourceID), state);
+        AnalyticsEntryPoint.get(mContext).reportUiEvent(PlausibleAnalytics.REPORT_DONATE_EVENT_URL, mResources.getString(resourceID), state);
     }
 
     // endregion

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapNavigation.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapNavigation.kt
@@ -16,11 +16,9 @@
 package org.onebusaway.android.map
 
 import android.content.Context
-import com.google.firebase.analytics.FirebaseAnalytics
 import org.onebusaway.android.R
 import org.onebusaway.android.app.Application
 import org.onebusaway.android.app.di.AnalyticsEntryPoint
-import org.onebusaway.android.analytics.ObaAnalytics
 import org.onebusaway.android.analytics.PlausibleAnalytics
 import org.onebusaway.android.models.ObaTripStatus
 import org.onebusaway.android.ui.tripdetails.TripDetailsLauncher
@@ -57,9 +55,7 @@ object MapNavigation {
         if (region.id != RegionUtils.TAMPA_REGION_ID.toLong()) {
             return
         }
-        ObaAnalytics.reportUiEvent(
-            FirebaseAnalytics.getInstance(context),
-            AnalyticsEntryPoint.get(context).plausible,
+        AnalyticsEntryPoint.get(context).reportUiEvent(
             PlausibleAnalytics.REPORT_BIKE_EVENT_URL,
             context.getString(
                 if (station.isFloatingBike) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapNavigation.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapNavigation.kt
@@ -17,7 +17,7 @@ package org.onebusaway.android.map
 
 import android.content.Context
 import org.onebusaway.android.R
-import org.onebusaway.android.app.Application
+import org.onebusaway.android.app.di.RegionEntryPoint
 import org.onebusaway.android.app.di.AnalyticsEntryPoint
 import org.onebusaway.android.analytics.PlausibleAnalytics
 import org.onebusaway.android.models.ObaTripStatus
@@ -50,8 +50,7 @@ object MapNavigation {
      */
     @JvmStatic
     fun openBikeDeepLink(context: Context, station: BikeRentalStation) {
-        val app = Application.get()
-        val region = app.currentRegion ?: return
+        val region = RegionEntryPoint.get(context).currentRegion() ?: return
         if (region.id != RegionUtils.TAMPA_REGION_ID.toLong()) {
             return
         }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/nav/FeedbackReceiver.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/nav/FeedbackReceiver.java
@@ -92,48 +92,48 @@ public class FeedbackReceiver extends BroadcastReceiver {
                     new NotificationCompat.Builder(context
                             , Application.CHANNEL_DESTINATION_ALERT_ID)
                             .setSmallIcon(R.drawable.ic_stat_notification)
-                            .setContentTitle(Application.get().getResources()
+                            .setContentTitle(context.getResources()
                                     .getString(R.string.feedback_notify_title))
-                            .setContentText(Application.get().getResources()
+                            .setContentText(context.getResources()
                                     .getString(R.string.feedback_notify_confirmation));
 
             Log.d(TAG, "Thank you!");
             repliedNotification.setOngoing(false);
 
             NotificationManager mNotificationManager = (NotificationManager)
-                    Application.get().getSystemService(Context.NOTIFICATION_SERVICE);
+                    context.getSystemService(Context.NOTIFICATION_SERVICE);
             mNotificationManager.notify(notifyId, repliedNotification.build());
 
             if (response == FEEDBACK_YES) {
-                userResponse = Application.get().getString(R.string.analytics_label_destination_reminder_yes);
+                userResponse = context.getString(R.string.analytics_label_destination_reminder_yes);
             } else {
-                userResponse = Application.get().getString(R.string.analytics_label_destination_reminder_no);
+                userResponse = context.getString(R.string.analytics_label_destination_reminder_no);
             }
 
             Log.d(TAG, "cancelling notification");
             mNotificationManager.cancel(notifyId);
 
-            Boolean pref = PreferenceUtils.getBoolean(Application.get().getResources()
+            Boolean pref = PreferenceUtils.getBoolean(context.getResources()
                     .getString(R.string.preferences_key_user_share_destination_logs), true);
 
             if (pref) {
                 Log.d(TAG, "True");
-                moveLog(feedback, userResponse, logFile);
+                moveLog(context, feedback, userResponse, logFile);
             } else {
                 Log.d(TAG, "False");
                 deleteLog(logFile);
-                logFeedback(feedback, userResponse);
+                logFeedback(context, feedback, userResponse);
             }
         }
     }
 
-    private void moveLog(String feedback, String userResponse, String logFile) {
+    private void moveLog(Context context, String feedback, String userResponse, String logFile) {
         try {
             File lFile = new File(logFile);
             FileUtils.write(lFile, System.getProperty("line.separator") + "User Feedback - " + feedback, true);
             Log.d(TAG, "Feedback appended");
 
-            File destFolder = new File(Application.get().getApplicationContext().getFilesDir()
+            File destFolder = new File(context.getFilesDir()
                     .getAbsolutePath() + File.separator + LOG_DIRECTORY + File.separator + userResponse);
 
             Log.d(TAG, "sourceLocation: " + lFile);
@@ -174,14 +174,14 @@ public class FeedbackReceiver extends BroadcastReceiver {
         WorkManager.getInstance().enqueue(uploadCheckWork);
     }
 
-    private void logFeedback(String feedbackText, String userResponse) {
+    private void logFeedback(Context context, String feedbackText, String userResponse) {
         Boolean wasGoodReminder;
-        if (userResponse.equals(Application.get().getString(R.string.analytics_label_destination_reminder_yes))) {
+        if (userResponse.equals(context.getString(R.string.analytics_label_destination_reminder_yes))) {
             wasGoodReminder = true;
         } else {
             wasGoodReminder = false;
         }
-        AnalyticsEntryPoint.get(Application.get()).reportDestinationReminderFeedback(wasGoodReminder
+        AnalyticsEntryPoint.get(context).reportDestinationReminderFeedback(wasGoodReminder
                 , ((!isEmpty(feedbackText)) ? feedbackText : null), null);
         Log.d(TAG, "User feedback logged to Firebase Analytics :: wasGoodReminder - "
                 + wasGoodReminder + ", feedbackText - " + ((!isEmpty(feedbackText)) ? feedbackText : null));

--- a/onebusaway-android/src/main/java/org/onebusaway/android/nav/FeedbackReceiver.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/nav/FeedbackReceiver.java
@@ -22,13 +22,12 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.util.Log;
 
-import com.google.firebase.analytics.FirebaseAnalytics;
 
 import org.apache.commons.io.FileUtils;
 import org.onebusaway.android.BuildConfig;
 import org.onebusaway.android.R;
 import org.onebusaway.android.app.Application;
-import org.onebusaway.android.analytics.ObaAnalytics;
+import org.onebusaway.android.app.di.AnalyticsEntryPoint;
 import org.onebusaway.android.util.PreferenceUtils;
 
 import java.io.File;
@@ -56,13 +55,11 @@ public class FeedbackReceiver extends BroadcastReceiver {
     public static final int FEEDBACK_NO = 1;
     public static final int FEEDBACK_YES = 2;
 
-    private FirebaseAnalytics mFirebaseAnalytics;
 
     @Override
     public void onReceive(Context context, Intent intent) {
         Log.d(TAG, "onReceive");
 
-        mFirebaseAnalytics = FirebaseAnalytics.getInstance(context);
 
         int notifyId = intent.getIntExtra(NOTIFICATION_ID,
                 NavigationServiceProvider.NOTIFICATION_ID + 1);
@@ -184,7 +181,7 @@ public class FeedbackReceiver extends BroadcastReceiver {
         } else {
             wasGoodReminder = false;
         }
-        ObaAnalytics.reportDestinationReminderFeedback(mFirebaseAnalytics, wasGoodReminder
+        AnalyticsEntryPoint.get(Application.get()).reportDestinationReminderFeedback(wasGoodReminder
                 , ((!isEmpty(feedbackText)) ? feedbackText : null), null);
         Log.d(TAG, "User feedback logged to Firebase Analytics :: wasGoodReminder - "
                 + wasGoodReminder + ", feedbackText - " + ((!isEmpty(feedbackText)) ? feedbackText : null));

--- a/onebusaway-android/src/main/java/org/onebusaway/android/nav/NavigationCleanupWorker.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/nav/NavigationCleanupWorker.java
@@ -18,7 +18,6 @@ package org.onebusaway.android.nav;
 import android.content.Context;
 import android.util.Log;
 
-import org.onebusaway.android.app.Application;
 
 import java.io.File;
 import java.util.Calendar;
@@ -46,9 +45,9 @@ public class NavigationCleanupWorker extends Worker {
     }
 
     private void cleanDir() {
-        File dir = new File(Application.get().getApplicationContext().getFilesDir()
+        File dir = new File(getApplicationContext().getFilesDir()
                 .getAbsolutePath() + File.separator + LOG_DIRECTORY);
-        Log.d(TAG, "Directory - " + Application.get().getApplicationContext()
+        Log.d(TAG, "Directory - " + getApplicationContext()
                 .getFilesDir().getAbsolutePath() + File.separator + LOG_DIRECTORY);
         Calendar time = Calendar.getInstance();
         time.add(Calendar.HOUR_OF_DAY, -24);

--- a/onebusaway-android/src/main/java/org/onebusaway/android/nav/NavigationService.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/nav/NavigationService.kt
@@ -31,7 +31,6 @@ import androidx.core.app.NotificationCompat
 import androidx.core.app.RemoteInput
 import androidx.work.PeriodicWorkRequest
 import androidx.work.WorkManager
-import com.google.firebase.analytics.FirebaseAnalytics
 import com.google.firebase.auth.FirebaseAuth
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -44,7 +43,6 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import org.apache.commons.io.FileUtils
 import org.onebusaway.android.R
-import org.onebusaway.android.analytics.AnalyticsProvider
 import org.onebusaway.android.app.Application
 import org.onebusaway.android.app.di.LocationEntryPoint
 import org.onebusaway.android.analytics.ObaAnalytics
@@ -84,7 +82,7 @@ class NavigationService : Service() {
     @Inject lateinit var navStopDao: NavStopDao
     @Inject lateinit var stopDao: StopDao
     @Inject lateinit var importGate: ImportGate
-    @Inject lateinit var analyticsProvider: AnalyticsProvider
+    @Inject lateinit var obaAnalytics: ObaAnalytics
 
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
     private var navJob: Job? = null
@@ -102,11 +100,8 @@ class NavigationService : Service() {
 
     private var finishedTime: Long = 0
 
-    private lateinit var firebaseAnalytics: FirebaseAnalytics
-
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         Log.d(TAG, "Starting Service")
-        firebaseAnalytics = FirebaseAnalytics.getInstance(this)
         val currentTime = System.currentTimeMillis()
         // The nav-stop read/write is now Room-backed (suspend), so the setup runs on the service scope
         // after the one-time import gate. Dispatchers.Main.immediate keeps startForeground on the main
@@ -247,8 +242,7 @@ class NavigationService : Service() {
             if (finishedTime == 0L) {
                 finishedTime = System.currentTimeMillis()
             } else if (System.currentTimeMillis() - finishedTime >= 30000) {
-                ObaAnalytics.reportUiEvent(
-                    firebaseAnalytics, analyticsProvider.plausible,
+                obaAnalytics.reportUiEvent(
                     PlausibleAnalytics.REPORT_DESTINATION_REMINDER_EVENT_URL,
                     getString(R.string.analytics_label_destination_reminder),
                     getString(R.string.analytics_label_destination_reminder_variant_ended)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/nav/NavigationService.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/nav/NavigationService.kt
@@ -125,14 +125,14 @@ class NavigationService : Service() {
                     )
                 )
 
-                navProvider = NavigationServiceProvider(tripId, destinationStopId)
+                navProvider = NavigationServiceProvider(this@NavigationService, tripId, destinationStopId)
             } else {
                 val args = navStopDao.getDetails("1")
                 if (args != null) {
                     tripId = args.tripId
                     destinationStopId = args.destinationId
                     beforeStopId = args.beforeId
-                    navProvider = NavigationServiceProvider(tripId, destinationStopId, 1)
+                    navProvider = NavigationServiceProvider(this@NavigationService, tripId, destinationStopId, 1)
                 }
             }
 
@@ -289,7 +289,7 @@ class NavigationService : Service() {
             val readableDate = sdf.format(Calendar.getInstance().time)
 
             val subFolder = File(
-                Application.get().applicationContext
+                applicationContext
                     .filesDir.absolutePath + File.separator + LOG_DIRECTORY
             )
 
@@ -347,14 +347,13 @@ class NavigationService : Service() {
     }
 
     fun getUserFeedback() {
-        val app = Application.get()
         val builder: NotificationCompat.Builder
 
-        val message = Application.get().getString(R.string.feedback_notify_dialog_msg)
+        val message = getString(R.string.feedback_notify_dialog_msg)
         mFirstFeedback = PreferenceUtils.getBoolean(FIRST_FEEDBACK, true)
 
         // Create delete intent to set flag for snackbar creation next time the app is opened.
-        val delIntent = Intent(app.applicationContext, FeedbackReceiver::class.java)
+        val delIntent = Intent(applicationContext, FeedbackReceiver::class.java)
         delIntent.putExtra(FeedbackReceiver.NOTIFICATION_ID, NavigationServiceProvider.NOTIFICATION_ID + 1)
 
         if (mFirstFeedback || Build.VERSION.SDK_INT < Build.VERSION_CODES.N ||
@@ -363,7 +362,7 @@ class NavigationService : Service() {
             // Feedback is a HomeActivity NavHost destination; makeIntent builds the
             // explicit HomeActivity intent carrying the feedback route (with these args as nav-args).
             var fdIntent = FeedbackLauncher.makeIntent(
-                app.applicationContext, FeedbackLauncher.FEEDBACK_NO, logFile!!.absolutePath, tripId,
+                applicationContext, FeedbackLauncher.FEEDBACK_NO, logFile!!.absolutePath, tripId,
                 NavigationServiceProvider.NOTIFICATION_ID + 1
             )
             fdIntent.action = FeedbackReceiver.ACTION_REPLY
@@ -375,16 +374,16 @@ class NavigationService : Service() {
             }
 
             // Pending intent used to handle feedback when user taps on 'No'
-            val fdPendingIntentNo = PendingIntent.getActivity(app.applicationContext, 1, fdIntent, flags)
+            val fdPendingIntentNo = PendingIntent.getActivity(applicationContext, 1, fdIntent, flags)
 
             fdIntent = FeedbackLauncher.makeIntent(
-                app.applicationContext, FeedbackLauncher.FEEDBACK_YES, logFile!!.absolutePath, tripId,
+                applicationContext, FeedbackLauncher.FEEDBACK_YES, logFile!!.absolutePath, tripId,
                 NavigationServiceProvider.NOTIFICATION_ID + 1
             )
             fdIntent.action = FeedbackReceiver.ACTION_REPLY
 
             // Pending intent used to handle feedback when user taps on 'Yes'
-            val fdPendingIntentYes = PendingIntent.getActivity(app.applicationContext, 2, fdIntent, flags)
+            val fdPendingIntentYes = PendingIntent.getActivity(applicationContext, 2, fdIntent, flags)
 
             delIntent.action = FeedbackReceiver.ACTION_DISMISS_FEEDBACK
             val delFlags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
@@ -392,27 +391,27 @@ class NavigationService : Service() {
             } else {
                 0
             }
-            val pDelIntent = PendingIntent.getBroadcast(app.applicationContext, 0, delIntent, delFlags)
+            val pDelIntent = PendingIntent.getBroadcast(applicationContext, 0, delIntent, delFlags)
 
             builder = NotificationCompat.Builder(
-                Application.get().applicationContext, Application.CHANNEL_DESTINATION_ALERT_ID
+                applicationContext, Application.CHANNEL_DESTINATION_ALERT_ID
             )
                 .setSmallIcon(R.drawable.ic_stat_notification)
-                .setContentTitle(Application.get().resources.getString(R.string.feedback_notify_title))
+                .setContentTitle(resources.getString(R.string.feedback_notify_title))
                 .setContentText(message)
                 .addAction(
-                    0, Application.get().resources.getString(R.string.feedback_action_reply_no),
+                    0, resources.getString(R.string.feedback_action_reply_no),
                     fdPendingIntentNo
                 )
                 .addAction(
-                    0, Application.get().resources.getString(R.string.feedback_action_reply_yes),
+                    0, resources.getString(R.string.feedback_action_reply_yes),
                     fdPendingIntentYes
                 )
                 .setDeleteIntent(pDelIntent)
                 .setAutoCancel(true)
         } else {
             // Intent to handle user feedback when a user taps on 'No'
-            val intentNo = Intent(Application.get().applicationContext, FeedbackReceiver::class.java)
+            val intentNo = Intent(applicationContext, FeedbackReceiver::class.java)
             intentNo.action = FeedbackReceiver.ACTION_REPLY
             intentNo.putExtra(FeedbackReceiver.NOTIFICATION_ID, NavigationServiceProvider.NOTIFICATION_ID + 1)
             intentNo.putExtra(FeedbackReceiver.TRIP_ID, tripId)
@@ -427,10 +426,10 @@ class NavigationService : Service() {
 
             // PendingIntent to handle user feedback when a user taps on 'No'
             val fdPendingIntentNo = PendingIntent.getBroadcast(
-                Application.get().applicationContext, 100, intentNo, flags
+                applicationContext, 100, intentNo, flags
             )
 
-            val replyLabelNo = Application.get().resources.getString(R.string.feedback_action_reply_no)
+            val replyLabelNo = resources.getString(R.string.feedback_action_reply_no)
 
             val remoteInput = RemoteInput.Builder(KEY_TEXT_REPLY).setLabel(replyLabelNo).build()
 
@@ -439,7 +438,7 @@ class NavigationService : Service() {
                 .build()
 
             // Intent to handle user feedback when a user taps on 'Yes'
-            val intentYes = Intent(Application.get().applicationContext, FeedbackReceiver::class.java)
+            val intentYes = Intent(applicationContext, FeedbackReceiver::class.java)
             intentYes.action = FeedbackReceiver.ACTION_REPLY
             intentYes.putExtra(FeedbackReceiver.NOTIFICATION_ID, NavigationServiceProvider.NOTIFICATION_ID + 1)
             intentYes.putExtra(FeedbackReceiver.TRIP_ID, tripId)
@@ -448,10 +447,10 @@ class NavigationService : Service() {
 
             // PendingIntent to handle user feedback when a user taps on 'No'
             val fdPendingIntentYes = PendingIntent.getBroadcast(
-                Application.get().applicationContext, 101, intentYes, flags
+                applicationContext, 101, intentYes, flags
             )
 
-            val replyLabelYes = Application.get().resources.getString(R.string.feedback_action_reply_yes)
+            val replyLabelYes = resources.getString(R.string.feedback_action_reply_yes)
 
             val remoteInput1 = RemoteInput.Builder(KEY_TEXT_REPLY).setLabel(replyLabelYes).build()
 
@@ -460,13 +459,13 @@ class NavigationService : Service() {
                 .build()
 
             delIntent.action = FeedbackReceiver.ACTION_DISMISS_FEEDBACK
-            val pDelIntent = PendingIntent.getBroadcast(app.applicationContext, 0, delIntent, flags)
+            val pDelIntent = PendingIntent.getBroadcast(applicationContext, 0, delIntent, flags)
 
             builder = NotificationCompat.Builder(
-                Application.get().applicationContext, Application.CHANNEL_DESTINATION_ALERT_ID
+                applicationContext, Application.CHANNEL_DESTINATION_ALERT_ID
             )
                 .setSmallIcon(R.drawable.ic_stat_notification)
-                .setContentTitle(Application.get().resources.getString(R.string.feedback_notify_title))
+                .setContentTitle(resources.getString(R.string.feedback_notify_title))
                 .setContentText(message)
                 .addAction(replyActionNo)
                 .addAction(replyActionYes)
@@ -477,7 +476,7 @@ class NavigationService : Service() {
         builder.setOngoing(false)
 
         val notificationManager =
-            Application.get().getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
         notificationManager.notify(NavigationServiceProvider.NOTIFICATION_ID + 1, builder.build())
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/nav/NavigationServiceProvider.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/nav/NavigationServiceProvider.java
@@ -571,9 +571,8 @@ public class NavigationServiceProvider implements TextToSpeech.OnInitListener {
      * @return the notification to use for the foreground service if eventType == EVENT_TYPE_INITIAL_STARTUP, otherwise returns null
      */
     private Notification updateUi(int eventType) {
-        Context app = mContext;
         TripDetailsLauncher.Builder bldr = new TripDetailsLauncher.Builder(
-                app.getApplicationContext(), mTripId);
+                mContext, mTripId);
 
         bldr = bldr.setDestinationId(mStopId);
         Intent intent = bldr.getIntent();
@@ -586,11 +585,11 @@ public class NavigationServiceProvider implements TextToSpeech.OnInitListener {
             flags = FLAG_UPDATE_CURRENT;
         }
 
-        PendingIntent pIntent = getActivity(app.getApplicationContext(), 1, intent,
+        PendingIntent pIntent = getActivity(mContext, 1, intent,
                 flags);
 
         // Create deletion intent to stop repeated voice comands.
-        Intent receiverIntent = new Intent(app.getApplicationContext(), NavigationReceiver.class);
+        Intent receiverIntent = new Intent(mContext, NavigationReceiver.class);
         int cancelFlags;
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
             cancelFlags = FLAG_MUTABLE;
@@ -609,19 +608,19 @@ public class NavigationServiceProvider implements TextToSpeech.OnInitListener {
             // Build initial notification used to start the service in the foreground
             receiverIntent.putExtra(NavigationReceiver.ACTION_NUM, NavigationReceiver.CANCEL_TRIP);
             receiverIntent.putExtra(NavigationReceiver.NOTIFICATION_ID, NOTIFICATION_ID);
-            PendingIntent pCancelIntent = getBroadcast(app.getApplicationContext(),
+            PendingIntent pCancelIntent = getBroadcast(mContext,
                     0, receiverIntent, cancelFlags);
             mBuilder.addAction(R.drawable.ic_navigation_close,
-                    app.getString(R.string.destination_reminder_cancel_trip), pCancelIntent);
+                    mContext.getString(R.string.destination_reminder_cancel_trip), pCancelIntent);
             mBuilder.setOngoing(true);
             return mBuilder.build();
         } else if (eventType == EVENT_TYPE_UPDATE_DISTANCE) {
             // Retrieve preferred unit and calculate distance.
-            String IMPERIAL = app.getString(R.string.preferences_preferred_units_option_imperial);
-            String METRIC = app.getString(R.string.preferences_preferred_units_option_metric);
-            String AUTOMATIC = app.getString(R.string.preferences_preferred_units_option_automatic);
+            String IMPERIAL = mContext.getString(R.string.preferences_preferred_units_option_imperial);
+            String METRIC = mContext.getString(R.string.preferences_preferred_units_option_metric);
+            String AUTOMATIC = mContext.getString(R.string.preferences_preferred_units_option_automatic);
             String preferredUnits = PreferenceUtils
-                    .getString(app.getString(R.string.preference_key_preferred_units), AUTOMATIC);
+                    .getString(mContext.getString(R.string.preference_key_preferred_units), AUTOMATIC);
             double distance = mProxCalculator.endDistance;
             double miles = distance * RegionUtils.METERS_TO_MILES;  // Get miles.
             double kilometers = distance / 1000;                    // Get kilometers.
@@ -673,11 +672,11 @@ public class NavigationServiceProvider implements TextToSpeech.OnInitListener {
 
             receiverIntent.putExtra(NavigationReceiver.ACTION_NUM, NavigationReceiver.CANCEL_TRIP);
             receiverIntent.putExtra(NavigationReceiver.NOTIFICATION_ID, NOTIFICATION_ID);
-            PendingIntent pCancelIntent = getBroadcast(app.getApplicationContext(),
+            PendingIntent pCancelIntent = getBroadcast(mContext,
                     0, receiverIntent, cancelFlags);
 
             mBuilder.addAction(R.drawable.ic_navigation_close,
-                    app.getString(R.string.destination_reminder_cancel_trip), pCancelIntent);
+                    mContext.getString(R.string.destination_reminder_cancel_trip), pCancelIntent);
 
             mBuilder.setOngoing(true);
             NotificationManager mNotificationManager = (NotificationManager)
@@ -688,7 +687,7 @@ public class NavigationServiceProvider implements TextToSpeech.OnInitListener {
             receiverIntent.putExtra(NavigationReceiver.NOTIFICATION_ID, NOTIFICATION_ID + 1);
             receiverIntent.putExtra(NavigationReceiver.ACTION_NUM,
                     NavigationReceiver.DISMISS_NOTIFICATION);
-            PendingIntent pDelIntent = getBroadcast(app.getApplicationContext(),
+            PendingIntent pDelIntent = getBroadcast(mContext,
                     0, receiverIntent, cancelFlags);
 
             String message = mContext.getString(R.string.destination_voice_get_ready);
@@ -714,7 +713,7 @@ public class NavigationServiceProvider implements TextToSpeech.OnInitListener {
             receiverIntent.putExtra(NavigationReceiver.ACTION_NUM,
                     NavigationReceiver.DISMISS_NOTIFICATION);
             receiverIntent.putExtra(NavigationReceiver.NOTIFICATION_ID, NOTIFICATION_ID + 2);
-            PendingIntent pDelIntent = getBroadcast(app.getApplicationContext(),
+            PendingIntent pDelIntent = getBroadcast(mContext,
                     0, receiverIntent, cancelFlags);
 
             String message = mContext.getString(R.string.destination_voice_request_stop);

--- a/onebusaway-android/src/main/java/org/onebusaway/android/nav/NavigationServiceProvider.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/nav/NavigationServiceProvider.java
@@ -97,22 +97,27 @@ public class NavigationServiceProvider implements TextToSpeech.OnInitListener {
     private String mTripId;             // Trip ID
     private String mStopId;             // Stop ID
 
+    // Application context, threaded from the hosting NavigationService (replaces the Application static).
+    private final Context mContext;
 
-    public NavigationServiceProvider(String tripId, String stopId) {
+
+    public NavigationServiceProvider(Context context, String tripId, String stopId) {
         Log.d(TAG, "Creating NavigationServiceProvider...");
+        mContext = context.getApplicationContext();
         if (mTTS == null) {
-            mTTS = new TextToSpeech(Application.get().getApplicationContext(), this);
+            mTTS = new TextToSpeech(mContext, this);
         }
         mTripId = tripId;
         mStopId = stopId;
 
     }
 
-    public NavigationServiceProvider(String tripId, String stopId, int flag) {
+    public NavigationServiceProvider(Context context, String tripId, String stopId, int flag) {
         Log.d(TAG, "Creating NavigationServiceProvider...");
+        mContext = context.getApplicationContext();
         mResuming = flag == 1;
         if (mTTS == null) {
-            mTTS = new TextToSpeech(Application.get().getApplicationContext(), this);
+            mTTS = new TextToSpeech(mContext, this);
         }
         mTripId = tripId;
         mStopId = stopId;
@@ -499,7 +504,7 @@ public class NavigationServiceProvider implements TextToSpeech.OnInitListener {
                     if (proximityEvent(EVENT_TYPE_GET_READY, ALERT_STATE_NONE)) {
                         mNavProvider.updateUi(EVENT_TYPE_GET_READY);
                         Log.d(TAG, "-----Get ready!");
-                        AnalyticsEntryPoint.get(Application.get()).reportUiEvent(PlausibleAnalytics.REPORT_DESTINATION_REMINDER_EVENT_URL, Application.get().getString(R.string.analytics_label_destination_reminder), Application.get().getString(R.string.analytics_label_destination_reminder_variant_get_ready));
+                        AnalyticsEntryPoint.get(mContext).reportUiEvent(PlausibleAnalytics.REPORT_DESTINATION_REMINDER_EVENT_URL, mContext.getString(R.string.analytics_label_destination_reminder), mContext.getString(R.string.analytics_label_destination_reminder_variant_get_ready));
                         return EVENT_TYPE_GET_READY; //Get ready alert played
                     }
                 }
@@ -509,7 +514,7 @@ public class NavigationServiceProvider implements TextToSpeech.OnInitListener {
                     if (proximityEvent(EVENT_TYPE_PULL_CORD, ALERT_STATE_SHOWN_TO_RIDER)) {
                         mNavProvider.updateUi(EVENT_TYPE_PULL_CORD);
                         Log.d(TAG, "-----Get off the bus!");
-                        AnalyticsEntryPoint.get(Application.get()).reportUiEvent(PlausibleAnalytics.REPORT_DESTINATION_REMINDER_EVENT_URL, Application.get().getString(R.string.analytics_label_destination_reminder), Application.get().getString(R.string.analytics_label_destination_reminder_variant_exit_at_next_stop));
+                        AnalyticsEntryPoint.get(mContext).reportUiEvent(PlausibleAnalytics.REPORT_DESTINATION_REMINDER_EVENT_URL, mContext.getString(R.string.analytics_label_destination_reminder), mContext.getString(R.string.analytics_label_destination_reminder_variant_exit_at_next_stop));
                         return EVENT_TYPE_PULL_CORD; // Get off bus alert played
                     }
                 }
@@ -566,7 +571,7 @@ public class NavigationServiceProvider implements TextToSpeech.OnInitListener {
      * @return the notification to use for the foreground service if eventType == EVENT_TYPE_INITIAL_STARTUP, otherwise returns null
      */
     private Notification updateUi(int eventType) {
-        Application app = Application.get();
+        Context app = mContext;
         TripDetailsLauncher.Builder bldr = new TripDetailsLauncher.Builder(
                 app.getApplicationContext(), mTripId);
 
@@ -594,10 +599,10 @@ public class NavigationServiceProvider implements TextToSpeech.OnInitListener {
         }
 
         NotificationCompat.Builder mBuilder =
-                new NotificationCompat.Builder(Application.get().getApplicationContext()
+                new NotificationCompat.Builder(mContext
                         , Application.CHANNEL_DESTINATION_ALERT_ID)
                         .setSmallIcon(R.drawable.ic_content_flag)
-                        .setContentTitle(Application.get().getResources()
+                        .setContentTitle(mContext.getResources()
                                 .getString(R.string.destination_reminder_title))
                         .setContentIntent(pIntent);
         if (eventType == EVENT_TYPE_INITIAL_STARTUP) {
@@ -647,21 +652,21 @@ public class NavigationServiceProvider implements TextToSpeech.OnInitListener {
             if (useImperial) {
                 if (miles < 0.1) {
                     // Show feet when distance is less than 0.1 miles
-                    mBuilder.setContentText(Application.get().getResources().getQuantityString(
+                    mBuilder.setContentText(mContext.getResources().getQuantityString(
                             R.plurals.distance_feet, roundedFeet, roundedFeet));
                 } else {
                     // Show miles
-                    mBuilder.setContentText(Application.get().getResources().getQuantityString(
+                    mBuilder.setContentText(mContext.getResources().getQuantityString(
                             R.plurals.distance_miles, (int) miles, fmt.format(miles)));
                 }
             } else {
                 if (kilometers < 1) {
                     // Show meters when distance is less than 1 km
-                    mBuilder.setContentText(Application.get().getResources().getQuantityString(
+                    mBuilder.setContentText(mContext.getResources().getQuantityString(
                             R.plurals.distance_meters, meters, meters));
                 } else {
                     // Show kilometers
-                    mBuilder.setContentText(Application.get().getResources().getQuantityString(
+                    mBuilder.setContentText(mContext.getResources().getQuantityString(
                             R.plurals.distance_kilometers, (int) kilometers, fmt.format(kilometers)));
                 }
             }
@@ -676,7 +681,7 @@ public class NavigationServiceProvider implements TextToSpeech.OnInitListener {
 
             mBuilder.setOngoing(true);
             NotificationManager mNotificationManager = (NotificationManager)
-                    Application.get().getSystemService(Context.NOTIFICATION_SERVICE);
+                    mContext.getSystemService(Context.NOTIFICATION_SERVICE);
             mNotificationManager.notify(NOTIFICATION_ID, mBuilder.build());
         } else if (eventType == EVENT_TYPE_GET_READY) {   // Get ready to pack
             mGetReady = true;
@@ -686,7 +691,7 @@ public class NavigationServiceProvider implements TextToSpeech.OnInitListener {
             PendingIntent pDelIntent = getBroadcast(app.getApplicationContext(),
                     0, receiverIntent, cancelFlags);
 
-            String message = Application.get().getString(R.string.destination_voice_get_ready);
+            String message = mContext.getString(R.string.destination_voice_get_ready);
             for (int i = 0; i < NUM_GET_READY_REPEAT; i++) {
                 speak(message, i == 0 ? TextToSpeech.QUEUE_FLUSH : TextToSpeech.QUEUE_ADD);
                 if (i < NUM_GET_READY_REPEAT - 1) {
@@ -699,7 +704,7 @@ public class NavigationServiceProvider implements TextToSpeech.OnInitListener {
             mBuilder.setDeleteIntent(pDelIntent);
 
             NotificationManager mNotificationManager =
-                    (NotificationManager) Application.get()
+                    (NotificationManager) mContext
                             .getSystemService(Context.NOTIFICATION_SERVICE);
 
             mNotificationManager.notify(NOTIFICATION_ID + 1, mBuilder.build());
@@ -712,7 +717,7 @@ public class NavigationServiceProvider implements TextToSpeech.OnInitListener {
             PendingIntent pDelIntent = getBroadcast(app.getApplicationContext(),
                     0, receiverIntent, cancelFlags);
 
-            String message = Application.get().getString(R.string.destination_voice_request_stop);
+            String message = mContext.getString(R.string.destination_voice_request_stop);
             // TODO: Slow down voice commands, add count as property.
             for (int i = 0; i < NUM_PULL_CORD_REPEAT; i++) {
                 speak(message, i == 0 ? TextToSpeech.QUEUE_FLUSH : TextToSpeech.QUEUE_ADD);
@@ -725,20 +730,20 @@ public class NavigationServiceProvider implements TextToSpeech.OnInitListener {
             mBuilder.setDeleteIntent(pDelIntent);
 
             NotificationManager mNotificationManager =
-                    (NotificationManager) Application.get()
+                    (NotificationManager) mContext
                             .getSystemService(Context.NOTIFICATION_SERVICE);
 
             mNotificationManager.cancel(NOTIFICATION_ID + 1);
             mNotificationManager.notify(NOTIFICATION_ID + 2, mBuilder.build());
 
-            mBuilder = new NotificationCompat.Builder(Application.get().getApplicationContext()
+            mBuilder = new NotificationCompat.Builder(mContext
                     , Application.CHANNEL_DESTINATION_ALERT_ID)
                     .setSmallIcon(R.drawable.ic_content_flag)
                     .setContentTitle(
-                            Application.get().getResources().getString(R.string.destination_reminder_title))
+                            mContext.getResources().getString(R.string.destination_reminder_title))
                     .setContentIntent(pIntent)
                     .setAutoCancel(true);
-            message = Application.get().getString(R.string.destination_voice_arriving_destination);
+            message = mContext.getString(R.string.destination_voice_arriving_destination);
             mBuilder.setContentText(message);
             mBuilder.setOngoing(false);
             mNotificationManager.notify(NOTIFICATION_ID, mBuilder.build());

--- a/onebusaway-android/src/main/java/org/onebusaway/android/nav/NavigationServiceProvider.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/nav/NavigationServiceProvider.java
@@ -17,12 +17,10 @@ package org.onebusaway.android.nav;
 
 import static android.app.PendingIntent.*;
 
-import com.google.firebase.analytics.FirebaseAnalytics;
 
 import org.onebusaway.android.R;
 import org.onebusaway.android.app.Application;
 import org.onebusaway.android.app.di.AnalyticsEntryPoint;
-import org.onebusaway.android.analytics.ObaAnalytics;
 import org.onebusaway.android.analytics.PlausibleAnalytics;
 import org.onebusaway.android.nav.model.Path;
 import org.onebusaway.android.nav.model.PathLink;
@@ -99,11 +97,9 @@ public class NavigationServiceProvider implements TextToSpeech.OnInitListener {
     private String mTripId;             // Trip ID
     private String mStopId;             // Stop ID
 
-    private FirebaseAnalytics mFirebaseAnalytics;
 
     public NavigationServiceProvider(String tripId, String stopId) {
         Log.d(TAG, "Creating NavigationServiceProvider...");
-        mFirebaseAnalytics = FirebaseAnalytics.getInstance(Application.get().getApplicationContext());
         if (mTTS == null) {
             mTTS = new TextToSpeech(Application.get().getApplicationContext(), this);
         }
@@ -114,7 +110,6 @@ public class NavigationServiceProvider implements TextToSpeech.OnInitListener {
 
     public NavigationServiceProvider(String tripId, String stopId, int flag) {
         Log.d(TAG, "Creating NavigationServiceProvider...");
-        mFirebaseAnalytics = FirebaseAnalytics.getInstance(Application.get().getApplicationContext());
         mResuming = flag == 1;
         if (mTTS == null) {
             mTTS = new TextToSpeech(Application.get().getApplicationContext(), this);
@@ -504,7 +499,7 @@ public class NavigationServiceProvider implements TextToSpeech.OnInitListener {
                     if (proximityEvent(EVENT_TYPE_GET_READY, ALERT_STATE_NONE)) {
                         mNavProvider.updateUi(EVENT_TYPE_GET_READY);
                         Log.d(TAG, "-----Get ready!");
-                        ObaAnalytics.reportUiEvent(mFirebaseAnalytics, AnalyticsEntryPoint.get(Application.get()).getPlausible(), PlausibleAnalytics.REPORT_DESTINATION_REMINDER_EVENT_URL, Application.get().getString(R.string.analytics_label_destination_reminder), Application.get().getString(R.string.analytics_label_destination_reminder_variant_get_ready));
+                        AnalyticsEntryPoint.get(Application.get()).reportUiEvent(PlausibleAnalytics.REPORT_DESTINATION_REMINDER_EVENT_URL, Application.get().getString(R.string.analytics_label_destination_reminder), Application.get().getString(R.string.analytics_label_destination_reminder_variant_get_ready));
                         return EVENT_TYPE_GET_READY; //Get ready alert played
                     }
                 }
@@ -514,7 +509,7 @@ public class NavigationServiceProvider implements TextToSpeech.OnInitListener {
                     if (proximityEvent(EVENT_TYPE_PULL_CORD, ALERT_STATE_SHOWN_TO_RIDER)) {
                         mNavProvider.updateUi(EVENT_TYPE_PULL_CORD);
                         Log.d(TAG, "-----Get off the bus!");
-                        ObaAnalytics.reportUiEvent(mFirebaseAnalytics, AnalyticsEntryPoint.get(Application.get()).getPlausible(), PlausibleAnalytics.REPORT_DESTINATION_REMINDER_EVENT_URL, Application.get().getString(R.string.analytics_label_destination_reminder), Application.get().getString(R.string.analytics_label_destination_reminder_variant_exit_at_next_stop));
+                        AnalyticsEntryPoint.get(Application.get()).reportUiEvent(PlausibleAnalytics.REPORT_DESTINATION_REMINDER_EVENT_URL, Application.get().getString(R.string.analytics_label_destination_reminder), Application.get().getString(R.string.analytics_label_destination_reminder_variant_exit_at_next_stop));
                         return EVENT_TYPE_PULL_CORD; // Get off bus alert played
                     }
                 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/nav/NavigationUploadWorker.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/nav/NavigationUploadWorker.java
@@ -21,7 +21,6 @@ import android.util.Log;
 
 import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.OnSuccessListener;
-import com.google.firebase.analytics.FirebaseAnalytics;
 import com.google.firebase.storage.FirebaseStorage;
 import com.google.firebase.storage.StorageMetadata;
 import com.google.firebase.storage.StorageReference;
@@ -29,7 +28,7 @@ import com.google.firebase.storage.UploadTask;
 
 import org.onebusaway.android.R;
 import org.onebusaway.android.app.Application;
-import org.onebusaway.android.analytics.ObaAnalytics;
+import org.onebusaway.android.app.di.AnalyticsEntryPoint;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -47,11 +46,9 @@ public class NavigationUploadWorker extends Worker {
 
     public static final String TAG = "NavigationUploadWorker";
 
-    private FirebaseAnalytics mFirebaseAnalytics;
 
     public NavigationUploadWorker(@NonNull Context context, @NonNull WorkerParameters workerParams) {
         super(context, workerParams);
-        mFirebaseAnalytics = FirebaseAnalytics.getInstance(context);
     }
 
     @NonNull
@@ -128,7 +125,7 @@ public class NavigationUploadWorker extends Worker {
         } else {
             wasGoodReminder = false;
         }
-        ObaAnalytics.reportDestinationReminderFeedback(mFirebaseAnalytics, wasGoodReminder
+        AnalyticsEntryPoint.get(Application.get()).reportDestinationReminderFeedback(wasGoodReminder
                 , ((!isEmpty(feedbackText)) ? feedbackText : null), fileName);
         Log.d(TAG, "User feedback logged to Firebase Analytics :: wasGoodReminder - "
                 + wasGoodReminder + ", feedbackText - " + ((!isEmpty(feedbackText)) ? feedbackText : null) + ", filename - " + fileName);

--- a/onebusaway-android/src/main/java/org/onebusaway/android/nav/NavigationUploadWorker.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/nav/NavigationUploadWorker.java
@@ -27,7 +27,6 @@ import com.google.firebase.storage.StorageReference;
 import com.google.firebase.storage.UploadTask;
 
 import org.onebusaway.android.R;
-import org.onebusaway.android.app.Application;
 import org.onebusaway.android.app.di.AnalyticsEntryPoint;
 
 import java.io.BufferedReader;
@@ -54,8 +53,8 @@ public class NavigationUploadWorker extends Worker {
     @NonNull
     @Override
     public Result doWork() {
-        uploadLog(Application.get().getString(R.string.analytics_label_destination_reminder_yes));
-        uploadLog(Application.get().getString(R.string.analytics_label_destination_reminder_no));
+        uploadLog(getApplicationContext().getString(R.string.analytics_label_destination_reminder_yes));
+        uploadLog(getApplicationContext().getString(R.string.analytics_label_destination_reminder_no));
         return Result.success();
     }
 
@@ -63,7 +62,7 @@ public class NavigationUploadWorker extends Worker {
 
         FirebaseStorage storage = FirebaseStorage.getInstance();
         StorageReference storageRef = storage.getReference();
-        File dir = new File(Application.get().getApplicationContext().getFilesDir()
+        File dir = new File(getApplicationContext().getFilesDir()
                 .getAbsolutePath() + File.separator + LOG_DIRECTORY + File.separator + response);
         if (dir.exists()) {
             Log.d(TAG, "Directory exists");
@@ -101,10 +100,8 @@ public class NavigationUploadWorker extends Worker {
                     @Override
                     public void onSuccess(UploadTask.TaskSnapshot taskSnapshot) {
                         Log.d(TAG, logFileName + " uploaded successful");
-                        String userResponse = taskSnapshot.getMetadata().getCustomMetadata(Application
-                                .get().getString(R.string.analytics_label_custom_metadata_response));
-                        String feedbackText = taskSnapshot.getMetadata().getCustomMetadata(Application
-                                .get().getString(R.string.analytics_label_custom_metadata_feedback));
+                        String userResponse = taskSnapshot.getMetadata().getCustomMetadata(getApplicationContext().getString(R.string.analytics_label_custom_metadata_response));
+                        String feedbackText = taskSnapshot.getMetadata().getCustomMetadata(getApplicationContext().getString(R.string.analytics_label_custom_metadata_feedback));
                         String fileURL = taskSnapshot.getStorage().getDownloadUrl().toString();
                         Log.d(TAG, "Response - " + userResponse);
                         Log.d(TAG, "FeedbackText - " + feedbackText);
@@ -120,12 +117,12 @@ public class NavigationUploadWorker extends Worker {
 
     private void logFeedback(String feedbackText, String userResponse, String fileName) {
         Boolean wasGoodReminder;
-        if (userResponse.equals(Application.get().getString(R.string.analytics_label_destination_reminder_yes))) {
+        if (userResponse.equals(getApplicationContext().getString(R.string.analytics_label_destination_reminder_yes))) {
             wasGoodReminder = true;
         } else {
             wasGoodReminder = false;
         }
-        AnalyticsEntryPoint.get(Application.get()).reportDestinationReminderFeedback(wasGoodReminder
+        AnalyticsEntryPoint.get(getApplicationContext()).reportDestinationReminderFeedback(wasGoodReminder
                 , ((!isEmpty(feedbackText)) ? feedbackText : null), fileName);
         Log.d(TAG, "User feedback logged to Firebase Analytics :: wasGoodReminder - "
                 + wasGoodReminder + ", feedbackText - " + ((!isEmpty(feedbackText)) ? feedbackText : null) + ", filename - " + fileName);

--- a/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/CustomerServiceDestination.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/CustomerServiceDestination.kt
@@ -21,10 +21,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
-import com.google.firebase.analytics.FirebaseAnalytics
 import org.onebusaway.android.R
 import org.onebusaway.android.app.di.AnalyticsEntryPoint
-import org.onebusaway.android.analytics.ObaAnalytics
 import org.onebusaway.android.analytics.PlausibleAnalytics
 import org.onebusaway.android.report.ReportContext
 import org.onebusaway.android.ui.compose.findActivity
@@ -39,12 +37,9 @@ import org.onebusaway.android.util.ExternalIntents
 @Composable
 fun CustomerServiceDestination(navController: NavController, reportContext: ReportContext) {
     val activity = LocalContext.current.findActivity()
-    val firebaseAnalytics = remember { FirebaseAnalytics.getInstance(activity) }
 
     fun reportContactEvent(agencyName: String, labelRes: Int) {
-        ObaAnalytics.reportUiEvent(
-            firebaseAnalytics,
-            AnalyticsEntryPoint.get(activity).plausible,
+        AnalyticsEntryPoint.get(activity).reportUiEvent(
             PlausibleAnalytics.REPORT_MORE_EVENT_URL,
             agencyName + "_" + activity.getString(R.string.analytics_customer_service),
             activity.getString(labelRes)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/InfrastructureIssueScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/InfrastructureIssueScreen.kt
@@ -80,7 +80,6 @@ import android.content.Context
 import android.net.Uri
 import android.util.Log
 import android.widget.Toast
-import com.google.firebase.analytics.FirebaseAnalytics
 import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
@@ -88,7 +87,6 @@ import org.onebusaway.android.app.di.AnalyticsEntryPoint
 import org.onebusaway.android.app.di.ArrivalsViewModelFactoryEntryPoint
 import org.onebusaway.android.app.di.LocationEntryPoint
 import org.onebusaway.android.app.di.NetworkEntryPoint
-import org.onebusaway.android.analytics.ObaAnalytics
 import org.onebusaway.android.analytics.PlausibleAnalytics
 import org.onebusaway.android.report.ReportContext
 import org.onebusaway.android.report.TripReportContext
@@ -506,9 +504,7 @@ private fun createProblemReportViewModel(
 /** Port of ProblemReportFragment.reportAnalytics — the stop/trip problem Plausible event. */
 private fun reportProblemAnalytics(context: Context, kind: ProblemKind) {
     val isTrip = kind == ProblemKind.TRIP
-    ObaAnalytics.reportUiEvent(
-        FirebaseAnalytics.getInstance(context),
-        AnalyticsEntryPoint.get(context).plausible,
+    AnalyticsEntryPoint.get(context).reportUiEvent(
         if (isTrip) {
             PlausibleAnalytics.REPORT_VEHICLE_PROBLEM_EVENT_URL
         } else {
@@ -605,14 +601,11 @@ private fun Open311FormInline(
 
     // Publish the send action to the app bar while shown; clear it (and the spinner) on leave. Port of
     // onSend: submit + the Open311 server analytics event.
-    val firebaseAnalytics = remember { FirebaseAnalytics.getInstance(context) }
     DisposableEffect(vm) {
         onSubmit {
             vm.submit()
             (target.category.raw as? Service)?.let { service ->
-                ObaAnalytics.reportUiEvent(
-                    firebaseAnalytics,
-                    AnalyticsEntryPoint.get(context).plausible,
+                AnalyticsEntryPoint.get(context).reportUiEvent(
                     PlausibleAnalytics.REPORT_OPEN311_SERVER_EVENT_URL,
                     resources.getString(R.string.analytics_problem),
                     service.service_name,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/InfrastructureIssueScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/InfrastructureIssueScreen.kt
@@ -50,7 +50,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -541,7 +540,6 @@ private fun Open311FormInline(
     onSubmittingChanged: (Boolean) -> Unit,
 ) {
     val context = LocalContext.current
-    val resources = LocalResources.current
     val scope = rememberCoroutineScope()
     val vm: Open311ProblemViewModel = viewModel(
         key = "open311:${target.category.code ?: target.category.name}",
@@ -607,7 +605,7 @@ private fun Open311FormInline(
             (target.category.raw as? Service)?.let { service ->
                 AnalyticsEntryPoint.get(context).reportUiEvent(
                     PlausibleAnalytics.REPORT_OPEN311_SERVER_EVENT_URL,
-                    resources.getString(R.string.analytics_problem),
+                    context.getString(R.string.analytics_problem),
                     service.service_name,
                 )
             }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/ReportLauncher.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/ReportLauncher.kt
@@ -33,13 +33,11 @@ import androidx.compose.ui.window.DialogProperties
 import androidx.appcompat.app.AppCompatActivity
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
-import com.google.firebase.analytics.FirebaseAnalytics
 import org.onebusaway.android.BuildConfig
 import org.onebusaway.android.R
 import org.onebusaway.android.app.di.AnalyticsEntryPoint
 import org.onebusaway.android.app.di.LocationEntryPoint
 import org.onebusaway.android.app.di.RegionEntryPoint
-import org.onebusaway.android.analytics.ObaAnalytics
 import org.onebusaway.android.analytics.PlausibleAnalytics
 import org.onebusaway.android.region.Region
 import org.onebusaway.android.report.ReportContext
@@ -116,7 +114,6 @@ object ReportLauncher {
 @Composable
 fun ReportDestination(navController: NavController, reportContext: ReportContext) {
     val activity = LocalContext.current.findActivity()
-    val firebaseAnalytics = remember { FirebaseAnalytics.getInstance(activity) }
 
     // Whether the region needs validating: false → show the type list straight away. Computed once.
     val needsValidation = remember { showValidateRegionDialog(activity) }
@@ -160,7 +157,7 @@ fun ReportDestination(navController: NavController, reportContext: ReportContext
             viewModel = hiltViewModel(),
             onBack = { navController.popBackStack() },
             onActionSelected = { action ->
-                onReportActionSelected(activity, firebaseAnalytics, navController, action, reportContext)
+                onReportActionSelected(activity, navController, action, reportContext)
             }
         )
     }
@@ -168,7 +165,6 @@ fun ReportDestination(navController: NavController, reportContext: ReportContext
 
 private fun onReportActionSelected(
     activity: AppCompatActivity,
-    firebaseAnalytics: FirebaseAnalytics,
     navController: NavController,
     action: ReportAction,
     reportContext: ReportContext
@@ -180,7 +176,7 @@ private fun onReportActionSelected(
         ReportAction.CUSTOMER_SERVICE -> {
             navController.navigate(NavRoutes.customerService(encodedContext))
             reportEvent(
-                activity, firebaseAnalytics,
+                activity,
                 PlausibleAnalytics.REPORT_MORE_EVENT_URL, R.string.analytics_label_customer_service
             )
         }
@@ -192,7 +188,7 @@ private fun onReportActionSelected(
                 )
             )
             reportEvent(
-                activity, firebaseAnalytics,
+                activity,
                 PlausibleAnalytics.REPORT_STOP_PROBLEM_EVENT_URL, R.string.analytics_label_stop_problem
             )
         }
@@ -204,28 +200,27 @@ private fun onReportActionSelected(
                 )
             )
             reportEvent(
-                activity, firebaseAnalytics,
+                activity,
                 PlausibleAnalytics.REPORT_VEHICLE_PROBLEM_EVENT_URL, R.string.analytics_label_trip_problem
             )
         }
 
-        ReportAction.APP_FEEDBACK -> sendAppFeedback(activity, firebaseAnalytics, reportContext.locationString)
+        ReportAction.APP_FEEDBACK -> sendAppFeedback(activity, reportContext.locationString)
     }
 }
 
 private fun sendAppFeedback(
     activity: AppCompatActivity,
-    firebaseAnalytics: FirebaseAnalytics,
     locationString: String?
 ) {
     ExternalIntents.sendEmail(activity, activity.getString(R.string.ri_app_feedback_email), locationString)
     reportEvent(
-        activity, firebaseAnalytics,
+        activity,
         PlausibleAnalytics.REPORT_MORE_EVENT_URL, R.string.analytics_label_app_feedback
     )
     if (locationString == null) {
         reportEvent(
-            activity, firebaseAnalytics,
+            activity,
             PlausibleAnalytics.REPORT_VEHICLE_PROBLEM_EVENT_URL,
             R.string.analytics_label_app_feedback_without_location
         )
@@ -234,13 +229,10 @@ private fun sendAppFeedback(
 
 private fun reportEvent(
     activity: AppCompatActivity,
-    firebaseAnalytics: FirebaseAnalytics,
     eventUrl: String,
     labelRes: Int
 ) {
-    ObaAnalytics.reportUiEvent(
-        firebaseAnalytics,
-        AnalyticsEntryPoint.get(activity).plausible,
+    AnalyticsEntryPoint.get(activity).reportUiEvent(
         eventUrl,
         activity.getString(R.string.analytics_problem),
         activity.getString(labelRes)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsRepository.kt
@@ -21,7 +21,6 @@ import org.onebusaway.android.api.data.RouteDataSource
 
 import android.content.Context
 import android.os.SystemClock
-import com.google.firebase.analytics.FirebaseAnalytics
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.io.IOException
 import javax.inject.Inject
@@ -35,7 +34,6 @@ import org.onebusaway.android.analytics.ObaAnalytics
 import org.onebusaway.android.analytics.PlausibleAnalytics
 import org.onebusaway.android.api.ObaApi
 import org.onebusaway.android.api.ObaApiException
-import org.onebusaway.android.analytics.AnalyticsProvider
 import org.onebusaway.android.database.oba.ImportGate
 import org.onebusaway.android.database.oba.RouteDao
 import org.onebusaway.android.database.oba.RouteHeadsignFavoriteDao
@@ -242,7 +240,7 @@ class DefaultArrivalsRepository @Inject constructor(
     private val routeHeadsignFavoriteDao: RouteHeadsignFavoriteDao,
     private val importGate: ImportGate,
     private val preferences: PreferencesRepository,
-    private val analyticsProvider: AnalyticsProvider,
+    private val obaAnalytics: ObaAnalytics,
 ) : ArrivalsRepository {
 
     /** The last good snapshot paired with the monotonic device time it was received, so the
@@ -454,9 +452,7 @@ class DefaultArrivalsRepository @Inject constructor(
             if (favorite) R.string.analytics_label_star_route else R.string.analytics_label_unstar_route
         )
         val param = "${routeId}_$headsign for ${stopId ?: "all stops"}"
-        ObaAnalytics.reportUiEvent(
-            FirebaseAnalytics.getInstance(context),
-            analyticsProvider.plausible,
+        obaAnalytics.reportUiEvent(
             PlausibleAnalytics.REPORT_BOOKMARK_EVENT_URL,
             event,
             param,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/feedback/Feedback.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/feedback/Feedback.kt
@@ -51,13 +51,12 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.work.PeriodicWorkRequest
 import androidx.work.WorkManager
-import com.google.firebase.analytics.FirebaseAnalytics
 import java.io.File
 import java.io.IOException
 import java.util.concurrent.TimeUnit
 import org.apache.commons.io.FileUtils
 import org.onebusaway.android.R
-import org.onebusaway.android.analytics.ObaAnalytics
+import org.onebusaway.android.app.di.AnalyticsEntryPoint
 import org.onebusaway.android.nav.NavigationService
 import org.onebusaway.android.nav.NavigationUploadWorker
 import org.onebusaway.android.preferences.PreferencesRepository
@@ -178,8 +177,8 @@ class FeedbackSubmitter(
     }
 
     private fun logFeedback(liked: Boolean, feedbackText: String) {
-        ObaAnalytics.reportDestinationReminderFeedback(
-            FirebaseAnalytics.getInstance(context), liked, feedbackText.ifEmpty { null }, null
+        AnalyticsEntryPoint.get(context).reportDestinationReminderFeedback(
+            liked, feedbackText.ifEmpty { null }, null
         )
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeNavHost.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeNavHost.kt
@@ -43,7 +43,6 @@ import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
-import com.google.firebase.analytics.FirebaseAnalytics
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharedFlow
@@ -284,10 +283,7 @@ internal fun AccessibilityAnalyticsEffect() {
     val context = LocalContext.current
     LifecycleEventEffect(Lifecycle.Event.ON_START) {
         val am = context.getSystemService(Context.ACCESSIBILITY_SERVICE) as AccessibilityManager
-        ObaAnalytics.setAccessibility(
-            FirebaseAnalytics.getInstance(context),
-            am.isTouchExplorationEnabled,
-        )
+        AnalyticsEntryPoint.get(context).setAccessibility(am.isTouchExplorationEnabled)
     }
 }
 
@@ -302,14 +298,13 @@ internal fun HomeAnalyticsEffect(analyticsEvents: SharedFlow<HomeAnalyticsEvent>
     val resources = LocalResources.current
     LaunchedEffect(analyticsEvents) {
         analyticsEvents.collect { event ->
-            val firebase = FirebaseAnalytics.getInstance(context)
-            val plausible = AnalyticsEntryPoint.get(context).plausible
+            val analytics = AnalyticsEntryPoint.get(context)
             when (event) {
                 is HomeAnalyticsEvent.RegionSelected ->
-                    ObaAnalytics.setRegion(firebase, event.regionName)
+                    analytics.setRegion(event.regionName)
                 is HomeAnalyticsEvent.MenuItem ->
-                    ObaAnalytics.reportUiEvent(
-                        firebase, plausible, PlausibleAnalytics.REPORT_MENU_EVENT_URL,
+                    analytics.reportUiEvent(
+                        PlausibleAnalytics.REPORT_MENU_EVENT_URL,
                         resources.getString(event.labelRes), null,
                     )
             }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
@@ -57,11 +57,9 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.google.firebase.analytics.FirebaseAnalytics
 import org.onebusaway.android.R
 import org.onebusaway.android.app.Application
 import org.onebusaway.android.app.di.AnalyticsEntryPoint
-import org.onebusaway.android.analytics.ObaAnalytics
 import org.onebusaway.android.analytics.PlausibleAnalytics
 import org.onebusaway.android.models.ObaStop
 import org.onebusaway.android.models.ObaTripStatus
@@ -103,7 +101,6 @@ fun MapFeature(
 ) {
     val context = LocalContext.current
     val resources = LocalResources.current
-    val firebaseAnalytics = remember { FirebaseAnalytics.getInstance(context) }
 
     // Compose-native permission launcher: deliver the result to the map view model (blue dot) + the
     // home view model (the deferred first-launch region check).
@@ -116,7 +113,7 @@ fun MapFeature(
         homeViewModel.onLocationPermissionResult()
     }
 
-    val callbacks = remember(mapViewModel, homeViewModel, firebaseAnalytics) {
+    val callbacks = remember(mapViewModel, homeViewModel) {
         object : ObaMapCallbacks {
             override fun onStopClick(stop: ObaStop) {
                 mapViewModel.onStopTapped(stop)
@@ -128,9 +125,7 @@ fun MapFeature(
                 homeViewModel.onStopFocused(
                     FocusedStop(stop.id, stop.name, stop.stopCode, stop.latitude, stop.longitude)
                 )
-                ObaAnalytics.reportUiEvent(
-                    firebaseAnalytics,
-                    AnalyticsEntryPoint.get(context).plausible,
+                AnalyticsEntryPoint.get(context).reportUiEvent(
                     PlausibleAnalytics.REPORT_MAP_EVENT_URL,
                     resources.getString(R.string.analytics_label_button_press_map_icon),
                     null,
@@ -148,9 +143,7 @@ fun MapFeature(
                 if (bikeId == null || !bikeId.equals(station.id, ignoreCase = true)) {
                     homeViewModel.onBikeStationFocused(station.id)
                 }
-                ObaAnalytics.reportUiEvent(
-                    firebaseAnalytics,
-                    AnalyticsEntryPoint.get(context).plausible,
+                AnalyticsEntryPoint.get(context).reportUiEvent(
                     PlausibleAnalytics.REPORT_BIKE_EVENT_URL,
                     resources.getString(
                         if (station.isFloatingBike) {
@@ -327,9 +320,7 @@ fun MapFeature(
             )
             PreferenceUtils.setUserDeniedLocationPermissions(false)
             mapViewModel.requestMyLocation(useDefaultZoom = true, animate = true)
-            ObaAnalytics.reportUiEvent(
-                firebaseAnalytics,
-                AnalyticsEntryPoint.get(context).plausible,
+            AnalyticsEntryPoint.get(context).reportUiEvent(
                 PlausibleAnalytics.REPORT_MAP_EVENT_URL,
                 resources.getString(R.string.analytics_label_button_press_location),
                 null,
@@ -342,9 +333,7 @@ fun MapFeature(
             // Persist the toggled state (DataStore) + drive the bike loader. MapChromeViewModel observes
             // the visibility pref reactively, so the bikeshare-active tint updates without a host push.
             mapViewModel.setBikeshareLayerVisible(!active, persist = true)
-            ObaAnalytics.reportUiEvent(
-                firebaseAnalytics,
-                AnalyticsEntryPoint.get(context).plausible,
+            AnalyticsEntryPoint.get(context).reportUiEvent(
                 PlausibleAnalytics.REPORT_MAP_EVENT_URL,
                 resources.getString(R.string.analytics_layer_bikeshare),
                 resources.getString(

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
@@ -58,7 +58,6 @@ import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import org.onebusaway.android.R
-import org.onebusaway.android.app.Application
 import org.onebusaway.android.app.di.AnalyticsEntryPoint
 import org.onebusaway.android.analytics.PlausibleAnalytics
 import org.onebusaway.android.models.ObaStop
@@ -407,6 +406,7 @@ private fun OutOfRangeDialog(regionName: String, onConfirm: () -> Unit, onDismis
 @Composable
 private fun NoLocationDialog(onEnable: () -> Unit, onDismiss: () -> Unit) {
     var neverAskAgain by remember { mutableStateOf(false) }
+    val neverShowDialogKey = stringResource(R.string.preference_key_never_show_location_dialog)
     AlertDialog(
         onDismissRequest = onDismiss,
         title = { Text(stringResource(R.string.main_nolocation_title)) },
@@ -421,11 +421,7 @@ private fun NoLocationDialog(onEnable: () -> Unit, onDismiss: () -> Unit) {
                         checked = neverAskAgain,
                         onCheckedChange = {
                             neverAskAgain = it
-                            PreferenceUtils.saveBoolean(
-                                Application.get()
-                                    .getString(R.string.preference_key_never_show_location_dialog),
-                                it,
-                            )
+                            PreferenceUtils.saveBoolean(neverShowDialogKey, it)
                         },
                     )
                     Text(stringResource(R.string.main_never_ask_again))

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/nav/ExtraDestinations.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/nav/ExtraDestinations.kt
@@ -26,10 +26,8 @@ import androidx.navigation.NavHostController
 import androidx.navigation.NavType
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
-import com.google.firebase.analytics.FirebaseAnalytics
 import org.onebusaway.android.app.Application
 import org.onebusaway.android.app.di.AnalyticsEntryPoint
-import org.onebusaway.android.analytics.ObaAnalytics
 import org.onebusaway.android.ui.compose.findActivity
 import org.onebusaway.android.ui.nav.revealRouteOnMap
 import org.onebusaway.android.ui.nav.revealStopOnMap
@@ -109,13 +107,10 @@ fun NavGraphBuilder.extraDestinations(navController: NavHostController) {
         val activity = LocalContext.current.findActivity()
         // The Firebase analytics process-singleton, fetched from the Context like everywhere else
         // (MapFeature/TripPlanScreen) rather than reaching into the host for it.
-        val firebaseAnalytics = remember { FirebaseAnalytics.getInstance(activity) }
         val query = backStackEntry.arguments?.getString(NavRoutes.ARG_QUERY).orEmpty()
         val searchVm: SearchResultsViewModel = hiltViewModel()
         LaunchedEffect(query) {
-            ObaAnalytics.reportSearchEvent(
-                AnalyticsEntryPoint.get(activity).plausible, firebaseAnalytics, query
-            )
+            AnalyticsEntryPoint.get(activity).reportSearchEvent(query)
             searchVm.search(query)
         }
         ObaTheme {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/nav/ExtraDestinations.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/nav/ExtraDestinations.kt
@@ -105,8 +105,8 @@ fun NavGraphBuilder.extraDestinations(navController: NavHostController) {
         ),
     ) { backStackEntry ->
         val activity = LocalContext.current.findActivity()
-        // The Firebase analytics process-singleton, fetched from the Context like everywhere else
-        // (MapFeature/TripPlanScreen) rather than reaching into the host for it.
+        // Analytics is reached via AnalyticsEntryPoint off the Context (as in MapFeature/TripPlanScreen)
+        // rather than reaching into the host for it.
         val query = backStackEntry.arguments?.getString(NavRoutes.ARG_QUERY).orEmpty()
         val searchVm: SearchResultsViewModel = hiltViewModel()
         LaunchedEffect(query) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/regions/RegionsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/regions/RegionsRepository.kt
@@ -16,14 +16,12 @@
 package org.onebusaway.android.ui.regions
 
 import android.content.Context
-import com.google.firebase.analytics.FirebaseAnalytics
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.io.IOException
 import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.onebusaway.android.R
-import org.onebusaway.android.analytics.AnalyticsProvider
 import org.onebusaway.android.analytics.ObaAnalytics
 import org.onebusaway.android.analytics.PlausibleAnalytics
 import org.onebusaway.android.region.Region
@@ -78,7 +76,7 @@ class DefaultRegionsRepository @Inject constructor(
     private val regionRepository: RegionRepository,
     private val regionCache: RegionCache,
     private val locationRepository: LocationRepository,
-    private val analyticsProvider: AnalyticsProvider,
+    private val obaAnalytics: ObaAnalytics,
 ) : RegionsRepository {
 
     // Domain objects from the last successful load, so selectRegion(id) can resolve the Region
@@ -127,9 +125,7 @@ class DefaultRegionsRepository @Inject constructor(
             prefs.setBoolean(R.string.preference_key_auto_select_region, false)
         }
 
-        ObaAnalytics.reportUiEvent(
-            FirebaseAnalytics.getInstance(context),
-            analyticsProvider.plausible,
+        obaAnalytics.reportUiEvent(
             PlausibleAnalytics.REPORT_REGION_EVENT_URL,
             context.getString(R.string.region_selected_manually),
             region.name

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/settings/SettingsAnalytics.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/settings/SettingsAnalytics.kt
@@ -17,16 +17,12 @@ package org.onebusaway.android.ui.settings
 
 import android.content.Context
 import androidx.annotation.StringRes
-import com.google.firebase.analytics.FirebaseAnalytics
 import org.onebusaway.android.app.di.AnalyticsEntryPoint
-import org.onebusaway.android.analytics.ObaAnalytics
 import org.onebusaway.android.analytics.PlausibleAnalytics
 
 /** Reports a settings UI event (label [labelRes]) to the preferences analytics page. */
 internal fun reportPreferencesEvent(context: Context, @StringRes labelRes: Int) {
-    ObaAnalytics.reportUiEvent(
-        FirebaseAnalytics.getInstance(context),
-        AnalyticsEntryPoint.get(context).plausible,
+    AnalyticsEntryPoint.get(context).reportUiEvent(
         PlausibleAnalytics.REPORT_PREFERENCES_EVENT_URL,
         context.getString(labelRes),
         null,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/settings/SettingsViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/settings/SettingsViewModel.kt
@@ -19,7 +19,6 @@ import android.content.Context
 import android.os.Build
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.google.firebase.analytics.FirebaseAnalytics
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
@@ -65,6 +64,7 @@ class SettingsViewModel @Inject constructor(
     private val regionRepository: RegionRepository,
     private val serviceAlertDao: ServiceAlertDao,
     private val importGate: ImportGate,
+    private val obaAnalytics: ObaAnalytics,
 ) : ViewModel() {
 
     private val env = SettingsEnvironment(
@@ -72,8 +72,6 @@ class SettingsViewModel @Inject constructor(
         sdkInt = Build.VERSION.SDK_INT,
         isObaFlavor = BuildFlavorUtils.isOBABuildFlavor(),
     )
-
-    private val firebaseAnalytics: FirebaseAnalytics by lazy { FirebaseAnalytics.getInstance(context) }
 
     val state: StateFlow<SettingsUiState> =
         combine(prefs.observeChanges(), regionRepository.region) { _, region -> compute(region) }
@@ -138,7 +136,7 @@ class SettingsViewModel @Inject constructor(
 
     fun onShowNegativeArrivalsChanged(value: Boolean) {
         prefs.setBoolean(R.string.preference_key_show_negative_arrivals, value)
-        ObaAnalytics.setShowDepartedVehicles(firebaseAnalytics, value)
+        obaAnalytics.setShowDepartedVehicles(value)
     }
 
     fun onHideAlertsChanged(value: Boolean) {
@@ -168,7 +166,7 @@ class SettingsViewModel @Inject constructor(
 
     fun onLeftHandModeChanged(value: Boolean) {
         prefs.setBoolean(R.string.preference_key_left_hand_mode, value)
-        ObaAnalytics.setLeftHanded(firebaseAnalytics, value)
+        obaAnalytics.setLeftHanded(value)
     }
 
     fun onShowHeaderArrivalsChanged(value: Boolean) =
@@ -182,7 +180,7 @@ class SettingsViewModel @Inject constructor(
 
     fun onAnalyticsChanged(value: Boolean) {
         prefs.setBoolean(R.string.preferences_key_analytics, value)
-        ObaAnalytics.setSendAnonymousData(firebaseAnalytics, value)
+        obaAnalytics.setSendAnonymousData(value)
     }
 
     fun onShareDestinationLogsChanged(value: Boolean) =

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/survey/utils/SurveyUtils.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/survey/utils/SurveyUtils.kt
@@ -6,6 +6,7 @@ import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
 import org.onebusaway.android.app.Application
+import org.onebusaway.android.util.PreferenceUtils
 import org.onebusaway.android.models.ObaStop
 import org.onebusaway.android.models.Survey
 import org.onebusaway.android.models.SurveyQuestion
@@ -261,7 +262,7 @@ object SurveyUtils {
 
     fun shouldShowSurveyView(context: Context, isVisibleOnStops: Boolean): Boolean {
         // User will receive a survey every `surveyLaunchCount` app launches
-        if (Application.get().appLaunchCount % launchesUntilSurveyShown != 0) return false
+        if (PreferenceUtils.getInt(Application.APP_LAUNCH_COUNT_KEY, 0) % launchesUntilSurveyShown != 0) return false
 
         // Don't show the UI if there's a reminder date that is still in the future.
         val reminderDate = getSurveyRequestReminderDate(context)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/survey/utils/SurveyUtils.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/survey/utils/SurveyUtils.kt
@@ -6,7 +6,6 @@ import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
 import org.onebusaway.android.app.Application
-import org.onebusaway.android.util.PreferenceUtils
 import org.onebusaway.android.models.ObaStop
 import org.onebusaway.android.models.Survey
 import org.onebusaway.android.models.SurveyQuestion
@@ -262,7 +261,7 @@ object SurveyUtils {
 
     fun shouldShowSurveyView(context: Context, isVisibleOnStops: Boolean): Boolean {
         // User will receive a survey every `surveyLaunchCount` app launches
-        if (PreferenceUtils.getInt(Application.APP_LAUNCH_COUNT_KEY, 0) % launchesUntilSurveyShown != 0) return false
+        if (Application.get().appLaunchCount % launchesUntilSurveyShown != 0) return false
 
         // Don't show the UI if there's a reminder date that is still in the future.
         val reminderDate = getSurveyRequestReminderDate(context)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripdetails/DestinationReminder.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripdetails/DestinationReminder.kt
@@ -49,10 +49,8 @@ import com.google.android.gms.location.LocationServices
 import com.google.android.gms.location.LocationSettingsRequest
 import com.google.android.gms.location.LocationSettingsStatusCodes
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
-import com.google.firebase.analytics.FirebaseAnalytics
 import org.onebusaway.android.R
 import org.onebusaway.android.app.di.AnalyticsEntryPoint
-import org.onebusaway.android.analytics.ObaAnalytics
 import org.onebusaway.android.analytics.PlausibleAnalytics
 import org.onebusaway.android.nav.NavigationService
 import org.onebusaway.android.preferences.PreferencesRepository
@@ -168,8 +166,7 @@ internal fun rememberDestinationReminderAction(
         if (!prefsRepository.getBoolean(R.string.preference_key_never_show_destination_reminder_beta_dialog, false)) {
             destinationReminderBetaDialog()
         }
-        ObaAnalytics.reportUiEvent(
-            FirebaseAnalytics.getInstance(context), AnalyticsEntryPoint.get(context).plausible,
+        AnalyticsEntryPoint.get(context).reportUiEvent(
             PlausibleAnalytics.REPORT_DESTINATION_REMINDER_EVENT_URL,
             resources.getString(R.string.analytics_label_destination_reminder),
             resources.getString(R.string.analytics_label_destination_reminder_variant_started)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanScreen.kt
@@ -70,7 +70,6 @@ import com.google.android.material.datepicker.MaterialDatePicker
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.timepicker.MaterialTimePicker
 import com.google.android.material.timepicker.TimeFormat
-import com.google.firebase.analytics.FirebaseAnalytics
 import java.util.Calendar
 import java.util.TimeZone
 import kotlinx.coroutines.launch
@@ -83,7 +82,6 @@ import org.onebusaway.android.directions.util.ConversionUtils
 import org.onebusaway.android.directions.util.CustomAddress
 import org.onebusaway.android.directions.util.OTPConstants
 import org.onebusaway.android.directions.util.TripRequestBuilder
-import org.onebusaway.android.analytics.ObaAnalytics
 import org.onebusaway.android.analytics.PlausibleAnalytics
 import org.onebusaway.android.region.RegionRepository
 import org.onebusaway.android.ui.compose.components.ObaTopAppBar
@@ -110,7 +108,6 @@ fun TripPlanDestination(navController: NavHostController, onBack: () -> Unit) {
     val activity = LocalContext.current.findActivity()
 
     // Built once for the lifetime of this destination (analytics + region email for "report problem").
-    val firebaseAnalytics = remember { FirebaseAnalytics.getInstance(activity) }
     // HomeActivity doesn't inject RegionRepository; reach the shared singleton via the EntryPoint.
     val regionRepository = remember { RegionEntryPoint.get(activity) }
 
@@ -177,9 +174,9 @@ fun TripPlanDestination(navController: NavHostController, onBack: () -> Unit) {
     LaunchedEffect(viewModel) {
         viewModel.planState.collect { state ->
             when (state) {
-                is PlanResult.Loading -> reportPlanAnalytics(activity, firebaseAnalytics)
+                is PlanResult.Loading -> reportPlanAnalytics(activity)
                 is PlanResult.Error -> {
-                    showFeedbackDialog(activity, firebaseAnalytics, regionRepository, state.message)
+                    showFeedbackDialog(activity, regionRepository, state.message)
                     viewModel.clearPlanResult()
                 }
                 else -> {}
@@ -209,7 +206,7 @@ fun TripPlanDestination(navController: NavHostController, onBack: () -> Unit) {
         onFromPickOnMap = { launchMapPicker("from", viewModel.formState.value.from) },
         onToPickOnMap = { launchMapPicker("to", viewModel.formState.value.to) },
         onAdvancedSettings = { showAdvanced = true },
-        onReportProblem = { reportProblem(activity, firebaseAnalytics, regionRepository) }
+        onReportProblem = { reportProblem(activity, regionRepository) }
     )
 
     if (showAdvanced) {
@@ -541,7 +538,6 @@ private fun AdvancedSettingsDialog(
 
 private fun showFeedbackDialog(
     activity: AppCompatActivity,
-    firebaseAnalytics: FirebaseAnalytics,
     regionRepository: RegionRepository,
     message: String
 ) {
@@ -550,14 +546,13 @@ private fun showFeedbackDialog(
         .setMessage(message)
         .setPositiveButton(android.R.string.ok, null)
         .setNegativeButton(R.string.report_problem_report) { _, _ ->
-            reportProblem(activity, firebaseAnalytics, regionRepository)
+            reportProblem(activity, regionRepository)
         }
         .show()
 }
 
 private fun reportProblem(
     activity: AppCompatActivity,
-    firebaseAnalytics: FirebaseAnalytics,
     regionRepository: RegionRepository
 ) {
     val email = regionRepository.region.value?.otpContactEmail
@@ -569,19 +564,16 @@ private fun reportProblem(
     val location = LocationEntryPoint.get(activity.applicationContext).lastKnownLocation()
     val locationString = location?.let { LocationUtils.printLocationDetails(it) }
     ExternalIntents.sendEmail(activity, email, locationString, null, true)
-    ObaAnalytics.reportUiEvent(
-        firebaseAnalytics, AnalyticsEntryPoint.get(activity).plausible,
+    AnalyticsEntryPoint.get(activity).reportUiEvent(
         PlausibleAnalytics.REPORT_TRIP_PLANNER_EVENT_URL,
         activity.getString(R.string.analytics_label_app_feedback_otp), null
     )
 }
 
 private fun reportPlanAnalytics(
-    activity: AppCompatActivity,
-    firebaseAnalytics: FirebaseAnalytics
+    activity: AppCompatActivity
 ) {
-    ObaAnalytics.reportUiEvent(
-        firebaseAnalytics, AnalyticsEntryPoint.get(activity).plausible,
+    AnalyticsEntryPoint.get(activity).reportUiEvent(
         PlausibleAnalytics.REPORT_TRIP_PLANNER_EVENT_URL,
         activity.getString(R.string.analytics_label_trip_plan), null
     )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/ExternalIntents.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/ExternalIntents.kt
@@ -31,7 +31,6 @@ import android.widget.Toast
 import com.google.android.gms.common.GoogleApiAvailability
 
 import org.onebusaway.android.R
-import org.onebusaway.android.app.Application
 import org.onebusaway.android.app.di.AnalyticsEntryPoint
 import org.onebusaway.android.app.di.RegionEntryPoint
 import org.onebusaway.android.analytics.PlausibleAnalytics
@@ -288,18 +287,18 @@ object ExternalIntents {
             activity.startActivity(intent)
             AnalyticsEntryPoint.get(activity).reportUiEvent(
                 PlausibleAnalytics.REPORT_FARE_PAYMENT_EVENT_URL,
-                Application.get().getString(R.string.analytics_label_button_fare_payment),
-                Application.get().getString(R.string.analytics_label_open_app)
+                activity.getString(R.string.analytics_label_button_fare_payment),
+                activity.getString(R.string.analytics_label_open_app)
             )
         } else {
             // Go to Play Store listing to download app
             intent = Intent(Intent.ACTION_VIEW)
-            intent.setData(Uri.parse(Application.get().getString(R.string.google_play_listing_prefix, paymentAndroidAppId)))
+            intent.setData(Uri.parse(activity.getString(R.string.google_play_listing_prefix, paymentAndroidAppId)))
             activity.startActivity(intent)
             AnalyticsEntryPoint.get(activity).reportUiEvent(
                 PlausibleAnalytics.REPORT_FARE_PAYMENT_EVENT_URL,
-                Application.get().getString(R.string.analytics_label_button_fare_payment),
-                Application.get().getString(R.string.analytics_label_download_app)
+                activity.getString(R.string.analytics_label_button_fare_payment),
+                activity.getString(R.string.analytics_label_download_app)
             )
         }
     }
@@ -319,18 +318,18 @@ object ExternalIntents {
             context.startActivity(intent)
             AnalyticsEntryPoint.get(context).reportUiEvent(
                 PlausibleAnalytics.REPORT_FARE_PAYMENT_EVENT_URL,
-                Application.get().getString(R.string.analytics_label_button_bike_share),
-                Application.get().getString(R.string.analytics_label_open_app)
+                context.getString(R.string.analytics_label_button_bike_share),
+                context.getString(R.string.analytics_label_open_app)
             )
         } else {
             // Go to Play Store listing to download app
             intent = Intent(Intent.ACTION_VIEW)
-            intent.setData(Uri.parse(Application.get().getString(R.string.google_play_listing_prefix, context.getString(R.string.hopr_android_app_id))))
+            intent.setData(Uri.parse(context.getString(R.string.google_play_listing_prefix, context.getString(R.string.hopr_android_app_id))))
             context.startActivity(intent)
             AnalyticsEntryPoint.get(context).reportUiEvent(
                 PlausibleAnalytics.REPORT_FARE_PAYMENT_EVENT_URL,
-                Application.get().getString(R.string.analytics_label_button_bike_share),
-                Application.get().getString(R.string.analytics_label_download_app)
+                context.getString(R.string.analytics_label_button_bike_share),
+                context.getString(R.string.analytics_label_download_app)
             )
         }
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/ExternalIntents.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/ExternalIntents.kt
@@ -29,13 +29,11 @@ import android.text.TextUtils
 import android.widget.Toast
 
 import com.google.android.gms.common.GoogleApiAvailability
-import com.google.firebase.analytics.FirebaseAnalytics
 
 import org.onebusaway.android.R
 import org.onebusaway.android.app.Application
 import org.onebusaway.android.app.di.AnalyticsEntryPoint
 import org.onebusaway.android.app.di.RegionEntryPoint
-import org.onebusaway.android.analytics.ObaAnalytics
 import org.onebusaway.android.analytics.PlausibleAnalytics
 import org.onebusaway.android.region.Region
 
@@ -288,9 +286,7 @@ object ExternalIntents {
             // Launch installed app
             intent.addCategory(Intent.CATEGORY_LAUNCHER)
             activity.startActivity(intent)
-            ObaAnalytics.reportUiEvent(
-                FirebaseAnalytics.getInstance(activity),
-                AnalyticsEntryPoint.get(activity).plausible,
+            AnalyticsEntryPoint.get(activity).reportUiEvent(
                 PlausibleAnalytics.REPORT_FARE_PAYMENT_EVENT_URL,
                 Application.get().getString(R.string.analytics_label_button_fare_payment),
                 Application.get().getString(R.string.analytics_label_open_app)
@@ -300,9 +296,7 @@ object ExternalIntents {
             intent = Intent(Intent.ACTION_VIEW)
             intent.setData(Uri.parse(Application.get().getString(R.string.google_play_listing_prefix, paymentAndroidAppId)))
             activity.startActivity(intent)
-            ObaAnalytics.reportUiEvent(
-                FirebaseAnalytics.getInstance(activity),
-                AnalyticsEntryPoint.get(activity).plausible,
+            AnalyticsEntryPoint.get(activity).reportUiEvent(
                 PlausibleAnalytics.REPORT_FARE_PAYMENT_EVENT_URL,
                 Application.get().getString(R.string.analytics_label_button_fare_payment),
                 Application.get().getString(R.string.analytics_label_download_app)
@@ -323,9 +317,7 @@ object ExternalIntents {
             // Launch installed app
             intent.addCategory(Intent.CATEGORY_LAUNCHER)
             context.startActivity(intent)
-            ObaAnalytics.reportUiEvent(
-                FirebaseAnalytics.getInstance(context),
-                AnalyticsEntryPoint.get(context).plausible,
+            AnalyticsEntryPoint.get(context).reportUiEvent(
                 PlausibleAnalytics.REPORT_FARE_PAYMENT_EVENT_URL,
                 Application.get().getString(R.string.analytics_label_button_bike_share),
                 Application.get().getString(R.string.analytics_label_open_app)
@@ -335,9 +327,7 @@ object ExternalIntents {
             intent = Intent(Intent.ACTION_VIEW)
             intent.setData(Uri.parse(Application.get().getString(R.string.google_play_listing_prefix, context.getString(R.string.hopr_android_app_id))))
             context.startActivity(intent)
-            ObaAnalytics.reportUiEvent(
-                FirebaseAnalytics.getInstance(context),
-                AnalyticsEntryPoint.get(context).plausible,
+            AnalyticsEntryPoint.get(context).reportUiEvent(
                 PlausibleAnalytics.REPORT_FARE_PAYMENT_EVENT_URL,
                 Application.get().getString(R.string.analytics_label_button_bike_share),
                 Application.get().getString(R.string.analytics_label_download_app)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/LocationHelper.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/LocationHelper.java
@@ -83,7 +83,7 @@ public class LocationHelper implements android.location.LocationListener {
      */
     public LocationHelper(Context context, int interval) {
         mContext = context;
-        mLocationManager = (LocationManager) Application.get().getBaseContext()
+        mLocationManager = (LocationManager) mContext
                 .getSystemService(Context.LOCATION_SERVICE);
         // Create the LocationRequest object with high accuracy and the requested update
         // interval, allowing updates as fast as every second

--- a/onebusaway-android/src/main/java/org/onebusaway/android/widealerts/GtfsAlerts.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/widealerts/GtfsAlerts.java
@@ -3,7 +3,8 @@ package org.onebusaway.android.widealerts;
 import com.google.transit.realtime.GtfsRealtime;
 
 import org.onebusaway.android.R;
-import org.onebusaway.android.app.Application;
+import org.onebusaway.android.app.di.RegionEntryPoint;
+import org.onebusaway.android.region.Region;
 import org.onebusaway.android.util.PreferenceUtils;
 
 import android.content.Context;
@@ -83,7 +84,7 @@ public class GtfsAlerts {
             String url = GtfsAlertsHelper.getAlertUrl(alert);
 
             Log.d(TAG, "Alert: " + id + " - " + title + " - " + description + " - " + url);
-            GtfsAlertsHelper.markAlertAsRead(Application.get().getApplicationContext(), entity);
+            GtfsAlertsHelper.markAlertAsRead(mContext, entity);
             callback.onAlert(title, description, url);
             // Only trigger the callback for one alert.
             break;
@@ -97,11 +98,12 @@ public class GtfsAlerts {
      * @return The URL to fetch GTFS alerts.
      */
     public String getGtfsAlertsUrl(String regionId) {
-        Application app = Application.get();
-        String baseUrl = app.getCurrentRegion().getSidecarBaseUrl();
+        Region region = RegionEntryPoint.get(mContext).currentRegion();
+        if (region == null) return null;
+        String baseUrl = region.getSidecarBaseUrl();
         if (baseUrl == null) return null;
-        boolean isTestAlert = PreferenceUtils.getBoolean(app.getString(R.string.preferences_display_test_alerts), false);
-        String alertAPIURL = baseUrl + app.getString(R.string.alerts_api_endpoint);
+        boolean isTestAlert = PreferenceUtils.getBoolean(mContext.getString(R.string.preferences_display_test_alerts), false);
+        String alertAPIURL = baseUrl + mContext.getString(R.string.alerts_api_endpoint);
         alertAPIURL = alertAPIURL.replace("regionID", regionId);
         if (isTestAlert) alertAPIURL += "?test=1";
         return alertAPIURL;

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/DonationViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/DonationViewModelTest.kt
@@ -42,7 +42,7 @@ class DonationViewModelTest {
 
     // These tests cover only the dialog/effect logic, which never calls the DonationsManager, so a
     // bare instance (its Android collaborators are never touched) is enough to satisfy the constructor.
-    private fun donationViewModel() = DonationViewModel(DonationsManager(null, null, null, 0))
+    private fun donationViewModel() = DonationViewModel(DonationsManager(null, null, 0))
 
     @Test
     fun `close requests the dismiss confirmation, cancel clears it`() = runTest {


### PR DESCRIPTION
The lower-priority half of #1631 — retire the benign `Application.get().getX()` **context/resource** reaches (`getString`/`getResources`/`getSystemService`/`getApplicationContext`/`getBaseContext`) in favor of a `Context` that's already in scope, or one threaded a single hop. No app-global state — just context resolution.

> ⚠️ **Stacked on #1634** (the injectable-`ObaAnalytics` PR). Until #1634 merges, this PR's diff shows both changesets; review #1634 first. Once #1634 lands in `main`, this diff collapses to just the ~9 benign-sweep files.

## Converted (44 of the 58 reaches)

- **NavigationServiceProvider** — threads a `Context` from the hosting `NavigationService` (its two construction sites pass `this@NavigationService`); all ~22 reaches + the `AnalyticsEntryPoint` handle go through the field now.
- **NavigationService** — its own Service context.
- **ExternalIntents** — `activity`/`context` in the fare-payment + bikeshare launchers.
- **FeedbackReceiver** — the receiver's `Context`, threaded one hop into `moveLog`/`logFeedback`.
- **NavigationUploadWorker** / **NavigationCleanupWorker** — the Worker's `getApplicationContext()`.
- **GtfsAlerts** / **LocationHelper** — their existing `mContext` field (`GtfsAlerts`' stray `currentRegion` reach also moved to `RegionEntryPoint`).

## Deliberately deferred (14 reaches)

All context-less static hubs/helpers where conversion needs a threading cascade disproportionate to benign context: `PreferenceUtils` (4), `VehicleBitmaps.createXIcon` (5), `RegionUtils.isRegionUsable` (1), `MapUtils.showMapError` (1), `NavigationReceiver.cancelTrip` (1). `TripRequestBuilder`'s 2 are owned by #1630 (#1632).

## Behavior

No user-facing change — the same resources/strings resolved from an equivalent `Context`. Builds clean; unit **and** androidTest compile; full JVM suite passes (`NavigationTest` ctor updated for the threaded `NavigationServiceProvider`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app stability around navigation, feedback, and upload flows by tightening how app context is used.
  * Fixed several interactions where notifications, region changes, and reminder feedback could be tracked inconsistently.

* **Chores**
  * Updated analytics handling across the app to use a more consistent shared setup.
  * Refined launch-count storage and other app settings handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->