### PR TITLE
Donation effect carries the URL; host builds the intent

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/donations/DonationsManager.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/donations/DonationsManager.java
@@ -157,10 +157,24 @@ public class DonationsManager {
 
     // region UI/Activities
 
-    public Intent buildOpenDonationsPageIntent() {
+    /** Fires the "donate button pressed" analytics event (Firebase + Plausible). */
+    public void reportDonateButtonPress() {
         reportUIEvent(R.string.analytics_label_button_press_donate, null);
-        Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(mContext.getResources().getString(R.string.donate_url)));
-        return intent;
+    }
+
+    /** The donations-page URL — the single source both the intent builder and the host (Compose) read. */
+    public String donateUrl() {
+        return mContext.getResources().getString(R.string.donate_url);
+    }
+
+    /**
+     * Reports the donate-button event and builds the donations-page intent, for callers without a
+     * ViewModel (the settings / learn-more nav destinations). ViewModel-backed UI reports via
+     * {@link #reportDonateButtonPress()} and lets its host build the intent from {@link #donateUrl()}.
+     */
+    public Intent buildOpenDonationsPageIntent() {
+        reportDonateButtonPress();
+        return new Intent(Intent.ACTION_VIEW, Uri.parse(donateUrl()));
     }
 
     // endregion

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/donation/DonationCard.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/donation/DonationCard.kt
@@ -50,6 +50,7 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.repeatOnLifecycle
 import org.onebusaway.android.R
+import org.onebusaway.android.util.ExternalIntents
 
 /**
  * Self-wiring donation feature module: collects [DonationViewModel] state, builds its callbacks, runs
@@ -82,8 +83,8 @@ fun DonationFeature(
             viewModel.effects.collect { effect ->
                 when (effect) {
                     DonationEffect.OpenLearnMore -> currentOnLearnMore()
-                    DonationEffect.OpenDonatePage ->
-                        context.startActivity(viewModel.buildDonationsPageIntent())
+                    is DonationEffect.OpenDonatePage ->
+                        ExternalIntents.goToUrl(context, effect.url)
                 }
             }
         }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/donation/DonationViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/donation/DonationViewModel.kt
@@ -15,7 +15,6 @@
  */
 package org.onebusaway.android.ui.home.donation
 
-import android.content.Intent
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -37,7 +36,9 @@ data class DonationUiState(
 /** One-shot donation navigation the activity carries out (it owns startActivity + the intents). */
 sealed interface DonationEffect {
     object OpenLearnMore : DonationEffect
-    object OpenDonatePage : DonationEffect
+
+    /** Open the donations page at [url]. The host builds/starts the intent (mirrors [SurveyEffect]). */
+    data class OpenDonatePage(val url: String) : DonationEffect
 }
 
 /**
@@ -70,14 +71,12 @@ class DonationViewModel @Inject constructor(
         _effects.tryEmit(DonationEffect.OpenLearnMore)
     }
 
-    /** Donate now: stop asking (the legacy order), then open the donations page. */
+    /** Donate now: stop asking (the legacy order), report the tap, then open the donations page. */
     fun donate() {
         manager.dismissDonationRequests()
-        _effects.tryEmit(DonationEffect.OpenDonatePage)
+        manager.reportDonateButtonPress()
+        _effects.tryEmit(DonationEffect.OpenDonatePage(manager.donateUrl()))
     }
-
-    /** The donations-page intent for the [DonationEffect.OpenDonatePage] handler to start. */
-    fun buildDonationsPageIntent(): Intent = manager.buildOpenDonationsPageIntent()
 
     /** "I don't want to help" — stop asking, hide the dialog, and re-gate the card. */
     fun dismissForever() {


### PR DESCRIPTION
Closes #1664.

`DonationViewModel.buildDonationsPageIntent()` returned an `android.content.Intent`, which contradicted `DonationEffect`'s own documented contract — *"the activity carries out (it owns startActivity + the intents)"* — and diverged from the `SurveyEffect` data-carrying pattern the ViewModel explicitly says it mirrors. This tightens the VM/host boundary to that altitude.

### Changes
- **`DonationEffect.OpenDonatePage`** is now a `data class` carrying the `url`, emitted from `donate()`. **`DonationCard`** builds the `ACTION_VIEW` intent from `effect.url` and starts it — the host owns the intent, and the ViewModel carries no Android framework type. The `buildDonationsPageIntent()` passthrough and the `Intent` import are gone from the VM. Both `when` arms now route the same way (learn-more via a hoisted callback, donate via a host-built intent).
- **`DonationsManager`**: `buildOpenDonationsPageIntent()` bundled analytics + intent construction; it's split into `reportDonateButtonPress()` + `donateUrl()`. `donate()` now fires the analytics itself (decoupled from intent construction), and `donateUrl()` is the single source both the intent builder and the host read. The composed `buildOpenDonationsPageIntent()` stays for the two **ViewModel-less nav destinations** (settings / learn-more), so their behavior is unchanged.

### No behavior change
The donate-button analytics still fires on the tap (now in `donate()` instead of at intent-build time — same tap, same event), and the donations page still opens. This is exactly the analytics-timing shift #1663 flagged as out-of-scope-for-a-cleanup and deferred here.

### Deliberately left
`ExtraDestinations`' learn-more `onDonate` still expresses "dismiss then open" without a ViewModel (the issue's optional item). Routing it through `donate()` would require injecting a `DonationViewModel` into a standalone nav destination, which adds machinery rather than simplifying — so it's left as-is.

### Verification
`compileObaGoogleDebugSources` + `compileObaGoogleDebugUnitTestSources` pass; `DonationViewModelTest` (dialog/effect logic) passes. The manager-backed `donate()` path is exercised by on-device verification, per the test's existing note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the donation flow so tapping **Donate** reliably opens the donation page directly in the browser.
  - Ensured a single, consistent donation URL is used whenever the donation page is launched.
- **Refactor**
  - Updated the donation navigation to use a URL-driven action and centralized link handling, simplifying how the donate event is processed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->