### PR TITLE
Add Android Lint to the CI approval gate (#1692)

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -35,6 +35,12 @@ jobs:
       - name: Gradle cache
         uses: gradle/actions/setup-gradle@v3
 
+      # Android Lint gate: catches minSdk (NewApi) regressions and other lint errors that
+      # compile + API-33 tests can't see (#1692). Runs on the host before the emulator so it
+      # fails fast; `check` below keeps skipping lint (-x lint) to avoid running it twice.
+      - name: Android Lint
+        run: ./gradlew :onebusaway-android:lintObaGoogleDebug --stacktrace
+
       - name: AVD cache
         uses: actions/cache@v4
         id: avd-cache

--- a/onebusaway-android/build.gradle
+++ b/onebusaway-android/build.gradle
@@ -153,6 +153,9 @@ android {
     namespace='org.onebusaway.android'
     lint {
         disable 'MissingTranslation', 'ExtraTranslation'
+        // Fail the build (and CI, #1692) on any lint error — notably NewApi minSdk violations,
+        // which compile + API-33 instrumented tests can't catch.
+        abortOnError true
     }
 
     useLibrary 'android.test.runner'

--- a/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/InfrastructureIssueScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/InfrastructureIssueScreen.kt
@@ -522,6 +522,9 @@ private fun Open311FormInline(
 ) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
+    // Read the analytics label in composition (stringResource) rather than context.getString() inside
+    // the submit callback below, which lint flags (LocalContextGetResourceValueCall, #1692).
+    val analyticsProblem = stringResource(R.string.analytics_problem)
     val vm: Open311ProblemViewModel = viewModel(
         key = "open311:${target.category.code ?: target.category.name}",
         factory = viewModelFactory {
@@ -586,7 +589,7 @@ private fun Open311FormInline(
             (target.category.raw as? Service)?.let { service ->
                 AnalyticsEntryPoint.get(context).reportUiEvent(
                     PlausibleAnalytics.REPORT_OPEN311_SERVER_EVENT_URL,
-                    context.getString(R.string.analytics_problem),
+                    analyticsProblem,
                     service.service_name,
                 )
             }


### PR DESCRIPTION
## Problem

The CI approval gate couldn't catch `minSdk` (`NewApi`) violations or other lint errors. The workflow ran `./gradlew test check connectedObaGoogleDebugAndroidTest -x lint` — lint explicitly skipped — and instrumented tests run only on API 33, so a minSdk regression compiles green, tests green, and merges. That's exactly how the `directions/` `java.time` migration shipped a latent API 23–25 crash.

## Changes

1. **Run lint in CI.** `.github/workflows/android.yml` gains a dedicated `:onebusaway-android:lintObaGoogleDebug` step on the host, before the emulator, so it fails fast. `check` keeps `-x lint` so lint isn't run twice.
2. **Fail on lint errors.** `build.gradle` sets `lint { abortOnError true }`, so any lint error aborts the build/CI.
3. **Fix the one remaining error.** With core-library desugaring already on `main`, the only error is a Compose `LocalContextGetResourceValueCall` in `InfrastructureIssueScreen` — read the analytics label via `stringResource()` in composition instead of `context.getString(...)` inside the submit callback.

## Verification

- Before the fix, `lintObaGoogleDebug` → **BUILD FAILED** on the 1 error (the gate bites).
- After the fix, `lintObaGoogleDebug` → **BUILD SUCCESSFUL**, 0 errors.

The gate fails only on **errors**; the 349 pre-existing **warnings** stay non-fatal and are tracked for follow-up in #1701–#1705.

Closes #1692.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Android quality checks so build issues and `minSdk`/API compatibility problems are caught earlier, reducing the chance of shipping crashes or failed installs.
  * Kept emulator-based tests focused on runtime behavior by separating them from lint checks.
* **Chores**
  * Made the app’s issue-reporting flow use a more consistent label when sending analytics events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->