### PR TITLE
Make DonationsManager an injectable @Singleton, drop the Application holder

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/app/Application.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/app/Application.java
@@ -24,7 +24,6 @@ import android.util.Log;
 
 import org.onebusaway.android.BuildConfig;
 import org.onebusaway.android.R;
-import org.onebusaway.android.donations.DonationsManager;
 import org.onebusaway.android.notifications.NotificationChannels;
 import org.onebusaway.android.app.di.AnalyticsEntryPoint;
 import org.onebusaway.android.api.ObaApi;
@@ -56,8 +55,6 @@ public class Application extends android.app.Application {
 
     // Region preference (long id)
     private static final String TAG = "Application";
-
-    private DonationsManager mDonationsManager;
 
     private static Application mApp;
 
@@ -97,8 +94,6 @@ public class Application extends android.app.Application {
         incrementAppLaunchCount();
 
         FirebaseMessagingEntryPoint.get(this).fetchAndStoreToken();
-
-        mDonationsManager = new DonationsManager(getApplicationContext(), getResources(), getAppLaunchCount());
     }
 
     /**
@@ -118,8 +113,6 @@ public class Application extends android.app.Application {
     public static Application get() {
         return mApp;
     }
-
-    public static DonationsManager getDonationsManager() { return get().mDonationsManager; }
 
 
     // Preserve the original preference-key value so persisted launch counts survive upgrades.

--- a/onebusaway-android/src/main/java/org/onebusaway/android/app/di/AppModule.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/app/di/AppModule.kt
@@ -33,16 +33,14 @@ import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
-import org.onebusaway.android.app.Application
-import org.onebusaway.android.donations.DonationsManager
 import org.onebusaway.android.util.TimeProvider
 
 /**
- * Provides the process-wide singletons that still live on [Application] (the de-facto DI container), so
- * Hilt-managed code can inject them instead of reaching `Application.getX()` statically. During the
- * transition they're sourced from the existing [Application] instances. (RegionRepository and
- * LocationRepository are real Hilt `@Singleton`s — they're bound in
- * `RepositoryModule`, not here.) More singletons get added here as converted consumers need them.
+ * Provides process-wide infrastructure singletons that aren't a repository binding: the app-lifetime
+ * [AppScope] coroutine scope, the Preferences [DataStore], and the wall-clock [TimeProvider]. (Feature
+ * singletons like `RegionRepository`/`LocationRepository`/`DonationsManager` are real Hilt
+ * `@Singleton`s — bound in `RepositoryModule` or constructed from their own `@Inject` constructors, not
+ * sourced from `Application` here.)
  */
 @Module
 @InstallIn(SingletonComponent::class)
@@ -76,10 +74,6 @@ object AppModule {
         scope = scope,
         produceFile = { context.preferencesDataStoreFile("settings") },
     )
-
-    @Provides
-    @Singleton
-    fun provideDonationsManager(): DonationsManager = Application.getDonationsManager()
 
     /** Wall-clock source — the single `System.currentTimeMillis()` boundary for injected consumers. */
     @Provides

--- a/onebusaway-android/src/main/java/org/onebusaway/android/app/di/DonationsEntryPoint.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/app/di/DonationsEntryPoint.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.app.di
+
+import android.content.Context
+import dagger.hilt.EntryPoint
+import dagger.hilt.InstallIn
+import dagger.hilt.android.EntryPointAccessors
+import dagger.hilt.components.SingletonComponent
+import org.onebusaway.android.donations.DonationsManager
+
+/**
+ * A Hilt [EntryPoint] that lets code which can't be constructor-injected — composable nav destinations
+ * without a ViewModel — reach the injected [DonationsManager] singleton (mirrors [AnalyticsEntryPoint]).
+ * It needs a [Context] only to resolve the singleton graph; the returned manager is the same
+ * app-singleton every injected consumer shares.
+ *
+ * Use it only where injection genuinely isn't available — Hilt-reachable classes (ViewModels,
+ * Activities, Services) should inject [DonationsManager] directly.
+ */
+@EntryPoint
+@InstallIn(SingletonComponent::class)
+interface DonationsEntryPoint {
+
+    fun donationsManager(): DonationsManager
+
+    companion object {
+        /** Resolves the [DonationsManager] singleton from any [context] (its application is used). */
+        @JvmStatic
+        fun get(context: Context): DonationsManager =
+            EntryPointAccessors.fromApplication(context, DonationsEntryPoint::class.java)
+                .donationsManager()
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/donations/DonationsManager.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/donations/DonationsManager.java
@@ -3,34 +3,42 @@ package org.onebusaway.android.donations;
 import org.onebusaway.android.R;
 import org.onebusaway.android.app.di.AnalyticsEntryPoint;
 import org.onebusaway.android.analytics.PlausibleAnalytics;
+import org.onebusaway.android.preferences.PreferencesRepository;
 import org.onebusaway.android.util.BuildFlavorUtils;
 import org.onebusaway.android.util.PreferenceUtils;
 
 import android.content.Context;
 import android.content.Intent;
-import android.content.res.Resources;
 import android.net.Uri;
 
 import java.util.Date;
 
-public class DonationsManager {
-    private Resources mResources;
-    private int mAppLaunchCount;
+import javax.inject.Inject;
+import javax.inject.Singleton;
 
-    // Application context, kept only to resolve the AnalyticsProvider (for the region-derived Plausible
-    // emitter) lazily at event time. Resolving it lazily — rather than injecting AnalyticsProvider into
-    // this constructor — matters because DonationsManager is built eagerly in Application.onCreate, and
-    // AnalyticsProvider pulls in the RegionRepository, which is deliberately constructed lazily
-    // post-onCreate to avoid the region-init ordering hazard.
+import dagger.hilt.android.qualifiers.ApplicationContext;
+
+@Singleton
+public class DonationsManager {
+
+    // Application context, used at event time to (a) read Resources for event labels / the donate URL and
+    // (b) lazily resolve the AnalyticsProvider (for the region-derived Plausible emitter). Resolving the
+    // AnalyticsProvider lazily — rather than injecting it into this constructor — keeps the constructor off
+    // the region graph: AnalyticsProvider pulls in the RegionRepository, which is deliberately constructed
+    // lazily to avoid the region-init ordering hazard.
     private final Context mContext;
 
+    private final PreferencesRepository mPreferences;
+
+    // The constructor only captures its collaborators — no dereferencing — so a bare instance can back
+    // the JVM unit tests of consumers whose exercised paths never touch the manager. Resources and the
+    // launch count are read lazily at their use sites.
+    @Inject
     public DonationsManager(
-            Context context,
-            Resources resources,
-            int appLaunchCount) {
+            @ApplicationContext Context context,
+            PreferencesRepository preferences) {
         this.mContext = context;
-        this.mResources = resources;
-        this.mAppLaunchCount = appLaunchCount;
+        this.mPreferences = preferences;
     }
 
     // region Analytics
@@ -41,7 +49,7 @@ public class DonationsManager {
      * @param state the state or variant of the UI item, or null if the item doesn't have a state or variant
      */
     private void reportUIEvent(Integer resourceID, String state) {
-        AnalyticsEntryPoint.get(mContext).reportUiEvent(PlausibleAnalytics.REPORT_DONATE_EVENT_URL, mResources.getString(resourceID), state);
+        AnalyticsEntryPoint.get(mContext).reportUiEvent(PlausibleAnalytics.REPORT_DONATE_EVENT_URL, mContext.getResources().getString(resourceID), state);
     }
 
     // endregion
@@ -131,7 +139,7 @@ public class DonationsManager {
         }
 
         // Don't show the donations UI on the first few launches of the app.
-        if (mAppLaunchCount < 3) {
+        if (mPreferences.getAppLaunchCount() < 3) {
             return false;
         }
 
@@ -151,7 +159,7 @@ public class DonationsManager {
 
     public Intent buildOpenDonationsPageIntent() {
         reportUIEvent(R.string.analytics_label_button_press_donate, null);
-        Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(mResources.getString(R.string.donate_url)));
+        Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(mContext.getResources().getString(R.string.donate_url)));
         return intent;
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/donation/DonationCard.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/donation/DonationCard.kt
@@ -50,7 +50,6 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.repeatOnLifecycle
 import org.onebusaway.android.R
-import org.onebusaway.android.app.Application
 
 /**
  * Self-wiring donation feature module: collects [DonationViewModel] state, builds its callbacks, runs
@@ -84,7 +83,7 @@ fun DonationFeature(
                 when (effect) {
                     DonationEffect.OpenLearnMore -> currentOnLearnMore()
                     DonationEffect.OpenDonatePage ->
-                        context.startActivity(Application.getDonationsManager().buildOpenDonationsPageIntent())
+                        context.startActivity(viewModel.buildDonationsPageIntent())
                 }
             }
         }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/donation/DonationViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/donation/DonationViewModel.kt
@@ -15,6 +15,7 @@
  */
 package org.onebusaway.android.ui.home.donation
 
+import android.content.Intent
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -74,6 +75,9 @@ class DonationViewModel @Inject constructor(
         manager.dismissDonationRequests()
         _effects.tryEmit(DonationEffect.OpenDonatePage)
     }
+
+    /** The donations-page intent for the [DonationEffect.OpenDonatePage] handler to start. */
+    fun buildDonationsPageIntent(): Intent = manager.buildOpenDonationsPageIntent()
 
     /** "I don't want to help" — stop asking, hide the dialog, and re-gate the card. */
     fun dismissForever() {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/nav/ExtraDestinations.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/nav/ExtraDestinations.kt
@@ -26,7 +26,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.NavType
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
-import org.onebusaway.android.app.Application
+import org.onebusaway.android.app.di.DonationsEntryPoint
 import org.onebusaway.android.app.di.AnalyticsEntryPoint
 import org.onebusaway.android.ui.compose.findActivity
 import org.onebusaway.android.ui.nav.revealRouteOnMap
@@ -56,10 +56,9 @@ fun NavGraphBuilder.extraDestinations(navController: NavHostController) {
             DonationLearnMoreScreen(
                 onBack = { navController.popBackStack() },
                 onDonate = {
-                    Application.getDonationsManager().dismissDonationRequests()
-                    context.startActivity(
-                        Application.getDonationsManager().buildOpenDonationsPageIntent()
-                    )
+                    val donationsManager = DonationsEntryPoint.get(context)
+                    donationsManager.dismissDonationRequests()
+                    context.startActivity(donationsManager.buildOpenDonationsPageIntent())
                     navController.popBackStack()
                 },
             )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/settings/AdvancedSettingsViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/settings/AdvancedSettingsViewModel.kt
@@ -32,7 +32,7 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
 import org.onebusaway.android.BuildConfig
 import org.onebusaway.android.R
-import org.onebusaway.android.app.Application
+import org.onebusaway.android.donations.DonationsManager
 import org.onebusaway.android.map.StopsMapController
 import org.onebusaway.android.preferences.PreferencesRepository
 import org.onebusaway.android.region.Region
@@ -58,6 +58,7 @@ class AdvancedSettingsViewModel @Inject constructor(
     @ApplicationContext private val context: Context,
     private val prefs: PreferencesRepository,
     private val regionRepository: RegionRepository,
+    private val donationsManager: DonationsManager,
 ) : ViewModel() {
 
     init {
@@ -158,8 +159,8 @@ class AdvancedSettingsViewModel @Inject constructor(
     }
 
     fun onResetDonationTimestamps() {
-        Application.getDonationsManager().setDonationRequestReminderDate(null)
-        Application.getDonationsManager().setDonationRequestDismissedDate(null)
+        donationsManager.setDonationRequestReminderDate(null)
+        donationsManager.setDonationRequestDismissedDate(null)
     }
 }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/settings/SettingsDestinations.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/settings/SettingsDestinations.kt
@@ -26,7 +26,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import org.onebusaway.android.R
-import org.onebusaway.android.app.Application
+import org.onebusaway.android.app.di.DonationsEntryPoint
 import org.onebusaway.android.ui.about.AboutScreen
 import org.onebusaway.android.ui.about.buildVersionText
 import org.onebusaway.android.ui.agencies.AgenciesRoute
@@ -106,7 +106,7 @@ fun NavGraphBuilder.settingsGraph(navController: NavHostController) {
                 onGoHomeResetTutorial = { NavHelp.goHome(activity, true) },
                 onOpenDonate = {
                     activity.startActivity(
-                        Application.getDonationsManager().buildOpenDonationsPageIntent()
+                        DonationsEntryPoint.get(activity).buildOpenDonationsPageIntent()
                     )
                 },
                 onOpenPoweredByOba = {

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/DonationViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/DonationViewModelTest.kt
@@ -41,8 +41,8 @@ class DonationViewModelTest {
     val mainDispatcherRule = MainDispatcherRule()
 
     // These tests cover only the dialog/effect logic, which never calls the DonationsManager, so a
-    // bare instance (its Android collaborators are never touched) is enough to satisfy the constructor.
-    private fun donationViewModel() = DonationViewModel(DonationsManager(null, null, 0))
+    // bare instance (its collaborators are captured but never dereferenced) satisfies the constructor.
+    private fun donationViewModel() = DonationViewModel(DonationsManager(null, null))
 
     @Test
     fun `close requests the dismiss confirmation, cancel clears it`() = runTest {


### PR DESCRIPTION
Slice 3 of #1659 (Application.java decomposition) — the largest fan-out.

`DonationsManager` was held on `Application.mDonationsManager`, reached via the static `getDonationsManager()`, and re-exported through a delegating `@Provides` in `AppModule`. This makes it a real Hilt `@Singleton` and routes every consumer to injection.

### Changes
- **`DonationsManager`** → `@Singleton` + `@Inject constructor(@ApplicationContext Context, PreferencesRepository)`. The constructor now only *captures* its collaborators — no dereferencing — with `Resources` and the app-launch count read lazily at their use sites. This keeps the `@Singleton` off the region graph at construction *and* preserves the property that a bare instance can back `DonationViewModelTest` (whose exercised paths never touch the manager).
- **`AppModule`** drops `provideDonationsManager()` (Hilt builds it directly from the `@Inject` constructor) and its now-unused `Application`/`DonationsManager` imports; class doc refreshed.
- **ViewModels inject it**: `DonationViewModel`/`SurveyViewModel` already did (through the old `@Provides`, unchanged); `AdvancedSettingsViewModel` now constructor-injects it instead of the static.
- **Compose nav destinations without a ViewModel** (`SettingsDestinations`, `ExtraDestinations`) reach it through a new **`DonationsEntryPoint`** (mirrors `AnalyticsEntryPoint`). `DonationCard` — which *does* have a `DonationViewModel` — routes through it (new `buildDonationsPageIntent()` passthrough) rather than a locator.
- **`Application`** loses the field, the `onCreate` construction, `getDonationsManager()`, and the import.

No behavior change.

### Verification
- `:onebusaway-android:compileObaGoogleDebugSources` + `compileObaGoogleDebugUnitTestSources` pass (Java + Kotlin + Hilt/KSP).
- `DonationViewModelTest` passes against the new constructor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a more reliable way to open donation-related pages from multiple parts of the app.

* **Bug Fixes**
  * Improved donation reminder and dismiss state handling in settings.
  * Updated donation screen behavior so actions continue to work consistently across home and settings flows.

* **Refactor**
  * Modernized how donation-related app services are accessed, reducing reliance on shared app-level state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->