### PR TITLE
Remove dead OTP-URL config accessors from Application

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/app/Application.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/app/Application.java
@@ -274,46 +274,6 @@ public class Application extends android.app.Application {
         PreferenceUtils.saveString(getString(R.string.preference_key_oba_api_url), url);
     }
 
-    /**
-     * Returns the custom OTP URL if the user has set a custom API URL manually via Preferences, or
-     * null
-     * if it has not been set
-     *
-     * @return the custom URL if the user has set a custom API URL manually via Preferences, or null
-     * if it has not been set
-     */
-    public String getCustomOtpApiUrl() {
-        return PreferenceUtils.getString(getString(R.string.preference_key_otp_api_url));
-    }
-
-    /**
-     * Sets the custom OTP URL used to reach a OBA REST API server that is not available via the
-     * Regions
-     * REST API
-     *
-     * @param url the custom URL
-     */
-    public void setCustomOtpApiUrl(String url) {
-        PreferenceUtils.saveString(getString(R.string.preference_key_otp_api_url), url);
-    }
-
-    /**
-     * @return true if the OTP url version is old, or false  if it has not been set
-     */
-    public boolean getUseOldOtpApiUrlVersion() {
-        return PreferenceUtils.getBoolean(getString(R.string.preference_key_otp_api_url_version), false);
-    }
-
-    /**
-     * Sets the OTP Api url version
-     *
-     * @param useOldOtpApiUrlVersion indicates that if otp url structure belongs to older version
-     */
-    public void setUseOldOtpApiUrlVersion(boolean useOldOtpApiUrlVersion) {
-        PreferenceUtils.saveBoolean(getString(R.string.preference_key_otp_api_url_version),
-                useOldOtpApiUrlVersion);
-    }
-
     private static final String HEXES = "0123456789abcdef";
 
     public static String getHex(byte[] raw) {


### PR DESCRIPTION
Cleanup tail of the `Application`-as-service-locator retirement (#1624 → #1627/#1630).

The OTP custom-URL and url-version config is fully owned by the injected `PreferencesRepository` path now:
- **read** via `PreferencesEntryPoint.get(context)` in `TripRequestBuilder`
- **written**/read via `prefs` in `AdvancedSettingsViewModel`, `TripPlanRepository`, `BikeStationsRepository`, `RegionRepository`

The four `Application` shims that mirrored those same prefs have had **zero callers** (main or test) since that work landed:

- `getCustomOtpApiUrl()`
- `setCustomOtpApiUrl(String)`
- `getUseOldOtpApiUrlVersion()`
- `setUseOldOtpApiUrlVersion(boolean)`

This deletes them. No behavior change — the prefs and every live read/write are untouched.

### Deliberately kept
`getCustomApiUrl` / `setCustomApiUrl` / `getCurrentRegion` remain: they still back the internal analytics region-id digest in `Application` and the instrumented tests (`ObaTestCase`, `UIUtilTest`), so they are not vestigial.

Verified: `:onebusaway-android:compileObaGoogleDebugJavaWithJavac` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)