### PR TITLE
Lint cleanup: internationalization & string formatting (#1701)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/ConversionUtils.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/ConversionUtils.kt
@@ -32,6 +32,7 @@ import java.time.ZoneId
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
 import java.util.Date
+import java.util.Locale
 import java.util.TimeZone
 
 /**
@@ -111,21 +112,21 @@ object ConversionUtils {
 
         if (PreferenceUtils.getUnitsAreMetricFromPreferences(applicationContext)) {
             if (value < 1000) {
-                text += String.format(OTPConstants.FORMAT_DISTANCE_METERS, value) + " " +
+                text += String.format(Locale.getDefault(), OTPConstants.FORMAT_DISTANCE_METERS, value) + " " +
                     applicationContext.resources.getString(R.string.meters_abbreviation)
             } else {
                 value /= 1000
-                text += String.format(OTPConstants.FORMAT_DISTANCE_KILOMETERS, value) + " " +
+                text += String.format(Locale.getDefault(), OTPConstants.FORMAT_DISTANCE_KILOMETERS, value) + " " +
                     applicationContext.resources.getString(R.string.kilometers_abbreviation)
             }
         } else {
             var feet = value * FEET_PER_METER
             if (feet < 1000) {
-                text += String.format(OTPConstants.FORMAT_DISTANCE_METERS, feet) + " " +
+                text += String.format(Locale.getDefault(), OTPConstants.FORMAT_DISTANCE_METERS, feet) + " " +
                     applicationContext.resources.getString(R.string.feet_abbreviation)
             } else {
                 feet /= 5280
-                text += String.format(OTPConstants.FORMAT_DISTANCE_KILOMETERS, feet) + " " +
+                text += String.format(Locale.getDefault(), OTPConstants.FORMAT_DISTANCE_KILOMETERS, feet) + " " +
                     applicationContext.resources.getString(R.string.miles_abbreviation)
             }
         }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/compose/VehicleInfoWindow.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/compose/VehicleInfoWindow.kt
@@ -309,12 +309,12 @@ internal fun serverNowMs(serverTimeMs: Long, deviceStartMs: Long, deviceNowMs: L
  */
 internal fun formatDataAge(res: Resources, elapsedSeconds: Long, estimating: Boolean = false): String {
     val s = elapsedSeconds.coerceAtLeast(0)
-    val secRes = if (estimating) R.string.vehicle_estimate_from_update_sec else R.string.vehicle_last_updated_sec
+    val secRes = if (estimating) R.plurals.vehicle_estimate_from_update_sec else R.plurals.vehicle_last_updated_sec
     val minSecRes =
-        if (estimating) R.string.vehicle_estimate_from_update_min_and_sec else R.string.vehicle_last_updated_min_and_sec
+        if (estimating) R.plurals.vehicle_estimate_from_update_min_and_sec else R.plurals.vehicle_last_updated_min_and_sec
     return if (s < 60) {
-        res.getString(secRes, s)
+        res.getQuantityString(secRes, s.toInt(), s)
     } else {
-        res.getString(minSecRes, TimeUnit.SECONDS.toMinutes(s), s % 60)
+        res.getQuantityString(minSecRes, (s % 60).toInt(), TimeUnit.SECONDS.toMinutes(s), s % 60)
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/VehicleBitmaps.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/VehicleBitmaps.java
@@ -32,6 +32,7 @@ import org.onebusaway.android.util.ArrivalInfoUtils;
 import org.onebusaway.android.util.BitmapUtils;
 import org.onebusaway.android.util.MathUtils;
 
+import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -159,7 +160,7 @@ public final class VehicleBitmaps {
             vehicleType = DEFAULT_VEHICLE_TYPE;
         }
 
-        String cacheKey = String.format("%d %d", halfWind, vehicleType);
+        String cacheKey = String.format(Locale.US, "%d %d", halfWind, vehicleType);
         Bitmap b = sUncoloredIcons.get(cacheKey);
         if (b == null) {
             switch (vehicleType) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/util/ServiceUtils.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/util/ServiceUtils.java
@@ -21,6 +21,7 @@ import org.onebusaway.android.report.constants.ReportConstants;
 import android.content.Context;
 
 import java.util.List;
+import java.util.Locale;
 
 import edu.usf.cutr.open311client.models.Service;
 
@@ -136,7 +137,7 @@ public class ServiceUtils {
         String[] transitKeywords = context.getResources().
                 getStringArray(R.array.report_stop_transit_category_keywords);
         for (String keyword : transitKeywords) {
-            if (text != null && text.toLowerCase().contains(keyword)) {
+            if (text != null && text.toLowerCase(Locale.getDefault()).contains(keyword)) {
                 return true;
             }
         }
@@ -157,7 +158,7 @@ public class ServiceUtils {
                 getStringArray(R.array.report_trip_transit_category_keywords);
 
         for (String keyword : transitKeywords) {
-            if (text != null && text.toLowerCase().contains(keyword)) {
+            if (text != null && text.toLowerCase(Locale.getDefault()).contains(keyword)) {
                 return true;
             }
         }
@@ -214,7 +215,7 @@ public class ServiceUtils {
         boolean didMatch = false;
 
         for (String keyword : stopIdKeywords) {
-            if (desc != null && desc.toLowerCase().contains(keyword)) {
+            if (desc != null && desc.toLowerCase(Locale.getDefault()).contains(keyword)) {
                 if (didMatch) {
                     // if this is the second matched keyword then return true
                     return true;

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalInfo.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalInfo.kt
@@ -233,15 +233,15 @@ class ArrivalInfo(
             val time: ServerTime
 
             if (now < frequency.startTime) {
-                statusLabelId = R.string.stop_info_frequency_from
+                statusLabelId = R.plurals.stop_info_frequency_from
                 time = frequency.startTime
             } else {
-                statusLabelId = R.string.stop_info_frequency_until
+                statusLabelId = R.plurals.stop_info_frequency_until
                 time = frequency.endTime
             }
 
             val label = formatter.format(Date(time.epochMs))
-            return context.getString(statusLabelId, headwayAsMinutes, label)
+            return res.getQuantityString(statusLabelId, headwayAsMinutes, headwayAsMinutes, label)
         }
 
         if (hasPrediction) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripdetails/TripDetailsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripdetails/TripDetailsRepository.kt
@@ -253,13 +253,13 @@ class DefaultTripDetailsRepository @Inject constructor(
             val lastUpdate = DisplayFormat.formatTime(context, status.lastUpdateTime)
             when {
                 deviation >= 0 && deviation < 60 ->
-                    context.getString(R.string.trip_details_real_time_sec_late, seconds, lastUpdate)
+                    context.resources.getQuantityString(R.plurals.trip_details_real_time_sec_late, seconds.toInt(), seconds, lastUpdate)
                 deviation >= 0 ->
-                    context.getString(R.string.trip_details_real_time_min_sec_late, minutes, seconds, lastUpdate)
+                    context.resources.getQuantityString(R.plurals.trip_details_real_time_min_sec_late, seconds.toInt(), minutes, seconds, lastUpdate)
                 deviation > -60 ->
-                    context.getString(R.string.trip_details_real_time_sec_early, seconds, lastUpdate)
+                    context.resources.getQuantityString(R.plurals.trip_details_real_time_sec_early, seconds.toInt(), seconds, lastUpdate)
                 else ->
-                    context.getString(R.string.trip_details_real_time_min_sec_early, minutes, seconds, lastUpdate)
+                    context.resources.getQuantityString(R.plurals.trip_details_real_time_min_sec_early, seconds.toInt(), minutes, seconds, lastUpdate)
             }
         }
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/LocationUtils.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/LocationUtils.java
@@ -37,6 +37,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 
 import edu.usf.cutr.pelias.AutocompleteRequest;
@@ -258,7 +259,7 @@ public class LocationUtils {
             sb.append(loc.getAccuracy());
         }
         sb.append(", ");
-        sb.append(String.format("%.0f", timeDiffSec) + " second(s) ago");
+        sb.append(String.format(Locale.US, "%.0f", timeDiffSec) + " second(s) ago");
 
         return sb.toString();
     }

--- a/onebusaway-android/src/main/res/values-es/strings.xml
+++ b/onebusaway-android/src/main/res/values-es/strings.xml
@@ -16,7 +16,8 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <string name="app_name">OneBusAway</string>
 
@@ -148,11 +149,19 @@
             <xliff:g id="count">%d</xliff:g>
             min tarde
         </item>
+        <item quantity="many">
+            <xliff:g id="count">%d</xliff:g>
+            min tarde
+        </item>
     </plurals>
     <plurals name="stop_info_arrive_early">
         <item quantity="one">1 min antes</item>
         <!-- Below element should remain on same line if XML is reformatted - see #99 -->
         <item quantity="other">
+            <xliff:g id="count">%d</xliff:g>
+            min antes
+        </item>
+        <item quantity="many">
             <xliff:g id="count">%d</xliff:g>
             min antes
         </item>
@@ -164,11 +173,19 @@
             <xliff:g id="count">%d</xliff:g>
             min tarde
         </item>
+        <item quantity="many">Sale
+            <xliff:g id="count">%d</xliff:g>
+            min tarde
+        </item>
     </plurals>
     <plurals name="stop_info_depart_early">
         <item quantity="one">Sale 1 min antes</item>
         <!-- Entire element below should be on a single line if XML is reformatted - see #99 -->
         <item quantity="other">Sale
+            <xliff:g id="count">%d</xliff:g>
+            min antes
+        </item>
+        <item quantity="many">Sale
             <xliff:g id="count">%d</xliff:g>
             min antes
         </item>
@@ -180,11 +197,19 @@
             <xliff:g id="count">%d</xliff:g>
             min tarde
         </item>
+        <item quantity="many">Llegó
+            <xliff:g id="count">%d</xliff:g>
+            min tarde
+        </item>
     </plurals>
     <plurals name="stop_info_arrived_early">
         <item quantity="one">Llegó 1 min antes</item>
         <!-- Entire element below should be on a single line if XML is reformatted - see #99 -->
         <item quantity="other">Llegó
+            <xliff:g id="count">%d</xliff:g>
+            min antes
+        </item>
+        <item quantity="many">Llegó
             <xliff:g id="count">%d</xliff:g>
             min antes
         </item>
@@ -196,6 +221,10 @@
             <xliff:g id="count">%d</xliff:g>
             min tarde
         </item>
+        <item quantity="many">
+            <xliff:g id="count">%d</xliff:g>
+            min tarde
+        </item>
     </plurals>
     <plurals name="stop_info_status_early_without_arrive_depart">
         <item quantity="one">1 min antes</item>
@@ -204,11 +233,19 @@
             <xliff:g id="count">%d</xliff:g>
             min antes
         </item>
+        <item quantity="many">
+            <xliff:g id="count">%d</xliff:g>
+            min antes
+        </item>
     </plurals>
     <plurals name="stop_info_car_count">
         <item quantity="one">1 coche</item>
         <!-- Entire element below should be on a single line if XML is reformatted - see #99 -->
         <item quantity="other">
+            <xliff:g id="count">%d</xliff:g>
+            coches
+        </item>
+        <item quantity="many">
             <xliff:g id="count">%d</xliff:g>
             coches
         </item>
@@ -221,8 +258,16 @@
     <string name="stop_info_time_arrived_at">Llegó a las %1s</string>
     <string name="stop_info_time_departed_at">Salió a las %1s</string>
 
-    <string name="stop_info_frequency_from">Cada %1$d mins desde %2$s</string>
-    <string name="stop_info_frequency_until">Cada %1$d mins hasta %2$s</string>
+    <plurals name="stop_info_frequency_from">
+        <item quantity="one">Cada %1$d mins desde %2$s</item>
+        <item quantity="many">Cada %1$d mins desde %2$s</item>
+        <item quantity="other">Cada %1$d mins desde %2$s</item>
+    </plurals>
+    <plurals name="stop_info_frequency_until">
+        <item quantity="one">Cada %1$d mins hasta %2$s</item>
+        <item quantity="many">Cada %1$d mins hasta %2$s</item>
+        <item quantity="other">Cada %1$d mins hasta %2$s</item>
+    </plurals>
     <string name="stop_info_eta_now">AHORA</string>
     <string name="stop_info_option_showonmap">Mostrar sobre el Mapa</string>
     <string name="menu_option_sort_by">Ordenar por</string>
@@ -244,11 +289,17 @@
             <xliff:g id="count">%2$d</xliff:g>
             horas y %1$d min.
         </item>
+        <item quantity="many">Sin llegadas en las siguientes
+            <xliff:g id="count">%2$d</xliff:g>
+            horas y %1$d min.
+        </item>
     </plurals>
     <plurals name="stop_info_nodata_hours_minutes_short_format">
         <item quantity="one">1h %1$d+ min</item>
         <!-- Entire element below should be on a single line if XML is reformatted - see #99 -->
         <item quantity="other"><xliff:g id="count">%2$d</xliff:g>h %1$d+ min
+        </item>
+        <item quantity="many"><xliff:g id="count">%2$d</xliff:g>h %1$d+ min
         </item>
     </plurals>
     <string name="stop_info_no_additional_data_minutes">Sin llegadas adicionales en los próximos %1$d
@@ -262,11 +313,17 @@
             <xliff:g id="count">%2$d</xliff:g>
             horas y %1$d min.
         </item>
+        <item quantity="many">Sin llegadas adicionales en las siguientes
+            <xliff:g id="count">%2$d</xliff:g>
+            horas y %1$d min.
+        </item>
     </plurals>
     <plurals name="stop_info_no_additional_data_hours_minutes_short_format">
         <item quantity="one">1h %1$d+ min</item>
         <!-- Entire element below should be on a single line if XML is reformatted - see #99 -->
         <item quantity="other"><xliff:g id="count">%2$d</xliff:g>h %1$d+ min
+        </item>
+        <item quantity="many"><xliff:g id="count">%2$d</xliff:g>h %1$d+ min
         </item>
     </plurals>
     <string name="stop_info_load_more_arrivals">Cargar más llegadas</string>
@@ -345,10 +402,12 @@
     <plurals name="alert_filter_text">
         <item quantity="one">%1$d alerta oculta</item>
         <item quantity="other"><xliff:g id="count">%1$d</xliff:g> alertas ocultas</item>
+        <item quantity="many"><xliff:g id="count">%1$d</xliff:g> alertas ocultas</item>
     </plurals>
     <plurals name="alert_show_more">
         <item quantity="one">%1$d alerta más</item>
         <item quantity="other"><xliff:g id="count">%1$d</xliff:g> alertas más</item>
+        <item quantity="many"><xliff:g id="count">%1$d</xliff:g> alertas más</item>
     </plurals>
 
     <!-- Find -->
@@ -427,11 +486,19 @@
             <xliff:g id="count">%s</xliff:g>
             millas de distancia
         </item>
+        <item quantity="many">
+            <xliff:g id="count">%s</xliff:g>
+            millas de distancia
+        </item>
     </plurals>
     <plurals name="distance_feet">
         <item quantity="one">1 pie de distancia</item>
         <!-- Entire element below should be on a single line if XML is reformatted - see #99 -->
         <item quantity="other">
+            <xliff:g id="count">%s</xliff:g>
+            pies de distancia
+        </item>
+        <item quantity="many">
             <xliff:g id="count">%s</xliff:g>
             pies de distancia
         </item>
@@ -443,11 +510,19 @@
             <xliff:g id="count">%s</xliff:g>
             kilómetros de distancia
         </item>
+        <item quantity="many">
+            <xliff:g id="count">%s</xliff:g>
+            kilómetros de distancia
+        </item>
     </plurals>
     <plurals name="distance_meters">
         <item quantity="one">1 metro de distancia</item>
         <!-- Entire element below should be on a single line if XML is reformatted - see #99 -->
         <item quantity="other">
+            <xliff:g id="count">%s</xliff:g>
+            metros de distancia
+        </item>
+        <item quantity="many">
             <xliff:g id="count">%s</xliff:g>
             metros de distancia
         </item>
@@ -674,20 +749,41 @@
     <!-- Trip Details -->
     <string name="trip_details_vehicle">Vehículo: %1$s</string>
     <string name="trip_details_scheduled_data">Datos de horario</string>
-    <string name="trip_details_real_time_sec_late">%1$d seg tarde (Última actualización: %2$s)</string>
-    <string name="trip_details_real_time_min_sec_late">%1$d min %2$d seg tarde (Última actualización: %3$s)
-    </string>
-    <string name="trip_details_real_time_sec_early">%1$d seg antes (Última actualización: %2$s)</string>
-    <string name="trip_details_real_time_min_sec_early">%1$d min %2$d seg antes (Última actualización:
-        %3$s)
-    </string>
+    <plurals name="trip_details_real_time_sec_late">
+        <item quantity="one">%1$d seg tarde (Última actualización: %2$s)</item>
+        <item quantity="many">%1$d seg tarde (Última actualización: %2$s)</item>
+        <item quantity="other">%1$d seg tarde (Última actualización: %2$s)</item>
+    </plurals>
+    <plurals name="trip_details_real_time_min_sec_late">
+        <item quantity="one">%1$d min %2$d seg tarde (Última actualización: %3$s)</item>
+        <item quantity="many">%1$d min %2$d seg tarde (Última actualización: %3$s)</item>
+        <item quantity="other">%1$d min %2$d seg tarde (Última actualización: %3$s)</item>
+    </plurals>
+    <plurals name="trip_details_real_time_sec_early">
+        <item quantity="one">%1$d seg antes (Última actualización: %2$s)</item>
+        <item quantity="many">%1$d seg antes (Última actualización: %2$s)</item>
+        <item quantity="other">%1$d seg antes (Última actualización: %2$s)</item>
+    </plurals>
+    <plurals name="trip_details_real_time_min_sec_early">
+        <item quantity="one">%1$d min %2$d seg antes (Última actualización: %3$s)</item>
+        <item quantity="many">%1$d min %2$d seg antes (Última actualización: %3$s)</item>
+        <item quantity="other">%1$d min %2$d seg antes (Última actualización: %3$s)</item>
+    </plurals>
     <string name="trip_details_current_stop">Parada actual</string>
     <string name="trip_details_current_bus_position">El bus se encuentra actualmente en</string>
     <string name="trip_details_dest_stop">Parada de destino</string>
 
     <!-- Vehicles on Map -->
-    <string name="vehicle_last_updated_sec">Datos actualizados hace %1$d seg</string>
-    <string name="vehicle_last_updated_min_and_sec">Datos acualizados hace %1$d min %2$d seg</string>
+    <plurals name="vehicle_last_updated_sec">
+        <item quantity="one">Datos actualizados hace %1$d seg</item>
+        <item quantity="many">Datos actualizados hace %1$d seg</item>
+        <item quantity="other">Datos actualizados hace %1$d seg</item>
+    </plurals>
+    <plurals name="vehicle_last_updated_min_and_sec">
+        <item quantity="one">Datos acualizados hace %1$d min %2$d seg</item>
+        <item quantity="many">Datos acualizados hace %1$d min %2$d seg</item>
+        <item quantity="other">Datos acualizados hace %1$d min %2$d seg</item>
+    </plurals>
     <string name="vehicle_last_updated_scheduled">Posición calculada a partir de la planificación</string>
 
     <!-- Night Light -->
@@ -739,7 +835,7 @@
     <!-- About -->
     <!-- About screen: structured prose; the name lists are in the string-arrays below -->
     <string name="about_welcome_title">¡Bienvenido a %1$s!</string>
-    <string name="about_intro">Esta aplicación ha sido creada por un equipo de voluntarios y depende de la dedicación, pasión y talentos de sus colaboradores de código abierto.</string>
+    <string name="about_intro">%1$s ha sido creada por un equipo de voluntarios y depende de la dedicación, pasión y talentos de sus colaboradores de código abierto.</string>
     <string name="about_contributors_header">Colaboradores de Código:</string>
     <string name="about_contributors_intro">Nuestros dedicados colaboradores mejoran la funcionalidad y la experiencia del usuario de la aplicación:</string>
     <string name="about_translations_header">Traducciones:</string>
@@ -752,7 +848,8 @@
     <string name="about_thanks_material_icons">Un agradecimiento especial a Google por los increíbles íconos de diseño de material (https://github.com/google/material-design-icons), que añaden un toque de elegancia a nuestra aplicación. Su generosidad al licenciar estos íconos bajo la licencia Apache v2.0 (https://www.apache.org/licenses/LICENSE-2.0) ha enriquecido enormemente nuestra experiencia de usuario.</string>
     <string name="about_thanks_amcharts">Agradecimiento especial a amCharts por los iconos del clima en SVG gratuitos (https://www.amcharts.com/free-animated-svg-weather-icons/), estos íconos están bajo la licencia Creative Commons Attribution 4.0 (https://creativecommons.org/licenses/by/4.0/).</string>
     <string name="about_outro">¡Explora nuestra aplicación y emprende un viaje en transporte público sin contratiempos con %1$s!</string>
-    <string-array name="about_code_contributors">
+    <!-- "Area" is part of the proper agency name "Hillsborough Area Regional Transit". -->
+    <string-array name="about_code_contributors" tools:ignore="Typos">
         <item>Paul Watts</item>
         <item>Brian Ferris</item>
         <item>Daniel Welsh</item>
@@ -999,7 +1096,8 @@
     <string name="donation_dismiss_dialog_remind_me_later_button">Recuérdame Más Tarde</string>
     <string name="donation_dismiss_dialog_cancel_button">Cancelar</string>
     <string name="title_activity_donation_learn_more">Por qué necesitamos tu ayuda</string>
-    <string name="donation_learn_more_explanation">Tenemos grandes planes para mejorar %1$s, pero no podemos hacerlo sin tu ayuda. Esta aplicación está actualmente desarrollada con un 100%% de trabajo voluntario, y necesitamos que nos ayudes a financiar el desarrollo futuro.\n\nComo un proyecto clave de la Open Transit Software Foundation, una organización sin fines de lucro 501(c)(3), dependemos de la buena voluntad de usuarios como tú para seguir funcionando y mejorando este software.\n\nCada año, solo una pequeña fracción de nuestros usuarios dona, pero cada contribución, grande o pequeña, ayuda a asegurar que %1$s permanezca gratuito, actualizado y accesible para todos. Una pequeña donación, incluso solo el costo de una semana de viaje, $27.50, puede marcar la diferencia.\n\nTu contribución deducible de impuestos asegura que %1$s permanezca libre y accesible para todos. ¡Formemos juntos el futuro del transporte!\n\nGracias,\nEl equipo de %1$s</string>
+    <!-- "(c)" here is the "501(c)(3)" US tax-code designation, not a copyright symbol. -->
+    <string name="donation_learn_more_explanation" tools:ignore="TypographyOther">Tenemos grandes planes para mejorar %1$s, pero no podemos hacerlo sin tu ayuda. Esta aplicación está actualmente desarrollada con un 100%% de trabajo voluntario, y necesitamos que nos ayudes a financiar el desarrollo futuro.\n\nComo un proyecto clave de la Open Transit Software Foundation, una organización sin fines de lucro 501(c)(3), dependemos de la buena voluntad de usuarios como tú para seguir funcionando y mejorando este software.\n\nCada año, solo una pequeña fracción de nuestros usuarios dona, pero cada contribución, grande o pequeña, ayuda a asegurar que %1$s permanezca gratuito, actualizado y accesible para todos. Una pequeña donación, incluso solo el costo de una semana de viaje, $27.50, puede marcar la diferencia.\n\nTu contribución deducible de impuestos asegura que %1$s permanezca libre y accesible para todos. ¡Formemos juntos el futuro del transporte!\n\nGracias,\nEl equipo de %1$s</string>
     <string name="preferences_reset_donation_timestamps_title">Restablecer las marcas de tiempo de donación</string>
     <string name="preferences_reset_donation_timestamps_summary">Al tocar esta opción se borrarán las marcas de tiempo de \'Recuérdame más tarde\' y \'No me molestes\' asociadas con las solicitudes de donación.</string>
     <string name="preferences_show_weather_view">Mostrar vista del clima</string>

--- a/onebusaway-android/src/main/res/values-fi/strings.xml
+++ b/onebusaway-android/src/main/res/values-fi/strings.xml
@@ -14,7 +14,8 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <string name="app_name">OneBusAway</string>
 
@@ -217,8 +218,14 @@
     <string name="stop_info_time_arrived_at">Saapui %1s</string>
     <string name="stop_info_time_departed_at">Lähti %1s</string>
 
-    <string name="stop_info_frequency_from">Joka %1$d. min %2$s lähtien</string>
-    <string name="stop_info_frequency_until">Joka %1$d. min %2$s asti</string>
+    <plurals name="stop_info_frequency_from">
+        <item quantity="one">Joka %1$d. min %2$s lähtien</item>
+        <item quantity="other">Joka %1$d. min %2$s lähtien</item>
+    </plurals>
+    <plurals name="stop_info_frequency_until">
+        <item quantity="one">Joka %1$d. min %2$s asti</item>
+        <item quantity="other">Joka %1$d. min %2$s asti</item>
+    </plurals>
     <string name="stop_info_eta_now">NYT</string>
     <string name="stop_info_option_showonmap">Näytä kartalla</string>
     <string name="menu_option_sort_by">Järjestä</string>
@@ -582,19 +589,40 @@
     <!-- Trip Details -->
     <string name="trip_details_vehicle">Ajoneuvo: %1$s</string>
     <string name="trip_details_scheduled_data">Aikataulu</string>
-    <string name="trip_details_real_time_sec_late">%1$d s myöhässä (Viim. päivitys: %2$s)</string>
-    <string name="trip_details_real_time_min_sec_late">%1$d min %2$d s myöhässä (Viim. päivitys: %3$s)
-    </string>
-    <string name="trip_details_real_time_sec_early">%1$d s etuajassa (Viim. päivitys: %2$s)</string>
-    <string name="trip_details_real_time_min_sec_early">%1$d min %2$d s etuajassa (Viim. päivitys:
+    <plurals name="trip_details_real_time_sec_late">
+        <item quantity="one">%1$d s myöhässä (Viim. päivitys: %2$s)</item>
+        <item quantity="other">%1$d s myöhässä (Viim. päivitys: %2$s)</item>
+    </plurals>
+    <plurals name="trip_details_real_time_min_sec_late">
+        <item quantity="one">%1$d min %2$d s myöhässä (Viim. päivitys: %3$s)
+    </item>
+        <item quantity="other">%1$d min %2$d s myöhässä (Viim. päivitys: %3$s)
+    </item>
+    </plurals>
+    <plurals name="trip_details_real_time_sec_early">
+        <item quantity="one">%1$d s etuajassa (Viim. päivitys: %2$s)</item>
+        <item quantity="other">%1$d s etuajassa (Viim. päivitys: %2$s)</item>
+    </plurals>
+    <plurals name="trip_details_real_time_min_sec_early">
+        <item quantity="one">%1$d min %2$d s etuajassa (Viim. päivitys:
         %3$s)
-    </string>
+    </item>
+        <item quantity="other">%1$d min %2$d s etuajassa (Viim. päivitys:
+        %3$s)
+    </item>
+    </plurals>
     <string name="trip_details_current_stop">Nykyinen pysäkki</string>
     <string name="trip_details_current_bus_position">Bussin nykyinen sijainti</string>
 
     <!-- Vehicles on Map -->
-    <string name="vehicle_last_updated_sec">Tiedot päivitetty %1$d s sitten</string>
-    <string name="vehicle_last_updated_min_and_sec">Tiedot päivitetty %1$d min %2$d s sitten</string>
+    <plurals name="vehicle_last_updated_sec">
+        <item quantity="one">Tiedot päivitetty %1$d s sitten</item>
+        <item quantity="other">Tiedot päivitetty %1$d s sitten</item>
+    </plurals>
+    <plurals name="vehicle_last_updated_min_and_sec">
+        <item quantity="one">Tiedot päivitetty %1$d min %2$d s sitten</item>
+        <item quantity="other">Tiedot päivitetty %1$d min %2$d s sitten</item>
+    </plurals>
     <string name="vehicle_last_updated_scheduled">Sijainti laskettu aikataulun perusteella</string>
 
     <!-- Night Light -->
@@ -637,7 +665,7 @@
     <!-- About -->
     <!-- About screen: structured prose; the name lists are in the string-arrays below -->
     <string name="about_welcome_title">Tervetuloa %1$s-hankkeeseen!</string>
-    <string name="about_intro">Tämä sovellus on vapaaehtoistiimin tekemä ja se nojaa sen avoimen lähdekoodin avustajien omistautumiseen, intohimoon ja kykyihin.</string>
+    <string name="about_intro">%1$s on vapaaehtoistiimin tekemä ja se nojaa sen avoimen lähdekoodin avustajien omistautumiseen, intohimoon ja kykyihin.</string>
     <string name="about_contributors_header">Koodinkehittäjät:</string>
     <string name="about_contributors_intro">Omistautuneet avustajamme parantavat sovelluksen toiminnallisuutta ja käyttäjäkokemusta:</string>
     <string name="about_translations_header">Kääntäjät:</string>
@@ -691,7 +719,8 @@
     <string name="donation_dismiss_dialog_remind_me_later_button">Muistuta Minua Myöhemmin</string>
     <string name="donation_dismiss_dialog_cancel_button">Peruuta</string>
     <string name="title_activity_donation_learn_more">Miksi tarvitsemme apuasi</string>
-    <string name="donation_learn_more_explanation">Meillä on suuria suunnitelmia %1$sn parantamiseksi, mutta emme voi tehdä sitä ilman apuasi. Tämä sovellus on tällä hetkellä rakennettu 100%% vapaaehtoistyöllä, ja tarvitsemme sinua auttamaan meitä rahoittamaan tulevan kehityksen.\n\nOpen Transit Software Foundationin, 501(c)(3) voittoa tavoittelemattoman järjestön, keskeisenä hankkeena me luotamme käyttäjien, kuten sinun, hyväntahtoisuuteen pysyäksemme toiminnassa ja tehdäksemme tästä ohjelmistosta paremman.\n\nJoka vuosi vain pieni osa käyttäjistämme lahjoittaa, mutta jokainen panos, suuri tai pieni, auttaa varmistamaan, että %1$s pysyy ilmaisena, päivitettynä ja kaikkien saavutettavissa. Pieni lahjoitus, vaikkapa vain yhden viikon työmatkakustannusten verran, 27,50 dollaria, voi tehdä suuren eron.\n\nVerovähennyskelpoinen panoksesi varmistaa, että %1$s pysyy vapaana ja kaikkien saavutettavissa. Muovataan yhdessä joukkoliikenteen tulevaisuutta!\n\nKiitos,\n%1$s-tiimi</string>
+    <!-- "(c)" here is the "501(c)(3)" US tax-code designation, not a copyright symbol. -->
+    <string name="donation_learn_more_explanation" tools:ignore="TypographyOther">Meillä on suuria suunnitelmia %1$sn parantamiseksi, mutta emme voi tehdä sitä ilman apuasi. Tämä sovellus on tällä hetkellä rakennettu 100%% vapaaehtoistyöllä, ja tarvitsemme sinua auttamaan meitä rahoittamaan tulevan kehityksen.\n\nOpen Transit Software Foundationin, 501(c)(3) voittoa tavoittelemattoman järjestön, keskeisenä hankkeena me luotamme käyttäjien, kuten sinun, hyväntahtoisuuteen pysyäksemme toiminnassa ja tehdäksemme tästä ohjelmistosta paremman.\n\nJoka vuosi vain pieni osa käyttäjistämme lahjoittaa, mutta jokainen panos, suuri tai pieni, auttaa varmistamaan, että %1$s pysyy ilmaisena, päivitettynä ja kaikkien saavutettavissa. Pieni lahjoitus, vaikkapa vain yhden viikon työmatkakustannusten verran, 27,50 dollaria, voi tehdä suuren eron.\n\nVerovähennyskelpoinen panoksesi varmistaa, että %1$s pysyy vapaana ja kaikkien saavutettavissa. Muovataan yhdessä joukkoliikenteen tulevaisuutta!\n\nKiitos,\n%1$s-tiimi</string>
     <string name="preferences_reset_donation_timestamps_title">Nollaa Lahjoituksen Aikaleimat</string>
     <string name="preferences_reset_donation_timestamps_summary">Tämän vaihtoehdon napauttaminen poistaa sekä \'Muistuta minua myöhemmin\' että \'Älä vaivaudu\' aikaleimat, jotka liittyvät lahjoituspyyntöihin.</string>
     <string name="preferences_show_weather_view">Näytä säätönäkymä</string>

--- a/onebusaway-android/src/main/res/values-it/strings.xml
+++ b/onebusaway-android/src/main/res/values-it/strings.xml
@@ -15,7 +15,7 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
---><resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+--><resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" xmlns:tools="http://schemas.android.com/tools">
 
     <string name="app_name">OneBusAway</string>
 
@@ -80,7 +80,7 @@
     <string name="main_never_ask_again">Non chiedere più</string>
     <string name="main_never_show_again">Non mostrare più</string>
 
-    <string name="main_waiting_for_location">Ricerca della posizione...</string>
+    <string name="main_waiting_for_location">Ricerca della posizione…</string>
     <string name="no_location_permission">Impossibile individuare la posizione. Fornisci all\'app l\'accesso alla posizione nelle impostazioni di sistema.</string>
     <string name="main_outofrange_title">Fuori portata</string>
     <string name="main_outofrange">Il servizio di trasporti di %1$s non copre il luogo in cui ti trovi.\n\nSpostare mappa su %1$s?</string>
@@ -106,37 +106,47 @@
         <!-- Entire element below should be on a single line if XML is reformatted - see #99 -->
         <item quantity="other">
             <xliff:g id="count">%d</xliff:g> min di ritardo</item>
+        <item quantity="many">
+            <xliff:g id="count">%d</xliff:g> min di ritardo</item>
     </plurals>
     <plurals name="stop_info_arrive_early">
         <item quantity="one">1 min di anticipo</item>
         <!-- Below element should remain on same line if XML is reformatted - see #99 -->
         <item quantity="other">
             <xliff:g id="count">%d</xliff:g> min di anticipo</item>
+        <item quantity="many">
+            <xliff:g id="count">%d</xliff:g> min di anticipo</item>
     </plurals>
     <plurals name="stop_info_depart_delayed">
         <item quantity="one">Partito in ritardo di 1 min</item>
         <!-- Entire element below should be on a single line if XML is reformatted - see #99 -->
         <item quantity="other">Partito in ritardo di  <xliff:g id="count">%d</xliff:g> min</item>
+        <item quantity="many">Partito in ritardo di  <xliff:g id="count">%d</xliff:g> min</item>
     </plurals>
     <plurals name="stop_info_depart_early">
         <item quantity="one">Partito in anticipo di 1 min</item>
         <!-- Entire element below should be on a single line if XML is reformatted - see #99 -->
         <item quantity="other">Partito in anticipo di <xliff:g id="count">%d</xliff:g> min</item>
+        <item quantity="many">Partito in anticipo di <xliff:g id="count">%d</xliff:g> min</item>
     </plurals>
     <plurals name="stop_info_arrived_delayed">
         <item quantity="one">Arrivato in ritardo di 1 min</item>
         <!-- Entire element below should be on a single line if XML is reformatted - see #99 -->
         <item quantity="other">Arrivato in ritardo di <xliff:g id="count">%d</xliff:g> min</item>
+        <item quantity="many">Arrivato in ritardo di <xliff:g id="count">%d</xliff:g> min</item>
     </plurals>
     <plurals name="stop_info_arrived_early">
         <item quantity="one">Arrivato in anticipo di 1 min</item>
         <!-- Entire element below should be on a single line if XML is reformatted - see #99 -->
         <item quantity="other">Arrivato in anticipo di <xliff:g id="count">%d</xliff:g> min</item>
+        <item quantity="many">Arrivato in anticipo di <xliff:g id="count">%d</xliff:g> min</item>
     </plurals>
     <plurals name="stop_info_status_late_without_arrive_depart">
         <item quantity="one">1 min di ritardo</item>
         <!-- Entire element below should be on a single line if XML is reformatted - see #99 -->
         <item quantity="other">
+            <xliff:g id="count">%d</xliff:g> min di ritardo</item>
+        <item quantity="many">
             <xliff:g id="count">%d</xliff:g> min di ritardo</item>
     </plurals>
     <plurals name="stop_info_status_early_without_arrive_depart">
@@ -144,11 +154,17 @@
         <!-- Entire element below should be on a single line if XML is reformatted - see #99 -->
         <item quantity="other">
             <xliff:g id="count">%d</xliff:g> min di anticipo</item>
+        <item quantity="many">
+            <xliff:g id="count">%d</xliff:g> min di anticipo</item>
     </plurals>
     <plurals name="stop_info_car_count">
         <item quantity="one">1 vagone</item>
         <!-- Entire element below should be on a single line if XML is reformatted - see #99 -->
         <item quantity="other">
+            <xliff:g id="count">%d</xliff:g>
+            vagoni
+        </item>
+        <item quantity="many">
             <xliff:g id="count">%d</xliff:g>
             vagoni
         </item>
@@ -164,8 +180,16 @@
     <string name="stop_info_time_arrived_at">Arrivato alle ore %1s</string>
     <string name="stop_info_time_departed_at">Partito alle ore %1s</string>
 
-    <string name="stop_info_frequency_from">Ogni %1$d min dalle ore %2$s</string>
-    <string name="stop_info_frequency_until">Ogni %1$d min fino alle ore %2$s</string>
+    <plurals name="stop_info_frequency_from">
+        <item quantity="one">Ogni %1$d min dalle ore %2$s</item>
+        <item quantity="many">Ogni %1$d min dalle ore %2$s</item>
+        <item quantity="other">Ogni %1$d min dalle ore %2$s</item>
+    </plurals>
+    <plurals name="stop_info_frequency_until">
+        <item quantity="one">Ogni %1$d min fino alle ore %2$s</item>
+        <item quantity="many">Ogni %1$d min fino alle ore %2$s</item>
+        <item quantity="other">Ogni %1$d min fino alle ore %2$s</item>
+    </plurals>
     <string name="stop_info_eta_now">ORA</string>
     <string name="stop_info_option_showonmap">Mostra sulla mappa</string>
     <string name="menu_option_sort_by">Ordina per</string>
@@ -181,11 +205,14 @@
         <item quantity="one">Nessun arrivo nella prossima ora e %1$d min.</item>
         <!-- Entire element below should be on a single line if XML is reformatted - see #99 -->
         <item quantity="other">Nessun arrivo nelle prossime <xliff:g id="count">%2$d</xliff:g> ore e %1$d min.</item>
+        <item quantity="many">Nessun arrivo nelle prossime <xliff:g id="count">%2$d</xliff:g> ore e %1$d min.</item>
     </plurals>
     <plurals name="stop_info_nodata_hours_minutes_short_format">
         <item quantity="one">1h %1$d+ min</item>
         <!-- Entire element below should be on a single line if XML is reformatted - see #99 -->
         <item quantity="other"><xliff:g id="count">%2$d</xliff:g>h %1$d+ min
+        </item>
+        <item quantity="many"><xliff:g id="count">%2$d</xliff:g>h %1$d+ min
         </item>
     </plurals>
     <string name="stop_info_no_additional_data_minutes">Nessun altro arrivo nei prossimi %1$d min.</string>
@@ -194,11 +221,14 @@
         <item quantity="one">Nessun altro arrivo nella prossima ora e %1$d min.</item>
         <!-- Entire element below should be on a single line if XML is reformatted - see #99 -->
         <item quantity="other">Nessun altro arrivo nelle prossime<xliff:g id="count">%2$d</xliff:g> ore e %1$d min.</item>
+        <item quantity="many">Nessun altro arrivo nelle prossime<xliff:g id="count">%2$d</xliff:g> ore e %1$d min.</item>
     </plurals>
     <plurals name="stop_info_no_additional_data_hours_minutes_short_format">
         <item quantity="one">1h %1$d+ min</item>
         <!-- Entire element below should be on a single line if XML is reformatted - see #99 -->
         <item quantity="other"><xliff:g id="count">%2$d</xliff:g>h %1$d+ min
+        </item>
+        <item quantity="many"><xliff:g id="count">%2$d</xliff:g>h %1$d+ min
         </item>
     </plurals>
     <string name="stop_info_load_more_arrivals">Carica più arrivi</string>
@@ -301,10 +331,12 @@
     <plurals name="alert_filter_text">
         <item quantity="one">%1$d avviso nascosto</item>
         <item quantity="other"><xliff:g id="count">%1$d</xliff:g> avvisi nascosti</item>
+        <item quantity="many"><xliff:g id="count">%1$d</xliff:g> avvisi nascosti</item>
     </plurals>
     <plurals name="alert_show_more">
         <item quantity="one">%1$d altro avviso</item>
         <item quantity="other"><xliff:g id="count">%1$d</xliff:g> altri avvisi</item>
+        <item quantity="many"><xliff:g id="count">%1$d</xliff:g> altri avvisi</item>
     </plurals>
 
     <!-- Find -->
@@ -375,11 +407,15 @@
         <!-- Entire element below should be on a single line if XML is reformatted - see #99 -->
         <item quantity="other">
             <xliff:g id="count">%s</xliff:g> miglia di distanza</item>
+        <item quantity="many">
+            <xliff:g id="count">%s</xliff:g> miglia di distanza</item>
     </plurals>
     <plurals name="distance_feet">
         <item quantity="one">1 piede di distanza</item>
         <!-- Entire element below should be on a single line if XML is reformatted - see #99 -->
         <item quantity="other">
+            <xliff:g id="count">%s</xliff:g> piedi di distanza</item>
+        <item quantity="many">
             <xliff:g id="count">%s</xliff:g> piedi di distanza</item>
     </plurals>
     <plurals name="distance_kilometers">
@@ -387,11 +423,15 @@
         <!-- Entire element below should be on a single line if XML is reformatted - see #99 -->
         <item quantity="other">
             <xliff:g id="count">%s</xliff:g> chilometri di distanza</item>
+        <item quantity="many">
+            <xliff:g id="count">%s</xliff:g> chilometri di distanza</item>
     </plurals>
     <plurals name="distance_meters">
         <item quantity="one">1 metro di distanza</item>
         <!-- Entire element below should be on a single line if XML is reformatted - see #99 -->
         <item quantity="other">
+            <xliff:g id="count">%s</xliff:g> metri di distanza</item>
+        <item quantity="many">
             <xliff:g id="count">%s</xliff:g> metri di distanza</item>
     </plurals>
 
@@ -570,17 +610,41 @@
     <!-- Trip Details -->
     <string name="trip_details_vehicle">Mezzo: %1$s</string>
     <string name="trip_details_scheduled_data">Dati orario</string>
-    <string name="trip_details_real_time_sec_late">%1$d s di ritardo (Ultimo aggiornamento: %2$s)</string>
-    <string name="trip_details_real_time_min_sec_late">%1$d min e %2$d s di ritardo (Ultimo aggiornamento: %3$s)</string>
-    <string name="trip_details_real_time_sec_early">%1$d s di anticipo (Ultimo aggiornamento: %2$s)</string>
-    <string name="trip_details_real_time_min_sec_early">%1$d min e %2$d s di anticipo (Ultimo aggiornamento: %3$s)</string>
+    <plurals name="trip_details_real_time_sec_late">
+        <item quantity="one">%1$d s di ritardo (Ultimo aggiornamento: %2$s)</item>
+        <item quantity="many">%1$d s di ritardo (Ultimo aggiornamento: %2$s)</item>
+        <item quantity="other">%1$d s di ritardo (Ultimo aggiornamento: %2$s)</item>
+    </plurals>
+    <plurals name="trip_details_real_time_min_sec_late">
+        <item quantity="one">%1$d min e %2$d s di ritardo (Ultimo aggiornamento: %3$s)</item>
+        <item quantity="many">%1$d min e %2$d s di ritardo (Ultimo aggiornamento: %3$s)</item>
+        <item quantity="other">%1$d min e %2$d s di ritardo (Ultimo aggiornamento: %3$s)</item>
+    </plurals>
+    <plurals name="trip_details_real_time_sec_early">
+        <item quantity="one">%1$d s di anticipo (Ultimo aggiornamento: %2$s)</item>
+        <item quantity="many">%1$d s di anticipo (Ultimo aggiornamento: %2$s)</item>
+        <item quantity="other">%1$d s di anticipo (Ultimo aggiornamento: %2$s)</item>
+    </plurals>
+    <plurals name="trip_details_real_time_min_sec_early">
+        <item quantity="one">%1$d min e %2$d s di anticipo (Ultimo aggiornamento: %3$s)</item>
+        <item quantity="many">%1$d min e %2$d s di anticipo (Ultimo aggiornamento: %3$s)</item>
+        <item quantity="other">%1$d min e %2$d s di anticipo (Ultimo aggiornamento: %3$s)</item>
+    </plurals>
     <string name="trip_details_current_stop">Fermata attuale</string>
     <string name="trip_details_current_bus_position">L\'autobus si trova qui:</string>
     <string name="trip_details_dest_stop">Fermata di destinazione</string>
 
     <!-- Vehicles on Map -->
-    <string name="vehicle_last_updated_sec">Dati aggiornati %1$d s fa</string>
-    <string name="vehicle_last_updated_min_and_sec">Data aggiornati %1$d min %2$d s fa</string>
+    <plurals name="vehicle_last_updated_sec">
+        <item quantity="one">Dati aggiornati %1$d s fa</item>
+        <item quantity="many">Dati aggiornati %1$d s fa</item>
+        <item quantity="other">Dati aggiornati %1$d s fa</item>
+    </plurals>
+    <plurals name="vehicle_last_updated_min_and_sec">
+        <item quantity="one">Data aggiornati %1$d min %2$d s fa</item>
+        <item quantity="many">Data aggiornati %1$d min %2$d s fa</item>
+        <item quantity="other">Data aggiornati %1$d min %2$d s fa</item>
+    </plurals>
     <string name="vehicle_last_updated_scheduled">Posizione calcolata in base all\'orario</string>
 
     <!-- Night Light -->
@@ -613,7 +677,7 @@
     <!-- About -->
     <!-- About screen: structured prose; the name lists are in the string-arrays below -->
     <string name="about_welcome_title">Benvenuti in %1$s!</string>
-    <string name="about_intro">Questa app è stata realizzata da un team di volontari e si basa sulla dedizione, passione e talenti dei suoi contributori open source.</string>
+    <string name="about_intro">%1$s è stata realizzata da un team di volontari e si basa sulla dedizione, passione e talenti dei suoi contributori open source.</string>
     <string name="about_contributors_header">Contributori al Codice:</string>
     <string name="about_contributors_intro">I nostri dedicati contributori migliorano la funzionalità e l\'esperienza utente dell\'applicazione:</string>
     <string name="about_translations_header">Traduttori:</string>
@@ -875,7 +939,8 @@
     <string name="donation_dismiss_dialog_remind_me_later_button">Ricordamelo Più Tardi</string>
     <string name="donation_dismiss_dialog_cancel_button">Annulla</string>
     <string name="title_activity_donation_learn_more">Perché abbiamo bisogno del tuo aiuto</string>
-    <string name="donation_learn_more_explanation">"Abbiamo grandi piani per migliorare %1$s, ma non possiamo farlo senza il tuo aiuto. Questa app è attualmente sviluppata con il 100%% di lavoro volontario, e abbiamo bisogno del tuo aiuto per finanziare lo sviluppo futuro.\n\nCome progetto chiave della Open Transit Software Foundation, un'organizzazione non profit 501(c)(3), ci affidiamo alla buona volontà di utenti come te per continuare a funzionare e migliorare questo software.\n\nOgni anno, solo una piccola frazione dei nostri utenti dona, ma ogni contributo, grande o piccolo, aiuta a garantire che %1$s rimanga gratuito, aggiornato e accessibile a tutti. Una piccola donazione, anche solo il costo di una settimana di pendolarismo, $27.50, può fare tutta la differenza.\n\nIl tuo contributo deducibile dalle tasse assicura che %1$s rimanga libero e accessibile per tutti. Modelliamo insieme il futuro del trasporto pubblico!\n\nGrazie,\nIl Team di %1$s"</string>
+    <!-- "(c)" here is the "501(c)(3)" US tax-code designation, not a copyright symbol. -->
+    <string name="donation_learn_more_explanation" tools:ignore="TypographyOther">"Abbiamo grandi piani per migliorare %1$s, ma non possiamo farlo senza il tuo aiuto. Questa app è attualmente sviluppata con il 100%% di lavoro volontario, e abbiamo bisogno del tuo aiuto per finanziare lo sviluppo futuro.\n\nCome progetto chiave della Open Transit Software Foundation, un'organizzazione non profit 501(c)(3), ci affidiamo alla buona volontà di utenti come te per continuare a funzionare e migliorare questo software.\n\nOgni anno, solo una piccola frazione dei nostri utenti dona, ma ogni contributo, grande o piccolo, aiuta a garantire che %1$s rimanga gratuito, aggiornato e accessibile a tutti. Una piccola donazione, anche solo il costo di una settimana di pendolarismo, $27.50, può fare tutta la differenza.\n\nIl tuo contributo deducibile dalle tasse assicura che %1$s rimanga libero e accessibile per tutti. Modelliamo insieme il futuro del trasporto pubblico!\n\nGrazie,\nIl Team di %1$s"</string>
     <string name="preferences_reset_donation_timestamps_title">Reimposta i Timestamp delle Donazioni</string>
     <string name="preferences_reset_donation_timestamps_summary">Toccando questa opzione verranno cancellati i timestamp di \'Ricordamelo più tardi\' e \'Non disturbarmi\' associati alle richieste di donazione.</string>
     <string name="preferences_show_weather_view">Mostra vista meteo</string>

--- a/onebusaway-android/src/main/res/values-pl/strings.xml
+++ b/onebusaway-android/src/main/res/values-pl/strings.xml
@@ -193,8 +193,18 @@
     <string name="stop_info_time_arrived_at">Przyjedzie o %1s</string>
     <string name="stop_info_time_departed_at">Odjedzie o %1s</string>
 
-    <string name="stop_info_frequency_from">Co %1$d min od %2$s</string>
-    <string name="stop_info_frequency_until">Co %1$d min do %2$s</string>
+    <plurals name="stop_info_frequency_from">
+        <item quantity="one">Co %1$d min od %2$s</item>
+        <item quantity="few">Co %1$d min od %2$s</item>
+        <item quantity="many">Co %1$d min od %2$s</item>
+        <item quantity="other">Co %1$d min od %2$s</item>
+    </plurals>
+    <plurals name="stop_info_frequency_until">
+        <item quantity="one">Co %1$d min do %2$s</item>
+        <item quantity="few">Co %1$d min do %2$s</item>
+        <item quantity="many">Co %1$d min do %2$s</item>
+        <item quantity="other">Co %1$d min do %2$s</item>
+    </plurals>
     <string name="stop_info_eta_now">TERAZ</string>
     <string name="stop_info_option_showonmap">Pokaż na mapie</string>
     <string name="menu_option_sort_by">Sortuj</string>
@@ -676,20 +686,59 @@
     <!-- Trip Details -->
     <string name="trip_details_vehicle">Pojazd: %1$s</string>
     <string name="trip_details_scheduled_data">Planowany</string>
-    <string name="trip_details_real_time_sec_late">%1$d sek spóźnienia (Ostatnia aktualizacja: %2$s)</string>
-    <string name="trip_details_real_time_min_sec_late">%1$d min %2$d sek spóźnienia (Ostatnia aktualizacja: %3$s)
-    </string>
-    <string name="trip_details_real_time_sec_early">%1$d sek wcześniej (Ostatnia aktualizacja: %2$s)</string>
-    <string name="trip_details_real_time_min_sec_early">%1$d min %2$d sek wcześniej (Last update:
+    <plurals name="trip_details_real_time_sec_late">
+        <item quantity="one">%1$d sek spóźnienia (Ostatnia aktualizacja: %2$s)</item>
+        <item quantity="few">%1$d sek spóźnienia (Ostatnia aktualizacja: %2$s)</item>
+        <item quantity="many">%1$d sek spóźnienia (Ostatnia aktualizacja: %2$s)</item>
+        <item quantity="other">%1$d sek spóźnienia (Ostatnia aktualizacja: %2$s)</item>
+    </plurals>
+    <plurals name="trip_details_real_time_min_sec_late">
+        <item quantity="one">%1$d min %2$d sek spóźnienia (Ostatnia aktualizacja: %3$s)
+    </item>
+        <item quantity="few">%1$d min %2$d sek spóźnienia (Ostatnia aktualizacja: %3$s)
+    </item>
+        <item quantity="many">%1$d min %2$d sek spóźnienia (Ostatnia aktualizacja: %3$s)
+    </item>
+        <item quantity="other">%1$d min %2$d sek spóźnienia (Ostatnia aktualizacja: %3$s)
+    </item>
+    </plurals>
+    <plurals name="trip_details_real_time_sec_early">
+        <item quantity="one">%1$d sek wcześniej (Ostatnia aktualizacja: %2$s)</item>
+        <item quantity="few">%1$d sek wcześniej (Ostatnia aktualizacja: %2$s)</item>
+        <item quantity="many">%1$d sek wcześniej (Ostatnia aktualizacja: %2$s)</item>
+        <item quantity="other">%1$d sek wcześniej (Ostatnia aktualizacja: %2$s)</item>
+    </plurals>
+    <plurals name="trip_details_real_time_min_sec_early">
+        <item quantity="one">%1$d min %2$d sek wcześniej (Last update:
         %3$s)
-    </string>
+    </item>
+        <item quantity="few">%1$d min %2$d sek wcześniej (Last update:
+        %3$s)
+    </item>
+        <item quantity="many">%1$d min %2$d sek wcześniej (Last update:
+        %3$s)
+    </item>
+        <item quantity="other">%1$d min %2$d sek wcześniej (Last update:
+        %3$s)
+    </item>
+    </plurals>
     <string name="trip_details_current_stop">Obecny przystanek</string>
     <string name="trip_details_current_bus_position">Autobus jest obecnie na</string>
     <string name="trip_details_dest_stop">Przystanek docelowy</string>
 
     <!-- Vehicles on Map -->
-    <string name="vehicle_last_updated_sec">Dane zaaktualizaowane %1$d sek temu</string>
-    <string name="vehicle_last_updated_min_and_sec">Dane zaaktualizowane %1$d min %2$d sek temu</string>
+    <plurals name="vehicle_last_updated_sec">
+        <item quantity="one">Dane zaaktualizaowane %1$d sek temu</item>
+        <item quantity="few">Dane zaaktualizaowane %1$d sek temu</item>
+        <item quantity="many">Dane zaaktualizaowane %1$d sek temu</item>
+        <item quantity="other">Dane zaaktualizaowane %1$d sek temu</item>
+    </plurals>
+    <plurals name="vehicle_last_updated_min_and_sec">
+        <item quantity="one">Dane zaaktualizowane %1$d min %2$d sek temu</item>
+        <item quantity="few">Dane zaaktualizowane %1$d min %2$d sek temu</item>
+        <item quantity="many">Dane zaaktualizowane %1$d min %2$d sek temu</item>
+        <item quantity="other">Dane zaaktualizowane %1$d min %2$d sek temu</item>
+    </plurals>
     <string name="vehicle_last_updated_scheduled">Pozycja obliczona na podstawie rozkładu</string>
 
     <!-- Night Light -->
@@ -786,7 +835,8 @@
     <string name="donation_dismiss_dialog_remind_me_later_button">Przypomnij mi później</string>
     <string name="donation_dismiss_dialog_cancel_button">Anuluj</string>
     <string name="title_activity_donation_learn_more">Dlaczego potrzebujemy Twojej pomocy</string>
-    <string name="donation_learn_more_explanation">Mamy wielkie plany na ulepszenie %1$s, ale nie możemy tego zrobić bez Twojej pomocy. Ta aplikacja jest obecnie tworzona w 100%% dzięki pracy wolontariuszy, i potrzebujemy Ciebie, abyś pomógł nam sfinansować przyszły rozwój.\n\nJako kluczowy projekt Open Transit Software Foundation, organizacji non-profit 501(c)(3), polegamy na dobrej woli użytkowników takich jak Ty, aby kontynuować działanie i ulepszanie tego oprogramowania.\n\nCo roku tylko mała część naszych użytkowników dokonuje darowizn, ale każdy wkład, duży czy mały, pomaga zapewnić, że %1$s pozostanie darmowe, aktualne i dostępne dla wszystkich. Mała darowizna, nawet tylko koszt tygodniowego dojazdu do pracy, 27,50 dolarów, może zrobić różnicę.\n\nTwoja darowizna odliczalna od podatku zapewnia, że %1$s pozostanie darmowe i dostępne dla każdego. Kształtujmy razem przyszłość transportu publicznego!\n\nDziękujemy,\nZespół %1$s</string>
+    <!-- "(c)" here is the "501(c)(3)" US tax-code designation, not a copyright symbol. -->
+    <string name="donation_learn_more_explanation" tools:ignore="TypographyOther">Mamy wielkie plany na ulepszenie %1$s, ale nie możemy tego zrobić bez Twojej pomocy. Ta aplikacja jest obecnie tworzona w 100%% dzięki pracy wolontariuszy, i potrzebujemy Ciebie, abyś pomógł nam sfinansować przyszły rozwój.\n\nJako kluczowy projekt Open Transit Software Foundation, organizacji non-profit 501(c)(3), polegamy na dobrej woli użytkowników takich jak Ty, aby kontynuować działanie i ulepszanie tego oprogramowania.\n\nCo roku tylko mała część naszych użytkowników dokonuje darowizn, ale każdy wkład, duży czy mały, pomaga zapewnić, że %1$s pozostanie darmowe, aktualne i dostępne dla wszystkich. Mała darowizna, nawet tylko koszt tygodniowego dojazdu do pracy, 27,50 dolarów, może zrobić różnicę.\n\nTwoja darowizna odliczalna od podatku zapewnia, że %1$s pozostanie darmowe i dostępne dla każdego. Kształtujmy razem przyszłość transportu publicznego!\n\nDziękujemy,\nZespół %1$s</string>
     <string name="preferences_reset_donation_timestamps_title">Zresetuj Znaczniki Czasu Dotacji</string>
     <string name="preferences_reset_donation_timestamps_summary">Dotknięcie tej opcji spowoduje wyczyszczenie znaczników czasu \'Przypomnij mi później\' i \'Nie przeszkadzaj mi\' związanych z prośbami o darowizny.</string>
     <string name="preferences_show_weather_view">Pokaż widok pogody</string>

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -15,7 +15,8 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <string name="app_name">OneBusAway</string>
 
@@ -223,8 +224,14 @@
     <string name="stop_info_time_arrived_at">Arrived at %1s</string>
     <string name="stop_info_time_departed_at">Departed at %1s</string>
 
-    <string name="stop_info_frequency_from">Every %1$d mins from %2$s</string>
-    <string name="stop_info_frequency_until">Every %1$d mins until %2$s</string>
+    <plurals name="stop_info_frequency_from">
+        <item quantity="one">Every %1$d min from %2$s</item>
+        <item quantity="other">Every %1$d mins from %2$s</item>
+    </plurals>
+    <plurals name="stop_info_frequency_until">
+        <item quantity="one">Every %1$d min until %2$s</item>
+        <item quantity="other">Every %1$d mins until %2$s</item>
+    </plurals>
     <string name="stop_info_eta_now">NOW</string>
     <string name="stop_info_option_showonmap">Show on map</string>
     <string name="menu_option_sort_by">Sort by</string>
@@ -272,7 +279,9 @@
     <string name="stop_info_load_more_arrivals">Load more arrivals</string>
     <string name="stop_info_item_options_title">Bus options</string>
     <string name="stop_info_filter_title">Show only these routes</string>
-    <string name="stop_info_filter_header">Showing %1$d of %2$d routes</string>
+    <!-- Not a plural candidate: "%2$d routes" is a ratio's denominator ("N of M"), not a count that
+         inflects on its own; getQuantityString would key off the wrong number. -->
+    <string name="stop_info_filter_header" tools:ignore="PluralsCandidate">Showing %1$d of %2$d routes</string>
     <string name="stop_info_save">Save</string>
     <string name="stop_info_cancel">Cancel</string>
     <string name="stop_info_clear">Clear</string>
@@ -657,7 +666,8 @@
     <string name="map_zoom_in_for_more_stops">Zoom in to see more stops</string>
     <string name="preferences_map_stop_cache_size_title">Map stop cache size</string>
     <string name="preferences_map_stop_cache_size_summary">Max bus stops kept on the map while panning (currently %1$d)</string>
-    <string name="preferences_map_stop_cache_size_error">Enter a number between %1$d and %2$d</string>
+    <!-- Not a plural candidate: "%1$d and %2$d" are the bounds of a range, not a count that inflects. -->
+    <string name="preferences_map_stop_cache_size_error" tools:ignore="PluralsCandidate">Enter a number between %1$d and %2$d</string>
     <string name="preferences_experimental_regions_enable_warning">Experimental regions may be
         unstable and without real-time info! Go ahead?
     </string>
@@ -754,22 +764,43 @@
     <string name="trip_status">Trip status</string>
     <string name="trip_details_vehicle">Vehicle: %1$s</string>
     <string name="trip_details_scheduled_data">Schedule data</string>
-    <string name="trip_details_real_time_sec_late">%1$d sec late (Last update: %2$s)</string>
-    <string name="trip_details_real_time_min_sec_late">%1$d min %2$d sec late (Last update: %3$s)
-    </string>
-    <string name="trip_details_real_time_sec_early">%1$d sec early (Last update: %2$s)</string>
-    <string name="trip_details_real_time_min_sec_early">%1$d min %2$d sec early (Last update:
-        %3$s)
-    </string>
+    <plurals name="trip_details_real_time_sec_late">
+        <item quantity="one">%1$d sec late (Last update: %2$s)</item>
+        <item quantity="other">%1$d sec late (Last update: %2$s)</item>
+    </plurals>
+    <plurals name="trip_details_real_time_min_sec_late">
+        <item quantity="one">%1$d min %2$d sec late (Last update: %3$s)</item>
+        <item quantity="other">%1$d min %2$d sec late (Last update: %3$s)</item>
+    </plurals>
+    <plurals name="trip_details_real_time_sec_early">
+        <item quantity="one">%1$d sec early (Last update: %2$s)</item>
+        <item quantity="other">%1$d sec early (Last update: %2$s)</item>
+    </plurals>
+    <plurals name="trip_details_real_time_min_sec_early">
+        <item quantity="one">%1$d min %2$d sec early (Last update: %3$s)</item>
+        <item quantity="other">%1$d min %2$d sec early (Last update: %3$s)</item>
+    </plurals>
     <string name="trip_details_current_stop">Current stop</string>
     <string name="trip_details_current_bus_position">Bus is currently at</string>
     <string name="trip_details_dest_stop">Destination stop</string>
 
     <!-- Vehicles on Map -->
-    <string name="vehicle_last_updated_sec">Data updated %1$d sec ago</string>
-    <string name="vehicle_last_updated_min_and_sec">Data updated %1$d min %2$d sec ago</string>
-    <string name="vehicle_estimate_from_update_sec">Estimate from data updated %1$d sec ago</string>
-    <string name="vehicle_estimate_from_update_min_and_sec">Estimate from data updated %1$d min %2$d sec ago</string>
+    <plurals name="vehicle_last_updated_sec">
+        <item quantity="one">Data updated %1$d sec ago</item>
+        <item quantity="other">Data updated %1$d sec ago</item>
+    </plurals>
+    <plurals name="vehicle_last_updated_min_and_sec">
+        <item quantity="one">Data updated %1$d min %2$d sec ago</item>
+        <item quantity="other">Data updated %1$d min %2$d sec ago</item>
+    </plurals>
+    <plurals name="vehicle_estimate_from_update_sec">
+        <item quantity="one">Estimate from data updated %1$d sec ago</item>
+        <item quantity="other">Estimate from data updated %1$d sec ago</item>
+    </plurals>
+    <plurals name="vehicle_estimate_from_update_min_and_sec">
+        <item quantity="one">Estimate from data updated %1$d min %2$d sec ago</item>
+        <item quantity="other">Estimate from data updated %1$d min %2$d sec ago</item>
+    </plurals>
     <string name="vehicle_last_updated_scheduled">Position calculated from schedule</string>
 
     <!-- Night Light -->
@@ -1114,7 +1145,8 @@
     <string name="donation_dismiss_dialog_cancel_button">Cancel</string>
     <string name="title_activity_donation_learn_more">Why we need your help</string>
     <!-- Note: %1$s is replaced with app_name for white-label support -->
-    <string name="donation_learn_more_explanation">We have big plans to improve %1$s, but we can\'t do it without your help. This app is currently built with 100%% volunteer labor, and we need you to help us fund future development.\n\nAs a key project of the Open Transit Software Foundation, a 501(c)(3) non-profit, we rely on the goodwill of users like you to keep running and making this software better.\n\nEvery year, only a small fraction of our users donate, but every contribution, big or small, helps ensure that %1$s remains free, updated, and accessible to everyone. A small donation, even just the cost of one week of commuting, $27.50, can make all the difference.\n\nYour tax-deductible contribution ensures that %1$s remains free and accessible for everyone. Let\'s shape the future of transit together!\n\nThank you,\nThe %1$s Team</string>
+    <!-- "(c)" here is the "501(c)(3)" US tax-code designation, not a copyright symbol. -->
+    <string name="donation_learn_more_explanation" tools:ignore="TypographyOther">We have big plans to improve %1$s, but we can\'t do it without your help. This app is currently built with 100%% volunteer labor, and we need you to help us fund future development.\n\nAs a key project of the Open Transit Software Foundation, a 501(c)(3) non-profit, we rely on the goodwill of users like you to keep running and making this software better.\n\nEvery year, only a small fraction of our users donate, but every contribution, big or small, helps ensure that %1$s remains free, updated, and accessible to everyone. A small donation, even just the cost of one week of commuting, $27.50, can make all the difference.\n\nYour tax-deductible contribution ensures that %1$s remains free and accessible for everyone. Let\'s shape the future of transit together!\n\nThank you,\nThe %1$s Team</string>
     <string name="preferences_reset_donation_timestamps_title">Reset Donation Timestamps</string>
     <string name="preferences_reset_donation_timestamps_summary">Tapping this option will clear both the \'Remind Me Later\' and \'Don\'t Bother Me\' timestamps associated with donation requests.</string>
     <string name="preferences_show_weather_view">Show weather view</string>


### PR DESCRIPTION
Resolves #1701 — clears all 69 i18n / string-formatting lint **warnings** surfaced by the CI lint gate (#1692). `./gradlew :onebusaway-android:lintObaGoogleDebug` now reports **0** for every one of the seven categories, and the project compiles.

### What changed

- **MissingQuantity (38)** — added the CLDR-required `many` plural form to 19 plurals each in `values-es` and `values-it`, reusing each plural's existing `other` text (behaviour-preserving).
- **PluralsCandidate (12)** — converted the 10 genuine count strings (frequency, trip real-time deviation, vehicle data-age) to `<plurals>` across **all** locales and switched the call sites (`ArrivalInfo`, `TripDetailsRepository`, `VehicleInfoWindow`) to `getQuantityString`. Translated locales reuse the existing translation verbatim across the required quantity forms — no new/invented translations. The two **false positives** are suppressed with a documented `tools:ignore`:
  - `"Showing %d of %d routes"` — a ratio, not a self-inflecting count.
  - `"Enter a number between %d and %d"` — the bounds of a range.
- **DefaultLocale (9)** — passed an explicit `Locale` to `String.format` / `toLowerCase`: `Locale.getDefault()` for user-facing distances (`ConversionUtils`) and matching against **localized** keyword arrays (`ServiceUtils`); `Locale.US` for a machine cache key (`VehicleBitmaps`) and a diagnostic string (`LocationUtils`).
- **StringFormatCount (3)** — restored the `%1$s` app-name placeholder in the `es`/`fi`/`it` `about_intro` translations to match the base string (aligns with the white-label branding pattern).
- **TypographyEllipsis (1)** — `"..."` → `"…"` in `it` `main_waiting_for_location`.

### False positives (suppressed, not "fixed")

Two of the issue's suggested edits would have introduced bugs, so they're suppressed with an explanatory `tools:ignore` + comment instead:

- **TypographyOther (5)** — the flagged `(c)` is inside `"501(c)(3)"`, the US tax-code designation, **not** a copyright glyph. Replacing it with `©` would corrupt the text.
- **Typos (1)** — `"Area"` is part of the proper agency name *"Hillsborough Area Regional Transit"* (HART); it is not a misspelling of *Área*.

### Verification

- `./gradlew :onebusaway-android:lintObaGoogleDebug` → 0 findings across MissingQuantity / PluralsCandidate / DefaultLocale / TypographyOther / StringFormatCount / Typos / TypographyEllipsis, and no new `UnusedQuantity`/`ImpliedQuantity` regressions.
- Build compiles (lint's source analysis passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved distance, time, and status text so counts and units are shown correctly across languages and locale settings.
  * Updated arrival, departure, vehicle, and trip status messages to use the proper singular/plural wording.
  * Fixed matching behavior for transit-related text by respecting device locale when comparing strings.
  * Refined several translated app labels and informational texts for better readability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->