### PR TITLE
Move OTP contact email to TripPlanViewModel

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanScreen.kt
@@ -77,12 +77,10 @@ import kotlinx.coroutines.launch
 import org.onebusaway.android.R
 import org.onebusaway.android.app.di.AnalyticsEntryPoint
 import org.onebusaway.android.app.di.LocationEntryPoint
-import org.onebusaway.android.app.di.RegionEntryPoint
 import org.onebusaway.android.directions.util.ConversionUtils
 import org.onebusaway.android.directions.util.OTPConstants
 import org.onebusaway.android.directions.util.TripRequestBuilder
 import org.onebusaway.android.analytics.PlausibleAnalytics
-import org.onebusaway.android.region.RegionRepository
 import org.onebusaway.android.ui.compose.components.ObaTopAppBar
 import org.onebusaway.android.ui.compose.components.SwitchRow
 import org.onebusaway.android.ui.compose.findActivity
@@ -109,10 +107,6 @@ import org.opentripplanner.api.model.Itinerary
 fun TripPlanDestination(navController: NavHostController, onBack: () -> Unit) {
     val viewModel = hiltViewModel<TripPlanViewModel>()
     val activity = LocalContext.current.findActivity()
-
-    // Built once for the lifetime of this destination (analytics + region email for "report problem").
-    // HomeActivity doesn't inject RegionRepository; reach the shared singleton via the EntryPoint.
-    val regionRepository = remember { RegionEntryPoint.get(activity) }
 
     // -- Contacts pick: a launcher + the endpoint a pending pick should populate. A contacts pick
     // doesn't dispose this composable, so a plain remember (not rememberSaveable) suffices.
@@ -175,7 +169,7 @@ fun TripPlanDestination(navController: NavHostController, onBack: () -> Unit) {
             when (state) {
                 is PlanResult.Loading -> reportPlanAnalytics(activity)
                 is PlanResult.Error -> {
-                    showFeedbackDialog(activity, regionRepository, state.message)
+                    showFeedbackDialog(activity, viewModel.otpContactEmail, state.message)
                     viewModel.clearPlanResult()
                 }
                 else -> {}
@@ -205,7 +199,7 @@ fun TripPlanDestination(navController: NavHostController, onBack: () -> Unit) {
         onFromPickOnMap = { launchMapPicker("from", viewModel.formState.value.from) },
         onToPickOnMap = { launchMapPicker("to", viewModel.formState.value.to) },
         onAdvancedSettings = { showAdvanced = true },
-        onReportProblem = { reportProblem(activity, regionRepository) }
+        onReportProblem = { reportProblem(activity, viewModel.otpContactEmail) }
     )
 
     if (showAdvanced) {
@@ -563,7 +557,7 @@ private fun AdvancedSettingsDialog(
 
 private fun showFeedbackDialog(
     activity: AppCompatActivity,
-    regionRepository: RegionRepository,
+    contactEmail: String?,
     message: String
 ) {
     MaterialAlertDialogBuilder(activity)
@@ -571,24 +565,23 @@ private fun showFeedbackDialog(
         .setMessage(message)
         .setPositiveButton(android.R.string.ok, null)
         .setNegativeButton(R.string.report_problem_report) { _, _ ->
-            reportProblem(activity, regionRepository)
+            reportProblem(activity, contactEmail)
         }
         .show()
 }
 
 private fun reportProblem(
     activity: AppCompatActivity,
-    regionRepository: RegionRepository
+    contactEmail: String?
 ) {
-    val email = regionRepository.region.value?.otpContactEmail
-    if (email.isNullOrEmpty()) {
+    if (contactEmail.isNullOrEmpty()) {
         Toast.makeText(activity, activity.getString(R.string.tripplanner_no_contact), Toast.LENGTH_SHORT)
             .show()
         return
     }
     val location = LocationEntryPoint.get(activity.applicationContext).lastKnownLocation()
     val locationString = location?.let { LocationUtils.printLocationDetails(it) }
-    ExternalIntents.sendEmail(activity, email, locationString, null, true)
+    ExternalIntents.sendEmail(activity, contactEmail, locationString, null, true)
     AnalyticsEntryPoint.get(activity).reportUiEvent(
         PlausibleAnalytics.REPORT_TRIP_PLANNER_EVENT_URL,
         activity.getString(R.string.analytics_label_app_feedback_otp), null

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanViewModel.kt
@@ -34,6 +34,7 @@ import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
+import org.onebusaway.android.region.RegionRepository
 import org.onebusaway.android.util.TimeProvider
 import org.opentripplanner.api.model.Itinerary
 
@@ -49,12 +50,22 @@ import org.opentripplanner.api.model.Itinerary
 class TripPlanViewModel @Inject constructor(
     private val geocode: GeocodeRepository,
     private val planRepository: TripPlanRepository,
+    private val regionRepository: RegionRepository,
     timeProvider: TimeProvider,
     settingsRepository: AdvancedSettingsRepository,
 ) : ViewModel() {
 
     private val initialDateTimeMillis = timeProvider.now()
     private val initialSettings = settingsRepository.load()
+
+    /**
+     * The active region's OTP "report a problem" contact email, or null when none is configured. The
+     * VM owns the [RegionRepository] dependency so the host destination never reaches into the data
+     * layer itself; it's a one-shot read at report time (the host builds the feedback email) rather
+     * than surfaced form state, mirroring [RegionRepository.currentRegion].
+     */
+    val otpContactEmail: String?
+        get() = regionRepository.region.value?.otpContactEmail
 
     private val _formState = MutableStateFlow(
         TripPlanFormState(

--- a/onebusaway-android/src/test/java/org/onebusaway/android/region/RegionTestFixtures.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/region/RegionTestFixtures.kt
@@ -58,6 +58,7 @@ internal fun region(
     id: Long,
     supportsOtpBikeshare: Boolean = false,
     twitterUrl: String? = null,
+    otpContactEmail: String? = null,
 ): Region = Region(
         id,            // id
         "Region $id",  // name
@@ -75,7 +76,7 @@ internal fun region(
         false,         // experimental
         null,          // stopInfoUrl
         null,          // otpBaseUrl
-        null,          // otpContactEmail
+        otpContactEmail, // otpContactEmail
         supportsOtpBikeshare, // supportsOtpBikeshare
         false,         // supportsEmbeddedSocial
         null,          // paymentAndroidAppId

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/ArrivalInfoTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/ArrivalInfoTest.kt
@@ -138,6 +138,7 @@ private data class FakeArrivalData(
     override val predictedDepartureTime: ServerTime = ServerTime(0L),
     override val status: Status? = null,
     override val frequency: FrequencyWindow? = null,
+    override val situationIds: List<String> = emptyList(),
     override val historicalOccupancy: Occupancy? = null,
     override val predictedOccupancy: Occupancy? = null,
     override val hasTripStatus: Boolean = false,

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripPlanViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripPlanViewModelTest.kt
@@ -26,6 +26,9 @@ import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.onebusaway.android.directions.util.TripRequestBuilder
+import org.onebusaway.android.region.FakeRegionRepository
+import org.onebusaway.android.region.RegionRepository
+import org.onebusaway.android.region.region
 import org.onebusaway.android.testing.MainDispatcherRule
 import org.onebusaway.android.util.TimeProvider
 import org.opentripplanner.api.model.Itinerary
@@ -77,8 +80,9 @@ class TripPlanViewModelTest {
 
     private fun viewModel(
         geocode: GeocodeRepository = FakeGeocodeRepository(Result.success(emptyList())),
-        plan: TripPlanRepository = FakeTripPlanRepository(Result.success(listOf(Itinerary())))
-    ) = TripPlanViewModel(geocode, plan, TimeProvider { 0L }, FakeAdvancedSettingsRepository())
+        plan: TripPlanRepository = FakeTripPlanRepository(Result.success(listOf(Itinerary()))),
+        region: RegionRepository = FakeRegionRepository()
+    ) = TripPlanViewModel(geocode, plan, region, TimeProvider { 0L }, FakeAdvancedSettingsRepository())
 
     /** Sets both resolved endpoints (which auto-submits a plan once both have coordinates). */
     private fun setBothEndpoints(vm: TripPlanViewModel) {
@@ -264,6 +268,17 @@ class TripPlanViewModelTest {
         setBothEndpoints(vm)
         advanceUntilIdle()
         assertEquals(PlanResult.Error("no route"), vm.planState.value)
+    }
+
+    @Test
+    fun `otpContactEmail reflects the active region's OTP contact`() = runTest {
+        val regionRepo = FakeRegionRepository(region(id = 1, otpContactEmail = "otp@example.com"))
+        val vm = viewModel(region = regionRepo)
+        assertEquals("otp@example.com", vm.otpContactEmail)
+
+        // A region change (or clearing) is reflected on the next read — it isn't cached in the VM.
+        regionRepo.emit(region(id = 2, otpContactEmail = null))
+        assertEquals(null, vm.otpContactEmail)
     }
 
     @Test


### PR DESCRIPTION
## Description

Refactors the trip planner to access the OTP "report a problem" contact email through the view model instead of directly accessing `RegionRepository` in the composable.

### Changes

- **TripPlanViewModel**: Added `RegionRepository` dependency and exposed `otpContactEmail` property that reads from the active region
- **TripPlanScreen**: Removed direct `RegionRepository` access via `RegionEntryPoint`; now uses `viewModel.otpContactEmail` for feedback dialogs and problem reporting
- **Test fixtures**: Updated `region()` builder to support `otpContactEmail` parameter for testing
- **Tests**: Added `otpContactEmail` test to verify the property reflects the active region's contact email

### Rationale

This change improves separation of concerns by:
1. Centralizing region data access in the view model (the data layer owner)
2. Eliminating direct EntryPoint usage in the composable
3. Making the dependency explicit in the ViewModel constructor for better testability
4. Allowing the composable to remain focused on UI logic

The email is read on-demand at report time rather than cached, mirroring `RegionRepository.currentRegion` behavior and ensuring it reflects region changes.

### Testing

- Added unit test `otpContactEmail reflects the active region's OTP contact` verifying the property reads from the region and reflects changes
- Existing tests continue to pass with the updated ViewModel constructor signature

https://claude.ai/code/session_01QtuN3KNjFX2ue75q5ifcyL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Trip-planning feedback and “Report trip problem” now use the active region’s contact email directly for improved consistency.
  * The trip-planning view now surfaces the current report-a-problem email from the active region.

* **Bug Fixes**
  * Prevented stale or unavailable contact emails when the active region changes.
  * If no contact email is configured, error reporting now exits cleanly and informs you instead of attempting to send a report.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->