### PR TITLE
Drop Application.currentRegion/setCurrentRegion; migrate last region readers (#1678)

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/api/test/ObaTestCase.java
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/api/test/ObaTestCase.java
@@ -19,8 +19,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.onebusaway.android.R;
-import org.onebusaway.android.app.Application;
 import org.onebusaway.android.app.di.PreferencesEntryPoint;
+import org.onebusaway.android.app.di.RegionEntryPoint;
 import org.onebusaway.android.region.Region;
 
 import androidx.test.runner.AndroidJUnit4;
@@ -45,7 +45,7 @@ public abstract class ObaTestCase {
         getTargetContext().setTheme(R.style.Theme_OneBusAway);
 
         // Save the current region / custom API URL so the override below can be undone in after().
-        mOldRegion = Application.get().getCurrentRegion();
+        mOldRegion = RegionEntryPoint.get(getTargetContext()).currentRegion();
         mOldCustomApiUrl = mOldRegion == null
                 ? PreferencesEntryPoint.get(getTargetContext())
                         .getString(R.string.preference_key_oba_api_url, null)
@@ -63,14 +63,14 @@ public abstract class ObaTestCase {
     @After
     public void after() {
         if (mOldRegion != null) {
-            Application.get().setCurrentRegion(mOldRegion);
+            RegionEntryPoint.get(getTargetContext()).applyRegion(mOldRegion, true);
         } else if (mOldCustomApiUrl != null) {
             PreferencesEntryPoint.get(getTargetContext())
                     .setString(R.string.preference_key_oba_api_url, mOldCustomApiUrl);
         } else {
             PreferencesEntryPoint.get(getTargetContext())
                     .setString(R.string.preference_key_oba_api_url, null);
-            Application.get().setCurrentRegion(null);
+            RegionEntryPoint.get(getTargetContext()).applyRegion(null, true);
         }
     }
 }

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/util/test/UIUtilTest.java
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/util/test/UIUtilTest.java
@@ -23,8 +23,8 @@ import androidx.test.runner.AndroidJUnit4;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.onebusaway.android.R;
-import org.onebusaway.android.app.Application;
 import org.onebusaway.android.app.di.PreferencesEntryPoint;
+import org.onebusaway.android.app.di.RegionEntryPoint;
 import org.onebusaway.android.api.contract.ArrivalsForStop;
 import org.onebusaway.android.api.contract.EntryWithReferences;
 import org.onebusaway.android.api.contract.ObaEnvelope;
@@ -229,7 +229,7 @@ public class UIUtilTest extends ObaTestCase {
         // Load a captured arrivals fixture and project it via the production DTO path
         Region tampa = MockRegion.getTampa(getTargetContext());
         assertNotNull(tampa);
-        Application.get().setCurrentRegion(tampa);
+        RegionEntryPoint.get(getTargetContext()).applyRegion(tampa, true);
 
         ObaEnvelope<EntryWithReferences<ArrivalsForStop>> env =
                 ArrivalsFixtures.load(getTargetContext(), "arrivals_and_departures_for_stop_hart_6497");
@@ -275,7 +275,7 @@ public class UIUtilTest extends ObaTestCase {
         // Load a captured arrivals fixture and project it via the production DTO path
         Region tampa = MockRegion.getTampa(getTargetContext());
         assertNotNull(tampa);
-        Application.get().setCurrentRegion(tampa);
+        RegionEntryPoint.get(getTargetContext()).applyRegion(tampa, true);
 
         ObaEnvelope<EntryWithReferences<ArrivalsForStop>> env =
                 ArrivalsFixtures.load(getTargetContext(), "arrivals_and_departures_for_stop_hart_6497");

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleCameraCommands.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleCameraCommands.kt
@@ -23,7 +23,7 @@ import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
 import com.google.android.gms.maps.model.LatLngBounds
 import org.onebusaway.android.R
-import org.onebusaway.android.app.Application
+import org.onebusaway.android.app.di.RegionEntryPoint
 import org.onebusaway.android.map.googlemapsv2.MapHelpV2
 import org.onebusaway.android.map.render.CameraCommand
 import org.onebusaway.android.map.render.FramingIntent
@@ -135,7 +135,7 @@ fun applyFramingIntent(
         }
 
         FramingIntent.Region -> {
-            val region = Application.get().currentRegion ?: return
+            val region = RegionEntryPoint.get(context).currentRegion() ?: return
             val bounds = MapHelpV2.getRegionBounds(region)
             // Use screen dimensions to avoid IllegalStateException (#581).
             val dm = context.resources.displayMetrics

--- a/onebusaway-android/src/main/java/org/onebusaway/android/app/Application.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/app/Application.kt
@@ -30,7 +30,6 @@ import org.onebusaway.android.app.di.LocationEntryPoint
 import org.onebusaway.android.app.di.PreferencesEntryPoint
 import org.onebusaway.android.app.di.RegionEntryPoint
 import org.onebusaway.android.notifications.NotificationChannels
-import org.onebusaway.android.region.Region
 import org.onebusaway.android.region.RegionSubsystems
 import org.onebusaway.android.util.BuildFlavorUtils
 import org.onebusaway.android.util.CustomApiUrlLabel
@@ -65,7 +64,8 @@ class Application : android.app.Application() {
         // @Singletons, constructed lazily on first injection after onCreate. The region repo seeds
         // itself from persistence (the saved region-id → ContentProvider lookup); the location repo
         // starts empty and fills from setLastKnownLocation (listener updates) / its lazy provider poll.
-        // The legacy setCurrentRegion / setLastKnownLocation writers reach them via their EntryPoints.
+        // The legacy setLastKnownLocation writer reaches the location repo via its EntryPoint; region
+        // reads/writes now go straight through RegionRepository (via injection or RegionEntryPoint).
         // So nothing to construct here.
         // The region-derived Open311 endpoints observe the region flow (A7) via RegionSubsystems — this
         // performs their initial init (the StateFlow replays the repo's seeded region) and re-inits on
@@ -92,28 +92,6 @@ class Application : android.app.Application() {
         mApp = null
     }
 
-    /**
-     * The current region. RegionRepository is the sole owner; this reads its current value and stays as
-     * a convenience for the remaining non-injectable readers that go through Application (Java tests via
-     * `getCurrentRegion()`; the flavor camera-command composables via `currentRegion`).
-     */
-    val currentRegion: Region?
-        @Synchronized get() = RegionEntryPoint.get(this).currentRegion()
-
-    /**
-     * Sets the current region directly. The production region writers all route
-     * through [org.onebusaway.android.region.RegionRepository] (`refresh`/`choose`/`clear`); this
-     * remains only as the instrumented-test seam (the `io/` request tests that pin a known region
-     * synchronously). It delegates the canonical region write to `RegionRepository.applyRegion`; the
-     * region-derived subsystems (Open311 via RegionSubsystems, the Plausible/Umami emitters via
-     * AnalyticsProvider) re-init reactively by observing the published flow.
-     */
-    @Synchronized
-    @JvmOverloads
-    fun setCurrentRegion(region: Region?, regionChanged: Boolean = true) {
-        RegionEntryPoint.get(this).applyRegion(region, regionChanged)
-    }
-
     private fun reportAnalytics() {
         // The Plausible/Umami emitters are owned + built reactively by AnalyticsProvider; here we only set
         // the initial Firebase/Umami region label via setRegion (which resolves the Umami emitter through
@@ -123,7 +101,7 @@ class Application : android.app.Application() {
         val label = if (customApiUrl != null) {
             CustomApiUrlLabel.forUrl(this, customApiUrl)
         } else {
-            currentRegion?.name
+            RegionEntryPoint.get(this).currentRegion()?.name
         }
         label?.let { AnalyticsEntryPoint.get(this).setRegion(it) }
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/region/RegionStateHolder.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/region/RegionStateHolder.kt
@@ -24,8 +24,7 @@ import org.onebusaway.android.region.Region
  * The observable region state ([region] + [state]) that [DefaultRegionRepository] exposes. Extracted
  * so the state transitions stay JVM-unit-testable without a `Context` — the
  * repository's resolution is `Context`-coupled (it calls `RegionUtils.getRegions` etc.), but the
- * holder is pure. Both the repository's `refresh`/`choose` and the legacy `Application.setCurrentRegion`
- * bridge feed it.
+ * holder is pure. The repository's `refresh`/`choose`/`applyRegion` writers feed it.
  *
  * [region] holds the last-set region (null when a custom API URL is configured); [state] adds the
  * transient [RegionState.Resolving] / [RegionState.NeedsManualChoice] / [RegionState.Failed] nuance.

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreCameraCommands.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreCameraCommands.kt
@@ -15,12 +15,13 @@
  */
 package org.onebusaway.android.map.maplibre.compose
 
+import android.content.Context
 import org.maplibre.android.camera.CameraPosition
 import org.maplibre.android.camera.CameraUpdateFactory
 import org.maplibre.android.geometry.LatLng
 import org.maplibre.android.geometry.LatLngBounds
 import org.maplibre.android.maps.MapLibreMap
-import org.onebusaway.android.app.Application
+import org.onebusaway.android.app.di.RegionEntryPoint
 import org.onebusaway.android.map.maplibre.MapHelpMapLibre
 import org.onebusaway.android.map.render.CameraCommand
 import org.onebusaway.android.map.render.FramingIntent
@@ -88,7 +89,7 @@ fun applyCameraCommand(cmd: CameraCommand, map: MapLibreMap) {
  * route shape (the screen-dimension padding was a Google-only refinement); the bounds are re-read from
  * [renderState]/the region live, so it's safe to re-apply when a re-created adapter replays the framing.
  */
-fun applyFramingIntent(intent: FramingIntent, map: MapLibreMap, renderState: MapRenderState) {
+fun applyFramingIntent(intent: FramingIntent, map: MapLibreMap, renderState: MapRenderState, context: Context) {
     when (intent) {
         FramingIntent.Route,
         FramingIntent.Itinerary -> {
@@ -97,7 +98,7 @@ fun applyFramingIntent(intent: FramingIntent, map: MapLibreMap, renderState: Map
         }
 
         FramingIntent.Region -> {
-            val region = Application.get().currentRegion ?: return
+            val region = RegionEntryPoint.get(context).currentRegion() ?: return
             map.animateCamera(CameraUpdateFactory.newLatLngBounds(MapHelpMapLibre.getRegionBounds(region), 0))
         }
 

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreComposeAdapter.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreComposeAdapter.kt
@@ -222,7 +222,7 @@ class MapLibreComposeAdapter : ObaComposeMapAdapter {
                 renderState.cameraGestures.collect { command -> applyCameraCommand(command, map) }
             }
             LaunchedEffect(map) {
-                renderState.framingIntent.filterNotNull().collect { applyFramingIntent(it, map, renderState) }
+                renderState.framingIntent.filterNotNull().collect { applyFramingIntent(it, map, renderState, context) }
             }
         }
 


### PR DESCRIPTION
Closes #1678.

Follow-up to #1659 (PR #1676, the `Application` Kotlin conversion), which deliberately kept a few `Application.get()`-reached region seams as non-goals. Now that `RegionRepository` is the sole owner of region state (A7), those `Application` accessors are pure vestigial glue and their `@Synchronized` guards nothing local — they only survived because a handful of non-injectable callers still reached them through `Application.get()`.

## What changed

Migrated the last 4 callers to the `RegionRepository` seam, then deleted the accessors.

- **Flavor camera composables** — `GoogleCameraCommands.applyFramingIntent` and `MapLibreCameraCommands.applyFramingIntent` now read the region via `RegionEntryPoint.get(context).currentRegion()` instead of `Application.get().currentRegion`. The MapLibre helper gains a `context` parameter, threaded from the adapter's `collect` block (`context` is already in scope there), bringing it to parity with the Google helper which already took `context`. Resolution stays lazily inside the `FramingIntent.Region` branch, so `Route`/`Itinerary`/`Point` intents don't fetch the region.
- **Instrumented tests** — `ObaTestCase` and `UIUtilTest` pin/read the region via `RegionEntryPoint.get(getTargetContext())` (`.currentRegion()` / `.applyRegion(..., true)`), mirroring how the custom-API-URL test seam already moved to `PreferencesEntryPoint`.
- **Deleted** `Application.currentRegion` + `Application.setCurrentRegion` and their `@Synchronized`. Repointed the one internal user (`reportAnalytics`) to `RegionEntryPoint`, dropped the now-unused `Region` import, and refreshed the stale "legacy bridge" comments in `Application` and `RegionStateHolder`.

Left the location delegate (`getLastKnownLocation`/`setLastKnownLocation`) and the deliberate magnetic-declination keep untouched, as the issue scopes them out.

## Verification

Compiled clean across variants: `compileObaGoogleDebug{Kotlin,JavaWithJavac}`, `compileObaMaplibreDebugKotlin`, and `compileObaGoogleDebugAndroidTest{Kotlin,JavaWithJavac}` (where the migrated tests live). Only pre-existing MapLibre deprecation warnings remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved region selection and restoration so maps and arrival views use the correct saved region more reliably.
  * Fixed camera framing behavior to better follow the active region in map views.
  * Updated test coverage for region-based arrival loading and search flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->