### PR TITLE
Make arrivals-sheet collapse declarative, drop the SheetCommand channel (#1649)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeNavHost.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeNavHost.kt
@@ -199,7 +199,6 @@ fun HomeNavHost(
             }
             HomeScreen(
                 state = state,
-                sheetCommands = home.homeViewModel.sheetCommands,
                 homeViewModel = home.homeViewModel,
                 mapViewModel = home.mapViewModel,
                 routeHeader = routeHeader,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -62,7 +62,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.launch
 import org.onebusaway.android.R
 import org.onebusaway.android.ui.arrivals.ArrivalsLoaded
@@ -160,8 +159,8 @@ class HomeActivityActions(
  * fights a user drag. The sheet has no `Hidden` drag anchor (`skipHiddenState = true`), so peek is the
  * hard floor of the drag; show/hide is instead an animated peek height (0 <-> real peek) that slides
  * the whole sheet in and out. **Expansion (peek<->full)** is the live `SheetState`, toggled by the drag
- * handle and nudged by the one-shot [SheetCommand.CollapseSheet] command (the screen alone knows the
- * live state), plus [BackHandler]. The arrivals panel is hosted directly per focused stop (see [ArrivalsSheetHost]);
+ * handle and collapsed as a declarative reaction to route mode activating (`routeHeader != null`;
+ * the screen alone knows the live state), plus [BackHandler]. The arrivals panel is hosted directly per focused stop (see [ArrivalsSheetHost]);
  * the map ([MapFeature]), the route-mode header ([RouteHeaderOverlay]), and the survey ([org.onebusaway.android.ui.survey.SurveyOverlay])
  * are all composables now — no map-related `AndroidView` / View seam remains.
  */
@@ -169,7 +168,6 @@ class HomeActivityActions(
 @Composable
 fun HomeScreen(
     state: HomeUiState,
-    sheetCommands: SharedFlow<SheetCommand>,
     // The map is a self-wiring [MapFeature]; it composes only while HOME is the current destination, so
     // SDK init is already lazy. The route-mode header and survey are Compose overlays over it.
     homeViewModel: HomeViewModel,
@@ -211,8 +209,8 @@ fun HomeScreen(
 
         // Tapping the drag handle toggles the live sheet between peek and full (a full sheet collapses
         // to peek, anything else expands). This lives next to the SheetState now — the header used to
-        // trigger it via a VM round-trip (SheetCommand.ToggleSheet), needed only because the header was
-        // in a different composable tree; the handle is right here, so it toggles directly.
+        // trigger it via a VM round-trip, needed only because the header was in a different composable
+        // tree; the handle is right here, so it toggles directly.
         val toggleSheet: () -> Unit = remember {
             {
                 scope.launch {
@@ -303,13 +301,12 @@ fun HomeScreen(
             }
         }
 
-        // One-shot sheet commands from the ViewModel (the screen holds the live SheetState).
-        LaunchedEffect(Unit) {
-            sheetCommands.collect { command ->
-                when (command) {
-                    SheetCommand.CollapseSheet -> runCatching { sheetState.partialExpand() }
-                }
-            }
+        // Collapse the sheet to peek when the map enters route mode ("show vehicles on map"). A
+        // declarative reaction to route-mode state rather than a VM command — the screen holds the live
+        // SheetState, and route mode surfaces here as `routeHeader != null`.
+        val routeModeActive = routeHeader != null
+        LaunchedEffect(routeModeActive) {
+            if (routeModeActive) runCatching { sheetState.partialExpand() }
         }
 
         // The "Found X region" snackbar (replaces the legacy toast): a one-shot VM event, shown once per

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
@@ -73,9 +73,6 @@ class HomeViewModel @Inject constructor(
     )
     val uiState: StateFlow<HomeUiState> = _uiState.asStateFlow()
 
-    private val _sheetCommands = MutableSharedFlow<SheetCommand>(extraBufferCapacity = 4)
-    val sheetCommands: SharedFlow<SheetCommand> = _sheetCommands.asSharedFlow()
-
     // The map's bottom inset (driven by the arrivals sheet) — idempotent last-wins state, applied by
     // MapFeature. A StateFlow (not an event) so a re-entering map re-reads the latest value.
     private val _mapBottomPadding = MutableStateFlow(0)
@@ -83,8 +80,8 @@ class HomeViewModel @Inject constructor(
 
     // One-shot outbound map interactions (recenter / show route / focus / clear focus) that can't be
     // modeled as state. MapFeature collects these and calls the map view model — so this VM needs no
-    // reference to the map's VM (the seam the old MapInteractionBus filled). Buffered like sheetCommands
-    // so a directive issued just before the collector is active isn't dropped.
+    // reference to the map's VM (the seam the old MapInteractionBus filled). Buffered so a directive
+    // issued just before the collector is active isn't dropped.
     private val _mapDirectives = MutableSharedFlow<MapDirective>(extraBufferCapacity = 8)
     val mapDirectives: SharedFlow<MapDirective> = _mapDirectives.asSharedFlow()
 
@@ -246,11 +243,11 @@ class HomeViewModel @Inject constructor(
     }
 
     /**
-     * "Show vehicles on map" — collapse the sheet (screen), then switch the map to route mode. The
-     * [request] carries the route and (for the arrivals-row launch) the direction stop to focus on.
+     * "Show vehicles on map" — switch the map to route mode. The [request] carries the route and (for
+     * the arrivals-row launch) the direction stop to focus on. The sheet collapse is a declarative
+     * reaction to route mode activating (see [HomeScreen]'s `routeModeActive` effect), not a command.
      */
     fun requestShowRouteOnMap(request: ShowRouteRequest) {
-        emit(SheetCommand.CollapseSheet)
         emitMapDirective(MapDirective.ShowRoute(request))
     }
 
@@ -272,13 +269,8 @@ class HomeViewModel @Inject constructor(
         _analyticsEvents.tryEmit(HomeAnalyticsEvent.MenuItem(labelRes))
     }
 
-    // tryEmit (not a launched emit): the buffer (capacity 4, 0 replay) has room for these low-frequency
-    // one-shot commands, matching the codebase effect-flow idiom (MapViewModel etc.).
-    private fun emit(command: SheetCommand) {
-        _sheetCommands.tryEmit(command)
-    }
-
-    // The outbound-map-directive counterpart of [emit] (buffered, replay-less; see [mapDirectives]).
+    // tryEmit (not a launched emit): the buffer (capacity 8, 0 replay) has room for these low-frequency
+    // one-shot directives, matching the codebase effect-flow idiom (MapViewModel etc.).
     private fun emitMapDirective(directive: MapDirective) {
         _mapDirectives.tryEmit(directive)
     }
@@ -371,16 +363,6 @@ sealed interface HomeAnalyticsEvent {
 
     /** A nav-drawer / help-menu selection identified by its analytics label string resource. */
     data class MenuItem(@StringRes val labelRes: Int) : HomeAnalyticsEvent
-}
-
-/**
- * One-shot sheet commands driven from the ViewModel, consumed by [HomeScreen] (which alone holds the
- * live `SheetState`) off its own [HomeViewModel.sheetCommands] flow. (The drawer is opened directly by
- * [org.onebusaway.android.ui.home.chrome.HomeTopBar]'s hamburger, so it needs no command.)
- */
-sealed interface SheetCommand {
-    /** Collapse the sheet to its peek (e.g. after "show vehicles on map"). */
-    object CollapseSheet : SheetCommand
 }
 
 /**

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
@@ -90,14 +90,14 @@ class HomeViewModelTest {
     @Test
     fun `the initial sheet reveal from hidden emits no map effects`() = runTest {
         val vm = viewModel()
-        val events = mutableListOf<SheetCommand>()
-        val job = launch { vm.sheetCommands.collect { events.add(it) } }
+        val map = MapDirectiveRecorder(vm)
+        val job = launch { map.collect() }
         advanceUntilIdle()
 
         vm.onSheetSettled(ArrivalsSheetState.Collapsed, 120) // previous == Hidden -> skip
         advanceUntilIdle()
 
-        assertTrue(events.isEmpty())
+        assertTrue(map.sent.isEmpty())
         assertEquals(ArrivalsSheetState.Collapsed, vm.lastSettledSheet)
         job.cancel()
     }
@@ -246,21 +246,19 @@ class HomeViewModelTest {
     }
 
     @Test
-    fun `show route on map collapses the sheet and shows the route`() = runTest {
+    fun `show route on map shows the route`() = runTest {
         val vm = viewModel()
         val map = MapDirectiveRecorder(vm)
         val mapJob = launch { map.collect() }
-        val events = mutableListOf<SheetCommand>()
-        val eventJob = launch { vm.sheetCommands.collect { events.add(it) } }
         advanceUntilIdle()
 
         vm.requestShowRouteOnMap(ShowRouteRequest("42"))
         advanceUntilIdle()
 
-        assertEquals(listOf<SheetCommand>(SheetCommand.CollapseSheet), events)
+        // The sheet collapse is now a declarative UI reaction to route mode (routeHeader != null),
+        // not a VM command — so this covers only the route directive.
         assertEquals(listOf("42"), map.routesShown)
         mapJob.cancel()
-        eventJob.cancel()
     }
 
     @Test


### PR DESCRIPTION
Closes #1649.

After #1639 the `SheetCommand` VM→UI channel carried exactly one command, `CollapseSheet`, from a single emitter. This replaces it with a declarative reaction to route-mode activation so the whole `SharedFlow` + sealed interface + collect loop goes away.

## What changed
- **`HomeScreen`** now collapses the sheet via a `LaunchedEffect` keyed on `routeHeader != null` (route mode active); the screen alone holds the live `SheetState`.
- Deleted `_sheetCommands`/`sheetCommands`, the `SheetCommand` sealed interface, the `emit()` helper, and the `emit(CollapseSheet)` in `requestShowRouteOnMap` (which now only issues the `ShowRoute` directive), plus the `sheetCommands` param/plumbing through `HomeScreen` and `HomeNavHost`.
- Tests updated to assert on map directives rather than the removed `sheetCommands` flow.

## Behavior note
Keying off route-mode *state* rather than the single command emitter means the **reveal-from-pushed-destination** path (`HomeNavHost` → `mapViewModel.toRoute`) now also collapses the sheet, whereas the old command only fired on "show vehicles on map". This is a small, **deliberate** broadening to the more coherent "collapse on any route-mode entry" behavior — the state seam is more fundamental than the command was.

## Verification
- Main + unit-test Kotlin compile cleanly; `HomeViewModelTest` passes.
- Cleanup review (reuse/simplification/efficiency/altitude) found nothing to fix.
- On-device: confirm the sheet still collapses promptly when tapping "show vehicles on map" (timing wrinkle from the issue — collapse now fires when the map finishes entering route mode rather than synchronously with the directive).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Route mode now opens the map route view directly and keeps the arrivals sheet collapsed as part of the screen behavior.
  * Improved home screen behavior so bottom-sheet state updates happen more reliably when switching into route mode.

* **Refactor**
  * Simplified home screen interactions by removing an extra command path and keeping sheet behavior managed within the screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->