### PR TITLE
Extract Open311 endpoint init into an Open311Subsystem

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/app/Application.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/app/Application.java
@@ -19,8 +19,6 @@ package org.onebusaway.android.app;
 import android.content.Context;
 import android.hardware.GeomagneticField;
 import android.location.Location;
-import android.text.TextUtils;
-import android.util.Log;
 
 import org.onebusaway.android.BuildConfig;
 import org.onebusaway.android.R;
@@ -39,8 +37,6 @@ import org.onebusaway.android.util.ThemeUtils;
 import java.security.MessageDigest;
 import java.util.UUID;
 
-import edu.usf.cutr.open311client.Open311Manager;
-import edu.usf.cutr.open311client.models.Open311Option;
 
 import static com.google.android.gms.location.LocationServices.getFusedLocationProviderClient;
 import java.nio.charset.StandardCharsets;
@@ -53,9 +49,6 @@ import org.onebusaway.android.app.di.PreferencesEntryPoint;
 
 @HiltAndroidApp
 public class Application extends android.app.Application {
-
-    // Region preference (long id)
-    private static final String TAG = "Application";
 
     private static Application mApp;
 
@@ -212,18 +205,6 @@ public class Application extends android.app.Application {
     }
 
     /**
-     * Re-initializes the region-*derived* Open311 reporting endpoints for [region]. Driven reactively by
-     * {@link org.onebusaway.android.region.RegionSubsystems}, which observes the region flow (A7), rather
-     * than poked imperatively by a region write transaction. The Plausible/Umami analytics emitters are
-     * likewise region-derived, but they are owned + rebuilt by
-     * {@link org.onebusaway.android.analytics.AnalyticsProvider} (which observes the same flow).
-     */
-    public void onRegionChanged(Region region) {
-        initOpen311(region);
-    }
-
-
-    /**
      * Returns the custom URL if the user has set a custom API URL manually via Preferences, or
      * null
      * if it has not been set
@@ -255,30 +236,6 @@ public class Application extends android.app.Application {
                     .append(HEXES.charAt((b & 0x0F)));
         }
         return hex.toString();
-    }
-
-    private void initOpen311(Region region) {
-        if (BuildConfig.DEBUG) {
-            Open311Manager.getSettings().setDebugMode(true);
-            Open311Manager.getSettings().setDryRun(true);
-            Log.w(TAG,
-                    "Open311 issue reporting is in debug/dry run mode - no issues will be submitted.");
-        }
-
-        // Clear all open311 endpoints
-        Open311Manager.clearOpen311();
-
-        // Read the open311 preferences from the region and set
-        if (region != null && region.getOpen311Servers() != null) {
-            for (Region.Open311Server open311Server : region.getOpen311Servers()) {
-                String jurisdictionId = open311Server.getJuridisctionId();
-
-                Open311Option option = new Open311Option(open311Server.getBaseUrl(),
-                        open311Server.getApiKey(),
-                        TextUtils.isEmpty(jurisdictionId) ? null : jurisdictionId);
-                Open311Manager.initOpen311WithOption(option);
-            }
-        }
     }
 
     private void reportAnalytics() {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/region/Open311Subsystem.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/region/Open311Subsystem.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.region
+
+import android.util.Log
+import edu.usf.cutr.open311client.Open311Manager
+import edu.usf.cutr.open311client.models.Open311Option
+import org.onebusaway.android.BuildConfig
+
+/**
+ * The region-derived Open311 reporting endpoints: reconfigures the (process-global) [Open311Manager]
+ * whenever the active region changes. Driven by [RegionSubsystems] (which observes the region flow);
+ * this holds the endpoint-init body that used to live on `Application`. Stateless glue over the
+ * `Open311Manager` singleton.
+ */
+object Open311Subsystem {
+
+    private const val TAG = "Open311Subsystem"
+
+    /** Rebuilds the Open311 endpoints for [region]: clears the current set, then re-registers each of the
+     * region's configured servers. A [region] with no servers (or null) just clears them. */
+    fun applyRegion(region: Region?) {
+        if (BuildConfig.DEBUG) {
+            Open311Manager.getSettings().setDebugMode(true)
+            Open311Manager.getSettings().setDryRun(true)
+            Log.w(TAG, "Open311 issue reporting is in debug/dry run mode - no issues will be submitted.")
+        }
+
+        Open311Manager.clearOpen311()
+
+        region?.open311Servers?.forEach { server ->
+            val option = Open311Option(
+                server.baseUrl,
+                server.apiKey,
+                server.jurisdictionId?.takeIf { it.isNotEmpty() },
+            )
+            Open311Manager.initOpen311WithOption(option)
+        }
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/region/RegionSubsystems.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/region/RegionSubsystems.kt
@@ -43,7 +43,7 @@ object RegionSubsystems {
     fun observe(app: Application) {
         scope.launch {
             RegionEntryPoint.get(app).region.collect { region ->
-                app.onRegionChanged(region)
+                Open311Subsystem.applyRegion(region)
             }
         }
     }


### PR DESCRIPTION
Slice 7 of #1659 (Application.java decomposition).

The region-derived Open311 endpoint setup lived on `Application` as `initOpen311(Region)` plus an `onRegionChanged(Region)` shim that `RegionSubsystems` poked. This moves the init body off the god-object.

### Changes
- New **`region/Open311Subsystem`** — a stateless Kotlin `object` holding the endpoint-init body (debug/dry-run flags + `clearOpen311()` + re-register each of the region's servers) over the process-global `Open311Manager`.
- **`RegionSubsystems`** now drives it directly: its region-flow collector calls `Open311Subsystem.applyRegion(region)` instead of routing through `app.onRegionChanged(region)`.
- **`Application`** loses `onRegionChanged()`, `initOpen311()`, the `Open311Manager` / `Open311Option` / `TextUtils` / `Log` imports, and the now-unused `TAG` constant — it no longer references the Open311 client library at all.

### No behavior change
The same collector fires the same init on the same region emissions (RegionSubsystems is the sole caller of the old `onRegionChanged`). The jurisdiction `empty → null` rule is preserved (`jurisdictionId?.takeIf { it.isNotEmpty() }` ≡ the old `TextUtils.isEmpty(...) ? null : ...`). A null region (or one with no servers) just clears the endpoints, as before.

### Placement note
`Open311Subsystem` lives in the `region` package next to its driver `RegionSubsystems`, which already owns the region→subsystem wiring — this avoids a new `region → ui.report` back-dependency (the neutral `region` package shouldn't depend on the report UI).

### Verification
`compileObaGoogleDebugSources` + `compileObaGoogleDebugUnitTestSources` pass. No test referenced the removed `onRegionChanged`. The init touches only the global `Open311Manager` singleton (side-effecting), so — like the untested private method it replaces — it's not unit-tested; a mechanical move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Open311 settings now update reliably when switching regions.
  * Existing Open311 configuration is cleared before applying the selected region’s settings to prevent stale or incorrect endpoint behavior.
* **Refactor**
  * Region-based Open311 handling has been moved into a dedicated subsystem for more consistent region-change processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->