### PR TITLE
Fix vehicle-marker flicker from duplicate trips sharing a marker key

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/extrapolation/test/ExtrapolatedVehiclesTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/extrapolation/test/ExtrapolatedVehiclesTest.kt
@@ -26,6 +26,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.onebusaway.android.extrapolation.data.TripState
+import org.onebusaway.android.extrapolation.data.toObservations
 import org.onebusaway.android.extrapolation.extrapolatedVehicles
 import org.onebusaway.android.api.contract.ListWithReferences
 import org.onebusaway.android.api.contract.ObaEnvelope
@@ -132,6 +133,55 @@ class ExtrapolatedVehiclesTest {
             directionResponse().asRouteTrips(), setOf("route_1"), nowMs = WallTime(1_000_000L), lookupState = noState
         )
         assertEquals(listOf("trip_out", "trip_in"), vehicles.map { it.status.activeTripId })
+    }
+
+    // A trips-for-route response listing the same trip twice — a schedule-only entry (position, no
+    // fix) and a real-time entry (lastKnownLocation), in each order — the #1667/#50 flicker fixture.
+    private fun duplicateResponse(): ObaEnvelope<ListWithReferences<TripDetailsEntry>> =
+        Resources.read(getTargetContext(), Resources.getTestUri("trips_for_route_duplicate_trip"))
+            .use { json.decodeFromString(it.readText()) }
+
+    @Test
+    fun wireDedupCollapsesDuplicateTripKeepingTheRealtimeFix() {
+        // asRouteTrips() collapses each doubled trip id to one entry, keeping the GPS-fix entry
+        // regardless of which order it appeared in (dup1: scheduled then GPS; dup2: GPS then scheduled).
+        val trips = duplicateResponse().asRouteTrips().trips
+        assertEquals(listOf("trip_dup1", "trip_dup2"), trips.map { it.id })
+        assertEquals(47.201, trips[0].status!!.lastKnownLocation!!.latitude, 1e-6)
+        assertEquals(47.202, trips[1].status!!.lastKnownLocation!!.latitude, 1e-6)
+    }
+
+    @Test
+    fun oneMarkerPerTripWhenTheResponseDuplicatesIt() {
+        // End to end: the doubled trip yields a single vehicle at the real-time point, not two
+        // vehicles fighting over one activeTripId marker key.
+        val vehicles = extrapolatedVehicles(
+            duplicateResponse().asRouteTrips(), setOf("route_1"), nowMs = WallTime(1_000_000L), lookupState = noState
+        )
+        assertEquals(listOf("trip_dup1", "trip_dup2"), vehicles.map { it.status.activeTripId })
+        assertEquals(47.201, vehicles[0].point.latitude, 1e-6)
+        assertEquals(47.202, vehicles[1].point.latitude, 1e-6)
+    }
+
+    // Two distinct trips both reporting the same active trip (a vehicle mid-rollover): the ghost
+    // predecessor (scheduled) and the real-time successor — collide on activeTripId, not trip id.
+    private fun rolloverResponse(): ObaEnvelope<ListWithReferences<TripDetailsEntry>> =
+        Resources.read(getTargetContext(), Resources.getTestUri("trips_for_route_rollover"))
+            .use { json.decodeFromString(it.readText()) }
+
+    @Test
+    fun wireDedupCollapsesRolloverAcrossRenderAndStore() {
+        // The seam keys on activeTripId, so the ghost predecessor and the real-time successor collapse
+        // to one entry there — fixing both consumers of RouteTrips at once: the render vehicles...
+        val trips = rolloverResponse().asRouteTrips()
+        val vehicles = extrapolatedVehicles(
+            trips, setOf("route_1"), nowMs = WallTime(1_000_000L), lookupState = noState
+        )
+        assertEquals(1, vehicles.size)
+        assertEquals("trip_next", vehicles[0].status.activeTripId)
+        assertEquals(47.99, vehicles[0].point.latitude, 1e-6)
+        // ...and the store's observations (which forEachActiveTrip keys by activeTripId): one, not two.
+        assertEquals(listOf("trip_next"), trips.toObservations().map { it.tripId })
     }
 
     @Test

