### PR TITLE
Pass Context into the stop-icon factories instead of Application.get()

### DIFF
--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
@@ -280,10 +280,10 @@ class GoogleMapRenderer(
     }
 
     private fun stopIcon(stop: StopMarker, kind: StopIconKind): BitmapDescriptor = when (kind) {
-        StopIconKind.FULL -> StopIconFactory.stopIcon(stop.direction, stop.routeType)
-        StopIconKind.FULL_FOCUSED -> StopIconFactory.focusedStopIcon(stop.direction, stop.routeType)
-        StopIconKind.DOT -> StopIconFactory.dotStopIcon()
-        StopIconKind.DOT_FOCUSED -> StopIconFactory.focusedDotStopIcon()
+        StopIconKind.FULL -> StopIconFactory.stopIcon(context, stop.direction, stop.routeType)
+        StopIconKind.FULL_FOCUSED -> StopIconFactory.focusedStopIcon(context, stop.direction, stop.routeType)
+        StopIconKind.DOT -> StopIconFactory.dotStopIcon(context)
+        StopIconKind.DOT_FOCUSED -> StopIconFactory.focusedDotStopIcon(context)
     }
 
     private fun stopAnchor(stop: StopMarker, kind: StopIconKind): Pair<Float, Float> =

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/StopIconFactory.java
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/StopIconFactory.java
@@ -40,7 +40,6 @@ import com.google.android.gms.maps.model.BitmapDescriptor;
 import com.google.android.gms.maps.model.BitmapDescriptorFactory;
 
 import org.onebusaway.android.R;
-import org.onebusaway.android.app.Application;
 import org.onebusaway.android.map.render.StopBitmaps;
 import org.onebusaway.android.models.ObaRoute;
 
@@ -163,23 +162,27 @@ public final class StopIconFactory {
                 new PorterDuffColorFilter(Color.WHITE, PorterDuff.Mode.SRC_IN));
     }
 
