### PR TITLE
Enable core-library desugaring (java.time on minSdk 23)

### DIFF
--- a/onebusaway-android/build.gradle
+++ b/onebusaway-android/build.gradle
@@ -139,6 +139,8 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
+        // Backport java.time.* (API 26) to minSdk 23. See issue #1693.
+        coreLibraryDesugaringEnabled true
     }
     kotlin {
         compilerOptions {
@@ -222,6 +224,8 @@ configurations {
 }
 
 dependencies {
+    // Core library desugaring: backports java.time.* to minSdk 23 (issue #1693)
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.5'
     // Firebase Analytics
     implementation 'com.google.firebase:firebase-core:21.1.1'
     implementation 'com.google.firebase:firebase-analytics:22.1.2'


### PR DESCRIPTION
Fixes #1693.

## Problem

The app uses `java.time.*` (API 26) with `minSdkVersion 23` and **no core-library desugaring** configured anywhere in the repo — introduced by the `directions/` modernization (#1625 / PR #1677). It compiles because compilation targets `compileSdk`, but on a real Android 6.0–7.1 device (API 23–25) this is a **runtime crash** (`NoClassDefFoundError` / `NoSuchMethodError`). Lint's `NewApi` check reported **67 errors**.

## Change

`onebusaway-android/build.gradle`:
- `coreLibraryDesugaringEnabled true` in `compileOptions`
- `coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.5'` in `dependencies`

This backports `java.time.*` to API 23, legitimizing the existing migration repo-wide.

## Verification

- `lintObaGoogleDebug`: `NewApi` errors **67 → 0** (the one remaining lint error is a pre-existing, unrelated Compose `LocalContextGetResourceValueCall`).
- `assembleObaGoogleDebug`: BUILD SUCCESSFUL.

## Notes

- Should land **before** the CI-lint gate (#1692) so `NewApi` enforcement starts from a green baseline for `java.time`.
- Unblocks the ConversionUtils `java.time` port (#1690), to be rebased onto the desugared `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Android build compatibility for devices targeting a lower minimum SDK, helping the app run more reliably on older Android versions.
  * Enabled support for newer Java language features during builds without changing app behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->