--- a/onebusaway-android/src/androidTest/res/raw/trips_for_route_duplicate_trip.json
+++ b/onebusaway-android/src/androidTest/res/raw/trips_for_route_duplicate_trip.json
@@ -1,0 +1,68 @@
+{
+  "code": 200,
+  "currentTime": 1444073094612,
+  "text": "OK",
+  "version": 2,
+  "data": {
+    "limitExceeded": false,
+    "outOfRange": false,
+    "list": [
+      {
+        "tripId": "trip_dup1",
+        "serviceDate": 1444017600000,
+        "status": {
+          "activeTripId": "trip_dup1",
+          "lastUpdateTime": 1000,
+          "status": "default",
+          "distanceAlongTrip": 100.0,
+          "position": { "lat": 47.101, "lon": -122.101 }
+        }
+      },
+      {
+        "tripId": "trip_dup1",
+        "serviceDate": 1444017600000,
+        "status": {
+          "activeTripId": "trip_dup1",
+          "lastUpdateTime": 1000,
+          "status": "default",
+          "distanceAlongTrip": 250.0,
+          "position": { "lat": 47.111, "lon": -122.111 },
+          "lastKnownLocation": { "lat": 47.201, "lon": -122.201 }
+        }
+      },
+      {
+        "tripId": "trip_dup2",
+        "serviceDate": 1444017600000,
+        "status": {
+          "activeTripId": "trip_dup2",
+          "lastUpdateTime": 2000,
+          "status": "default",
+          "distanceAlongTrip": 250.0,
+          "position": { "lat": 47.112, "lon": -122.112 },
+          "lastKnownLocation": { "lat": 47.202, "lon": -122.202 }
+        }
+      },
+      {
+        "tripId": "trip_dup2",
+        "serviceDate": 1444017600000,
+        "status": {
+          "activeTripId": "trip_dup2",
+          "lastUpdateTime": 2000,
+          "status": "default",
+          "distanceAlongTrip": 100.0,
+          "position": { "lat": 47.102, "lon": -122.102 }
+        }
+      }
+    ],
+    "references": {
+      "agencies": [],
+      "routes": [],
+      "situations": [],
+      "stops": [],
+      "trips": [
+        { "id": "trip_dup1", "routeId": "route_1" },
+        { "id": "trip_dup2", "routeId": "route_1" }
+      ]
+    }
+  }
+}