-    /** Builds the icon caches on first use (the old constructor called loadIcons() each time). */
-    public static synchronized void ensureLoaded() {
+    /**
+     * Builds the icon caches on first use (the old constructor called loadIcons() each time). The
+     * [context] is used only to read app resources while rendering the bitmaps; only the first call
+     * (which populates the caches) touches it.
+     */
+    public static synchronized void ensureLoaded(Context context) {
         if (!sLoaded) {
-            loadIcons();
+            loadIcons(context);
             sLoaded = true;
         }
     }
 
     /** The normal (unfocused) stop icon for a direction + primary route type. */
-    public static synchronized BitmapDescriptor stopIcon(String direction, int routeType) {
-        ensureLoaded();
+    public static synchronized BitmapDescriptor stopIcon(Context context, String direction, int routeType) {
+        ensureLoaded(context);
         return getStopBitmapDescriptor(direction, routeType);
     }
 
     /** The focused (1.5x) stop icon for a direction + primary route type. */
-    public static synchronized BitmapDescriptor focusedStopIcon(String direction, int routeType) {
-        ensureLoaded();
+    public static synchronized BitmapDescriptor focusedStopIcon(Context context, String direction, int routeType) {
+        ensureLoaded(context);
         return getFocusedStopBitmapDescriptor(direction, routeType);
     }
 
@@ -187,14 +190,14 @@ public final class StopIconFactory {
      * The small dot shown in place of the full icon at distant zoom. Directionless and route-type
      * agnostic (a neutral themed point), so the caller anchors it at the marker center (0.5, 0.5).
      */
-    public static synchronized BitmapDescriptor dotStopIcon() {
-        ensureLoaded();
+    public static synchronized BitmapDescriptor dotStopIcon(Context context) {
+        ensureLoaded(context);
         return sDotDescriptor;
     }
 
     /** The focused (accent) dot, shown for the selected stop at distant zoom. */
-    public static synchronized BitmapDescriptor focusedDotStopIcon() {
-        ensureLoaded();
+    public static synchronized BitmapDescriptor focusedDotStopIcon(Context context) {
+        ensureLoaded(context);
         return sDotDescriptorFocused;
     }
 
@@ -211,9 +214,9 @@ public final class StopIconFactory {
     /**
      * Cache the BitmapDescriptors that hold the images used for icons
      */
-    private static final void loadIcons() {
+    private static final void loadIcons(Context context) {
         // Initialize variables used for all marker icons
-        Resources r = Application.get().getResources();
+        Resources r = context.getResources();
         mPx = r.getDimensionPixelSize(R.dimen.map_stop_shadow_size_6);
         float arrowHeightPx = mPx / 3f;
         float arrowSpacingReductionPx = mPx / 10f;
@@ -241,8 +244,8 @@ public final class StopIconFactory {
             Bitmap[] icons = new Bitmap[NUM_DIRECTIONS];
             Bitmap[] iconsFocused = new Bitmap[NUM_DIRECTIONS];
             for (int i = 0; i < directions.length; i++) {
-                icons[i] = createStopIcon(directions[i], false, routeType);
-                iconsFocused[i] = createStopIcon(directions[i], true, routeType);
+                icons[i] = createStopIcon(context, directions[i], false, routeType);
+                iconsFocused[i] = createStopIcon(context, directions[i], true, routeType);
             }
             // Scale the focused icons to be larger than the normal icons
             for (int i = 0; i < NUM_DIRECTIONS; i++) {
@@ -281,13 +284,12 @@ public final class StopIconFactory {
      * @return a stop icon bitmap with the arrow pointing the given direction, or with no arrow
      * if direction is NO_DIRECTION
      */
-    private static Bitmap createStopIcon(String direction, boolean selected, int routeType) {
+    private static Bitmap createStopIcon(Context context, String direction, boolean selected, int routeType) {
         if (direction == null) {
             throw new IllegalArgumentException("direction must not be null");
         }
 
-        Resources r = Application.get().getResources();
-        Context context = Application.get();
+        Resources r = context.getResources();
 
         // All stops get a slightly larger circle so the vehicle glyph is clearly visible
         int px = (int) (mPx * GLYPH_ICON_SCALE);

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
@@ -232,10 +232,10 @@ class MapLibreRenderer(
     }
 
     private fun stopIcon(stop: StopMarker, kind: StopIconKind): Icon = when (kind) {
-        StopIconKind.FULL -> MapLibreStopIcons.iconForDirection(stop.direction)
-        StopIconKind.FULL_FOCUSED -> MapLibreStopIcons.focusedIconForDirection(stop.direction)
-        StopIconKind.DOT -> MapLibreStopIcons.dotIcon()
-        StopIconKind.DOT_FOCUSED -> MapLibreStopIcons.focusedDotIcon()
+        StopIconKind.FULL -> MapLibreStopIcons.iconForDirection(context, stop.direction)
+        StopIconKind.FULL_FOCUSED -> MapLibreStopIcons.focusedIconForDirection(context, stop.direction)
+        StopIconKind.DOT -> MapLibreStopIcons.dotIcon(context)
+        StopIconKind.DOT_FOCUSED -> MapLibreStopIcons.focusedDotIcon(context)
     }
 
     /**

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreStopIcons.java
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreStopIcons.java
@@ -33,7 +33,6 @@ import org.maplibre.android.annotations.Icon;
 import org.maplibre.android.annotations.IconFactory;
 
 import org.onebusaway.android.R;
-import org.onebusaway.android.app.Application;
 import org.onebusaway.android.map.render.StopBitmaps;
 
 import java.util.HashMap;
@@ -102,23 +101,26 @@ public final class MapLibreStopIcons {
     private static float mPercentOffset = 0.5f;
     private static Paint mArrowPaintStroke;
 
-    /** Builds the icon caches on first use. */
-    public static synchronized void ensureLoaded() {
+    /**
+     * Builds the icon caches on first use. The [context] is used only to read app resources while
+     * rendering the bitmaps; only the first call (which populates the caches) touches it.
+     */
+    public static synchronized void ensureLoaded(Context context) {
         if (!sLoaded) {
-            loadIcons();
+            loadIcons(context);
             sLoaded = true;
         }
     }
 
     /** The normal (unfocused) stop icon for a direction string ("N".."NW" / "null"). */
-    public static synchronized Icon iconForDirection(String direction) {
-        ensureLoaded();
+    public static synchronized Icon iconForDirection(Context context, String direction) {
+        ensureLoaded(context);
         return bus_stop_icons[indexFor(direction)];
     }
 
     /** The focused (1.5x) stop icon for a direction string. */
-    public static synchronized Icon focusedIconForDirection(String direction) {
-        ensureLoaded();
+    public static synchronized Icon focusedIconForDirection(Context context, String direction) {
+        ensureLoaded(context);
         return bus_stop_icons_focused[indexFor(direction)];
     }
 
@@ -127,14 +129,14 @@ public final class MapLibreStopIcons {
      * agnostic (a neutral themed point). maplibre centers the icon on the position, so it lands on
      * the stop without anchor math.
      */
-    public static synchronized Icon dotIcon() {
-        ensureLoaded();
+    public static synchronized Icon dotIcon(Context context) {
+        ensureLoaded(context);
         return dot_stop_icon;
     }
 
     /** The focused (accent) dot, shown for the selected stop at distant zoom. */
-    public static synchronized Icon focusedDotIcon() {
-        ensureLoaded();
+    public static synchronized Icon focusedDotIcon(Context context) {
+        ensureLoaded(context);
         return dot_stop_icon_focused;
     }
 
@@ -143,8 +145,8 @@ public final class MapLibreStopIcons {
         return index != null ? index : 8;
     }
 
-    private static void loadIcons() {
-        Resources r = Application.get().getResources();
+    private static void loadIcons(Context context) {
+        Resources r = context.getResources();
         mPx = r.getDimensionPixelSize(R.dimen.map_stop_shadow_size_6);
         mArrowWidthPx = mPx / 2f;
         mArrowHeightPx = mPx / 3f;
@@ -159,11 +161,11 @@ public final class MapLibreStopIcons {
         mArrowPaintStroke.setStrokeWidth(1.0f);
         mArrowPaintStroke.setAntiAlias(true);
 
-        IconFactory iconFactory = IconFactory.getInstance(Application.get());
+        IconFactory iconFactory = IconFactory.getInstance(context);
         String[] directions = {NORTH, NORTH_WEST, WEST, SOUTH_WEST, SOUTH, SOUTH_EAST, EAST, NORTH_EAST, NO_DIRECTION};
         for (int i = 0; i < directions.length; i++) {
-            bus_stop_icons[i] = iconFactory.fromBitmap(createBusStopIcon(directions[i], false));
-            Bitmap focused = createBusStopIcon(directions[i], true);
+            bus_stop_icons[i] = iconFactory.fromBitmap(createBusStopIcon(context, directions[i], false));
+            Bitmap focused = createBusStopIcon(context, directions[i], true);
             focused = Bitmap.createScaledBitmap(focused,
                     (int) (focused.getWidth() * FOCUS_ICON_SCALE),
                     (int) (focused.getHeight() * FOCUS_ICON_SCALE), true);
@@ -175,13 +177,12 @@ public final class MapLibreStopIcons {
     }
 
     @SuppressWarnings("deprecation")
-    private static Bitmap createBusStopIcon(String direction, boolean selected) {
+    private static Bitmap createBusStopIcon(Context context, String direction, boolean selected) {
         if (direction == null) {
             throw new IllegalArgumentException("direction is null");
         }
 
-        Resources r = Application.get().getResources();
-        Context context = Application.get();
+        Resources r = context.getResources();
 
         Float directionAngle = null;
         Bitmap bm;


### PR DESCRIPTION
> **Stacked on #1685** — this branch is based on the location-scrub branch, so its diff currently includes that commit too. Once #1685 merges, I'll rebase onto `main` and this becomes a self-contained 4-file change. Review the top commit (`Pass Context into the stop-icon factories…`) in isolation for now.

## What

Removes the last **non-deliberate** `Application.get()` reaches, part of the #1659 effort to dissolve the `Application` god-object.

`StopIconFactory` (google) and `MapLibreStopIcons` (maplibre) are static stop-marker icon caches that reached the app `Context` via `Application.get()` while rendering their bitmaps. Both funnel that need through a single load boundary (`ensureLoaded` → `loadIcons` → `createStopIcon`), and their only callers are the per-flavor renderers (`GoogleMapRenderer`, `MapLibreRenderer`), which already hold a constructor-injected `Context`.

This threads that `Context` in as a parameter on the public icon accessors — the same *"reaches that need a real Context take one as a parameter"* pattern `PreferenceUtils` documents for #1636. Anchor accessors stay `Context`-free (they need nothing).

## Effect on the static locator

After this change, `Application.get()` has **exactly one caller left**: `PreferenceUtils.repo()`, the sanctioned keep (it's a pure DI graph handle reached from ~90 `Context`-less call sites; removing it means making `PreferenceUtils` injectable, deferred under #1636). So this doesn't delete `get()` yet — it shrinks the locator to its single documented floor.

## Testing

- `:onebusaway-android:compileObaGoogleDebugJavaWithJavac` and `:onebusaway-android:compileObaMaplibreDebugJavaWithJavac` both pass (exercises both factories + both renderers).
- Pure mechanical parameter threading; icon rendering behavior is unchanged. The icons render on the map canvas, which only exercises on a device — worth a visual smoke of stop markers (full icon + dot at far zoom, focused variants) on both flavors before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A96pfjbvs9yQpiLy2iM1kb