### PR TITLE
Trip planner: map-overlay layout (top-sheet form + bottom-sheet directions)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanFormSheet.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanFormSheet.kt
@@ -1,0 +1,337 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.tripplan
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.MutableTransitionState
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.slideInVertically
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.AnchoredDraggableState
+import androidx.compose.foundation.gestures.DraggableAnchors
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.anchoredDraggable
+import androidx.compose.foundation.gestures.animateTo
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowForward
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.layout
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import kotlin.math.min
+import kotlin.math.roundToInt
+import kotlinx.coroutines.launch
+import org.onebusaway.android.R
+
+/** The two rest positions of the form sheet: the full form (maximized) or the From/To summary bar. */
+enum class FormAnchor { Collapsed, Expanded }
+
+/**
+ * The trip-plan form as a **top sheet** over the directions map: a top-anchored surface that slides down
+ * from the top on first appearance (mirroring `MoreStopsBanner`'s slide-in in
+ * [org.onebusaway.android.ui.home.map.MapFeature]).
+ *
+ * It drags like the directions sheet — the sheet's **height** is driven by [dragState] (its `offset` is
+ * the visible body height), so dragging the bottom handle grows/shrinks it continuously and snaps between
+ * two anchors: **expanded** (the full [TripPlanForm]) and **collapsed** (a compact `From → To` bar). The
+ * two layouts **cross-fade** with the drag: the full form fades out and the bar fades in as it shrinks,
+ * so the collapsed state reads as a distinct minimized summary rather than a clipped form. Both are
+ * measured (via [onSizeChanged]) so the anchors land exactly on each layout's height.
+ *
+ * All form/date/contacts callbacks pass straight through to [TripPlanForm]; [onBack] and
+ * [onReportProblem] are the former [org.onebusaway.android.ui.tripplan] toolbar actions, now hosted here.
+ */
+@Composable
+fun TripPlanFormSheet(
+    dragState: AnchoredDraggableState<FormAnchor>,
+    state: TripPlanFormState,
+    onFromQueryChange: (String) -> Unit,
+    onToQueryChange: (String) -> Unit,
+    onSelectFrom: (TripEndpoint.Geocoded) -> Unit,
+    onSelectTo: (TripEndpoint.Geocoded) -> Unit,
+    onClearFrom: () -> Unit,
+    onClearTo: () -> Unit,
+    onFromCurrentLocation: () -> Unit,
+    onToCurrentLocation: () -> Unit,
+    onFromContacts: () -> Unit,
+    onToContacts: () -> Unit,
+    onFromPickOnMap: () -> Unit,
+    onToPickOnMap: () -> Unit,
+    onSetArriving: (Boolean) -> Unit,
+    onPickDate: () -> Unit,
+    onPickTime: () -> Unit,
+    onReverse: () -> Unit,
+    onAdvancedSettings: () -> Unit,
+    onBack: () -> Unit,
+    onReportProblem: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    // Play the slide-in once, on first composition of the destination.
+    val visibleState = remember { MutableTransitionState(false).apply { targetState = true } }
+    val density = LocalDensity.current
+    // Cap the expanded form so it can't cover the whole map; the natural height is used when smaller.
+    val maxFormPx = with(density) { (LocalConfiguration.current.screenHeightDp * 0.6f).dp.toPx() }
+    // The two layouts' natural heights, reported by the content below; the anchors sit on these.
+    var formPx by remember { mutableStateOf(0f) }
+    var barPx by remember { mutableStateOf(0f) }
+    val scope = rememberCoroutineScope()
+
+    val expandedPx = min(formPx, maxFormPx)
+
+    // Place the anchors once both layouts are measured: collapsed = the bar's height, expanded = the form
+    // (capped). The offset between them is used directly as the sheet's body height and cross-fade point.
+    LaunchedEffect(barPx, expandedPx) {
+        if (barPx > 0f && expandedPx > barPx) {
+            dragState.updateAnchors(
+                DraggableAnchors {
+                    FormAnchor.Collapsed at barPx
+                    FormAnchor.Expanded at expandedPx
+                }
+            )
+        }
+    }
+
+    // 0 at the collapsed (bar) anchor, 1 at the expanded (form) anchor — read at draw time so the
+    // cross-fade follows the drag without recomposing. Defaults to fully expanded until anchored.
+    val formAlpha = {
+        val o = dragState.offset
+        val range = expandedPx - barPx
+        if (o.isNaN() || range <= 0f) 1f else ((o - barPx) / range).coerceIn(0f, 1f)
+    }
+
+    val toggle: () -> Unit = {
+        scope.launch {
+            runCatching {
+                dragState.animateTo(
+                    if (dragState.targetValue == FormAnchor.Expanded) FormAnchor.Collapsed else FormAnchor.Expanded
+                )
+            }
+        }
+    }
+    // While collapsed, the bar (on top) is tappable to expand; while expanded it's non-interactive so
+    // taps fall through to the real form fields beneath it.
+    val collapsed = dragState.targetValue == FormAnchor.Collapsed
+
+    AnimatedVisibility(
+        visibleState = visibleState,
+        enter = slideInVertically(initialOffsetY = { -it }) + fadeIn(),
+        modifier = modifier,
+    ) {
+        Surface(
+            modifier = Modifier.fillMaxWidth(),
+            color = MaterialTheme.colorScheme.surface,
+            // Rounded bottom corners so it reads as a sheet hanging from the top edge; the top edge
+            // tucks flush under the status bar (the content Column carries the inset).
+            shape = RoundedCornerShape(bottomStart = 16.dp, bottomEnd = 16.dp),
+            shadowElevation = 6.dp,
+        ) {
+            Column(Modifier.statusBarsPadding()) {
+                SheetHeader(onBack = onBack, onReportProblem = onReportProblem)
+                // The body, clipped to the drag-controlled height. The full form and the compact bar are
+                // stacked and cross-faded by [formAlpha]; the layout node reports `offset` as its height so
+                // the sheet grows/shrinks with the drag.
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clipToBounds()
+                        .layout { measurable, constraints ->
+                            val placeable = measurable.measure(constraints)
+                            val visible = dragState.offset
+                                .let { if (it.isNaN()) placeable.height.toFloat() else it }
+                                .roundToInt()
+                                .coerceIn(0, placeable.height)
+                            layout(placeable.width, visible) { placeable.place(0, 0) }
+                        }
+                ) {
+                    // Full form (fades in as the sheet grows).
+                    Box(
+                        Modifier
+                            .graphicsLayer { alpha = formAlpha() }
+                            .onSizeChanged { formPx = it.height.toFloat() }
+                    ) {
+                        TripPlanForm(
+                            state = state,
+                            onFromQueryChange = onFromQueryChange,
+                            onToQueryChange = onToQueryChange,
+                            onSelectFrom = onSelectFrom,
+                            onSelectTo = onSelectTo,
+                            onClearFrom = onClearFrom,
+                            onClearTo = onClearTo,
+                            onFromCurrentLocation = onFromCurrentLocation,
+                            onToCurrentLocation = onToCurrentLocation,
+                            onFromContacts = onFromContacts,
+                            onToContacts = onToContacts,
+                            onFromPickOnMap = onFromPickOnMap,
+                            onToPickOnMap = onToPickOnMap,
+                            onSetArriving = onSetArriving,
+                            onPickDate = onPickDate,
+                            onPickTime = onPickTime,
+                            onReverse = onReverse,
+                            onAdvancedSettings = onAdvancedSettings,
+                        )
+                    }
+                    // Compact From → To bar (fades in as the sheet shrinks), on top and tappable-to-expand
+                    // only while collapsed so it doesn't shadow the form fields when open.
+                    Box(
+                        Modifier
+                            .graphicsLayer { alpha = 1f - formAlpha() }
+                            .onSizeChanged { barPx = it.height.toFloat() }
+                            .then(if (collapsed) Modifier.clickable(onClick = toggle) else Modifier)
+                    ) {
+                        CompactRouteBar(from = state.from, to = state.to)
+                    }
+                }
+                // The pull tab at the sheet's bottom edge: drag to resize, tap to toggle.
+                FormDragHandle(dragState = dragState, onToggle = toggle)
+            }
+        }
+    }
+}
+
+/** The form sheet's header: a back arrow and the "report trip problem" overflow menu. */
+@Composable
+private fun SheetHeader(onBack: () -> Unit, onReportProblem: () -> Unit) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        IconButton(onClick = onBack) {
+            Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.navigate_up))
+        }
+        Text(
+            text = stringResource(R.string.trip_plan_title),
+            style = MaterialTheme.typography.titleMedium,
+            modifier = Modifier.weight(1f).padding(start = 4.dp),
+        )
+        ReportProblemMenu(onReportProblem)
+    }
+}
+
+/** The compact `From → To` summary shown when the sheet is minimized. */
+@Composable
+private fun CompactRouteBar(from: TripEndpoint, to: TripEndpoint) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalArrangement = Arrangement.spacedBy(2.dp),
+    ) {
+        EndpointSummary(endpoint = from)
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.ArrowForward,
+                contentDescription = null,
+                modifier = Modifier.padding(end = 6.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            EndpointSummary(endpoint = to)
+        }
+    }
+}
+
+/** A one-line label for an endpoint, resolving the fixed-label kinds to their string resources. */
+@Composable
+private fun EndpointSummary(endpoint: TripEndpoint) {
+    val label = endpoint.displayText ?: when (endpoint) {
+        is TripEndpoint.MapPoint -> stringResource(R.string.trip_plan_map_location)
+        else -> stringResource(R.string.tripplanner_current_location)
+    }
+    Text(
+        text = label,
+        style = MaterialTheme.typography.bodyLarge,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
+    )
+}
+
+/**
+ * The form sheet's bottom grab handle — its minimize/maximize affordance, symmetric to the directions
+ * sheet's top handle. It carries the sheet's vertical drag ([dragState], driving the sheet height), and
+ * a tap toggles the two modes via [onToggle]. Sits at the sheet's bottom edge as its pull tab.
+ */
+@Composable
+private fun FormDragHandle(
+    dragState: AnchoredDraggableState<FormAnchor>,
+    onToggle: () -> Unit,
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .anchoredDraggable(dragState, Orientation.Vertical)
+            .clickable(onClick = onToggle)
+            .padding(vertical = 10.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Surface(
+            color = colorResource(R.color.navdrawer_icon_tint),
+            shape = RoundedCornerShape(percent = 50),
+        ) {
+            Box(Modifier.size(width = 32.dp, height = 4.dp))
+        }
+    }
+}
+
+/** The "report trip problem" overflow menu (ported from the old toolbar). */
+@Composable
+private fun ReportProblemMenu(onReportProblem: () -> Unit) {
+    var menuExpanded by remember { mutableStateOf(false) }
+    IconButton(onClick = { menuExpanded = true }) {
+        Icon(Icons.Filled.MoreVert, contentDescription = null)
+    }
+    DropdownMenu(expanded = menuExpanded, onDismissRequest = { menuExpanded = false }) {
+        DropdownMenuItem(
+            text = { Text(stringResource(R.string.tripplanner_report_trip_problem)) },
+            onClick = {
+                menuExpanded = false
+                onReportProblem()
+            },
+        )
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanScreen.kt
@@ -25,31 +25,34 @@ import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult
 import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.AnchoredDraggableState
+import androidx.compose.foundation.gestures.DraggableAnchors
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.anchoredDraggable
+import androidx.compose.foundation.gestures.animateTo
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.BottomSheetScaffold
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.SheetValue
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.rememberBottomSheetScaffoldState
-import androidx.compose.material3.rememberStandardBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -60,10 +63,16 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
+import kotlin.math.roundToInt
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
@@ -83,8 +92,8 @@ import org.onebusaway.android.directions.util.OTPConstants
 import org.onebusaway.android.directions.util.TripRequestBuilder
 import org.onebusaway.android.analytics.PlausibleAnalytics
 import org.onebusaway.android.region.RegionRepository
-import org.onebusaway.android.ui.compose.components.ObaTopAppBar
 import org.onebusaway.android.ui.compose.components.SwitchRow
+import org.onebusaway.android.ui.compose.navigationBarBottomPadding
 import org.onebusaway.android.ui.compose.findActivity
 import org.onebusaway.android.ui.nav.NavRoutes
 import org.onebusaway.android.map.DirectionsMapViewModel
@@ -214,15 +223,15 @@ fun TripPlanDestination(navController: NavHostController, onBack: () -> Unit) {
 }
 
 /**
- * The trip-plan container: before a plan completes the [TripPlanForm] is the scaffold body; once results
- * arrive, the directions map ([TripResultsMap]) takes over the scaffold *body* and the results header +
- * directions list appear in a Material3 bottom sheet over it ([TripResultsSheet]). Dragging the sheet
- * down reveals the map — so the interactive map owns its own gesture area instead of being trapped in the
- * draggable sheet (#1640). Back walks the sheet from expanded → peek → dismissed (form) before exiting.
- * Date/time/contacts/current-location/advanced/report are platform interactions delegated to the host
- * Activity.
+ * The trip-plan container: the directions map ([TripResultsMap]) is the constant scaffold *body*, with
+ * the form hovering over it as a top sheet ([TripPlanFormSheet], slides down from the top) and — once a
+ * plan completes — the results header + directions list in a Material3 bottom sheet over it
+ * ([TripResultsSheet]). Both sheets keep their gestures off the map, which owns its whole area and pans
+ * with vertical drags (#1640). When results arrive the top form collapses to a compact `From → To` bar
+ * (tap to re-edit); the bottom sheet expands. Back walks: directions-expanded → peek → form-collapsed →
+ * results-cleared → exit. Date/time/contacts/current-location/advanced/report are platform interactions
+ * delegated to the host Activity.
  */
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TripPlanRoute(
     viewModel: TripPlanViewModel,
@@ -241,121 +250,215 @@ fun TripPlanRoute(
     val formState by viewModel.formState.collectAsStateWithLifecycle()
     val planState by viewModel.planState.collectAsStateWithLifecycle()
 
-    // The results VMs are hoisted here (not created inside the sheet content) so the map can render as
-    // the scaffold *body* — behind the sheet — while the results header + directions list stay in the
-    // sheet. The map is revealed by dragging the sheet down, so an interactive map never sits inside the
-    // draggable bottom sheet, which would otherwise steal its vertical drags (#1640). Both are scoped to
-    // this destination's back-stack entry, so hoisting doesn't change their identity or lifetime.
+    // The results VMs are hoisted here (not created inside the sheet content) so the map renders as the
+    // constant backdrop behind both sheets, while the results header + directions list live in the bottom
+    // sheet. Both are scoped to this destination's back-stack entry, so hoisting doesn't change their
+    // identity/lifetime.
     val resultsViewModel: TripResultsViewModel = hiltViewModel()
     val mapViewModel: DirectionsMapViewModel = hiltViewModel(key = "tripResultsMap")
 
-    val scaffoldState = rememberBottomSheetScaffoldState(
-        bottomSheetState = rememberStandardBottomSheetState(
-            initialValue = SheetValue.Hidden,
-            skipHiddenState = false
-        )
-    )
     val hasResults = planState is PlanResult.Success
     val scope = rememberCoroutineScope()
-    val sheetExpanded = scaffoldState.bottomSheetState.currentValue == SheetValue.Expanded
+    val density = LocalDensity.current
 
-    // Back (system or toolbar) walks the results back to the form before exiting: an expanded sheet
-    // collapses to its peek (revealing the map behind it), the peek dismisses the results (returning the
-    // form as the scaffold body), and only then does back exit the screen. Since the map — not the form —
-    // now sits behind the sheet, this peek step is how the user gets back to the form to re-plan.
+    // The directions sheet is a fixed half-screen tall; its two positions (fully open vs. handle-only)
+    // are driven by an AnchoredDraggable state whose drag gesture is attached to the *handle only* (see
+    // [DirectionsSheet]) — so the handle opens/closes the sheet while the directions list inside scrolls
+    // freely, never hijacked by the sheet drag.
+    // The sheet's usable content is 40% of the screen; the sheet then extends *past* that down to the
+    // very bottom edge by the system nav-bar inset, so there's no gap below it. That inset is reserved as
+    // bottom padding inside the sheet (see [DirectionsSheet]) — the top edge is raised to make room while
+    // the bottom stays flush, keeping the content (and collapsed handle) above the gesture/nav chrome.
+    val navInset = navigationBarBottomPadding()
+    val contentHeight = (LocalConfiguration.current.screenHeightDp * 0.4f).dp
+    val sheetHeight = contentHeight + navInset
+    // Collapsed slides the sheet down until just the handle remains above the nav chrome.
+    val collapsedOffsetPx = with(density) { (contentHeight - DIRECTIONS_HANDLE_PEEK).toPx() }
+    val dragState = remember { AnchoredDraggableState(initialValue = DirectionsAnchor.Expanded) }
+    val anchors = remember(collapsedOffsetPx) {
+        DraggableAnchors {
+            DirectionsAnchor.Expanded at 0f
+            DirectionsAnchor.Collapsed at collapsedOffsetPx
+        }
+    }
+    LaunchedEffect(anchors) { dragState.updateAnchors(anchors) }
+    val directionsExpanded = dragState.targetValue == DirectionsAnchor.Expanded
+
+    val toggleDirections: () -> Unit = {
+        scope.launch {
+            runCatching {
+                dragState.animateTo(
+                    if (directionsExpanded) DirectionsAnchor.Collapsed else DirectionsAnchor.Expanded
+                )
+            }
+        }
+    }
+
+    // The top form sheet drags like the directions sheet (finger-following height): expanded = full form,
+    // collapsed = the From/To summary. Its anchors are set inside the sheet once the form is measured.
+    val formDragState = remember { AnchoredDraggableState(initialValue = FormAnchor.Expanded) }
+    val formExpanded = formDragState.targetValue == FormAnchor.Expanded
+
+    // Back walks the flow back to front: an open directions sheet collapses to its handle, then an
+    // expanded form collapses to its From/To summary, then the results are dropped (returning to the
+    // form), and only then does back exit the screen.
     val collapseOrBack: () -> Unit = {
         when {
-            sheetExpanded -> scope.launch { scaffoldState.bottomSheetState.partialExpand() }
+            hasResults && directionsExpanded -> toggleDirections()
+            hasResults && formExpanded ->
+                scope.launch { runCatching { formDragState.animateTo(FormAnchor.Collapsed) } }
             hasResults -> viewModel.clearPlanResult()
             else -> onBack()
         }
     }
     BackHandler(enabled = hasResults) { collapseOrBack() }
 
-    // Expand the sheet when results arrive; hide it when the form is reset to Idle.
+    // React to plan state: fresh results collapse the form to its summary and open the directions sheet;
+    // resetting to Idle re-expands the form (the directions sheet unmounts with the results).
     LaunchedEffect(planState) {
         when (planState) {
-            is PlanResult.Success -> scaffoldState.bottomSheetState.expand()
-            PlanResult.Idle -> scaffoldState.bottomSheetState.hide()
+            is PlanResult.Success -> {
+                runCatching { formDragState.animateTo(FormAnchor.Collapsed) }
+                runCatching { dragState.animateTo(DirectionsAnchor.Expanded) }
+            }
+            PlanResult.Idle -> runCatching { formDragState.animateTo(FormAnchor.Expanded) }
             else -> {}
         }
     }
 
-    // The toolbar lives above the sheet (not in the scaffold's topBar slot) so the results sheet
-    // only ever fills the area *below* the toolbar — the toolbar stays visible even when the sheet
-    // is fully expanded, matching the legacy panel.
-    Column(Modifier.fillMaxSize()) {
-        TripPlanTopBar(onBack = collapseOrBack, onReportProblem = onReportProblem)
-        BottomSheetScaffold(
-            modifier = Modifier.weight(1f),
-            scaffoldState = scaffoldState,
-            sheetPeekHeight = if (hasResults) 220.dp else 0.dp,
-            sheetContent = {
-                val result = planState
-                if (result is PlanResult.Success) {
-                    TripResultsSheet(
-                        itineraries = result.itineraries,
-                        resultsViewModel = resultsViewModel,
-                        mapViewModel = mapViewModel,
-                        modifier = Modifier.fillMaxSize()
-                    )
-                }
-            }
-        ) { padding ->
-            // With results, the directions map fills the scaffold body, behind the peeking sheet, so it
-            // owns its whole gesture area and vertical drags pan the map — dragging the sheet down reveals
-            // it (#1640). Before a plan completes, the body is the trip-plan form.
-            if (hasResults) {
-                TripResultsMap(
+    Box(Modifier.fillMaxSize()) {
+        // The directions map is the constant backdrop both sheets hover over. It owns its whole gesture
+        // area (#1640); before a plan completes it shows the base map centered on the user's location,
+        // and draws the selected itinerary once results arrive.
+        TripResultsMap(
+            mapViewModel = mapViewModel,
+            modifier = Modifier.fillMaxSize()
+        )
+        if (planState is PlanResult.Loading) {
+            LinearProgressIndicator(
+                Modifier
+                    .align(Alignment.TopCenter)
+                    .fillMaxWidth()
+            )
+        }
+        // The bottom directions sheet — half-screen when open, handle-only when closed. Mounts with the
+        // results; the handle drags/toggles it while the list inside scrolls.
+        val result = planState
+        if (result is PlanResult.Success) {
+            DirectionsSheet(
+                dragState = dragState,
+                sheetHeight = sheetHeight,
+                onToggle = toggleDirections,
+                modifier = Modifier.align(Alignment.BottomCenter),
+            ) {
+                TripResultsSheet(
+                    itineraries = result.itineraries,
+                    resultsViewModel = resultsViewModel,
                     mapViewModel = mapViewModel,
+                    // The sheet's surface reaches the bottom edge; keep the last directions row scrollable
+                    // clear of the nav chrome via list content padding instead of an empty inset strip.
+                    listBottomInset = navInset,
                     modifier = Modifier.fillMaxSize()
                 )
-            } else {
-                Column(Modifier.padding(padding)) {
-                    if (planState is PlanResult.Loading) {
-                        LinearProgressIndicator(Modifier.fillMaxWidth())
-                    }
-                    TripPlanForm(
-                        state = formState,
-                        onFromQueryChange = viewModel::onFromQueryChange,
-                        onToQueryChange = viewModel::onToQueryChange,
-                        onSelectFrom = viewModel::setFrom,
-                        onSelectTo = viewModel::setTo,
-                        onClearFrom = viewModel::clearFrom,
-                        onClearTo = viewModel::clearTo,
-                        onFromCurrentLocation = onFromCurrentLocation,
-                        onToCurrentLocation = onToCurrentLocation,
-                        onFromContacts = onFromContacts,
-                        onToContacts = onToContacts,
-                        onFromPickOnMap = onFromPickOnMap,
-                        onToPickOnMap = onToPickOnMap,
-                        onSetArriving = viewModel::setArriving,
-                        onPickDate = onPickDate,
-                        onPickTime = onPickTime,
-                        onReverse = viewModel::reverseTrip,
-                        onAdvancedSettings = onAdvancedSettings
-                    )
-                }
             }
+        }
+        // The top form sheet, slid down from the top edge over the map.
+        TripPlanFormSheet(
+            dragState = formDragState,
+            state = formState,
+            onFromQueryChange = viewModel::onFromQueryChange,
+            onToQueryChange = viewModel::onToQueryChange,
+            onSelectFrom = viewModel::setFrom,
+            onSelectTo = viewModel::setTo,
+            onClearFrom = viewModel::clearFrom,
+            onClearTo = viewModel::clearTo,
+            onFromCurrentLocation = onFromCurrentLocation,
+            onToCurrentLocation = onToCurrentLocation,
+            onFromContacts = onFromContacts,
+            onToContacts = onToContacts,
+            onFromPickOnMap = onFromPickOnMap,
+            onToPickOnMap = onToPickOnMap,
+            onSetArriving = viewModel::setArriving,
+            onPickDate = onPickDate,
+            onPickTime = onPickTime,
+            onReverse = viewModel::reverseTrip,
+            onAdvancedSettings = onAdvancedSettings,
+            onBack = collapseOrBack,
+            onReportProblem = onReportProblem,
+            modifier = Modifier.align(Alignment.TopCenter)
+        )
+    }
+}
+
+// The directions sheet's drag handle geometry. The peek height equals the whole handle strip so that,
+// collapsed, exactly the handle shows; the bar + vertical padding also drive what the strip draws.
+private val DIRECTIONS_HANDLE_BAR_HEIGHT = 4.dp
+private val DIRECTIONS_HANDLE_VERTICAL_PADDING = 14.dp
+private val DIRECTIONS_HANDLE_PEEK = DIRECTIONS_HANDLE_BAR_HEIGHT + DIRECTIONS_HANDLE_VERTICAL_PADDING * 2
+
+/** The two rest positions of the directions sheet: fully open (half-screen) or handle-only. */
+private enum class DirectionsAnchor { Collapsed, Expanded }
+
+/**
+ * The bottom directions sheet: a fixed [sheetHeight] tall, pinned to the bottom edge and translated by
+ * [dragState] between fully open (offset 0) and handle-only (slid down). The drag gesture lives on the
+ * handle **only**, so the directions list ([content]) inside scrolls freely — a body drag never moves
+ * the sheet. Tapping the handle also toggles it via [onToggle].
+ *
+ * The sheet extends past its content down to the very bottom edge (no gap); [content] fills all the way
+ * down. Nav-bar clearance for the list is handled as scroll content padding by the caller, so the last
+ * directions row can still be scrolled clear of the chrome without leaving an empty strip here.
+ */
+@Composable
+private fun DirectionsSheet(
+    dragState: AnchoredDraggableState<DirectionsAnchor>,
+    sheetHeight: Dp,
+    onToggle: () -> Unit,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    Surface(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(sheetHeight)
+            .offset {
+                // `offset` is NaN until the anchors are applied; rest at the open position (0) until then.
+                IntOffset(0, dragState.offset.let { if (it.isNaN()) 0 else it.roundToInt() })
+            },
+        shape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp),
+        color = MaterialTheme.colorScheme.surface,
+        shadowElevation = 8.dp,
+    ) {
+        Column {
+            DirectionsDragHandle(dragState = dragState, onToggle = onToggle)
+            Box(Modifier.weight(1f)) { content() }
         }
     }
 }
 
+/**
+ * The directions sheet's grab handle — the only open/close control. It carries the sheet's drag gesture
+ * (so the body/list can scroll independently), and a tap toggles open/closed via [onToggle]. Mirrors the
+ * home arrivals sheet's [org.onebusaway.android.ui.home] handle styling.
+ */
 @Composable
-private fun TripPlanTopBar(onBack: () -> Unit, onReportProblem: () -> Unit) {
-    var menuExpanded by remember { mutableStateOf(false) }
-    ObaTopAppBar(title = stringResource(R.string.trip_plan_title), onBack = onBack) {
-        IconButton(onClick = { menuExpanded = true }) {
-            Icon(Icons.Filled.MoreVert, contentDescription = null)
-        }
-        DropdownMenu(expanded = menuExpanded, onDismissRequest = { menuExpanded = false }) {
-            DropdownMenuItem(
-                text = { Text(stringResource(R.string.tripplanner_report_trip_problem)) },
-                onClick = {
-                    menuExpanded = false
-                    onReportProblem()
-                }
-            )
+private fun DirectionsDragHandle(
+    dragState: AnchoredDraggableState<DirectionsAnchor>,
+    onToggle: () -> Unit,
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .anchoredDraggable(dragState, Orientation.Vertical)
+            .clickable(onClick = onToggle)
+            .padding(vertical = DIRECTIONS_HANDLE_VERTICAL_PADDING),
+        contentAlignment = Alignment.Center,
+    ) {
+        Surface(
+            color = colorResource(R.color.navdrawer_icon_tint),
+            shape = RoundedCornerShape(percent = 50),
+        ) {
+            Box(Modifier.size(width = 32.dp, height = DIRECTIONS_HANDLE_BAR_HEIGHT))
         }
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -55,6 +56,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import android.app.Activity
 import android.app.NotificationManager
@@ -142,7 +144,11 @@ private fun RowScope.OptionCard(
  * is the scaffold body behind the sheet ([TripResultsMap]), not a sibling tab.
  */
 @Composable
-fun TripResultsList(state: TripResultsUiState, modifier: Modifier = Modifier) {
+fun TripResultsList(
+    state: TripResultsUiState,
+    modifier: Modifier = Modifier,
+    bottomInset: Dp = 0.dp,
+) {
     Box(
         modifier
             .fillMaxSize()
@@ -160,7 +166,12 @@ fun TripResultsList(state: TripResultsUiState, modifier: Modifier = Modifier) {
                     .padding(32.dp)
             )
 
-            is TripResultsUiState.Success -> LazyColumn(Modifier.fillMaxSize()) {
+            // The surface reaches the bottom edge; a bottom content padding lets the final directions row
+            // be scrolled clear of the nav chrome without an empty strip below the list.
+            is TripResultsUiState.Success -> LazyColumn(
+                modifier = Modifier.fillMaxSize(),
+                contentPadding = PaddingValues(bottom = bottomInset),
+            ) {
                 itemsIndexed(state.directions) { _, item ->
                     DirectionRow(item)
                     HorizontalDivider()
@@ -190,6 +201,7 @@ fun TripResultsSheet(
     resultsViewModel: TripResultsViewModel,
     mapViewModel: DirectionsMapViewModel,
     modifier: Modifier = Modifier,
+    listBottomInset: Dp = 0.dp,
 ) {
     val state by resultsViewModel.state.collectAsStateWithLifecycle()
     val activity = LocalContext.current.findActivity()
@@ -219,7 +231,7 @@ fun TripResultsSheet(
             state = state,
             onSelectOption = resultsViewModel::selectOption,
         )
-        TripResultsList(state, Modifier.weight(1f))
+        TripResultsList(state, Modifier.weight(1f), bottomInset = listBottomInset)
     }
 }
 


### PR DESCRIPTION
## What

Restructures the **Plan a trip** flow so the directions map is the constant backdrop of the whole flow, instead of the form being a separate full screen.

- **Form → top sheet.** The from/to form now slides down over the map from the top. It drags like a bottom sheet: an `AnchoredDraggable` state drives its **height**, and the full form **cross-fades** with a compact `From → To` summary bar as you minimize/maximize (drag the bottom handle, or tap it). Auto-collapses to the summary once a plan completes.
- **Directions → bottom sheet.** A custom `AnchoredDraggable` sheet whose drag gesture lives on the **handle only**, so the directions `LazyColumn` scrolls freely inside. Opens to **40%** of the screen, collapses to just the handle, seated above the nav-bar chrome while its surface still reaches the bottom edge (last row cleared via list scroll content padding).
- **Map is always present.** `DirectionsMapViewModel` is mounted for the whole flow (base map before a plan, the drawn itinerary after). The standalone trip-plan toolbar is folded into the top sheet's header (back + "report problem").

## Notes

- `TripPlanTopBar` and the `BottomSheetScaffold` usage in the trip-plan container are removed; `TripResultsSheet` / `TripResultsMap` are reused unchanged aside from a new optional list bottom-inset.
- Presentation-only change; no ViewModel/data changes.
- Filed as a **draft** — still wants a broader on-device pass (both handsets/gesture vs. 3-button nav) and design eyes on the collapsed-height / cross-fade feel.

## Testing

- Builds: `./gradlew installObaGoogleDebug` (verified on a Pixel 7 Pro).
- Exercised on device: open Plan a trip → form slides down over the map; entering from/to computes a plan → form collapses to the summary bar, directions open in the bottom sheet, itinerary draws on the map; handle drag/tap on both sheets; back walks directions → form → results → exit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)