### PR TITLE
Model map framing as retained intent, not per-command deferral flags (#1648)

### DIFF
--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleCameraCommands.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleCameraCommands.kt
@@ -26,6 +26,7 @@ import org.onebusaway.android.R
 import org.onebusaway.android.app.Application
 import org.onebusaway.android.map.googlemapsv2.MapHelpV2
 import org.onebusaway.android.map.render.CameraCommand
+import org.onebusaway.android.map.render.FramingIntent
 import org.onebusaway.android.map.render.MapRenderState
 import org.onebusaway.android.util.ViewUtils
 import kotlin.math.abs
@@ -35,17 +36,15 @@ private const val CAMERA_DEFAULT_ZOOM = 16.0f
 private const val DEFAULT_MAP_PADDING_DP = 20.0f
 
 /**
- * Applies one [CameraCommand] to the imperative [GoogleMap] — a faithful port of the `GoogleMapHost`
- * methods that called `mMap.animateCamera/moveCamera` directly (the maps-compose `CameraPositionState`
- * detour is gone). The math (bounds, the route-header recenter bias, the closest-vehicle visibility
- * short-circuit) is unchanged, now reading the live camera from [map] and the route shape from
- * [renderState]. Google's camera calls are fire-and-forget, so this is not a suspend function.
+ * Applies one transient [CameraCommand] gesture to the imperative [GoogleMap] — a faithful port of the
+ * `GoogleMapHost` methods that called `mMap.animateCamera/moveCamera` directly (the maps-compose
+ * `CameraPositionState` detour is gone). The route-header recenter bias is unchanged, now reading the
+ * live camera from [map]. Google's camera calls are fire-and-forget, so this is not a suspend function.
+ * Retained framing (fit route / itinerary / region) is applied by [applyFramingIntent].
  */
 fun applyCameraCommand(
     cmd: CameraCommand,
     map: GoogleMap,
-    renderState: MapRenderState,
-    context: Context,
 ) {
     when (cmd) {
         is CameraCommand.Recenter -> {
@@ -85,36 +84,6 @@ fun applyCameraCommand(
 
         is CameraCommand.SetZoom -> map.moveCamera(CameraUpdateFactory.zoomTo(cmd.zoom))
 
-        CameraCommand.FitToRoute -> {
-            val bounds = routePolylineBounds(renderState)
-            if (bounds == null) {
-                Toast.makeText(context, R.string.route_info_no_shape_data, Toast.LENGTH_SHORT).show()
-            } else {
-                map.moveCamera(
-                    CameraUpdateFactory.newLatLngBounds(bounds, ViewUtils.dpToPixels(context, DEFAULT_MAP_PADDING_DP))
-                )
-            }
-        }
-
-        CameraCommand.FitToItinerary -> {
-            val bounds = routePolylineBounds(renderState) ?: return
-            val dm = context.resources.displayMetrics
-            map.moveCamera(
-                CameraUpdateFactory.newLatLngBounds(
-                    bounds, dm.widthPixels, dm.heightPixels,
-                    ViewUtils.dpToPixels(context, DEFAULT_MAP_PADDING_DP)
-                )
-            )
-        }
-
-        CameraCommand.ZoomToRegion -> {
-            val region = Application.get().currentRegion ?: return
-            val bounds = MapHelpV2.getRegionBounds(region)
-            // Use screen dimensions to avoid IllegalStateException (#581).
-            val dm = context.resources.displayMetrics
-            map.animateCamera(CameraUpdateFactory.newLatLngBounds(bounds, dm.widthPixels, dm.heightPixels, 0))
-        }
-
         CameraCommand.ZoomIn -> map.animateCamera(CameraUpdateFactory.zoomIn())
 
         CameraCommand.ZoomOut -> map.animateCamera(CameraUpdateFactory.zoomOut())
@@ -127,6 +96,55 @@ fun applyCameraCommand(
                 )
             )
         }
+    }
+}
+
+/**
+ * Applies the map's retained [FramingIntent] to the imperative [GoogleMap] — the bounds/target math
+ * ported unchanged from the former `FitToRoute`/`FitToItinerary`/`ZoomToRegion` camera commands,
+ * re-reading the route shape from [renderState] and the region bounds live so it's safe to re-apply when
+ * a re-created adapter replays the current framing. Fire-and-forget, so not a suspend function.
+ */
+fun applyFramingIntent(
+    intent: FramingIntent,
+    map: GoogleMap,
+    renderState: MapRenderState,
+    context: Context,
+) {
+    when (intent) {
+        FramingIntent.Route -> {
+            val bounds = routePolylineBounds(renderState)
+            if (bounds == null) {
+                Toast.makeText(context, R.string.route_info_no_shape_data, Toast.LENGTH_SHORT).show()
+            } else {
+                map.moveCamera(
+                    CameraUpdateFactory.newLatLngBounds(bounds, ViewUtils.dpToPixels(context, DEFAULT_MAP_PADDING_DP))
+                )
+            }
+        }
+
+        FramingIntent.Itinerary -> {
+            val bounds = routePolylineBounds(renderState) ?: return
+            val dm = context.resources.displayMetrics
+            map.moveCamera(
+                CameraUpdateFactory.newLatLngBounds(
+                    bounds, dm.widthPixels, dm.heightPixels,
+                    ViewUtils.dpToPixels(context, DEFAULT_MAP_PADDING_DP)
+                )
+            )
+        }
+
+        FramingIntent.Region -> {
+            val region = Application.get().currentRegion ?: return
+            val bounds = MapHelpV2.getRegionBounds(region)
+            // Use screen dimensions to avoid IllegalStateException (#581).
+            val dm = context.resources.displayMetrics
+            map.animateCamera(CameraUpdateFactory.newLatLngBounds(bounds, dm.widthPixels, dm.heightPixels, 0))
+        }
+
+        is FramingIntent.Point -> map.moveCamera(
+            CameraUpdateFactory.newLatLngZoom(LatLng(intent.lat, intent.lon), intent.zoom)
+        )
     }
 }
 

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleComposeAdapter.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleComposeAdapter.kt
@@ -48,9 +48,9 @@ import com.google.android.gms.maps.model.MapStyleOptions
 import com.google.android.gms.maps.model.Marker
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
-import kotlinx.coroutines.flow.onSubscription
 import org.onebusaway.android.R
 import org.onebusaway.android.map.MapHost
 import org.onebusaway.android.map.compose.BikeInfoWindow
@@ -79,8 +79,9 @@ private const val FRAME_INTERVAL_NANOS = 50_000_000L
  * android-maps-compose), bridging the MapView's imperative lifecycle to Compose via a
  * [LifecycleEventObserver], and drives the shared [MapHost]. It sets the style, builds the
  * [GoogleMapRenderer] and re-renders on every render-state change, wires map/marker/info-window clicks
