### PR TITLE
Drop Application's custom-API-URL pref wrappers

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/api/test/ObaTestCase.java
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/api/test/ObaTestCase.java
@@ -20,6 +20,7 @@ import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.onebusaway.android.R;
 import org.onebusaway.android.app.Application;
+import org.onebusaway.android.app.di.PreferencesEntryPoint;
 import org.onebusaway.android.region.Region;
 
 import androidx.test.runner.AndroidJUnit4;
@@ -45,14 +46,18 @@ public abstract class ObaTestCase {
 
         // Save the current region / custom API URL so the override below can be undone in after().
         mOldRegion = Application.get().getCurrentRegion();
-        mOldCustomApiUrl = mOldRegion == null ? Application.get().getCustomApiUrl() : null;
+        mOldCustomApiUrl = mOldRegion == null
+                ? PreferencesEntryPoint.get(getTargetContext())
+                        .getString(R.string.preference_key_oba_api_url, null)
+                : null;
 
         /*
          * Assume Puget Sound API, mainly for backwards compatibility with older tests
          * that were written before multi-region functionality. This is overwritten in some
          * subclasses so multiple regions / APIs can be tested.
          */
-        Application.get().setCustomApiUrl("api.pugetsound.onebusaway.org");
+        PreferencesEntryPoint.get(getTargetContext())
+                .setString(R.string.preference_key_oba_api_url, "api.pugetsound.onebusaway.org");
     }
 
     @After
@@ -60,9 +65,11 @@ public abstract class ObaTestCase {
         if (mOldRegion != null) {
             Application.get().setCurrentRegion(mOldRegion);
         } else if (mOldCustomApiUrl != null) {
-            Application.get().setCustomApiUrl(mOldCustomApiUrl);
+            PreferencesEntryPoint.get(getTargetContext())
+                    .setString(R.string.preference_key_oba_api_url, mOldCustomApiUrl);
         } else {
-            Application.get().setCustomApiUrl(null);
+            PreferencesEntryPoint.get(getTargetContext())
+                    .setString(R.string.preference_key_oba_api_url, null);
             Application.get().setCurrentRegion(null);
         }
     }

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/util/test/UIUtilTest.java
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/util/test/UIUtilTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.onebusaway.android.R;
 import org.onebusaway.android.app.Application;
+import org.onebusaway.android.app.di.PreferencesEntryPoint;
 import org.onebusaway.android.api.contract.ArrivalsForStop;
 import org.onebusaway.android.api.contract.EntryWithReferences;
 import org.onebusaway.android.api.contract.ObaEnvelope;
@@ -543,7 +544,8 @@ public class UIUtilTest extends ObaTestCase {
      */
     @Test
     public void testGetAllSituations() throws Exception {
-        Application.get().setCustomApiUrl("sdmts.onebusway.org/api");
+        PreferencesEntryPoint.get(getTargetContext())
+                .setString(R.string.preference_key_oba_api_url, "sdmts.onebusway.org/api");
 
         /**
          * Test route-specific alerts only

--- a/onebusaway-android/src/main/java/org/onebusaway/android/app/Application.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/app/Application.java
@@ -203,38 +203,17 @@ public class Application extends android.app.Application {
         RegionEntryPoint.get(this).applyRegion(region, regionChanged);
     }
 
-    /**
-     * Returns the custom URL if the user has set a custom API URL manually via Preferences, or
-     * null
-     * if it has not been set
-     *
-     * @return the custom URL if the user has set a custom API URL manually via Preferences, or null
-     * if it has not been set
-     */
-    public String getCustomApiUrl() {
-        return PreferenceUtils.getString(getString(R.string.preference_key_oba_api_url));
-    }
-
-    /**
-     * Sets the custom URL used to reach a OBA REST API server that is not available via the
-     * Regions
-     * REST API
-     *
-     * @param url the custom URL
-     */
-    public void setCustomApiUrl(String url) {
-        PreferenceUtils.saveString(getString(R.string.preference_key_oba_api_url), url);
-    }
-
     private void reportAnalytics() {
         // The Plausible/Umami emitters are owned + built reactively by AnalyticsProvider; here we only set
         // the initial Firebase/Umami region label via setRegion (which resolves the Umami emitter through
         // the provider itself).
-        if (getCustomApiUrl() == null && getCurrentRegion() != null) {
+        String customApiUrl = PreferencesEntryPoint.get(this)
+                .getString(R.string.preference_key_oba_api_url, null);
+        if (customApiUrl == null && getCurrentRegion() != null) {
             AnalyticsEntryPoint.get(this).setRegion(getCurrentRegion().getName());
-        } else if (getCustomApiUrl() != null) {
+        } else if (customApiUrl != null) {
             AnalyticsEntryPoint.get(this)
-                    .setRegion(CustomApiUrlLabel.forUrl(this, getCustomApiUrl()));
+                    .setRegion(CustomApiUrlLabel.forUrl(this, customApiUrl));
         }
     }
 


### PR DESCRIPTION
Slice 9 of #1659 (Application.java decomposition).

`Application.getCustomApiUrl()` / `setCustomApiUrl(url)` were thin wrappers over the `preference_key_oba_api_url` pref — which `PreferencesRepository` already owns (`ObaEndpointResolver` reads it, `AdvancedSettingsViewModel` / `RegionRepository` write it). This retires the wrappers and routes the remaining callers to the pref directly.

### Changes
- **`reportAnalytics`** reads the custom URL once via `PreferencesEntryPoint` into a local (replacing three `getCustomApiUrl()` calls).
- The instrumented tests (`ObaTestCase`, `UIUtilTest`) that set/read the custom API URL now go through `PreferencesEntryPoint.get(context).getString/setString(R.string.preference_key_oba_api_url, ...)`.
- `Application` drops both methods (and their javadoc). `getCurrentRegion`/`setCurrentRegion` stay — they're the region getter/setter, tracked separately.

### No behavior change
`PreferenceUtils` already delegated to `PreferencesRepository`, so every read/write hits the same DataStore before and after — only the redundant `Application` façade is gone.

### Verification
`compileObaGoogleDebugSources` + `compileObaGoogleDebugUnitTestSources` + `compileObaGoogleDebugAndroidTestSources` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how the app remembers and restores the selected API endpoint, reducing unexpected changes when switching regions or returning to the app.
* **Refactor**
  * Simplified API URL handling across the app and test flows to use a more consistent settings-based approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->