### PR TITLE
Enlarge the selected stop's dot in zoomed-out mode (#1679)

### DIFF
--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/StopIconFactory.java
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/StopIconFactory.java
@@ -111,7 +111,10 @@ public final class StopIconFactory {
     /** The small directionless dot shown in place of the full icon at distant zoom (declutter). */
     private static BitmapDescriptor sDotDescriptor;
 
-    /** The focused (accent) variant of {@link #sDotDescriptor}, so a selection stays visible far out. */
+    /**
+     * The focused variant of {@link #sDotDescriptor}: a larger ({@link StopBitmaps#FOCUSED_DOT_SCALE})
+     * accent dot, so the selected stop stays visible and clearly larger than its neighbours far out.
+     */
     private static BitmapDescriptor sDotDescriptorFocused;
 
     /**
@@ -261,7 +264,8 @@ public final class StopIconFactory {
         sDotDescriptor = BitmapDescriptorFactory.fromBitmap(
                 StopBitmaps.dot(mPx, r.getColor(R.color.theme_primary)));
         sDotDescriptorFocused = BitmapDescriptorFactory.fromBitmap(
-                StopBitmaps.dot(mPx, r.getColor(R.color.map_stop_focus)));
+                StopBitmaps.dot(mPx, r.getColor(R.color.map_stop_focus),
+                        StopBitmaps.FOCUSED_DOT_SCALE));
     }
 
     /** Wraps each pre-rendered bitmap into a BitmapDescriptor once, so callers can reuse them. */

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/StopBitmaps.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/StopBitmaps.kt
@@ -30,12 +30,22 @@ import kotlin.math.roundToInt
  */
 object StopBitmaps {
     /**
+     * How much larger the focused (selected) dot is drawn than a normal dot, so the selected stop
+     * stays visibly larger than its neighbours even in the zoomed-out dot band (#1679). Mirrors the
+     * full-icon focus enlargement the flavour factories apply up close (their `FOCUS_ICON_SCALE`).
+     */
+    const val FOCUSED_DOT_SCALE = 1.5f
+
+    /**
      * A filled circle in [fillColor] with a thin white outline for contrast against the map, sized
-     * from [baseIconPx] (the full stop icon size) so a dense viewport reads as points.
+     * from [baseIconPx] (the full stop icon size) so a dense viewport reads as points. [scale]
+     * enlarges the dot relative to that base — the focused stop passes [FOCUSED_DOT_SCALE] so its
+     * selection reads as larger than surrounding dots.
      */
     @JvmStatic
-    fun dot(baseIconPx: Int, fillColor: Int): Bitmap {
-        val sizePx = max(6, (baseIconPx * 0.5f).roundToInt())
+    @JvmOverloads
+    fun dot(baseIconPx: Int, fillColor: Int, scale: Float = 1f): Bitmap {
+        val sizePx = max(6, (baseIconPx * 0.5f * scale).roundToInt())
         val bm = Bitmap.createBitmap(sizePx, sizePx, Bitmap.Config.ARGB_8888)
         val canvas = Canvas(bm)
         val center = sizePx / 2f

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreStopIcons.java
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreStopIcons.java
@@ -89,7 +89,10 @@ public final class MapLibreStopIcons {
     /** The small directionless dot shown in place of the full icon at distant zoom (declutter). */
     private static Icon dot_stop_icon;
 
-    /** The focused (accent) variant of {@link #dot_stop_icon}, so a selection stays visible far out. */
+    /**
+     * The focused variant of {@link #dot_stop_icon}: a larger ({@link StopBitmaps#FOCUSED_DOT_SCALE})
+     * accent dot, so the selected stop stays visible and clearly larger than its neighbours far out.
+     */
     private static Icon dot_stop_icon_focused;
 
     private static final float FOCUS_ICON_SCALE = 1.5f;
@@ -173,7 +176,8 @@ public final class MapLibreStopIcons {
         }
 
         dot_stop_icon = iconFactory.fromBitmap(StopBitmaps.dot(mPx, r.getColor(R.color.theme_primary)));
-        dot_stop_icon_focused = iconFactory.fromBitmap(StopBitmaps.dot(mPx, r.getColor(R.color.map_stop_focus)));
+        dot_stop_icon_focused = iconFactory.fromBitmap(StopBitmaps.dot(mPx,
+                r.getColor(R.color.map_stop_focus), StopBitmaps.FOCUSED_DOT_SCALE));
     }
 
     @SuppressWarnings("deprecation")


### PR DESCRIPTION
Closes #1679.

When zoomed out (below the stop-dot zoom threshold), stops collapse from their full directional icon to a small `dot`. The selected stop already got a distinct **accent-colored** dot, but it was drawn at the **same size** as every other dot — so at that scale it was hard to tell which stop is selected.

## What changed

Give the focused dot a larger size, mirroring the 1.5× enlargement the full focused icon already gets up close.

- **`StopBitmaps.dot()`** (shared, `src/main`) gains an optional `scale` factor (`@JvmOverloads`, default `1f`) applied to the dot size, plus a shared `FOCUSED_DOT_SCALE = 1.5f` constant — one source of truth for both flavors.
- **Google `StopIconFactory`** and **maplibre `MapLibreStopIcons`** now build the focused dot through that shared builder at `FOCUSED_DOT_SCALE`. Normal dots are untouched.

No anchor changes: both flavors center the dot on the stop (Google anchors `0.5, 0.5`; maplibre auto-centers), so the larger bitmap stays on the stop. The pure `stopIconKind()` decision (FULL / FULL_FOCUSED / DOT / DOT_FOCUSED) is unchanged.

## Verification

- Compiles clean on both `obaGoogleDebug` and `obaMaplibreDebug` (Java + Kotlin).
- Installed on device (`installObaGoogleDebug`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the appearance of focused stop markers on the map when zoomed out, making the selected stop easier to spot.
  * Added support for rendering a larger focused dot style for stop icons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->