### PR TITLE
Delete dead isIgnoringBatteryOptimizations from Application

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/app/Application.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/app/Application.java
@@ -22,7 +22,6 @@ import android.content.Context;
 import android.hardware.GeomagneticField;
 import android.location.Location;
 import android.os.Build;
-import android.os.PowerManager;
 import android.text.TextUtils;
 import android.util.Log;
 
@@ -449,20 +448,6 @@ public class Application extends android.app.Application {
             manager.createNotificationChannel(channel2);
             manager.createNotificationChannel(channel3);
         }
-    }
-
-    public static Boolean isIgnoringBatteryOptimizations(Context applicationContext) {
-        PowerManager pm = (PowerManager) applicationContext.getSystemService(Context.POWER_SERVICE);
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M &&
-                pm.isIgnoringBatteryOptimizations(applicationContext.getPackageName())) {
-            return true;
-        }
-
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
-            return null;
-        }
-
-        return false;
     }
 
     private void initFirebaseMessaging() {


### PR DESCRIPTION
Slice 1 of #1659 (Application.java decomposition).

`Application.isIgnoringBatteryOptimizations(Context)` has **zero callers** across `src/main`, `src/androidTest`, and the flavor source sets. Deleting it also removes the now-orphaned `android.os.PowerManager` import.

No behavior change. Verified: `:onebusaway-android:compileObaGoogleDebugJavaWithJavac` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed an app-level battery optimization check that is no longer used, simplifying startup behavior.
  * Cleaned up related app initialization code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->