--- a/onebusaway-android/src/androidTest/res/raw/trips_for_route_rollover.json
+++ b/onebusaway-android/src/androidTest/res/raw/trips_for_route_rollover.json
@@ -1,0 +1,45 @@
+{
+  "code": 200,
+  "currentTime": 1444073094612,
+  "text": "OK",
+  "version": 2,
+  "data": {
+    "limitExceeded": false,
+    "outOfRange": false,
+    "list": [
+      {
+        "tripId": "trip_prev",
+        "serviceDate": 1444017600000,
+        "status": {
+          "activeTripId": "trip_next",
+          "lastUpdateTime": 1000,
+          "status": "default",
+          "predicted": false,
+          "position": { "lat": 47.10, "lon": -122.10 }
+        }
+      },
+      {
+        "tripId": "trip_next",
+        "serviceDate": 1444017600000,
+        "status": {
+          "activeTripId": "trip_next",
+          "lastUpdateTime": 2000,
+          "status": "default",
+          "predicted": true,
+          "position": { "lat": 47.90, "lon": -122.90 },
+          "lastKnownLocation": { "lat": 47.99, "lon": -122.99 }
+        }
+      }
+    ],
+    "references": {
+      "agencies": [],
+      "routes": [],
+      "situations": [],
+      "stops": [],
+      "trips": [
+        { "id": "trip_prev", "routeId": "route_1" },
+        { "id": "trip_next", "routeId": "route_1" }
+      ]
+    }
+  }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/data/TripVehiclesDataSource.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/data/TripVehiclesDataSource.kt
@@ -44,10 +44,47 @@ private fun routeTripsOf(
     references: References,
     serverTimeMs: Long,
 ): RouteTrips = object : RouteTrips {
-    override val trips: List<ObaTripDetails> = entries.map { DtoTripDetails(it) }
+    override val trips: List<ObaTripDetails> =
+        entries.dedupeByActiveTripKeepingBestFix().map { DtoTripDetails(it) }
     override fun trip(tripId: String?): ObaTrip? = tripId?.let { references.trip(it) }?.let { DtoTrip(it) }
     override fun route(routeId: String): ObaRoute? = references.route(routeId)?.let { DtoRoute(it) }
     override val currentTimeMs: Long = serverNowOrDeviceClock(serverTimeMs)
+}
+
+/**
+ * Collapses trip-details entries that share an active trip, keeping the one whose status is the best
+ * live fix.
+ *
+ * OBA trips-for-route can carry the same active trip more than once — the same trip listed twice (a
+ * real-time GPS entry plus a schedule-only entry, at different `distanceAlongTrip`), or, during a block
+ * rollover, two *distinct* trips both reporting the successor as active. Both forms collide downstream
+ * on `activeTripId`: the render layer keys its vehicle markers by it (the marker's position then flips
+ * between the two entries every frame — upstream #1667 / origin #50), and the store keys its
+ * observations by it ([RouteTrips.toObservations] via `forEachActiveTrip` — a conflicting
+ * double-record). Keying the dedup on `activeTripId` at this one wire→model seam fixes every consumer
+ * at once; fall back to `tripId` when a status is absent, and preserve first-seen order.
+ */
+private fun List<TripDetailsEntry>.dedupeByActiveTripKeepingBestFix(): List<TripDetailsEntry> {
+    if (size < 2) return this
+    val byKey = LinkedHashMap<String, TripDetailsEntry>(size)
+    for (entry in this) {
+        val key = entry.status?.activeTripId?.ifBlank { null } ?: entry.tripId
+        val kept = byKey[key]
+        if (kept == null || entry.fixRank() > kept.fixRank()) byKey[key] = entry
+    }
+    return if (byKey.size == size) this else byKey.values.toList()
+}
+
+/**
+ * How good a live fix an entry's status is, higher = better: a raw GPS `lastKnownLocation` is the
+ * measured vehicle position and outranks a schedule-only entry; `predicted` breaks the no-fix tie.
+ * This is a "which record is the better fix" tiebreak for de-duplication — deliberately not the #1621
+ * realtime *classifier* `isLocationRealtime`, which would tie a GPS entry with a position-only one and
+ * so couldn't pick the fix. Reads the wire DTO directly, so it never materializes an `android.Location`.
+ */
+private fun TripDetailsEntry.fixRank(): Int {
+    val s = status ?: return 0
+    return (if (s.lastKnownLocation != null) 2 else 0) + (if (s.predicted) 1 else 0)
 }
 
 /** Adapts a modernized trips-for-route envelope (a list of vehicles) to [RouteTrips]. */


### PR DESCRIPTION
## Problem

Vehicle markers on the route map flicker on a near-per-frame basis when a vehicle is near the start or
end of its trip — the marker snaps back and forth between its real position and a second point ~100–500 m
away, settling after a few frames and recurring. Fixes #1667.

## Root cause (confirmed on-device)

OBA `trips-for-route` can carry the same **active trip** more than once:

- the **same trip listed twice** — a real-time entry (a raw GPS `lastKnownLocation`) and a schedule-only
  entry (interpolated `position`, no fix), at different `distanceAlongTrip`; or
- during a block **rollover**, two *distinct* trips both reporting the successor as active.

Both forms collide downstream on `activeTripId`:

- the route map keys its vehicle markers by `activeTripId` (`vehicleMarkersByTripId`), so both entries
  drove the one marker every frame → the position flip; and
- the extrapolation store keys its observations by `activeTripId` (`RouteTrips.toObservations` via
  `forEachActiveTrip`) → a conflicting double-record per trip.

A per-frame diagnostic captured the two point sources for one `activeTripId` alternating every 10–50 ms
(e.g. `trip 1_811078050`: GPS `47.60121,-122.33026` ↔ scheduled `47.60219,-122.33088`). This **refuted**
the initial hypotheses in the issue — it is not the `dt < 0` staleness gate (dt was a stable ~45 s) nor a
50 m pre-departure/trip-end threshold crossing (constant `lastDist`); the `ExtrapolationResult` never
flipped.

## Fix

Normalize at the single wire→model seam (`routeTripsOf` in `TripVehiclesDataSource`): de-duplicate the
raw `trips` entries by **`activeTripId`** (falling back to `tripId` when a status is absent), keeping the
entry with the best live fix. Keying on the collision key fixes every consumer of `RouteTrips` at once —
the renderer, the store, and trip-details — so no per-consumer guard is needed. The rank prefers a raw
GPS `lastKnownLocation` over a schedule-only entry (`predicted` breaks the tie) and reads the wire DTO
directly, so it never materializes an `android.Location`.

## Upstream

The server behavior — `trips-for-route` returning the same trip twice — is filed against the API at
OneBusAway/onebusaway-application-modules#468 so it can be fixed at the source too. This client dedup
stands regardless.

## Tests

Two fixtures (duplicate-trip in both orders; rollover) and three cases in `ExtrapolatedVehiclesTest`,
including that the rollover collapses across **both** the render vehicles and the store's observations.
All 10 pass on device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
