### PR TITLE
Draw only the selected direction's route segment, with a direction arrow (#1638)

### DIFF
--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
@@ -181,9 +181,14 @@ class GoogleMapRenderer(
 
         for (polyline in snapshot.routePolylines) {
             val width = polyline.widthDp?.let { it * density } ?: DEFAULT_ROUTE_WIDTH_PX
+            // Stamp travel-direction chevrons only when the line asked for them (a single trip/leg or a
+            // route narrowed to one direction); an undirected whole-route shape draws a plain stroke.
+            val stroke = StrokeStyle.colorBuilder(polyline.resolvedColor)
+                .apply { if (polyline.directional) stamp(arrowStamp) }
+                .build()
             val options = PolylineOptions()
                 .width(width)
-                .addSpan(StyleSpan(StrokeStyle.colorBuilder(polyline.resolvedColor).stamp(arrowStamp).build()))
+                .addSpan(StyleSpan(stroke))
             for (point in polyline.points) options.add(point.toLatLng())
             staticPolylines.add(map.addPolyline(options))
         }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/contract/ObaApiModels.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/contract/ObaApiModels.kt
@@ -175,13 +175,18 @@ data class StopGrouping(
 
 /**
  * One directional group: its [id] (the GTFS direction id, "0"/"1", for a `type: "direction"`
- * grouping), a display [name], and the ordered [stopIds] it contains.
+ * grouping), a display [name], the ordered [stopIds] it contains, and (when `includePolylines=true`)
+ * the [polylines] for that direction — the encoded shapes a vehicle travelling this direction follows,
+ * ordered in the direction of travel and possibly several (route branches/variants). This is the
+ * per-direction shape the whole-route [StopsForRoute.polylines] merges (and fragments); the map draws
+ * it, not the merged set, once a direction is selected.
  */
 @Serializable
 data class StopGroup(
     val id: String? = null,
     val name: StopGroupName = StopGroupName(),
     val stopIds: List<String> = emptyList(),
+    val polylines: List<ShapeEntry> = emptyList(),
 ) {
     /** The group's display name — the first entry of the name object's `names` array, like legacy. */
     val displayName: String? get() = name.names.firstOrNull()

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/data/MapDataSource.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/data/MapDataSource.kt
@@ -23,6 +23,7 @@ import org.onebusaway.android.api.requireData
 import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import org.onebusaway.android.api.contract.ShapeEntry
 import org.onebusaway.android.api.contract.StopGrouping
 import org.onebusaway.android.models.NearbyStops
 import org.onebusaway.android.models.RouteMapDirection
@@ -74,6 +75,17 @@ class DefaultMapDataSource @Inject constructor(
         // The route's selectable directions + each stop's direction membership, from one pass over the
         // direction stop groups.
         val dirs = directionsFrom(data.entry.stopGroupings)
+        // Decoding the route's shape polylines is the one bit of non-trivial CPU work in this layer;
+        // offload just it (the Retrofit calls are already main-safe, like the other sources). Both the
+        // whole-route merged set and each direction's own (cleaner, travel-ordered) shape are decoded
+        // here; the controller draws the merged set for the whole route and a direction's own shape once
+        // one is selected.
+        val (wholeRoute, byDirection) = withContext(Dispatchers.Default) {
+            data.entry.polylines.map { it.decode() } to
+                // distinct() drops a shape a direction listed under more than one group, so it isn't
+                // drawn (and arrow-stamped) twice over itself.
+                dirs.polylinesByDirection.mapValues { (_, shapes) -> shapes.distinct().map { it.decode() } }
+        }
         RouteMapData(
             route = route,
             agencyName = route?.agencyId?.let { data.references.agency(it)?.name },
@@ -81,19 +93,23 @@ class DefaultMapDataSource @Inject constructor(
                 .map { RouteMapStop(it, dirs.directionsByStop[it.id].orEmpty()) },
             routes = data.references.routes.map(::DtoRoute),
             directions = dirs.directions,
-            // Decoding the route's shape polylines is the one bit of non-trivial CPU work in this
-            // layer; offload just it (the Retrofit calls are already main-safe, like the other sources).
-            polylines = withContext(Dispatchers.Default) {
-                data.entry.polylines.map { PolylineDecoder.decodeLine(it.points, it.length) }
-            },
+            polylines = wholeRoute,
+            polylinesByDirection = byDirection,
         )
     }
+
+    private fun ShapeEntry.decode(): List<android.location.Location> =
+        PolylineDecoder.decodeLine(points, length)
 }
 
-/** A route's selectable [directions] plus the [directionsByStop] membership, from one pass. */
+/**
+ * A route's selectable [directions], the [directionsByStop] membership, and each direction's own
+ * (still-encoded) [polylinesByDirection] shapes — all from one pass over the stop groups.
+ */
 internal data class RouteDirections(
     val directions: List<RouteMapDirection>,
     val directionsByStop: Map<String, Set<Int>>,
+    val polylinesByDirection: Map<Int, List<ShapeEntry>>,
 )
 
 /**
@@ -109,17 +125,25 @@ internal data class RouteDirections(
  * that instead exposes branch/variant ids beyond 0/1 will still list those directions and their stops,
  * but no vehicle's trip `directionId` will match, so selecting such a direction shows its stops with an
  * empty vehicle layer. Non-numeric ids are dropped (they can't be a GTFS direction).
+ *
+ * A direction's shapes are accumulated across every group that carries its id (so a direction split
+ * over several groups keeps all its branches); a direction whose groups carried no polylines is absent
+ * from [RouteDirections.polylinesByDirection], and the caller falls back to the whole-route shape.
  */
 internal fun directionsFrom(stopGroupings: List<StopGrouping>): RouteDirections {
     val directions = mutableListOf<RouteMapDirection>()
     val seen = mutableSetOf<Int>()
     val byStop = mutableMapOf<String, MutableSet<Int>>()
+    val polylinesByDir = mutableMapOf<Int, MutableList<ShapeEntry>>()
     stopGroupings.forEach { grouping ->
         grouping.stopGroups.forEach { group ->
             val dir = group.id?.toIntOrNull() ?: return@forEach
             if (seen.add(dir)) directions += RouteMapDirection(dir, group.displayName.orEmpty())
             group.stopIds.forEach { byStop.getOrPut(it) { mutableSetOf() }.add(dir) }
+            if (group.polylines.isNotEmpty()) {
+                polylinesByDir.getOrPut(dir) { mutableListOf() } += group.polylines
+            }
         }
     }
-    return RouteDirections(directions.sortedBy { it.directionId }, byStop)
+    return RouteDirections(directions.sortedBy { it.directionId }, byStop, polylinesByDir)
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/DirectionsMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/DirectionsMapController.kt
@@ -67,7 +67,12 @@ class DirectionsMapController(private val host: MapHost) {
         val legPolylines = legs.mapNotNull { leg ->
             val shape = LegShape(leg.legGeometry)
             if (shape.length > 0) {
-                RoutePolyline(resolveLegColor(leg), shape.points.map { it.toGeoPoint() })
+                // An itinerary leg is traversed one way; keep its travel-direction chevrons.
+                RoutePolyline(
+                    resolveLegColor(leg),
+                    shape.points.map { it.toGeoPoint() },
+                    directional = true,
+                )
             } else {
                 null
             }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
@@ -98,6 +98,10 @@ class RouteMapController(
 
     private var directions: List<RouteMapDirection> = emptyList()
 
+    // The loaded route's shape (whole-route merged set + each direction's own travel-ordered shape),
+    // retained so a direction switch re-narrows the drawn line without a reload. Null until first load.
+    private var routeShape: RouteMap? = null
+
     // The direction shown now (null = whole route). Derived from [directionState] rather than stored
     // separately, so the stop filter and the vehicle filter can never disagree. Meaningful only once
     // resolved (it reads null during the Pending window, which no caller relies on).
@@ -199,6 +203,7 @@ class RouteMapController(
         routeStops = emptyList()
         routeStopRoutes = emptyList()
         directions = emptyList()
+        routeShape = null
         directionState = DirectionState.Resolved(null)
         latestPoll = null
         renderState.clearRoutePolylines()
@@ -260,18 +265,15 @@ class RouteMapController(
         routeStops = routeMap.stops
         routeStopRoutes = routeMap.routes
         directions = routeMap.directions
+        routeShape = routeMap
         val override = initialDirectionOverride
         val resolved =
             if (override != null && directions.any { it.directionId == override }) override
             else routeMap.initialDirectionId
         directionState = DirectionState.Resolved(resolved)
         _loadedRoute.value = LoadedRoute.Loaded(route, routeMap.agencyName, directions, resolved)
-        // Pass the route's raw GTFS color through; the render layer picks the fallback when it's absent.
-        // The shape is whole-route (never narrowed by direction), so a switch leaves it untouched.
-        renderState.setRoutePolylines(
-            routeMap.polylines.map { points -> RoutePolyline(route.color, points) }
-        )
         showDirectionStops()
+        showDirectionPolylines()
         // The load resolved the filter (Pending -> Resolved); push the now-visible vehicle set in case a
         // poll already landed while it was held back.
         publishVehicleSet()
@@ -289,6 +291,25 @@ class RouteMapController(
     }
 
     /**
+     * Re-draw the route shape for [currentDirectionId]: the selected direction's own travel-ordered
+     * shape (with direction arrows), or the whole-route merged shape drawn undirected when none is
+     * selected. Passes the route's raw GTFS color through; the render layer picks the fallback when
+     * it's absent. Called on load and on every direction switch.
+     */
+    private fun showDirectionPolylines() {
+        val route = routeShape ?: return
+        // shapeForDirection pairs the drawn shape with its directionality, so arrows are stamped only
+        // when the selected direction's own travel-ordered shape is used — never on the whole-route
+        // merged fallback (a direction that carried no shape on the wire).
+        val shape = route.shapeForDirection(currentDirectionId)
+        renderState.setRoutePolylines(
+            shape.polylines.map { points ->
+                RoutePolyline(route.route?.color, points, directional = shape.directional)
+            }
+        )
+    }
+
+    /**
      * Switch the shown direction to [directionId] (one of [directions]' ids, or null for the whole
      * route) without a network reload: re-filter the stops and the vehicle set against the current poll,
      * republish both, and update the header. The renderer reconciles markers from the pushed vehicle set,
@@ -301,6 +322,7 @@ class RouteMapController(
         // A vehicle selected in the old direction is now filtered out — drop the selection.
         renderState.setSelectedVehicle(null)
         showDirectionStops()
+        showDirectionPolylines()
         // Re-filter the vehicle set against the same poll and push it — the renderer reconciles markers on
         // this emission, so the swap is immediate instead of waiting for the next poll.
         publishVehicleSet()

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapRepository.kt
@@ -22,14 +22,19 @@ import org.onebusaway.android.models.ObaRoute
 import org.onebusaway.android.models.ObaStop
 import org.onebusaway.android.models.RouteMapDirection
 import org.onebusaway.android.models.RouteMapStop
+import android.location.Location
 import org.onebusaway.android.map.render.GeoPoint
 
 /**
  * A route's full stops (each tagged with the direction(s) it serves, so the controller can re-filter
  * to any direction without a reload), the serving routes (for stop-marker icons), the route + agency
  * name, its shape, the route's selectable [directions] (id + headsign), and the
- * [initialDirectionId] resolved from the launch's anchor stop (null = whole route). The shape is
- * never narrowed by direction — both directions share it.
+ * [initialDirectionId] resolved from the launch's anchor stop (null = whole route).
+ *
+ * [polylines] is the whole-route (merged, undirected) shape shown when no direction is selected;
+ * [polylinesByDirection] holds each direction's own shape (keyed by GTFS direction id, travel-ordered),
+ * shown once a direction is selected. Use [polylinesForDirection] to pick between them with the
+ * whole-route fallback.
  */
 data class RouteMap(
     val route: ObaRoute?,
@@ -37,9 +42,26 @@ data class RouteMap(
     val stops: List<RouteMapStop>,
     val routes: List<ObaRoute>,
     val polylines: List<List<GeoPoint>>,
+    val polylinesByDirection: Map<Int, List<List<GeoPoint>>>,
     val directions: List<RouteMapDirection>,
     val initialDirectionId: Int?,
-)
+) {
+    /**
+     * The shape to draw for [directionId], paired with whether it reads as directional. A selected
+     * direction with its own (travel-ordered) shape yields that shape with [DirectionShape.directional]
+     * true; the whole route ([directionId] null) or a direction that carried no shape of its own on the
+     * wire falls back to the merged [polylines] with [DirectionShape.directional] false — so arrows are
+     * never stamped on the undirected merged shape. Both facts come from one place, so they can't
+     * diverge. Pure; unit-tested.
+     */
+    fun shapeForDirection(directionId: Int?): DirectionShape {
+        val own = directionId?.let { polylinesByDirection[it]?.takeIf(List<*>::isNotEmpty) }
+        return DirectionShape(own ?: polylines, directional = own != null)
+    }
+}
+
+/** A route shape to draw and whether it's a single travel direction (so the renderer stamps arrows). */
+data class DirectionShape(val polylines: List<List<GeoPoint>>, val directional: Boolean)
 
 /**
  * Loads a route's stops + shapes (one-shot, stops-for-route with polylines) for the route/stop
@@ -71,8 +93,9 @@ class DefaultRouteMapRepository @Inject constructor(
                     agencyName = it.agencyName,
                     stops = it.stops,
                     routes = it.routes,
-                    polylines = it.polylines.map { line ->
-                        line.map { p -> GeoPoint(p.latitude, p.longitude) }
+                    polylines = it.polylines.map { line -> line.map(Location::toGeoPoint) },
+                    polylinesByDirection = it.polylinesByDirection.mapValues { (_, lines) ->
+                        lines.map { line -> line.map(Location::toGeoPoint) }
                     },
                     directions = it.directions,
                     initialDirectionId = it.stops.anchorDirectionId(directionStopId),

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/TripFocusController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/TripFocusController.kt
@@ -85,6 +85,8 @@ class TripFocusController(
                         color = routeColorArgb,
                         points = shape.points.map { it.toGeoPoint() },
                         widthDp = TRIP_LINE_WIDTH_DP,
+                        // A single trip shape runs one way; keep its travel-direction chevrons.
+                        directional = true,
                     )
                 )
             )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
@@ -56,13 +56,24 @@ data class MapPadding(val topPx: Int = 0, val bottomPx: Int = 0)
 const val DEFAULT_ROUTE_LINE_COLOR: Int = 0xFF0000FF.toInt()
 
 /**
- * One route/itinerary polyline: an ordered list of points and an optional [color]. The directional-arrow
- * stamp is a rendering detail added by the flavor renderer, so it isn't part of the state. A null [color]
+ * One route/itinerary polyline: an ordered list of points and an optional [color]. A null [color]
  * means "use the [DEFAULT_ROUTE_LINE_COLOR]" — choosing the fallback is a display decision, so producers
  * can pass a route's raw (possibly absent) GTFS color straight through and renderers draw [resolvedColor].
  * [widthDp] overrides the renderer's default line width when set (the trip-focus map draws a thicker line).
+ *
+ * [directional] asks the flavor renderer to stamp travel-direction arrows/chevrons along the line — set
+ * it only when [points] are ordered in the direction of travel and that orientation is meaningful (a
+ * single trip/leg shape, or a route narrowed to one selected direction). The whole-route merged shape,
+ * whose points aren't a single travel order, leaves it false so the line reads as undirected. Whether a
+ * renderer can honor it is flavor-specific (Google stamps a chevron texture; the maplibre classic
+ * annotation has no arrow support yet).
  */
-data class RoutePolyline(val color: Int?, val points: List<GeoPoint>, val widthDp: Float? = null) {
+data class RoutePolyline(
+    val color: Int?,
+    val points: List<GeoPoint>,
+    val widthDp: Float? = null,
+    val directional: Boolean = false,
+) {
     /** The [color] to draw, applying the [DEFAULT_ROUTE_LINE_COLOR] fallback in one place for every renderer. */
     val resolvedColor: Int get() = color ?: DEFAULT_ROUTE_LINE_COLOR
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/models/MapData.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/models/MapData.kt
@@ -31,6 +31,11 @@ data class NearbyStops(
  * into its render `GeoPoint`s. Each [RouteMapStop] carries the direction(s) it serves, so the overlay
  * can be narrowed to a single stop-relevant direction without a separate id index. [directions]
  * enumerates the route's selectable directions (id + headsign) so the header can offer a switch.
+ *
+ * [polylines] is the whole-route (merged, undirected) shape drawn when no direction is selected;
+ * [polylinesByDirection] holds each direction's own shape (keyed by GTFS [RouteMapDirection.directionId],
+ * travel-ordered, possibly several branches), drawn once that direction is selected. A direction absent
+ * from the map (no per-direction shape on the wire) falls back to [polylines].
  */
 data class RouteMapData(
     val route: ObaRoute?,
@@ -39,6 +44,7 @@ data class RouteMapData(
     val routes: List<ObaRoute>,
     val directions: List<RouteMapDirection>,
     val polylines: List<List<Location>>,
+    val polylinesByDirection: Map<Int, List<List<Location>>>,
 )
 
 /**

--- a/onebusaway-android/src/test/java/org/onebusaway/android/api/data/MapDataSourceDirectionsTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/api/data/MapDataSourceDirectionsTest.kt
@@ -17,6 +17,7 @@ package org.onebusaway.android.api.data
 
 import org.junit.Assert.assertEquals
 import org.junit.Test
+import org.onebusaway.android.api.contract.ShapeEntry
 import org.onebusaway.android.api.contract.StopGroup
 import org.onebusaway.android.api.contract.StopGroupName
 import org.onebusaway.android.api.contract.StopGrouping
@@ -25,8 +26,14 @@ import org.onebusaway.android.models.RouteMapDirection
 /** [directionsFrom] — building the route's selectable directions + stop membership from stop groups. */
 class MapDataSourceDirectionsTest {
 
-    private fun group(id: String?, names: List<String> = emptyList(), stopIds: List<String> = emptyList()) =
-        StopGroup(id = id, name = StopGroupName(names), stopIds = stopIds)
+    private fun group(
+        id: String?,
+        names: List<String> = emptyList(),
+        stopIds: List<String> = emptyList(),
+        polylines: List<ShapeEntry> = emptyList(),
+    ) = StopGroup(id = id, name = StopGroupName(names), stopIds = stopIds, polylines = polylines)
+
+    private fun shape(points: String) = ShapeEntry(points = points, length = points.length)
 
     private fun grouping(vararg groups: StopGroup) = StopGrouping(groups.toList())
 
@@ -93,5 +100,55 @@ class MapDataSourceDirectionsTest {
         assertEquals(setOf(1), result.directionsByStop["b"])
         assertEquals(setOf(0, 1), result.directionsByStop["shared"])
         assertEquals(null, result.directionsByStop["absent"])
+    }
+
+    @Test
+    fun polylinesAreCollectedPerDirection() {
+        val result = directionsFrom(
+            listOf(
+                grouping(
+                    group("0", polylines = listOf(shape("aaa"))),
+                    group("1", polylines = listOf(shape("bbb"), shape("ccc"))),
+                )
+            )
+        ).polylinesByDirection
+        assertEquals(listOf(shape("aaa")), result[0])
+        assertEquals(listOf(shape("bbb"), shape("ccc")), result[1])
+    }
+
+    @Test
+    fun polylinesAccumulateForADirectionSplitAcrossGroups() {
+        // A direction whose branches arrive in two groups keeps both, in order.
+        val result = directionsFrom(
+            listOf(
+                grouping(group("0", polylines = listOf(shape("aaa")))),
+                grouping(group("0", polylines = listOf(shape("bbb")))),
+            )
+        ).polylinesByDirection
+        assertEquals(listOf(shape("aaa"), shape("bbb")), result[0])
+    }
+
+    @Test
+    fun repeatedShapeAcrossGroupsIsKeptForDedupDownstream() {
+        // The same shape listed under one direction in two groups accumulates both here; the data
+        // source de-dups before decoding (so it isn't drawn twice). directionsFrom itself keeps both.
+        val result = directionsFrom(
+            listOf(
+                grouping(
+                    group("0", polylines = listOf(shape("aaa"))),
+                    group("0", polylines = listOf(shape("aaa"))),
+                )
+            )
+        ).polylinesByDirection
+        assertEquals(listOf(shape("aaa"), shape("aaa")), result[0])
+        assertEquals(listOf(shape("aaa")), result[0]!!.distinct())
+    }
+
+    @Test
+    fun directionWithoutPolylinesIsAbsentFromTheMap() {
+        // No group-level shape (e.g. an older server) leaves the direction out, so the caller falls back.
+        val result = directionsFrom(listOf(grouping(group("0", listOf("to Downtown")))))
+            .polylinesByDirection
+        assertEquals(null, result[0])
     }
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteDirectionFocusTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteDirectionFocusTest.kt
@@ -16,14 +16,19 @@
 package org.onebusaway.android.map
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.onebusaway.android.api.adapters.ObaStopElement
+import org.onebusaway.android.map.render.GeoPoint
 import org.onebusaway.android.models.RouteMapStop
 
 /**
  * [anchorDirectionId] (resolve the launch anchor stop → its direction) and [stopsForDirection]
- * (narrow a route's stops to a direction) — the pure repository/controller direction helpers.
+ * (narrow a route's stops to a direction) — the pure repository/controller direction helpers, plus
+ * [RouteMap.shapeForDirection] (pick the drawn shape + its directionality, with the whole-route fallback).
  */
 class RouteDirectionFocusTest {
 
@@ -89,5 +94,52 @@ class RouteDirectionFocusTest {
         // A stop serving both directions shows for the selected one (not dropped).
         val withShared = stops + stop("s", 0, 1)
         assertEquals(listOf("a", "b", "s"), withShared.stopsForDirection(0).map { it.id })
+    }
+
+    // ----- shapeForDirection -----
+
+    private val whole = listOf(listOf(GeoPoint(0.0, 0.0), GeoPoint(1.0, 1.0)))
+    private val dir0Shape = listOf(listOf(GeoPoint(2.0, 2.0)))
+
+    private fun routeMap(byDirection: Map<Int, List<List<GeoPoint>>>) = RouteMap(
+        route = null,
+        agencyName = null,
+        stops = emptyList(),
+        routes = emptyList(),
+        polylines = whole,
+        polylinesByDirection = byDirection,
+        directions = emptyList(),
+        initialDirectionId = null,
+    )
+
+    @Test
+    fun nullDirectionDrawsWholeRouteShapeUndirected() {
+        val shape = routeMap(mapOf(0 to dir0Shape)).shapeForDirection(null)
+        assertSame(whole, shape.polylines)
+        assertFalse(shape.directional)
+    }
+
+    @Test
+    fun selectedDirectionDrawsItsOwnShapeDirectional() {
+        val shape = routeMap(mapOf(0 to dir0Shape)).shapeForDirection(0)
+        assertSame(dir0Shape, shape.polylines)
+        assertTrue(shape.directional)
+    }
+
+    @Test
+    fun directionWithoutShapeFallsBackToWholeRouteUndirected() {
+        // A direction absent from the map (no per-direction shape on the wire) -> whole-route shape,
+        // drawn undirected so arrows are never stamped on the merged both-directions line.
+        val shape = routeMap(mapOf(0 to dir0Shape)).shapeForDirection(1)
+        assertSame(whole, shape.polylines)
+        assertFalse(shape.directional)
+    }
+
+    @Test
+    fun directionWithEmptyShapeFallsBackToWholeRouteUndirected() {
+        // An empty (present-but-blank) entry is treated the same as absent.
+        val shape = routeMap(mapOf(0 to emptyList())).shapeForDirection(0)
+        assertSame(whole, shape.polylines)
+        assertFalse(shape.directional)
     }
 }


### PR DESCRIPTION
Closes #1638. Follow-up to #1637.

### Problem

After #1637 added direction switching to the "show vehicles on map" route view, selecting a direction filtered the **stops** and the live **vehicles** but left the route **shape** as the whole route in both directions, drawn undirected — so the map showed one direction's stops/buses over a both-directions line with no sense of travel.

### What this does

When a direction is selected:

1. **Draws only that direction's segment** instead of the merged both-directions shape.
2. **Renders it with direction arrows** (chevrons) pointing the way that direction travels.

Whole-route (no direction selected) keeps the merged shape, drawn undirected.

### The per-direction shape is already on the wire

The worry in the issue was that `stops-for-route` might only give a merged/union polyline, forcing us to derive each direction's segment from ordered stops (a heuristic). It doesn't: **each `stopGroup` carries its own `polylines`** — travel-ordered, sometimes several branches — which the client was simply dropping. Verified against live `stops-for-route` data on the Puget Sound server:

- Per-direction groups return clean, travel-ordered shapes (a shape's first point sits within ~9 m of its direction's first ordered stop, last point within ~9 m of its last).
- The entry-level "merged" set is a fragmented union (5–79 tiny pieces), which is what we keep for the undirected whole-route view.

So this is source-of-truth driven, **no heuristics** (per the repo's no-heuristics rule).

### Implementation

- Decode `StopGroup.polylines` (contract model previously ignored it).
- Thread a `polylinesByDirection` map through `RouteMapData` → `RouteMap`.
- `RouteMap.shapeForDirection(directionId)` returns the shape to draw **and** whether it's a single travel direction, from one place so the two can't diverge; falls back to the merged whole-route shape (undirected) when a direction carried no shape of its own (older servers).
- `RouteMapController` re-pushes the narrowed shape on load **and** on every direction switch (it previously never updated polylines on a switch).
- `RoutePolyline` gains a `directional` flag; `GoogleMapRenderer` stamps its chevron texture only when set. Trip-focus and directions-leg polylines opt in to preserve their existing arrows.

### Flavors

- **Google**: full feature (segment + arrows).
- **MapLibre**: honors the direction narrowing (correct single-direction segment), but no arrows yet — its classic annotation API has no line-symbol support. Tracked as a follow-up.

### Interlining note

Some routes (e.g. KC Metro 45, which interlines with the 75) have asymmetric directions where one direction legitimately doesn't serve a section the other does. This change makes the map reflect that honestly, instead of the old merged line running through stops that direction doesn't serve. Filed #1691 to explore surfacing an explicit interlining signal.

### Testing

- Unit tests for `directionsFrom` per-direction polyline accumulation (incl. split-across-groups and de-dup) and `RouteMap.shapeForDirection` (selection, whole-route fallback, empty-shape fallback, directionality).
- Both `obaGoogleDebug` and the MapLibre flavor compile; unit tests pass.
- On-device: installed and exercised on the route-vehicles map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QTT8Mbj5ZAoe6EptF2Lpu4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Route maps now support direction-specific shapes, so selected directions can display the correct travel-ordered path.
  * Trip and directions views now show directional chevrons on route lines when applicable.
  * Route line rendering now updates immediately when switching directions, without reloading data.

* **Bug Fixes**
  * Improved fallback behavior to show the full route shape when a direction-specific shape isn’t available.
  * Route shapes are now displayed more consistently across map views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->