### PR TITLE
Give starred stops a distinctive star icon + tap preference (#1680)

### DIFF
--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
@@ -88,6 +88,9 @@ class GoogleMapRenderer(
     private var renderedFocusedStopId: String? = null
     // The zoom band the stop icons were last drawn for (full icon vs dot); see [reconcileStopMarkers].
     private var renderedStopBand = StopBand.FULL
+    // The stop ids drawn as starred (favorite) last reconcile, so a star/unstar flips the icon (+ tap
+    // z-index) even when focus and band are unchanged; see [reconcileStopMarkers].
+    private var renderedFavoriteStopIds: Set<String> = emptySet()
 
     private val bikeByMarker = HashMap<Marker, BikeMarker>()
 
@@ -259,7 +262,7 @@ class GoogleMapRenderer(
             }
         }
         for (stop in stops) {
-            val kind = stopIconKind(stop.id == focusedStopId, band)
+            val kind = stopIconKind(stop.id == focusedStopId, band, stop.favorite)
             val existing = stopMarkersByStopId[stop.id]
             if (existing == null) {
                 val (anchorX, anchorY) = stopAnchor(stop, kind)
@@ -269,19 +272,28 @@ class GoogleMapRenderer(
                         .icon(stopIcon(stop, kind))
                         .flat(true)
                         .anchor(anchorX, anchorY)
+                        // A starred stop sits above its neighbours so it wins an overlapping tap (#1680).
+                        .zIndex(if (stop.favorite) FAVORITE_STOP_Z_INDEX else 0f)
                 )!!
                 stopMarkersByStopId[stop.id] = marker
                 stopByMarker[marker] = stop
-            } else if (stopIconKind(stop.id == renderedFocusedStopId, renderedStopBand) != kind) {
+            } else if (stopIconKind(
+                    stop.id == renderedFocusedStopId,
+                    renderedStopBand,
+                    stop.id in renderedFavoriteStopIds,
+                ) != kind
+            ) {
                 // Only the markers whose icon kind changed need a new icon (and matching anchor: the
-                // full icon is anchored on its circle per direction, the dot at the marker center).
+                // full icon is anchored on its circle per direction, the dot/star at the marker center).
                 existing.setIcon(stopIcon(stop, kind))
                 val (anchorX, anchorY) = stopAnchor(stop, kind)
                 existing.setAnchor(anchorX, anchorY)
+                existing.zIndex = if (stop.favorite) FAVORITE_STOP_Z_INDEX else 0f
             }
         }
         renderedFocusedStopId = focusedStopId
         renderedStopBand = band
+        renderedFavoriteStopIds = buildSet { for (s in stops) if (s.favorite) add(s.id) }
     }
 
     private fun stopIcon(stop: StopMarker, kind: StopIconKind): BitmapDescriptor = when (kind) {
@@ -289,12 +301,19 @@ class GoogleMapRenderer(
         StopIconKind.FULL_FOCUSED -> StopIconFactory.focusedStopIcon(context, stop.direction, stop.routeType)
         StopIconKind.DOT -> StopIconFactory.dotStopIcon(context)
         StopIconKind.DOT_FOCUSED -> StopIconFactory.focusedDotStopIcon(context)
+        StopIconKind.FAVORITE -> StopIconFactory.favoriteStopIcon(context, stop.direction)
+        StopIconKind.FAVORITE_FOCUSED -> StopIconFactory.focusedFavoriteStopIcon(context, stop.direction)
+        StopIconKind.FAVORITE_DOT -> StopIconFactory.favoriteDotStopIcon(context)
+        StopIconKind.FAVORITE_DOT_FOCUSED -> StopIconFactory.focusedFavoriteDotStopIcon(context)
     }
 
     private fun stopAnchor(stop: StopMarker, kind: StopIconKind): Pair<Float, Float> =
         when (kind) {
-            StopIconKind.DOT, StopIconKind.DOT_FOCUSED -> 0.5f to 0.5f
-            else -> StopIconFactory.anchorX(stop.direction) to StopIconFactory.anchorY(stop.direction)
+            // The full directional icon is anchored on its circle per direction. The dot and every star
+            // (its star is centered, with the arrow drawn symmetrically around it) are centered.
+            StopIconKind.FULL, StopIconKind.FULL_FOCUSED ->
+                StopIconFactory.anchorX(stop.direction) to StopIconFactory.anchorY(stop.direction)
+            else -> 0.5f to 0.5f
         }
 
     /**
@@ -312,6 +331,7 @@ class GoogleMapRenderer(
         stopMarkersByStopId.clear()
         stopByMarker.clear()
         renderedFocusedStopId = null
+        renderedFavoriteStopIds = emptySet()
 
         vehicleMarkersByTripId.values.forEach { it.remove() }
         vehicleMarkersByTripId.clear()
@@ -610,6 +630,11 @@ class GoogleMapRenderer(
 
         // z-index used to show vehicle markers on top of stop markers (default marker z-index is 0).
         private const val VEHICLE_Z_INDEX = 1f
+
+        // A starred stop draws just above normal stops (default z-index 0) but below vehicles, so it wins
+        // an overlapping tap over a neighbouring plain stop — the "tap preference" of #1680. gms dispatches
+        // an overlapping-marker click to the highest z-index marker.
+        private const val FAVORITE_STOP_Z_INDEX = 0.5f
 
         // The uncertainty band draws above the static route line; the estimate markers above the band,
         // each at a distinct z-index so overlapping ones keep a stable draw order (no per-frame alpha

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/StopIconFactory.java
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/StopIconFactory.java
@@ -118,6 +118,23 @@ public final class StopIconFactory {
     private static BitmapDescriptor sDotDescriptorFocused;
 
     /**
+     * The distinctive star shown for a starred (favorite) stop (#1680), in place of its directional
+     * icon up close / its dot far out — with a focused (enlarged) variant of each.
+     *
+     * The full-band star keeps the direction arrow the other stop markers carry, so it's per-direction
+     * (indexed like {@link #sStopDescriptors}) and anchored the same way. The dot-band star has no arrow
+     * (matching the plain dot), so it's a single direction-agnostic descriptor anchored at the marker
+     * center (0.5, 0.5). Route-type agnostic in both bands (no route glyph on the star).
+     */
+    private static BitmapDescriptor[] sFavoriteDescriptors;
+
+    private static BitmapDescriptor[] sFavoriteDescriptorsFocused;
+
+    private static BitmapDescriptor sStarDotDescriptor;
+
+    private static BitmapDescriptor sStarDotDescriptorFocused;
+
+    /**
      * Route types that get distinct stop icons on the map.
      * TYPE_CABLECAR uses TYPE_TRAM icon; TYPE_GONDOLA/TYPE_FUNICULAR fall back to TYPE_BUS.
      */
@@ -204,6 +221,30 @@ public final class StopIconFactory {
         return sDotDescriptorFocused;
     }
 
+    /** The distinctive star (with the direction arrow) for a starred stop up close. */
+    public static synchronized BitmapDescriptor favoriteStopIcon(Context context, String direction) {
+        ensureLoaded(context);
+        return sFavoriteDescriptors[getDirectionIndex(direction)];
+    }
+
+    /** The focused (enlarged) star (with the direction arrow) for the selected starred stop up close. */
+    public static synchronized BitmapDescriptor focusedFavoriteStopIcon(Context context, String direction) {
+        ensureLoaded(context);
+        return sFavoriteDescriptorsFocused[getDirectionIndex(direction)];
+    }
+
+    /** The smaller star shown for a starred stop in the far-zoom dot band. */
+    public static synchronized BitmapDescriptor favoriteDotStopIcon(Context context) {
+        ensureLoaded(context);
+        return sStarDotDescriptor;
+    }
+
+    /** The focused (enlarged) star for the selected starred stop in the dot band. */
+    public static synchronized BitmapDescriptor focusedFavoriteDotStopIcon(Context context) {
+        ensureLoaded(context);
+        return sStarDotDescriptorFocused;
+    }
+
     /** Marker anchor X for the given direction (positions the pin tip on the circle center). */
     public static float anchorX(String direction) {
         return getXPercentOffsetForDirection(direction);
@@ -252,20 +293,56 @@ public final class StopIconFactory {
             }
             // Scale the focused icons to be larger than the normal icons
             for (int i = 0; i < NUM_DIRECTIONS; i++) {
-                Bitmap bmp = iconsFocused[i];
-                iconsFocused[i] = Bitmap.createScaledBitmap(bmp,
-                        (int) (bmp.getWidth() * FOCUS_ICON_SCALE),
-                        (int) (bmp.getHeight() * FOCUS_ICON_SCALE), true);
+                iconsFocused[i] = StopBitmaps.scale(iconsFocused[i], FOCUS_ICON_SCALE);
             }
             sStopDescriptors.put(routeType, toDescriptors(icons));
             sStopDescriptorsFocused.put(routeType, toDescriptors(iconsFocused));
         }
 
+        // Star colors: the normal star is the gold gradient (light→dark); a selected star uses the same
+        // focus color as every other selected stop (solid). The arrow keeps the theme primary→accent.
+        int starLight = r.getColor(R.color.map_stop_favorite_light);
+        int starDark = r.getColor(R.color.map_stop_favorite_dark);
+        int focusColor = r.getColor(R.color.map_stop_focus);
+        int arrowTip = r.getColor(R.color.theme_primary);
+        int arrowBase = r.getColor(R.color.theme_accent);
+        // The star outline matches the plain circle's ring width (same for full- and dot-band), drawn at
+        // the star's own scale so the star inflation doesn't thicken it.
+        float starOutlinePx = StopBitmaps.STAR_OUTLINE_WIDTH_DP * r.getDisplayMetrics().density;
+
+        // Starred-stop full-band icons: an inflated star with the normal-sized direction arrow drawn on
+        // top, per direction. Route-type agnostic (no route glyph), so build the 9 directions once. The
+        // focused variant is the selected-color star, enlarged like every other focused marker.
+        int normalPx = (int) (mPx * GLYPH_ICON_SCALE);
+        int starPx = Math.round(mPx * StopBitmaps.STAR_SIZE_SCALE);
+        Bitmap[] favorites = new Bitmap[NUM_DIRECTIONS];
+        Bitmap[] favoritesFocused = new Bitmap[NUM_DIRECTIONS];
+        for (int i = 0; i < directions.length; i++) {
+            boolean hasArrow = !directions[i].equals(NO_DIRECTION);
+            float angle = StopBitmaps.compassAngle(directions[i]);
+            favorites[i] = StopBitmaps.favoriteMarker(normalPx, starPx, hasArrow, angle,
+                    starLight, starDark, arrowTip, arrowBase, starOutlinePx);
+            favoritesFocused[i] = StopBitmaps.scale(
+                    StopBitmaps.favoriteMarker(normalPx, starPx, hasArrow, angle,
+                            focusColor, focusColor, arrowTip, arrowBase, starOutlinePx),
+                    FOCUS_ICON_SCALE);
+        }
+        sFavoriteDescriptors = toDescriptors(favorites);
+        sFavoriteDescriptorsFocused = toDescriptors(favoritesFocused);
+
         sDotDescriptor = BitmapDescriptorFactory.fromBitmap(
                 StopBitmaps.dot(mPx, r.getColor(R.color.theme_primary)));
         sDotDescriptorFocused = BitmapDescriptorFactory.fromBitmap(
-                StopBitmaps.dot(mPx, r.getColor(R.color.map_stop_focus),
-                        StopBitmaps.FOCUSED_DOT_SCALE));
+                StopBitmaps.dot(mPx, focusColor, StopBitmaps.FOCUSED_DOT_SCALE));
+
+        // Dot-band starred stops: a plain star (no arrow, matching the plain dot), dot-sized and enlarged
+        // when focused. Gold gradient normally, the selected color when focused; same thin outline.
+        int starDotPx = Math.round(mPx * 0.5f * StopBitmaps.STAR_SIZE_SCALE);
+        sStarDotDescriptor = BitmapDescriptorFactory.fromBitmap(
+                StopBitmaps.star(starDotPx, starLight, starDark, starOutlinePx));
+        sStarDotDescriptorFocused = BitmapDescriptorFactory.fromBitmap(
+                StopBitmaps.star(Math.round(starDotPx * StopBitmaps.FOCUSED_DOT_SCALE),
+                        focusColor, focusColor, starOutlinePx));
     }
 
     /** Wraps each pre-rendered bitmap into a BitmapDescriptor once, so callers can reuse them. */

