### PR TITLE
Tap an arrivals row to show its route on the map

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
@@ -243,7 +243,8 @@ fun ArrivalRowStyleA(
         isFavorite = actions?.isRouteFavorite,
         onFavorite = { actions?.let { callbacks.onRouteFavorite(it) } },
         onMore = { expanded = true },
-        onContentClick = { expanded = true },
+        // Tapping the row body defaults to "Show vehicles on map"; the overflow icon opens the menu.
+        onContentClick = { callbacks.onShowVehiclesOnMap(arrival) },
         overflow = {
             ArrivalActionsMenu(expanded, { expanded = false }, arrival, actions, filterActive, callbacks)
         }
@@ -378,6 +379,9 @@ fun ArrivalCardStyleB(
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
+                        // Tapping a row shows its route/direction on the map (same as Style A); HomeScreen's
+                        // wrapped onShowRouteOnMap drags the sheet down to peek on every such tap.
+                        .clickable { callbacks.onShowVehiclesOnMap(arrival) }
                         .padding(top = if (index == 0) 8.dp else 0.dp)
                         // Subsequent arrivals are dimmed, matching the legacy card
                         .alpha(if (index == 0) 1f else 0.55f),

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -224,6 +224,14 @@ fun HomeScreen(
             }
         }
 
+        // Drag the sheet down to peek. Unlike the declarative routeModeActive effect below (which only
+        // fires on the off->on route-mode transition), this is a per-tap action, so it also drags an
+        // already-expanded sheet down when the user taps a "show vehicles on map" row while route mode
+        // is already active for another route.
+        val collapseSheet: () -> Unit = remember {
+            { scope.launch { runCatching { sheetState.partialExpand() } } }
+        }
+
         // The arrivals sheet's measurement state, reported by the panel via onPreferredHeight — local to
         // the screen, since the panel and the sheet both live here (no need to round-trip the VM). Seeded
         // at the two-arrivals height so the first reveal doesn't flash undersized (legacy default), and
@@ -401,7 +409,12 @@ fun HomeScreen(
                             expandProgress = sheetProgress.fraction,
                             arrivalsViewModelFactory = arrivalsViewModelFactory,
                             onArrivalsLoaded = onArrivalsLoaded,
-                            onShowRouteOnMap = onShowRouteOnMap,
+                            // Showing vehicles on the map drags the sheet down to peek so the route is
+                            // visible, whether or not route mode was already active (see collapseSheet).
+                            onShowRouteOnMap = { request ->
+                                onShowRouteOnMap(request)
+                                collapseSheet()
+                            },
                             onShowTrip = onShowTrip,
                             onEditReminder = onEditReminder,
                             onPreferredHeight = { count, filtering ->


### PR DESCRIPTION
## Summary
Tapping an arrivals row now shows that arrival's route/direction on the map, instead of opening the three-dot menu.

- **Style A (flat rows):** tapping the row body now does what the "Show vehicles on map" menu item does — puts the map into route/direction mode for that arrival. The overflow icon (top-right) still opens the per-arrival menu, so every other action stays reachable.
- **Style B (grouped cards):** each grouped arrival row is now tappable with the same behavior.
- Showing vehicles on the map also drags the arrivals sheet down to peek so the route is visible. This now runs on **every** such tap (via HomeScreen's wrapped `onShowRouteOnMap`), so an already-expanded sheet collapses even when route mode is already active for another route — the declarative `routeModeActive` effect alone only fired on the off→on transition.

## Testing
- Built and installed `obaGoogleDebug` on device; exercised tapping rows in both styles.

## Follow-up
- #52 — animate the map camera on UI-driven bounding-box changes (the Google flavor currently jumps to the route bounds instead of easing).
