### PR TITLE
Trip planner: typed endpoints with cancellable pills + Geocoder fallback

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.kt
@@ -24,6 +24,12 @@ import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.navigation.compose.rememberNavController
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -127,23 +133,28 @@ class HomeActivity : AppCompatActivity() {
             // The welcome tutorial (now the Compose green welcome + map-stop spotlight sequence) is
             // started by HomeScreen off the same showWelcomeTutorial latch — no host effect needed.
             SettingsRehomeEffect(navController)
-            HomeNavHost(
-                navController = navController,
-                home = HomeDestinationDeps(
-                    homeViewModel = viewModel,
-                    mapViewModel = mapViewModel,
-                    surveyViewModel = surveyViewModel,
-                    donationViewModel = donationViewModel,
-                    weatherViewModel = weatherViewModel,
-                    helpViewModel = helpViewModel,
-                    arrivalsViewModelFactory = arrivalsViewModelFactory,
-                    activityActions = activityActions,
-                ),
-            )
-            PaymentWarningDialog(viewModel.paymentWarning, viewModel::dismissPaymentWarning)
-            // The forced region picker, driven reactively off the repository (RegionPickerViewModel). At the
-            // setContent root so its window overlays whatever screen triggered the re-resolve.
-            RegionPickerHost()
+            // Surface Compose testTags as UIAutomator resource-ids app-wide, so screens can be driven
+            // semantically (by tag/text) instead of by coordinate taps in tests + tooling.
+            @OptIn(ExperimentalComposeUiApi::class)
+            Box(Modifier.fillMaxSize().semantics { testTagsAsResourceId = true }) {
+                HomeNavHost(
+                    navController = navController,
+                    home = HomeDestinationDeps(
+                        homeViewModel = viewModel,
+                        mapViewModel = mapViewModel,
+                        surveyViewModel = surveyViewModel,
+                        donationViewModel = donationViewModel,
+                        weatherViewModel = weatherViewModel,
+                        helpViewModel = helpViewModel,
+                        arrivalsViewModelFactory = arrivalsViewModelFactory,
+                        activityActions = activityActions,
+                    ),
+                )
+                PaymentWarningDialog(viewModel.paymentWarning, viewModel::dismissPaymentWarning)
+                // The forced region picker, driven reactively off the repository (RegionPickerViewModel). At the
+                // setContent root so its window overlays whatever screen triggered the re-resolve.
+                RegionPickerHost()
+            }
         }
 
         setupMapState()

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/GeocodeRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/GeocodeRepository.kt
@@ -22,36 +22,47 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.onebusaway.android.directions.util.CustomAddress
 import org.onebusaway.android.region.RegionRepository
+import org.onebusaway.android.util.BuildFlavorUtils
 import org.onebusaway.android.util.LocationUtils
 
 /** Address-autocomplete suggestions for the trip-plan endpoints. */
 interface GeocodeRepository {
-    suspend fun suggest(query: String): Result<List<PlaceItem>>
+    suspend fun suggest(query: String): Result<List<TripEndpoint.Geocoded>>
 }
 
 /**
- * Pelias-backed geocoding. All four product flavors set `USE_PELIAS_GEOCODING = true`, so the
- * legacy Google-Places intent path is not carried over. Wraps the blocking
- * [LocationUtils.processPeliasGeocoding] on the IO thread and projects [CustomAddress] onto the
- * JVM-pure [PlaceItem] so the ViewModel stays testable.
+ * Address suggestions for the trip-plan endpoints. Prefers Pelias (real autocomplete, with
+ * `transport:public` results flagged as transit), but falls back to the on-device
+ * [android.location.Geocoder] when no Pelias API key is configured — so key-free dev builds still
+ * geocode. Both paths reuse the existing [LocationUtils] geocoders (which handle the region bbox
+ * biasing/filtering); the Geocoder fallback has no typeahead/transit categories, so it's degraded only.
+ * Runs the blocking work on the IO thread and projects onto the JVM-pure [TripEndpoint.Geocoded].
  */
 class DefaultGeocodeRepository @Inject constructor(
     @ApplicationContext private val context: Context,
     private val regionRepository: RegionRepository,
 ) : GeocodeRepository {
 
-    override suspend fun suggest(query: String): Result<List<PlaceItem>> =
+    override suspend fun suggest(query: String): Result<List<TripEndpoint.Geocoded>> =
         withContext(Dispatchers.IO) {
             runCatching {
                 val region = regionRepository.region.value
-                LocationUtils.processPeliasGeocoding(context, region, query).map { it.toPlaceItem() }
+                val addresses = if (BuildFlavorUtils.isPeliasApiKeyDefined()) {
+                    LocationUtils.processPeliasGeocoding(context, region, query)
+                } else {
+                    // No-key fallback: the platform Geocoder, region-biased + filtered — the same helper
+                    // the legacy trip planner already geocodes its endpoint addresses with.
+                    LocationUtils.processGeocoding(context, region, false, query)
+                }
+                addresses.orEmpty().map { it.toGeocoded() }
             }
         }
-
-    private fun CustomAddress.toPlaceItem(): PlaceItem = PlaceItem(
-        displayName = toString(),
-        lat = if (isSet) latitude else null,
-        lon = if (isSet) longitude else null,
-        isTransit = isTransitCategory
-    )
 }
+
+/** Mints the domain [TripEndpoint.Geocoded] from a geocoder [CustomAddress] result (the wire boundary). */
+internal fun CustomAddress.toGeocoded(): TripEndpoint.Geocoded = TripEndpoint.Geocoded(
+    displayName = toString(),
+    lat = if (isSet) latitude else null,
+    lon = if (isSet) longitude else null,
+    isTransit = isTransitCategory
+)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanForm.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanForm.kt
@@ -15,22 +15,30 @@
  */
 package org.onebusaway.android.ui.tripplan
 
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.InputChip
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.MenuAnchorType
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -38,6 +46,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -52,13 +61,29 @@ import org.onebusaway.android.ui.compose.theme.ObaTheme
  * actions. Stateless and driven by [TripPlanFormState]; the date/time/contacts/current-location
  * actions are platform interactions launched by the host.
  */
