### PR TITLE
Make GtfsAlerts an injectable @Singleton, drop the Application holder

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/app/Application.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/app/Application.java
@@ -41,7 +41,6 @@ import org.onebusaway.android.util.BuildFlavorUtils;
 import org.onebusaway.android.util.LocationUtils;
 import org.onebusaway.android.util.PreferenceUtils;
 import org.onebusaway.android.util.ThemeUtils;
-import org.onebusaway.android.widealerts.GtfsAlerts;
 
 import java.security.MessageDigest;
 import java.util.UUID;
@@ -67,8 +66,6 @@ public class Application extends android.app.Application {
     public static final String CHANNEL_DESTINATION_ALERT_ID = "destination_alerts";
 
     private DonationsManager mDonationsManager;
-
-    private GtfsAlerts mGtfsAlerts;
 
     private static Application mApp;
 
@@ -110,8 +107,6 @@ public class Application extends android.app.Application {
         initFirebaseMessaging();
 
         mDonationsManager = new DonationsManager(getApplicationContext(), getResources(), getAppLaunchCount());
-
-        mGtfsAlerts = new GtfsAlerts(getApplicationContext());
     }
 
     /**
@@ -133,10 +128,6 @@ public class Application extends android.app.Application {
     }
 
     public static DonationsManager getDonationsManager() { return get().mDonationsManager; }
-
-    public static GtfsAlerts getGtfsAlerts() {
-        return get().mGtfsAlerts;
-    }
 
 
     // Preserve the original preference-key value so persisted launch counts survive upgrades.

--- a/onebusaway-android/src/main/java/org/onebusaway/android/region/RegionRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/region/RegionRepository.kt
@@ -45,8 +45,8 @@ import org.onebusaway.android.util.RegionUtils
  * re-centering) collect [region]/[state]; the resolution action ([refresh]/[choose]) lives here too,
  * folding in the former `RegionStatusRepository`.
  *
- * One process-singleton instance is held on `Application` (mirroring `getGtfsAlerts()`), so every view
- * model shares the same flow; tests substitute a fake. It lives in the neutral `region` package so both
+ * One process-singleton instance is provided by Hilt (like the other app-scoped `@Singleton`s), so every
+ * view model shares the same flow; tests substitute a fake. It lives in the neutral `region` package so both
  * the map and the home UI can depend on it without a backward dependency.
  */
 interface RegionRepository {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/widealert/WideAlertsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/widealert/WideAlertsRepository.kt
@@ -19,7 +19,7 @@ import javax.inject.Inject
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
-import org.onebusaway.android.app.Application
+import org.onebusaway.android.widealerts.GtfsAlerts
 
 /** A region-wide GTFS alert to surface to the user (drives the home wide-alert dialog). */
 data class WideAlert(val title: String, val message: String, val url: String?)
@@ -38,10 +38,12 @@ interface WideAlertsRepository {
  * [kotlinx.coroutines.Dispatchers.IO] is needed because the fetcher already threads itself; the
  * collector's context decides where emissions are observed.
  */
-class DefaultWideAlertsRepository @Inject constructor() : WideAlertsRepository {
+class DefaultWideAlertsRepository @Inject constructor(
+    private val gtfsAlerts: GtfsAlerts,
+) : WideAlertsRepository {
 
     override fun wideAlerts(regionId: String): Flow<WideAlert> = callbackFlow {
-        Application.getGtfsAlerts().fetchAlerts(regionId) { title, message, url ->
+        gtfsAlerts.fetchAlerts(regionId) { title, message, url ->
             trySend(WideAlert(title, message, url))
         }
         // The fetcher exposes no cancellation handle; its background thread is short-lived.

--- a/onebusaway-android/src/main/java/org/onebusaway/android/widealerts/GtfsAlerts.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/widealerts/GtfsAlerts.java
@@ -15,16 +15,23 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import dagger.hilt.android.qualifiers.ApplicationContext;
+
 /**
  * Fetches GTFS alerts and processes them.
  */
+@Singleton
 public class GtfsAlerts {
 
     private static final String TAG = "GtfsAlerts";
     private static final Set<String> fetchedRegions = new HashSet<>();
     private final Context mContext;
 
-    public GtfsAlerts(Context context) {
+    @Inject
+    public GtfsAlerts(@ApplicationContext Context context) {
         mContext = context;
     }
 


### PR DESCRIPTION
Slice 2 of #1659 (Application.java decomposition).

`GtfsAlerts` was held on `Application.mGtfsAlerts` and reached through the static `Application.getGtfsAlerts()`. It has exactly **one** real caller — `DefaultWideAlertsRepository`, which is already a Hilt `@Inject` class — so this is a clean constructor injection, no EntryPoint needed:

- `GtfsAlerts` → `@Singleton` + `@Inject constructor(@ApplicationContext Context)`.
- `DefaultWideAlertsRepository` constructor-injects `GtfsAlerts` instead of calling the static getter.
- `Application` loses the `mGtfsAlerts` field, its `onCreate` construction, `getGtfsAlerts()`, and the now-unused `GtfsAlerts` import.
- Updated the stale `RegionRepository` doc comment that referenced `getGtfsAlerts()` as the process-singleton precedent.

`GtfsAlerts.fetchedRegions` stays a static dedup set (harmless under a true singleton); behavior is unchanged.

Verified: `:onebusaway-android:compileObaGoogleDebugSources` passes (Java + Kotlin + Hilt/KSP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)