### PR TITLE
Extract notification channels out of Application into NotificationChannels

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/app/Application.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/app/Application.java
@@ -16,18 +16,16 @@
  */
 package org.onebusaway.android.app;
 
-import android.app.NotificationChannel;
-import android.app.NotificationManager;
 import android.content.Context;
 import android.hardware.GeomagneticField;
 import android.location.Location;
-import android.os.Build;
 import android.text.TextUtils;
 import android.util.Log;
 
 import org.onebusaway.android.BuildConfig;
 import org.onebusaway.android.R;
 import org.onebusaway.android.donations.DonationsManager;
+import org.onebusaway.android.notifications.NotificationChannels;
 import org.onebusaway.android.app.di.AnalyticsEntryPoint;
 import org.onebusaway.android.api.ObaApi;
 import org.onebusaway.android.region.Region;
@@ -58,10 +56,6 @@ public class Application extends android.app.Application {
 
     // Region preference (long id)
     private static final String TAG = "Application";
-
-    public static final String CHANNEL_TRIP_PLAN_UPDATES_ID = "trip_plan_updates";
-    public static final String CHANNEL_ARRIVAL_REMINDERS_ID = "arrival_reminders";
-    public static final String CHANNEL_DESTINATION_ALERT_ID = "destination_alerts";
 
     private DonationsManager mDonationsManager;
 
@@ -98,7 +92,7 @@ public class Application extends android.app.Application {
 
         reportAnalytics();
 
-        createNotificationChannels();
+        NotificationChannels.registerAll(this);
 
         incrementAppLaunchCount();
 
@@ -370,33 +364,6 @@ public class Application extends android.app.Application {
                 customUrl = getString(R.string.analytics_label_custom_url);
             }
             AnalyticsEntryPoint.get(this).setRegion(customUrl);
-        }
-    }
-
-    private void createNotificationChannels() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            NotificationChannel channel1 = new NotificationChannel(
-                    CHANNEL_TRIP_PLAN_UPDATES_ID,
-                    "Trip plan notifications (beta)",
-                    NotificationManager.IMPORTANCE_DEFAULT);
-            channel1.setDescription("After planning a trip, send notifications if the trip is delayed or no longer recommended.");
-
-            NotificationChannel channel2 = new NotificationChannel(
-                    CHANNEL_ARRIVAL_REMINDERS_ID,
-                    "Bus arrival notifications",
-                    NotificationManager.IMPORTANCE_DEFAULT);
-            channel2.setDescription("Notifications to remind the user of an arriving bus.");
-
-            NotificationChannel channel3 = new NotificationChannel(
-                    CHANNEL_DESTINATION_ALERT_ID,
-                    "Destination alerts",
-                    NotificationManager.IMPORTANCE_LOW);
-            channel3.setDescription("All notifications relating to Destination alerts");
-
-            NotificationManager manager = getSystemService(NotificationManager.class);
-            manager.createNotificationChannel(channel1);
-            manager.createNotificationChannel(channel2);
-            manager.createNotificationChannel(channel3);
         }
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/realtime/RealtimeService.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/realtime/RealtimeService.java
@@ -29,7 +29,7 @@ import android.util.Log;
 import androidx.core.app.NotificationCompat;
 
 import org.onebusaway.android.R;
-import org.onebusaway.android.app.Application;
+import org.onebusaway.android.notifications.NotificationChannels;
 import org.onebusaway.android.app.di.TripPlanRepositoryEntryPoint;
 import org.onebusaway.android.directions.model.ItineraryDescription;
 import org.onebusaway.android.directions.util.OTPConstants;
@@ -270,7 +270,7 @@ public class RealtimeService extends IntentService {
                         flags);
 
         NotificationCompat.Builder mBuilder =
-                new NotificationCompat.Builder(getApplicationContext(), Application.CHANNEL_TRIP_PLAN_UPDATES_ID)
+                new NotificationCompat.Builder(getApplicationContext(), NotificationChannels.TRIP_PLAN_UPDATES_ID)
                         .setSmallIcon(R.drawable.ic_stat_notification)
                         .setContentTitle(titleText)
                         .setStyle(new NotificationCompat.BigTextStyle().bigText(messageText))

--- a/onebusaway-android/src/main/java/org/onebusaway/android/nav/FeedbackReceiver.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/nav/FeedbackReceiver.java
@@ -26,7 +26,7 @@ import android.util.Log;
 import org.apache.commons.io.FileUtils;
 import org.onebusaway.android.BuildConfig;
 import org.onebusaway.android.R;
-import org.onebusaway.android.app.Application;
+import org.onebusaway.android.notifications.NotificationChannels;
 import org.onebusaway.android.app.di.AnalyticsEntryPoint;
 import org.onebusaway.android.util.PreferenceUtils;
 
