### PR TITLE
Fix garbage ETA for closed-stop arrivals with suppressed predictions (#1687)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/adapters/ArrivalAdapters.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/adapters/ArrivalAdapters.kt
@@ -26,6 +26,15 @@ import org.onebusaway.android.time.ServerTime
 /** Adapts a modernized [ArrivalDeparture] DTO (arrivals fetch) to the [ArrivalData] model. */
 internal fun ArrivalDeparture.asArrivalData(): ArrivalData = DtoArrivalData(this)
 
+/**
+ * A closed (or otherwise suppressed) stop keeps `predicted:true` but replaces the near-term
+ * prediction with a non-positive sentinel — observed `-1` and `0` for stop `1_82673` in issue #1687.
+ * Collapse any non-positive predicted instant to the single canonical "no prediction" value `0`
+ * here at the wire→domain boundary, so downstream `!= 0` / `> 0` guards all see one sentinel and a
+ * `-1` can never be treated as a real epoch-millis timestamp.
+ */
+private fun predictedOrAbsent(epochMs: Long): Long = if (epochMs > 0L) epochMs else 0L
+
 private class DtoArrivalData(private val d: ArrivalDeparture) : ArrivalData {
     override val routeId get() = d.routeId
     override val tripId get() = d.tripId
@@ -39,9 +48,9 @@ private class DtoArrivalData(private val d: ArrivalDeparture) : ArrivalData {
     override val predicted get() = d.predicted
     // Wire→server mint: these are the server clock, already epoch millis.
     override val scheduledArrivalTime get() = ServerTime(d.scheduledArrivalTime)
-    override val predictedArrivalTime get() = ServerTime(d.predictedArrivalTime)
+    override val predictedArrivalTime get() = ServerTime(predictedOrAbsent(d.predictedArrivalTime))
     override val scheduledDepartureTime get() = ServerTime(d.scheduledDepartureTime)
-    override val predictedDepartureTime get() = ServerTime(d.predictedDepartureTime)
+    override val predictedDepartureTime get() = ServerTime(predictedOrAbsent(d.predictedDepartureTime))
     override val status get() = d.tripStatus?.status?.let { Status.fromString(it) }
     override val frequency
         get() = d.frequency?.let { FrequencyWindow(ServerTime(it.startTime), ServerTime(it.endTime), it.headway) }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalInfo.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalInfo.kt
@@ -103,7 +103,7 @@ class ArrivalInfo(
 
     /** The departure time to set a reminder for: the predicted time if known, else the scheduled. */
     val reminderDepartureTime: Long
-        get() = if (data.predictedDepartureTime.epochMs != 0L) data.predictedDepartureTime.epochMs
+        get() = if (data.predictedDepartureTime.epochMs > 0L) data.predictedDepartureTime.epochMs
         else data.scheduledDepartureTime.epochMs
 
     /** Flattens this arrival into the report flow's scalar context (was ObaArrivalInfo-based). */
@@ -116,7 +116,11 @@ class ArrivalInfo(
         vehicleId = data.vehicleId,
         stopId = data.stopId,
         serviceDate = data.serviceDate,
-        predicted = data.predicted,
+        // The normalized flag (data.predicted AND a positive predicted instant), not the raw
+        // server flag: at a closed stop the server keeps predicted:true but suppresses the
+        // instants to 0 (issue #1687), and the report builder branches on this to pick the
+        // predicted vs scheduled times — the raw flag would format Date(0) as a 1969 garbage time.
+        predicted = predicted,
         predictedArrivalTime = data.predictedArrivalTime.epochMs,
         predictedDepartureTime = data.predictedDepartureTime.epochMs,
         scheduledArrivalTime = data.scheduledArrivalTime.epochMs,
@@ -150,7 +154,13 @@ class ArrivalInfo(
         val scheduledMins = scheduled.epochMs / MS_IN_MINS
         val predictedMins = predictedTime.epochMs / MS_IN_MINS
 
-        if (data.predicted) {
+        // A prediction is only usable when the server actually gave us a positive instant. A closed
+        // stop keeps `predicted:true` but suppresses the near-term prediction to a non-positive
+        // sentinel (normalized to 0 at the wire→domain boundary, issue #1687); keying the ETA off the
+        // boolean alone would subtract a 0 timestamp from "now" and render garbage (~ -29,718,596 min).
+        val hasPrediction = data.predicted && predictedTime.epochMs > 0L
+
+        if (hasPrediction) {
             predicted = true
             eta = predictedMins - nowMins
             displayTime = predictedTime.epochMs
@@ -163,7 +173,7 @@ class ArrivalInfo(
         color = ArrivalInfoUtils.computeColor(scheduledMins, predictedMins)
 
         statusText = computeStatusLabel(
-            context, now, predictedTime, scheduledMins, predictedMins,
+            context, now, hasPrediction, scheduledMins, predictedMins,
             includeArrivalDepartureInStatusLabel
         )
         timeText = computeTimeLabel(context)
@@ -186,7 +196,7 @@ class ArrivalInfo(
     private fun computeStatusLabel(
         context: Context?,
         now: ServerTime,
-        predictedTime: ServerTime,
+        hasPrediction: Boolean,
         scheduledMins: Long,
         predictedMins: Long,
         includeArrivalDeparture: Boolean
@@ -231,7 +241,7 @@ class ArrivalInfo(
             return context.getString(statusLabelId, headwayAsMinutes, label)
         }
 
-        if (predictedTime.epochMs != 0L) {
+        if (hasPrediction) {
             // Real-time info
             var delay = predictedMins - scheduledMins
 

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/ArrivalInfoTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/ArrivalInfoTest.kt
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.arrivals
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.onebusaway.android.models.ArrivalData
+import org.onebusaway.android.models.FrequencyWindow
+import org.onebusaway.android.models.Occupancy
+import org.onebusaway.android.models.Status
+import org.onebusaway.android.time.ServerTime
+
+/**
+ * JVM unit tests for [ArrivalInfo]'s numeric ETA/display projection (issue #1687).
+ *
+ * A closed stop keeps `predicted:true` but suppresses the near-term prediction to a non-positive
+ * sentinel (observed `-1` and `0`). The pre-#1687 logic keyed the ETA off the `predicted` boolean
+ * alone, so it subtracted a ~0 timestamp from "now" and rendered a garbage `~ -29,718,596 min` ETA
+ * (and a bogus "early" status for `-1` / a "Scheduled" label with a garbage time for `0`).
+ *
+ * `context` is null here so the resource-backed status/time strings collapse to "" — this exercises
+ * the pure `eta`/`displayTime`/`predicted` computation, which is where the bug lived.
+ */
+class ArrivalInfoTest {
+
+    /** ~2026-04-13, matching the issue's `currentTime ≈ 1783116081756`. */
+    private val now = ServerTime(1_783_116_081_756L)
+
+    /** A valid scheduled arrival ~50 min out, mirroring the issue's `scheduledArrivalTime`. */
+    private val scheduledArrival = 1_783_119_110_000L
+
+    private fun arrival(
+        predicted: Boolean,
+        predictedArrivalTime: Long,
+        scheduledArrivalTime: Long = scheduledArrival,
+    ): ArrivalData = FakeArrivalData(
+        predicted = predicted,
+        predictedArrivalTime = ServerTime(predictedArrivalTime),
+        scheduledArrivalTime = ServerTime(scheduledArrivalTime),
+    )
+
+    private fun infoFor(data: ArrivalData) = ArrivalInfo(
+        context = null,
+        data = data,
+        now = now,
+        includeArrivalDepartureInStatusLabel = false,
+        favorite = false,
+    )
+
+    @Test
+    fun `predicted true with a minus-one sentinel falls back to the scheduled time`() {
+        val info = infoFor(arrival(predicted = true, predictedArrivalTime = -1L))
+
+        assertFalse("a -1 predicted sentinel is not a real prediction", info.predicted)
+        assertEquals("displayTime falls back to the scheduled instant", scheduledArrival, info.displayTime)
+        // ETA is scheduled - now (~50 min), never the ~ -29,718,596 min garbage.
+        assertEquals(scheduledArrival / 60_000 - now.epochMs / 60_000, info.eta)
+        assertTrue("ETA is a sane near-future value", info.eta in 0..120)
+    }
+
+    @Test
+    fun `predicted true with a zero sentinel falls back to the scheduled time`() {
+        val info = infoFor(arrival(predicted = true, predictedArrivalTime = 0L))
+
+        assertFalse("a 0 predicted sentinel is not a real prediction", info.predicted)
+        assertEquals(scheduledArrival, info.displayTime)
+        assertEquals(scheduledArrival / 60_000 - now.epochMs / 60_000, info.eta)
+        assertTrue("ETA is a sane near-future value", info.eta in 0..120)
+    }
+
+    @Test
+    fun `a genuine positive prediction is still honored`() {
+        val predictedArrival = 1_783_119_500_000L // slightly later than scheduled
+        val info = infoFor(arrival(predicted = true, predictedArrivalTime = predictedArrival))
+
+        assertTrue(info.predicted)
+        assertEquals(predictedArrival, info.displayTime)
+        assertEquals(predictedArrival / 60_000 - now.epochMs / 60_000, info.eta)
+    }
+
+    @Test
+    fun `an unpredicted arrival uses the scheduled time`() {
+        val info = infoFor(arrival(predicted = false, predictedArrivalTime = 0L))
+
+        assertFalse(info.predicted)
+        assertEquals(scheduledArrival, info.displayTime)
+        assertEquals(scheduledArrival / 60_000 - now.epochMs / 60_000, info.eta)
+    }
+
+    @Test
+    fun `report context carries the normalized predicted flag for a suppressed prediction`() {
+        // Closed stop: server keeps predicted:true but suppresses the instant to a sentinel. The
+        // report builder branches on TripReportContext.predicted to pick predicted vs scheduled
+        // times, so it must see false here — otherwise it formats Date(0) as a 1969 garbage time.
+        val info = infoFor(arrival(predicted = true, predictedArrivalTime = -1L))
+
+        assertFalse("suppressed prediction is not real-time in the report", info.toTripReportContext().predicted)
+    }
+
+    @Test
+    fun `report context carries the normalized predicted flag for a genuine prediction`() {
+        val info = infoFor(arrival(predicted = true, predictedArrivalTime = 1_783_119_500_000L))
+
+        assertTrue("a genuine prediction stays real-time in the report", info.toTripReportContext().predicted)
+    }
+}
+
+/** Minimal [ArrivalData] stub; only the arrival-time fields matter for these ETA assertions. */
+private data class FakeArrivalData(
+    override val predicted: Boolean,
+    override val predictedArrivalTime: ServerTime,
+    override val scheduledArrivalTime: ServerTime,
+    override val routeId: String = "1_100",
+    override val tripId: String = "1_trip",
+    override val stopId: String = "1_82673",
+    override val headsign: String? = "Downtown",
+    override val shortName: String? = "230",
+    override val routeLongName: String? = null,
+    override val stopSequence: Int = 5,
+    override val serviceDate: Long = 0L,
+    override val vehicleId: String? = null,
+    override val scheduledDepartureTime: ServerTime = ServerTime(0L),
+    override val predictedDepartureTime: ServerTime = ServerTime(0L),
+    override val status: Status? = null,
+    override val frequency: FrequencyWindow? = null,
+    override val historicalOccupancy: Occupancy? = null,
+    override val predictedOccupancy: Occupancy? = null,
+    override val hasTripStatus: Boolean = false,
+    override val scheduleDeviation: Long = 0L,
+    override val lastKnownLat: Double? = null,
+    override val lastKnownLon: Double? = null,
+) : ArrivalData


### PR DESCRIPTION
Fixes #1687 (Bug 1).

## Problem

At a stop with a "stop closed" service alert, the server keeps `predicted:true` but suppresses the near-term prediction to a **non-positive sentinel** (observed `-1` and `0`). `ArrivalInfo` selected the ETA purely off the `predicted` boolean, so it subtracted a ~0 epoch timestamp from "now" and rendered a garbage `~ -29,718,596 min` ETA — plus a bogus "N min early" status for `-1`, or a "Scheduled" label paired with a garbage time for `0`.

## Fix

- **Normalize at the wire→domain boundary** (`ArrivalAdapters`): a `predictedOrAbsent` helper collapses any non-positive predicted instant to the single canonical "no prediction" value `0`, so both `-1` and `0` are handled in one place and a `-1` can never be treated as a real epoch-millis timestamp (per CLAUDE.md's "normalize units/shape at the wire boundary" guidance).
- **`ArrivalInfo`** now treats a prediction as usable only when the predicted instant is positive (`data.predicted && predictedTime > 0`). ETA, display time, and the status label all branch on that one flag, so a suppressed arrival cleanly falls back to the scheduled time / "Scheduled" label instead of garbage.
- **Harden `reminderDepartureTime`** against the `-1` sentinel (`> 0`, not `!= 0`) — otherwise it would set a reminder at epoch −1.
- **JVM unit tests** for `ArrivalInfo` covering `predicted=true` with `predictedArrivalTime` of `-1` and `0`, plus a genuine positive prediction and an unpredicted arrival.

## Acceptance criteria

- ✅ Closed-stop arrivals with a non-positive predicted time never show a garbage ETA — they render as scheduled.
- ✅ Added the requested JVM unit test.

## Note: Bug 1 fix widens the Bug 2 surface

Issue #1687 also describes **Bug 2** (a healthy far-out arrival appearing at a closed stop with no closure cue on the row), which it explicitly defers to a product decision. This PR does **not** address Bug 2, and reviewers should be aware it makes the Bug 2 symptom slightly more prevalent:

Previously, a closed-stop entry with a `-1` sentinel had a garbage negative ETA and so was dropped by `convertArrivals`' `eta >= 0` filter (for users who disable "show negative arrivals"). Now that its ETA is a sane positive scheduled value, that row surfaces as a normal-looking "N min"/"Scheduled" arrival — with the closure still shown only as a separate banner. This is the intended "render sanely" outcome for Bug 1, but it means fixing the garbage ETA un-hides these rows. A follow-up (e.g. surfacing per-arrival `situationIds` on the row, or annotating/suppressing arrivals at a closed stop) is the natural home for Bug 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved arrival handling so invalid or non-positive predicted times are treated as unavailable, preventing them from showing as real-time.
  * Arrivals, reminder selection, and status/ETA labeling now consistently fall back to scheduled times when predictions are suppressed, and the reported “predicted” flag matches usability.

* **Tests**
  * Added/expanded unit tests for predicted, unpredicted, and sentinel predicted-time cases to verify display time, ETA calculations, and trip report context behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->