--- a/onebusaway-android/src/main/java/org/onebusaway/android/database/oba/StopDao.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/database/oba/StopDao.kt
@@ -134,6 +134,10 @@ interface StopDao {
     )
     fun starredByFrequency(regionId: Long?): Flow<List<StopListRow>>
 
+    /** The ids of every starred (favorite) stop, live — the map stars these on its markers (#1680). */
+    @Query("SELECT _id FROM stops WHERE favorite = 1")
+    fun favoriteStopIds(): Flow<List<String>>
+
     // --- Recents/starred mutations ---
 
     @Query("UPDATE stops SET use_count = 0, access_time = NULL WHERE _id = :stopId")

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
@@ -32,6 +32,7 @@ import org.onebusaway.android.models.ObaRoute
 import org.onebusaway.android.models.ObaStop
 import org.onebusaway.android.models.RouteMapDirection
 import org.onebusaway.android.api.data.MapDataSource
+import org.onebusaway.android.database.oba.StopDao
 import org.onebusaway.android.extrapolation.data.TripObservationRepository
 import org.onebusaway.android.models.ObaTripStatus
 import org.onebusaway.android.map.bike.BikeStationsRepository
@@ -98,6 +99,7 @@ class MapViewModel @Inject constructor(
     private val locationRepository: LocationRepository,
     private val prefsRepository: PreferencesRepository,
     private val tripObservationRepository: TripObservationRepository,
+    private val stopDao: StopDao,
     @ApplicationContext private val context: Context,
 ) : ViewModel() {
 
@@ -136,6 +138,9 @@ class MapViewModel @Inject constructor(
                 StopsMapController.DEFAULT_STOP_CACHE_SIZE,
             )
         },
