### PR TITLE
Fix trip planner map trapped in draggable results sheet (#1640)

### DIFF
--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleComposeAdapter.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleComposeAdapter.kt
@@ -50,6 +50,7 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.flow.onSubscription
 import org.onebusaway.android.R
 import org.onebusaway.android.map.MapHost
 import org.onebusaway.android.map.compose.BikeInfoWindow
@@ -244,7 +245,12 @@ class GoogleComposeAdapter : ObaComposeMapAdapter {
                 onDispose { host.setMapAttached(false) }
             }
             LaunchedEffect(map) {
-                renderState.cameraCommands.collect { applyCameraCommand(it, map, renderState, context) }
+                renderState.cameraCommands
+                    // Flush any frame deferred while the map was detached the moment this collector is
+                    // registered — emissions made in onSubscription are delivered here, so a deferred
+                    // fit isn't dropped by the no-replay flow if the first camera-idle beats us (#1640).
+                    .onSubscription { host.onCameraCommandsSubscribed() }
+                    .collect { applyCameraCommand(it, map, renderState, context) }
             }
             // Publish a flavor-neutral lat/lng -> root-space projector so map-SDK-agnostic callers (the
             // onboarding spotlight) can locate a marker on screen without touching the Google SDK.

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/DirectionsMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/DirectionsMapController.kt
@@ -21,7 +21,6 @@ import android.util.Log
 import org.onebusaway.android.directions.util.OTPConstants
 import org.onebusaway.android.models.ObaShape
 import org.onebusaway.android.util.PolylineDecoder
-import org.onebusaway.android.map.render.CameraCommand
 import org.onebusaway.android.map.render.GeoPoint
 import org.onebusaway.android.map.render.RoutePolyline
 import org.opentripplanner.api.model.EncodedPolylineBean
@@ -87,19 +86,16 @@ class DirectionsMapController(private val host: MapHost) {
 
     /**
      * Frames the current directions itinerary: fit the route shape, or (no route — start == end)
-     * center on the start at the default zoom. Re-appliable so the owner can frame once the map is
-     * ready (the frame dispatched at [start] time is lost before the adapter subscribes).
+     * center on the start at the default zoom. Both cases route through [MapHost] framing helpers
+     * ([MapHost.frameItinerary] / [MapHost.frameStart]), which dispatch now if the map adapter is
+     * attached and otherwise defer until it subscribes — so a frame issued before the adapter subscribes
+     * (the map is drawn behind the results sheet the instant a plan completes) isn't dropped.
      */
     fun frameDirections() {
         if (directionsHasRoute) {
-            host.dispatchCamera(CameraCommand.FitToItinerary)
+            host.frameItinerary()
         } else {
-            directionsStart?.let {
-                host.dispatchCamera(
-                    CameraCommand.Recenter(it.latitude, it.longitude, animate = false, applyRouteBias = false)
-                )
-                host.dispatchCamera(CameraCommand.SetZoom(MapParams.DEFAULT_ZOOM.toFloat()))
-            }
+            directionsStart?.let { host.frameStart(it.latitude, it.longitude) }
         }
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/DirectionsMapViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/DirectionsMapViewModel.kt
@@ -22,10 +22,8 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
-import kotlinx.coroutines.flow.StateFlow
 import org.onebusaway.android.location.LocationRepository
 import org.onebusaway.android.map.bike.BikeStationsRepository
-import org.onebusaway.android.map.render.CameraSnapshot
 import org.onebusaway.android.preferences.PreferencesRepository
 import org.onebusaway.android.region.RegionRepository
 import org.opentripplanner.api.model.Itinerary
@@ -36,8 +34,10 @@ import org.opentripplanner.api.model.Itinerary
  * route header / vehicle poll, no trip-focus overlay, no Home command bus. That keeps the trip-results
  * map from instantiating the home map's full machinery just to draw an itinerary.
  *
- * [showItinerary] draws the selected itinerary (and turns on its own bike-share stations);
- * [frameDirections] re-fits it once the map is ready. Deps are constructor-injected by Hilt.
+ * [showItinerary] draws the selected itinerary (and turns on its own bike-share stations) and frames
+ * it — deferring the frame to the first camera-idle if the map adapter isn't attached yet (see
+ * [MapHost.frameItinerary]), so the initial fit isn't lost when the map is composed behind the results
+ * sheet on plan completion. Deps are constructor-injected by Hilt.
  */
 @HiltViewModel
 class DirectionsMapViewModel @Inject constructor(
@@ -61,9 +61,6 @@ class DirectionsMapViewModel @Inject constructor(
     /** The shared map surface the flavor adapter binds to. */
     val host: MapHost get() = mapHost
 
-    /** The live camera, published by the adapter on each idle (the screen frames on the first idle). */
-    val camera: StateFlow<CameraSnapshot?> get() = mapHost.camera
-
     private val directionsController = DirectionsMapController(mapHost)
 
     private val bikeController = BikeLayerController(
@@ -84,7 +81,4 @@ class DirectionsMapViewModel @Inject constructor(
             selectedBikeStationIds = DirectionsMapController.bikeStationIdsFromItinerary(itinerary),
         )
     }
-
-    /** Re-fit the current itinerary once the map is ready (re-appliable). */
-    fun frameDirections() = directionsController.frameDirections()
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapHost.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapHost.kt
@@ -94,17 +94,47 @@ class MapHost(
         savedStateHandle[MapParams.CENTER_LAT] = snapshot.center.latitude
         savedStateHandle[MapParams.CENTER_LON] = snapshot.center.longitude
         savedStateHandle[MapParams.ZOOM] = snapshot.zoom.toFloat()
-        // A region change that arrived before the map was ready deferred its framing to here (the first
-        // idle means the adapter is composed + subscribed to cameraCommands, so the command won't be lost).
+        // Apply any frame deferred while the map wasn't ready, but ONLY once the adapter's command
+        // collector is actually subscribed — not merely attached. [setMapAttached] runs in a
+        // DisposableEffect that fires *before* the separate LaunchedEffect that subscribes to
+        // [MapRenderState.cameraCommands], so there's a window where mapAttached is true but no collector
+        // exists yet; a map tearing down likewise reports a final idle after its collector is gone.
+        // Flushing then would dispatch the pending frame into a no-replay flow with no subscriber, losing
+        // it and stranding the camera at the (0,0) seed. This path only covers the
+        // "attached + subscribed but not yet idled" window (e.g. a region resolving just after attach);
+        // the reliable flush on (re)attach is [onCameraCommandsSubscribed].
+        if (mapAttached && cameraCommandsSubscribed) applyDeferredCameraFrames()
+    }
+
+    /**
+     * Apply any camera frame requested while the map was detached: the region re-zoom ([rezoomForRegion]),
+     * the route re-fit ([frameRoute]), or the directions itinerary fit ([frameItinerary]). The
+     * camera-command flow has no replay, so a frame dispatched before a collector exists is lost —
+     * these deferrals hold the intent until the map is ready, then dispatch it against a live subscriber.
+     */
+    private fun applyDeferredCameraFrames() {
         if (pendingRegionFrame) {
             pendingRegionFrame = false
             frameCurrentRegion()
         }
-        // Likewise a route re-frame requested while the map was detached (see [frameRoute]).
-        if (pendingRouteFrame) {
-            pendingRouteFrame = false
-            dispatchCamera(CameraCommand.FitToRoute)
+        if (pendingFrameCommands.isNotEmpty()) {
+            val commands = pendingFrameCommands
+            pendingFrameCommands = emptyList()
+            commands.forEach { dispatchCamera(it) }
         }
+    }
+
+    /**
+     * The flavor adapter calls this the instant it subscribes to [MapRenderState.cameraCommands] (from
+     * `Flow.onSubscription`), so a frame deferred while the map was detached is dispatched against a
+     * guaranteed-live collector rather than racing it. The first `onCameraIdle` can fire *before* the
+     * adapter's collector is registered — with a no-replay command flow that dropped the deferred frame,
+     * leaving the camera at the (0,0) world seed (the trip-plan directions map, drawn behind the results
+     * sheet the moment a plan completes, hit this every time).
+     */
+    fun onCameraCommandsSubscribed() {
+        cameraCommandsSubscribed = true
+        applyDeferredCameraFrames()
     }
 
     /**
@@ -166,34 +196,71 @@ class MapHost(
 
     fun dispatchCamera(command: CameraCommand) = renderState.dispatchCamera(command)
 
-    // Whether a flavor map adapter is currently composed + subscribed to [cameraCommands]. Toggled by the
-    // adapter on composition enter/leave; lets [frameRoute] choose between dispatching now and deferring.
+    // Whether a flavor map adapter is currently composed. Toggled by the adapter on composition
+    // enter/leave; lets [frameOrDefer] choose between dispatching now and deferring.
     private var mapAttached = false
 
-    // Set when a route re-frame is requested while the map is detached — the camera-command flow has no
-    // replay, so a command dispatched before the adapter (re)subscribes is lost. Consumed on the first
-    // onCameraIdle after it re-attaches (when it's composed, laid out, and subscribed). Like [pendingRegionFrame].
-    private var pendingRouteFrame = false
+    // Whether the adapter's [MapRenderState.cameraCommands] collector is actually subscribed. Distinct
+    // from [mapAttached] because the adapter sets attached in a DisposableEffect that runs *before* the
+    // LaunchedEffect that subscribes, so there's an attached-but-not-subscribed window; a deferred flush
+    // into the no-replay command flow during it would be lost. Set on subscribe ([onCameraCommandsSubscribed]),
+    // cleared on detach so a re-attach re-arms it.
+    private var cameraCommandsSubscribed = false
+
+    // Set when a framing move (route/itinerary bounds fit, or the degenerate directions start-center) is
+    // requested while the map is detached — the camera-command flow has no replay, so a command
+    // dispatched before the adapter (re)subscribes is lost. Holds the latest such frame's commands until
+    // the map is ready (see [frameOrDefer]); a single pending frame is enough because a given host only
+    // ever fits one thing (the home map fits a route, the trip-results map fits an itinerary), but the
+    // start-center frame is two commands (recenter + zoom), so it's a list. The region re-zoom is
+    // deferred separately via [pendingRegionFrame] because it runs decision logic ([frameCurrentRegion]).
+    private var pendingFrameCommands: List<CameraCommand> = emptyList()
 
     /** The flavor adapter reports when its render-state subscription starts/ends (the map composable enter/leave). */
     fun setMapAttached(attached: Boolean) {
         mapAttached = attached
+        if (!attached) cameraCommandsSubscribed = false
     }
 
     /**
-     * Frame the active route's bounding box (the "zoom to route" camera move). Dispatches now when a map
-     * adapter is attached; otherwise defers to the first [onCameraIdle] after one re-attaches, so the frame
-     * isn't dropped when re-selecting the already-shown route from a list that navigates back to a freshly
-     * re-created map (the recent-routes case). The route's shape is already in the render state, so the
-     * deferred [CameraCommand.FitToRoute] has bounds to fit.
+     * Dispatch a framing move now when the map adapter's command collector is subscribed; otherwise hold
+     * it until the map is ready (flushed by [onCameraCommandsSubscribed], or [applyDeferredCameraFrames]
+     * on the first idle), so a frame isn't dropped into the no-replay command flow when it's requested
+     * against a map that's attached but hasn't subscribed yet (the [setMapAttached] DisposableEffect runs
+     * before the subscribing LaunchedEffect). The shape/route is already in the render state, so a
+     * deferred bounds-fit has bounds to fit.
      */
-    fun frameRoute() {
-        if (mapAttached) {
-            dispatchCamera(CameraCommand.FitToRoute)
+    private fun frameOrDefer(vararg commands: CameraCommand) {
+        if (mapAttached && cameraCommandsSubscribed) {
+            commands.forEach { dispatchCamera(it) }
         } else {
-            pendingRouteFrame = true
+            pendingFrameCommands = commands.toList()
         }
     }
+
+    /**
+     * Frame the active route's bounding box (the "zoom to route" camera move). Deferred if the map isn't
+     * ready — e.g. re-selecting the already-shown route from a list that navigates back to a freshly
+     * re-created map (the recent-routes case).
+     */
+    fun frameRoute() = frameOrDefer(CameraCommand.FitToRoute)
+
+    /**
+     * Frame the current directions itinerary's bounding box. Deferred if the map isn't ready — the
+     * directions map is composed behind the results sheet the instant a plan completes, before the
+     * adapter subscribes to the command flow.
+     */
+    fun frameItinerary() = frameOrDefer(CameraCommand.FitToItinerary)
+
+    /**
+     * Frame a degenerate directions itinerary (no route shape — start == end): center on [lat],[lon] at
+     * the default zoom. Deferred like [frameItinerary] if the map isn't ready, since it's dispatched at
+     * the same moment (a plan completing behind the results sheet) and the command flow has no replay.
+     */
+    fun frameStart(lat: Double, lon: Double) = frameOrDefer(
+        CameraCommand.Recenter(lat, lon, animate = false, applyRouteBias = false),
+        CameraCommand.SetZoom(MapParams.DEFAULT_ZOOM.toFloat()),
+    )
 
     /** Animate/move the camera to a point with no route-header bias (a general recenter for any screen). */
     fun centerOn(lat: Double, lon: Double, animate: Boolean) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanScreen.kt
@@ -88,7 +88,10 @@ import org.onebusaway.android.ui.compose.components.ObaTopAppBar
 import org.onebusaway.android.ui.compose.components.SwitchRow
 import org.onebusaway.android.ui.compose.findActivity
 import org.onebusaway.android.ui.nav.NavRoutes
-import org.onebusaway.android.ui.tripresults.TripResults
+import org.onebusaway.android.map.DirectionsMapViewModel
+import org.onebusaway.android.ui.tripresults.TripResultsMap
+import org.onebusaway.android.ui.tripresults.TripResultsSheet
+import org.onebusaway.android.ui.tripresults.TripResultsViewModel
 import org.onebusaway.android.util.BikeshareAvailability
 import org.onebusaway.android.util.ExternalIntents
 import org.onebusaway.android.util.LocationUtils
@@ -216,10 +219,13 @@ fun TripPlanDestination(navController: NavHostController, onBack: () -> Unit) {
 }
 
 /**
- * The trip-plan container: the [TripPlanForm] is the main content; when a plan completes, the
- * results appear inline in a Material3 bottom sheet via [TripResults] (Compose, owning its own
- * directions-mode map). Date/time/contacts/current-location/advanced/report are platform interactions
- * delegated to the host Activity.
+ * The trip-plan container: before a plan completes the [TripPlanForm] is the scaffold body; once results
+ * arrive, the directions map ([TripResultsMap]) takes over the scaffold *body* and the results header +
+ * directions list appear in a Material3 bottom sheet over it ([TripResultsSheet]). Dragging the sheet
+ * down reveals the map — so the interactive map owns its own gesture area instead of being trapped in the
+ * draggable sheet (#1640). Back walks the sheet from expanded → peek → dismissed (form) before exiting.
+ * Date/time/contacts/current-location/advanced/report are platform interactions delegated to the host
+ * Activity.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -240,6 +246,14 @@ fun TripPlanRoute(
     val formState by viewModel.formState.collectAsStateWithLifecycle()
     val planState by viewModel.planState.collectAsStateWithLifecycle()
 
+    // The results VMs are hoisted here (not created inside the sheet content) so the map can render as
+    // the scaffold *body* — behind the sheet — while the results header + directions list stay in the
+    // sheet. The map is revealed by dragging the sheet down, so an interactive map never sits inside the
+    // draggable bottom sheet, which would otherwise steal its vertical drags (#1640). Both are scoped to
+    // this destination's back-stack entry, so hoisting doesn't change their identity or lifetime.
+    val resultsViewModel: TripResultsViewModel = hiltViewModel()
+    val mapViewModel: DirectionsMapViewModel = hiltViewModel(key = "tripResultsMap")
+
     val scaffoldState = rememberBottomSheetScaffoldState(
         bottomSheetState = rememberStandardBottomSheetState(
             initialValue = SheetValue.Hidden,
@@ -250,13 +264,18 @@ fun TripPlanRoute(
     val scope = rememberCoroutineScope()
     val sheetExpanded = scaffoldState.bottomSheetState.currentValue == SheetValue.Expanded
 
-    // Back (system or toolbar) collapses an expanded results sheet first, then exits — mirrors
-    // the legacy sliding-panel behavior (onBackPressed collapsed the panel before finishing).
+    // Back (system or toolbar) walks the results back to the form before exiting: an expanded sheet
+    // collapses to its peek (revealing the map behind it), the peek dismisses the results (returning the
+    // form as the scaffold body), and only then does back exit the screen. Since the map — not the form —
+    // now sits behind the sheet, this peek step is how the user gets back to the form to re-plan.
     val collapseOrBack: () -> Unit = {
-        if (sheetExpanded) scope.launch { scaffoldState.bottomSheetState.partialExpand() }
-        else onBack()
+        when {
+            sheetExpanded -> scope.launch { scaffoldState.bottomSheetState.partialExpand() }
+            hasResults -> viewModel.clearPlanResult()
+            else -> onBack()
+        }
     }
-    BackHandler(enabled = sheetExpanded) { collapseOrBack() }
+    BackHandler(enabled = hasResults) { collapseOrBack() }
 
     // Expand the sheet when results arrive; hide it when the form is reset to Idle.
     LaunchedEffect(planState) {
@@ -279,35 +298,47 @@ fun TripPlanRoute(
             sheetContent = {
                 val result = planState
                 if (result is PlanResult.Success) {
-                    TripResults(
+                    TripResultsSheet(
                         itineraries = result.itineraries,
+                        resultsViewModel = resultsViewModel,
+                        mapViewModel = mapViewModel,
                         modifier = Modifier.fillMaxSize()
                     )
                 }
             }
         ) { padding ->
-            Column(Modifier.padding(padding)) {
-                if (planState is PlanResult.Loading) {
-                    LinearProgressIndicator(Modifier.fillMaxWidth())
-                }
-                TripPlanForm(
-                    state = formState,
-                    onFromQueryChange = viewModel::onFromQueryChange,
-                    onToQueryChange = viewModel::onToQueryChange,
-                    onSelectFrom = viewModel::setFrom,
-                    onSelectTo = viewModel::setTo,
-                    onFromCurrentLocation = onFromCurrentLocation,
-                    onToCurrentLocation = onToCurrentLocation,
-                    onFromContacts = onFromContacts,
-                    onToContacts = onToContacts,
-                    onFromPickOnMap = onFromPickOnMap,
-                    onToPickOnMap = onToPickOnMap,
-                    onSetArriving = viewModel::setArriving,
-                    onPickDate = onPickDate,
-                    onPickTime = onPickTime,
-                    onReverse = viewModel::reverseTrip,
-                    onAdvancedSettings = onAdvancedSettings
+            // With results, the directions map fills the scaffold body, behind the peeking sheet, so it
+            // owns its whole gesture area and vertical drags pan the map — dragging the sheet down reveals
+            // it (#1640). Before a plan completes, the body is the trip-plan form.
+            if (hasResults) {
+                TripResultsMap(
+                    mapViewModel = mapViewModel,
+                    modifier = Modifier.fillMaxSize()
                 )
+            } else {
+                Column(Modifier.padding(padding)) {
+                    if (planState is PlanResult.Loading) {
+                        LinearProgressIndicator(Modifier.fillMaxWidth())
+                    }
+                    TripPlanForm(
+                        state = formState,
+                        onFromQueryChange = viewModel::onFromQueryChange,
+                        onToQueryChange = viewModel::onToQueryChange,
+                        onSelectFrom = viewModel::setFrom,
+                        onSelectTo = viewModel::setTo,
+                        onFromCurrentLocation = onFromCurrentLocation,
+                        onToCurrentLocation = onToCurrentLocation,
+                        onFromContacts = onFromContacts,
+                        onToContacts = onToContacts,
+                        onFromPickOnMap = onFromPickOnMap,
+                        onToPickOnMap = onToPickOnMap,
+                        onSetArriving = viewModel::setArriving,
+                        onPickDate = onPickDate,
+                        onPickTime = onPickTime,
+                        onReverse = viewModel::reverseTrip,
+                        onAdvancedSettings = onAdvancedSettings
+                    )
+                }
             }
         }
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
@@ -37,21 +37,19 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Tab
-import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -63,7 +61,6 @@ import android.app.NotificationManager
 import android.content.Context
 import android.os.Build
 import android.os.Bundle
-import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import org.onebusaway.android.R
 import org.onebusaway.android.app.Application
@@ -79,49 +76,29 @@ import org.onebusaway.android.ui.compose.theme.ObaTheme
 import org.opentripplanner.api.model.Itinerary
 
 /**
- * The results header: the (1–3) itinerary option cards plus the list/map tab row. Shown above the
- * directions list / map frame. Empty until the first [TripResultsUiState.Success].
+ * The results header: the (1–3) itinerary option cards. Shown above the directions list, pinned at the
+ * top of the results sheet. Empty until the first [TripResultsUiState.Success]. The map is revealed by
+ * dragging this sheet down — it renders as the scaffold body behind it ([TripResultsMap]) — so there is
+ * no list/map tab here (#1640).
  */
 @Composable
 fun TripResultsHeader(
     state: TripResultsUiState,
-    onSelectOption: (Int) -> Unit,
-    onTabSelected: (showMap: Boolean) -> Unit
+    onSelectOption: (Int) -> Unit
 ) {
     val success = state as? TripResultsUiState.Success ?: return
-    Column(Modifier.background(MaterialTheme.colorScheme.surface)) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(4.dp),
-            horizontalArrangement = Arrangement.spacedBy(2.dp)
-        ) {
-            success.options.forEachIndexed { index, option ->
-                OptionCard(
-                    option = option,
-                    selected = index == success.selectedIndex,
-                    onClick = { onSelectOption(index) }
-                )
-            }
-        }
-        val selectedTab = if (success.showMap) 1 else 0
-        TabRow(selectedTabIndex = selectedTab) {
-            Tab(
-                selected = selectedTab == 0,
-                onClick = { onTabSelected(false) },
-                text = { Text(stringResource(R.string.trip_plan_list_view)) },
-                icon = { Icon(painterResource(R.drawable.ic_list), contentDescription = null) }
-            )
-            Tab(
-                selected = selectedTab == 1,
-                onClick = { onTabSelected(true) },
-                text = { Text(stringResource(R.string.trip_plan_map_view)) },
-                icon = {
-                    Icon(
-                        painter = painterResource(R.drawable.ic_arrivals_styleb_action_map),
-                        contentDescription = null
-                    )
-                }
+    Row(
+        modifier = Modifier
+            .background(MaterialTheme.colorScheme.surface)
+            .fillMaxWidth()
+            .padding(4.dp),
+        horizontalArrangement = Arrangement.spacedBy(2.dp)
+    ) {
+        success.options.forEachIndexed { index, option ->
+            OptionCard(
+                option = option,
+                selected = index == success.selectedIndex,
+                onClick = { onSelectOption(index) }
             )
         }
     }
@@ -161,13 +138,13 @@ private fun RowScope.OptionCard(
 }
 
 /**
- * The directions list (or the loading/error state). Shown when the list tab is selected; the map tab
- * shows the declarative [ObaMap] instead.
+ * The directions list (or the loading/error state), filling the results sheet below the header. The map
+ * is the scaffold body behind the sheet ([TripResultsMap]), not a sibling tab.
  */
 @Composable
-fun TripResultsList(state: TripResultsUiState) {
+fun TripResultsList(state: TripResultsUiState, modifier: Modifier = Modifier) {
     Box(
-        Modifier
+        modifier
             .fillMaxSize()
             .background(colorResource(R.color.md_theme_surfaceContainer))
     ) {
@@ -194,54 +171,46 @@ fun TripResultsList(state: TripResultsUiState) {
 }
 
 /**
- * Stateful trip-results entry hosted inline in the trip-plan bottom sheet (Tier 1: replaces the former
- * `TripResultsFragment`). Owns the [TripResultsViewModel] (option cards + directions) and a
- * directions-mode [DirectionsMapViewModel]; renders the header plus either the directions list or the declarative
- * [ObaMap] per the list/map tab, frames the selected itinerary once the map settles, and starts the
- * background trip-update poller when the user has trip-update notifications enabled.
+ * The trip-results **sheet content**: the header (option cards) plus the directions list. Drives the
+ * [TripResultsViewModel] (option cards + directions) and the directions-mode [DirectionsMapViewModel] —
+ * seeds the plan and follows option selection onto the map — and starts the background trip-update
+ * poller when the user has trip-update notifications enabled. [DirectionsMapViewModel.showItinerary]
+ * both draws and frames the itinerary (deferring the frame until the map is ready), so no separate
+ * "map ready" step is needed here.
+ *
+ * The map itself is deliberately **not** drawn here: it renders as the trip-plan scaffold *body* (behind
+ * this sheet) via [TripResultsMap], revealed by dragging this sheet down. That keeps an interactive
+ * [ObaMap] out of the draggable bottom sheet, where the sheet's
+ * [androidx.compose.material3.BottomSheetScaffold] would otherwise steal its vertical drags (#1640).
+ * Both VMs are hoisted to the caller so the body and this sheet share them.
  */
 @Composable
-fun TripResults(
+fun TripResultsSheet(
     itineraries: List<Itinerary>,
+    resultsViewModel: TripResultsViewModel,
+    mapViewModel: DirectionsMapViewModel,
     modifier: Modifier = Modifier,
 ) {
-    val resultsViewModel: TripResultsViewModel = hiltViewModel()
-    val mapViewModel: DirectionsMapViewModel = hiltViewModel(key = "tripResultsMap")
     val state by resultsViewModel.state.collectAsStateWithLifecycle()
     val activity = LocalContext.current.findActivity()
 
-    // Re-frame the selected itinerary on the next camera idle (set on itinerary / map-shown change).
-    var needsFraming by remember { mutableStateOf(false) }
-
     // Seed from the completed plan + point the map at the first itinerary (the old bindResults).
     LaunchedEffect(itineraries) {
-        resultsViewModel.setItineraries(itineraries, initialIndex = 0, showMap = false)
-        itineraries.firstOrNull()?.let {
-            mapViewModel.showItinerary(it)
-            needsFraming = true
-        }
+        resultsViewModel.setItineraries(itineraries, initialIndex = 0)
+        itineraries.firstOrNull()?.let { mapViewModel.showItinerary(it) }
         maybeStartTripUpdates(activity, itineraries, index = 0)
     }
 
-    // Follow the selected option onto the map (the old observeSelection).
+    // Follow the selected option onto the map (the old observeSelection). Read [itineraries] through
+    // rememberUpdatedState so the long-lived collector always sees the latest list — keying the effect on
+    // resultsViewModel alone would pin the first snapshot, so a later selection could start trip updates
+    // for a stale plan after new results arrive (selectedItinerary is a no-replay SharedFlow, so keeping
+    // one collector — rather than restarting it — also can't drop a concurrent emission).
+    val currentItineraries by rememberUpdatedState(itineraries)
     LaunchedEffect(resultsViewModel) {
         resultsViewModel.selectedItinerary.collect { (index, itinerary) ->
             mapViewModel.showItinerary(itinerary)
-            needsFraming = true
-            maybeStartTripUpdates(activity, itineraries, index)
-        }
-    }
-
-    val showMap = (state as? TripResultsUiState.Success)?.showMap == true
-
-    // Frame the itinerary once the map is shown + settled (the old observeMapReady): the map VM
-    // publishes its camera on each idle, so the first non-null camera while shown is "map ready".
-    LaunchedEffect(resultsViewModel, showMap) {
-        mapViewModel.camera.collect { camera ->
-            if (camera != null && needsFraming && showMap) {
-                needsFraming = false
-                mapViewModel.frameDirections()
-            }
+            maybeStartTripUpdates(activity, currentItineraries, index)
         }
     }
 
@@ -249,27 +218,27 @@ fun TripResults(
         TripResultsHeader(
             state = state,
             onSelectOption = resultsViewModel::selectOption,
-            onTabSelected = { show ->
-                resultsViewModel.toggleMap(show)
-                if (show) needsFraming = true
-            },
         )
-        Box(
-            Modifier
-                .weight(1f)
-                .fillMaxWidth()
-        ) {
-            if (showMap) {
-                ObaMap(
-                    host = mapViewModel.host,
-                    callbacks = NoOpObaMapCallbacks,
-                    modifier = Modifier.fillMaxSize(),
-                )
-            } else {
-                TripResultsList(state)
-            }
-        }
+        TripResultsList(state, Modifier.weight(1f))
     }
+}
+
+/**
+ * The trip-results **map**, rendered as the trip-plan scaffold *body* (behind the results sheet) while
+ * the map tab is active. Kept out of the draggable sheet so vertical drags pan the map rather than
+ * moving the sheet (#1640); [mapViewModel] is the shared directions-mode VM that [TripResultsSheet]
+ * drives (draws the selected itinerary, frames it on the first idle).
+ */
+@Composable
+fun TripResultsMap(
+    mapViewModel: DirectionsMapViewModel,
+    modifier: Modifier = Modifier,
+) {
+    ObaMap(
+        host = mapViewModel.host,
+        callbacks = NoOpObaMapCallbacks,
+        modifier = modifier,
+    )
 }
 
 /**
@@ -398,11 +367,10 @@ private fun TripResultsPreview() {
                     isTransit = true,
                     subItems = listOf(DirectionItem(NO_ICON_PREVIEW, "Capitol Hill Station"))
                 )
-            ),
-            showMap = false
+            )
         )
         Column {
-            TripResultsHeader(state, onSelectOption = {}, onTabSelected = {})
+            TripResultsHeader(state, onSelectOption = {})
             TripResultsList(state)
         }
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
@@ -53,13 +53,11 @@ sealed interface TripResultsUiState {
      * @param options the itinerary option cards (1–3)
      * @param selectedIndex the currently-selected option
      * @param directions the directions for the selected option
-     * @param showMap whether the map tab (rather than the list) is selected
      */
     data class Success(
         val options: List<ItineraryOption>,
         val selectedIndex: Int,
-        val directions: List<DirectionItem>,
-        val showMap: Boolean
+        val directions: List<DirectionItem>
     ) : TripResultsUiState
 
     data class Error(val message: String) : TripResultsUiState

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsViewModel.kt
@@ -48,13 +48,11 @@ class TripResultsViewModel @Inject constructor(
 
     private var itineraries: List<Itinerary> = emptyList()
     private var selectedIndex: Int = 0
-    private var showMap: Boolean = false
 
-    /** Seeds the results from a completed plan. [initialIndex]/[showMap] restore prior UI state. */
-    fun setItineraries(itineraries: List<Itinerary>, initialIndex: Int, showMap: Boolean) {
+    /** Seeds the results from a completed plan. [initialIndex] restores the prior option selection. */
+    fun setItineraries(itineraries: List<Itinerary>, initialIndex: Int) {
         this.itineraries = itineraries
         this.selectedIndex = initialIndex.coerceIn(0, (itineraries.size - 1).coerceAtLeast(0))
-        this.showMap = showMap
         load()
     }
 
@@ -64,14 +62,6 @@ class TripResultsViewModel @Inject constructor(
         selectedIndex = index
         itineraries.getOrNull(index)?.let { _selectedItinerary.tryEmit(index to it) }
         load()
-    }
-
-    /** Switches between the list and map tabs. */
-    fun toggleMap(show: Boolean) {
-        showMap = show
-        (_state.value as? TripResultsUiState.Success)?.let {
-            _state.value = it.copy(showMap = show)
-        }
     }
 
     private fun load() {
@@ -84,8 +74,7 @@ class TripResultsViewModel @Inject constructor(
                     _state.value = TripResultsUiState.Success(
                         options = options,
                         selectedIndex = selectedIndex,
-                        directions = directions,
-                        showMap = showMap
+                        directions = directions
                     )
                 },
                 onFailure = { error ->

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreComposeAdapter.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreComposeAdapter.kt
@@ -62,6 +62,7 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.flow.onSubscription
 import kotlin.math.abs
 
 private const val STYLE_URL_LIGHT = "https://tiles.openfreemap.org/styles/liberty"
@@ -212,9 +213,14 @@ class MapLibreComposeAdapter : ObaComposeMapAdapter {
                 onDispose { host.setMapAttached(false) }
             }
             LaunchedEffect(map) {
-                renderState.cameraCommands.collect { command ->
-                    applyCameraCommand(command, map, renderState)
-                }
+                renderState.cameraCommands
+                    // Flush any frame deferred while the map was detached the moment this collector is
+                    // registered — emissions in onSubscription reach this collector, so a deferred fit
+                    // isn't dropped by the no-replay flow if the first camera-idle beats us (#1640).
+                    .onSubscription { host.onCameraCommandsSubscribed() }
+                    .collect { command ->
+                        applyCameraCommand(command, map, renderState)
+                    }
             }
         }
 

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/TripResultsViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/TripResultsViewModelTest.kt
@@ -22,7 +22,6 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -64,18 +63,17 @@ class TripResultsViewModelTest {
     @Test
     fun `setItineraries emits Success with the options and selected index`() = runTest {
         val viewModel = TripResultsViewModel(FakeTripResultsRepository(Result.success(options)))
-        viewModel.setItineraries(itineraries(2), initialIndex = 1, showMap = false)
+        viewModel.setItineraries(itineraries(2), initialIndex = 1)
         advanceUntilIdle()
         val state = viewModel.state.value as TripResultsUiState.Success
         assertEquals(options, state.options)
         assertEquals(1, state.selectedIndex)
-        assertFalse(state.showMap)
     }
 
     @Test
     fun `an out-of-range initial index is clamped`() = runTest {
         val viewModel = TripResultsViewModel(FakeTripResultsRepository(Result.success(options)))
-        viewModel.setItineraries(itineraries(2), initialIndex = 9, showMap = false)
+        viewModel.setItineraries(itineraries(2), initialIndex = 9)
         advanceUntilIdle()
         assertEquals(1, (viewModel.state.value as TripResultsUiState.Success).selectedIndex)
     }
@@ -85,7 +83,7 @@ class TripResultsViewModelTest {
         val repository = FakeTripResultsRepository(Result.success(options))
         val viewModel = TripResultsViewModel(repository)
         val list = itineraries(2)
-        viewModel.setItineraries(list, initialIndex = 0, showMap = false)
+        viewModel.setItineraries(list, initialIndex = 0)
         advanceUntilIdle()
         repository.directionsForCalls.clear()
 
@@ -100,7 +98,7 @@ class TripResultsViewModelTest {
     fun `selectOption ignores the current index and out-of-range indices`() = runTest {
         val repository = FakeTripResultsRepository(Result.success(options))
         val viewModel = TripResultsViewModel(repository)
-        viewModel.setItineraries(itineraries(2), initialIndex = 0, showMap = false)
+        viewModel.setItineraries(itineraries(2), initialIndex = 0)
         advanceUntilIdle()
         repository.directionsForCalls.clear()
 
@@ -120,7 +118,7 @@ class TripResultsViewModelTest {
         backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
             viewModel.selectedItinerary.collect { emitted.add(it.first) }
         }
-        viewModel.setItineraries(list, initialIndex = 0, showMap = false)
+        viewModel.setItineraries(list, initialIndex = 0)
         advanceUntilIdle()
 
         viewModel.selectOption(1)
@@ -130,21 +128,11 @@ class TripResultsViewModelTest {
     }
 
     @Test
-    fun `toggleMap flips showMap on the Success state`() = runTest {
-        val viewModel = TripResultsViewModel(FakeTripResultsRepository(Result.success(options)))
-        viewModel.setItineraries(itineraries(1), initialIndex = 0, showMap = false)
-        advanceUntilIdle()
-
-        viewModel.toggleMap(true)
-        assertTrue((viewModel.state.value as TripResultsUiState.Success).showMap)
-    }
-
-    @Test
     fun `a summarize failure surfaces Error with the message`() = runTest {
         val viewModel = TripResultsViewModel(
             FakeTripResultsRepository(Result.failure(IOException("boom")))
         )
-        viewModel.setItineraries(itineraries(1), initialIndex = 0, showMap = false)
+        viewModel.setItineraries(itineraries(1), initialIndex = 0)
         advanceUntilIdle()
 
         assertEquals(TripResultsUiState.Error("boom"), viewModel.state.value)


### PR DESCRIPTION
## Summary

Fixes #1640. In the trip planner, the results **map** rendered *inside* the draggable Material3 bottom sheet, so vertical drags on the map were intercepted by the sheet (expand/collapse) instead of panning the map — the map was effectively unusable.

This relocates the map to the scaffold **body**, behind the sheet, matching how the home screen keeps its map behind the arrivals sheet.

## Changes

**Map out of the sheet**
- Split the former `TripResults` into `TripResultsSheet` (option cards + directions list, in the sheet) and `TripResultsMap` (the map, rendered as the scaffold body). Both view models are hoisted to `TripPlanRoute` so the body and sheet share one instance.
- **Removed the list/map tabs entirely** — the map is always behind the sheet and revealed by dragging it down. This deletes the `showMap` state field, `toggleMap()`, the `onTabSelected` param, and the paired test.
- Back walks results → peek → form (then exits), keeping the form reachable to re-plan now that the map, not the form, sits behind the sheet.

**Framing fix (surfaced by the relocation)**
The directions map opened at the (0,0) world view instead of framing the route. Root cause: `cameraCommands` is a replay-0 flow, so a `FitToItinerary` dispatched before the flavor adapter subscribes is dropped — and the directions map is drawn behind the sheet the instant a plan completes, well before it subscribes.
- Added `MapHost.frameForBounds()` deferral (shared by `frameRoute()`/`frameItinerary()`): dispatch now if the adapter is attached, else hold the frame until it is.
- Flush deferred frames from the adapter's `cameraCommands.onSubscription` (Google + MapLibre), guaranteed to deliver to the just-registered collector, rather than racing the subscription from the first camera-idle.
- Gate the `onCameraIdle` flush on `mapAttached` so a stray idle from a tearing-down map doesn't consume the pending frame into a dead flow.

This also removes the previous fragile client-side "observe first non-null camera" framing dance (and the `DirectionsMapViewModel.camera` / `frameDirections()` passthroughs it needed).

## Testing
- Both flavors (`ObaGoogle`, `ObaMaplibre`) compile.
- `TripResultsViewModelTest` passes (updated for the `showMap` removal).
- Verified on a physical device (Pixel 7 Pro): map pans freely, frames the route's bounding box on load, re-frames on option-card selection, and back returns to the form.

## Follow-up
A deeper refactor of the camera-command mechanism (retained framing-intent `StateFlow` vs. transient-gesture `SharedFlow`, which would remove the pending-frame deferral machinery entirely) is tracked separately — it changes config-change re-framing behavior and warrants its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Trip planning and trip results now use a split layout with a map behind a draggable results sheet.
  * Added more dependable itinerary framing behavior, including deferring framing until the map is ready.

* **Bug Fixes**
  * Improved camera command timing so route/map updates are applied more consistently once the map subscribes.
  * Back navigation now collapses the expanded sheet step-by-step before exiting or clearing.

* **Refactor**
  * Removed the old trip results map/list toggle and simplified UI state and composables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->