- * to [callbacks], reports camera idles to [MapHost.onCameraIdle], applies the dispatched camera intents,
- * and enables the location blue dot from the host's permission-derived flag.
+ * to [callbacks], reports camera idles to [MapHost.onCameraIdle], applies the render state's camera
+ * gestures + retained framing intent, and enables the location blue dot from the host's
+ * permission-derived flag.
  *
  * The live route vehicles + the trip-focus estimate markers are native [Marker]s moved in place at
  * ~20Hz (the [GoogleMapRenderer.renderDynamic] loop below), so they glide with the map — no Compose
@@ -245,19 +246,16 @@ class GoogleComposeAdapter : ObaComposeMapAdapter {
             LaunchedEffect(map) {
                 renderState.padding.collect { map.setPadding(0, it.topPx, 0, it.bottomPx) }
             }
-            // Declarative camera: apply the host-dispatched camera intents to the map once ready, and
-            // tell the host the adapter is subscribed (so a deferred route re-frame can dispatch now).
-            DisposableEffect(map) {
-                host.setMapAttached(true)
-                onDispose { host.setMapAttached(false) }
+            // Declarative camera. Transient gestures apply as they arrive (dropped if none pending when
+            // the map wasn't subscribed). The retained framing intent is replayed to this collector when
+            // the map (re)composes, so a fit requested before the adapter subscribed — the directions map
+            // composed behind the results sheet (#1640), or a re-tap of the already-shown route — is
+            // re-applied here rather than deferred through a host flag; null clears it (no framing to apply).
+            LaunchedEffect(map) {
+                renderState.cameraGestures.collect { applyCameraCommand(it, map) }
             }
             LaunchedEffect(map) {
-                renderState.cameraCommands
-                    // Flush any frame deferred while the map was detached the moment this collector is
-                    // registered — emissions made in onSubscription are delivered here, so a deferred
-                    // fit isn't dropped by the no-replay flow if the first camera-idle beats us (#1640).
-                    .onSubscription { host.onCameraCommandsSubscribed() }
-                    .collect { applyCameraCommand(it, map, renderState, context) }
+                renderState.framingIntent.filterNotNull().collect { applyFramingIntent(it, map, renderState, context) }
             }
             // Publish a flavor-neutral lat/lng -> root-space projector so map-SDK-agnostic callers (the
             // onboarding spotlight) can locate a marker on screen without touching the Google SDK.

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapHost.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapHost.kt
@@ -23,12 +23,15 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import androidx.lifecycle.SavedStateHandle
 import org.onebusaway.android.R
 import org.onebusaway.android.location.LocationRepository
 import org.onebusaway.android.map.render.CameraCommand
 import org.onebusaway.android.map.render.CameraSnapshot
+import org.onebusaway.android.map.render.FramingIntent
 import org.onebusaway.android.map.render.GeoPoint
 import org.onebusaway.android.map.render.MapRenderState
 import org.onebusaway.android.preferences.PreferencesRepository
@@ -94,47 +97,6 @@ class MapHost(
         savedStateHandle[MapParams.CENTER_LAT] = snapshot.center.latitude
         savedStateHandle[MapParams.CENTER_LON] = snapshot.center.longitude
         savedStateHandle[MapParams.ZOOM] = snapshot.zoom.toFloat()
-        // Apply any frame deferred while the map wasn't ready, but ONLY once the adapter's command
-        // collector is actually subscribed — not merely attached. [setMapAttached] runs in a
-        // DisposableEffect that fires *before* the separate LaunchedEffect that subscribes to
-        // [MapRenderState.cameraCommands], so there's a window where mapAttached is true but no collector
-        // exists yet; a map tearing down likewise reports a final idle after its collector is gone.
-        // Flushing then would dispatch the pending frame into a no-replay flow with no subscriber, losing
-        // it and stranding the camera at the (0,0) seed. This path only covers the
-        // "attached + subscribed but not yet idled" window (e.g. a region resolving just after attach);
-        // the reliable flush on (re)attach is [onCameraCommandsSubscribed].
-        if (mapAttached && cameraCommandsSubscribed) applyDeferredCameraFrames()
-    }
-
-    /**
-     * Apply any camera frame requested while the map was detached: the region re-zoom ([rezoomForRegion]),
-     * the route re-fit ([frameRoute]), or the directions itinerary fit ([frameItinerary]). The
-     * camera-command flow has no replay, so a frame dispatched before a collector exists is lost —
-     * these deferrals hold the intent until the map is ready, then dispatch it against a live subscriber.
-     */
-    private fun applyDeferredCameraFrames() {
-        if (pendingRegionFrame) {
-            pendingRegionFrame = false
-            frameCurrentRegion()
-        }
-        if (pendingFrameCommands.isNotEmpty()) {
-            val commands = pendingFrameCommands
-            pendingFrameCommands = emptyList()
-            commands.forEach { dispatchCamera(it) }
-        }
-    }
-
-    /**
-     * The flavor adapter calls this the instant it subscribes to [MapRenderState.cameraCommands] (from
-     * `Flow.onSubscription`), so a frame deferred while the map was detached is dispatched against a
-     * guaranteed-live collector rather than racing it. The first `onCameraIdle` can fire *before* the
-     * adapter's collector is registered — with a no-replay command flow that dropped the deferred frame,
-     * leaving the camera at the (0,0) world seed (the trip-plan directions map, drawn behind the results
-     * sheet the moment a plan completes, hit this every time).
-     */
-    fun onCameraCommandsSubscribed() {
-        cameraCommandsSubscribed = true
-        applyDeferredCameraFrames()
     }
 
     /**
@@ -194,85 +156,50 @@ class MapHost(
 
     fun setBottomPadding(px: Int) = renderState.setBottomPadding(px)
 
-    fun dispatchCamera(command: CameraCommand) = renderState.dispatchCamera(command)
+    /** Dispatch a transient camera gesture (zoom step / recenter / my-location move / stop-tap center). */
+    fun dispatchGesture(command: CameraCommand) = renderState.dispatchGesture(command)
 
-    // Whether a flavor map adapter is currently composed. Toggled by the adapter on composition
-    // enter/leave; lets [frameOrDefer] choose between dispatching now and deferring.
-    private var mapAttached = false
+    /** Set the map's retained framing intent (fit route / itinerary / region / a fixed point). */
+    fun frame(intent: FramingIntent) = renderState.frame(intent)
 
-    // Whether the adapter's [MapRenderState.cameraCommands] collector is actually subscribed. Distinct
-    // from [mapAttached] because the adapter sets attached in a DisposableEffect that runs *before* the
-    // LaunchedEffect that subscribes, so there's an attached-but-not-subscribed window; a deferred flush
-    // into the no-replay command flow during it would be lost. Set on subscribe ([onCameraCommandsSubscribed]),
-    // cleared on detach so a re-attach re-arms it.
-    private var cameraCommandsSubscribed = false
-
-    // Set when a framing move (route/itinerary bounds fit, or the degenerate directions start-center) is
-    // requested while the map is detached — the camera-command flow has no replay, so a command
-    // dispatched before the adapter (re)subscribes is lost. Holds the latest such frame's commands until
-    // the map is ready (see [frameOrDefer]); a single pending frame is enough because a given host only
-    // ever fits one thing (the home map fits a route, the trip-results map fits an itinerary), but the
-    // start-center frame is two commands (recenter + zoom), so it's a list. The region re-zoom is
-    // deferred separately via [pendingRegionFrame] because it runs decision logic ([frameCurrentRegion]).
-    private var pendingFrameCommands: List<CameraCommand> = emptyList()
-
-    /** The flavor adapter reports when its render-state subscription starts/ends (the map composable enter/leave). */
-    fun setMapAttached(attached: Boolean) {
-        mapAttached = attached
-        if (!attached) cameraCommandsSubscribed = false
-    }
+    /** Clear the retained framing so a stale fit isn't re-applied when the map leaves a framed view. */
+    fun clearFraming() = renderState.clearFraming()
 
     /**
-     * Dispatch a framing move now when the map adapter's command collector is subscribed; otherwise hold
-     * it until the map is ready (flushed by [onCameraCommandsSubscribed], or [applyDeferredCameraFrames]
-     * on the first idle), so a frame isn't dropped into the no-replay command flow when it's requested
-     * against a map that's attached but hasn't subscribed yet (the [setMapAttached] DisposableEffect runs
-     * before the subscribing LaunchedEffect). The shape/route is already in the render state, so a
-     * deferred bounds-fit has bounds to fit.
+     * Frame the active route's bounding box (the "zoom to route" camera move). Sets the retained
+     * [FramingIntent.Route], so a late or re-created adapter replays it — the frame isn't dropped when
+     * re-selecting the already-shown route from a list that navigates back to a freshly re-created map
+     * (the recent-routes case), nor swallowed when re-tapping the same route to snap back to its extent.
+     * The route's shape is already in the render state, so the framing has bounds to fit.
      */
-    private fun frameOrDefer(vararg commands: CameraCommand) {
-        if (mapAttached && cameraCommandsSubscribed) {
-            commands.forEach { dispatchCamera(it) }
-        } else {
-            pendingFrameCommands = commands.toList()
-        }
-    }
+    fun frameRoute() = frame(FramingIntent.Route)
 
     /**
-     * Frame the active route's bounding box (the "zoom to route" camera move). Deferred if the map isn't
-     * ready — e.g. re-selecting the already-shown route from a list that navigates back to a freshly
-     * re-created map (the recent-routes case).
-     */
-    fun frameRoute() = frameOrDefer(CameraCommand.FitToRoute)
-
-    /**
-     * Frame the current directions itinerary's bounding box. Deferred if the map isn't ready — the
+     * Frame the current directions itinerary's bounding box. Retained, so it isn't lost when the
      * directions map is composed behind the results sheet the instant a plan completes, before the
-     * adapter subscribes to the command flow.
+     * adapter subscribes (#1640) — the replay catches the late subscriber up.
      */
-    fun frameItinerary() = frameOrDefer(CameraCommand.FitToItinerary)
+    fun frameItinerary() = frame(FramingIntent.Itinerary)
 
     /**
      * Frame a degenerate directions itinerary (no route shape — start == end): center on [lat],[lon] at
-     * the default zoom. Deferred like [frameItinerary] if the map isn't ready, since it's dispatched at
-     * the same moment (a plan completing behind the results sheet) and the command flow has no replay.
+     * the default zoom. Retained like [frameItinerary] since it's requested at the same moment (a plan
+     * completing behind the results sheet).
      */
-    fun frameStart(lat: Double, lon: Double) = frameOrDefer(
-        CameraCommand.Recenter(lat, lon, animate = false, applyRouteBias = false),
-        CameraCommand.SetZoom(MapParams.DEFAULT_ZOOM.toFloat()),
-    )
+    fun frameStart(lat: Double, lon: Double) =
+        frame(FramingIntent.Point(lat, lon, MapParams.DEFAULT_ZOOM.toFloat()))
 
     /** Animate/move the camera to a point with no route-header bias (a general recenter for any screen). */
     fun centerOn(lat: Double, lon: Double, animate: Boolean) {
-        dispatchCamera(CameraCommand.Recenter(lat, lon, animate, applyRouteBias = false))
+        dispatchGesture(CameraCommand.Recenter(lat, lon, animate, applyRouteBias = false))
     }
 
-    fun zoomIn() = dispatchCamera(CameraCommand.ZoomIn)
+    fun zoomIn() = dispatchGesture(CameraCommand.ZoomIn)
 
-    fun zoomOut() = dispatchCamera(CameraCommand.ZoomOut)
+    fun zoomOut() = dispatchGesture(CameraCommand.ZoomOut)
 
     /** Frame the current region's bounds (the out-of-range dialog's "take me there"). */
-    fun zoomToRegion() = dispatchCamera(CameraCommand.ZoomToRegion)
+    fun zoomToRegion() = frame(FramingIntent.Region)
 
     // ----- Generic markers -----
 
@@ -343,7 +270,7 @@ class MapHost(
         )
         when (action) {
             MyLocationAction.MoveToLocation -> last?.let {
-                dispatchCamera(
+                dispatchGesture(
                     CameraCommand.MoveToLocation(it.latitude, it.longitude, useDefaultZoom, animate)
                 )
             }
@@ -356,37 +283,40 @@ class MapHost(
 
     // ----- Region re-zoom (the old ObaRegionsTask.Callback.onRegionTaskFinished) -----
 
-    // Set when a region change wants to re-center but the map hasn't published its camera yet — the
-    // camera-command flow has no replay, so a command dispatched before the adapter subscribes is lost.
-    // Consumed on the first onCameraIdle (when the adapter is definitely subscribed).
-    private var pendingRegionFrame = false
-
     /**
      * The current region changed (driven by the region collector, so this only fires on a real change to
-     * a present region). Frames it once the map is ready; if the map hasn't published a camera yet, defer
-     * to the first [onCameraIdle] so the camera command isn't lost.
+     * a present region). Frames it once the map has published a camera — awaiting the first non-null
+     * [camera] reactively rather than deferring through a boolean flushed in [onCameraIdle]. Waiting for
+     * the camera lets the `cameraAtSeed` decision read the real restored/seed viewport (not a premature
+     * null). Both outcomes are retained framings ([FramingIntent]), so the frame survives even if the
+     * first camera idle beats the adapter's subscription (#1640) — the exact seed-window this decision
+     * runs in — rather than being dropped into the no-replay gesture flow.
      */
     private fun rezoomForRegion() {
-        if (_camera.value == null) {
-            pendingRegionFrame = true
-            return
+        scope.launch {
+            val cam = camera.filterNotNull().first()
+            frameCurrentRegion(cam)
         }
-        frameCurrentRegion()
     }
 
     /**
      * Frame the current region: if we have no location, or the camera is still at the (0,0) seed, frame
      * the user's location if we have one, else the region — but don't yank a camera the user already moved.
+     * Both frames go through the retained [FramingIntent] flow (not the FAB's [requestMyLocation] gesture
+     * path), so neither can be lost in the first-idle-before-subscribe window this cold-start decision
+     * runs in. The my-location leg has already established a fix here (regionRezoom returns FrameMyLocation
+     * only when one exists), so it centers on it directly rather than re-deriving the FAB's dialog logic.
      */
-    private fun frameCurrentRegion() {
+    private fun frameCurrentRegion(cam: CameraSnapshot) {
         // lastKnownLocation() (not the repo's .value): this runs at cold-start framing and must trigger
         // the lazy provider poll so the first frame can target the user's location.
         val location = locationRepository.lastKnownLocation()
-        val center = _camera.value?.center
-        val atSeed = center == null || (center.latitude == 0.0 && center.longitude == 0.0)
+        val center = cam.center
+        val atSeed = center.latitude == 0.0 && center.longitude == 0.0
         when (regionRezoom(changed = true, hasLocation = location != null, cameraAtSeed = atSeed)) {
-            RegionRezoom.FrameMyLocation -> requestMyLocation(useDefaultZoom = true, animate = false)
-            RegionRezoom.FrameRegion -> dispatchCamera(CameraCommand.ZoomToRegion)
+            RegionRezoom.FrameMyLocation ->
+                location?.let { frame(FramingIntent.Point(it.latitude, it.longitude, SEED_DEFAULT_ZOOM)) }
+            RegionRezoom.FrameRegion -> frame(FramingIntent.Region)
             RegionRezoom.None -> {}
         }
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
@@ -283,6 +283,10 @@ class MapViewModel @Inject constructor(
         stopsController.clearStops(false)
         mapHost.setProgress(false)
         mapHost.setMoreStopsAvailable(false)
+        // Drop any retained framing (route/itinerary/region fit) so it isn't replayed onto the next view
+        // — e.g. a stale route fit re-applied when a re-created adapter re-subscribes in nearby-stops
+        // mode. The view we enter next sets its own framing (or none, for nearby stops).
+        mapHost.clearFraming()
     }
 
     // ----- Focus + taps (delegated to [stopsController], except the vehicle selection) -----
@@ -306,7 +310,7 @@ class MapViewModel @Inject constructor(
 
     /** Recenter on the focused stop after the arrivals sheet expands over it (a Home map directive). */
     fun recenterOnFocusedStop(lat: Double, lon: Double) {
-        mapHost.dispatchCamera(
+        mapHost.dispatchGesture(
             CameraCommand.Recenter(lat, lon, animate = true, applyRouteBias = routeController.isActive)
         )
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/StopsMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/StopsMapController.kt
@@ -205,7 +205,7 @@ class StopsMapController(
     fun onStopTapped(stop: ObaStop) {
         setFocusedStopId(stop.id)
         val loc = stop.location
-        host.dispatchCamera(CameraCommand.CenterOnStopTap(loc.latitude, loc.longitude))
+        host.dispatchGesture(CameraCommand.CenterOnStopTap(loc.latitude, loc.longitude))
     }
 
     /** A tap away from any marker clears the stop render focus (the old onMapClick). */
@@ -220,7 +220,7 @@ class StopsMapController(
      */
     fun focusStop(stop: ObaStop, routes: List<ObaRoute>?, overlayExpanded: Boolean) {
         val loc = stop.location
-        host.dispatchCamera(
+        host.dispatchGesture(
             CameraCommand.Recenter(
                 loc.latitude, loc.longitude,
                 animate = false,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/TripFocusController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/TripFocusController.kt
@@ -26,7 +26,7 @@ import org.onebusaway.android.extrapolation.extrapolationFromState
 import org.onebusaway.android.time.WallTime
 import org.onebusaway.android.extrapolation.data.TripObservationRepository
 import org.onebusaway.android.map.render.BandSegment
-import org.onebusaway.android.map.render.CameraCommand
+import org.onebusaway.android.map.render.FramingIntent
 import org.onebusaway.android.map.render.RoutePolyline
 import org.onebusaway.android.map.render.TripOverlay
 import org.onebusaway.android.map.render.TripStopDot
@@ -88,7 +88,7 @@ class TripFocusController(
                     )
                 )
             )
-            host.dispatchCamera(CameraCommand.FitToRoute)
+            host.frame(FramingIntent.Route)
         }
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/CameraCommand.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/CameraCommand.kt
@@ -16,15 +16,18 @@
 package org.onebusaway.android.map.render
 
 /**
- * A one-shot camera intent. A use-case controller dispatches one of these to
- * [MapRenderState.cameraCommands], and the flavor adapter applies it against its imperative map
- * (`GoogleMap`/`MapLibreMap.animateCamera(...)`) — so the camera is driven from state, decoupled from
- * any one screen, rather than poked directly on the map.
+ * A one-shot, **transient** camera gesture (zoom step, recenter, my-location move, stop-tap centering).
+ * A use-case controller dispatches one of these to [MapRenderState.cameraGestures], and the flavor
+ * adapter applies it against its imperative map (`GoogleMap`/`MapLibreMap.animateCamera(...)`) — so the
+ * camera is driven from state, decoupled from any one screen, rather than poked directly on the map.
+ *
+ * Transient: a gesture dispatched while no map is subscribed is *meant* to be discarded (the flow has no
+ * replay). Persistent framing — fit the route / itinerary / region — is the separate [FramingIntent],
+ * which is retained so a late subscriber catches up.
  *
  * Flavor-neutral: it carries *intent*, never a Google/maplibre `CameraUpdate`. The renderer computes
- * the actual bounds/target from the current render state + the live viewport. Bounds-fitting commands
- * read [MapRenderSnapshot.routePolylines]; framing math that needs the map (the closest-vehicle
- * visibility check, the route-mode recenter bias) is resolved by the renderer from the live camera.
+ * the actual target from the current render state + the live viewport; the route-mode recenter bias is
+ * resolved by the renderer from the live camera.
  */
 sealed interface CameraCommand {
 
@@ -53,15 +56,6 @@ sealed interface CameraCommand {
 
     /** Set the zoom level (preserving the current center). */
     data class SetZoom(val zoom: Float) : CameraCommand
-
-    /** Fit the route/itinerary polyline bounds with the default padding. */
-    object FitToRoute : CameraCommand
-
-    /** Fit the route/itinerary polyline bounds, padding against the screen dimensions. */
-    object FitToItinerary : CameraCommand
-
-    /** Fit the current region's bounds. */
-    object ZoomToRegion : CameraCommand
 
     /** Step zoom in/out (the zoom FABs). */
     object ZoomIn : CameraCommand

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/FramingIntent.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/FramingIntent.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.map.render
+
+/**
+ * A **retained** camera framing — "what the map is currently framing" — as opposed to a transient
+ * [CameraCommand] gesture. A controller sets one via [MapRenderState.frame] and the flavor adapter fits
+ * its imperative map to it; unlike a gesture, the current framing is held (replayed) so a late or
+ * re-created adapter catches up and re-applies it. That replay is what lets the host drop the old
+ * deferral machinery (`pendingFrameCommands`, `mapAttached`/`cameraCommandsSubscribed`, and the
+ * `onCameraCommandsSubscribed` flush): a frame requested before the adapter subscribes — the directions
+ * map composed behind the results sheet the instant a plan completes (#1640), or the region re-zoom
+ * resolved at cold start — is caught by the replay instead of dropped into a no-replay flow.
+ *
+ * Flavor-neutral: like [CameraCommand] it carries *intent*, never a Google/maplibre `CameraUpdate`. The
+ * bounds-fitting cases re-derive their bounds from the live render state + region each time they're
+ * applied (so they are idempotent and safe to re-apply); [Point] carries an explicit target + zoom.
+ */
+sealed interface FramingIntent {
+
+    /** Fit the route polyline bounds with the default padding. */
+    object Route : FramingIntent
+
+    /** Fit the itinerary polyline bounds, padding against the screen dimensions. */
+    object Itinerary : FramingIntent
+
+    /** Fit the current region's bounds. */
+    object Region : FramingIntent
+
+    /** Center on a fixed point at a fixed zoom (the degenerate directions itinerary: start == end). */
+    data class Point(val lat: Double, val lon: Double, val zoom: Float) : FramingIntent
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
@@ -15,6 +15,7 @@
  */
 package org.onebusaway.android.map.render
 
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -202,15 +203,41 @@ class MapRenderState {
         _projector.value = projector
     }
 
-    // One-shot camera intents a controller dispatches and the flavor adapter applies against its
-    // imperative map (animateCamera/moveCamera). Buffered so the synchronous dispatch never suspends or
-    // drops under a brief burst (e.g. the vehicle poll).
-    private val _cameraCommands = MutableSharedFlow<CameraCommand>(extraBufferCapacity = 16)
+    // Transient one-shot camera gestures a controller dispatches and the flavor adapter applies against
+    // its imperative map (animateCamera/moveCamera). replay=0: a gesture dispatched with no map
+    // subscribed is meant to be discarded — it carries no lasting intent to catch a late subscriber up
+    // on (that's [framingIntent]'s job). Buffered so the synchronous dispatch never suspends or drops
+    // under a brief burst (e.g. the vehicle poll).
+    private val _cameraGestures = MutableSharedFlow<CameraCommand>(extraBufferCapacity = 16)
 
-    val cameraCommands: SharedFlow<CameraCommand> = _cameraCommands.asSharedFlow()
+    val cameraGestures: SharedFlow<CameraCommand> = _cameraGestures.asSharedFlow()
 
-    fun dispatchCamera(command: CameraCommand) {
-        _cameraCommands.tryEmit(command)
+    fun dispatchGesture(command: CameraCommand) {
+        _cameraGestures.tryEmit(command)
+    }
+
+    // The map's retained framing intent (fit route / itinerary / region / a fixed point), or null for no
+    // framing. A replay=1 SharedFlow rather than a StateFlow, for two reasons a plain StateFlow can't
+    // serve at once: (1) a fresh adapter — a config-change or process-restore recompose, or the map
+    // composed behind the directions results sheet (#1640) — replays the current framing and re-applies
+    // it, which is what lets the host drop the pendingFrameCommands / cameraCommandsSubscribed deferral
+    // machinery a replay=0 flow forced; and (2) re-emitting the *same* framing (re-tapping the shown
+    // route to snap back to its extent) still re-fires, whereas a StateFlow would swallow the identical
+    // value as a no-op. Null is emitted to clear framing when the map leaves a framed view, so a stale
+    // route fit isn't re-applied in nearby-stops mode.
+    private val _framingIntent = MutableSharedFlow<FramingIntent?>(
+        replay = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
+
+    val framingIntent: SharedFlow<FramingIntent?> = _framingIntent.asSharedFlow()
+
+    fun frame(intent: FramingIntent) {
+        _framingIntent.tryEmit(intent)
+    }
+
+    fun clearFraming() {
+        _framingIntent.tryEmit(null)
     }
 
     fun getRoutePolylines(): List<RoutePolyline> = _snapshot.value.routePolylines

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreCameraCommands.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreCameraCommands.kt
@@ -23,6 +23,7 @@ import org.maplibre.android.maps.MapLibreMap
 import org.onebusaway.android.app.Application
 import org.onebusaway.android.map.maplibre.MapHelpMapLibre
 import org.onebusaway.android.map.render.CameraCommand
+import org.onebusaway.android.map.render.FramingIntent
 import org.onebusaway.android.map.render.MapRenderState
 import kotlin.math.abs
 
@@ -30,17 +31,14 @@ import kotlin.math.abs
 private const val CAMERA_DEFAULT_ZOOM = 16.0
 
 /**
- * Applies one [CameraCommand] to the maplibre [MapLibreMap] — the declarative counterpart of the
- * Google adapter's `applyCameraCommand`. It's a faithful port of the old `MapLibreMapHost` camera
- * methods (which called `mMap.animateCamera/moveCamera` directly); now the host dispatches intents and
- * the adapter applies them here. maplibre's camera calls are fire-and-forget (not suspending), so this
- * isn't a suspend function. Bounds-fitting reads the route shape from [renderState]; the route-header
- * recenter bias reads the live viewport from [map].
- *
- * As on the old host, route/itinerary/closest-vehicle framing all just frame the route shape — the
- * screen-dimension padding and closest-vehicle inclusion were Google-only refinements.
+ * Applies one transient [CameraCommand] gesture to the maplibre [MapLibreMap] — the declarative
+ * counterpart of the Google adapter's `applyCameraCommand`. It's a faithful port of the old
+ * `MapLibreMapHost` camera methods (which called `mMap.animateCamera/moveCamera` directly); now the host
+ * dispatches gestures and the adapter applies them here. maplibre's camera calls are fire-and-forget
+ * (not suspending), so this isn't a suspend function. The route-header recenter bias reads the live
+ * viewport from [map]. Retained framing is applied by [applyFramingIntent].
  */
-fun applyCameraCommand(cmd: CameraCommand, map: MapLibreMap, renderState: MapRenderState) {
+fun applyCameraCommand(cmd: CameraCommand, map: MapLibreMap) {
     when (cmd) {
         is CameraCommand.Recenter -> {
             val cp = map.cameraPosition
@@ -75,23 +73,37 @@ fun applyCameraCommand(cmd: CameraCommand, map: MapLibreMap, renderState: MapRen
 
         is CameraCommand.SetZoom -> map.moveCamera(CameraUpdateFactory.zoomTo(cmd.zoom.toDouble()))
 
-        CameraCommand.FitToRoute,
-        CameraCommand.FitToItinerary -> {
-            val bounds = routePolylineBounds(renderState) ?: return
-            map.animateCamera(CameraUpdateFactory.newLatLngBounds(bounds, 0))
-        }
-
-        CameraCommand.ZoomToRegion -> {
-            val region = Application.get().currentRegion ?: return
-            map.animateCamera(CameraUpdateFactory.newLatLngBounds(MapHelpMapLibre.getRegionBounds(region), 0))
-        }
-
         CameraCommand.ZoomIn -> map.animateCamera(CameraUpdateFactory.zoomIn())
 
         CameraCommand.ZoomOut -> map.animateCamera(CameraUpdateFactory.zoomOut())
 
         // maplibre has no map-type tilt reset, so its host never dispatches this.
         CameraCommand.ResetTilt -> Unit
+    }
+}
+
+/**
+ * Applies the map's retained [FramingIntent] to the maplibre [MapLibreMap] — the counterpart of the
+ * Google adapter's `applyFramingIntent`. As on the old host, route/itinerary framing both just frame the
+ * route shape (the screen-dimension padding was a Google-only refinement); the bounds are re-read from
+ * [renderState]/the region live, so it's safe to re-apply when a re-created adapter replays the framing.
+ */
+fun applyFramingIntent(intent: FramingIntent, map: MapLibreMap, renderState: MapRenderState) {
+    when (intent) {
+        FramingIntent.Route,
+        FramingIntent.Itinerary -> {
+            val bounds = routePolylineBounds(renderState) ?: return
+            map.animateCamera(CameraUpdateFactory.newLatLngBounds(bounds, 0))
+        }
+
+        FramingIntent.Region -> {
+            val region = Application.get().currentRegion ?: return
+            map.animateCamera(CameraUpdateFactory.newLatLngBounds(MapHelpMapLibre.getRegionBounds(region), 0))
+        }
+
+        is FramingIntent.Point -> map.moveCamera(
+            CameraUpdateFactory.newLatLngZoom(LatLng(intent.lat, intent.lon), intent.zoom.toDouble())
+        )
     }
 }
 

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreComposeAdapter.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreComposeAdapter.kt
@@ -62,7 +62,7 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
-import kotlinx.coroutines.flow.onSubscription
+import kotlinx.coroutines.flow.filterNotNull
 import kotlin.math.abs
 
 private const val STYLE_URL_LIGHT = "https://tiles.openfreemap.org/styles/liberty"
@@ -76,8 +76,8 @@ private const val FRAME_INTERVAL_NANOS = 8_333_333L
  * [AndroidView] (there is no maplibre-compose), bridging the MapView's imperative lifecycle to Compose
  * via a [LifecycleEventObserver], and drives the [MapHost]: it sets the style, builds the
  * [MapLibreRenderer] and re-renders on every render-state change, wires map/marker/info-window clicks
- * to [callbacks], reports camera idles to [MapHost.onCameraIdle], applies the dispatched camera intents
- * from the render state's cameraCommands, and enables the location blue dot from the host's
+ * to [callbacks], reports camera idles to [MapHost.onCameraIdle], applies the render state's camera
+ * gestures + retained framing intent, and enables the location blue dot from the host's
  * permission-derived flag. There is no imperative host.
  *
  * Lifecycle note: `addObserver` on an already-STARTED/RESUMED lifecycle synchronously dispatches the
@@ -211,23 +211,18 @@ class MapLibreComposeAdapter : ObaComposeMapAdapter {
             }
         }
 
-        // Declarative camera: apply the dispatched camera intents to the map once ready, and tell the host
-        // the adapter is subscribed (so a deferred route re-frame can dispatch now rather than waiting).
+        // Declarative camera. Transient gestures apply as they arrive (dropped if none pending when the
+        // map wasn't subscribed); the retained framing intent is replayed to this collector when the map
+        // (re)composes, so a fit requested before the adapter subscribed — the directions map composed
+        // behind the results sheet (#1640), or a re-tap of the shown route — is re-applied here rather
+        // than deferred through a host flag; null clears it (no framing to apply).
         val map = mapLibreMap
         if (map != null) {
-            DisposableEffect(map) {
-                host.setMapAttached(true)
-                onDispose { host.setMapAttached(false) }
+            LaunchedEffect(map) {
+                renderState.cameraGestures.collect { command -> applyCameraCommand(command, map) }
             }
             LaunchedEffect(map) {
-                renderState.cameraCommands
-                    // Flush any frame deferred while the map was detached the moment this collector is
-                    // registered — emissions in onSubscription reach this collector, so a deferred fit
-                    // isn't dropped by the no-replay flow if the first camera-idle beats us (#1640).
-                    .onSubscription { host.onCameraCommandsSubscribed() }
-                    .collect { command ->
-                        applyCameraCommand(command, map, renderState)
-                    }
+                renderState.framingIntent.filterNotNull().collect { applyFramingIntent(it, map, renderState) }
             }
         }
 

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/render/MapRenderStateFramingTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/render/MapRenderStateFramingTest.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.map.render
+
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * The behavioral contract the framing/gesture split (#1648) depends on: retained framing replays to a
+ * late subscriber (so a fit requested before the adapter subscribes — the directions map behind the
+ * results sheet, a re-created map — isn't dropped), re-fires on an identical value (unlike a StateFlow),
+ * and can be cleared; transient gestures are dropped when nothing is listening.
+ */
+class MapRenderStateFramingTest {
+
+    @Test
+    fun `framing replays the current intent to a late subscriber`() = runTest {
+        val state = MapRenderState()
+        // Frame before anyone subscribes — the old replay=0 flow would drop this.
+        state.frame(FramingIntent.Route)
+
+        assertEquals(FramingIntent.Route, state.framingIntent.first())
+    }
+
+    @Test
+    fun `re-emitting the same framing re-fires (a StateFlow would swallow it)`() = runTest {
+        val state = MapRenderState()
+        val seen = mutableListOf<FramingIntent?>()
+        // UnconfinedTestDispatcher subscribes eagerly, so the collector is active before we emit.
+        val job = backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            state.framingIntent.toList(seen)
+        }
+
+        state.frame(FramingIntent.Route)
+        state.frame(FramingIntent.Route) // identical — must still be delivered
+
+        assertEquals(listOf(FramingIntent.Route, FramingIntent.Route), seen)
+        job.cancel()
+    }
+
+    @Test
+    fun `clearFraming replays null so a stale fit is not re-applied`() = runTest {
+        val state = MapRenderState()
+        state.frame(FramingIntent.Region)
+        state.clearFraming()
+
+        assertNull(state.framingIntent.first())
+    }
+
+    @Test
+    fun `a gesture dispatched with no subscriber is dropped`() = runTest {
+        val state = MapRenderState()
+        // No collector yet: this gesture has nowhere to go and must not be replayed.
+        state.dispatchGesture(CameraCommand.ZoomIn)
+
+        val seen = mutableListOf<CameraCommand>()
+        val job = backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            state.cameraGestures.toList(seen)
+        }
+        state.dispatchGesture(CameraCommand.ZoomOut)
+
+        assertEquals(listOf(CameraCommand.ZoomOut), seen)
+        job.cancel()
+    }
+}


### PR DESCRIPTION
## Summary

Models map camera **framing** as retained intent instead of the hand-rolled per-command deferral flags, closing #1648.

`MapRenderState` had a single `replay = 0` `cameraCommands` `SharedFlow`, which drops any command dispatched before a map adapter subscribes. To work around that, `MapHost` had grown a pile of deferral state — `mapAttached`, `cameraCommandsSubscribed`, `pendingFrameCommands`, `frameOrDefer(...)`, `applyDeferredCameraFrames()`, and the `onCameraCommandsSubscribed()` flush-on-subscribe added in #1640 (the directions map, composed behind the results sheet the instant a plan completes, was stranding the camera at (0,0)).

## What changed

Split the one flow into two, by intent type:

- **`framingIntent: SharedFlow<FramingIntent?>` (`replay = 1`)** — retained framing: route fit, itinerary fit, region fit, and a fixed-point fit (the degenerate start == end itinerary). A late or re-created adapter replays the current value and re-applies it, so a frame requested before the adapter subscribes is caught by the replay rather than dropped. `replay = 1` (not a `StateFlow`) because re-emitting the *same* framing — re-tapping the already-shown route to snap back to its extent — must still re-fire, which a `StateFlow` would swallow as a no-op. `null` clears it when the map leaves a framed view.
- **`cameraGestures: SharedFlow<CameraCommand>` (`replay = 0`)** — the transient one-shots kept as-is (zoom step, recenter, my-location move, stop-tap center), which are meant to be discarded when no map is listening.

The retained framing subsumes the entire deferral system, which is deleted: `mapAttached` / `cameraCommandsSubscribed`, `pendingFrameCommands`, `frameOrDefer`, `applyDeferredCameraFrames`, `onCameraCommandsSubscribed()` / the adapters' `onSubscription` flush, and the `onCameraIdle` flush block. The #1640 directions-behind-the-sheet fit is now caught by the replay instead of a subscribe-time flush.

Region re-zoom awaits the first non-null camera reactively (so the `cameraAtSeed` decision reads the real seed/restored viewport) instead of a boolean flushed on idle. Both of its outcomes — region fit **and** the cold-start my-location fit — go through the retained flow, so neither can be dropped in the first-idle-before-subscribe window this seed-condition decision runs in.

## Behavior notes for review

- **Re-application on re-subscription is now intended.** Because framing is retained, a config-change / process-restore recompose re-applies the current framing (e.g. rotating in route mode re-fits the route rather than preserving a pan). This is the behavioral change #1648 anticipated; `MapViewModel.leaveCurrentView()` clears framing so a stale fit isn't replayed in nearby-stops mode.
- **Cold-start my-location framing** no longer routes through the my-location FAB's dialog logic — it directly frames the already-established fix (region re-zoom only picks that branch when one exists). In the edge case where location services are toggled off / permission is revoked between acquiring the last-known fix and cold start, the old path showed a dialog during silent framing; the new path frames the known location.

## Testing

- Builds on both `oba*Google` and `oba*Maplibre` flavors.
- New `MapRenderStateFramingTest` covers the replay / re-fire / clear / drop contract of the two flows.
- **On-device verification still pending** — the retained-framing behavior change should be exercised across route mode, the directions itinerary, trip-focus, region change, and rotation in nearby-stops mode before merge.

Closes #1648.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Map movements now distinguish between quick camera gestures and retained framing, improving map behavior when switching views.
  * Route, itinerary, region, and point framing now restore more reliably, including after returning to a screen.

* **Bug Fixes**
  * Prevented stale map framing from carrying over to the next view.
  * Improved route/region fitting so map updates are less likely to fail or show incorrect bounds.
  * Tap-to-center and recenter actions now behave more consistently across map modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->