### PR TITLE
Arrivals drawer UX: peek-floor sheet, matched shorter handle, drop chevron (#1639)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.kt
@@ -174,7 +174,6 @@ class HomeActivity : AppCompatActivity() {
         onClearFocus = viewModel::requestClearMapFocus,
         onArrivalsLoaded = ::onArrivalsLoaded,
         onShowRouteOnMap = viewModel::requestShowRouteOnMap,
-        onToggleSheet = viewModel::requestToggleSheet,
         onCancelRouteMode = ::onCancelRouteMode,
     )
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalsPanel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalsPanel.kt
@@ -13,14 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-// This panel threads named per-element anchor modifiers (etaAnchor/starAnchor/chevronAnchor) a host
+// This panel threads named per-element anchor modifiers (etaAnchor/starAnchor/headerAnchor) a host
 // attaches to specific sub-elements for the onboarding spotlight — several per composable, none being
 // the root `modifier` — so ModifierParameter's "name it modifier" rule doesn't apply here.
 @file:Suppress("ModifierParameter")
 
 package org.onebusaway.android.ui.arrivals.components
 
-import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -53,7 +52,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
@@ -86,10 +84,10 @@ import org.onebusaway.android.util.ArrivalInfoUtils
 
 /**
  * The arrivals content for HomeActivity's map slide-up panel. Unlike the standalone screen, the
- * drawer is laid out top-to-bottom as: the arrivals (a compact 2-row peek when [collapsed], the full
- * scrollable list when expanded), then the stop header pinned at the bottom with the expand/collapse
- * chevron — matching the legacy ArrivalsListHeader. The hosting BottomSheetScaffold supplies the drag
- * handle above this content.
+ * drawer is laid out top-to-bottom as: the pinned stop header, then the arrivals (a compact 2-row peek
+ * at rest, morphing into the full scrollable list as the drawer opens). The hosting BottomSheetScaffold
+ * supplies the drag handle above this content; tapping/dragging it drives expand/collapse (the header
+ * no longer carries a chevron or tap-to-toggle).
  *
  * The peek height is driven by the host: this composable reports the preferred-arrival count +
  * filter state via [onPreferredHeight] so the host can size the collapsed panel. Polling, callbacks,
@@ -99,19 +97,17 @@ import org.onebusaway.android.util.ArrivalInfoUtils
 fun ArrivalsPanel(
     viewModel: ArrivalsViewModel,
     listState: LazyListState,
-    collapsed: Boolean,
     // The drawer's live open fraction (0 = collapsed peek, 1 = fully expanded), read each frame to
     // morph the leading peek rows in lockstep with the drag and to reveal the rest of the list.
     expandProgress: () -> Float,
     initialTitle: String,
     handler: ArrivalActionHandler,
-    onToggleExpand: () -> Unit,
     onPreferredHeight: (previewCount: Int, filtering: Boolean) -> Unit,
     // Opaque anchor modifiers a host may attach to the first peek row's ETA pill + favorite star and the
-    // header chevron (e.g. for an onboarding spotlight). The panel stays ignorant of what they're for.
+    // pinned header (e.g. for an onboarding spotlight). The panel stays ignorant of what they're for.
     etaAnchor: Modifier = Modifier,
     starAnchor: Modifier = Modifier,
-    chevronAnchor: Modifier = Modifier,
+    headerAnchor: Modifier = Modifier,
 ) {
     // The system navigation-bar inset (height varies by handset); see the list contentPadding below.
     val navBarInset = navigationBarBottomPadding()
@@ -169,10 +165,8 @@ fun ArrivalsPanel(
                 showActions = content != null,
                 hasAlerts = content?.hasAlerts == true,
                 filtering = filtering,
-                collapsed = collapsed,
-                onToggleExpand = onToggleExpand,
                 onToggleFavorite = viewModel::toggleFavorite,
-                chevronModifier = chevronAnchor,
+                headerModifier = headerAnchor,
             )
             if (content == null) {
                 LinearProgressIndicator(Modifier.fillMaxWidth())
@@ -417,10 +411,11 @@ internal fun EtaPill(
 }
 
 /**
- * The stop header pinned at the bottom of the panel: the favorite star and stop name (with a
+ * The stop header pinned at the top of the panel: the favorite star and stop name (with a
  * compass-direction tag appended, e.g. "Pine St & 3rd Ave (N)") as one centered unit, any
- * filter/alert indicators plus the expand/collapse chevron right-justified. Tapping the row toggles
- * the panel. [starSize]/[chevronSize] are exposed so the icon sizing can be tuned in the preview.
+ * filter/alert indicators right-justified. Expand/collapse is driven by the sheet's drag handle now,
+ * so the header no longer toggles on tap or shows a chevron. [starSize] is exposed so the star's
+ * sizing can be tuned in the preview.
  */
 @Composable
 private fun ArrivalsPanelHeader(
@@ -430,22 +425,17 @@ private fun ArrivalsPanelHeader(
     showActions: Boolean,
     hasAlerts: Boolean,
     filtering: Boolean,
-    collapsed: Boolean,
-    onToggleExpand: () -> Unit,
     onToggleFavorite: () -> Unit,
-    chevronModifier: Modifier = Modifier,
+    headerModifier: Modifier = Modifier,
     starSize: Dp = 20.dp,
-    chevronSize: Dp = 18.dp
 ) {
-    val chevronRotation by animateFloatAsState(if (collapsed) 0f else 180f, label = "chevron")
     val name = if (!direction.isNullOrBlank()) "$title (${direction.trim()})" else title
     Box(
-        Modifier
+        headerModifier
             .fillMaxWidth()
-            .clickable { onToggleExpand() }
             .padding(horizontal = 8.dp, vertical = 10.dp)
     ) {
-        // Star + name as one centered unit (kept clear of the right-justified chevron).
+        // Star + name as one centered unit (kept clear of the right-justified indicators).
         Row(
             modifier = Modifier
                 .align(Alignment.Center)
@@ -472,7 +462,7 @@ private fun ArrivalsPanelHeader(
                 overflow = TextOverflow.Ellipsis
             )
         }
-        // Filter/alert indicators + chevron, right-justified.
+        // Filter/alert indicators, right-justified.
         Row(
             modifier = Modifier.align(Alignment.CenterEnd),
             verticalAlignment = Alignment.CenterVertically
@@ -491,14 +481,6 @@ private fun ArrivalsPanelHeader(
                     tint = MaterialTheme.colorScheme.error
                 )
             }
-            Icon(
-                painter = painterResource(R.drawable.ic_navigation_expand_more),
-                contentDescription = stringResource(R.string.stop_header_sliding_panel_collapsed),
-                modifier = chevronModifier
-                    .rotate(chevronRotation)
-                    .size(chevronSize),
-                tint = MaterialTheme.colorScheme.onSurfaceVariant
-            )
         }
     }
 }
@@ -540,12 +522,9 @@ private fun DrawerCollapsedPreview() {
                     showActions = true,
                     hasAlerts = false,
                     filtering = false,
-                    collapsed = true,
-                    onToggleExpand = {},
                     onToggleFavorite = {},
-                    // Tune these in the preview to dial in the star / chevron sizing
+                    // Tune this in the preview to dial in the star sizing
                     starSize = 20.dp,
-                    chevronSize = 18.dp
                 )
             }
         }
