### PR TITLE
Collapse block-id phantom duplicate arrivals (#1710)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/data/ArrivalDedup.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/data/ArrivalDedup.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.api.data
+
+import org.onebusaway.android.models.ArrivalData
+
+/**
+ * Collapse block-id "phantom" duplicate arrivals.
+ *
+ * When a trip's real-time prediction reaches the OBA server with no assigned vehicle, the server
+ * stamps the GTFS **block id** onto it as a stand-in `vehicleId` (the block-id fallback in the
+ * server's `GtfsRealtimeTripLibrary`). If the real vehicle later matches the same block, one trip
+ * instance briefly yields two `arrivalsAndDepartures` entries — the real coach and the schedule-only
+ * phantom — so the arrivals list shows two identical-looking rows for one trip (same route, same
+ * minute-floored ETA) until the phantom ages out of the server cache. See onebusaway-android#1710
+ * and the server root cause onebusaway-application-modules#469.
+ *
+ * The phantom is identified exactly, not by guesswork: it is the entry whose `vehicleId` is the
+ * trip's block id ([blockIdOf]). A real coach reports its own vehicle id, which is never the block
+ * id, so this can't misfire on a genuine second vehicle that merely hasn't reported a GPS position
+ * yet. When the block id can't be resolved (trip absent from the references), the trip is left
+ * untouched rather than guessed at.
+ *
+ * For each trip instance — keyed by (tripId, serviceDate, stopSequence) so a loop route's two
+ * genuine visits to one stop stay distinct — a phantom is dropped only when a non-phantom sibling
+ * survives it. Order is preserved.
+ */
+internal fun List<ArrivalData>.collapseBlockIdPhantoms(
+    blockIdOf: (tripId: String) -> String?,
+): List<ArrivalData> {
+    if (size < 2) return this
+    fun ArrivalData.isBlockIdPhantom(): Boolean = vehicleId != null && vehicleId == blockIdOf(tripId)
+    val tripInstance = { a: ArrivalData -> Triple(a.tripId, a.serviceDate, a.stopSequence) }
+    val collapsible = groupBy(tripInstance)
+        .filterValues { group -> group.any { it.isBlockIdPhantom() } && group.any { !it.isBlockIdPhantom() } }
+        .keys
+    if (collapsible.isEmpty()) return this
+    return filterNot { tripInstance(it) in collapsible && it.isBlockIdPhantom() }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/data/StopArrivalsDataSource.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/data/StopArrivalsDataSource.kt
@@ -55,8 +55,13 @@ class StopArrivals internal constructor(
     /** The focused stop, or null when the references don't include it. */
     val stop: ObaStop? get() = refs.stop(stopId)?.let(::DtoStop)
 
-    /** The arrivals/departures, adapted to the [ArrivalData] model (display-ready). */
-    val arrivals: List<ArrivalData> get() = entry.arrivalsAndDepartures.map { it.asArrivalData() }
+    /**
+     * The arrivals/departures, adapted to the [ArrivalData] model (display-ready), with block-id
+     * "phantom" duplicates collapsed (see [collapseBlockIdPhantoms] / #1710).
+     */
+    val arrivals: List<ArrivalData>
+        get() = entry.arrivalsAndDepartures.map { it.asArrivalData() }
+            .collapseBlockIdPhantoms { tripId -> refs.trip(tripId)?.blockId }
 
     /** Every referenced route (for the map overlay + the route-filter options). */
     val routes: List<ObaRoute> get() = refs.routes.map(::DtoRoute)

--- a/onebusaway-android/src/test/java/org/onebusaway/android/api/data/ArrivalDedupTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/api/data/ArrivalDedupTest.kt
@@ -1,0 +1,150 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.api.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.onebusaway.android.models.ArrivalData
+import org.onebusaway.android.models.FrequencyWindow
+import org.onebusaway.android.models.Occupancy
+import org.onebusaway.android.models.Status
+import org.onebusaway.android.time.ServerTime
+
+/**
+ * Unit tests for [collapseBlockIdPhantoms]. It drops the OBA server's block-id "phantom" duplicate
+ * (an entry whose `vehicleId` is the trip's block id) when a real-vehicle sibling shares the trip
+ * instance, and leaves everything else alone (#1710 / onebusaway-application-modules#469).
+ */
+class ArrivalDedupTest {
+
+    private companion object {
+        const val TRIP = "1_801565550"
+        const val BLOCK = "1_8110104" // block id of TRIP; the phantom's vehicleId equals this
+        const val COACH = "1_7099"    // a real coach number
+        val blockIds: (String) -> String? = { tripId -> if (tripId == TRIP) BLOCK else null }
+    }
+
+    @Test
+    fun `collapses the phantom (vehicleId == block id) when a real sibling shares the trip instance`() {
+        val real = arrival(vehicleId = COACH)
+        val phantom = arrival(vehicleId = BLOCK)
+        assertEquals(listOf(real), listOf(real, phantom).collapseBlockIdPhantoms(blockIds))
+        assertEquals(listOf(real), listOf(phantom, real).collapseBlockIdPhantoms(blockIds))
+    }
+
+    @Test
+    fun `collapses even with no AVL anywhere (block-id signal, not position, distinguishes them)`() {
+        // A TripUpdates-only deployment: neither entry carries a last-known location, but the
+        // phantom is still identifiable by vehicleId == block id.
+        val real = arrival(vehicleId = COACH, hasAvl = false)
+        val phantom = arrival(vehicleId = BLOCK, hasAvl = false)
+        assertEquals(listOf(real), listOf(real, phantom).collapseBlockIdPhantoms(blockIds))
+    }
+
+    @Test
+    fun `keeps a genuine second vehicle that has not reported a position (real vehicleId, no AVL)`() {
+        // Two real coaches on one trip instance (the rare genuine double); one hasn't reported GPS
+        // yet. Neither vehicleId is the block id, so neither is a phantom — both survive.
+        val located = arrival(vehicleId = COACH, hasAvl = true)
+        val notYetLocated = arrival(vehicleId = "1_7033", hasAvl = false)
+        val input = listOf(located, notYetLocated)
+        assertEquals(input, input.collapseBlockIdPhantoms(blockIds))
+    }
+
+    @Test
+    fun `keeps both when the block id can't be resolved (trip absent from references)`() {
+        val a = arrival(vehicleId = BLOCK)
+        val b = arrival(vehicleId = COACH)
+        val input = listOf(a, b)
+        assertEquals(input, input.collapseBlockIdPhantoms { null })
+    }
+
+    @Test
+    fun `keeps a lone phantom when no non-phantom sibling survives it`() {
+        val phantomOnly = listOf(arrival(vehicleId = BLOCK))
+        assertEquals(phantomOnly, phantomOnly.collapseBlockIdPhantoms(blockIds))
+    }
+
+    @Test
+    fun `does not collapse across different trips`() {
+        val realA = arrival(tripId = TRIP, vehicleId = COACH)
+        val phantomB = arrival(tripId = "1_other", vehicleId = BLOCK)
+        val input = listOf(realA, phantomB)
+        assertEquals(input, input.collapseBlockIdPhantoms(blockIds))
+    }
+
+    @Test
+    fun `does not collapse a loop route's two genuine visits (same trip, different stopSequence)`() {
+        val first = arrival(vehicleId = COACH, stopSequence = 5)
+        val phantomFirst = arrival(vehicleId = BLOCK, stopSequence = 5)
+        val second = arrival(vehicleId = COACH, stopSequence = 42)
+        // The phantom collapses against the first visit; both real visits survive.
+        assertEquals(
+            listOf(first, second),
+            listOf(first, phantomFirst, second).collapseBlockIdPhantoms(blockIds),
+        )
+    }
+
+    @Test
+    fun `empty and singleton lists pass through unchanged`() {
+        assertEquals(emptyList<ArrivalData>(), emptyList<ArrivalData>().collapseBlockIdPhantoms(blockIds))
+        val one = listOf(arrival(vehicleId = BLOCK))
+        assertEquals(one, one.collapseBlockIdPhantoms(blockIds))
+    }
+
+    private fun arrival(
+        tripId: String = TRIP,
+        serviceDate: Long = 1_783_234_800_000L,
+        stopSequence: Int = 15,
+        vehicleId: String?,
+        hasAvl: Boolean = true,
+    ): ArrivalData = FakeArrivalData(
+        tripId = tripId,
+        serviceDate = serviceDate,
+        stopSequence = stopSequence,
+        vehicleId = vehicleId,
+        hasTripStatus = true,
+        lastKnownLat = if (hasAvl) 47.615 else null,
+        lastKnownLon = if (hasAvl) -122.317 else null,
+    )
+}
+
+/** Minimal [ArrivalData] stub; only trip-instance identity + vehicleId matter here. */
+private data class FakeArrivalData(
+    override val tripId: String,
+    override val serviceDate: Long,
+    override val stopSequence: Int,
+    override val vehicleId: String?,
+    override val hasTripStatus: Boolean,
+    override val lastKnownLat: Double?,
+    override val lastKnownLon: Double?,
+    override val routeId: String = "1_100252",
+    override val stopId: String = "1_13330",
+    override val headsign: String? = "Interlaken Park Via 19th Ave",
+    override val shortName: String? = "12",
+    override val routeLongName: String? = null,
+    override val predicted: Boolean = true,
+    override val scheduledArrivalTime: ServerTime = ServerTime(0L),
+    override val predictedArrivalTime: ServerTime = ServerTime(0L),
+    override val scheduledDepartureTime: ServerTime = ServerTime(0L),
+    override val predictedDepartureTime: ServerTime = ServerTime(0L),
+    override val status: Status? = null,
+    override val frequency: FrequencyWindow? = null,
+    override val situationIds: List<String> = emptyList(),
+    override val historicalOccupancy: Occupancy? = null,
+    override val predictedOccupancy: Occupancy? = null,
+    override val scheduleDeviation: Long = 0L,
+) : ArrivalData


### PR DESCRIPTION
Fixes #1710.

### Problem
A stop's arrivals list can show two identical rows for the same route — same headsign, same minute-floored ETA (e.g. "12 / 21 min" twice back-to-back). The two entries are the *same* trip instance (same `tripId` + `serviceDate` + `stopSequence`), differing only in `vehicleId` and a sub-minute prediction gap that minute-flooring hides.

The cause is server-side (root-caused in [onebusaway-application-modules#469](https://github.com/OneBusAway/onebusaway-application-modules/issues/469)): when a trip's real-time prediction reaches the OBA server with no assigned vehicle, the server stamps the GTFS **block id** onto it as a stand-in `vehicleId`. When the real vehicle later matches the same block, one trip instance briefly yields two `arrivalsAndDepartures` entries — the real coach and the schedule-only phantom — until the phantom ages out of the server cache.

Verified against live Puget Sound data at stop `1_13330` (19th Ave E & E Thomas St, NB):

| | real | phantom |
|---|---|---|
| tripId / serviceDate / stopSequence | `1_801565550` … | same |
| vehicleId | `1_7099` (coach) | `1_8110104` (**= the trip's block id**) |

### Fix
Collapse the duplicates at the wire→model boundary, in `StopArrivals.arrivals`. For each trip instance keyed by `(tripId, serviceDate, stopSequence)`, drop the **phantom** — the entry whose `vehicleId` equals the trip's block id (resolved from the references) — but only when a non-phantom sibling survives it.

Identifying the phantom by its block id is an exact distinction in the data, not a magnitude/threshold guess (per CLAUDE.md "no unsanctioned heuristics"). Consequences of that precision:
- A **genuine second vehicle that hasn't reported a GPS position yet** (real coach id, no location) is *not* misclassified — its vehicleId is never the block id, so it survives.
- The match works **with or without a vehicle-positions feed** (an earlier draft keyed on last-known-location presence, which no-op'd on TripUpdates-only deployments).
- When the **block id can't be resolved** (trip absent from the references), the trip is left untouched rather than guessed at.

`(tripId, serviceDate, stopSequence)` keying keeps a loop route's two genuine visits to one stop distinct.

### Testing
New JVM unit test `ArrivalDedupTest` covers: phantom collapsed against a real sibling (either order); collapse with no AVL anywhere (block-id signal, not position); a genuine positionless second vehicle preserved; block-id unresolvable → untouched; lone phantom preserved; no cross-trip collapse; loop-route two-visit preservation; empty/singleton pass-through. `./gradlew :onebusaway-android:testObaGoogleDebugUnitTest` passes.

### Notes
- This is the arrivals-list sibling of the route-map duplicate-vehicle issue (#1667 / #50).
- Client-side guard against a transient upstream/server state; the durable fix is server-side (#469).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced duplicate arrival entries by removing temporary “phantom” arrivals when a real vehicle update is available.
  * Kept legitimate arrivals intact, including cases with no location data, loop-route repeats, and trips where duplicate collapse should not apply.

* **Tests**
  * Added coverage for duplicate arrival handling across matching trips, different trips, missing trip lookup data, and empty or single-item lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->