+        // The home map stars the user's favorite stops (#1680). Room runs the query off the main thread
+        // and re-emits on any favorite change, so starring a stop updates the map immediately.
+        favoriteStopIds = stopDao.favoriteStopIds().map { it.toSet() },
     )
 
     // ----- Map-host surface (delegated) -----

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/StopsMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/StopsMapController.kt
@@ -23,9 +23,11 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterNot
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import org.onebusaway.android.api.data.MapDataSource
@@ -63,6 +65,10 @@ class StopsMapController(
     private val routeActive: () -> Boolean = { false },
     // The LRU cache size, read on each load so a change in advanced settings applies on the next pan.
     private val cacheSize: () -> Int = { DEFAULT_STOP_CACHE_SIZE },
+    // The ids of the user's starred (favorite) stops, live: starring/unstarring re-flags the drawn
+    // markers so their star icon + tap preference appear immediately (#1680). Defaults to no favorites
+    // for the slim stop maps (the report/picker) that don't surface starred stops.
+    private val favoriteStopIds: Flow<Set<String>> = flowOf(emptySet()),
 ) {
 
     private val renderState get() = host.renderState
@@ -77,6 +83,10 @@ class StopsMapController(
     // routeId -> ObaRoute.TYPE_*, maintained alongside cachedRoutes so toStopMarker doesn't rebuild
     // the lookup on every pan.
     private val routeTypeById = HashMap<String, Int>()
+
+    // The user's current favorite stop ids, kept in sync by the collector in init. Read on the main
+    // thread only (all mutators here run there), so a plain field is safe.
+    private var favoriteIds: Set<String> = emptySet()
 
     private var loadJob: Job? = null
 
@@ -93,6 +103,32 @@ class StopsMapController(
                 .distinctUntilChanged()
                 .collect { renderState.setStopBand(it) }
         }
+
+        // Track the user's starred stops: re-flag the already-accumulated markers on any change so a
+        // star/unstar shows/hides the star icon + tap preference without waiting for the next pan (#1680).
+        scope.launch {
+            favoriteStopIds.collect { ids ->
+                favoriteIds = ids
+                applyFavorites()
+            }
+        }
+    }
+
+    /**
+     * Re-flag the accumulated markers against the current [favoriteIds] and republish if any changed.
+     * Collects the changes before mutating [stopAccum] so we never write to the access-ordered map while
+     * iterating it.
+     */
+    private fun applyFavorites() {
+        val updates = buildList {
+            for ((id, marker) in stopAccum) {
+                val favorite = id in favoriteIds
+                if (marker.favorite != favorite) add(id to marker.copy(favorite = favorite))
+            }
+        }
+        if (updates.isEmpty()) return
+        for ((id, marker) in updates) stopAccum[id] = marker
+        renderState.setStops(ArrayList(stopAccum.values))
     }
 
     /** (Re)start the viewport stop loader (the old StopMapController's camera watch). */
@@ -297,7 +333,10 @@ class StopsMapController(
         val routeType = primaryRouteType(stop.routeIds, routeTypeById)
         // ObaStop.getDirection() is "N".."NW" or the literal "null" string for no direction.
         val direction = stop.direction ?: "null"
-        return StopMarker(stop.id, stop.location.toGeoPoint(), direction, routeType, stop)
+        return StopMarker(
+            stop.id, stop.location.toGeoPoint(), direction, routeType, stop,
+            favorite = stop.id in favoriteIds,
+        )
     }
 
     companion object {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
@@ -127,6 +127,8 @@ data class BikeMarker(
  * One bus-stop marker. [direction]/[routeType] choose the icon + anchor; [stop] is the raw pojo
  * couriered so a tap can notify focus listeners. Whether this stop renders focused (the 1.5x icon) is
  * decided by [MapRenderSnapshot.focusedStopId], not stored here, so focusing is a one-field change.
+ * [favorite] is stored here (it's a per-stop property that changes as the user stars/unstars), driving
+ * the distinctive star icon + tap preference (#1680).
  */
 data class StopMarker(
     val id: String,
@@ -134,6 +136,7 @@ data class StopMarker(
     val direction: String,
     val routeType: Int,
     val stop: ObaStop,
+    val favorite: Boolean = false,
 )
 
 /** Immutable snapshot of everything the map should render. Grows one overlay per phase. */

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/StopBitmaps.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/StopBitmaps.kt
@@ -18,9 +18,15 @@ package org.onebusaway.android.map.render
 import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.Color
+import android.graphics.LinearGradient
 import android.graphics.Paint
+import android.graphics.Path
+import android.graphics.Shader
+import kotlin.math.ceil
+import kotlin.math.cos
 import kotlin.math.max
 import kotlin.math.roundToInt
+import kotlin.math.sin
 
 /**
  * Shared builder for the small "dot" bus-stop marker shown at distant zoom (the full-icon ⇄ dot
@@ -35,6 +41,45 @@ object StopBitmaps {
      * full-icon focus enlargement the flavour factories apply up close (their `FOCUS_ICON_SCALE`).
      */
     const val FOCUSED_DOT_SCALE = 1.5f
+
+    /**
+     * How much larger the starred-stop [star] is drawn relative to the base dot/full-icon size, so the
+     * star reads clearly as a distinct favorite marker (#1680). Applied to both the full-band and
+     * dot-band star sizes by the flavor factories, keeping the two map flavors in sync.
+     */
+    const val STAR_SIZE_SCALE = 1.75f
+
+    /**
+     * The starred-stop star's white outline width, in dp — used for both the full-band and dot-band
+     * star. Tuned on device to read like the plain stop circle's border; the circle's *rendered* white
+     * ring measures ~1.15dp, but the star's spiky edge reads a touch thinner at that width, so it's bumped
+     * up. The factories multiply by display density to get pixels.
+     */
+    const val STAR_OUTLINE_WIDTH_DP = 1.5f
+
+    /** Scales [bitmap] uniformly by [factor] — shared by the flavor factories' focused/star variants. */
+    @JvmStatic
+    fun scale(bitmap: Bitmap, factor: Float): Bitmap =
+        Bitmap.createScaledBitmap(
+            bitmap, (bitmap.width * factor).toInt(), (bitmap.height * factor).toInt(), true
+        )
+
+    /**
+     * Clockwise degrees from north for a stop [direction] string ("N".."NW"), used to rotate the star's
+     * direction arrow ([favoriteMarker]). "null"/unknown map to 0° — the caller passes `hasArrow=false`
+     * for a directionless stop, so the angle is unused there. Shared so the table lives in one place.
+     */
+    @JvmStatic
+    fun compassAngle(direction: String): Float = when (direction) {
+        "NE" -> 45f
+        "E" -> 90f
+        "SE" -> 135f
+        "S" -> 180f
+        "SW" -> 225f
+        "W" -> 270f
+        "NW" -> 315f
+        else -> 0f // N (and "null", unused since it has no arrow)
+    }
 
     /**
      * A filled circle in [fillColor] with a thin white outline for contrast against the map, sized
@@ -65,5 +110,159 @@ object StopBitmaps {
         }
         canvas.drawCircle(center, center, radius, outline)
         return bm
+    }
+
+    /**
+     * A five-pointed star filled with the same vertical [topColor]→[bottomColor] gradient and white
+     * outline as the stop circle, sized to the [sizePx] bounding box, marking a starred (favorite) stop
+     * (#1680) — direction- and route-type agnostic, so the caller centers it on the marker. Shared by
+     * both flavors like [dot]; used for the dot-band favorite (no direction arrow), while the full-band
+     * factories draw the star with an arrow via [favoriteMarker]. [outlineWidthPx] is passed the same
+     * circle-matched width the full-band star uses (see [STAR_OUTLINE_WIDTH_DP]).
+     */
+    @JvmStatic
+    fun star(sizePx: Int, topColor: Int, bottomColor: Int, outlineWidthPx: Float): Bitmap {
+        val size = max(8, sizePx)
+        val bm = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888)
+        drawStar(Canvas(bm), size / 2f, size / 2f, size.toFloat(), topColor, bottomColor, outlineWidthPx)
+        return bm
+    }
+
+    /**
+     * Fills a [size]-wide five-pointed star at ([cx], [cy]) with a vertical [topColor]→[bottomColor]
+     * gradient, plus a white outline of [outlineWidthPx] (matched by the caller to the circle's border).
+     */
+    private fun drawStar(
+        canvas: Canvas, cx: Float, cy: Float, size: Float,
+        topColor: Int, bottomColor: Int, outlineWidthPx: Float,
+    ) {
+        // Inset the star tips so the outline stays inside the bounds.
+        val inset = max(1f, size / 12f)
+        val outerRadius = size / 2f - inset
+        // 0.42 gives a classic five-point star (not too spindly, not a blob).
+        val innerRadius = outerRadius * 0.42f
+        val path = starPath(cx, cy, outerRadius, innerRadius)
+
+        val fill = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            style = Paint.Style.FILL
+            shader = LinearGradient(
+                cx, cy - outerRadius, cx, cy + outerRadius,
+                topColor, bottomColor, Shader.TileMode.CLAMP
+            )
+        }
+        canvas.drawPath(path, fill)
+
+        val outline = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            style = Paint.Style.STROKE
+            strokeWidth = max(1f, outlineWidthPx)
+            strokeJoin = Paint.Join.ROUND
+            color = Color.WHITE
+        }
+        canvas.drawPath(path, outline)
+    }
+
+    /**
+     * The full-band starred-stop marker (#1680): an inflated [starDiameterPx] star centered on the
+     * marker, with the *normal-sized* direction arrow the other stop markers carry drawn on top,
+     * pointing [directionAngleDeg] degrees clockwise from north (ignored when [hasArrow] is false, for a
+     * directionless stop). Inflating only the star — not the whole marker — keeps the arrow the same
+     * size as on plain stops; the bigger star simply overlaps the arrow's base, which is why the arrow
+     * is drawn last (on top).
+     *
+     * The arrow's shape/position derive from [basePx] (the flavor's normal stop-circle diameter), so it
+     * matches that flavor's plain markers — the arrow constants below (`/2`, `/3`, `/12`, `/10`) mirror
+     * the plain directional-icon arrow in each flavor's Java factory. That match is by convention, not
+     * enforced: if the plain arrow geometry changes, update it here too. The star is centered, so the caller anchors this at
+     * the marker center (0.5, 0.5) — the star lands on the stop and the arrow points outward. Shared by
+     * both flavors so the two maps draw an identical marker.
+     *
+     * The star is filled with a vertical [starTopColor]→[starBottomColor] gradient (its own gold hue)
+     * and outlined at [starOutlineWidthPx] (the caller passes the circle's white-ring width) — the same
+     * gradient-plus-white-outline styling as the stop circle, in the star's colour. The direction arrow
+     * keeps the plain markers' [arrowTipColor]→[arrowBaseColor] (theme primary→accent) shading.
+     */
+    @JvmStatic
+    fun favoriteMarker(
+        basePx: Int,
+        starDiameterPx: Int,
+        hasArrow: Boolean,
+        directionAngleDeg: Float,
+        starTopColor: Int,
+        starBottomColor: Int,
+        arrowTipColor: Int,
+        arrowBaseColor: Int,
+        starOutlineWidthPx: Float,
+    ): Bitmap {
+        val circleRadius = basePx / 2f
+        val arrowWidth = basePx / 2f
+        val arrowHeight = basePx / 3f
+        val cutout = basePx / 12f
+        val tuck = basePx / 10f
+        // Radial distances from the marker center to the arrow's tip and base, matching the plain
+        // marker's arrow-vs-circle geometry (the arrow base tucks slightly under the circle edge).
+        val tipDistance = circleRadius + arrowHeight - tuck
+        val baseDistance = circleRadius - tuck
+        val starRadius = starDiameterPx / 2f
+
+        // Square canvas big enough for whichever reaches further from center — the inflated star or the
+        // arrow tip — so the arrow fits at any rotation. +2 leaves room for the anti-aliased outline.
+        val reach = max(starRadius, if (hasArrow) tipDistance else 0f)
+        val size = ceil(2 * reach).toInt() + 2
+        val bm = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(bm)
+        val center = size / 2f
+
+        drawStar(
+            canvas, center, center, starDiameterPx.toFloat(),
+            starTopColor, starBottomColor, starOutlineWidthPx
+        )
+
+        if (hasArrow) {
+            // A north-pointing arrow about the center; rotating the whole canvas turns both the path and
+            // its gradient to the compass direction in one step.
+            val path = Path().apply {
+                fillType = Path.FillType.EVEN_ODD
+                moveTo(center, center - tipDistance)                    // tip
+                lineTo(center - arrowWidth / 2, center - baseDistance)  // lower left
+                lineTo(center, center - baseDistance - cutout)          // cutout notch
+                lineTo(center + arrowWidth / 2, center - baseDistance)  // lower right
+                lineTo(center, center - tipDistance)
+                close()
+            }
+            canvas.save()
+            canvas.rotate(directionAngleDeg, center, center)
+            val fill = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+                style = Paint.Style.FILL
+                // Darkest at the tip, matching the plain markers' arrow shading.
+                shader = LinearGradient(
+                    center, center - tipDistance, center, center - tipDistance + arrowHeight,
+                    arrowTipColor, arrowBaseColor, Shader.TileMode.MIRROR
+                )
+            }
+            canvas.drawPath(path, fill)
+            val stroke = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+                style = Paint.Style.STROKE
+                strokeWidth = 1f
+                color = Color.WHITE
+            }
+            canvas.drawPath(path, stroke)
+            canvas.restore()
+        }
+        return bm
+    }
+
+    /** Builds the 10-vertex path of a five-pointed star centered at ([cx], [cy]), tip up. */
+    private fun starPath(cx: Float, cy: Float, outerRadius: Float, innerRadius: Float): Path {
+        val path = Path()
+        // Start at the top tip and alternate outer/inner vertices every 36 degrees.
+        for (i in 0 until 10) {
+            val radius = if (i % 2 == 0) outerRadius else innerRadius
+            val angle = Math.toRadians((i * 36 - 90).toDouble())
+            val x = cx + radius * cos(angle).toFloat()
+            val y = cy + radius * sin(angle).toFloat()
+            if (i == 0) path.moveTo(x, y) else path.lineTo(x, y)
+        }
+        path.close()
+        return path
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/StopZoomBand.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/StopZoomBand.kt
@@ -29,16 +29,28 @@ enum class StopBand { DOT, FULL }
 fun stopZoomBand(zoom: Float): StopBand =
     if (zoom < STOP_DOT_ZOOM_THRESHOLD) StopBand.DOT else StopBand.FULL
 
-/** The icon variants a stop marker can show: full icon (normal/focused) or dot (normal/focused). */
-enum class StopIconKind { FULL, FULL_FOCUSED, DOT, DOT_FOCUSED }
+/**
+ * The icon variants a stop marker can show: the full directional icon or the far-zoom dot (each
+ * normal/focused), plus the distinctive star a starred (favorite) stop gets in place of either
+ * (#1680), likewise normal/focused.
+ */
+enum class StopIconKind {
+    FULL, FULL_FOCUSED, DOT, DOT_FOCUSED,
+    FAVORITE, FAVORITE_FOCUSED, FAVORITE_DOT, FAVORITE_DOT_FOCUSED,
+}
 
 /**
- * The icon a stop marker should show given whether it's the [focused] stop and the current zoom
- * [band]. The focused stop always gets a distinct (accent) icon — the enlarged full icon up close,
- * an accent-colored dot far out — so a selection stays visible at every zoom. Pure, so the renderers'
- * "did this marker's icon change?" decision is unit-testable and identical across both map flavors.
+ * The icon a stop marker should show given whether it's the [focused] stop, whether it's a
+ * [favorite] (starred) stop, and the current zoom [band]. A starred stop gets a distinctive star
+ * (full-size close up, smaller in the dot band) instead of its directional icon/dot, so it's easy to
+ * pick out and navigate to (#1680); the focused stop always gets a distinct (enlarged/accent) variant
+ * so a selection stays visible at every zoom. Pure, so the renderers' "did this marker's icon change?"
+ * decision is unit-testable and identical across both map flavors.
  */
-fun stopIconKind(focused: Boolean, band: StopBand): StopIconKind = when {
+fun stopIconKind(focused: Boolean, band: StopBand, favorite: Boolean = false): StopIconKind = when {
+    favorite && band == StopBand.DOT ->
+        if (focused) StopIconKind.FAVORITE_DOT_FOCUSED else StopIconKind.FAVORITE_DOT
+    favorite -> if (focused) StopIconKind.FAVORITE_FOCUSED else StopIconKind.FAVORITE
     band == StopBand.DOT -> if (focused) StopIconKind.DOT_FOCUSED else StopIconKind.DOT
     focused -> StopIconKind.FULL_FOCUSED
     else -> StopIconKind.FULL

--- a/onebusaway-android/src/main/res/values/colors.xml
+++ b/onebusaway-android/src/main/res/values/colors.xml
@@ -29,6 +29,10 @@
     <!-- The focused/selected map stop highlight: the selected_map_stop_icon.xml fill + the focused dot. -->
     <color name="map_stop_focus">#FF9500</color>
 
+    <!-- The starred (favorite) stop marker's star: a gold gradient (light top, dark bottom), #1680. -->
+    <color name="map_stop_favorite_light">#FFD54F</color>
+    <color name="map_stop_favorite_dark">#FFA000</color>
+
     <color name="body_text_1">#de000000</color>
     <color name="body_text_2">#8a000000</color>
     <color name="body_text_disabled">#44000000</color>

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
@@ -86,6 +86,11 @@ class MapLibreRenderer(
     private var renderedFocusedStopId: String? = null
     // The zoom band the stop icons were last drawn for (full icon vs dot); see [reconcileStopMarkers].
     private var renderedStopBand = StopBand.FULL
+    // The stop ids drawn as starred (favorite) last reconcile, so a star/unstar flips the icon even
+    // when focus and band are unchanged; see [reconcileStopMarkers]. (Unlike the Google renderer,
+    // maplibre markers carry no z-index, so the #1680 tap-preference is icon-only here — a starred stop
+    // can't be given draw/tap priority over an overlapping plain stop on this flavor.)
+    private var renderedFavoriteStopIds: Set<String> = emptySet()
 
     private val bikeByMarker = HashMap<Marker, BikeMarker>()
 
@@ -213,7 +218,7 @@ class MapLibreRenderer(
             }
         }
         for (stop in stops) {
-            val kind = stopIconKind(stop.id == focusedStopId, band)
+            val kind = stopIconKind(stop.id == focusedStopId, band, stop.favorite)
             val existing = stopMarkersByStopId[stop.id]
             if (existing == null) {
                 val marker = map.addMarker(
@@ -221,14 +226,20 @@ class MapLibreRenderer(
                 )
                 stopMarkersByStopId[stop.id] = marker
                 stopByMarker[marker] = stop
-            } else if (stopIconKind(stop.id == renderedFocusedStopId, renderedStopBand) != kind) {
+            } else if (stopIconKind(
+                    stop.id == renderedFocusedStopId,
+                    renderedStopBand,
+                    stop.id in renderedFavoriteStopIds,
+                ) != kind
+            ) {
                 // Only the markers whose icon kind changed need a new icon (maplibre centers the icon
-                // on the position, so the dot lands on the stop with no anchor change).
+                // on the position, so the dot/star lands on the stop with no anchor change).
                 existing.icon = stopIcon(stop, kind)
             }
         }
         renderedFocusedStopId = focusedStopId
         renderedStopBand = band
+        renderedFavoriteStopIds = buildSet { for (s in stops) if (s.favorite) add(s.id) }
     }
 
     private fun stopIcon(stop: StopMarker, kind: StopIconKind): Icon = when (kind) {
@@ -236,6 +247,10 @@ class MapLibreRenderer(
         StopIconKind.FULL_FOCUSED -> MapLibreStopIcons.focusedIconForDirection(context, stop.direction)
         StopIconKind.DOT -> MapLibreStopIcons.dotIcon(context)
         StopIconKind.DOT_FOCUSED -> MapLibreStopIcons.focusedDotIcon(context)
+        StopIconKind.FAVORITE -> MapLibreStopIcons.favoriteIcon(context, stop.direction)
+        StopIconKind.FAVORITE_FOCUSED -> MapLibreStopIcons.focusedFavoriteIcon(context, stop.direction)
+        StopIconKind.FAVORITE_DOT -> MapLibreStopIcons.favoriteDotIcon(context)
+        StopIconKind.FAVORITE_DOT_FOCUSED -> MapLibreStopIcons.focusedFavoriteDotIcon(context)
     }
 
     /**

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreStopIcons.java
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreStopIcons.java
@@ -95,6 +95,20 @@ public final class MapLibreStopIcons {
      */
     private static Icon dot_stop_icon_focused;
 
+    /**
+     * The distinctive star shown for a starred (favorite) stop (#1680), in place of its directional
+     * icon up close / its dot far out — with a focused (enlarged) variant of each. The full-band star
+     * keeps the direction arrow the other stop markers carry, so it's per-direction; the dot-band star
+     * has no arrow (matching the plain dot), so it's a single direction-agnostic icon.
+     */
+    private static final Icon[] star_stop_icons = new Icon[NUM_DIRECTIONS];
+
+    private static final Icon[] star_stop_icons_focused = new Icon[NUM_DIRECTIONS];
+
+    private static Icon star_dot_stop_icon;
+
+    private static Icon star_dot_stop_icon_focused;
+
     private static final float FOCUS_ICON_SCALE = 1.5f;
 
     private static int mPx;
@@ -143,6 +157,30 @@ public final class MapLibreStopIcons {
         return dot_stop_icon_focused;
     }
 
+    /** The distinctive star (with the direction arrow) for a starred stop up close. */
+    public static synchronized Icon favoriteIcon(Context context, String direction) {
+        ensureLoaded(context);
+        return star_stop_icons[indexFor(direction)];
+    }
+
+    /** The focused (enlarged) star (with the direction arrow) for the selected starred stop up close. */
+    public static synchronized Icon focusedFavoriteIcon(Context context, String direction) {
+        ensureLoaded(context);
+        return star_stop_icons_focused[indexFor(direction)];
+    }
+
+    /** The smaller star shown for a starred stop in the far-zoom dot band. */
+    public static synchronized Icon favoriteDotIcon(Context context) {
+        ensureLoaded(context);
+        return star_dot_stop_icon;
+    }
+
+    /** The focused (enlarged) star for the selected starred stop in the dot band. */
+    public static synchronized Icon focusedFavoriteDotIcon(Context context) {
+        ensureLoaded(context);
+        return star_dot_stop_icon_focused;
+    }
+
     private static int indexFor(String direction) {
         Integer index = directionToIndexMap.get(direction);
         return index != null ? index : 8;
@@ -166,18 +204,45 @@ public final class MapLibreStopIcons {
 
         IconFactory iconFactory = IconFactory.getInstance(context);
         String[] directions = {NORTH, NORTH_WEST, WEST, SOUTH_WEST, SOUTH, SOUTH_EAST, EAST, NORTH_EAST, NO_DIRECTION};
+
+        // Star colors: the normal star is the gold gradient (light→dark); a selected star uses the same
+        // focus color as every other selected stop (solid). The arrow keeps the theme primary→accent.
+        int starLight = r.getColor(R.color.map_stop_favorite_light);
+        int starDark = r.getColor(R.color.map_stop_favorite_dark);
+        int focusColor = r.getColor(R.color.map_stop_focus);
+        int arrowTip = r.getColor(R.color.theme_primary);
+        int arrowBase = r.getColor(R.color.theme_accent);
+        // The star outline matches the plain circle's ring width (same for full- and dot-band).
+        float starOutlinePx = StopBitmaps.STAR_OUTLINE_WIDTH_DP * r.getDisplayMetrics().density;
+        int starPx = Math.round(mPx * StopBitmaps.STAR_SIZE_SCALE);
+
         for (int i = 0; i < directions.length; i++) {
             bus_stop_icons[i] = iconFactory.fromBitmap(createBusStopIcon(context, directions[i], false));
-            Bitmap focused = createBusStopIcon(context, directions[i], true);
-            focused = Bitmap.createScaledBitmap(focused,
-                    (int) (focused.getWidth() * FOCUS_ICON_SCALE),
-                    (int) (focused.getHeight() * FOCUS_ICON_SCALE), true);
-            bus_stop_icons_focused[i] = iconFactory.fromBitmap(focused);
+            // Starred-stop full-band icon: an inflated star with the normal-sized direction arrow drawn
+            // on top; the focused variant is the selected-color star, enlarged as a whole.
+            boolean hasArrow = !directions[i].equals(NO_DIRECTION);
+            float angle = StopBitmaps.compassAngle(directions[i]);
+            star_stop_icons[i] = iconFactory.fromBitmap(StopBitmaps.favoriteMarker(
+                    mPx, starPx, hasArrow, angle, starLight, starDark, arrowTip, arrowBase, starOutlinePx));
+            star_stop_icons_focused[i] = iconFactory.fromBitmap(StopBitmaps.scale(
+                    StopBitmaps.favoriteMarker(mPx, starPx, hasArrow, angle,
+                            focusColor, focusColor, arrowTip, arrowBase, starOutlinePx),
+                    FOCUS_ICON_SCALE));
+            bus_stop_icons_focused[i] = iconFactory.fromBitmap(
+                    StopBitmaps.scale(createBusStopIcon(context, directions[i], true), FOCUS_ICON_SCALE));
         }
 
         dot_stop_icon = iconFactory.fromBitmap(StopBitmaps.dot(mPx, r.getColor(R.color.theme_primary)));
-        dot_stop_icon_focused = iconFactory.fromBitmap(StopBitmaps.dot(mPx,
-                r.getColor(R.color.map_stop_focus), StopBitmaps.FOCUSED_DOT_SCALE));
+        dot_stop_icon_focused = iconFactory.fromBitmap(
+                StopBitmaps.dot(mPx, focusColor, StopBitmaps.FOCUSED_DOT_SCALE));
+
+        // Dot-band starred stops: a plain star (no arrow, matching the plain dot), dot-sized and enlarged
+        // when focused. Gold gradient normally, the selected color when focused; same thin outline.
+        int starDotPx = Math.round(mPx * 0.5f * StopBitmaps.STAR_SIZE_SCALE);
+        star_dot_stop_icon = iconFactory.fromBitmap(
+                StopBitmaps.star(starDotPx, starLight, starDark, starOutlinePx));
+        star_dot_stop_icon_focused = iconFactory.fromBitmap(StopBitmaps.star(
+                Math.round(starDotPx * StopBitmaps.FOCUSED_DOT_SCALE), focusColor, focusColor, starOutlinePx));
     }
 
     @SuppressWarnings("deprecation")

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/render/StopZoomBandTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/render/StopZoomBandTest.kt
@@ -54,4 +54,30 @@ class StopZoomBandTest {
         assertEquals(StopIconKind.FULL, stopIconKind(focused = false, band = StopBand.FULL))
         assertEquals(StopIconKind.FULL_FOCUSED, stopIconKind(focused = true, band = StopBand.FULL))
     }
+
+    @Test
+    fun `a starred stop gets the star in place of its icon or dot, focus enlarging it`() {
+        assertEquals(
+            StopIconKind.FAVORITE,
+            stopIconKind(focused = false, band = StopBand.FULL, favorite = true)
+        )
+        assertEquals(
+            StopIconKind.FAVORITE_FOCUSED,
+            stopIconKind(focused = true, band = StopBand.FULL, favorite = true)
+        )
+        assertEquals(
+            StopIconKind.FAVORITE_DOT,
+            stopIconKind(focused = false, band = StopBand.DOT, favorite = true)
+        )
+        assertEquals(
+            StopIconKind.FAVORITE_DOT_FOCUSED,
+            stopIconKind(focused = true, band = StopBand.DOT, favorite = true)
+        )
+    }
+
+    @Test
+    fun `favorite defaults to false so a non-starred stop keeps its plain icon`() {
+        assertEquals(StopIconKind.FULL, stopIconKind(focused = false, band = StopBand.FULL))
+        assertEquals(StopIconKind.DOT, stopIconKind(focused = false, band = StopBand.DOT))
+    }
 }


### PR DESCRIPTION
Closes #1680.

## What

Starred (favorite) stops now render a distinctive **star** on the map instead of the plain circle, so they're easy to pick out and navigate to.

- **Styled like a normal stop, just star-shaped**: same white outline and a gold gradient fill, inflated (1.75×) with the normal-size direction arrow drawn on top. The star is centered on the stop; the arrow points outward exactly like every other marker.
- **Every zoom / focus state**: full star + arrow up close; a smaller plain star in the far-zoom dot band; when selected, the star turns the same focus color (`map_stop_focus`) as any other selected stop.
- **Tap preference**: on Google Maps a starred stop draws just above its neighbours (z-index) so it wins an overlapping tap. (MapLibre has no per-marker z-index, so there it's icon-only — noted in code.)
- **Live**: `StopDao.favoriteStopIds()` → `MapViewModel` → `StopsMapController` re-flags the drawn markers the instant you star/unstar — no pan needed.

## How

- `StopBitmaps` (shared, `src/main`) gains `star()` + `favoriteMarker()` (inflated star + normal arrow) plus shared `scale()`/`compassAngle()` helpers, so both map flavors draw an identical marker from one place.
- `StopIconKind` gains `FAVORITE_*` variants; `stopIconKind(focused, band, favorite)` is the pure, unit-tested selector.
- `StopMarker` carries a `favorite` flag; each renderer tracks `renderedFavoriteStopIds` and re-icons in place (mirrors the existing `renderedFocusedStopId`/`renderedStopBand` pattern).

## Notes

- The star's white outline width (`STAR_OUTLINE_WIDTH_DP`) was tuned on device to read like the circle's border.
- Deliberately deferred (tracked as a note in code): the plain directional-icon **arrow geometry** is still duplicated in each flavor's Java factory; `favoriteMarker` mirrors it by convention. Hoisting all of it into `src/main` is a larger refactor out of scope here.

Both flavors compile; `StopZoomBandTest` covers the icon-kind selector; device-verified on a Pixel 7 Pro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added starred/favorite stop marker support on the map, including distinct icons for close and zoomed-out views.
  * Favorite stops now render with a gold-themed appearance and can take tap priority when overlapping other markers.

* **Bug Fixes**
  * Favorite status now updates immediately on the map when a stop is starred or unstarred.
  * Marker placement and refresh behavior were improved so favorite icons stay consistent during map updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->