@@ -90,7 +90,7 @@ public class FeedbackReceiver extends BroadcastReceiver {
 
             NotificationCompat.Builder repliedNotification =
                     new NotificationCompat.Builder(context
-                            , Application.CHANNEL_DESTINATION_ALERT_ID)
+                            , NotificationChannels.DESTINATION_ALERT_ID)
                             .setSmallIcon(R.drawable.ic_stat_notification)
                             .setContentTitle(context.getResources()
                                     .getString(R.string.feedback_notify_title))

--- a/onebusaway-android/src/main/java/org/onebusaway/android/nav/NavigationService.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/nav/NavigationService.kt
@@ -43,7 +43,7 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import org.apache.commons.io.FileUtils
 import org.onebusaway.android.R
-import org.onebusaway.android.app.Application
+import org.onebusaway.android.notifications.NotificationChannels
 import org.onebusaway.android.app.di.LocationEntryPoint
 import org.onebusaway.android.analytics.ObaAnalytics
 import org.onebusaway.android.analytics.PlausibleAnalytics
@@ -394,7 +394,7 @@ class NavigationService : Service() {
             val pDelIntent = PendingIntent.getBroadcast(applicationContext, 0, delIntent, delFlags)
 
             builder = NotificationCompat.Builder(
-                applicationContext, Application.CHANNEL_DESTINATION_ALERT_ID
+                applicationContext, NotificationChannels.DESTINATION_ALERT_ID
             )
                 .setSmallIcon(R.drawable.ic_stat_notification)
                 .setContentTitle(resources.getString(R.string.feedback_notify_title))
@@ -462,7 +462,7 @@ class NavigationService : Service() {
             val pDelIntent = PendingIntent.getBroadcast(applicationContext, 0, delIntent, flags)
 
             builder = NotificationCompat.Builder(
-                applicationContext, Application.CHANNEL_DESTINATION_ALERT_ID
+                applicationContext, NotificationChannels.DESTINATION_ALERT_ID
             )
                 .setSmallIcon(R.drawable.ic_stat_notification)
                 .setContentTitle(resources.getString(R.string.feedback_notify_title))

--- a/onebusaway-android/src/main/java/org/onebusaway/android/nav/NavigationServiceProvider.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/nav/NavigationServiceProvider.java
@@ -19,7 +19,7 @@ import static android.app.PendingIntent.*;
 
 
 import org.onebusaway.android.R;
-import org.onebusaway.android.app.Application;
+import org.onebusaway.android.notifications.NotificationChannels;
 import org.onebusaway.android.app.di.AnalyticsEntryPoint;
 import org.onebusaway.android.analytics.PlausibleAnalytics;
 import org.onebusaway.android.nav.model.Path;
@@ -599,7 +599,7 @@ public class NavigationServiceProvider implements TextToSpeech.OnInitListener {
 
         NotificationCompat.Builder mBuilder =
                 new NotificationCompat.Builder(mContext
-                        , Application.CHANNEL_DESTINATION_ALERT_ID)
+                        , NotificationChannels.DESTINATION_ALERT_ID)
                         .setSmallIcon(R.drawable.ic_content_flag)
                         .setContentTitle(mContext.getResources()
                                 .getString(R.string.destination_reminder_title))
@@ -736,7 +736,7 @@ public class NavigationServiceProvider implements TextToSpeech.OnInitListener {
             mNotificationManager.notify(NOTIFICATION_ID + 2, mBuilder.build());
 
             mBuilder = new NotificationCompat.Builder(mContext
-                    , Application.CHANNEL_DESTINATION_ALERT_ID)
+                    , NotificationChannels.DESTINATION_ALERT_ID)
                     .setSmallIcon(R.drawable.ic_content_flag)
                     .setContentTitle(
                             mContext.getResources().getString(R.string.destination_reminder_title))

--- a/onebusaway-android/src/main/java/org/onebusaway/android/notifications/NotificationChannels.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/notifications/NotificationChannels.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.notifications
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.os.Build
+import android.util.Log
+
+/**
+ * The app's notification channels: their stable IDs and one-time registration. Extracted from
+ * `Application` so `onCreate` just calls [registerAll]. The IDs are referenced by the notification
+ * builders across `nav`, `tripservice`, and `directions` (Java and Kotlin), so they live here as the
+ * single source of truth rather than on the Application god-object.
+ */
+object NotificationChannels {
+
+    private const val TAG = "NotificationChannels"
+
+    const val TRIP_PLAN_UPDATES_ID = "trip_plan_updates"
+    const val ARRIVAL_REMINDERS_ID = "arrival_reminders"
+    const val DESTINATION_ALERT_ID = "destination_alerts"
+
+    /**
+     * Registers the app's notification channels. A no-op below API 26 (channels didn't exist);
+     * idempotent above it, since registering an existing channel id just updates it.
+     */
+    @JvmStatic
+    fun registerAll(context: Context) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            return
+        }
+        // NotificationManager is a platform type with a nullable getSystemService return; it's never
+        // null on a real API 26+ device, but guard the restricted/instrumented-context edge rather
+        // than NPE. Nothing to register (or recover) if the service is absent.
+        val manager = context.getSystemService(NotificationManager::class.java)
+        if (manager == null) {
+            Log.w(TAG, "NotificationManager unavailable; skipping notification-channel registration")
+            return
+        }
+        manager.createNotificationChannel(
+            NotificationChannel(
+                TRIP_PLAN_UPDATES_ID,
+                "Trip plan notifications (beta)",
+                NotificationManager.IMPORTANCE_DEFAULT,
+            ).apply {
+                description =
+                    "After planning a trip, send notifications if the trip is delayed or no longer recommended."
+            }
+        )
+        manager.createNotificationChannel(
+            NotificationChannel(
+                ARRIVAL_REMINDERS_ID,
+                "Bus arrival notifications",
+                NotificationManager.IMPORTANCE_DEFAULT,
+            ).apply {
+                description = "Notifications to remind the user of an arriving bus."
+            }
+        )
+        manager.createNotificationChannel(
+            NotificationChannel(
+                DESTINATION_ALERT_ID,
+                "Destination alerts",
+                NotificationManager.IMPORTANCE_LOW,
+            ).apply {
+                description = "All notifications relating to Destination alerts"
+            }
+        )
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/tripservice/MyFirebaseMessagingService.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/tripservice/MyFirebaseMessagingService.kt
@@ -14,7 +14,7 @@ import com.google.firebase.messaging.RemoteMessage
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 import org.onebusaway.android.R
-import org.onebusaway.android.app.Application
+import org.onebusaway.android.notifications.NotificationChannels
 import org.onebusaway.android.preferences.PreferencesRepository
 import org.onebusaway.android.reminders.ReminderRepository
 import org.onebusaway.android.ui.arrivals.ArrivalsListLauncher
@@ -74,7 +74,7 @@ class MyFirebaseMessagingService : FirebaseMessagingService() {
         )
 
         val notificationBuilder =
-            NotificationCompat.Builder(this, Application.CHANNEL_ARRIVAL_REMINDERS_ID)
+            NotificationCompat.Builder(this, NotificationChannels.ARRIVAL_REMINDERS_ID)
                 .setSmallIcon(R.drawable.ic_stat_notification)
                 .setColor(NOTIFICATION_COLOR)
                 .setContentTitle("OneBusAway")

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
@@ -63,7 +63,7 @@ import android.os.Build
 import android.os.Bundle
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import org.onebusaway.android.R
-import org.onebusaway.android.app.Application
+import org.onebusaway.android.notifications.NotificationChannels
 import org.onebusaway.android.app.di.PreferencesEntryPoint
 import org.onebusaway.android.directions.realtime.RealtimeService
 import org.onebusaway.android.directions.util.OTPConstants
@@ -253,7 +253,7 @@ private fun maybeStartTripUpdates(activity: Activity, itineraries: List<Itinerar
     val context = activity.applicationContext
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
         val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-        val channel = manager.getNotificationChannel(Application.CHANNEL_TRIP_PLAN_UPDATES_ID)
+        val channel = manager.getNotificationChannel(NotificationChannels.TRIP_PLAN_UPDATES_ID)
         if (channel != null && channel.importance != NotificationManager.IMPORTANCE_NONE) {
             RealtimeService.start(activity, bundle)
         }


### PR DESCRIPTION
Slice 4 of #1659 (Application.java decomposition).

`Application` owned the three notification-channel id constants, the `createNotificationChannels()` registration, and the `NotificationChannel`/`NotificationManager` imports. This moves all of it into a new `notifications/NotificationChannels` object.

### Changes
- New **`NotificationChannels`** (Kotlin `object`, `@JvmStatic` + `const val` so the Java notification builders keep working): the three ids + `registerAll(context)`.
- IDs move to `NotificationChannels.{TRIP_PLAN_UPDATES,ARRIVAL_REMINDERS,DESTINATION_ALERT}_ID`, dropping the now-redundant `CHANNEL_` prefix. **The persisted id strings (`trip_plan_updates`, etc.) are unchanged**, so existing channels are unaffected.
- `onCreate` calls `NotificationChannels.registerAll(this)` instead of the inlined method.
- The 6 consumers repoint from `Application.CHANNEL_*` to `NotificationChannels.*`:
  - `nav/NavigationService.kt` (×2), `nav/NavigationServiceProvider.java` (×2), `nav/FeedbackReceiver.java`, `directions/realtime/RealtimeService.java`, `tripservice/MyFirebaseMessagingService.kt`, `ui/tripresults/TripResultsScreen.kt`.
- `Application` loses the constants, the method, and the `NotificationChannel`/`NotificationManager`/now-orphaned `Build` imports.

No behavior change. Verified: `:onebusaway-android:compileObaGoogleDebugSources` passes (Java + Kotlin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added centralized notification channel definitions and registration at app startup to ensure channels are consistently created on supported Android versions.

* **Bug Fixes**
  * Updated trip updates, arrival reminders, destination alerts, and feedback-related notifications to use the shared channel IDs instead of app-level constants, improving reliability and consistency across notification types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->