### PR TITLE
Extract FCM token handling out of Application into FirebaseMessagingManager

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/app/Application.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/app/Application.java
@@ -25,8 +25,6 @@ import android.os.Build;
 import android.text.TextUtils;
 import android.util.Log;
 
-import com.google.firebase.messaging.FirebaseMessaging;
-
 import org.onebusaway.android.BuildConfig;
 import org.onebusaway.android.R;
 import org.onebusaway.android.donations.DonationsManager;
@@ -53,6 +51,7 @@ import java.nio.charset.StandardCharsets;
 import dagger.hilt.android.EntryPointAccessors;
 import dagger.hilt.android.HiltAndroidApp;
 import org.onebusaway.android.app.di.DatabaseEntryPoint;
+import org.onebusaway.android.app.di.FirebaseMessagingEntryPoint;
 
 @HiltAndroidApp
 public class Application extends android.app.Application {
@@ -103,7 +102,7 @@ public class Application extends android.app.Application {
 
         incrementAppLaunchCount();
 
-        initFirebaseMessaging();
+        FirebaseMessagingEntryPoint.get(this).fetchAndStoreToken();
 
         mDonationsManager = new DonationsManager(getApplicationContext(), getResources(), getAppLaunchCount());
     }
@@ -399,24 +398,6 @@ public class Application extends android.app.Application {
             manager.createNotificationChannel(channel2);
             manager.createNotificationChannel(channel3);
         }
-    }
-
-    private void initFirebaseMessaging() {
-        FirebaseMessaging.getInstance().getToken()
-                .addOnCompleteListener(task -> {
-                    if (!task.isSuccessful()) {
-                        Log.e(TAG, "Fetching FCM registration token failed", task.getException());
-                        return;
-                    }
-                    String token = task.getResult();
-                    PreferenceUtils.saveString(getString(R.string.firebase_messaging_token), token);
-                });
-    }
-
-    public static String getUserPushID() {
-        String key = get().getApplicationContext().getString(R.string.firebase_messaging_token);
-        String token = PreferenceUtils.getString(key);
-        return token != null ? token : "";
     }
 
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/app/di/FirebaseMessagingEntryPoint.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/app/di/FirebaseMessagingEntryPoint.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.app.di
+
+import android.content.Context
+import dagger.hilt.EntryPoint
+import dagger.hilt.InstallIn
+import dagger.hilt.android.EntryPointAccessors
+import dagger.hilt.components.SingletonComponent
+import org.onebusaway.android.push.FirebaseMessagingManager
+
+/**
+ * A Hilt [EntryPoint] that lets code which can't be constructor-injected — `Application.onCreate`, a
+ * composable factory without a ViewModel — reach the injected [FirebaseMessagingManager] singleton
+ * (mirrors [AnalyticsEntryPoint]). It needs a [Context] only to resolve the singleton graph.
+ *
+ * Use it only where injection genuinely isn't available — Hilt-reachable classes (ViewModels,
+ * repositories, Services) should inject [FirebaseMessagingManager] directly.
+ */
+@EntryPoint
+@InstallIn(SingletonComponent::class)
+interface FirebaseMessagingEntryPoint {
+
+    fun firebaseMessagingManager(): FirebaseMessagingManager
+
+    companion object {
+        /** Resolves the [FirebaseMessagingManager] singleton from any [context] (its application is used). */
+        @JvmStatic
+        fun get(context: Context): FirebaseMessagingManager =
+            EntryPointAccessors.fromApplication(context, FirebaseMessagingEntryPoint::class.java)
+                .firebaseMessagingManager()
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/push/FirebaseMessagingManager.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/push/FirebaseMessagingManager.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.push
+
+import android.util.Log
+import com.google.firebase.messaging.FirebaseMessaging
+import javax.inject.Inject
+import javax.inject.Singleton
+import org.onebusaway.android.R
+import org.onebusaway.android.preferences.PreferencesRepository
+
+/**
+ * Owns the FCM registration token: fetching it at startup and exposing the stored value. Extracted
+ * from `Application` (the god-object) so onCreate just kicks [fetchAndStoreToken]. The token is
+ * persisted through [PreferencesRepository] — the same seam `MyFirebaseMessagingService.onNewToken`
+ * uses — so the startup fetch and later token rotations write the one `firebase_messaging_token` slot.
+ */
+@Singleton
+class FirebaseMessagingManager @Inject constructor(
+    private val prefs: PreferencesRepository,
+) {
+
+    /**
+     * Fetches the current FCM registration token and persists it. Fire-and-forget; called once from
+     * `Application.onCreate` so a token obtained before the app first read it is captured.
+     */
+    fun fetchAndStoreToken() {
+        FirebaseMessaging.getInstance().token.addOnCompleteListener { task ->
+            if (!task.isSuccessful) {
+                Log.e(TAG, "Fetching FCM registration token failed", task.exception)
+                return@addOnCompleteListener
+            }
+            prefs.setString(R.string.firebase_messaging_token, task.result)
+        }
+    }
+
+    /** The FCM registration token, or "" if one hasn't been obtained yet. */
+    fun userPushId(): String = prefs.getString(R.string.firebase_messaging_token, null) ?: ""
+
+    /** Whether an FCM push token has been obtained yet. */
+    fun hasPushToken(): Boolean = userPushId().isNotEmpty()
+
+    private companion object {
+        const val TAG = "FirebaseMessagingManager"
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalActionHandlers.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalActionHandlers.kt
@@ -26,10 +26,10 @@ import androidx.appcompat.app.AppCompatActivity
 import org.onebusaway.android.R
 import org.onebusaway.android.ui.nav.ReminderEditorArgs
 import org.onebusaway.android.app.di.DatabaseEntryPoint
+import org.onebusaway.android.app.di.FirebaseMessagingEntryPoint
 import org.onebusaway.android.report.ui.InfrastructureIssueLauncher
 import org.onebusaway.android.util.ExternalIntents
 import org.onebusaway.android.util.PreferenceUtils
-import org.onebusaway.android.util.ReminderUtils
 
 /**
  * Builds the [ArrivalActionHandler] shared by the standalone arrivals activity and the map panel.
@@ -86,7 +86,7 @@ fun createArrivalActionHandler(
     }
 
     override fun onSetReminder(arrival: ArrivalInfo) {
-        if (!ReminderUtils.shouldShowReminders()) {
+        if (!FirebaseMessagingEntryPoint.get(activity).hasPushToken()) {
             Toast.makeText(activity, R.string.reminder_not_enabled, Toast.LENGTH_SHORT).show()
             return
         }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/drawer/NavItemsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/drawer/NavItemsRepository.kt
@@ -20,7 +20,7 @@ import javax.inject.Inject
 import org.onebusaway.android.R
 import org.onebusaway.android.preferences.PreferencesRepository
 import org.onebusaway.android.region.RegionRepository
-import org.onebusaway.android.util.ReminderUtils
+import org.onebusaway.android.push.FirebaseMessagingManager
 
 /** The (app-global) inputs that gate which home nav-drawer rows are shown — surfaced as a `StateFlow`
  *  by [NavDrawerViewModel] for [HomeNavDrawerSheet] to render. */
@@ -48,12 +48,13 @@ interface NavItemsRepository {
 class DefaultNavItemsRepository @Inject constructor(
     private val regionRepository: RegionRepository,
     private val prefs: PreferencesRepository,
+    private val firebaseMessagingManager: FirebaseMessagingManager,
 ) : NavItemsRepository {
 
     override fun availability(): NavItemAvailability {
         val region = regionRepository.region.value
         return NavItemAvailability(
-            showReminders = ReminderUtils.shouldShowReminders(),
+            showReminders = firebaseMessagingManager.hasPushToken(),
             planTripAvailable = region != null &&
                 (!TextUtils.isEmpty(region.otpBaseUrl) ||
                     !TextUtils.isEmpty(

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripinfo/TripInfoRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripinfo/TripInfoRepository.kt
@@ -22,7 +22,7 @@ import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.onebusaway.android.R
-import org.onebusaway.android.app.Application
+import org.onebusaway.android.push.FirebaseMessagingManager
 import org.onebusaway.android.api.contract.ReminderWebService
 import org.onebusaway.android.database.oba.ImportGate
 import org.onebusaway.android.database.oba.RouteDao
@@ -101,6 +101,7 @@ class DefaultTripInfoRepository @Inject constructor(
     private val tripDao: TripDao,
     private val stopDao: StopDao,
     private val importGate: ImportGate,
+    private val firebaseMessagingManager: FirebaseMessagingManager,
 ) : TripInfoRepository {
 
     override suspend fun load(args: TripInfoArgs): TripInfoData = withContext(Dispatchers.IO) {
@@ -232,8 +233,8 @@ class DefaultTripInfoRepository @Inject constructor(
         val base = region.sidecarBaseUrl ?: return null
         // The push id is the one required field not guaranteed by the typed args (it's absent until
         // push registration completes); the legacy builder returned null in that case.
-        val userPushId = Application.getUserPushID()
-        if (userPushId.isNullOrEmpty()) return null
+        val userPushId = firebaseMessagingManager.userPushId()
+        if (userPushId.isEmpty()) return null
         val url = base + context.getString(R.string.arrivals_reminders_api_endpoint) +
             region.id + "/alarms"
         return runCatching {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/ReminderUtils.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/ReminderUtils.java
@@ -16,7 +16,6 @@
 package org.onebusaway.android.util;
 
 import org.onebusaway.android.R;
-import org.onebusaway.android.app.Application;
 
 import android.content.Context;
 import android.util.Log;
@@ -73,15 +72,6 @@ public class ReminderUtils {
             Log.e(TAG, "Error parsing arrival_and_departure JSON", e);
             return null;
         }
-    }
-
-    /**
-     * Checks if reminders should be available by verifying an FCM push token has been obtained.
-     * Returns false if the token has not yet been fetched or registration failed.
-     */
-    public static boolean shouldShowReminders() {
-        String pushId = Application.getUserPushID();
-        return pushId != null && !pushId.isEmpty();
     }
 
     /**


### PR DESCRIPTION
Slice 5 of #1659 (Application.java decomposition).

`Application` owned `initFirebaseMessaging()` (startup token fetch + persist) and the static `getUserPushID()` reader. This moves both into a new `@Singleton` `push/FirebaseMessagingManager`.

### The manager
- `fetchAndStoreToken()` — the startup FCM `getToken()` fetch, persisted through `PreferencesRepository` (the **same seam** `MyFirebaseMessagingService.onNewToken` already writes, so the startup fetch and later token rotations share the one `firebase_messaging_token` slot).
- `userPushId()` — the stored token, or `""`.
- `hasPushToken()` — the "token present" predicate.

### Consumers move to injection
- `Application.onCreate` kicks `fetchAndStoreToken()` via a new **`FirebaseMessagingEntryPoint`** (mirrors `DonationsEntryPoint`), consistent with the existing `DatabaseEntryPoint` startup task next to it.
- `TripInfoRepository` and `NavItemsRepository` constructor-inject the manager.
- `ArrivalActionHandlers` (a composable factory with no ViewModel) reaches it through the EntryPoint using its `Activity` context.

### ReminderUtils
`ReminderUtils.shouldShowReminders()` existed **only** to wrap `getUserPushID()`, so its "FCM token present" predicate moves onto the manager as `hasPushToken()` and the static util's `Application` reach is retired too. Both call sites (`NavItemsRepository`, `ArrivalActionHandlers`) now use the manager. `Application` loses both methods and the `FirebaseMessaging` import.

### No behavior change
`PreferenceUtils` already delegates to `PreferencesRepository`, so the token read/write hit the **same DataStore** before and after this change — the storage seam is unchanged, only the ownership moved off the god-object.

### Verification
`:onebusaway-android:compileObaGoogleDebugSources` + `compileObaGoogleDebugUnitTestSources` pass (Java + Kotlin + Hilt/KSP). No test constructs the changed repositories directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)