@@ -585,12 +564,10 @@ private fun ArrivalsPanelHeaderPreview() {
                     showActions = true,
                     hasAlerts = false,
                     filtering = false,
-                    collapsed = true,
-                    onToggleExpand = {},
                     onToggleFavorite = {}
                 )
                 PeekDivider()
-                // Long stop name: it should ellipsize, kept clear of the right-justified chevron.
+                // Long stop name: it should ellipsize, kept clear of the right-justified indicators.
                 ArrivalsPanelHeader(
                     title = "Northgate Transit Center - Bay 3 & Light Rail Station Entrance",
                     direction = "SW",
@@ -598,8 +575,6 @@ private fun ArrivalsPanelHeaderPreview() {
                     showActions = true,
                     hasAlerts = true,
                     filtering = true,
-                    collapsed = false,
-                    onToggleExpand = {},
                     onToggleFavorite = {}
                 )
             }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/SheetExpandProgress.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/SheetExpandProgress.kt
@@ -19,6 +19,7 @@ package org.onebusaway.android.ui.compose
 
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.SheetState
+import androidx.compose.material3.SheetValue
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -59,12 +60,21 @@ class SheetExpandProgress internal constructor(
      * drags.
      */
     val fraction: () -> Float = {
-        val peekAnchor = containerHeightPx - peekHeightPx()
-        val offset = runCatching { sheetState.requireOffset() }.getOrNull()
-        if (peekAnchor <= 0f || offset == null) {
+        // While the sheet is animating to its peek (a collapse settle), report 0 rather than the live
+        // offset. The settle uses a slightly under-damped spring that overshoots a few px above the peek
+        // anchor as it comes to rest; that would make this briefly positive and flash the below-peek
+        // content in for a frame. During a drag (not animating) or a settle toward Expanded, the live
+        // offset is used, so the reveal still tracks the drag in lockstep.
+        if (sheetState.isAnimationRunning && sheetState.targetValue == SheetValue.PartiallyExpanded) {
             0f
         } else {
-            ((peekAnchor - offset) / peekAnchor).coerceIn(0f, 1f)
+            val peekAnchor = containerHeightPx - peekHeightPx()
+            val offset = runCatching { sheetState.requireOffset() }.getOrNull()
+            if (peekAnchor <= 0f || offset == null) {
+                0f
+            } else {
+                ((peekAnchor - offset) / peekAnchor).coerceIn(0f, 1f)
+            }
         }
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -16,22 +16,28 @@
 package org.onebusaway.android.ui.home
 
 import androidx.activity.compose.BackHandler
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.BottomSheetScaffold
 import androidx.compose.material3.DrawerState
 import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalNavigationDrawer
 import androidx.compose.material3.SheetValue
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
+import androidx.compose.material3.Surface
 import androidx.compose.material3.rememberBottomSheetScaffoldState
 import androidx.compose.material3.rememberDrawerState
 import androidx.compose.material3.rememberStandardBottomSheetState
@@ -50,6 +56,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Dp
@@ -140,7 +147,6 @@ class HomeActivityActions(
     val onClearFocus: () -> Unit,
     val onArrivalsLoaded: (ArrivalsLoaded) -> Unit,
     val onShowRouteOnMap: (ShowRouteRequest) -> Unit,
-    val onToggleSheet: () -> Unit,
     val onCancelRouteMode: () -> Unit,
 )
 
@@ -151,9 +157,11 @@ class HomeActivityActions(
  *
  * The arrivals sheet inverts to declarative: **visibility is business state** — the sheet peeks iff
  * a stop is focused on NEARBY — driven by a [LaunchedEffect] keyed on that derived flag, so it never
- * fights a user drag. **Expansion (peek<->full)** is the live `SheetState`, nudged by one-shot
- * [SheetCommand.ToggleSheet]/[SheetCommand.CollapseSheet] commands (the screen alone knows the live state),
- * plus [BackHandler]. The arrivals panel is hosted directly per focused stop (see [ArrivalsSheetHost]);
+ * fights a user drag. The sheet has no `Hidden` drag anchor (`skipHiddenState = true`), so peek is the
+ * hard floor of the drag; show/hide is instead an animated peek height (0 <-> real peek) that slides
+ * the whole sheet in and out. **Expansion (peek<->full)** is the live `SheetState`, toggled by the drag
+ * handle and nudged by the one-shot [SheetCommand.CollapseSheet] command (the screen alone knows the
+ * live state), plus [BackHandler]. The arrivals panel is hosted directly per focused stop (see [ArrivalsSheetHost]);
  * the map ([MapFeature]), the route-mode header ([RouteHeaderOverlay]), and the survey ([org.onebusaway.android.ui.survey.SurveyOverlay])
  * are all composables now — no map-related `AndroidView` / View seam remains.
  */
@@ -190,11 +198,33 @@ fun HomeScreen(
         // anchors can register) and read by [TutorialOverlay] below, which draws over the whole screen.
         val tutorialState = rememberTutorialState()
         val drawerState = rememberDrawerState(DrawerValue.Closed)
+        // The sheet has NO reachable `Hidden` anchor (`skipHiddenState = true`), so peek is the hard
+        // floor of the drag: the user can expand from peek or collapse back to it, but can never drag it
+        // below peek (which used to let the pinned peek content slide off-screen and snap back). Show /
+        // hide is therefore not a drag state — it's driven by animating the peek height between 0 and the
+        // real peek (see `visiblePeekDp` / `sheetShown` below), which slides the whole sheet in and out.
         val sheetState = rememberStandardBottomSheetState(
-            initialValue = SheetValue.Hidden,
-            skipHiddenState = false
+            initialValue = SheetValue.PartiallyExpanded,
+            skipHiddenState = true,
         )
         val scaffoldState = rememberBottomSheetScaffoldState(bottomSheetState = sheetState)
+
+        // Tapping the drag handle toggles the live sheet between peek and full (a full sheet collapses
+        // to peek, anything else expands). This lives next to the SheetState now — the header used to
+        // trigger it via a VM round-trip (SheetCommand.ToggleSheet), needed only because the header was
+        // in a different composable tree; the handle is right here, so it toggles directly.
+        val toggleSheet: () -> Unit = remember {
+            {
+                scope.launch {
+                    runCatching {
+                        when (toggleSheetTarget(sheetState.currentValue.toArrivalsSheetState())) {
+                            ArrivalsSheetState.Expanded -> sheetState.expand()
+                            else -> sheetState.partialExpand()
+                        }
+                    }
+                }
+            }
+        }
 
         // The arrivals sheet's measurement state, reported by the panel via onPreferredHeight — local to
         // the screen, since the panel and the sheet both live here (no need to round-trip the VM). Seeded
@@ -214,45 +244,62 @@ fun HomeScreen(
         // content inset (see ArrivalsPanel), so the revealed gap is empty rather than clipped content.
         val peekBottomPadding = navigationBarBottomPadding()
 
-        // The full collapsed-sheet peek: the reported header, plus room for the drag handle above it and
-        // the navigation-bar inset below. Both the scaffold's peek height and the FAB lift use this, so the
-        // FABs clear the whole collapsed sheet (handle included), not just the header.
-        val collapsedPeekDp = peekHeaderDp + DRAG_HANDLE_ALLOWANCE + peekBottomPadding
+        // The full collapsed-sheet peek: the reported header (less the phantom in-panel-handle budget its
+        // dimens still bake in — see LEGACY_IN_PANEL_HANDLE_BUDGET), plus the real scaffold drag handle
+        // above it, plus the navigation-bar inset below. Both the scaffold's peek height and the FAB lift
+        // use this, so the FABs clear the whole collapsed sheet (handle included), not just the header.
+        val collapsedPeekDp =
+            peekHeaderDp - LEGACY_IN_PANEL_HANDLE_BUDGET + DRAG_HANDLE_HEIGHT + peekBottomPadding
 
         // The drawer's live open fraction (0 = collapsed peek, 1 = fully expanded), read each frame by
         // the arrivals panel to morph the peek rows in lockstep with the drag. measureModifier feeds it
         // the sheet's container height (attached to the scaffold below).
         val sheetProgress = rememberSheetExpandProgress(sheetState, collapsedPeekDp)
 
-        // Visibility is business state. The key is the focused stop id while shown (else null), so the
-        // effect reacts to focus/tab changes but NOT to a user drag (same stop -> same key); the
-        // reconcile decision (hide / peek-open-if-hidden / leave) is the pure sheetReconcile().
+        // Visibility is business state: the sheet is shown (its peek slid up) iff a stop is focused.
+        // Because there's no `Hidden` drag anchor, "shown" is a plain flag that drives the animated peek
+        // height rather than a sheet drag state. The key is the focused stop id while shown (else null),
+        // so the effect reacts to focus/tab changes but NOT to a user drag (same stop -> same key).
+        var sheetShown by remember { mutableStateOf(false) }
         val showSheet = shouldShowSheet(state.focusedStop)
         val sheetKey = if (showSheet) state.focusedStop?.id else null
-        // Re-keyed on arrivalsReady so the peek opens once the focused stop's arrivals load.
+        // Re-keyed on arrivalsReady so the peek slides up once the focused stop's arrivals load.
         LaunchedEffect(sheetKey, arrivalsReady) {
-            runCatching {
-                when (sheetReconcile(sheetKey != null, sheetState.currentValue.toArrivalsSheetState())) {
-                    SheetReconcile.HIDE -> sheetState.hide()
-                    SheetReconcile.PEEK_OPEN -> {
-                        // Open only once the focused stop's arrivals have loaded, so the sheet animates
-                        // straight to its final peek height. Opening to a stale height and then resizing
-                        // when the count resolves moves the sheet's anchor mid-animation, which strands
-                        // BottomSheetScaffold's AnchoredDraggable (the sheet sticks partway up). The
-                        // effect re-runs when arrivalsReady flips true (cancelling this wait); the
-                        // timeout is a fallback so a stop whose arrivals are slow or fail still opens.
-                        if (!arrivalsReady) delay(SHEET_OPEN_LOAD_TIMEOUT_MS)
-                        sheetState.partialExpand()
-                    }
-                    SheetReconcile.LEAVE -> {}
+            if (sheetKey == null) {
+                // Hide: an expanded sheet is first collapsed to peek (so it then slides straight down as
+                // the peek retracts, rather than staying stuck at the top with no `Hidden` anchor to fall
+                // to); peek == the current value otherwise, so this is a no-op there.
+                runCatching {
+                    if (sheetState.currentValue == SheetValue.Expanded) sheetState.partialExpand()
                 }
+                sheetShown = false
+            } else {
+                // Show only once the focused stop's arrivals have loaded, so the peek animates straight to
+                // its final height. Growing to a stale height and then resizing when the count resolves
+                // moves the peek anchor mid-animation, which strands the AnchoredDraggable (the sheet
+                // sticks partway up). The effect re-runs when arrivalsReady flips true (cancelling this
+                // wait); the timeout is a fallback so a stop whose arrivals are slow or fail still shows.
+                if (!arrivalsReady) delay(SHEET_OPEN_LOAD_TIMEOUT_MS)
+                sheetShown = true
             }
         }
 
+        // The peek height actually handed to the scaffold: the real peek while shown, 0 while hidden.
+        // Animating between the two slides the whole sheet up from / down past the bottom edge — the
+        // slide-in/out that the removed `Hidden` anchor used to provide.
+        val visiblePeekDp by animateDpAsState(
+            targetValue = if (sheetShown) collapsedPeekDp else 0.dp,
+            label = "sheetPeek",
+        )
+
         // Report the resting position back to the activity (map padding / recenter / arrivals preview).
+        // While hidden the sheet still rests at `PartiallyExpanded` (just with a 0 peek), so fold the
+        // shown flag in: a hidden sheet reports `Hidden` (map padding 0), else its live expansion.
         LaunchedEffect(sheetState) {
-            snapshotFlow { sheetState.currentValue }.collect { value ->
-                onSheetSettled(value.toArrivalsSheetState(), peekHeaderPx)
+            snapshotFlow {
+                if (!sheetShown) ArrivalsSheetState.Hidden else sheetState.currentValue.toArrivalsSheetState()
+            }.collect { value ->
+                onSheetSettled(value, peekHeaderPx)
             }
         }
 
@@ -260,12 +307,6 @@ fun HomeScreen(
         LaunchedEffect(Unit) {
             sheetCommands.collect { command ->
                 when (command) {
-                    SheetCommand.ToggleSheet -> runCatching {
-                        when (toggleSheetTarget(sheetState.currentValue.toArrivalsSheetState())) {
-                            ArrivalsSheetState.Expanded -> sheetState.expand()
-                            else -> sheetState.partialExpand()
-                        }
-                    }
                     SheetCommand.CollapseSheet -> runCatching { sheetState.partialExpand() }
                 }
             }
@@ -295,8 +336,9 @@ fun HomeScreen(
         }
 
         // Back collapses an expanded sheet first, then (from peek) clears the focus, which hides it.
-        // A hidden sheet leaves back to the system (mirrors the legacy !isSheetHidden() gate).
-        BackHandler(enabled = sheetState.currentValue != SheetValue.Hidden) {
+        // A hidden sheet leaves back to the system (mirrors the legacy !isSheetHidden() gate). Gated on
+        // `sheetShown` since the sheet always rests at peek/expanded now (never a `Hidden` value).
+        BackHandler(enabled = sheetShown) {
             when (sheetBackAction(sheetState.currentValue.toArrivalsSheetState())) {
                 SheetBackAction.COLLAPSE -> scope.launch { runCatching { sheetState.partialExpand() } }
                 SheetBackAction.CLEAR_FOCUS -> onClearFocus()
@@ -343,19 +385,23 @@ fun HomeScreen(
                         .then(sheetProgress.measureModifier),
                     scaffoldState = scaffoldState,
                     snackbarHost = { SnackbarHost(snackbarHostState) },
-                    sheetPeekHeight = collapsedPeekDp,
+                    // The animated peek: real peek while shown, 0 while hidden — slides the sheet in/out.
+                    sheetPeekHeight = visiblePeekDp,
+                    // Paint the sheet container (incl. the strip behind the drag handle) the same color
+                    // the arrivals panel body paints, so the handle reads as part of the panel rather
+                    // than sitting on a separate default-colored strip.
+                    sheetContainerColor = MaterialTheme.colorScheme.surface,
+                    sheetDragHandle = { ArrivalsDragHandle(onToggle = toggleSheet) },
                     sheetContent = {
                         ArrivalsSheetHost(
                             focusedStop = state.focusedStop,
-                            collapsed = sheetState.currentValue != SheetValue.Expanded,
-                            sheetVisible = sheetState.currentValue != SheetValue.Hidden,
+                            sheetVisible = sheetShown,
                             expandProgress = sheetProgress.fraction,
                             arrivalsViewModelFactory = arrivalsViewModelFactory,
                             onArrivalsLoaded = onArrivalsLoaded,
                             onShowRouteOnMap = onShowRouteOnMap,
                             onShowTrip = onShowTrip,
                             onEditReminder = onEditReminder,
-                            onToggleSheet = onToggleSheet,
                             onPreferredHeight = { count, filtering ->
                                 peekArrivalCount = count
                                 routeFiltering = filtering
@@ -375,9 +421,14 @@ fun HomeScreen(
                     }
                 ) {
                     // Lift the FABs above the whole collapsed sheet peek; the target changes only on settle
-                    // and MapChrome animates it. Local here since the screen holds the live SheetState.
+                    // and MapChrome animates it. Local here since the screen holds the live SheetState. Only
+                    // while the sheet is shown at peek — a hidden sheet also rests at PartiallyExpanded now.
                     val fabInsetTarget =
-                        if (sheetState.currentValue == SheetValue.PartiallyExpanded) collapsedPeekDp else 0.dp
+                        if (sheetShown && sheetState.currentValue == SheetValue.PartiallyExpanded) {
+                            collapsedPeekDp
+                        } else {
+                            0.dp
+                        }
                     Box(Modifier.fillMaxSize()) {
                         // The map, with the chrome drawn over it: weather/donation/route-header/survey. The
                         // list "tabs" are now their own NavHost destinations, so HOME is always the map.
@@ -560,12 +611,44 @@ private fun arrivalsPeekHeight(arrivalCount: Int, filtering: Boolean): Dp {
     return base + offset
 }
 
+// The custom drag handle's geometry — the visible bar plus the vertical padding above and below it.
+// Shared by [ArrivalsDragHandle] (what it draws) and the peek-height math (how much room it needs), so
+// the two can't drift apart.
+private val DRAG_HANDLE_BAR_HEIGHT = 4.dp
+private val DRAG_HANDLE_VERTICAL_PADDING = 9.dp
+private val DRAG_HANDLE_HEIGHT = DRAG_HANDLE_BAR_HEIGHT + DRAG_HANDLE_VERTICAL_PADDING * 2
+
+// The reported arrivals-header dimens (arrival_header_height_*) still bake in this much room for the
+// legacy in-panel handle the scaffold drag handle replaced; collapsedPeekDp subtracts it back out and
+// adds the real DRAG_HANDLE_HEIGHT instead.
+private val LEGACY_IN_PANEL_HANDLE_BUDGET = 20.dp
+
 /**
- * Extra peek height for the scaffold drag handle above the arrivals content. The handle is ~48dp,
- * but the reported header dimens already budgeted ~20dp for the old in-panel handle the
- * BottomSheetScaffold handle now replaces, so only the net difference is added.
+ * The arrivals sheet's drag handle: a short grab bar tinted to sit on the panel surface (paired with
+ * the scaffold's `sheetContainerColor`) so it reads as part of the panel, not a separate strip. Tapping
+ * toggles peek<->full via [onToggle]; it never hides the sheet — the sheet has no `Hidden` drag anchor,
+ * so it only leaves programmatically (animated peek height) when focus clears. Its own click shadows the
+ * scaffold's built-in handle click.
  */
-private val DRAG_HANDLE_ALLOWANCE = 28.dp
+@Composable
+private fun ArrivalsDragHandle(onToggle: () -> Unit) {
+    // The click sits on the outer padded Box (before the padding) so the tap target covers more than the
+    // bar; it shadows the scaffold's own handle click. The bar itself is a short tinted pill.
+    Box(
+        modifier = Modifier
+            .clickable(onClick = onToggle)
+            .padding(horizontal = 24.dp, vertical = DRAG_HANDLE_VERTICAL_PADDING),
+        contentAlignment = Alignment.Center,
+    ) {
+        Surface(
+            // Same muted grey as the header's star/icon tint, so the handle matches the panel chrome.
+            color = colorResource(R.color.navdrawer_icon_tint),
+            shape = RoundedCornerShape(percent = 50),
+        ) {
+            Box(Modifier.size(width = 32.dp, height = DRAG_HANDLE_BAR_HEIGHT))
+        }
+    }
+}
 
 /**
  * How long the sheet waits for a freshly-focused stop's arrivals to load before peeking open anyway.

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeSheetLogic.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeSheetLogic.kt
@@ -21,33 +21,20 @@ package org.onebusaway.android.ui.home
  * from inside a `@Composable`) is unit-testable. [HomeScreen] does the Compose plumbing — keying the
  * effect, reading the live `SheetState`, animating — and defers every *decision* to these functions.
  *
- * The model: **visibility is business state** ([shouldShowSheet]) reconciled by [sheetReconcile];
- * **expansion is ephemeral UI** toggled by [toggleSheetTarget] and unwound by [sheetBackAction].
+ * The model: **visibility is business state** ([shouldShowSheet]); **expansion is ephemeral UI**
+ * toggled by [toggleSheetTarget] and unwound by [sheetBackAction].
  */
 
 /** The arrivals sheet's resting position, reported from the screen back to the activity and the state
- *  the reconcile/toggle/back decisions below operate on. */
+ *  the toggle/back decisions below operate on. */
 enum class ArrivalsSheetState { Hidden, Collapsed, Expanded }
 
 /** The sheet is shown (peeking or full) iff a stop is focused. (HOME is always the map now — the
- *  list screens are their own destinations — so a focused stop is the only condition.) */
+ *  list screens are their own destinations — so a focused stop is the only condition.) [HomeScreen]
+ *  translates this into an animated peek height (the sheet has no `Hidden` drag anchor). */
 internal fun shouldShowSheet(focusedStop: FocusedStop?): Boolean = focusedStop != null
 
-/** What [HomeScreen] does to the sheet when the focused stop / tab changes (not on a user drag). */
-enum class SheetReconcile { HIDE, PEEK_OPEN, LEAVE }
-
-/**
- * Reconcile the sheet toward its desired visibility. When it should show, only a *hidden* sheet is
- * peeked open — a peek/full sheet keeps the user's current position (mirrors the legacy
- * `showSlidingPanel()`, which only acted when the panel was hidden). When it shouldn't show, hide it.
- */
-internal fun sheetReconcile(shouldShow: Boolean, current: ArrivalsSheetState): SheetReconcile = when {
-    !shouldShow -> SheetReconcile.HIDE
-    current == ArrivalsSheetState.Hidden -> SheetReconcile.PEEK_OPEN
-    else -> SheetReconcile.LEAVE
-}
-
-/** The chevron toggle target: a full sheet collapses to peek; anything else expands to full. */
+/** The drag-handle toggle target: a full sheet collapses to peek; anything else expands to full. */
 internal fun toggleSheetTarget(current: ArrivalsSheetState): ArrivalsSheetState =
     if (current == ArrivalsSheetState.Expanded) ArrivalsSheetState.Collapsed else ArrivalsSheetState.Expanded
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
@@ -203,9 +203,6 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-    /** Chevron tap — ask the screen to toggle the sheet (it holds the live SheetState). */
-    fun requestToggleSheet() = emit(SheetCommand.ToggleSheet)
-
     /**
      * The host has a restored / deep-linked focus the imperative map hasn't been told about yet;
      * complete it once the arrivals load (see [onArrivalsLoaded]). A fresh map tap already centers the
@@ -377,9 +374,6 @@ sealed interface HomeAnalyticsEvent {
  * [org.onebusaway.android.ui.home.chrome.HomeTopBar]'s hamburger, so it needs no command.)
  */
 sealed interface SheetCommand {
-    /** The arrivals-sheet chevron was tapped — toggle peek <-> full. */
-    object ToggleSheet : SheetCommand
-
     /** Collapse the sheet to its peek (e.g. after "show vehicles on map"). */
     object CollapseSheet : SheetCommand
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/arrivals/ArrivalsSheetHost.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/arrivals/ArrivalsSheetHost.kt
@@ -59,13 +59,12 @@ import org.onebusaway.android.ui.tutorial.tutorialAnchor
  *
  * Polling lifecycle is owned by `ArrivalsPanel` itself (`ArrivalsPolling` → `repeatOnLifecycle`), so
  * it also pauses with the screen. Loaded responses are forwarded to the host via [onArrivalsLoaded]
- * (the map recenter / focus marker / tutorials), the chevron toggles the sheet via [onToggleSheet],
- * and the preview size drives the peek height via [onPreferredHeight].
+ * (the map recenter / focus marker / tutorials), and the preview size drives the peek height via
+ * [onPreferredHeight]. Expand/collapse is driven by the sheet's drag handle (in the host scaffold).
  */
 @Composable
 internal fun ArrivalsSheetHost(
     focusedStop: FocusedStop?,
-    collapsed: Boolean,
     // The sheet is actually on screen (not hidden) — gates the onboarding spotlight so it can't fire
     // over a hidden panel.
     sheetVisible: Boolean,
@@ -77,7 +76,6 @@ internal fun ArrivalsSheetHost(
     onShowRouteOnMap: (ShowRouteRequest) -> Unit,
     onShowTrip: (tripId: String, stopId: String) -> Unit,
     onEditReminder: (args: ReminderEditorArgs) -> Unit,
-    onToggleSheet: () -> Unit,
     onPreferredHeight: (previewCount: Int, filtering: Boolean) -> Unit,
     showUndoSnackbar: (messageRes: Int, actionRes: Int?, onAction: (() -> Unit)?) -> Unit,
 ) {
@@ -124,15 +122,15 @@ internal fun ArrivalsSheetHost(
                 ArrivalsPanel(
                     viewModel = viewModel,
                     listState = listState,
-                    collapsed = collapsed,
                     expandProgress = expandProgress,
                     initialTitle = stop.name.orEmpty(),
                     handler = handler,
-                    onToggleExpand = onToggleSheet,
                     onPreferredHeight = onPreferredHeight,
                     etaAnchor = Modifier.tutorialAnchor(tutorialState, ArrivalTutorial.KEY_ETA),
                     starAnchor = Modifier.tutorialAnchor(tutorialState, ArrivalTutorial.KEY_STAR),
-                    chevronAnchor = Modifier.tutorialAnchor(tutorialState, ArrivalTutorial.KEY_PANEL),
+                    // The onboarding "slide up to see more" spotlight now anchors on the pinned header
+                    // (the chevron it used to point at is gone).
+                    headerAnchor = Modifier.tutorialAnchor(tutorialState, ArrivalTutorial.KEY_PANEL),
                 )
             }
 

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -795,7 +795,7 @@
     </string>
     <string name="tutorial_arrival_header_sliding_panel_title">Slide up to show more arrivals
     </string>
-    <string name="tutorial_arrival_header_sliding_panel_text">Tap on the arrow or drag the panel up
+    <string name="tutorial_arrival_header_sliding_panel_text">Drag the panel up
         to see more arrivals for this stop.
     </string>
     <string name="tutorial_arrival_header_star_route_title">Star your favorite routes</string>

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeSheetLogicTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeSheetLogicTest.kt
@@ -38,35 +38,6 @@ class HomeSheetLogicTest {
         assertFalse(shouldShowSheet(null))
     }
 
-    // --- sheetReconcile (the parity-critical decision) ---
-
-    @Test
-    fun `when it should not show, the sheet hides from any resting state`() {
-        for (current in ArrivalsSheetState.entries) {
-            assertEquals(SheetReconcile.HIDE, sheetReconcile(shouldShow = false, current = current))
-        }
-    }
-
-    @Test
-    fun `when it should show, only a hidden sheet is peeked open`() {
-        assertEquals(
-            SheetReconcile.PEEK_OPEN,
-            sheetReconcile(shouldShow = true, current = ArrivalsSheetState.Hidden)
-        )
-    }
-
-    @Test
-    fun `when it should show, a peeking or full sheet keeps the user's position`() {
-        assertEquals(
-            SheetReconcile.LEAVE,
-            sheetReconcile(shouldShow = true, current = ArrivalsSheetState.Collapsed)
-        )
-        assertEquals(
-            SheetReconcile.LEAVE,
-            sheetReconcile(shouldShow = true, current = ArrivalsSheetState.Expanded)
-        )
-    }
-
     // --- toggleSheetTarget ---
 
     @Test

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
@@ -85,22 +85,6 @@ class HomeViewModelTest {
     // pending-focus gate, so one shared fixture suffices.
     private val obaStop = ObaStopElement("1", 47.6, -122.3, "Main St", "100")
 
-    // --- one-shot sheet / drawer commands ---
-
-    @Test
-    fun `the chevron tap emits ToggleSheet`() = runTest {
-        val vm = viewModel()
-        val events = mutableListOf<SheetCommand>()
-        val job = launch { vm.sheetCommands.collect { events.add(it) } }
-        advanceUntilIdle()
-
-        vm.requestToggleSheet()
-        advanceUntilIdle()
-
-        assertEquals(listOf<SheetCommand>(SheetCommand.ToggleSheet), events)
-        job.cancel()
-    }
-
     // --- arrivals sheet settled -> map padding / recenter ---
 
     @Test


### PR DESCRIPTION
Closes #1639.

Four independent UX refinements to the home arrivals bottom-sheet drawer (`HomeScreen.kt` `BottomSheetScaffold` + `ArrivalsSheetHost` / `ArrivalsPanel`). Pure presentation/UX — no arrivals data logic is affected.

## 1. No closed state; peek is the hard drag floor
While a stop is focused the drawer is always at least peek and can't be dragged shut. The sheet now uses `skipHiddenState = true` (no `Hidden` drag anchor), so the user can expand from peek or collapse back to it but can never drag below peek — which previously let the pinned peek content slide off-screen and snap back.

Show/hide is no longer a drag state: a `sheetShown` flag drives an animated peek height (`0 ↔ real peek` via `animateDpAsState`) that slides the whole sheet in and out, gated on arrivals load so the peek anchor stays stable during the slide. This replaces the old `Hidden`-anchor `hide()` / reconcile path (`sheetReconcile` removed).

## 2. Drag-handle color matches the panel
`sheetContainerColor` is set to the panel's surface color so the strip behind the handle is no longer a separate default color, and a custom handle is tinted to the header icon grey so it reads as part of the panel.

## 3. Shorter handle, with breathing room
A custom `sheetDragHandle` (a short tinted pill) replaces the ~48dp Material default. Its geometry lives in shared constants (`DRAG_HANDLE_BAR_HEIGHT` / `DRAG_HANDLE_VERTICAL_PADDING`) that both the handle draw and the peek-height math derive from, so they can't drift.

## 4. Remove the header chevron + tap-to-toggle
Expand/collapse is now driven entirely by the drag handle (its tap toggles peek↔full directly, replacing the header's VM round-trip `SheetCommand.ToggleSheet`, which is removed end-to-end). The onboarding "slide up" spotlight re-homes from the chevron to the pinned header, and its copy updates from "Tap on the arrow or drag…" to "Drag the panel up…".

## Notes
- One remaining polish: a drag-release collapse used to flash a sliver of below-peek content for a frame, because the settle spring overshoots a few px above the peek anchor and `SheetExpandProgress` briefly read positive. Fixed at the source — the progress reports 0 while the sheet is animating toward peek, so the reveal isn't tripped by settle overshoot (drag lockstep is untouched).
- Follow-up cleanup filed as #1649: the `SheetCommand` flow is now down to a single `CollapseSheet`, which could be made a declarative reaction to route mode and deleted.

## Testing
- `./gradlew test` (unit) green; `HomeSheetLogicTest` / `HomeViewModelTest` updated for the removed `sheetReconcile` / `ToggleSheet`.
- On-device verified on a Pixel 7 Pro (Android 16): peek-floor drag, slide in/out on stop select/clear, collapse-from-expanded, handle tap/drag toggle, and the below-peek flash fix.
