### PR TITLE
Add direction switching to the show-vehicles-on-map route view

### DIFF
--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
@@ -335,21 +335,28 @@ class GoogleMapRenderer(
      * decaying correction on the dead-reckon glide); the band is re-added.
      */
     fun renderDynamic(overlay: TripOverlay?, vehicles: MapVehicles?, nowMs: Long) {
-        updateVehicles(vehicles, nowMs)
+        moveVehicles(vehicles, nowMs)
         updateTripOverlay(overlay, nowMs)
     }
 
-    private fun updateVehicles(vehicles: MapVehicles?, nowMs: Long) {
+    /**
+     * Reconcile the vehicle marker *set* (add/remove markers, refresh icons/titles/tap-routing) against a
+     * pushed [MapRenderState.vehicleSet] emission — a new poll, a direction switch, or leaving route mode
+     * (null). Driven reactively by the adapter, not the frame loop, so the set changes the instant it's
+     * published rather than being inferred from the per-frame motion sample.
+     */
+    fun reconcileVehicles(set: MapVehicles?) {
+        reconcileVehicleMarkers(set?.markers.orEmpty(), set?.response)
+        // Publish after reconcile so a collector that re-renders an open bubble sees the fresh markers.
+        _vehicleResponse.value = set?.response
+    }
+
+    // Per-frame motion: move each already-reconciled marker to its smoothed extrapolated position (a
+    // decaying correction across a fix change) — no set diffing or icon work on the hot path, only an
+    // icon re-stamp when a vehicle's heading octant flips. Markers not yet reconciled are skipped.
+    private fun moveVehicles(vehicles: MapVehicles?, nowMs: Long) {
         val response = vehicles?.response
         val markers = vehicles?.markers.orEmpty()
-        // The vehicle set, icons/titles, and tap-routing only change on a new poll (response identity),
-        // so reconcile then. Every tick in between just moves each marker to its smoothed extrapolated
-        // position (a decaying correction across a fix change) — no set diffing or icon work on the hot path.
-        if (response !== _vehicleResponse.value) {
-            reconcileVehicleMarkers(markers, response)
-            // Publish after reconcile so a collector that re-renders an open bubble sees the fresh markers.
-            _vehicleResponse.value = response
-        }
         for (vehicle in markers) {
             val marker = vehicleMarkersByTripId[vehicle.activeTripId] ?: continue
             marker.position = vehicleSmoother

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleComposeAdapter.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleComposeAdapter.kt
@@ -183,6 +183,13 @@ class GoogleComposeAdapter : ObaComposeMapAdapter {
                     renderState.tripStops.map { },
                 ).collect { activeRenderer.renderStatic() }
             }
+            // The vehicle set (which vehicles exist + their icons): reconcile the markers whenever it's
+            // pushed — a poll, a direction switch, or leaving route mode (null). Discrete, so it's reactive
+            // (not inferred from the per-frame motion loop below), which is what makes a direction switch
+            // take effect immediately instead of waiting for the next poll.
+            LaunchedEffect(activeRenderer) {
+                renderState.vehicleSet.collect { activeRenderer.reconcileVehicles(it) }
+            }
             // Each fresh vehicle poll re-renders an open info window from the now-current live state, so a
             // shown bubble reflects the latest data instead of a tap-time snapshot.
             LaunchedEffect(activeRenderer, activeInfoWindows) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/data/MapDataSource.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/data/MapDataSource.kt
@@ -23,7 +23,9 @@ import org.onebusaway.android.api.requireData
 import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import org.onebusaway.android.api.contract.StopGrouping
 import org.onebusaway.android.models.NearbyStops
+import org.onebusaway.android.models.RouteMapDirection
 import org.onebusaway.android.models.RouteMapData
 import org.onebusaway.android.models.RouteMapStop
 import org.onebusaway.android.util.PolylineDecoder
@@ -69,23 +71,16 @@ class DefaultMapDataSource @Inject constructor(
     override suspend fun routeMap(routeId: String): Result<RouteMapData?> = api.callOrNull { service ->
         val data = service.stopsForRoute(routeId, includePolylines = true).requireData()
         val route = data.references.route(routeId)?.let(::DtoRoute)
-        // Invert the direction stop groups (type "direction") into a stop id -> direction ids map, so
-        // each stop can carry its own direction. Only numeric group ids are kept — they're what a
-        // vehicle's trip directionId matches; a stop listed under two groups gets both.
-        val directionsByStop = mutableMapOf<String, MutableSet<Int>>()
-        data.entry.stopGroupings.forEach { grouping ->
-            grouping.stopGroups.forEach { group ->
-                group.id?.toIntOrNull()?.let { dir ->
-                    group.stopIds.forEach { directionsByStop.getOrPut(it) { mutableSetOf() }.add(dir) }
-                }
-            }
-        }
+        // The route's selectable directions + each stop's direction membership, from one pass over the
+        // direction stop groups.
+        val dirs = directionsFrom(data.entry.stopGroupings)
         RouteMapData(
             route = route,
             agencyName = route?.agencyId?.let { data.references.agency(it)?.name },
             stops = data.references.stops.map(::DtoStop)
-                .map { RouteMapStop(it, directionsByStop[it.id].orEmpty()) },
+                .map { RouteMapStop(it, dirs.directionsByStop[it.id].orEmpty()) },
             routes = data.references.routes.map(::DtoRoute),
+            directions = dirs.directions,
             // Decoding the route's shape polylines is the one bit of non-trivial CPU work in this
             // layer; offload just it (the Retrofit calls are already main-safe, like the other sources).
             polylines = withContext(Dispatchers.Default) {
@@ -93,4 +88,38 @@ class DefaultMapDataSource @Inject constructor(
             },
         )
     }
+}
+
+/** A route's selectable [directions] plus the [directionsByStop] membership, from one pass. */
+internal data class RouteDirections(
+    val directions: List<RouteMapDirection>,
+    val directionsByStop: Map<String, Set<Int>>,
+)
+
+/**
+ * Derives a route's selectable directions and each stop's direction membership from its "direction"
+ * stop groups, in a single pass over the groups. Each numeric group id becomes a [RouteMapDirection]
+ * labelled with the group's display name (the headsign; blank when the group had none), de-duplicated
+ * by id (first group wins) and ordered by id so the header/picker is stable; the same id is added to
+ * every stop the group lists (a stop shared by two groups gets both). Pure; unit-tested.
+ *
+ * ASSUMPTION (no exact source, documented per the repo's no-heuristics rule): the numeric group id is
+ * treated as the GTFS direction id — the value a vehicle's trip `directionId` is matched against for
+ * the vehicle filter. That holds for a conformant `type: "direction"` grouping (ids 0/1). A grouping
+ * that instead exposes branch/variant ids beyond 0/1 will still list those directions and their stops,
+ * but no vehicle's trip `directionId` will match, so selecting such a direction shows its stops with an
+ * empty vehicle layer. Non-numeric ids are dropped (they can't be a GTFS direction).
+ */
+internal fun directionsFrom(stopGroupings: List<StopGrouping>): RouteDirections {
+    val directions = mutableListOf<RouteMapDirection>()
+    val seen = mutableSetOf<Int>()
+    val byStop = mutableMapOf<String, MutableSet<Int>>()
+    stopGroupings.forEach { grouping ->
+        grouping.stopGroups.forEach { group ->
+            val dir = group.id?.toIntOrNull() ?: return@forEach
+            if (seen.add(dir)) directions += RouteMapDirection(dir, group.displayName.orEmpty())
+            group.stopIds.forEach { byStop.getOrPut(it) { mutableSetOf() }.add(dir) }
+        }
+    }
+    return RouteDirections(directions.sortedBy { it.directionId }, byStop)
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapParams.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapParams.java
@@ -29,6 +29,10 @@ public class MapParams {
     // The stop a "show vehicles on map" launch anchored to, so route mode restores its direction filter.
     public static final String ROUTE_DIRECTION_STOP_ID = ".RouteDirectionStopId";
 
+    // The user-selected direction (via the route header's switch), restored across process death.
+    // Wins over the anchor stop when it's still a valid direction of the restored route.
+    public static final String ROUTE_DIRECTION_ID = ".RouteDirectionId";
+
     public static final String CENTER_LAT = ".MapCenterLat";
 
     public static final String CENTER_LON = ".MapCenterLon";

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.flow.stateIn
 import org.onebusaway.android.R
 import org.onebusaway.android.models.ObaRoute
 import org.onebusaway.android.models.ObaStop
+import org.onebusaway.android.models.RouteMapDirection
 import org.onebusaway.android.api.data.MapDataSource
 import org.onebusaway.android.extrapolation.data.TripObservationRepository
 import org.onebusaway.android.models.ObaTripStatus
@@ -48,13 +49,16 @@ import org.onebusaway.android.util.getRouteDisplayName
 /**
  * The route-mode header content (the old `R.id.route_info` overlay): the route's short/long name +
  * agency, or a loading state while the route loads. Published while a route is shown and rendered
- * as a Compose overlay by the home screen. Null when not in route mode.
+ * as a Compose overlay by the home screen. Null when not in route mode. [directions] +
+ * [currentDirectionId] drive the header's switch-direction affordance (empty/size-1 = no switch).
  */
 data class RouteHeader(
     val loading: Boolean,
     val shortName: String,
     val longName: String,
     val agency: String,
+    val directions: List<RouteMapDirection> = emptyList(),
+    val currentDirectionId: Int? = null,
 )
 
 /**
@@ -214,6 +218,8 @@ class MapViewModel @Inject constructor(
             shortName = MyTextUtils.formatDisplayText(getRouteDisplayName(route))!!,
             longName = MyTextUtils.formatDisplayText(getRouteDescription(route))!!,
             agency = agencyName ?: "",
+            directions = directions,
+            currentDirectionId = currentDirectionId,
         )
     }
 
@@ -237,21 +243,32 @@ class MapViewModel @Inject constructor(
      * restore). Callers ([toRoute] and the restore in `init`) only ever pass a route different from the
      * current one — re-selecting the active route is handled (re-framed) by [toRoute].
      */
-    private fun enterRoute(routeId: String, zoomToRoute: Boolean, directionStopId: String?) {
+    private fun enterRoute(
+        routeId: String,
+        zoomToRoute: Boolean,
+        directionStopId: String?,
+        initialDirectionId: Int? = null,
+    ) {
         leaveCurrentView()
-        persistRoute(routeId, directionStopId)
-        routeController.start(routeId, zoomToRoute, directionStopId)
+        persistRoute(routeId, directionStopId, initialDirectionId)
+        routeController.start(routeId, zoomToRoute, directionStopId, initialDirectionId)
         bikeController.start(directions = false, selectedBikeStationIds = null)
     }
 
     // Persist which route (if any) to restore across process death — null means nearby stops. This is
     // the whole "which view" state (the route controller is the single live source of truth), so there's
     // no separate mode to save. [directionStopId] rides along so a restored route keeps its direction
-    // filter. The transient trip-focus view deliberately doesn't touch this, so a back-press restores
-    // the prior view.
-    private fun persistRoute(routeId: String?, directionStopId: String? = null) {
+    // filter; [initialDirectionId] persists a later user switch (null on a fresh entry, clearing any
+    // prior route's saved direction). The transient trip-focus view deliberately doesn't touch this, so
+    // a back-press restores the prior view.
+    private fun persistRoute(
+        routeId: String?,
+        directionStopId: String? = null,
+        initialDirectionId: Int? = null,
+    ) {
         savedStateHandle[MapParams.ROUTE_ID] = routeId
         savedStateHandle[MapParams.ROUTE_DIRECTION_STOP_ID] = directionStopId
+        savedStateHandle[MapParams.ROUTE_DIRECTION_ID] = initialDirectionId
     }
 
     /**
@@ -331,6 +348,19 @@ class MapViewModel @Inject constructor(
 
     /** Leave route mode back to nearby stops, preserving the current camera (the route header's cancel). */
     fun exitRouteMode() = showNearbyStops()
+
+    /**
+     * Switch the shown route to another of its directions (one of the header's [RouteHeader.directions]
+     * ids) via the header's swap affordance. Re-filters the stops + vehicles in place (no reload /
+     * reframe). On a real switch, persists the choice and retires the launch anchor
+     * ([MapParams.ROUTE_DIRECTION_STOP_ID]) so a process-death restore honors this explicit selection
+     * rather than re-resolving the anchor stop.
+     */
+    fun selectRouteDirection(directionId: Int) {
+        if (!routeController.selectDirection(directionId)) return
+        savedStateHandle[MapParams.ROUTE_DIRECTION_STOP_ID] = null
+        savedStateHandle[MapParams.ROUTE_DIRECTION_ID] = directionId
+    }
 
     // ----- Trip-focus mode (the speed-estimation trip map) -----
 
@@ -419,6 +449,8 @@ class MapViewModel @Inject constructor(
                 restoreRouteId,
                 zoomToRoute = savedStateHandle[MapParams.ZOOM_TO_ROUTE] ?: false,
                 directionStopId = savedStateHandle[MapParams.ROUTE_DIRECTION_STOP_ID],
+                // A user-selected direction persisted before process death wins over the anchor stop.
+                initialDirectionId = savedStateHandle[MapParams.ROUTE_DIRECTION_ID],
             )
         } else {
             showNearbyStops()

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
@@ -32,6 +32,8 @@ import org.onebusaway.android.time.WallTime
 import java.net.HttpURLConnection
 import org.onebusaway.android.api.ObaApi
 import org.onebusaway.android.models.ObaRoute
+import org.onebusaway.android.models.RouteMapDirection
+import org.onebusaway.android.models.RouteMapStop
 import org.onebusaway.android.api.ObaApiException
 import org.onebusaway.android.map.render.MapRenderState
 import org.onebusaway.android.map.render.MapVehicles
@@ -85,6 +87,25 @@ class RouteMapController(
     var directionStopId: String? = null
         private set
 
+    // A restore/deep-link override for the initial direction (the user-selected direction persisted
+    // across process death); when set and still valid it wins over the anchor stop's direction.
+    private var initialDirectionOverride: Int? = null
+
+    // The full route retained after load so [selectDirection] can re-filter stops to any direction
+    // without a network reload. routeStops carries each stop's direction membership; directions is the
+    // selectable set (id + headsign) the header offers.
+    private var routeStops: List<RouteMapStop> = emptyList()
+
+    private var routeStopRoutes: List<ObaRoute> = emptyList()
+
+    private var directions: List<RouteMapDirection> = emptyList()
+
+    // The direction shown now (null = whole route). Derived from [directionState] rather than stored
+    // separately, so the stop filter and the vehicle filter can never disagree. Meaningful only once
+    // resolved (it reads null during the Pending window, which no caller relies on).
+    private val currentDirectionId: Int?
+        get() = (directionState as? DirectionState.Resolved)?.directionId
+
     // What direction the vehicle layer should show — the single source of truth the per-frame sampler
     // reads (so it's a field, not a captured value; the sampler is installed in start() before the route
     // loads). [DirectionState.Pending] holds the layer back while a direction-anchored launch waits for
@@ -111,15 +132,24 @@ class RouteMapController(
      * Show route [routeId]: load the route + header and start the vehicle poll. [zoomToRoute] frames
      * the shape once it loads (consumed once). [directionStopId], when non-null, narrows the overlay to
      * the single direction that serves that stop (the arrivals "show vehicles on map" launch); null
-     * shows the whole route.
+     * shows the whole route. [initialDirectionId] is a restore override (the user-selected direction
+     * persisted across process death) that wins over the anchor stop when it's still a valid direction.
      */
-    fun start(routeId: String, zoomToRoute: Boolean, directionStopId: String? = null) {
+    fun start(
+        routeId: String,
+        zoomToRoute: Boolean,
+        directionStopId: String? = null,
+        initialDirectionId: Int? = null,
+    ) {
         this.routeId = routeId
         this.directionStopId = directionStopId
+        this.initialDirectionOverride = initialDirectionId
         // A whole-route launch has no direction to wait for, so its vehicles show as soon as they poll;
-        // a direction-anchored launch stays Pending until the route load resolves the filter (below).
+        // a direction-anchored launch (an anchor stop or a restored direction) stays Pending until the
+        // route load resolves the filter (below).
         this.directionState =
-            if (directionStopId == null) DirectionState.Resolved(null) else DirectionState.Pending
+            if (directionStopId == null && initialDirectionId == null) DirectionState.Resolved(null)
+            else DirectionState.Pending
         _loadedRoute.value = LoadedRoute.Loading
         host.setProgress(true)
         // The live vehicle layer: the renderer pulls a frame from this sampler each display frame,
@@ -127,23 +157,36 @@ class RouteMapController(
         // decision lives here, not in the producer). Yields nothing until the first poll lands. The
         // route-id filter set is built once here, not per frame, since it's constant for this route;
         // directionState is read live since it's resolved only once the route loads.
-        val routeIds = setOf(routeId)
-        renderState.setVehiclesSampler { nowMs ->
-            // Pending holds the layer back until the direction is known, so a direction launch never
-            // flashes the opposite-direction vehicles before the (slower) route load lands to cull them.
-            val resolved = directionState as? DirectionState.Resolved ?: return@setVehiclesSampler null
-            latestPoll?.let { poll ->
-                MapVehicles(
-                    markers = extrapolatedVehicles(
-                        poll.response, routeIds, WallTime(nowMs), resolved.directionId,
-                        tripObservationRepository::lookupTripState,
-                    ).map { it.toMarker() },
-                    response = poll.response,
-                )
-            }
-        }
+        renderState.setVehiclesSampler { nowMs -> sampleVehicles(WallTime(nowMs)) }
         loadRoute(zoomToRoute)
         startVehiclePolling(0L)
+    }
+
+    // Builds the vehicle markers for the current poll + direction filter at [nowMs]. Returns null while
+    // the direction is still [DirectionState.Pending] (a direction launch holds the layer back until the
+    // route load resolves the filter, so it never flashes the opposite-direction vehicles) or before the
+    // first poll lands. Shared by the per-frame motion sampler and the discrete [currentVehicleLayer] push.
+    private fun sampleVehicles(now: WallTime): MapVehicles? {
+        val id = routeId ?: return null
+        val resolved = directionState as? DirectionState.Resolved ?: return null
+        val poll = latestPoll ?: return null
+        return MapVehicles(
+            markers = extrapolatedVehicles(
+                poll.response, setOf(id), now, resolved.directionId,
+                tripObservationRepository::lookupTripState,
+            ).map { it.toMarker() },
+            response = poll.response,
+        )
+    }
+
+    // The vehicle set to push whenever it changes (a poll, a direction switch, the load resolving the
+    // filter). Seeds marker positions at the device wall clock the per-frame sampler extrapolates
+    // against (matching TripState.anchorLocalTimeMs); the next frame supersedes the seed either way.
+    private fun currentVehicleLayer(): MapVehicles? = sampleVehicles(WallTime.now())
+
+    /** Recompute + push the vehicle set (the renderer reconciles markers from it). */
+    private fun publishVehicleSet() {
+        renderState.setVehicleSet(currentVehicleLayer())
     }
 
     /** Leave route mode: cancel the loads + poll and clear the route's shape, vehicle layer, and header. */
@@ -154,9 +197,16 @@ class RouteMapController(
         vehicleJob = null
         routeId = null
         directionStopId = null
+        initialDirectionOverride = null
+        routeStops = emptyList()
+        routeStopRoutes = emptyList()
+        directions = emptyList()
         directionState = DirectionState.Resolved(null)
         latestPoll = null
         renderState.clearRoutePolylines()
+        // setVehicleSet(null) is what clears the vehicle markers (the renderer reconciles the empty set);
+        // it must be nulled together with the motion sampler, which only moves already-reconciled markers.
+        renderState.setVehicleSet(null)
         renderState.setVehiclesSampler(null)
         renderState.setSelectedVehicle(null)
         _loadedRoute.value = null
@@ -190,32 +240,76 @@ class RouteMapController(
     }
 
     private fun onRouteLoaded(result: Result<RouteMap?>, zoomToRoute: Boolean) {
-        // The route load has resolved (success or failure), so release the vehicle layer the sampler
-        // held back in direction mode. Default to Resolved(null) here so an error path below falls back
-        // to showing vehicles unfiltered rather than hidden forever; the success path narrows it.
+        // The route load has resolved (success or failure), so release the vehicle layer the sampler held
+        // back in direction mode: fall back to Resolved(null) — vehicles unfiltered — and publish the set
+        // so the renderer reconciles them, rather than leaving them hidden until the next poll. The
+        // success path below narrows the filter and re-publishes.
         directionState = DirectionState.Resolved(null)
         val routeMap = result.getOrElse {
             MapUtils.showMapError((it as? ObaApiException)?.code ?: ObaApi.OBA_IO_EXCEPTION)
+            publishVehicleSet()
             return
         }
         // A null result (no endpoint) or an unresolved route reads as an error, like the legacy
         // null-response path.
         val route = routeMap?.route ?: run {
             MapUtils.showMapError(HttpURLConnection.HTTP_INTERNAL_ERROR)
+            publishVehicleSet()
             return
         }
-        _loadedRoute.value = LoadedRoute.Loaded(route, routeMap.agencyName)
+        // Retain the full route so a later direction switch re-filters locally (no reload). The shown
+        // direction prefers a valid restore override (a persisted user switch), else the anchor stop's.
+        routeStops = routeMap.stops
+        routeStopRoutes = routeMap.routes
+        directions = routeMap.directions
+        val override = initialDirectionOverride
+        val resolved =
+            if (override != null && directions.any { it.directionId == override }) override
+            else routeMap.initialDirectionId
+        directionState = DirectionState.Resolved(resolved)
+        _loadedRoute.value = LoadedRoute.Loaded(route, routeMap.agencyName, directions, resolved)
         // Pass the route's raw GTFS color through; the render layer picks the fallback when it's absent.
+        // The shape is whole-route (never narrowed by direction), so a switch leaves it untouched.
         renderState.setRoutePolylines(
             routeMap.polylines.map { points -> RoutePolyline(route.color, points) }
         )
-        // The repository already narrowed the stops to the stop-relevant direction (whole route when the
-        // launch had no anchor); its resolved direction id is what the vehicle sampler filters by.
-        directionState = DirectionState.Resolved(routeMap.directionId)
-        stopsController.showStops(routeMap.stops, routeMap.routes)
+        showDirectionStops()
+        // The load resolved the filter (Pending -> Resolved); push the now-visible vehicle set in case a
+        // poll already landed while it was held back.
+        publishVehicleSet()
         if (zoomToRoute) {
             host.frameRoute()
         }
+    }
+
+    /** Re-render the route's stops narrowed to [currentDirectionId], replacing the prior direction's. */
+    private fun showDirectionStops() {
+        // showStops accumulates while a route is active, so drop the prior direction's route stops
+        // first — otherwise the map would show the union of both directions. (Keeps a focused stop.)
+        stopsController.clearStops(false)
+        stopsController.showStops(routeStops.stopsForDirection(currentDirectionId), routeStopRoutes)
+    }
+
+    /**
+     * Switch the shown direction to [directionId] (one of [directions]' ids, or null for the whole
+     * route) without a network reload: re-filter the stops and the vehicle set against the current poll,
+     * republish both, and update the header. The renderer reconciles markers from the pushed vehicle set,
+     * so the swap is immediate. Returns true if the direction actually changed (false = no route, or
+     * already showing [directionId]), so the caller only persists a real switch.
+     */
+    fun selectDirection(directionId: Int?): Boolean {
+        if (routeId == null || directionId == currentDirectionId) return false
+        directionState = DirectionState.Resolved(directionId)
+        // A vehicle selected in the old direction is now filtered out — drop the selection.
+        renderState.setSelectedVehicle(null)
+        showDirectionStops()
+        // Re-filter the vehicle set against the same poll and push it — the renderer reconciles markers on
+        // this emission, so the swap is immediate instead of waiting for the next poll.
+        publishVehicleSet()
+        (_loadedRoute.value as? LoadedRoute.Loaded)?.let {
+            _loadedRoute.value = it.copy(currentDirectionId = directionId)
+        }
+        return true
     }
 
     /**
@@ -233,11 +327,13 @@ class RouteMapController(
             }
             // Keep the route's vehicles fresh while route mode is on screen: the repository polls
             // trips-for-route (backfilling each active trip's schedule + shape into the store) and
-            // records each response. Each emission is a fresh poll — stash it for the sampler and record
-            // its time so a resume mid-period waits only the remainder. The renderer's frame loop pulls
-            // the sampler to dead-reckon every vehicle between polls.
+            // records each response. Each emission is a fresh poll — stash it for the motion sampler,
+            // record its time so a resume mid-period waits only the remainder, and push the new vehicle
+            // set so the renderer reconciles the marker set. The renderer's frame loop then pulls the
+            // motion sampler to dead-reckon every vehicle between polls.
             tripObservationRepository.routeVehiclesStream(id, VEHICLE_REFRESH_PERIOD_MS).collect { response ->
                 latestPoll = VehiclePoll(response, SystemClock.elapsedRealtimeNanos())
+                publishVehicleSet()
             }
         }
     }
@@ -281,6 +377,15 @@ sealed interface LoadedRoute {
     /** The route is still loading. */
     data object Loading : LoadedRoute
 
-    /** The route resolved: its [route] and serving [agencyName]. */
-    data class Loaded(val route: ObaRoute, val agencyName: String?) : LoadedRoute
+    /**
+     * The route resolved: its [route] and serving [agencyName], the route's selectable [directions]
+     * (id + headsign, for the header's switch affordance), and the [currentDirectionId] shown now
+     * (null = whole route).
+     */
+    data class Loaded(
+        val route: ObaRoute,
+        val agencyName: String?,
+        val directions: List<RouteMapDirection>,
+        val currentDirectionId: Int?,
+    ) : LoadedRoute
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapRepository.kt
@@ -20,21 +20,25 @@ import org.onebusaway.android.api.data.MapDataSource
 import javax.inject.Inject
 import org.onebusaway.android.models.ObaRoute
 import org.onebusaway.android.models.ObaStop
+import org.onebusaway.android.models.RouteMapDirection
 import org.onebusaway.android.models.RouteMapStop
 import org.onebusaway.android.map.render.GeoPoint
 
 /**
- * A route's stops (narrowed to a single direction when the load was direction-focused), the serving
- * routes (for stop-marker icons), the route + agency name, its shape, and the resolved [directionId]
- * the vehicle layer keeps (null = both directions / whole route).
+ * A route's full stops (each tagged with the direction(s) it serves, so the controller can re-filter
+ * to any direction without a reload), the serving routes (for stop-marker icons), the route + agency
+ * name, its shape, the route's selectable [directions] (id + headsign), and the
+ * [initialDirectionId] resolved from the launch's anchor stop (null = whole route). The shape is
+ * never narrowed by direction — both directions share it.
  */
 data class RouteMap(
     val route: ObaRoute?,
     val agencyName: String?,
-    val stops: List<ObaStop>,
+    val stops: List<RouteMapStop>,
     val routes: List<ObaRoute>,
     val polylines: List<List<GeoPoint>>,
-    val directionId: Int?,
+    val directions: List<RouteMapDirection>,
+    val initialDirectionId: Int?,
 )
 
 /**
@@ -46,8 +50,10 @@ data class RouteMap(
  */
 interface RouteMapRepository {
     /**
-     * @param directionStopId when non-null, narrow the returned stops (and [RouteMap.directionId]) to
-     *   the single direction serving that stop; null (or an ambiguous stop) returns the whole route.
+     * @param directionStopId when non-null, resolve it to the single direction serving that stop and
+     *   report it as [RouteMap.initialDirectionId]; null (or an ambiguous stop) yields a null id
+     *   (whole route). The returned [RouteMap.stops] are always the full route — the controller
+     *   filters to a direction (and re-filters on a switch) without a reload.
      * @return the route's stops/shape, or `success(null)` when there is no API endpoint.
      */
     suspend fun getRoute(routeId: String, directionStopId: String? = null): Result<RouteMap?>
@@ -60,36 +66,37 @@ class DefaultRouteMapRepository @Inject constructor(
     override suspend fun getRoute(routeId: String, directionStopId: String?): Result<RouteMap?> =
         mapDataSource.routeMap(routeId).map { data ->
             data?.let {
-                val focus = it.stops.focusDirection(directionStopId)
                 RouteMap(
                     route = it.route,
                     agencyName = it.agencyName,
-                    stops = focus.stops,
+                    stops = it.stops,
                     routes = it.routes,
                     polylines = it.polylines.map { line ->
                         line.map { p -> GeoPoint(p.latitude, p.longitude) }
                     },
-                    directionId = focus.directionId,
+                    directions = it.directions,
+                    initialDirectionId = it.stops.anchorDirectionId(directionStopId),
                 )
             }
         }
 }
 
-/** The direction-narrowed [stops] plus the resolved vehicle [directionId] (null = show all). */
-internal data class DirectionFocus(val stops: List<ObaStop>, val directionId: Int?)
+/**
+ * Resolves the "show vehicles on map" launch's anchor stop to the single direction it serves — the
+ * initial direction filter. Returns null (whole route) when there's no anchor, the anchor isn't among
+ * the stops, or its direction is ambiguous (it belongs to zero or several direction groups — e.g. an
+ * ungrouped or shared/loop stop). Pure; unit-tested.
+ */
+internal fun List<RouteMapStop>.anchorDirectionId(anchorStopId: String?): Int? {
+    if (anchorStopId == null) return null
+    return firstOrNull { it.stop.id == anchorStopId }?.directionIds?.singleOrNull()
+}
 
 /**
- * Narrows a route's [RouteMapStop]s to the single direction serving [anchorStopId] — the stop a
- * "show vehicles on map" launch anchored to. Returns the whole route (all stops, null [directionId])
- * when there's no anchor, the anchor isn't among the stops, or its direction is ambiguous (it belongs
- * to zero or several direction groups — e.g. an ungrouped or shared/loop stop). When the anchor sits
- * in exactly one direction, the stops are filtered to that direction (shared stops that also serve it
- * included) and its id returned as the vehicle filter. Pure; unit-tested.
+ * Narrows a route's [RouteMapStop]s to a single [directionId] (null = whole route). Source order is
+ * preserved and stops shared between directions that also serve [directionId] are included. Pure;
+ * unit-tested.
  */
-internal fun List<RouteMapStop>.focusDirection(anchorStopId: String?): DirectionFocus {
-    val allStops = map { it.stop }
-    if (anchorStopId == null) return DirectionFocus(allStops, null)
-    val target = firstOrNull { it.stop.id == anchorStopId }?.directionIds?.singleOrNull()
-        ?: return DirectionFocus(allStops, null)
-    return DirectionFocus(filter { target in it.directionIds }.map { it.stop }, target)
-}
+internal fun List<RouteMapStop>.stopsForDirection(directionId: Int?): List<ObaStop> =
+    if (directionId == null) map { it.stop }
+    else filter { directionId in it.directionIds }.map { it.stop }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
@@ -141,10 +141,13 @@ data class MapRenderSnapshot(
 )
 
 /**
- * The route-mode vehicle layer: the markers and the [response] their icons/info-windows derive from.
- * Produced on demand by a [FrameSampler]: the renderer pulls a fresh frame (re-extrapolated to the
- * frame's clock) each display frame, so the per-frame motion lives in the UI's frame loop rather than a
- * ~20×/second push. The selected vehicle is tracked separately (see [MapRenderState.selectedVehicleTripId]).
+ * The route-mode vehicle **set**: which vehicles exist and the [response] their icons/info-windows
+ * derive from. This is discrete state — it changes only at events (a new poll, a direction switch,
+ * leaving route mode), so it's *pushed* (see [MapRenderState.vehicleSet]) and the renderer reconciles
+ * markers from each emission. Per-frame *motion* is a separate concern (see
+ * [MapRenderState.vehiclesSampler]); the [markers] here carry only a seed position for a freshly-added
+ * marker, which the motion sampler immediately supersedes. The selected vehicle is tracked separately
+ * (see [MapRenderState.selectedVehicleTripId]).
  */
 data class MapVehicles(
     val markers: List<VehicleMarker> = emptyList(),
@@ -237,12 +240,27 @@ class MapRenderState {
         _snapshot.update { it.copy(genericMarkers = it.genericMarkers - id) }
     }
 
-    // --- Vehicles (the old VehicleOverlay): the renderer pulls a live marker frame from this sampler ---
-    // --- each display frame (re-extrapolated to the frame's clock), so per-frame motion lives in the ---
-    // --- UI's frame loop, not a ~20Hz push. Null => not in route mode (the renderer draws nothing). ---
+    // --- Vehicles (the old VehicleOverlay). The layer is split by change-rate so the renderer never has ---
+    // --- to *infer* a discrete change from a per-frame value: ---
+    // ---   • the SET (which vehicles + their icons/response) is discrete, so it's pushed here and the ---
+    // ---     renderer reconciles markers on each emission (a poll, a direction switch, or leaving mode); ---
+    // ---   • MOTION (each vehicle's position) is continuous, so it stays a per-frame [vehiclesSampler] ---
+    // ---     the renderer pulls to move the already-reconciled markers. ---
+    // --- Both null => not in route mode (the renderer draws nothing). ---
+
+    private val _vehicleSet = MutableStateFlow<MapVehicles?>(null)
+
+    /** The current vehicle set; the renderer reconciles its markers whenever this emits. */
+    val vehicleSet: StateFlow<MapVehicles?> = _vehicleSet.asStateFlow()
+
+    /** Publish the vehicle set (on a poll / direction switch), or null on leaving route mode. */
+    fun setVehicleSet(set: MapVehicles?) {
+        _vehicleSet.value = set
+    }
 
     private val _vehiclesSampler = MutableStateFlow<FrameSampler<MapVehicles>?>(null)
 
+    /** Per-frame motion for the current set: the renderer pulls a frame to move markers in place. */
     val vehiclesSampler: StateFlow<FrameSampler<MapVehicles>?> = _vehiclesSampler.asStateFlow()
 
     fun setVehiclesSampler(sampler: FrameSampler<MapVehicles>?) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/models/MapData.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/models/MapData.kt
@@ -29,14 +29,26 @@ data class NearbyStops(
  * A route's stops, the serving routes (for stop-marker icons), the route + agency name, and its
  * decoded shape. Polylines are [Location] points (the neutral geo type); the map layer turns them
  * into its render `GeoPoint`s. Each [RouteMapStop] carries the direction(s) it serves, so the overlay
- * can be narrowed to a single stop-relevant direction without a separate id index.
+ * can be narrowed to a single stop-relevant direction without a separate id index. [directions]
+ * enumerates the route's selectable directions (id + headsign) so the header can offer a switch.
  */
 data class RouteMapData(
     val route: ObaRoute?,
     val agencyName: String?,
     val stops: List<RouteMapStop>,
     val routes: List<ObaRoute>,
+    val directions: List<RouteMapDirection>,
     val polylines: List<List<Location>>,
+)
+
+/**
+ * One selectable direction of a route: its GTFS [directionId] (0/1/…, what a vehicle's trip
+ * `directionId` matches) and the headsign [label] the header/picker shows. [label] may be blank
+ * when the stop group carried no display name; the UI supplies a fallback.
+ */
+data class RouteMapDirection(
+    val directionId: Int,
+    val label: String,
 )
 
 /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsScreen.kt
@@ -95,6 +95,7 @@ import org.onebusaway.android.ui.arrivals.dialogs.StopDetailsHost
 import org.onebusaway.android.util.BuildFlavorUtils
 import org.onebusaway.android.util.DisplayFormat
 import org.onebusaway.android.ui.compose.components.LoadingContent
+import org.onebusaway.android.ui.compose.components.RadioOptionList
 
 /** Refresh interval matching the legacy ArrivalsListFragment (fixed 60s, not the server value). */
 private const val REFRESH_PERIOD_MS = 60_000L
@@ -350,30 +351,6 @@ private fun SortByDialog(
             TextButton(onClick = onDismiss) { Text(stringResource(android.R.string.cancel)) }
         }
     )
-}
-
-/** A single-choice radio list (one row per option), shared by the sort and route-favorite dialogs. */
-@Composable
-internal fun RadioOptionList(
-    options: Array<String>,
-    selectedIndex: Int,
-    onSelect: (Int) -> Unit
-) {
-    Column {
-        options.forEachIndexed { index, label ->
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clickable { onSelect(index) }
-                    .padding(vertical = 8.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                RadioButton(selected = index == selectedIndex, onClick = { onSelect(index) })
-                Spacer(Modifier.width(8.dp))
-                Text(label, style = MaterialTheme.typography.bodyLarge)
-            }
-        }
-    }
 }
 
 @Composable

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/dialogs/RouteFavoriteDialog.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/dialogs/RouteFavoriteDialog.kt
@@ -30,7 +30,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import org.onebusaway.android.R
 import org.onebusaway.android.ui.arrivals.ArrivalActions
 import org.onebusaway.android.ui.arrivals.ArrivalsViewModel
-import org.onebusaway.android.ui.arrivals.RadioOptionList
+import org.onebusaway.android.ui.compose.components.RadioOptionList
 
 // Selections need to match strings.xml "route_favorite_options"
 private const val SELECTION_THIS_STOP = 0

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/RadioOptionList.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/RadioOptionList.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.compose.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+/**
+ * A single-choice radio list (one row per option), shared by the several `AlertDialog` pickers
+ * (sort-by, route-favorite, switch-direction). Tapping a row's text or radio selects it via [onSelect].
+ */
+@Composable
+fun RadioOptionList(
+    options: Array<String>,
+    selectedIndex: Int,
+    onSelect: (Int) -> Unit,
+) {
+    Column {
+        options.forEachIndexed { index, label ->
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { onSelect(index) }
+                    .padding(vertical = 8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                RadioButton(selected = index == selectedIndex, onClick = { onSelect(index) })
+                Spacer(Modifier.width(8.dp))
+                Text(label, style = MaterialTheme.typography.bodyLarge)
+            }
+        }
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -393,6 +393,9 @@ fun HomeScreen(
                             surveyViewModel = surveyViewModel,
                             routeHeader = routeHeader,
                             onCancelRouteMode = onCancelRouteMode,
+                            // The switch-direction affordance calls straight into the map VM (which
+                            // re-filters stops/vehicles + persists the choice), like the height report below.
+                            onSelectRouteDirection = mapViewModel::selectRouteDirection,
                             onLearnMore = onLearnMore,
                             onOpenSurvey = onOpenSurvey,
                             // The route header reports its height straight to the map VM (which owns the
@@ -492,6 +495,7 @@ private fun BoxScope.HomeMapOverlays(
     surveyViewModel: SurveyViewModel,
     routeHeader: RouteHeader?,
     onCancelRouteMode: () -> Unit,
+    onSelectRouteDirection: (Int) -> Unit,
     onLearnMore: () -> Unit,
     onOpenSurvey: (url: String) -> Unit,
     onRouteHeaderHeight: (Int) -> Unit,
@@ -519,6 +523,7 @@ private fun BoxScope.HomeMapOverlays(
         RouteHeaderOverlay(
             header = routeHeader,
             onCancel = onCancelRouteMode,
+            onSelectDirection = onSelectRouteDirection,
             onHeight = onRouteHeaderHeight,
             modifier = Modifier.align(Alignment.TopCenter).fillMaxWidth(),
         )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/RouteHeaderOverlay.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/RouteHeaderOverlay.kt
@@ -22,13 +22,19 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.onSizeChanged
@@ -41,19 +47,26 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.onebusaway.android.R
 import org.onebusaway.android.map.RouteHeader
+import org.onebusaway.android.models.RouteMapDirection
 import org.onebusaway.android.ui.compose.components.LineBadge
+import org.onebusaway.android.ui.compose.components.RadioOptionList
 import org.onebusaway.android.ui.compose.theme.ObaTheme
 
 /**
  * The route-mode header overlay (the Compose replacement for the legacy `route_info_head.xml` /
  * `RouteMapController.RoutePopup`). Renders the route short/long name + agency (or a spinner while the
- * route loads) and a cancel button that exits route mode. It reports its measured height via [onHeight]
- * so the host can set the map's top padding (keeping vehicle markers visible under it).
+ * route loads), the current direction's headsign, a switch-direction affordance (when the route has
+ * more than one direction), and a cancel button that exits route mode. It reports its measured height
+ * via [onHeight] so the host can set the map's top padding (keeping vehicle markers visible under it).
+ *
+ * [onSelectDirection] switches which direction of the route is shown (the id is one of
+ * [RouteHeader.directions]).
  */
 @Composable
 fun RouteHeaderOverlay(
     header: RouteHeader,
     onCancel: () -> Unit,
+    onSelectDirection: (Int) -> Unit,
     onHeight: (Int) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -73,6 +86,12 @@ fun RouteHeaderOverlay(
                 CircularProgressIndicator(Modifier.size(48.dp))
             }
         } else {
+            // The current direction's headsign (blank falls back to a generic label); null when the
+            // route is shown whole (no direction selected), so the subtitle is hidden.
+            val unnamed = stringResource(R.string.route_direction_unnamed)
+            val directionLabel = header.directions
+                .firstOrNull { it.directionId == header.currentDirectionId }
+                ?.labelOr(unnamed)
             Row(
                 Modifier
                     .fillMaxWidth()
@@ -97,9 +116,25 @@ fun RouteHeaderOverlay(
                             overflow = TextOverflow.Ellipsis,
                         )
                     }
+                    if (directionLabel != null) {
+                        Text(
+                            text = directionLabel,
+                            color = MaterialTheme.colorScheme.primary,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
                     if (header.agency.isNotEmpty()) {
                         Text(text = header.agency)
                     }
+                }
+                // A route with a single direction has nothing to switch to — the affordance is hidden.
+                if (header.directions.size >= 2) {
+                    SwitchDirectionAction(
+                        directions = header.directions,
+                        currentDirectionId = header.currentDirectionId,
+                        onSelectDirection = onSelectDirection,
+                    )
                 }
                 IconButton(onClick = onCancel) {
                     Icon(
@@ -112,32 +147,129 @@ fun RouteHeaderOverlay(
     }
 }
 
+/**
+ * The swap-direction icon button. With exactly two directions a tap toggles to the other; with more it
+ * opens a radio picker of the directions' headsigns. [currentDirectionId] is the shown direction (null
+ * when the route is shown whole — a whole-route launch); a toggle from there picks the first direction.
+ */
+@Composable
+private fun SwitchDirectionAction(
+    directions: List<RouteMapDirection>,
+    currentDirectionId: Int?,
+    onSelectDirection: (Int) -> Unit,
+) {
+    var showPicker by remember { mutableStateOf(false) }
+    IconButton(
+        onClick = {
+            if (directions.size == 2) {
+                onSelectDirection(directions.first { it.directionId != currentDirectionId }.directionId)
+            } else {
+                showPicker = true
+            }
+        }
+    ) {
+        Icon(
+            painter = painterResource(R.drawable.ic_swap_direction),
+            contentDescription = stringResource(R.string.route_header_switch_direction),
+        )
+    }
+    if (showPicker) {
+        val unnamed = stringResource(R.string.route_direction_unnamed)
+        AlertDialog(
+            onDismissRequest = { showPicker = false },
+            title = { Text(stringResource(R.string.route_header_switch_direction)) },
+            text = {
+                RadioOptionList(
+                    options = directions.map { it.labelOr(unnamed) }.toTypedArray(),
+                    selectedIndex = directions.indexOfFirst { it.directionId == currentDirectionId },
+                    onSelect = { index ->
+                        showPicker = false
+                        onSelectDirection(directions[index].directionId)
+                    },
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = { showPicker = false }) {
+                    Text(stringResource(android.R.string.cancel))
+                }
+            },
+        )
+    }
+}
+
+/** The direction's headsign, or [unnamed] when the stop group carried no display name. */
+private fun RouteMapDirection.labelOr(unnamed: String): String = label.ifBlank { unnamed }
+
 @Preview(showBackground = true, widthDp = 380)
 @Composable
 private fun RouteHeaderOverlayPreview() {
     ObaTheme {
         Column {
-            // A short route short name.
+            // Two directions: the swap icon toggles between them; the current headsign shows as a subtitle.
             RouteHeaderOverlay(
                 header = RouteHeader(
                     loading = false,
                     shortName = "40",
                     longName = "Downtown Seattle - Northgate",
                     agency = "King County Metro",
+                    directions = listOf(
+                        RouteMapDirection(0, "to Downtown Seattle"),
+                        RouteMapDirection(1, "to Northgate"),
+                    ),
+                    currentDirectionId = 0,
                 ),
                 onCancel = {},
+                onSelectDirection = {},
                 onHeight = {},
             )
             Spacer(Modifier.size(12.dp))
-            // A long route short name: it should ellipsize rather than crowd out the long name.
+            // Whole-route launch (no direction resolved yet): swap icon shown, no subtitle; a tap picks a direction.
+            RouteHeaderOverlay(
+                header = RouteHeader(
+                    loading = false,
+                    shortName = "40",
+                    longName = "Downtown Seattle - Northgate",
+                    agency = "King County Metro",
+                    directions = listOf(
+                        RouteMapDirection(0, "to Downtown Seattle"),
+                        RouteMapDirection(1, "to Northgate"),
+                    ),
+                    currentDirectionId = null,
+                ),
+                onCancel = {},
+                onSelectDirection = {},
+                onHeight = {},
+            )
+            Spacer(Modifier.size(12.dp))
+            // More than two directions: the swap icon opens a picker. A long route short name ellipsizes.
             RouteHeaderOverlay(
                 header = RouteHeader(
                     loading = false,
                     shortName = "Mount Si. Trailhead",
                     longName = "North Bend - Snoqualmie Falls Express",
                     agency = "King County Metro",
+                    directions = listOf(
+                        RouteMapDirection(0, "to North Bend"),
+                        RouteMapDirection(1, "to Snoqualmie Falls"),
+                        RouteMapDirection(2, "to Issaquah"),
+                    ),
+                    currentDirectionId = 1,
                 ),
                 onCancel = {},
+                onSelectDirection = {},
+                onHeight = {},
+            )
+            Spacer(Modifier.size(12.dp))
+            // A single-direction route: no swap icon, no subtitle.
+            RouteHeaderOverlay(
+                header = RouteHeader(
+                    loading = false,
+                    shortName = "8",
+                    longName = "Capitol Hill - Rainier Beach",
+                    agency = "King County Metro",
+                ),
+                onCancel = {},
+                onSelectDirection = {},
                 onHeight = {},
             )
             Spacer(Modifier.size(12.dp))
@@ -145,6 +277,7 @@ private fun RouteHeaderOverlayPreview() {
             RouteHeaderOverlay(
                 header = RouteHeader(loading = true, shortName = "", longName = "", agency = ""),
                 onCancel = {},
+                onSelectDirection = {},
                 onHeight = {},
             )
         }

--- a/onebusaway-android/src/main/res/drawable/ic_swap_direction.xml
+++ b/onebusaway-android/src/main/res/drawable/ic_swap_direction.xml
@@ -1,0 +1,12 @@
+<!-- Material Symbols "swap_vert" — the switch-direction affordance in the route header.
+     Tinted by the Compose Icon's content color at draw time. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M16,17.01L16,10h-2v7.01h-3L15,21l4,-3.99h-3zM9,3L5,6.99h3L8,14h2L10,6.99h3L9,3z" />
+</vector>

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -337,6 +337,10 @@
     <string name="route_info_context_showonmap">Show on map</string>
     <string name="route_info_no_shape_data">Sorry, map information isn\'t available for this route
     </string>
+    <!-- Route map header: switch which direction of the route is shown -->
+    <string name="route_header_switch_direction">Switch direction</string>
+    <!-- Fallback label for a route direction whose headsign is missing -->
+    <string name="route_direction_unnamed">Other direction</string>
 
     <!-- My stops/routes -->
     <string name="my_recent_title">Recent</string>

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
@@ -97,8 +97,8 @@ class MapLibreRenderer(
 
     // The dynamic layer, tracked by identity so [renderDynamic] can move markers in place: route
     // vehicles keyed by active trip id, the trip-focus estimate markers keyed by role, and the band's
-    // (interaction-free) polylines re-added each frame. [lastVehicleResponse] is the latest poll — both
-    // the change-detector for the vehicle reconcile and the source for [vehicleResponse].
+    // (interaction-free) polylines re-added each frame. [lastVehicleResponse] is the current poll, set on
+    // each vehicle-set reconcile and read by [vehicleResponse].
     private val vehicleMarkersByTripId = HashMap<String, Marker>()
     private val tripMarkersByRole = HashMap<String, Marker>()
     private val bandPolylines = mutableListOf<Polyline>()
@@ -244,20 +244,27 @@ class MapLibreRenderer(
      * fix via [nowMs]); the band is re-added.
      */
     fun renderDynamic(overlay: TripOverlay?, vehicles: MapVehicles?, nowMs: Long) {
-        updateVehicles(vehicles, nowMs)
+        moveVehicles(vehicles, nowMs)
         updateTripOverlay(overlay, nowMs)
     }
 
-    private fun updateVehicles(vehicles: MapVehicles?, nowMs: Long) {
+    /**
+     * Reconcile the vehicle marker *set* (add/remove markers, refresh icons/titles/tap-routing) against a
+     * pushed [MapRenderState.vehicleSet] emission — a new poll, a direction switch, or leaving route mode
+     * (null). Driven reactively by the adapter, not the frame loop, so the set changes the instant it's
+     * published rather than being inferred from the per-frame motion sample.
+     */
+    fun reconcileVehicles(set: MapVehicles?) {
+        reconcileVehicleMarkers(set?.markers.orEmpty(), set?.response)
+        lastVehicleResponse = set?.response
+    }
+
+    // Per-frame motion: move each already-reconciled marker to its smoothed extrapolated position — no set
+    // diffing or icon work on the hot path, only an icon re-stamp when a vehicle's heading octant flips.
+    // Markers not yet reconciled are skipped.
+    private fun moveVehicles(vehicles: MapVehicles?, nowMs: Long) {
         val response = vehicles?.response
         val markers = vehicles?.markers.orEmpty()
-        // The vehicle set, icons/titles, and tap-routing only change on a new poll (response identity),
-        // so reconcile then. Every display frame in between just moves each marker to its smoothed
-        // extrapolated position — no set diffing or icon work on the hot path.
-        if (response !== lastVehicleResponse) {
-            reconcileVehicleMarkers(markers, response)
-            lastVehicleResponse = response
-        }
         for (vehicle in markers) {
             val marker = vehicleMarkersByTripId[vehicle.activeTripId] ?: continue
             marker.moveTo(

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreComposeAdapter.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreComposeAdapter.kt
@@ -167,6 +167,13 @@ class MapLibreComposeAdapter : ObaComposeMapAdapter {
                     renderState.tripStops.map { },
                 ).collect { activeRenderer.renderStatic() }
             }
+            // The vehicle set (which vehicles exist + their icons): reconcile the markers whenever it's
+            // pushed — a poll, a direction switch, or leaving route mode (null). Discrete, so it's reactive
+            // (not inferred from the per-frame motion loop below), which is what makes a direction switch
+            // take effect immediately instead of waiting for the next poll.
+            LaunchedEffect(activeRenderer) {
+                renderState.vehicleSet.collect { activeRenderer.reconcileVehicles(it) }
+            }
             // Dynamic layer (the live vehicles + the trip-focus band/markers): while either sampler is
             // installed, pull a fresh frame each display frame and update the annotations in place.
             // withFrameNanos paces us to the display refresh and idles when nothing's drawing.

--- a/onebusaway-android/src/test/java/org/onebusaway/android/api/data/MapDataSourceDirectionsTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/api/data/MapDataSourceDirectionsTest.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.api.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.onebusaway.android.api.contract.StopGroup
+import org.onebusaway.android.api.contract.StopGroupName
+import org.onebusaway.android.api.contract.StopGrouping
+import org.onebusaway.android.models.RouteMapDirection
+
+/** [directionsFrom] — building the route's selectable directions + stop membership from stop groups. */
+class MapDataSourceDirectionsTest {
+
+    private fun group(id: String?, names: List<String> = emptyList(), stopIds: List<String> = emptyList()) =
+        StopGroup(id = id, name = StopGroupName(names), stopIds = stopIds)
+
+    private fun grouping(vararg groups: StopGroup) = StopGrouping(groups.toList())
+
+    private fun directionsOf(groupings: List<StopGrouping>) = directionsFrom(groupings).directions
+
+    @Test
+    fun numericGroupsBecomeDirectionsWithHeadsigns() {
+        val result = directionsOf(listOf(grouping(group("0", listOf("to Downtown")), group("1", listOf("to Northgate")))))
+        assertEquals(
+            listOf(RouteMapDirection(0, "to Downtown"), RouteMapDirection(1, "to Northgate")),
+            result,
+        )
+    }
+
+    @Test
+    fun nonNumericGroupIdsAreDropped() {
+        val result = directionsOf(listOf(grouping(group("loop", listOf("Loop")), group("0", listOf("to Downtown")))))
+        assertEquals(listOf(RouteMapDirection(0, "to Downtown")), result)
+    }
+
+    @Test
+    fun nullGroupIdsAreDropped() {
+        val result = directionsOf(listOf(grouping(group(null, listOf("Unnamed")), group("1", listOf("to Northgate")))))
+        assertEquals(listOf(RouteMapDirection(1, "to Northgate")), result)
+    }
+
+    @Test
+    fun duplicateIdsKeepTheFirstAndAreSorted() {
+        // Same id in two groups (across groupings): first wins; results sorted by id.
+        val result = directionsOf(
+            listOf(
+                grouping(group("1", listOf("to Northgate")), group("0", listOf("to Downtown"))),
+                grouping(group("1", listOf("to Northgate Alt"))),
+            )
+        )
+        assertEquals(
+            listOf(RouteMapDirection(0, "to Downtown"), RouteMapDirection(1, "to Northgate")),
+            result,
+        )
+    }
+
+    @Test
+    fun blankOrAbsentDisplayNameYieldsEmptyLabel() {
+        val result = directionsOf(listOf(grouping(group("0"), group("1", listOf("")))))
+        assertEquals(listOf(RouteMapDirection(0, ""), RouteMapDirection(1, "")), result)
+    }
+
+    @Test
+    fun emptyGroupingsYieldNoDirections() {
+        assertEquals(emptyList<RouteMapDirection>(), directionsOf(emptyList()))
+    }
+
+    @Test
+    fun directionsByStopTagsEachStopAndSharesBothForOverlaps() {
+        val result = directionsFrom(
+            listOf(
+                grouping(
+                    group("0", listOf("to Downtown"), stopIds = listOf("a", "shared")),
+                    group("1", listOf("to Northgate"), stopIds = listOf("b", "shared")),
+                )
+            )
+        )
+        assertEquals(setOf(0), result.directionsByStop["a"])
+        assertEquals(setOf(1), result.directionsByStop["b"])
+        assertEquals(setOf(0, 1), result.directionsByStop["shared"])
+        assertEquals(null, result.directionsByStop["absent"])
+    }
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteDirectionFocusTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteDirectionFocusTest.kt
@@ -21,7 +21,10 @@ import org.junit.Test
 import org.onebusaway.android.api.adapters.ObaStopElement
 import org.onebusaway.android.models.RouteMapStop
 
-/** [focusDirection] — the pure "narrow a route to the stop-relevant direction" repository helper. */
+/**
+ * [anchorDirectionId] (resolve the launch anchor stop → its direction) and [stopsForDirection]
+ * (narrow a route's stops to a direction) — the pure repository/controller direction helpers.
+ */
 class RouteDirectionFocusTest {
 
     private fun stop(id: String, vararg directions: Int) =
@@ -30,58 +33,61 @@ class RouteDirectionFocusTest {
     // Outbound (direction 0) serves a/b, inbound (direction 1) serves c/d.
     private val stops = listOf(stop("a", 0), stop("b", 0), stop("c", 1), stop("d", 1))
 
+    // ----- anchorDirectionId -----
+
     @Test
-    fun nullAnchorKeepsWholeRoute() {
-        val focus = stops.focusDirection(anchorStopId = null)
-        assertEquals(listOf("a", "b", "c", "d"), focus.stops.map { it.id })
-        assertNull(focus.directionId)
+    fun nullAnchorResolvesNoDirection() {
+        assertNull(stops.anchorDirectionId(anchorStopId = null))
     }
 
     @Test
-    fun anchorInOneDirectionFiltersStopsAndResolvesId() {
-        val focus = stops.focusDirection(anchorStopId = "c")
-        assertEquals(listOf("c", "d"), focus.stops.map { it.id })
-        assertEquals(1, focus.directionId)
+    fun anchorInOneDirectionResolvesItsId() {
+        assertEquals(1, stops.anchorDirectionId(anchorStopId = "c"))
+        assertEquals(0, stops.anchorDirectionId(anchorStopId = "a"))
+    }
+
+    @Test
+    fun ambiguousSharedAnchorResolvesNoDirection() {
+        // Anchoring on a stop that serves both directions is ambiguous -> whole route.
+        val withShared = stops + stop("s", 0, 1)
+        assertNull(withShared.anchorDirectionId(anchorStopId = "s"))
+    }
+
+    @Test
+    fun anchorNotAmongStopsResolvesNoDirection() {
+        assertNull(stops.anchorDirectionId(anchorStopId = "zzz"))
+    }
+
+    @Test
+    fun ungroupedAnchorResolvesNoDirection() {
+        // A stop with no direction membership (route without a numeric direction grouping) -> whole route.
+        val withUngrouped = stops + stop("u")
+        assertNull(withUngrouped.anchorDirectionId(anchorStopId = "u"))
+    }
+
+    // ----- stopsForDirection -----
+
+    @Test
+    fun nullDirectionKeepsWholeRoute() {
+        assertEquals(listOf("a", "b", "c", "d"), stops.stopsForDirection(null).map { it.id })
+    }
+
+    @Test
+    fun directionFiltersToItsStops() {
+        assertEquals(listOf("c", "d"), stops.stopsForDirection(1).map { it.id })
     }
 
     @Test
     fun filteredStopsPreserveSourceOrder() {
         // A source order of d before c must survive the filter to direction 1.
         val reordered = listOf(stop("d", 1), stop("c", 1), stop("a", 0))
-        assertEquals(listOf("d", "c"), reordered.focusDirection("c").stops.map { it.id })
+        assertEquals(listOf("d", "c"), reordered.stopsForDirection(1).map { it.id })
     }
 
     @Test
     fun sharedStopInTargetDirectionIsIncluded() {
-        // A stop serving both directions shows for the tapped one (not dropped).
+        // A stop serving both directions shows for the selected one (not dropped).
         val withShared = stops + stop("s", 0, 1)
-        val focus = withShared.focusDirection(anchorStopId = "a")
-        assertEquals(listOf("a", "b", "s"), focus.stops.map { it.id })
-        assertEquals(0, focus.directionId)
-    }
-
-    @Test
-    fun ambiguousSharedAnchorKeepsWholeRoute() {
-        // Anchoring on a stop that serves both directions is ambiguous -> whole route.
-        val withShared = stops + stop("s", 0, 1)
-        val focus = withShared.focusDirection(anchorStopId = "s")
-        assertEquals(5, focus.stops.size)
-        assertNull(focus.directionId)
-    }
-
-    @Test
-    fun anchorNotAmongStopsKeepsWholeRoute() {
-        val focus = stops.focusDirection(anchorStopId = "zzz")
-        assertEquals(4, focus.stops.size)
-        assertNull(focus.directionId)
-    }
-
-    @Test
-    fun ungroupedAnchorKeepsWholeRoute() {
-        // A stop with no direction membership (route without a numeric direction grouping) -> whole route.
-        val withUngrouped = stops + stop("u")
-        val focus = withUngrouped.focusDirection(anchorStopId = "u")
-        assertEquals(5, focus.stops.size)
-        assertNull(focus.directionId)
+        assertEquals(listOf("a", "b", "s"), withShared.stopsForDirection(0).map { it.id })
     }
 }


### PR DESCRIPTION
## Summary

The "show vehicles on map" route view is single-direction (anchored to the launching stop's direction). This adds a Material3 swap affordance to the route header so the rider can switch directions in place:

- **1 direction** → no icon
- **exactly 2** → tap toggles to the other direction
- **more than 2** → an `AlertDialog` picker lists each direction by headsign

The header also shows the current direction's headsign, and the choice is persisted across process death.

## How it works

- Directions (GTFS id + headsign) are now carried through the map data path (`stops-for-route` stop groups) — they were previously discarded. `RouteMapController` retains the full route and re-filters stops + vehicles on a switch with **no network reload**.
- The route-mode vehicle layer is split by change-rate so a switch takes effect immediately instead of waiting for the next poll: the vehicle **set** (membership + icons) is pushed declaratively via `MapRenderState.vehicleSet` and reconciled reactively by each renderer (Google + MapLibre), while per-frame **motion** stays in the pull-based sampler. This removes the previous reconcile gate that inferred set changes from response identity.

## Deliberate limitations

- A route whose "direction" stop grouping exposes branch ids beyond GTFS `0/1` will list those directions and their stops, but no vehicle's trip `directionId` will match, so the vehicle layer is empty for such a selection (documented at `directionsFrom`).
- After switching direction there is no header entry to return to the whole-route (both-directions) view; you exit route mode and re-launch. The swap toggles between concrete directions.

## Testing

- Unit tests: `RouteDirectionFocusTest` (anchor→direction resolution + stop narrowing), `MapDataSourceDirectionsTest` (`directionsFrom`).
- Both `google` and `maplibre` flavors compile; unit tests pass.
- On-device (Pixel 7 Pro): swap is instant, normal poll updates + the trip-focus map still behave, the >2 picker works, and the switched direction survives background/rotate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added route-direction switching in the map header, including swap control (2 directions) and a direction picker (3+).
  * Route maps now support direction-specific rendering and remember the selected direction across restarts.
* **Bug Fixes**
  * Improved responsiveness and smoothness of route-mode vehicle marker updates when direction or live data changes.
* **UI Improvements**
  * Added a reusable radio-option list component for route selection dialogs, and updated header visuals/text (including a fallback “unnamed” label).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->