### PR TITLE
Lint cleanup: manifest, security & parcel correctness (#1703)

### DIFF
--- a/onebusaway-android/src/main/AndroidManifest.xml
+++ b/onebusaway-android/src/main/AndroidManifest.xml
@@ -45,13 +45,20 @@
     <!-- For notifications, POST_NOTIFICATIONS is required when targeting Android 12 or higher-->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
+    <uses-feature
+        android:glEsVersion="0x00020000"
+        android:required="true"/>
+
     <application
         android:allowBackup="false"
         android:name="org.onebusaway.android.app.Application"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:theme="@style/Theme.OneBusAway.NoActionBar"
-        android:networkSecurityConfig="@xml/network_security_config">
+        android:dataExtractionRules="@xml/data_extraction_rules"
+        android:fullBackupContent="@xml/backup_rules"
+        android:networkSecurityConfig="@xml/network_security_config"
+        tools:targetApi="24">
 
 
         <meta-data
@@ -278,10 +285,12 @@
             android:name=".nav.NavigationService"
             android:foregroundServiceType="location" />
 
+        <!-- Triggered only by the app's own explicit-component notification PendingIntents
+             (NavigationServiceProvider), so it needs no cross-app access. -->
         <receiver
             android:name=".nav.NavigationReceiver"
             android:enabled="true"
-            android:exported="true" >
+            android:exported="false" >
             <intent-filter>
                 <action android:name=".nav.NavigationReceiver" />
             </intent-filter>
@@ -291,8 +300,10 @@
             android:enabled="true">
         </receiver>
 
+        <!-- Only receives the app's own realtime-check broadcasts (RealtimeService), so
+             it needs no cross-app access. The intent-filter still matches the same-app broadcast. -->
         <receiver android:name=".directions.realtime.RealtimeWakefulReceiver"
-            android:exported="true">
+            android:exported="false">
             <intent-filter>
                 <!-- Should match constants for actions defined in OTPConstants -->
                 <action android:name="${applicationId}.directions.action.START_CHECKS"/>
@@ -325,8 +336,4 @@
             </intent-filter>
         </service>
     </application>
-
-    <uses-feature
-        android:glEsVersion="0x00020000"
-        android:required="true"/>
 </manifest>

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/realtime/RealtimeService.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/realtime/RealtimeService.kt
@@ -421,6 +421,9 @@ open class RealtimeService : IntentService("RealtimeService") {
 
             bundle.putSerializable(OTPConstants.NOTIFICATION_TARGET, source.javaClass)
             val intent = Intent(OTPConstants.INTENT_START_CHECKS)
+            // Scope the broadcast to our own app: RealtimeWakefulReceiver is non-exported, and
+            // package-less implicit broadcasts aren't delivered to manifest receivers on API 26+.
+            intent.setPackage(source.packageName)
             intent.putExtras(bundle)
             source.sendBroadcast(intent)
         }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/CustomAddress.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/CustomAddress.kt
@@ -169,7 +169,7 @@ class CustomAddress(locale: Locale) : Address(locale) {
                     }
                     a.phone = parcel.readString()
                     a.url = parcel.readString()
-                    a.extras = parcel.readBundle()
+                    a.extras = parcel.readBundle(CustomAddress::class.java.classLoader)
                     return a
                 }
 

--- a/onebusaway-android/src/main/res/xml/backup_rules.xml
+++ b/onebusaway-android/src/main/res/xml/backup_rules.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2026 Open Transit Software Foundation
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<!--
+  Pre-Android 12 (< API 31) full-backup rules, the legacy companion to
+  data_extraction_rules.xml. Mirrors android:allowBackup="false" by excluding all app data.
+  allowBackup="false" already disables backup on these versions; this file makes the exclusion
+  explicit for the auto-backup framework.
+-->
+<full-backup-content>
+    <exclude domain="sharedpref" path="." />
+    <exclude domain="database" path="." />
+    <exclude domain="file" path="." />
+    <exclude domain="external" path="." />
+    <exclude domain="root" path="." />
+</full-backup-content>