+/**
+ * Stable UIAutomator/Compose-test handles for the trip-plan form. Surfaced as resource-ids by the
+ * app-wide `testTagsAsResourceId` in HomeActivity, so the form can be driven semantically (focus a
+ * field, tap a suggestion) without coordinate taps. The per-endpoint tags are `<prefix><suffix>`,
+ * e.g. `tripPlanFromField`, `tripPlanToPill`, `tripPlanFromSuggestion`.
+ */
+object TripPlanTestTags {
+    const val FROM_PREFIX = "tripPlanFrom"
+    const val TO_PREFIX = "tripPlanTo"
+    const val FIELD_SUFFIX = "Field"
+    const val PILL_SUFFIX = "Pill"
+    const val SUGGESTION_SUFFIX = "Suggestion"
+}
+
 @Composable
 fun TripPlanForm(
     state: TripPlanFormState,
     onFromQueryChange: (String) -> Unit,
     onToQueryChange: (String) -> Unit,
-    onSelectFrom: (PlaceItem) -> Unit,
-    onSelectTo: (PlaceItem) -> Unit,
+    onSelectFrom: (TripEndpoint.Geocoded) -> Unit,
+    onSelectTo: (TripEndpoint.Geocoded) -> Unit,
+    onClearFrom: () -> Unit,
+    onClearTo: () -> Unit,
     onFromCurrentLocation: () -> Unit,
     onToCurrentLocation: () -> Unit,
     onFromContacts: () -> Unit,
@@ -78,10 +103,12 @@ fun TripPlanForm(
     ) {
         AddressField(
             label = stringResource(R.string.trip_plan_from),
-            query = state.fromQuery,
+            tagPrefix = TripPlanTestTags.FROM_PREFIX,
+            endpoint = state.from,
             suggestions = state.fromSuggestions,
             onQueryChange = onFromQueryChange,
             onSelect = onSelectFrom,
+            onClear = onClearFrom,
             onCurrentLocation = onFromCurrentLocation,
             onContacts = onFromContacts,
             onPickOnMap = onFromPickOnMap
@@ -91,10 +118,12 @@ fun TripPlanForm(
         }
         AddressField(
             label = stringResource(R.string.trip_plan_to),
-            query = state.toQuery,
+            tagPrefix = TripPlanTestTags.TO_PREFIX,
+            endpoint = state.to,
             suggestions = state.toSuggestions,
             onQueryChange = onToQueryChange,
             onSelect = onSelectTo,
+            onClear = onClearTo,
             onCurrentLocation = onToCurrentLocation,
             onContacts = onToContacts,
             onPickOnMap = onToPickOnMap
@@ -122,14 +151,59 @@ fun TripPlanForm(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
+/**
+ * One trip-plan endpoint. A still-being-typed [TripEndpoint.FreeText] is an editable autocomplete
+ * field; any resolved kind is shown as a cancellable pill sitting *inside* the same field, where the
+ * text would be — the field is then inoperative (no typing) until the pill's ✕ clears it. The
+ * contacts / current-location / pick-on-map shortcuts stay live in both states, so picking another
+ * input method overrides the current pill.
+ */
 @Composable
 private fun AddressField(
     label: String,
-    query: String,
-    suggestions: List<PlaceItem>,
+    tagPrefix: String,
+    endpoint: TripEndpoint,
+    suggestions: List<TripEndpoint.Geocoded>,
     onQueryChange: (String) -> Unit,
-    onSelect: (PlaceItem) -> Unit,
+    onSelect: (TripEndpoint.Geocoded) -> Unit,
+    onClear: () -> Unit,
+    onCurrentLocation: () -> Unit,
+    onContacts: () -> Unit,
+    onPickOnMap: () -> Unit
+) {
+    when (endpoint) {
+        is TripEndpoint.FreeText -> EditableAddressField(
+            label = label,
+            tagPrefix = tagPrefix,
+            query = endpoint.query,
+            suggestions = suggestions,
+            onQueryChange = onQueryChange,
+            onSelect = onSelect,
+            onCurrentLocation = onCurrentLocation,
+            onContacts = onContacts,
+            onPickOnMap = onPickOnMap
+        )
+        else -> EndpointPillField(
+            label = label,
+            tagPrefix = tagPrefix,
+            endpoint = endpoint,
+            onClear = onClear,
+            onCurrentLocation = onCurrentLocation,
+            onContacts = onContacts,
+            onPickOnMap = onPickOnMap
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun EditableAddressField(
+    label: String,
+    tagPrefix: String,
+    query: String,
+    suggestions: List<TripEndpoint.Geocoded>,
+    onQueryChange: (String) -> Unit,
+    onSelect: (TripEndpoint.Geocoded) -> Unit,
     onCurrentLocation: () -> Unit,
     onContacts: () -> Unit,
     onPickOnMap: () -> Unit
@@ -146,29 +220,15 @@ private fun AddressField(
             label = { Text(label) },
             singleLine = true,
             trailingIcon = {
-                Row {
-                    IconButton(onClick = onContacts) {
-                        Icon(
-                            painter = painterResource(R.drawable.baseline_import_contacts_24),
-                            contentDescription = stringResource(R.string.trip_plan_from)
-                        )
-                    }
-                    IconButton(onClick = onCurrentLocation) {
-                        Icon(
-                            painter = painterResource(R.drawable.ic_my_location),
-                            contentDescription = stringResource(R.string.tripplanner_current_location)
-                        )
-                    }
-                    IconButton(onClick = onPickOnMap) {
-                        Icon(
-                            painter = painterResource(R.drawable.ic_action_location_map),
-                            contentDescription = stringResource(R.string.trip_plan_pick_on_map)
-                        )
-                    }
-                }
+                AddressActionIcons(
+                    onContacts = onContacts,
+                    onCurrentLocation = onCurrentLocation,
+                    onPickOnMap = onPickOnMap
+                )
             },
             modifier = Modifier
                 .fillMaxWidth()
+                .testTag(tagPrefix + TripPlanTestTags.FIELD_SUFFIX)
                 .menuAnchor(MenuAnchorType.PrimaryEditable)
         )
         ExposedDropdownMenu(expanded = showMenu, onDismissRequest = { expanded = false }) {
@@ -176,24 +236,136 @@ private fun AddressField(
                 DropdownMenuItem(
                     text = { Text(place.displayName) },
                     leadingIcon = if (place.isTransit) {
-                        {
-                            Icon(
-                                painter = painterResource(R.drawable.ic_bus),
-                                contentDescription = null,
-                                tint = colorResource(R.color.material_gray)
-                            )
-                        }
+                        { BusIcon() }
                     } else {
                         null
                     },
                     onClick = {
                         onSelect(place)
                         expanded = false
-                    }
+                    },
+                    modifier = Modifier.testTag(tagPrefix + TripPlanTestTags.SUGGESTION_SUFFIX)
                 )
             }
         }
     }
+}
+
+/**
+ * A resolved endpoint shown as a pill *inside* an outlined field. There is no editable text — the
+ * pill occupies the field's inner content slot, so the field can't be typed into until ✕ clears it.
+ * The action icons remain in the trailing slot so another input method can replace the pill.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun EndpointPillField(
+    label: String,
+    tagPrefix: String,
+    endpoint: TripEndpoint,
+    onClear: () -> Unit,
+    onCurrentLocation: () -> Unit,
+    onContacts: () -> Unit,
+    onPickOnMap: () -> Unit
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val endpointText = endpointLabel(endpoint)
+    // Read-only host text field gives the full-width sizing; we ignore its inner text field and drop
+    // the pill into the OutlinedTextField decoration instead, so it renders where the text would be.
+    BasicTextField(
+        value = "",
+        onValueChange = {},
+        readOnly = true,
+        singleLine = true,
+        interactionSource = interactionSource,
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag(tagPrefix + TripPlanTestTags.PILL_SUFFIX)
+    ) {
+        OutlinedTextFieldDefaults.DecorationBox(
+            value = endpointText, // non-empty so the label floats above the pill
+            innerTextField = {
+                InputChip(
+                    selected = true,
+                    onClick = onClear,
+                    label = {
+                        // Geocoder/contact names can be long; keep the pill to one line inside the
+                        // singleLine field so it doesn't wrap over the trailing clear icon.
+                        Text(endpointText, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                    },
+                    leadingIcon = if (endpoint.isTransit) {
+                        { BusIcon() }
+                    } else {
+                        null
+                    },
+                    trailingIcon = {
+                        Icon(
+                            imageVector = Icons.Filled.Close,
+                            contentDescription = stringResource(R.string.trip_plan_clear_endpoint)
+                        )
+                    }
+                )
+            },
+            enabled = true,
+            singleLine = true,
+            visualTransformation = VisualTransformation.None,
+            interactionSource = interactionSource,
+            label = { Text(label) },
+            trailingIcon = {
+                AddressActionIcons(
+                    onContacts = onContacts,
+                    onCurrentLocation = onCurrentLocation,
+                    onPickOnMap = onPickOnMap
+                )
+            },
+            contentPadding = OutlinedTextFieldDefaults.contentPadding(top = 8.dp, bottom = 8.dp)
+        )
+    }
+}
+
+/** The contacts / current-location / pick-on-map shortcuts shared by both endpoint states. */
+@Composable
+private fun AddressActionIcons(
+    onContacts: () -> Unit,
+    onCurrentLocation: () -> Unit,
+    onPickOnMap: () -> Unit
+) {
+    Row {
+        IconButton(onClick = onContacts) {
+            Icon(
+                painter = painterResource(R.drawable.baseline_import_contacts_24),
+                contentDescription = stringResource(R.string.trip_plan_contacts)
+            )
+        }
+        IconButton(onClick = onCurrentLocation) {
+            Icon(
+                painter = painterResource(R.drawable.ic_my_location),
+                contentDescription = stringResource(R.string.tripplanner_current_location)
+            )
+        }
+        IconButton(onClick = onPickOnMap) {
+            Icon(
+                painter = painterResource(R.drawable.ic_action_location_map),
+                contentDescription = stringResource(R.string.trip_plan_pick_on_map)
+            )
+        }
+    }
+}
+
+/** The user-visible label for a resolved endpoint; fixed kinds resolve a string resource. */
+@Composable
+private fun endpointLabel(endpoint: TripEndpoint): String = endpoint.displayText ?: when (endpoint) {
+    is TripEndpoint.MapPoint -> stringResource(R.string.trip_plan_map_location)
+    // Only the fixed-label kinds (CurrentLocation/MapPoint) have a null displayText.
+    else -> stringResource(R.string.tripplanner_current_location)
+}
+
+@Composable
+private fun BusIcon() {
+    Icon(
+        painter = painterResource(R.drawable.ic_bus),
+        contentDescription = null,
+        tint = colorResource(R.color.material_gray)
+    )
 }
 
 /** Leaving/arriving selector — the Compose equivalent of the legacy Spinner. */
@@ -231,14 +403,15 @@ private fun TripPlanFormPreview() {
     ObaTheme {
         TripPlanForm(
             state = TripPlanFormState(
-                fromQuery = "Current Location",
-                toQuery = "",
+                from = TripEndpoint.CurrentLocation(lat = 47.6, lon = -122.3),
+                to = TripEndpoint.FreeText(""),
                 dateTimeMillis = 0L,
                 dateLabel = "June 10",
                 timeLabel = "3:45 PM"
             ),
             onFromQueryChange = {}, onToQueryChange = {},
             onSelectFrom = {}, onSelectTo = {},
+            onClearFrom = {}, onClearTo = {},
             onFromCurrentLocation = {}, onToCurrentLocation = {},
             onFromContacts = {}, onToContacts = {},
             onFromPickOnMap = {}, onToPickOnMap = {},

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanFormState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanFormState.kt
@@ -19,20 +19,63 @@ import org.opentripplanner.api.model.Itinerary
 
 /**
  * A JVM-pure projection of a trip-plan endpoint (a [org.onebusaway.android.directions.util.CustomAddress]),
- * so the ViewModel and its tests don't depend on `android.location.Address`. [lat]/[lon] are null
- * for endpoints without coordinates (e.g. a contacts pick); the repository encodes those as a raw
- * string for the OTP server to geocode.
+ * so the ViewModel and its tests don't depend on `android.location.Address`. Modeled as a sealed type
+ * so the form can render each kind appropriately: only [FreeText] is an editable field; every resolved
+ * kind ([Geocoded]/[AddressBook]/[CurrentLocation]/[MapPoint]) is shown as a cancellable pill.
+ *
+ * [lat]/[lon] are null for endpoints without coordinates (e.g. a contacts pick or a still-typed query);
+ * the repository encodes those as a raw string for the OTP server to geocode.
  */
-data class PlaceItem(
-    val displayName: String,
-    val lat: Double? = null,
-    val lon: Double? = null,
-    /** The geocoder flagged this as a public-transit location (drives the suggestion icon). */
-    val isTransit: Boolean = false,
-    val isCurrentLocation: Boolean = false
-) {
+sealed interface TripEndpoint {
+    val lat: Double?
+    val lon: Double?
+
     /** Mirrors CustomAddress.isSet(): a usable endpoint must have coordinates. */
     val hasCoordinates: Boolean get() = lat != null && lon != null
+
+    /** The geocoder flagged this as a public-transit location (drives the pill/suggestion icon). */
+    val isTransit: Boolean get() = false
+
+    /**
+     * The text this endpoint carries itself (a typed query or a resolved place name), or null for the
+     * fixed-label kinds ([CurrentLocation]/[MapPoint]) whose label is a string resource resolved by the
+     * Android layer. Keeps the shared part of the endpoint→label mapping in one place instead of
+     * duplicated across each call site's `when`.
+     */
+    val displayText: String? get() = when (this) {
+        is FreeText -> query
+        is Geocoded -> displayName
+        is AddressBook -> displayName
+        is CurrentLocation, is MapPoint -> null
+    }
+
+    /** Empty or still-being-typed text — the only editable, non-pill state. Never has coordinates. */
+    data class FreeText(val query: String = "") : TripEndpoint {
+        override val lat: Double? get() = null
+        override val lon: Double? get() = null
+    }
+
+    /** A geocoder (Pelias) autocomplete pick. */
+    data class Geocoded(
+        val displayName: String,
+        override val lat: Double?,
+        override val lon: Double?,
+        /** The geocoder flagged this as a public-transit location (drives the pill/suggestion icon). */
+        override val isTransit: Boolean = false,
+    ) : TripEndpoint
+
+    /** An address-book (contacts) pick; may still need server-side geocoding (null coordinates). */
+    data class AddressBook(
+        val displayName: String,
+        override val lat: Double?,
+        override val lon: Double?,
+    ) : TripEndpoint
+
+    /** The device's current location. Its label is a fixed string resolved by the UI. */
+    data class CurrentLocation(override val lat: Double?, override val lon: Double?) : TripEndpoint
+
+    /** A point chosen on the map. Its label is a fixed string resolved by the UI. */
+    data class MapPoint(override val lat: Double, override val lon: Double) : TripEndpoint
 }
 
 /** The advanced trip options, persisted in preferences by the host. */
@@ -45,8 +88,8 @@ data class AdvancedSettings(
 
 /** A fully-specified plan request handed to [TripPlanRepository]. */
 data class TripPlanParams(
-    val from: PlaceItem,
-    val to: PlaceItem,
+    val from: TripEndpoint,
+    val to: TripEndpoint,
     val dateTimeMillis: Long,
     val arriving: Boolean,
     val modeId: Int,
@@ -57,12 +100,10 @@ data class TripPlanParams(
 
 /** The trip-plan form (origin/destination, when, and the advanced options). */
 data class TripPlanFormState(
-    val from: PlaceItem? = null,
-    val to: PlaceItem? = null,
-    val fromQuery: String = "",
-    val toQuery: String = "",
-    val fromSuggestions: List<PlaceItem> = emptyList(),
-    val toSuggestions: List<PlaceItem> = emptyList(),
+    val from: TripEndpoint = TripEndpoint.FreeText(),
+    val to: TripEndpoint = TripEndpoint.FreeText(),
+    val fromSuggestions: List<TripEndpoint.Geocoded> = emptyList(),
+    val toSuggestions: List<TripEndpoint.Geocoded> = emptyList(),
     val dateTimeMillis: Long = 0L,
     val arriving: Boolean = false,
     val dateLabel: String = "",
@@ -74,7 +115,7 @@ data class TripPlanFormState(
 ) {
     /** Mirrors TripRequestBuilder.ready(): both endpoints must resolve to coordinates. */
     val canSubmit: Boolean
-        get() = from?.hasCoordinates == true && to?.hasCoordinates == true
+        get() = from.hasCoordinates && to.hasCoordinates
 
     /** The current advanced options, for persistence by the host. */
     val advancedSettings: AdvancedSettings
@@ -82,8 +123,8 @@ data class TripPlanFormState(
 
     /** Builds the plan request; only call when [canSubmit] is true. */
     fun toParams(): TripPlanParams = TripPlanParams(
-        from = from!!,
-        to = to!!,
+        from = from,
+        to = to,
         dateTimeMillis = dateTimeMillis,
         arriving = arriving,
         modeId = modeId,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanRepository.kt
@@ -178,14 +178,23 @@ class DefaultTripPlanRepository @Inject constructor(
         return parsed
     }
 
-    private fun PlaceItem.toCustomAddress(): CustomAddress {
+    private fun TripEndpoint.toCustomAddress(): CustomAddress {
         val address = CustomAddress.getEmptyAddress()
+        val lat = lat
+        val lon = lon
         if (lat != null && lon != null) {
             address.latitude = lat
             address.longitude = lon
         }
-        address.setAddressLine(0, displayName)
+        address.setAddressLine(0, addressLine())
         return address
+    }
+
+    /** The string the OTP server geocodes (or just labels the request); fixed kinds resolve a resource. */
+    private fun TripEndpoint.addressLine(): String = displayText ?: when (this) {
+        is TripEndpoint.MapPoint -> context.getString(R.string.trip_plan_map_location)
+        // Only the fixed-label kinds (CurrentLocation/MapPoint) have a null displayText.
+        else -> context.getString(R.string.tripplanner_current_location)
     }
 
     private fun errorMessage(errorCode: Int): String = when (errorCode) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanScreen.kt
@@ -79,7 +79,6 @@ import org.onebusaway.android.app.di.AnalyticsEntryPoint
 import org.onebusaway.android.app.di.LocationEntryPoint
 import org.onebusaway.android.app.di.RegionEntryPoint
 import org.onebusaway.android.directions.util.ConversionUtils
-import org.onebusaway.android.directions.util.CustomAddress
 import org.onebusaway.android.directions.util.OTPConstants
 import org.onebusaway.android.directions.util.TripRequestBuilder
 import org.onebusaway.android.analytics.PlausibleAnalytics
@@ -117,17 +116,17 @@ fun TripPlanDestination(navController: NavHostController, onBack: () -> Unit) {
 
     // -- Contacts pick: a launcher + the endpoint a pending pick should populate. A contacts pick
     // doesn't dispose this composable, so a plain remember (not rememberSaveable) suffices.
-    var contactsTarget by remember { mutableStateOf<((PlaceItem) -> Unit)?>(null) }
+    var contactsTarget by remember { mutableStateOf<((TripEndpoint) -> Unit)?>(null) }
     val contactsLauncher = rememberLauncherForActivityResult(StartActivityForResult()) { result ->
         val uri = result.data?.data
         if (uri != null) {
             formattedAddress(activity, uri)?.let { address ->
-                contactsTarget?.invoke(PlaceItem(displayName = address))
+                contactsTarget?.invoke(TripEndpoint.AddressBook(address, lat = null, lon = null))
             }
         }
         contactsTarget = null
     }
-    val launchContacts: ((PlaceItem) -> Unit) -> Unit = { target ->
+    val launchContacts: ((TripEndpoint) -> Unit) -> Unit = { target ->
         contactsTarget = target
         contactsLauncher.launch(
             Intent(Intent.ACTION_PICK)
@@ -140,7 +139,7 @@ fun TripPlanDestination(navController: NavHostController, onBack: () -> Unit) {
     // MUST be rememberSaveable: navigating to the picker disposes this composable, and a lambda can't
     // be saved across that — so we save which endpoint to populate, not the setter.
     var mapPickTarget by rememberSaveable { mutableStateOf<String?>(null) }
-    val launchMapPicker: (String, PlaceItem?) -> Unit = { endpoint, initial ->
+    val launchMapPicker: (String, TripEndpoint?) -> Unit = { endpoint, initial ->
         val center = if (initial?.hasCoordinates == true) {
             LocationUtils.makeLocation(initial.lat!!, initial.lon!!)
         } else {
@@ -151,7 +150,7 @@ fun TripPlanDestination(navController: NavHostController, onBack: () -> Unit) {
             NavRoutes.tripPlanPickLocation(center?.latitude, center?.longitude)
         )
     }
-    // When the picker hands a result back to this entry's SavedStateHandle, build the PlaceItem and
+    // When the picker hands a result back to this entry's SavedStateHandle, build the endpoint and
     // dispatch it to the saved endpoint, then clear the keys + the target.
     val savedStateHandle = navController.currentBackStackEntry?.savedStateHandle
     LaunchedEffect(savedStateHandle, mapPickTarget) {
@@ -159,11 +158,7 @@ fun TripPlanDestination(navController: NavHostController, onBack: () -> Unit) {
         val lat = handle.get<Double>(NavRoutes.RESULT_PICK_LAT)
         val lon = handle.get<Double>(NavRoutes.RESULT_PICK_LON)
         if (lat != null && lon != null) {
-            val place = PlaceItem(
-                displayName = activity.getString(R.string.trip_plan_map_location),
-                lat = lat,
-                lon = lon
-            )
+            val place = TripEndpoint.MapPoint(lat = lat, lon = lon)
             when (mapPickTarget) {
                 "from" -> viewModel.setFrom(place)
                 "to" -> viewModel.setTo(place)
@@ -326,6 +321,8 @@ fun TripPlanRoute(
                         onToQueryChange = viewModel::onToQueryChange,
                         onSelectFrom = viewModel::setFrom,
                         onSelectTo = viewModel::setTo,
+                        onClearFrom = viewModel::clearFrom,
+                        onClearTo = viewModel::clearTo,
                         onFromCurrentLocation = onFromCurrentLocation,
                         onToCurrentLocation = onToCurrentLocation,
                         onFromContacts = onFromContacts,
@@ -415,21 +412,17 @@ private fun pickTime(activity: AppCompatActivity, viewModel: TripPlanViewModel) 
 
 private fun setCurrentLocation(
     activity: AppCompatActivity,
-    target: (PlaceItem) -> Unit
+    target: (TripEndpoint) -> Unit
 ) {
     val location = LocationEntryPoint.get(activity.applicationContext).lastKnownLocation()
     if (location == null) {
         Toast.makeText(activity, activity.getString(R.string.no_location_permission), Toast.LENGTH_SHORT)
             .show()
+        // Without a location this would be a coordinate-less, non-submittable pill that also drops any
+        // existing result — bail after the toast instead.
+        return
     }
-    target(
-        PlaceItem(
-            displayName = activity.getString(R.string.tripplanner_current_location),
-            lat = location?.latitude,
-            lon = location?.longitude,
-            isCurrentLocation = true
-        )
-    )
+    target(TripEndpoint.CurrentLocation(lat = location.latitude, lon = location.longitude))
 }
 
 private fun formattedAddress(
@@ -630,17 +623,11 @@ private fun maybeRestoreFromIntent(
 
     val builder = TripRequestBuilder.initFromBundleSimple(context, extras)
     viewModel.restoreFrom(
-        from = builder.from?.toPlaceItem(),
-        to = builder.to?.toPlaceItem(),
+        from = builder.from?.toGeocoded(),
+        to = builder.to?.toGeocoded(),
         dateTimeMillis = builder.dateTime?.time ?: System.currentTimeMillis(),
         arriving = builder.arriveBy,
         itineraries = itineraries
     )
     return Intent()
 }
-
-private fun CustomAddress.toPlaceItem(): PlaceItem = PlaceItem(
-    displayName = toString(),
-    lat = if (isSet) latitude else null,
-    lon = if (isSet) longitude else null
-)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanViewModel.kt
@@ -24,6 +24,7 @@ import java.util.Locale
 import javax.inject.Inject
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -31,8 +32,8 @@ import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
 import org.onebusaway.android.util.TimeProvider
 import org.opentripplanner.api.model.Itinerary
 
@@ -74,6 +75,15 @@ class TripPlanViewModel @Inject constructor(
     private val fromQueries = MutableStateFlow("")
     private val toQueries = MutableStateFlow("")
 
+    // Plan submissions, driven reactively. Each user action that can change the plan sends its params
+    // (or null when the form isn't submittable) here; the collector below [mapLatest]-cancels the plan
+    // in flight as soon as the next input arrives, so a slow plan that outlives its edit can't publish a
+    // stale result — the same latest-wins pattern as the suggestion pipelines, no request bookkeeping.
+    // A CONFLATED channel (not a SharedFlow) keeps only the latest input and retains it until the
+    // collector is ready, so an input sent before collection starts isn't lost. Deliberately NOT derived
+    // from [_formState]: restoreFrom injects a result without re-planning.
+    private val planInputs = Channel<TripPlanParams?>(Channel.CONFLATED)
+
     init {
         fromQueries
             .debounce(SUGGEST_DEBOUNCE_MS)
@@ -85,42 +95,72 @@ class TripPlanViewModel @Inject constructor(
             .mapLatest(::suggestionsFor)
             .onEach { suggestions -> _formState.update { it.copy(toSuggestions = suggestions) } }
             .launchIn(viewModelScope)
+        planInputs.receiveAsFlow()
+            .mapLatest { params ->
+                if (params == null) {
+                    // Form no longer submittable: drop a surfaced result (Success/Loading) back to Idle.
+                    if (_planState.value !is PlanResult.Idle) _planState.value = PlanResult.Idle
+                } else {
+                    _planState.value = PlanResult.Loading
+                    planRepository.plan(params).fold(
+                        onSuccess = { _planState.value = PlanResult.Success(it) },
+                        onFailure = { _planState.value = PlanResult.Error(it.message.orEmpty()) }
+                    )
+                }
+            }
+            .launchIn(viewModelScope)
     }
 
-    private suspend fun suggestionsFor(query: String): List<PlaceItem> =
+    private suspend fun suggestionsFor(query: String): List<TripEndpoint.Geocoded> =
         if (query.isBlank()) emptyList() else geocode.suggest(query).getOrDefault(emptyList())
 
     fun onFromQueryChange(query: String) {
-        _formState.update { it.copy(fromQuery = query) }
+        _formState.update { it.copy(from = TripEndpoint.FreeText(query)) }
         fromQueries.value = query
+        // Editing over a resolved endpoint makes the form non-submittable — drop any stale route too.
+        replanOrClearResult()
     }
 
     fun onToQueryChange(query: String) {
-        _formState.update { it.copy(toQuery = query) }
+        _formState.update { it.copy(to = TripEndpoint.FreeText(query)) }
         toQueries.value = query
+        replanOrClearResult()
     }
 
-    /** Sets the origin (from a suggestion, current location, or contacts) and re-plans if ready. */
-    fun setFrom(place: PlaceItem) {
-        _formState.update { it.copy(from = place, fromQuery = place.displayName, fromSuggestions = emptyList()) }
-        autoSubmitIfReady()
+    /** Sets the origin (from a suggestion, current location, contacts, or map) and re-plans if ready. */
+    fun setFrom(endpoint: TripEndpoint) {
+        _formState.update { it.copy(from = endpoint, fromSuggestions = emptyList()) }
+        replanOrClearResult()
     }
 
-    fun setTo(place: PlaceItem) {
-        _formState.update { it.copy(to = place, toQuery = place.displayName, toSuggestions = emptyList()) }
-        autoSubmitIfReady()
+    fun setTo(endpoint: TripEndpoint) {
+        _formState.update { it.copy(to = endpoint, toSuggestions = emptyList()) }
+        replanOrClearResult()
+    }
+
+    /** Clears the origin back to an empty editable field (the pill's ✕), dropping any stale result. */
+    fun clearFrom() {
+        _formState.update { it.copy(from = TripEndpoint.FreeText(), fromSuggestions = emptyList()) }
+        fromQueries.value = ""
+        replanOrClearResult()
+    }
+
+    fun clearTo() {
+        _formState.update { it.copy(to = TripEndpoint.FreeText(), toSuggestions = emptyList()) }
+        toQueries.value = ""
+        replanOrClearResult()
     }
 
     fun setDateTime(millis: Long) {
         _formState.update {
             it.copy(dateTimeMillis = millis, dateLabel = formatDate(millis), timeLabel = formatTime(millis))
         }
-        autoSubmitIfReady()
+        replanOrClearResult()
     }
 
     fun setArriving(arriving: Boolean) {
         _formState.update { it.copy(arriving = arriving) }
-        autoSubmitIfReady()
+        replanOrClearResult()
     }
 
     fun applyAdvancedSettings(settings: AdvancedSettings) {
@@ -132,31 +172,17 @@ class TripPlanViewModel @Inject constructor(
                 wheelchair = settings.wheelchair
             )
         }
-        autoSubmitIfReady()
+        replanOrClearResult()
     }
 
     fun reverseTrip() {
         _formState.update {
             it.copy(
                 from = it.to, to = it.from,
-                fromQuery = it.toQuery, toQuery = it.fromQuery,
                 fromSuggestions = emptyList(), toSuggestions = emptyList()
             )
         }
-        autoSubmitIfReady()
-    }
-
-    /** Submits the plan if both endpoints resolve to coordinates. */
-    fun planTrip() {
-        val form = _formState.value
-        if (!form.canSubmit) return
-        _planState.value = PlanResult.Loading
-        viewModelScope.launch {
-            planRepository.plan(form.toParams()).fold(
-                onSuccess = { _planState.value = PlanResult.Success(it) },
-                onFailure = { _planState.value = PlanResult.Error(it.message.orEmpty()) }
-            )
-        }
+        replanOrClearResult()
     }
 
     /** Clears a surfaced error after the host shows it. */
@@ -169,8 +195,8 @@ class TripPlanViewModel @Inject constructor(
      * without re-planning, so the user lands back on the trip they were watching.
      */
     fun restoreFrom(
-        from: PlaceItem?,
-        to: PlaceItem?,
+        from: TripEndpoint?,
+        to: TripEndpoint?,
         dateTimeMillis: Long,
         arriving: Boolean,
         itineraries: List<Itinerary>
@@ -179,8 +205,6 @@ class TripPlanViewModel @Inject constructor(
             it.copy(
                 from = from ?: it.from,
                 to = to ?: it.to,
-                fromQuery = from?.displayName ?: it.fromQuery,
-                toQuery = to?.displayName ?: it.toQuery,
                 dateTimeMillis = dateTimeMillis,
                 dateLabel = formatDate(dateTimeMillis),
                 timeLabel = formatTime(dateTimeMillis),
@@ -192,8 +216,15 @@ class TripPlanViewModel @Inject constructor(
         }
     }
 
-    private fun autoSubmitIfReady() {
-        if (_formState.value.canSubmit) planTrip()
+    /**
+     * Called after any form change: hand the latest plan inputs to the [planInputs] pipeline, which
+     * re-plans when both endpoints resolve and otherwise drops a stale result back to [PlanResult.Idle]
+     * so a changed or cleared endpoint can't leave an old route on screen (the results sheet keys off
+     * [PlanResult.Success]). Emitting supersedes any in-flight plan via the collector's [mapLatest].
+     */
+    private fun replanOrClearResult() {
+        val form = _formState.value
+        planInputs.trySend(if (form.canSubmit) form.toParams() else null)
     }
 
     private fun formatDate(millis: Long): String =

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -886,6 +886,8 @@
     <string name="trip_plan_pick_on_map">Pick location on map</string>
     <string name="trip_plan_use_this_location">Use this location</string>
     <string name="trip_plan_map_location">Selected location</string>
+    <string name="trip_plan_clear_endpoint">Clear</string>
+    <string name="trip_plan_contacts">Choose from contacts</string>
 
 
     <string name="trip_plan_list_view">List View</string>

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripPlanViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripPlanViewModelTest.kt
@@ -16,6 +16,7 @@
 package org.onebusaway.android.ui.tripplan
 
 import java.io.IOException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
@@ -36,12 +37,12 @@ class TripPlanViewModelTest {
     val mainDispatcherRule = MainDispatcherRule()
 
     private val settings = AdvancedSettings(modeId = 4, maxWalkMeters = 1600.0, optimizeTransfers = true, wheelchair = false)
-    private val origin = PlaceItem("Origin", lat = 47.6, lon = -122.3)
-    private val destination = PlaceItem("Destination", lat = 47.7, lon = -122.2)
+    private val origin = TripEndpoint.Geocoded("Origin", lat = 47.6, lon = -122.3)
+    private val destination = TripEndpoint.Geocoded("Destination", lat = 47.7, lon = -122.2)
 
-    private class FakeGeocodeRepository(var result: Result<List<PlaceItem>>) : GeocodeRepository {
+    private class FakeGeocodeRepository(var result: Result<List<TripEndpoint.Geocoded>>) : GeocodeRepository {
         var lastQuery: String? = null
-        override suspend fun suggest(query: String): Result<List<PlaceItem>> {
+        override suspend fun suggest(query: String): Result<List<TripEndpoint.Geocoded>> {
             lastQuery = query
             return result
         }
@@ -58,6 +59,18 @@ class TripPlanViewModelTest {
             result.getOrDefault(emptyList())
     }
 
+    /** A plan repository whose call suspends until [gate] is completed, to exercise the in-flight race. */
+    private class GatedTripPlanRepository : TripPlanRepository {
+        val gate = CompletableDeferred<Result<List<Itinerary>>>()
+        var calls = 0
+        override suspend fun plan(params: TripPlanParams): Result<List<Itinerary>> {
+            calls++
+            return gate.await()
+        }
+
+        override fun planBlocking(builder: TripRequestBuilder): List<Itinerary> = emptyList()
+    }
+
     private inner class FakeAdvancedSettingsRepository : AdvancedSettingsRepository {
         override fun load() = settings
     }
@@ -66,6 +79,12 @@ class TripPlanViewModelTest {
         geocode: GeocodeRepository = FakeGeocodeRepository(Result.success(emptyList())),
         plan: TripPlanRepository = FakeTripPlanRepository(Result.success(listOf(Itinerary())))
     ) = TripPlanViewModel(geocode, plan, TimeProvider { 0L }, FakeAdvancedSettingsRepository())
+
+    /** Sets both resolved endpoints (which auto-submits a plan once both have coordinates). */
+    private fun setBothEndpoints(vm: TripPlanViewModel) {
+        vm.setFrom(origin)
+        vm.setTo(destination)
+    }
 
     @Test
     fun `initial state carries the injected settings and cannot submit`() = runTest {
@@ -89,6 +108,42 @@ class TripPlanViewModelTest {
     }
 
     @Test
+    fun `a query change makes the origin a FreeText endpoint`() = runTest {
+        val vm = viewModel()
+        vm.onFromQueryChange("downtown")
+        assertEquals(TripEndpoint.FreeText("downtown"), vm.formState.value.from)
+        assertFalse(vm.formState.value.canSubmit)
+    }
+
+    @Test
+    fun `selecting a geocoded suggestion stores the resolved endpoint`() = runTest {
+        val vm = viewModel()
+        vm.onFromQueryChange("orig")
+        advanceUntilIdle()
+        vm.setFrom(origin)
+        advanceUntilIdle()
+        val state = vm.formState.value
+        assertEquals(origin, state.from)
+        assertTrue(state.fromSuggestions.isEmpty())
+    }
+
+    @Test
+    fun `clearFrom resets the origin to empty FreeText and does not submit`() = runTest {
+        val plan = FakeTripPlanRepository(Result.success(listOf(Itinerary())))
+        val vm = viewModel(plan = plan)
+        setBothEndpoints(vm)
+        advanceUntilIdle()
+        assertEquals(1, plan.calls)
+
+        vm.clearFrom()
+        advanceUntilIdle()
+        val state = vm.formState.value
+        assertEquals(TripEndpoint.FreeText(), state.from)
+        assertFalse(state.canSubmit)
+        assertEquals(1, plan.calls) // clearing must not re-plan
+    }
+
+    @Test
     fun `setting both endpoints with coordinates auto-submits the plan`() = runTest {
         val plan = FakeTripPlanRepository(Result.success(listOf(Itinerary())))
         val vm = viewModel(plan = plan)
@@ -105,12 +160,72 @@ class TripPlanViewModelTest {
     }
 
     @Test
+    fun `clearing an endpoint after a successful plan drops the stale result`() = runTest {
+        val vm = viewModel()
+        setBothEndpoints(vm)
+        advanceUntilIdle()
+        assertTrue(vm.planState.value is PlanResult.Success)
+
+        vm.clearTo()
+        advanceUntilIdle()
+        assertFalse(vm.formState.value.canSubmit)
+        assertEquals(PlanResult.Idle, vm.planState.value)
+    }
+
+    @Test
+    fun `typing over a resolved endpoint drops the stale result`() = runTest {
+        val vm = viewModel()
+        setBothEndpoints(vm)
+        advanceUntilIdle()
+        assertTrue(vm.planState.value is PlanResult.Success)
+
+        vm.onFromQueryChange("typing over the pill")
+        advanceUntilIdle()
+        assertFalse(vm.formState.value.canSubmit)
+        assertEquals(PlanResult.Idle, vm.planState.value)
+    }
+
+    @Test
+    fun `a plan finishing after the form is cleared cannot surface a stale route`() = runTest {
+        val plan = GatedTripPlanRepository()
+        val vm = viewModel(plan = plan)
+        setBothEndpoints(vm) // canSubmit -> a plan launches and suspends on the gate
+        advanceUntilIdle()
+        assertEquals(PlanResult.Loading, vm.planState.value)
+
+        vm.clearTo() // form no longer submittable: invalidates the in-flight plan
+        advanceUntilIdle()
+        assertEquals(PlanResult.Idle, vm.planState.value)
+
+        plan.gate.complete(Result.success(listOf(Itinerary()))) // late completion of the stale plan
+        advanceUntilIdle()
+        assertEquals(PlanResult.Idle, vm.planState.value)
+    }
+
+    @Test
+    fun `changing one endpoint while the other is unset does not surface a route`() = runTest {
+        val vm = viewModel()
+        // Seed a stale success, then reset both endpoints to empty as a fresh start.
+        setBothEndpoints(vm)
+        advanceUntilIdle()
+        vm.clearFrom()
+        vm.clearTo()
+        advanceUntilIdle()
+
+        // Selecting just one endpoint must not bring back the old route.
+        vm.setFrom(origin)
+        advanceUntilIdle()
+        assertFalse(vm.formState.value.canSubmit)
+        assertEquals(PlanResult.Idle, vm.planState.value)
+    }
+
+    @Test
     fun `an endpoint without coordinates does not enable submit`() = runTest {
         val plan = FakeTripPlanRepository(Result.success(listOf(Itinerary())))
         val vm = viewModel(plan = plan)
 
-        vm.setFrom(PlaceItem("Contact A", lat = null, lon = null))
-        vm.setTo(PlaceItem("Contact B", lat = null, lon = null))
+        vm.setFrom(TripEndpoint.AddressBook("Contact A", lat = null, lon = null))
+        vm.setTo(TripEndpoint.AddressBook("Contact B", lat = null, lon = null))
         advanceUntilIdle()
 
         assertFalse(vm.formState.value.canSubmit)
@@ -120,8 +235,7 @@ class TripPlanViewModelTest {
     @Test
     fun `reverseTrip swaps origin and destination`() = runTest {
         val vm = viewModel()
-        vm.setFrom(origin)
-        vm.setTo(destination)
+        setBothEndpoints(vm)
         advanceUntilIdle()
 
         vm.reverseTrip()
@@ -147,8 +261,7 @@ class TripPlanViewModelTest {
     @Test
     fun `a plan failure surfaces Error with the message`() = runTest {
         val vm = viewModel(plan = FakeTripPlanRepository(Result.failure(IOException("no route"))))
-        vm.setFrom(origin)
-        vm.setTo(destination)
+        setBothEndpoints(vm)
         advanceUntilIdle()
         assertEquals(PlanResult.Error("no route"), vm.planState.value)
     }


### PR DESCRIPTION
## Summary

Reworks the trip planner so location endpoints are typed and can't be edited as raw text when they shouldn't be.

- **Sealed `TripEndpoint`** replaces `PlaceItem`: `FreeText` / `Geocoded` / `AddressBook` / `CurrentLocation` / `MapPoint`. Only free text stays an editable autocomplete field; every resolved endpoint renders as a **non-editable, cancellable pill inside the field** (✕ clears it back to the empty field). Picking another input method (contacts / current location / map) overrides the current pill.
- **Android Geocoder fallback**: `DefaultGeocodeRepository` uses Pelias when a key is configured (`BuildFlavorUtils.isPeliasApiKeyDefined()`), else falls back to the on-device `android.location.Geocoder` so key-free builds still geocode. Degraded fallback (no typeahead / transit categories), region-bbox biased, off the main thread.
- **Stale-result fix**: changing or clearing an endpoint now drops a cached plan result (`replanOrClearResult`) so an old route can't remain on screen when the form is no longer submittable.
- **Semantic UI driving**: `testTagsAsResourceId` enabled app-wide and trip-plan fields tagged; fixed the contacts icon's mislabeled content description ("From:" → "Choose from contacts").

## Testing

- `TripPlanViewModelTest` updated for the new model, plus new coverage for endpoint clearing and stale-result invalidation. Passing (13/13).
- Built and exercised on a Pixel 7 Pro emulator: type → pick suggestion → in-field pill; clear a pill after planning → route sheet correctly disappears; Geocoder fallback returns results with no Pelias key.

## Rebase note

Rebased onto current `main`. Conflicts resolved in three places:
- `HomeActivity.kt` — kept upstream's structure (`activityActions`, `RegionPickerHost`) and layered in this PR's app-wide `testTagsAsResourceId` `Box` wrapper.
- `TripPlanScreen.kt` — kept upstream's `if (hasResults) TripResultsMap else …form…` body and added the new `onClearFrom`/`onClearTo` callbacks to the form call.
- `GeocodeRepository.kt` — retargeted the old `io.elements.ObaRegion` reference to the modernized `region.Region` type (`RegionUtils.getRegionSpan` / `LocationUtils.processPeliasGeocoding` already take it).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Trip planning now uses improved endpoint selection with resolved places shown as removable “pills,” plus support for choosing from contacts, current location, and map points.
  * Added “Clear” and “Choose from contacts” actions/labels for trip endpoints.
* **Bug Fixes**
  * Improved trip planning stability so changing, clearing, or editing endpoints reliably prevents stale routes from staying visible.
* **Style**
  * Enhanced UI automation support by improving Compose test tag exposure across the trip-planning flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->