### PR TITLE
Make SurveyUtils' appLaunchCount / DonationsManager reaches injectable (#1642)

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/database/oba/LegacyDataImporterTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/database/oba/LegacyDataImporterTest.kt
@@ -362,6 +362,7 @@ private object NoopPreferences : PreferencesRepository {
     override fun getLong(key: String, default: Long) = default
     override fun getFloat(keyRes: Int, default: Float) = default
     override fun getFloat(key: String, default: Float) = default
+    override fun getAppLaunchCount() = 0
     override fun setBoolean(keyRes: Int, value: Boolean) = Unit
     override fun setBoolean(key: String, value: Boolean) = Unit
     override fun setString(keyRes: Int, value: String?) = Unit

--- a/onebusaway-android/src/main/java/org/onebusaway/android/preferences/PreferencesRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/preferences/PreferencesRepository.kt
@@ -35,6 +35,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import org.onebusaway.android.app.Application
 import org.onebusaway.android.app.di.AppScope
 
 /**
@@ -80,6 +81,13 @@ interface PreferencesRepository {
 
     fun getFloat(@StringRes keyRes: Int, default: Float): Float
     fun getFloat(key: String, default: Float): Float
+
+    /**
+     * The persisted app-launch counter ([Application.APP_LAUNCH_COUNT_KEY]), 0 if never launched. A
+     * named read so consumers (e.g. the survey gate) inject this instead of re-inlining the key and its
+     * default — the injectable equivalent of the `Application.get().getAppLaunchCount()` reach (#1642).
+     */
+    fun getAppLaunchCount(): Int
 
     fun setBoolean(@StringRes keyRes: Int, value: Boolean)
     fun setBoolean(key: String, value: Boolean)
@@ -156,6 +164,8 @@ class DefaultPreferencesRepository @Inject constructor(
 
     override fun getFloat(keyRes: Int, default: Float) = getFloat(context.getString(keyRes), default)
     override fun getFloat(key: String, default: Float) = cache[floatPreferencesKey(key)] ?: default
+
+    override fun getAppLaunchCount() = getInt(Application.APP_LAUNCH_COUNT_KEY, 0)
 
     // --- writes (optimistic cache update + async persist) ---
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/survey/SurveyViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/survey/SurveyViewModel.kt
@@ -25,6 +25,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import org.onebusaway.android.app.di.AppScope
+import org.onebusaway.android.donations.DonationsManager
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -90,6 +91,7 @@ class SurveyViewModel @Inject constructor(
     private val surveyPreferences: SurveyPreferences,
     private val surveyRepo: SurveyDataSource,
     private val surveyStore: SurveyRepository,
+    private val donationsManager: DonationsManager,
     @AppScope private val appScope: CoroutineScope,
 ) : ViewModel() {
 
@@ -130,7 +132,13 @@ class SurveyViewModel @Inject constructor(
         if (regionRepository.region.value == null) return
         val studiesEnabled = prefs.getBoolean(R.string.preference_key_show_available_studies, true)
         if (!studiesEnabled ||
-            !SurveyUtils.shouldShowSurveyView(surveyPreferences, false)) return
+            !SurveyUtils.shouldShowSurveyView(
+                surveyPreferences,
+                prefs.getAppLaunchCount(),
+                donationsManager.shouldShowDonationUI(),
+                isVisibleOnStops = false,
+            )
+        ) return
         requested = true
         val url = studyUrl() ?: return
         viewModelScope.launch {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/survey/utils/SurveyUtils.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/survey/utils/SurveyUtils.kt
@@ -4,7 +4,6 @@ import android.util.Log
 import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
-import org.onebusaway.android.app.Application
 import org.onebusaway.android.models.ObaStop
 import org.onebusaway.android.models.Survey
 import org.onebusaway.android.models.SurveyQuestion
@@ -258,12 +257,24 @@ object SurveyUtils {
         return 0
     }
 
+    /**
+     * Decides whether the map survey may be shown. Stays a pure, JVM-testable object: the caller
+     * resolves the two bits of Application-lifecycle state and passes them in, rather than this helper
+     * reaching `Application.get()` (see #1642).
+     *
+     * @param appLaunchCount    number of app launches so far (the injected `APP_LAUNCH_COUNT_KEY` pref).
+     * @param donationUiShowing whether the donation UI is currently eligible to show — resolved by the
+     *                          caller from the injected `DonationsManager`; the survey defers to it on
+     *                          the map so the two don't compete.
+     */
     fun shouldShowSurveyView(
         surveyPreferences: SurveyPreferences,
+        appLaunchCount: Int,
+        donationUiShowing: Boolean,
         isVisibleOnStops: Boolean,
     ): Boolean {
         // User will receive a survey every `surveyLaunchCount` app launches
-        if (Application.get().appLaunchCount % launchesUntilSurveyShown != 0) return false
+        if (appLaunchCount % launchesUntilSurveyShown != 0) return false
 
         // Don't show the UI if there's a reminder date that is still in the future.
         val reminderDate = getSurveyRequestReminderDate(surveyPreferences)
@@ -275,7 +286,7 @@ object SurveyUtils {
         if (!isVisibleOnStops) {
             // If the donation UI is visible, do not show the survey on the map
             // Otherwise, show the survey on the map
-            return !Application.getDonationsManager().shouldShowDonationUI()
+            return !donationUiShowing
         }
 
         return true

--- a/onebusaway-android/src/test/java/org/onebusaway/android/testing/FakePreferencesRepository.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/testing/FakePreferencesRepository.kt
@@ -18,6 +18,7 @@ package org.onebusaway.android.testing
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
+import org.onebusaway.android.app.Application
 import org.onebusaway.android.preferences.PreferencesRepository
 
 /**
@@ -64,6 +65,9 @@ class FakePreferencesRepository(private val observeValue: Boolean = true) : Pref
     override fun getLong(key: String, default: Long) = read(key, default)
     override fun getFloat(keyRes: Int, default: Float) = read(keyRes, default)
     override fun getFloat(key: String, default: Float) = read(key, default)
+
+    // Mirrors the real impl: reads APP_LAUNCH_COUNT_KEY, so a test can seed it via setInt(key, n).
+    override fun getAppLaunchCount() = getInt(Application.APP_LAUNCH_COUNT_KEY, 0)
 
     override fun setBoolean(keyRes: Int, value: Boolean) { values[keyRes] = value; boolFlow(keyRes).value = value }
     override fun setBoolean(key: String, value: Boolean) { values[key] = value; boolFlow(key).value = value }


### PR DESCRIPTION
Closes #1642.

Removes the last two `Application.get()` **lifecycle** reaches inside `SurveyUtils.shouldShowSurveyView` — the every-Nth-launch survey gate (`Application.get().appLaunchCount`) and the donation-UI suppression check (`Application.getDonationsManager().shouldShowDonationUI()`).

## What changed

- **`SurveyUtils.shouldShowSurveyView`** now takes `appLaunchCount: Int` and `donationUiShowing: Boolean` as parameters instead of reaching `Application`. The helper stays a pure, JVM-testable `object` with no dependency on `Application` or `DonationsManager`.
- **`SurveyViewModel`** resolves both from injected sources and passes them in, mirroring how it already passes `SurveyPreferences`:
  - launch count via a new named **`PreferencesRepository.getAppLaunchCount()`** accessor — the injectable equivalent of `Application.getAppLaunchCount()`, owning `APP_LAUNCH_COUNT_KEY` + its default in one place (this is the "expose appLaunchCount as an injectable read" the issue proposed);
  - donation state via the already-Hilt-provided **`DonationsManager`** (constructor-injected).

`PreferenceUtils.getInt` delegates to the same `PreferencesRepository` DataStore, so `getAppLaunchCount()` reads the identical value `Application.getAppLaunchCount()` did — no behavior change.

## Acceptance

The only remaining `Application.get()` in the app is now the documented `PreferenceUtils.repo()` DI graph handle. Every other `Application.get()` match in main source is a doc comment.

## Verification

- Kotlin compile clean (`compileObaGoogleDebugKotlin`).
- Hilt DI graph validated (`kspObaGoogleDebugKotlin`) — the new `DonationsManager` injection resolves.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for tracking how many times the app has been launched, persisted in preferences.
* **Bug Fixes**
  * Improved survey eligibility so surveys appear only when the user is most likely to be ready, factoring in app launch activity and whether donation prompts are currently shown.
* **Tests**
  * Updated test and fake preference implementations to reflect the new launch-count behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->