### PR TITLE
Retire HttpURLConnection for OTP /plan: move to Retrofit OtpWebService (#1625)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/contract/OtpWebService.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/contract/OtpWebService.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.api.contract
+
+import okhttp3.ResponseBody
+import retrofit2.Call
+import retrofit2.http.GET
+import retrofit2.http.Url
+
+/**
+ * The OpenTripPlanner trip-planner client — separate from [ObaWebService] because the `/plan` request
+ * goes to the region's OTP server (its `otpBaseUrl`, or the user's custom OTP url), not the OBA
+ * `where` host. The caller ([org.onebusaway.android.ui.tripplan.DefaultTripPlanRepository]) assembles
+ * the full OTP URL (base + `routers/default/plan` + the query it builds from the OTP `Request`) and
+ * passes it via [Url], so — like [BikeWebService] — this runs WITHOUT `ApiParamsInterceptor` and the
+ * Retrofit base URL is a throwaway.
+ *
+ * Returns the raw [ResponseBody] (not a decoded DTO) as a **synchronous** [Call], for two reasons:
+ * the body is parsed through the shared [OtpPlanParser] (keeping the OTP-library `Response` mapping +
+ * malformed-body handling in one place, and letting the repository detect the old-server 404 to fall
+ * back to the legacy URL structure), and the repository has a blocking `planBlocking` path (the Java
+ * `RealtimeService` worker) that must call it without a coroutine.
+ */
+interface OtpWebService {
+
+    @GET
+    fun plan(@Url url: String): Call<ResponseBody>
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/app/di/NetworkModule.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/app/di/NetworkModule.kt
@@ -22,6 +22,7 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import java.util.concurrent.TimeUnit
 import javax.inject.Singleton
 import kotlinx.serialization.json.Json
 import okhttp3.MediaType.Companion.toMediaType
@@ -29,6 +30,7 @@ import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import org.onebusaway.android.BuildConfig
 import org.onebusaway.android.api.contract.BikeWebService
+import org.onebusaway.android.api.contract.OtpWebService
 import org.onebusaway.android.api.contract.RegionsWebService
 import org.onebusaway.android.api.contract.ReminderWebService
 import org.onebusaway.android.api.contract.SurveyWebService
@@ -118,11 +120,24 @@ object NetworkModule {
         plainRetrofit(json).create(ReminderWebService::class.java)
 
     /**
-     * A Retrofit built on a plain OkHttp client (debug logging only, no [ApiParamsInterceptor]) for
-     * services that pass an absolute `@Url` per call rather than relying on the region host rewrite.
+     * The OpenTripPlanner trip-planner client. Like [provideBikeWebService] it targets the region's OTP
+     * host via absolute `@Url`, so it uses a plain client without [ApiParamsInterceptor] — but with the
+     * legacy 15s connect/read timeouts the OTP `/plan` call has always used (OTP servers can be slow),
+     * rather than OkHttp's shorter defaults.
      */
-    private fun plainRetrofit(json: Json): Retrofit {
-        val client = OkHttpClient.Builder()
+    @Provides
+    @Singleton
+    fun provideOtpWebService(json: Json): OtpWebService {
+        val client = plainClient {
+            connectTimeout(OTP_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            readTimeout(OTP_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        }
+        return plainRetrofit(json, client).create(OtpWebService::class.java)
+    }
+
+    /** A plain OkHttp client (debug logging only, no [ApiParamsInterceptor]), optionally [configure]d. */
+    private fun plainClient(configure: OkHttpClient.Builder.() -> Unit = {}): OkHttpClient =
+        OkHttpClient.Builder()
             .apply {
                 if (BuildConfig.DEBUG) {
                     addInterceptor(
@@ -130,11 +145,19 @@ object NetworkModule {
                     )
                 }
             }
+            .apply(configure)
             .build()
-        return Retrofit.Builder()
+
+    /**
+     * A Retrofit built on a plain [client] (defaults to [plainClient]) for services that pass an
+     * absolute `@Url` per call rather than relying on the region host rewrite.
+     */
+    private fun plainRetrofit(json: Json, client: OkHttpClient = plainClient()): Retrofit =
+        Retrofit.Builder()
             .baseUrl("https://localhost/")
             .client(client)
             .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
             .build()
-    }
+
+    private const val OTP_TIMEOUT_SECONDS = 15L
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanRepository.kt
@@ -19,17 +19,15 @@ import android.content.Context
 import android.os.Bundle
 import androidx.annotation.WorkerThread
 import dagger.hilt.android.qualifiers.ApplicationContext
-import java.io.FileNotFoundException
 import java.io.IOException
 import java.net.HttpURLConnection
-import java.net.SocketTimeoutException
-import java.net.URL
 import java.util.Calendar
 import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.onebusaway.android.R
 import org.onebusaway.android.api.contract.OtpPlanParser
+import org.onebusaway.android.api.contract.OtpWebService
 import org.onebusaway.android.directions.util.CustomAddress
 import org.onebusaway.android.directions.util.TripRequestBuilder
 import org.opentripplanner.api.model.Itinerary
@@ -56,13 +54,15 @@ interface TripPlanRepository {
 
 /**
  * The coroutine replacement for the legacy `TripRequest` AsyncTask. Reuses [TripRequestBuilder] to
- * assemble the OTP request + base URL, then performs the (blocking) HTTP call + [OtpPlanParser]
- * parse on the IO thread — including the old-URL-structure fallback. OTP error codes are mapped to user-facing
- * messages (ported from TripPlanActivity.getErrorMessage) and surfaced as [Result.failure].
+ * assemble the OTP request + base URL, then performs the (blocking) Retrofit call ([OtpWebService]) +
+ * [OtpPlanParser] parse on the IO thread — including the old-URL-structure fallback. OTP error codes are
+ * mapped to user-facing messages (ported from TripPlanActivity.getErrorMessage) and surfaced as
+ * [Result.failure].
  */
 class DefaultTripPlanRepository @Inject constructor(
     @ApplicationContext private val context: Context,
     private val prefs: PreferencesRepository,
+    private val otpWebService: OtpWebService,
 ) : TripPlanRepository {
 
     override suspend fun plan(params: TripPlanParams): Result<List<Itinerary>> =
@@ -147,31 +147,35 @@ class DefaultTripPlanRepository @Inject constructor(
             baseUrl + PREFIX_NEW + PLAN_LOCATION + query
         }
 
-        var connection: HttpURLConnection? = null
-        try {
-            connection = (URL(url).openConnection() as HttpURLConnection).apply {
-                connectTimeout = HTTP_TIMEOUT_MS
-                readTimeout = HTTP_TIMEOUT_MS
-            }
-            val response: Response = OtpPlanParser.parse(connection.inputStream)
-            if (useOldUrlStructure) {
-                prefs.setBoolean(R.string.preference_key_otp_api_url_version, true)
-            }
-            return response
-        } catch (e: SocketTimeoutException) {
+        val response = try {
+            otpWebService.plan(url).execute()
+        } catch (e: IOException) {
+            // Transport failure / timeout (SocketTimeoutException is an IOException) — mirror the legacy
+            // catch-all mapping to the request-timeout message.
             throw IOException(errorMessage(Message.REQUEST_TIMEOUT.id), e)
-        } catch (e: FileNotFoundException) {
-            if (!useOldUrlStructure) {
-                connection?.disconnect()
-                connection = null
-                return requestPlan(request, baseUrl, useOldUrlStructure = true)
+        }
+
+        // A 404 on the new /routers/default structure means an older OTP server; retry the old /plan
+        // structure once (Retrofit has already buffered + closed the error body). On success below the
+        // preference is flipped so subsequent plans skip straight to the old structure.
+        if (response.code() == HttpURLConnection.HTTP_NOT_FOUND && !useOldUrlStructure) {
+            return requestPlan(request, baseUrl, useOldUrlStructure = true)
+        }
+
+        val parsed: Response = try {
+            val body = response.body()
+            if (!response.isSuccessful || body == null) {
+                throw IOException("OTP /plan returned HTTP ${response.code()}")
             }
-            throw IOException(errorMessage(Message.REQUEST_TIMEOUT.id), e)
+            body.use { OtpPlanParser.parse(it.byteStream()) }
         } catch (e: IOException) {
             throw IOException(errorMessage(Message.REQUEST_TIMEOUT.id), e)
-        } finally {
-            connection?.disconnect()
         }
+
+        if (useOldUrlStructure) {
+            prefs.setBoolean(R.string.preference_key_otp_api_url_version, true)
+        }
+        return parsed
     }
 
     private fun PlaceItem.toCustomAddress(): CustomAddress {
@@ -216,6 +220,5 @@ class DefaultTripPlanRepository @Inject constructor(
         const val PREFIX_NEW = "/routers/default"
         const val PLAN_LOCATION = "/plan"
         const val OTP_RENTAL_QUALIFIER = "_RENT"
-        const val HTTP_TIMEOUT_MS = 15000
     }
 }


### PR DESCRIPTION
Part of #1625 (does not fully close it — see "Remaining" below).

Retires the trip-planner's hand-rolled `java.net.HttpURLConnection` — the last one in the `directions/`/trip-planner subsystem — by moving the OpenTripPlanner `/plan` call onto the Retrofit/OkHttp stack every other endpoint already uses.

## What changed
- **New `OtpWebService`** (`api/contract/OtpWebService.kt`): `@GET fun plan(@Url url: String): Call<ResponseBody>`. Deliberately a **synchronous** `Call` returning the raw body (not a `suspend` fun / decoded DTO like the sibling `BikeWebService`), for two reasons:
  - The body is parsed through the shared `OtpPlanParser`, which maps onto the OTP library's own `org.opentripplanner.api.ws.Response` model — so no re-modeling of the whole OTP response as a serialization DTO, and the malformed-body handling stays in one place.
  - The repository has a blocking `planBlocking` path (the Java `RealtimeService` worker) that must call it without a coroutine; a synchronous `.execute()` avoids a `runBlocking` bridge. Both callers are already off-main (`plan` via `withContext(Dispatchers.IO)`, `planBlocking` is `@WorkerThread`).
- **`NetworkModule.provideOtpWebService`**: provides it like the other `@Url` sidecar services (no `ApiParamsInterceptor`), but on a dedicated client with the legacy **15s** connect/read timeouts OTP has always used (OTP servers can be slow). Extracted a small `plainClient { … }` helper so `plainRetrofit(json, client)` can take a configured client rather than duplicating the debug-logging setup.
- **`DefaultTripPlanRepository.requestPlan`**: swapped the `HttpURLConnection` block for `otpWebService.plan(url).execute()`. Behavior preserved exactly:
  - transport failure / timeout → the same request-timeout message;
  - HTTP 404 on the new `/routers/default` structure → the same retry against the old `/plan` structure + `preference_key_otp_api_url_version` flip;
  - success → `OtpPlanParser` as before.

URL construction, parsing, the fallback, and error mapping are unchanged — only the transport moves.

## Remaining for #1625
- Port the `directions/` package to Kotlin (still 9 Java files).
- Migrate the remaining `Date`/`Calendar` sites to `java.time`.

(The AsyncTask + Jackson goals of #1625 were already done in earlier work.)

## Testing
- `compileObaGoogleDebugKotlin` + Hilt processing green; trip-planner / trip-results / `OtpPlanDecodeTest` unit tests pass. Rebased cleanly on current `main` (compiles on the rebased base).
- On-device (Pixel 7 Pro, Android 16): app launches, DI graph resolves. **Please exercise an actual trip plan** to validate the live network path — including, if available, an older OTP server (the 404 → old-URL-structure fallback) and bike-rental routing (the one query where OkHttp's `HttpUrl` now percent-encodes a literal space as `%20`; commas in coordinates are unaffected).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for trip-planning requests through a newer network pathway, improving compatibility with the planner service.

* **Bug Fixes**
  * Updated request handling to keep existing timeout and fallback behavior while simplifying how responses are processed.
  * Preserved retry behavior when the planner endpoint uses an older URL structure.

* **Chores**
  * Adjusted networking configuration for planner requests to use consistent timeout settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->