--- a/onebusaway-android/src/main/res/xml/data_extraction_rules.xml
+++ b/onebusaway-android/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2026 Open Transit Software Foundation
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<!--
+  Android 12+ (API 31) data-extraction rules. Mirrors android:allowBackup="false":
+  excludes all app data from both cloud backup and device-to-device transfer.
+  allowBackup="false" already disables cloud backup on all versions; this file additionally
+  opts out of D2D transfer, which allowBackup no longer controls on Android 12+.
+-->
+<data-extraction-rules>
+    <cloud-backup>
+        <exclude domain="sharedpref" path="." />
+        <exclude domain="database" path="." />
+        <exclude domain="file" path="." />
+        <exclude domain="external" path="." />
+        <exclude domain="root" path="." />
+    </cloud-backup>
+    <device-transfer>
+        <exclude domain="sharedpref" path="." />
+        <exclude domain="database" path="." />
+        <exclude domain="file" path="." />
+        <exclude domain="external" path="." />
+        <exclude domain="root" path="." />
+    </device-transfer>
+</data-extraction-rules>

--- a/onebusaway-android/src/main/res/xml/shortcuts.xml
+++ b/onebusaway-android/src/main/res/xml/shortcuts.xml
@@ -19,10 +19,12 @@
   opens HomeActivity with a NAV_ROUTE extra (org.onebusaway.android.ui.HomeActivity.NAV_ROUTE) that
   HomeActivity's translator navigates to. Replaces the legacy launcher CREATE_SHORTCUT picker.
 -->
-<shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
+<shortcuts xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
     <shortcut
         android:shortcutId="starred_stops"
         android:enabled="true"
+        tools:targetApi="25"
         android:icon="@drawable/ic_drawer_star"
         android:shortcutShortLabel="@string/starred_stops_shortcut"
         android:shortcutLongLabel="@string/starred_stops_shortcut">
@@ -38,6 +40,7 @@
     <shortcut
         android:shortcutId="recent_stops"
         android:enabled="true"
+        tools:targetApi="25"
         android:icon="@drawable/ic_history"
         android:shortcutShortLabel="@string/recent_stops_shortcut"
         android:shortcutLongLabel="@string/recent_stops_shortcut">
@@ -53,6 +56,7 @@
     <shortcut
         android:shortcutId="recent_routes"
         android:enabled="true"
+        tools:targetApi="25"
         android:icon="@drawable/ic_bus"
         android:shortcutShortLabel="@string/recent_routes_shortcut"
         android:shortcutLongLabel="@string/recent_routes_shortcut">
@@ -68,6 +72,7 @@
     <shortcut
         android:shortcutId="recent"
         android:enabled="true"
+        tools:targetApi="25"
         android:icon="@drawable/ic_history"
         android:shortcutShortLabel="@string/my_recent_title"
         android:shortcutLongLabel="@string/my_recent_title">


### PR DESCRIPTION
Resolves #1703 — the ~19 non-blocking Android Lint warnings surfaced by the CI lint gate (#1692). Also fixes one lint **error** that the security fix uncovered.

## Changes

| Finding | Fix |
|---|---|
| **UnusedAttribute (13)** | `tools:targetApi="24"` on `<application>` (for `networkSecurityConfig`); `tools:targetApi="25"` on each of the 4 `<shortcut>` elements (app-shortcut attrs are API 25+) |
| **ExportedReceiver (2)** | `exported="false"` on `NavigationReceiver` and `RealtimeWakefulReceiver` — both are only ever triggered by the app itself, closing a broadcast-injection surface |
| **ParcelClassLoader (2)** | pass the class loader to `Parcel.readBundle` in `CustomAddress` |
| **ManifestOrder (1)** | move `<uses-feature>` above `<application>` |
| **DataExtractionRules (1)** | add `data_extraction_rules.xml` (API 31+) **and** `backup_rules.xml` (`fullBackupContent`, the required companion for minSdk 23), both mirroring `allowBackup="false"` |

## Knock-on error fix

Marking `RealtimeWakefulReceiver` non-exported turned the package-less implicit broadcast in `RealtimeService.start()` (`RealtimeService.kt:423`) into an `UnsafeImplicitIntentLaunch` lint **error**. Fixed by scoping the intent to our own app with `setPackage(...)`. This also repairs a **latent bug**: package-less implicit broadcasts have not been delivered to manifest-declared receivers since API 26, so this realtime-check start path was likely already broken on modern Android. The explicit-component broadcast paths were unaffected.

## Verification

`./gradlew :onebusaway-android:lintObaGoogleDebug` — **BUILD SUCCESSFUL**, all six targeted lint ids report 0 findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app stability on newer Android versions by updating backup and data-transfer settings.
  * Restricted a couple of internal broadcasts for better security and reliability.
  * Fixed parcel data handling for custom addresses to avoid deserialization issues.

* **Chores**
  * Updated app metadata and shortcut XML compatibility settings for newer Android API levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->