### PR TITLE
Show a per-arrival service-alert indicator on arrival rows (#1687 Bug 2)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/adapters/ArrivalAdapters.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/adapters/ArrivalAdapters.kt
@@ -43,6 +43,7 @@ private class DtoArrivalData(private val d: ArrivalDeparture) : ArrivalData {
     override val scheduledDepartureTime get() = ServerTime(d.scheduledDepartureTime)
     override val predictedDepartureTime get() = ServerTime(d.predictedDepartureTime)
     override val status get() = d.tripStatus?.status?.let { Status.fromString(it) }
+    override val situationIds get() = d.situationIds
     override val frequency
         get() = d.frequency?.let { FrequencyWindow(ServerTime(it.startTime), ServerTime(it.endTime), it.headway) }
     override val historicalOccupancy get() = Occupancy.fromString(d.historicalOccupancy)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/models/ArrivalData.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/models/ArrivalData.kt
@@ -40,6 +40,9 @@ interface ArrivalData {
     val predictedDepartureTime: ServerTime
     val status: Status?
     val frequency: FrequencyWindow?
+    /** Ids of the service alerts (situations) that reference this specific arrival, resolved against
+     *  the response's references pool. Empty when the arrival carries no per-trip alert. */
+    val situationIds: List<String>
     val historicalOccupancy: Occupancy?
     val predictedOccupancy: Occupancy?
     /** Real-time fields, for the report context; defaults when there is no trip status. */

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalInfo.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalInfo.kt
@@ -101,6 +101,9 @@ class ArrivalInfo(
     val serviceDate: Long get() = data.serviceDate
     val vehicleId: String? get() = data.vehicleId
 
+    /** The service-alert (situation) ids that reference this specific arrival; empty when none. */
+    val situationIds: List<String> get() = data.situationIds
+
     /** The departure time to set a reminder for: the predicted time if known, else the scheduled. */
     val reminderDepartureTime: Long
         get() = if (data.predictedDepartureTime.epochMs != 0L) data.predictedDepartureTime.epochMs

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsRepository.kt
@@ -80,6 +80,14 @@ internal fun planActiveAlerts(
             )
         }
 
+/**
+ * The representative *active* service-alert id for an arrival: the first of the arrival's referenced
+ * [situationIds] that is currently active, or null when none apply. Drives the per-row alert
+ * indicator (issue #1687 Bug 2) so a row lights up only for an alert the banner is also surfacing.
+ */
+internal fun activeAlertFor(situationIds: List<String>, activeSituationIds: Set<String>): String? =
+    situationIds.firstOrNull { it in activeSituationIds }
+
 /** Maps an ObaSituation severity onto the three banner styles, matching the legacy SituationAlert. */
 internal fun severityOf(severity: String?): AlertSeverity = when (severity) {
     ObaSituation.SEVERITY_NO_IMPACT -> AlertSeverity.INFO
@@ -339,10 +347,12 @@ class DefaultArrivalsRepository @Inject constructor(
         val routeOptions = buildRouteFilterOptions(snapshot, stop, routeFilter)
         // Pure grouping; no store write. Hidden state is derived in the ViewModel from [alertHideState]
         // plus [ArrivalsData.hideAlertsByDefault], so nothing on the load path can race the snapshot.
-        val activeAlerts = planActiveAlerts(
-            situations = snapshot.situations(ArrayList(routeFilter)),
-            isActive = { SituationUtils.isActiveWindowForSituation(it, now) }
-        )
+        val situations = snapshot.situations(ArrayList(routeFilter))
+        val isActive = { s: ObaSituation -> SituationUtils.isActiveWindowForSituation(s, now) }
+        val activeAlerts = planActiveAlerts(situations, isActive)
+        // The situation ids that are active right now, so a per-arrival alert indicator lights up
+        // only for currently-active alerts — matching the banner's active set (issue #1687 Bug 2).
+        val activeSituationIds = situations.filter(isActive).mapTo(HashSet()) { it.id }
         return ArrivalsData(
             arrivals = arrivals,
             header = header,
@@ -350,7 +360,7 @@ class DefaultArrivalsRepository @Inject constructor(
             style = style,
             isStale = isStale,
             effectiveRouteFilter = routeFilter,
-            actions = buildActions(snapshot, arrivals),
+            actions = buildActions(snapshot, arrivals, activeSituationIds),
             activeAlerts = activeAlerts,
             hideAlertsByDefault =
                 preferences.getBoolean(R.string.preference_key_hide_alerts, false),
@@ -374,7 +384,8 @@ class DefaultArrivalsRepository @Inject constructor(
     /** Precomputes the navigation/dialog data for each arrival (legacy reads these on menu tap). */
     private fun buildActions(
         snapshot: StopArrivals,
-        arrivals: List<ArrivalInfo>
+        arrivals: List<ArrivalInfo>,
+        activeSituationIds: Set<String>
     ): Map<String, ArrivalActions> = arrivals.associate { arrival ->
         val route = snapshot.route(arrival.routeId)
         arrival.tripId to ArrivalActions(
@@ -387,7 +398,8 @@ class DefaultArrivalsRepository @Inject constructor(
             scheduleUrl = route?.url,
             agencyName = route?.agencyId?.let { snapshot.agencyName(it) },
             blockId = snapshot.trip(arrival.tripId)?.blockId,
-            isRouteFavorite = arrival.isRouteAndHeadsignFavorite
+            isRouteFavorite = arrival.isRouteAndHeadsignFavorite,
+            alertSituationId = activeAlertFor(arrival.situationIds, activeSituationIds)
         )
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsScreen.kt
@@ -137,7 +137,8 @@ internal fun rememberArrivalRowCallbacks(
         onSetReminder = handler::onSetReminder,
         onShowOnlyRoute = viewModel::showOnlyRoute,
         onShowRouteSchedule = handler::onShowRouteSchedule,
-        onReportArrivalProblem = handler::onReportArrivalProblem
+        onReportArrivalProblem = handler::onReportArrivalProblem,
+        onShowAlert = handler::onShowAlert
     )
 }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsUiState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsUiState.kt
@@ -41,7 +41,10 @@ data class ArrivalActions(
     val scheduleUrl: String?,
     val agencyName: String?,
     val blockId: String?,
-    val isRouteFavorite: Boolean
+    val isRouteFavorite: Boolean,
+    /** The representative *active* service-alert id affecting this arrival, or null when none —
+     *  drives the per-row alert indicator and the situation it opens on tap (issue #1687 Bug 2). */
+    val alertSituationId: String? = null
 )
 
 /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
@@ -81,7 +81,9 @@ class ArrivalRowCallbacks(
     val onSetReminder: (ArrivalInfo) -> Unit,
     val onShowOnlyRoute: (String) -> Unit,
     val onShowRouteSchedule: (String) -> Unit,
-    val onReportArrivalProblem: (ArrivalActions) -> Unit
+    val onReportArrivalProblem: (ArrivalActions) -> Unit,
+    /** Opens the service-alert dialog for the given situation id (the per-row alert indicator). */
+    val onShowAlert: (String) -> Unit
 )
 
 /**
@@ -147,7 +149,8 @@ private fun ArrivalRowVisual(
     eta: Long,
     predicted: Boolean,
     canceled: Boolean,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    onAlertClick: (() -> Unit)? = null
 ) {
     val decoration = strikeThroughIf(canceled)
     Row(modifier = modifier, verticalAlignment = Alignment.CenterVertically) {
@@ -178,15 +181,36 @@ private fun ArrivalRowVisual(
                 )
             }
         }
+        if (onAlertClick != null) {
+            ArrivalAlertIndicator(onClick = onAlertClick)
+        }
         Spacer(Modifier.width(8.dp))
         EtaContent(eta, statusColor, predicted, canceled)
     }
 }
 
-/** Adapts the [ArrivalInfo] display model onto [ArrivalRowVisual]. Shared by the interactive Style
- *  A row and the report-flow picker (which wrap it with their own click + card). */
+/** The tappable per-row service-alert indicator (issue #1687 Bug 2): the same warning glyph the
+ *  header/banner uses, shown when this arrival is affected by an active alert; taps open its dialog. */
 @Composable
-internal fun ArrivalRowContent(arrival: ArrivalInfo, modifier: Modifier = Modifier) {
+internal fun ArrivalAlertIndicator(onClick: () -> Unit, modifier: Modifier = Modifier) {
+    IconButton(onClick = onClick, modifier = modifier) {
+        Icon(
+            painter = painterResource(R.drawable.baseline_warning_24),
+            contentDescription = stringResource(R.string.stop_info_arrival_service_alert),
+            tint = MaterialTheme.colorScheme.error
+        )
+    }
+}
+
+/** Adapts the [ArrivalInfo] display model onto [ArrivalRowVisual]. Shared by the interactive Style
+ *  A row and the report-flow picker (which wrap it with their own click + card). [onAlertClick] adds
+ *  the tappable alert indicator when the arrival is affected by an active alert (null hides it). */
+@Composable
+internal fun ArrivalRowContent(
+    arrival: ArrivalInfo,
+    modifier: Modifier = Modifier,
+    onAlertClick: (() -> Unit)? = null
+) {
     ArrivalRowVisual(
         shortName = arrival.shortName.orEmpty(),
         headsign = arrival.headsign.orEmpty(),
@@ -196,7 +220,8 @@ internal fun ArrivalRowContent(arrival: ArrivalInfo, modifier: Modifier = Modifi
         eta = arrival.eta,
         predicted = arrival.predicted,
         canceled = arrival.status == Status.CANCELED,
-        modifier = modifier
+        modifier = modifier,
+        onAlertClick = onAlertClick
     )
 }
 
@@ -223,9 +248,13 @@ fun ArrivalRowStyleA(
             ArrivalActionsMenu(expanded, { expanded = false }, arrival, actions, filterActive, callbacks)
         }
     ) {
-        ArrivalRowContent(arrival, Modifier.fillMaxWidth())
+        ArrivalRowContent(arrival, Modifier.fillMaxWidth(), alertClick(actions, callbacks))
     }
 }
+
+/** The alert-indicator tap for a row: opens the arrival's active alert, or null when it has none. */
+internal fun alertClick(actions: ArrivalActions?, callbacks: ArrivalRowCallbacks): (() -> Unit)? =
+    actions?.alertSituationId?.let { id -> { callbacks.onShowAlert(id) } }
 
 /**
  * The Style A card scaffold: the row content with a small favorite star tucked into the top-left

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalsPanel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalsPanel.kt
@@ -261,6 +261,7 @@ private fun PeekRow(
         isFavorite = actions?.isRouteFavorite == true,
         onFavorite = { actions?.let { callbacks.onRouteFavorite(it) } },
         onMore = { expanded = true },
+        onAlertClick = alertClick(actions, callbacks),
         etaModifier = etaModifier,
         starModifier = starModifier,
         menu = {
@@ -309,6 +310,7 @@ private fun PeekRowVisual(
     modifier: Modifier = Modifier,
     etaModifier: Modifier = Modifier,
     starModifier: Modifier = Modifier,
+    onAlertClick: (() -> Unit)? = null,
     menu: @Composable () -> Unit = {}
 ) {
     Row(
@@ -339,6 +341,9 @@ private fun PeekRowVisual(
             overflow = TextOverflow.Ellipsis,
             modifier = Modifier.weight(1f)
         )
+        if (onAlertClick != null) {
+            ArrivalAlertIndicator(onClick = onAlertClick)
+        }
         Spacer(Modifier.width(8.dp))
         EtaPill(eta, etaColor, predicted, modifier = etaModifier)
         Box {

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -234,6 +234,7 @@
     <string name="stop_info_option_report_problem">Report stop problem</string>
     <string name="stop_info_option_night_light">Night light</string>
     <string name="stop_info_option_hide_alerts">Hide active alerts</string>
+    <string name="stop_info_arrival_service_alert">View service alert for this arrival</string>
     <string name="stop_info_nodata_minutes">No arrivals in the next %1$d min.</string>
     <string name="stop_info_nodata_minutes_short_format">%1$d+ min</string>
     <plurals name="stop_info_nodata_hours_minutes">

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/ActiveAlertForTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/ActiveAlertForTest.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.arrivals
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Unit tests for [activeAlertFor], the pure mapping that picks the representative active alert for an
+ * arrival's per-row indicator (issue #1687 Bug 2). The row lights up only for an alert that is also
+ * active in the banner set, so a row can't show a cue for an expired/unreferenced situation.
+ */
+class ActiveAlertForTest {
+
+    @Test
+    fun `an arrival with no situations has no alert`() {
+        assertNull(activeAlertFor(emptyList(), activeSituationIds = setOf("1")))
+    }
+
+    @Test
+    fun `a referenced active situation is the row's alert`() {
+        assertEquals("1", activeAlertFor(listOf("1"), activeSituationIds = setOf("1", "2")))
+    }
+
+    @Test
+    fun `a referenced but inactive situation does not light the row`() {
+        // The closure alert has expired out of the active set — the row must show no cue for it.
+        assertNull(activeAlertFor(listOf("1"), activeSituationIds = emptySet()))
+    }
+
+    @Test
+    fun `the first active referenced situation wins when several apply`() {
+        // Arrival references 3 alerts; only 2 are active. The first active one in the arrival's order
+        // represents the row (and is what the tap opens).
+        assertEquals(
+            "b",
+            activeAlertFor(listOf("a", "b", "c"), activeSituationIds = setOf("b", "c"))
+        )
+    }
+}


### PR DESCRIPTION
Addresses #1687 (Bug 2). Independent of the Bug 1 PR (#1696); both touch the arrivals model, but this branches off `main`.

## Problem

Arrival rows never reflected service alerts — a stop closure was surfaced only as a separate banner at the top of the list. So a healthy far-out arrival (e.g. "114 min") could appear at a **closed** stop with no cue on the row itself that anything is wrong.

## Why not "detect the closure and suppress/flag the row"

The API gives us per-arrival `situationIds`, but **no explicit "stop closed" signal** — `severity` is only a graded scale (`unknown`→`verySevere`) and `reason`/`consequences` don't encode "no service." Positively classifying a *closure* would mean string-matching the alert text or guessing from severity, i.e. a heuristic, which CLAUDE.md ("No unsanctioned heuristics") forbids without a human sign-off gate. So this PR surfaces the alert **generically** instead of inventing a closure classifier.

## What this does

- **Carry per-arrival `situationIds` through the model.** `ArrivalData` (+ its wire adapter) and `ArrivalInfo` now expose the situation ids that reference each arrival.
- **Resolve the representative active alert per arrival.** The repository computes `activeAlertFor(...)` from the *same active set the banner uses*, and stamps it onto `ArrivalActions.alertSituationId`.
- **Render a tappable indicator.** The flat Style-A row and the drawer peek row show a warning glyph (the same icon the header/banner uses, `baseline_warning_24` tinted `colorScheme.error`) when an arrival is affected by an active alert. Tapping it opens the existing service-alert dialog through the current `onShowAlert` handler — no new dialog plumbing.
- **Test.** A JVM unit test for `activeAlertFor` (referenced-and-active only; first active wins; null when none apply).

The indicator lights up **only for currently-active alerts**, so a row can never show a cue for an expired or unreferenced situation — it stays consistent with the banner's active set.

```
230  Downtown            50 min
     Arriving at 4:27 PM   ⚠   ← tap → "Stop #82673 is closed through Fri Aug 28"
```

## Verification

Compile + resource processing + unit tests pass. The visual/tap behavior is UI-facing and best confirmed on-device (open a stop with an active alert — e.g. `1_82673` — and check the ⚠ on affected rows opens the alert).

## Notes

- No attempt to detect "closed" specifically (see above) — this is the CLAUDE.md-clean option chosen deliberately.
- The report-flow arrivals picker reuses `ArrivalRowContent` but passes no alert click, so it's unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
