### PR TITLE
Anchor the "slide up" arrivals-tutorial spotlight on the drag handle

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalsPanel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalsPanel.kt
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-// This panel threads named per-element anchor modifiers (etaAnchor/starAnchor/headerAnchor) a host
-// attaches to specific sub-elements for the onboarding spotlight — several per composable, none being
-// the root `modifier` — so ModifierParameter's "name it modifier" rule doesn't apply here.
+// This panel threads named per-element anchor modifiers (etaAnchor/starAnchor) a host attaches to
+// specific sub-elements for the onboarding spotlight — several per composable, none being the root
+// `modifier` — so ModifierParameter's "name it modifier" rule doesn't apply here.
 @file:Suppress("ModifierParameter")
 
 package org.onebusaway.android.ui.arrivals.components
@@ -106,11 +106,10 @@ fun ArrivalsPanel(
     // Tapping the pinned stop-name header invokes this (null = not tappable); the drawer host wires it
     // to an animated map recenter on the focused stop.
     onTitleClick: (() -> Unit)? = null,
-    // Opaque anchor modifiers a host may attach to the first peek row's ETA pill + favorite star and the
-    // pinned header (e.g. for an onboarding spotlight). The panel stays ignorant of what they're for.
+    // Opaque anchor modifiers a host may attach to the first peek row's ETA pill + favorite star (e.g.
+    // for an onboarding spotlight). The panel stays ignorant of what they're for.
     etaAnchor: Modifier = Modifier,
     starAnchor: Modifier = Modifier,
-    headerAnchor: Modifier = Modifier,
 ) {
     // The system navigation-bar inset (height varies by handset); see the list contentPadding below.
     val navBarInset = navigationBarBottomPadding()
@@ -170,7 +169,6 @@ fun ArrivalsPanel(
                 filtering = filtering,
                 onToggleFavorite = viewModel::toggleFavorite,
                 onTitleClick = onTitleClick,
-                headerModifier = headerAnchor,
             )
             if (content == null) {
                 LinearProgressIndicator(Modifier.fillMaxWidth())
@@ -432,12 +430,11 @@ private fun ArrivalsPanelHeader(
     filtering: Boolean,
     onToggleFavorite: () -> Unit,
     onTitleClick: (() -> Unit)? = null,
-    headerModifier: Modifier = Modifier,
     starSize: Dp = 20.dp,
 ) {
     val name = if (!direction.isNullOrBlank()) "$title (${direction.trim()})" else title
     Box(
-        headerModifier
+        Modifier
             .fillMaxWidth()
             .padding(horizontal = 8.dp, vertical = 10.dp)
     ) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -388,7 +388,12 @@ fun HomeScreen(
                     // the arrivals panel body paints, so the handle reads as part of the panel rather
                     // than sitting on a separate default-colored strip.
                     sheetContainerColor = MaterialTheme.colorScheme.surface,
-                    sheetDragHandle = { ArrivalsDragHandle(onToggle = toggleSheet) },
+                    sheetDragHandle = {
+                        ArrivalsDragHandle(
+                            onToggle = toggleSheet,
+                            modifier = Modifier.tutorialAnchor(tutorialState, ArrivalTutorial.KEY_PANEL),
+                        )
+                    },
                     sheetContent = {
                         ArrivalsSheetHost(
                             focusedStop = state.focusedStop,
@@ -634,11 +639,13 @@ private val LEGACY_IN_PANEL_HANDLE_BUDGET = 20.dp
  * scaffold's built-in handle click.
  */
 @Composable
-private fun ArrivalsDragHandle(onToggle: () -> Unit) {
+private fun ArrivalsDragHandle(onToggle: () -> Unit, modifier: Modifier = Modifier) {
     // The click sits on the outer padded Box (before the padding) so the tap target covers more than the
-    // bar; it shadows the scaffold's own handle click. The bar itself is a short tinted pill.
+    // bar; it shadows the scaffold's own handle click. The bar itself is a short tinted pill. [modifier]
+    // is the host's anchor slot (the onboarding "slide up" spotlight points here) — outermost so the
+    // spotlight hugs just the handle, not the full-width header.
     Box(
-        modifier = Modifier
+        modifier = modifier
             .clickable(onClick = onToggle)
             .padding(horizontal = 24.dp, vertical = DRAG_HANDLE_VERTICAL_PADDING),
         contentAlignment = Alignment.Center,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/arrivals/ArrivalsSheetHost.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/arrivals/ArrivalsSheetHost.kt
@@ -131,9 +131,8 @@ internal fun ArrivalsSheetHost(
                     onTitleClick = onTitleClick,
                     etaAnchor = Modifier.tutorialAnchor(tutorialState, ArrivalTutorial.KEY_ETA),
                     starAnchor = Modifier.tutorialAnchor(tutorialState, ArrivalTutorial.KEY_STAR),
-                    // The onboarding "slide up to see more" spotlight now anchors on the pinned header
-                    // (the chevron it used to point at is gone).
-                    headerAnchor = Modifier.tutorialAnchor(tutorialState, ArrivalTutorial.KEY_PANEL),
+                    // The onboarding "slide up to see more" spotlight (KEY_PANEL) anchors on the sheet's
+                    // drag handle in the host scaffold, not the panel — see ArrivalsDragHandle.
                 )
             }
 


### PR DESCRIPTION
### Problem

In the arrivals onboarding tutorial, the second step — **"slide up to see more"** (`ArrivalTutorial.KEY_PANEL`) — anchored its spotlight on the **full-width pinned stop header**. The spotlight cutout radius is derived from the anchored element's diagonal (`½·diagonal · 1.5`), so a full-width header blew the cutout up to cover most of the screen instead of pointing at anything.

### Fix

Move the `KEY_PANEL` anchor onto the sheet's **drag handle** (`ArrivalsDragHandle` in `HomeScreen.kt`) — the small grab bar the step is actually telling the user to slide, and the real successor to the chevron the step used to point at before the Compose migration. Its ~80×22 dp bounds make the spotlight hug the handle tightly. The anchor is applied outermost on the handle's `Box` so its reported bounds cover just the handle.

Since `headerAnchor` existed solely to route this one spotlight, the now-dead plumbing is removed too: `ArrivalsPanel`'s `headerAnchor` param and `ArrivalsPanelHeader`'s `headerModifier`.

No behavior change beyond the spotlight geometry.

### Verification

- `:onebusaway-android:compileObaGoogleDebugSources` passes.
- Built + installed `installObaGoogleDebug` on a Pixel 7 Pro; re-armed the tutorial (Settings → "Show tutorial"), focused a stop, and confirmed the second step's spotlight now sits neatly on the drag handle rather than ballooning over the header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)