### PR TITLE
Extract the onCreate startup chores out of Application

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/net/ObaEndpointResolver.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/net/ObaEndpointResolver.kt
@@ -60,7 +60,8 @@ class ObaEndpointResolver @Inject constructor(
     /** The app version code (`app_ver`) — a build constant, so no per-request lookup. */
     val appVersion: Int get() = BuildConfig.VERSION_CODE
 
-    /** The persisted per-install app UID (`app_uid`), generated once at app startup. Invariant per
-     * process, so read once at construction rather than on every request. */
+    /** The persisted per-install app UID (`app_uid`), seeded eagerly in `Application.onCreate` (it has
+     * other direct readers too, e.g. the Open311 report path). Invariant per process, so read once at
+     * construction rather than on every request. */
     val appUid: String? = preferences.getString(ObaApi.APP_UID, null)
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/app/Application.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/app/Application.java
@@ -49,6 +49,7 @@ import dagger.hilt.android.EntryPointAccessors;
 import dagger.hilt.android.HiltAndroidApp;
 import org.onebusaway.android.app.di.DatabaseEntryPoint;
 import org.onebusaway.android.app.di.FirebaseMessagingEntryPoint;
+import org.onebusaway.android.app.di.PreferencesEntryPoint;
 
 @HiltAndroidApp
 public class Application extends android.app.Application {
@@ -69,7 +70,16 @@ public class Application extends android.app.Application {
 
         mApp = this;
 
-        initOba();
+        // Seed the per-install app UID once, eagerly, before any reader needs it. It has multiple
+        // independent direct readers (ObaEndpointResolver sends it as app_uid; the Open311 report path
+        // reads it as device_id), so seeding lazily in one reader can't guarantee it for the others.
+        if (PreferenceUtils.getString(ObaApi.APP_UID) == null) {
+            PreferenceUtils.saveString(ObaApi.APP_UID, UUID.randomUUID().toString());
+        }
+
+        // Seed first-run OBA defaults: the build-flavor arrival-info style, and apply the saved theme.
+        BuildFlavorUtils.applyDefaultArrivalInfoStyleIfUnset(this);
+        ThemeUtils.applyPersistedTheme(this);
 
         // Kick the one-time legacy ContentProvider -> Room data import (fire-and-forget) so it overlaps
         // startup; every migrated repository read/write awaits this gate before touching the DB.
@@ -91,7 +101,7 @@ public class Application extends android.app.Application {
 
         NotificationChannels.registerAll(this);
 
-        incrementAppLaunchCount();
+        PreferencesEntryPoint.get(this).incrementAppLaunchCount();
 
         FirebaseMessagingEntryPoint.get(this).fetchAndStoreToken();
     }
@@ -112,20 +122,6 @@ public class Application extends android.app.Application {
     //
     public static Application get() {
         return mApp;
-    }
-
-
-    // Preserve the original preference-key value so persisted launch counts survive upgrades.
-    public static final String APP_LAUNCH_COUNT_KEY = "appLaunchCountPreferencesKey";
-
-    private void incrementAppLaunchCount() {
-        int count = PreferenceUtils.getInt(APP_LAUNCH_COUNT_KEY, 0);
-        count += 1;
-        PreferenceUtils.saveInt(APP_LAUNCH_COUNT_KEY, count);
-    }
-
-    public int getAppLaunchCount() {
-        return PreferenceUtils.getInt(APP_LAUNCH_COUNT_KEY, 0);
     }
 
     /**
@@ -259,61 +255,6 @@ public class Application extends android.app.Application {
                     .append(HEXES.charAt((b & 0x0F)));
         }
         return hex.toString();
-    }
-
-    private String getAppUid() {
-        return UUID.randomUUID().toString();
-    }
-
-    private void initOba() {
-        // Ensure a per-install app UID is persisted; ObaEndpointResolver reads it as app_uid.
-        if (PreferenceUtils.getString(ObaApi.APP_UID) == null) {
-            PreferenceUtils.saveString(ObaApi.APP_UID, getAppUid());
-        }
-
-        checkArrivalStylePreferenceDefault();
-        checkDarkMode();
-    }
-
-    private void checkArrivalStylePreferenceDefault() {
-        String arrivalInfoStylePrefKey = getResources()
-                .getString(R.string.preference_key_arrival_info_style);
-        String arrivalInfoStylePref = PreferenceUtils.getString(arrivalInfoStylePrefKey);
-        if (arrivalInfoStylePref == null) {
-            // First execution of app - set the default arrival info style based on the BuildConfig value
-            switch (BuildConfig.ARRIVAL_INFO_STYLE) {
-                case BuildFlavorUtils.ARRIVAL_INFO_STYLE_A:
-                    // Use OBA classic style for default
-                    PreferenceUtils.saveString(arrivalInfoStylePrefKey, BuildFlavorUtils
-                            .getPreferenceOptionForArrivalInfoBuildFlavorStyle(this,
-                                    BuildFlavorUtils.ARRIVAL_INFO_STYLE_A));
-                    Log.d(TAG, "Using arrival info style A (OBA Classic) as default preference");
-                    break;
-                case BuildFlavorUtils.ARRIVAL_INFO_STYLE_B:
-                    // Use a card-styled footer for default
-                    PreferenceUtils.saveString(arrivalInfoStylePrefKey, BuildFlavorUtils
-                            .getPreferenceOptionForArrivalInfoBuildFlavorStyle(this,
-                                    BuildFlavorUtils.ARRIVAL_INFO_STYLE_B));
-                    Log.d(TAG, "Using arrival info style B (Cards) as default preference");
-                    break;
-                default:
-                    // Use a card-styled footer for default
-                    PreferenceUtils.saveString(arrivalInfoStylePrefKey, BuildFlavorUtils
-                            .getPreferenceOptionForArrivalInfoBuildFlavorStyle(this,
-                                    BuildFlavorUtils.ARRIVAL_INFO_STYLE_B));
-                    Log.d(TAG, "Using arrival info style B (Cards) as default preference");
-                    break;
-            }
-        }
-    }
-
-    private void checkDarkMode() {
-        String appThemePrefKey = getResources()
-                .getString(R.string.preference_key_app_theme);
-        String appThemePref = PreferenceUtils.getString(appThemePrefKey);
-        if (appThemePref != null) {
-            ThemeUtils.setAppTheme(this, appThemePref);
-        }
     }
 
     private void initOpen311(Region region) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/preferences/PreferencesRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/preferences/PreferencesRepository.kt
@@ -35,7 +35,6 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import org.onebusaway.android.app.Application
 import org.onebusaway.android.app.di.AppScope
 
 /**
@@ -83,11 +82,20 @@ interface PreferencesRepository {
     fun getFloat(key: String, default: Float): Float
 
     /**
-     * The persisted app-launch counter ([Application.APP_LAUNCH_COUNT_KEY]), 0 if never launched. A
-     * named read so consumers (e.g. the survey gate) inject this instead of re-inlining the key and its
-     * default — the injectable equivalent of the `Application.get().getAppLaunchCount()` reach (#1642).
+     * The persisted app-launch counter ([APP_LAUNCH_COUNT_KEY]), 0 if never launched. A named read so
+     * consumers (e.g. the survey gate) inject this instead of re-inlining the key and its default — the
+     * injectable equivalent of the `Application.get().getAppLaunchCount()` reach (#1642).
      */
     fun getAppLaunchCount(): Int
+
+    /**
+     * Increments the persisted app-launch counter by one. Called once per launch at startup. A default
+     * method: it's pure composition of [getAppLaunchCount] + [setInt], so every implementation (and the
+     * test fakes) shares this one body.
+     */
+    fun incrementAppLaunchCount() {
+        setInt(APP_LAUNCH_COUNT_KEY, getAppLaunchCount() + 1)
+    }
 
     fun setBoolean(@StringRes keyRes: Int, value: Boolean)
     fun setBoolean(key: String, value: Boolean)
@@ -103,6 +111,12 @@ interface PreferencesRepository {
 
     fun setFloat(@StringRes keyRes: Int, value: Float)
     fun setFloat(key: String, value: Float)
+
+    companion object {
+        /** Preference key for the persisted app-launch counter. Preserves the original value so counts
+         * survive upgrades. Owned here (the counter's home) rather than on `Application`. */
+        const val APP_LAUNCH_COUNT_KEY = "appLaunchCountPreferencesKey"
+    }
 }
 
 /**
@@ -165,7 +179,7 @@ class DefaultPreferencesRepository @Inject constructor(
     override fun getFloat(keyRes: Int, default: Float) = getFloat(context.getString(keyRes), default)
     override fun getFloat(key: String, default: Float) = cache[floatPreferencesKey(key)] ?: default
 
-    override fun getAppLaunchCount() = getInt(Application.APP_LAUNCH_COUNT_KEY, 0)
+    override fun getAppLaunchCount() = getInt(PreferencesRepository.APP_LAUNCH_COUNT_KEY, 0)
 
     // --- writes (optimistic cache update + async persist) ---
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/BuildFlavorUtils.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/BuildFlavorUtils.java
@@ -65,6 +65,24 @@ public class BuildFlavorUtils {
     }
 
     /**
+     * On first run — when no arrival-info-style preference has been set yet — seeds the default style
+     * from this build flavor's {@link BuildConfig#ARRIVAL_INFO_STYLE}. User selections always override
+     * this, so it only writes when the preference is unset. (Extracted from {@code Application.onCreate}.)
+     */
+    public static void applyDefaultArrivalInfoStyleIfUnset(Context context) {
+        if (PreferencesEntryPoint.get(context)
+                .getString(R.string.preference_key_arrival_info_style, null) != null) {
+            return;
+        }
+        // Only STYLE_A maps to A; STYLE_B and any other value default to B (matches the legacy switch).
+        int style = BuildConfig.ARRIVAL_INFO_STYLE == ARRIVAL_INFO_STYLE_A
+                ? ARRIVAL_INFO_STYLE_A : ARRIVAL_INFO_STYLE_B;
+        PreferencesEntryPoint.get(context).setString(
+                R.string.preference_key_arrival_info_style,
+                getPreferenceOptionForArrivalInfoBuildFlavorStyle(context, style));
+    }
+
+    /**
      * Returns the current Arrival Info Style saved in the preferences, represented using the
      * ARRIVAL_INFO_STYLE_* constants in this class
      * @return the current Arrival Info Style saved in the preferences, which will be one of the

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/ThemeUtils.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/ThemeUtils.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import android.content.res.Configuration
 import androidx.appcompat.app.AppCompatDelegate
 import org.onebusaway.android.R
+import org.onebusaway.android.app.di.PreferencesEntryPoint
 
 /**
  * Applies the user's selected app theme to the AppCompat night-mode delegate.
@@ -48,6 +49,17 @@ object ThemeUtils {
             else -> return
         }
         AppCompatDelegate.setDefaultNightMode(mode)
+    }
+
+    /**
+     * Applies the persisted app-theme preference to the night-mode delegate, if the user has chosen
+     * one. Called at startup so the saved theme takes effect; a no-op when no theme has been set.
+     */
+    @JvmStatic
+    fun applyPersistedTheme(context: Context) {
+        val themeValue = PreferencesEntryPoint.get(context)
+            .getString(R.string.preference_key_app_theme, null) ?: return
+        setAppTheme(context, themeValue)
     }
 
     /**

--- a/onebusaway-android/src/test/java/org/onebusaway/android/preferences/AppLaunchCountTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/preferences/AppLaunchCountTest.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.preferences
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.onebusaway.android.testing.FakePreferencesRepository
+
+/**
+ * Unit tests for [PreferencesRepository]'s app-launch counter — the read/increment pair that moved
+ * off `Application` (slice 6 of #1659). [PreferencesRepository.incrementAppLaunchCount] is the one
+ * genuinely new piece: a shared default-method read-modify-write feeding the survey gate and the
+ * donations manager. Exercised through [FakePreferencesRepository], which round-trips getInt/setInt.
+ */
+class AppLaunchCountTest {
+
+    @Test
+    fun `count starts at zero`() {
+        assertEquals(0, FakePreferencesRepository().getAppLaunchCount())
+    }
+
+    @Test
+    fun `one increment from cold yields one`() {
+        val prefs = FakePreferencesRepository()
+        prefs.incrementAppLaunchCount()
+        assertEquals(1, prefs.getAppLaunchCount())
+    }
+
+    @Test
+    fun `N increments yield N`() {
+        val prefs = FakePreferencesRepository()
+        repeat(4) { prefs.incrementAppLaunchCount() }
+        assertEquals(4, prefs.getAppLaunchCount())
+    }
+
+    @Test
+    fun `increment builds on a pre-seeded value`() {
+        val prefs = FakePreferencesRepository()
+        prefs.setInt(PreferencesRepository.APP_LAUNCH_COUNT_KEY, 5)
+        prefs.incrementAppLaunchCount()
+        assertEquals(6, prefs.getAppLaunchCount())
+    }
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/testing/FakePreferencesRepository.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/testing/FakePreferencesRepository.kt
@@ -18,7 +18,6 @@ package org.onebusaway.android.testing
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
-import org.onebusaway.android.app.Application
 import org.onebusaway.android.preferences.PreferencesRepository
 
 /**
@@ -67,7 +66,8 @@ class FakePreferencesRepository(private val observeValue: Boolean = true) : Pref
     override fun getFloat(key: String, default: Float) = read(key, default)
 
     // Mirrors the real impl: reads APP_LAUNCH_COUNT_KEY, so a test can seed it via setInt(key, n).
-    override fun getAppLaunchCount() = getInt(Application.APP_LAUNCH_COUNT_KEY, 0)
+    // incrementAppLaunchCount() is inherited from the interface default (getAppLaunchCount + setInt).
+    override fun getAppLaunchCount() = getInt(PreferencesRepository.APP_LAUNCH_COUNT_KEY, 0)
 
     override fun setBoolean(keyRes: Int, value: Boolean) { values[keyRes] = value; boolFlow(keyRes).value = value }
     override fun setBoolean(key: String, value: Boolean) { values[key] = value; boolFlow(key).value = value }


### PR DESCRIPTION
Slice 6 of #1659 (Application.java decomposition) — the diffuse "startup chores" cleanup. Moves the small, unrelated first-run/startup chores off the `Application` god-object to their proper owners, so `onCreate`/`initOba` shrink to a short list of named steps.

### App-launch counter → `PreferencesRepository`
The repo already owned the *read* (`getAppLaunchCount`, #1642); it now also owns the **write** (`incrementAppLaunchCount()`) and the **key** (`APP_LAUNCH_COUNT_KEY` moves to its companion object — the read impl and both test fakes no longer reach back to `Application` for it). `onCreate` calls both through `PreferencesEntryPoint`. `Application` drops the constant and both methods.

### Per-install `app_uid` — seeding stays eager at startup (by design)
`app_uid` has **two independent direct readers** — `ObaEndpointResolver` (sends it as `app_uid`) and `DefaultOpen311Repository.submit()` (reads it as `device_id`) — so it can't be seeded lazily in one reader without risking a null read from the other (per CodeRabbit's review). It's a genuine cross-cutting install-identity invariant, so its unconditional one-time seed stays in `onCreate` (just re-homed out of the vague `initOba()`); the readers stay pure reads. Only `initOba()` as a wrapper is gone.

### First-run defaults → their util owners
- Arrival-info-style default → `BuildFlavorUtils.applyDefaultArrivalInfoStyleIfUnset()` (it already owns the flavor→pref mapping; the 3-case switch collapses to "only STYLE_A → A, else B", preserving behavior).
- Applying the saved theme → `ThemeUtils.applyPersistedTheme()` (it already owns `setAppTheme`).

`onCreate` calls these two directly; `initOba()` / `checkArrivalStylePreferenceDefault()` / `checkDarkMode()` are gone.

### No behavior change
`PreferenceUtils` already delegates to `PreferencesRepository`, so every read/write hits the same DataStore before and after; `app_uid` is still generated once at startup and persisted (invariant per install), and the API interceptor / Open311 `device_id` still read it exactly as before.

### Verification
main + unit + androidTest sources all compile (Java + Kotlin + Hilt/KSP); the `*Preferences*` / `*Survey*` unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App startup now restores your saved theme automatically.
  * First-time setup now applies a sensible default arrival-info style when none is saved.

* **Bug Fixes**
  * App launch counts are now tracked more consistently across the app.
  * Per-install app ID setup is handled earlier at startup, helping other features read it reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
