### PR TITLE
Recenter map on focused stop when arrivals drawer title is tapped

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalsPanel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalsPanel.kt
@@ -103,6 +103,9 @@ fun ArrivalsPanel(
     initialTitle: String,
     handler: ArrivalActionHandler,
     onPreferredHeight: (previewCount: Int, filtering: Boolean) -> Unit,
+    // Tapping the pinned stop-name header invokes this (null = not tappable); the drawer host wires it
+    // to an animated map recenter on the focused stop.
+    onTitleClick: (() -> Unit)? = null,
     // Opaque anchor modifiers a host may attach to the first peek row's ETA pill + favorite star and the
     // pinned header (e.g. for an onboarding spotlight). The panel stays ignorant of what they're for.
     etaAnchor: Modifier = Modifier,
@@ -166,6 +169,7 @@ fun ArrivalsPanel(
                 hasAlerts = content?.hasAlerts == true,
                 filtering = filtering,
                 onToggleFavorite = viewModel::toggleFavorite,
+                onTitleClick = onTitleClick,
                 headerModifier = headerAnchor,
             )
             if (content == null) {
@@ -414,8 +418,9 @@ internal fun EtaPill(
  * The stop header pinned at the top of the panel: the favorite star and stop name (with a
  * compass-direction tag appended, e.g. "Pine St & 3rd Ave (N)") as one centered unit, any
  * filter/alert indicators right-justified. Expand/collapse is driven by the sheet's drag handle now,
- * so the header no longer toggles on tap or shows a chevron. [starSize] is exposed so the star's
- * sizing can be tuned in the preview.
+ * so the header no longer toggles on tap or shows a chevron. Tapping the stop name instead invokes
+ * [onTitleClick] (null = not tappable), which the drawer host uses to recenter the map on the stop.
+ * [starSize] is exposed so the star's sizing can be tuned in the preview.
  */
 @Composable
 private fun ArrivalsPanelHeader(
@@ -426,6 +431,7 @@ private fun ArrivalsPanelHeader(
     hasAlerts: Boolean,
     filtering: Boolean,
     onToggleFavorite: () -> Unit,
+    onTitleClick: (() -> Unit)? = null,
     headerModifier: Modifier = Modifier,
     starSize: Dp = 20.dp,
 ) {
@@ -459,7 +465,8 @@ private fun ArrivalsPanelHeader(
                 text = name,
                 style = MaterialTheme.typography.titleMedium,
                 maxLines = 1,
-                overflow = TextOverflow.Ellipsis
+                overflow = TextOverflow.Ellipsis,
+                modifier = onTitleClick?.let { Modifier.clickable(onClick = it) } ?: Modifier
             )
         }
         // Filter/alert indicators, right-justified.

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -407,6 +407,7 @@ fun HomeScreen(
                                 routeFiltering = filtering
                                 arrivalsReady = true
                             },
+                            onTitleClick = homeViewModel::recenterOnFocusedStop,
                             showUndoSnackbar = { messageRes, actionRes, onAction ->
                                 scope.launch {
                                     val result = snackbarHostState.showSnackbar(

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
@@ -194,9 +194,7 @@ class HomeViewModel @Inject constructor(
         when (state) {
             ArrivalsSheetState.Expanded -> {
                 _mapBottomPadding.value = peekPx
-                _uiState.value.focusedStop?.let {
-                    emitMapDirective(MapDirective.RecenterOnFocusedStop(it.lat, it.lon))
-                }
+                recenterOnFocusedStop()
             }
             ArrivalsSheetState.Collapsed -> _mapBottomPadding.value = peekPx
             ArrivalsSheetState.Hidden -> _mapBottomPadding.value = 0
@@ -238,6 +236,13 @@ class HomeViewModel @Inject constructor(
         }
         pendingMapFocus = false
         emitMapDirective(MapDirective.FocusStop(stop, routes, settledSheet == ArrivalsSheetState.Expanded))
+    }
+
+    /** Animate the map's camera back onto the focused stop, if one is focused (else a no-op). */
+    fun recenterOnFocusedStop() {
+        _uiState.value.focusedStop?.let {
+            emitMapDirective(MapDirective.RecenterOnFocusedStop(it.lat, it.lon))
+        }
     }
 
     /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/arrivals/ArrivalsSheetHost.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/arrivals/ArrivalsSheetHost.kt
@@ -77,6 +77,8 @@ internal fun ArrivalsSheetHost(
     onShowTrip: (tripId: String, stopId: String) -> Unit,
     onEditReminder: (args: ReminderEditorArgs) -> Unit,
     onPreferredHeight: (previewCount: Int, filtering: Boolean) -> Unit,
+    // Tapping the drawer's stop-name title — the host recenters the map on the focused stop.
+    onTitleClick: () -> Unit,
     showUndoSnackbar: (messageRes: Int, actionRes: Int?, onAction: (() -> Unit)?) -> Unit,
 ) {
     val stop = focusedStop ?: return
@@ -126,6 +128,7 @@ internal fun ArrivalsSheetHost(
                     initialTitle = stop.name.orEmpty(),
                     handler = handler,
                     onPreferredHeight = onPreferredHeight,
+                    onTitleClick = onTitleClick,
                     etaAnchor = Modifier.tutorialAnchor(tutorialState, ArrivalTutorial.KEY_ETA),
                     starAnchor = Modifier.tutorialAnchor(tutorialState, ArrivalTutorial.KEY_STAR),
                     // The onboarding "slide up to see more" spotlight now anchors on the pinned header


### PR DESCRIPTION
## Summary

Small UX refinement: tapping the stop-name **title** in the arrivals bottom sheet now animates the map camera back onto that stop.

Previously the drawer title was inert. Now a tap re-centers the map on the focused stop with an animated camera move, making it easy to snap back to the stop after panning the map away.

## Implementation

- **`HomeViewModel.recenterOnFocusedStop()`** — emits the existing `MapDirective.RecenterOnFocusedStop(lat, lon)` for the current `focusedStop` (no-op if nothing is focused). This is the same directive the on-expand recenter already uses, so no new map-side entry point was added; `MapFeature` already consumes it → `MapViewModel.recenterOnFocusedStop(...)` → animated `CameraCommand.Recenter`. The prior inline copy of this snippet in `onSheetSettled` now delegates to this method.
- **`ArrivalsPanelHeader` / `ArrivalsPanel`** — the stop-name `Text` becomes `clickable` only when an optional `onTitleClick` handler is supplied, following the panel's existing hoisted-lambda convention (matching `onToggleFavorite`, `etaAnchor`, etc.). The default-null handler leaves the standalone `ArrivalsScreen` (its own top-bar title) untouched — the affordance is bottom-sheet-only.
- **`HomeScreen` / `ArrivalsSheetHost`** — thread the handler through to `HomeViewModel::recenterOnFocusedStop`.

## Testing

- Compiles clean (`compileObaGoogleDebugKotlin`).
- Built and installed on a Pixel 7 Pro (`installObaGoogleDebug`).
- Behavior is a map-canvas interaction; recommend a quick on-device tap to confirm the camera glide feels right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The arrivals title is now tappable when available, letting users quickly recenter the map on the selected stop.
  * Title tap behavior is now passed through the home screen so the focused stop can be brought back into view.
* **Bug Fixes**
  * Map recentering now uses a shared action, improving consistency when the arrivals panel settles or the title is tapped.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->