### PR TITLE
Replace the report screen's imperative marker reconcile with a DisposableEffect

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/InfrastructureIssueScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/InfrastructureIssueScreen.kt
@@ -99,7 +99,6 @@ import org.onebusaway.android.ui.report.infrastructure.GeoPoint
 import org.onebusaway.android.ui.report.infrastructure.InfrastructureControls
 import org.onebusaway.android.ui.report.infrastructure.InfrastructureIssueEvent
 import org.onebusaway.android.ui.report.infrastructure.InfrastructureIssueViewModel
-import org.onebusaway.android.ui.report.infrastructure.IssueLocation
 import org.onebusaway.android.ui.report.infrastructure.ReportTarget
 import org.onebusaway.android.ui.nav.NavRoutes
 import org.onebusaway.android.ui.report.open311.DefaultOpen311Repository
@@ -151,10 +150,6 @@ fun InfrastructureIssueDestination(
         }
     )
 
-    // The single manual marker reconciled from the ViewModel's markerLocation (an effect-held id, so
-    // it survives recomposition but not the destination leaving — which is correct).
-    val markerId = remember { intArrayOf(NO_MARKER) }
-
     // The "report submitted" dialog (Tier 1: was ReportSuccessDialog, a DialogFragment).
     var showSuccess by remember { mutableStateOf(false) }
 
@@ -190,13 +185,6 @@ fun InfrastructureIssueDestination(
         }
     }
 
-    // Reconcile the single manual marker.
-    LaunchedEffect(viewModel) {
-        viewModel.uiState.map { it.markerLocation }.distinctUntilChanged().collect { location ->
-            reconcileMarker(mapViewModel, markerId, location)
-        }
-    }
-
     // Loading-services progress drives the destination's local progress overlay.
     LaunchedEffect(viewModel) {
         viewModel.uiState.map { it.loadingServices }.distinctUntilChanged().collect { loading ->
@@ -225,6 +213,15 @@ fun InfrastructureIssueDestination(
     // Back: if a form/picker is showing, drop the spinner back to the hint (and clear the form);
     // otherwise pop the whole destination. Mirrors the former onBackPressed + form back-stack.
     val state by viewModel.uiState.collectAsStateWithLifecycle()
+
+    // The single manual pin IS the current markerLocation: for each value a marker exists, and it's
+    // disposed when the value changes or the destination leaves. Keyed on the (value-equal) location,
+    // so the map holds exactly one marker with no id bookkeeping (was reconcileMarker's IntArray box).
+    val markerLocation = state.markerLocation
+    DisposableEffect(markerLocation) {
+        val id = markerLocation?.let { mapViewModel.addMarker(it.latitude, it.longitude, null) }
+        onDispose { id?.let(mapViewModel::removeMarker) }
+    }
     // A form/picker is showing whenever the target isn't the hint (all forms are inline now bar Open311,
     // which is also driven by the target). Back drops the spinner back to the hint.
     BackHandler(enabled = state.target != ReportTarget.None) {
@@ -332,24 +329,8 @@ fun InfrastructureIssueDestination(
 
 // --- Ported imperative glue (was InfrastructureIssueActivity) -----------------------------------
 
-private const val NO_MARKER = -1
-
 // The former map FrameLayout was 200dp tall (infrastructure_issue.xml).
 private const val MAP_HEIGHT = 200
-
-private fun reconcileMarker(
-    mapViewModel: StopsMapViewModel,
-    markerId: IntArray,
-    location: IssueLocation?,
-) {
-    if (markerId[0] != NO_MARKER) {
-        mapViewModel.removeMarker(markerId[0])
-        markerId[0] = NO_MARKER
-    }
-    if (location != null) {
-        markerId[0] = mapViewModel.addMarker(location.latitude, location.longitude, null)
-    }
-}
 
 /**
  * Builds the [InfrastructureIssueViewModel] from the nav-arg [selectedService] and the decoded


### PR DESCRIPTION
## What

The infrastructure-issue report screen kept its single manual map pin in sync with the ViewModel's `markerLocation` using imperative glue ported verbatim from the old Activity — a `remember { intArrayOf(NO_MARKER) }` id box, a `LaunchedEffect` that collected `markerLocation`, and a `reconcileMarker` helper that removed the previous marker by id and added the new one.

This expresses the pin declaratively instead — the marker *is* the current `markerLocation`:

```kotlin
val markerLocation = state.markerLocation
DisposableEffect(markerLocation) {
    val id = markerLocation?.let { mapViewModel.addMarker(it.latitude, it.longitude, null) }
    onDispose { id?.let(mapViewModel::removeMarker) }
}
```

Keying on the value-equal `IssueLocation` gives the same dedup the old `distinctUntilChanged()` did; the effect's `onDispose` provides remove-on-change and remove-on-leave for free.

## Why

- Removes imperative reconciliation from a declarative Compose screen: deletes the `IntArray` box, the `NO_MARKER` sentinel, the `reconcileMarker` helper, the manual collector, and a now-unused import (+9 / −28).
- **Fixes a latent rotation bug:** the `remember {}` id box did not survive a configuration change, but the map ViewModel's markers did — so `reconcileMarker` skipped the removal and stacked a duplicate pin on every rotation. Tying the marker to the composition lifetime keeps exactly one pin across config changes.

## Scope / equivalence

- Only file touched: `InfrastructureIssueScreen.kt`. No changes to `StopsMapViewModel` / `MapHost` / `MapRenderState`, and no impact on the other `addMarker`/`removeMarker` user (`DirectionsMapController`).
- Remove-before-add ordering, single-marker invariant, and value-equality dedup are all preserved. `addMarker`/`removeMarker` are main-thread-only and `DisposableEffect` honors that.
- Compiles: `./gradlew :onebusaway-android:compileObaGoogleDebugKotlin`.