### PR TITLE
Derive predicted arrival/departure from scheduleDeviation (#1688)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/adapters/ArrivalAdapters.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/adapters/ArrivalAdapters.kt
@@ -36,6 +36,35 @@ internal fun ArrivalDeparture.asArrivalData(): ArrivalData = DtoArrivalData(this
 private fun predictedOrAbsent(epochMs: Long): Long = if (epochMs > 0L) epochMs else 0L
 
 private class DtoArrivalData(private val d: ArrivalDeparture) : ArrivalData {
+
+    /**
+     * The authoritative predicted instant for a stop, in epoch millis, computed at the wire→domain
+     * boundary from OBA's canonical relationship `predicted = scheduled + scheduleDeviation` rather
+     * than the absolute `predicted{Arrival,Departure}Time` field.
+     *
+     * The server derives BOTH the absolute predicted times and `tripStatus.scheduleDeviation` from
+     * the same deviation, so for healthy data this yields exactly the server's own predicted time (a
+     * no-op). But the two can disagree when the absolute field is corrupt: at the WSF "Seattle"
+     * terminal (stop `95_7`, issue #1688) the `predictedDepartureTime` for origin-terminal sailings
+     * is pinned ~15h stale near the service-day start, while `scheduleDeviation` stays sane (60s /
+     * 780s) and the same trip's `predictedArrivalTime` matches `scheduled + scheduleDeviation`
+     * exactly. Deriving from the deviation repairs that garbage (~ -900 min ETA).
+     *
+     * Only applied when the trip is actually tracked (`predicted` AND a `tripStatus` to read the
+     * deviation from) AND there is a real scheduled anchor to add the deviation to; otherwise there
+     * is no usable real-time source, so fall back to the sentinel-normalized absolute value (issue
+     * #1687). The `scheduledEpochMs > 0` guard matters because the wire defaults an absent scheduled
+     * time to 0: without it, `0 + deviation` would be a ~epoch-1970 instant that passes the downstream
+     * `> 0` prediction gate and reproduces the very garbage ETA this fix removes. [scheduleDeviation]
+     * is seconds (+late/−early); scheduled times are epoch millis.
+     */
+    private fun predictedInstant(scheduledEpochMs: Long, absolutePredictedEpochMs: Long): Long =
+        if (d.predicted && d.tripStatus != null && scheduledEpochMs > 0L) {
+            scheduledEpochMs + d.tripStatus.scheduleDeviation * MS_IN_SECOND
+        } else {
+            predictedOrAbsent(absolutePredictedEpochMs)
+        }
+
     override val routeId get() = d.routeId
     override val tripId get() = d.tripId
     override val stopId get() = d.stopId
@@ -48,9 +77,11 @@ private class DtoArrivalData(private val d: ArrivalDeparture) : ArrivalData {
     override val predicted get() = d.predicted
     // Wire→server mint: these are the server clock, already epoch millis.
     override val scheduledArrivalTime get() = ServerTime(d.scheduledArrivalTime)
-    override val predictedArrivalTime get() = ServerTime(predictedOrAbsent(d.predictedArrivalTime))
+    override val predictedArrivalTime
+        get() = ServerTime(predictedInstant(d.scheduledArrivalTime, d.predictedArrivalTime))
     override val scheduledDepartureTime get() = ServerTime(d.scheduledDepartureTime)
-    override val predictedDepartureTime get() = ServerTime(predictedOrAbsent(d.predictedDepartureTime))
+    override val predictedDepartureTime
+        get() = ServerTime(predictedInstant(d.scheduledDepartureTime, d.predictedDepartureTime))
     override val status get() = d.tripStatus?.status?.let { Status.fromString(it) }
     override val situationIds get() = d.situationIds
     override val frequency
@@ -61,4 +92,8 @@ private class DtoArrivalData(private val d: ArrivalDeparture) : ArrivalData {
     override val scheduleDeviation get() = d.tripStatus?.scheduleDeviation ?: 0L
     override val lastKnownLat get() = d.tripStatus?.lastKnownLocation?.lat
     override val lastKnownLon get() = d.tripStatus?.lastKnownLocation?.lon
+
+    private companion object {
+        private const val MS_IN_SECOND = 1000L
+    }
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/api/adapters/ArrivalAdaptersTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/api/adapters/ArrivalAdaptersTest.kt
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.api.adapters
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.onebusaway.android.api.contract.ArrivalDeparture
+import org.onebusaway.android.api.contract.TripStatus
+
+/**
+ * JVM unit tests for the wire→domain arrival adapter's predicted-instant derivation (issue #1688).
+ *
+ * When a trip is tracked (`predicted` + a `tripStatus`), the adapter derives the predicted instant
+ * from OBA's canonical `predicted = scheduled + scheduleDeviation` rather than the absolute
+ * `predicted{Arrival,Departure}Time` wire field. The server computes both from the same deviation,
+ * so this is a no-op for healthy data but repairs the WSF "Seattle" terminal (stop `95_7`) defect
+ * where the absolute `predictedDepartureTime` is pinned ~15h stale while `scheduleDeviation` is sane.
+ *
+ * Numbers are the live values captured in the issue (`currentTime = 1783117313123`).
+ */
+class ArrivalAdaptersTest {
+
+    @Test
+    fun `corrupt predicted departure is repaired from scheduleDeviation`() {
+        // WSF entry 1: Seattle -> Bremerton, origin terminal (stopSequence 0). The absolute
+        // predictedDepartureTime is ~15h stale; scheduleDeviation is a sane +60s.
+        val ad = ArrivalDeparture(
+            stopSequence = 0,
+            predicted = true,
+            scheduledDepartureTime = 1_783_120_500_000L,
+            predictedDepartureTime = 1_783_062_899_000L, // garbage, ~15h in the past
+            tripStatus = TripStatus(predicted = true, scheduleDeviation = 60),
+        ).asArrivalData()
+
+        // scheduled 1783120500000 + 60s -> a sane ~+54 min departure, not the -900 min garbage.
+        assertEquals(1_783_120_560_000L, ad.predictedDepartureTime.epochMs)
+    }
+
+    @Test
+    fun `healthy predicted arrival is derived to the same value the server sent (no-op)`() {
+        // WSF entry 3: Bainbridge -> Seattle, terminating (stopSequence 1). Here the server's own
+        // absolute predictedArrivalTime already equals scheduled + scheduleDeviation.
+        val ad = ArrivalDeparture(
+            stopSequence = 1,
+            predicted = true,
+            scheduledArrivalTime = 1_783_117_800_000L,
+            predictedArrivalTime = 1_783_118_580_000L, // == scheduled + 780s
+            tripStatus = TripStatus(predicted = true, scheduleDeviation = 780),
+        ).asArrivalData()
+
+        assertEquals(1_783_118_580_000L, ad.predictedArrivalTime.epochMs)
+    }
+
+    @Test
+    fun `an early (negative) deviation subtracts from the scheduled time`() {
+        val ad = ArrivalDeparture(
+            stopSequence = 0,
+            predicted = true,
+            scheduledDepartureTime = 1_783_120_500_000L,
+            predictedDepartureTime = 1_783_062_899_000L, // ignored when tracked
+            tripStatus = TripStatus(predicted = true, scheduleDeviation = -120),
+        ).asArrivalData()
+
+        assertEquals(1_783_120_500_000L - 120_000L, ad.predictedDepartureTime.epochMs)
+    }
+
+    @Test
+    fun `without a trip status the absolute predicted time is used (no deviation to derive from)`() {
+        val absolute = 1_783_119_500_000L
+        val ad = ArrivalDeparture(
+            stopSequence = 5,
+            predicted = true,
+            scheduledArrivalTime = 1_783_119_110_000L,
+            predictedArrivalTime = absolute,
+            tripStatus = null,
+        ).asArrivalData()
+
+        assertEquals(absolute, ad.predictedArrivalTime.epochMs)
+    }
+
+    @Test
+    fun `a non-positive absolute predicted sentinel still collapses to zero without a trip status`() {
+        // #1687 closed-stop sentinel path is unchanged when there is no tripStatus to derive from.
+        val ad = ArrivalDeparture(
+            stopSequence = 5,
+            predicted = true,
+            scheduledArrivalTime = 1_783_119_110_000L,
+            predictedArrivalTime = -1L,
+            tripStatus = null,
+        ).asArrivalData()
+
+        assertEquals(0L, ad.predictedArrivalTime.epochMs)
+    }
+
+    @Test
+    fun `a zero scheduled anchor falls back to the absolute predicted time instead of deviation-only garbage`() {
+        // The wire defaults an absent scheduled time to 0. Deriving 0 + deviation would be a
+        // ~epoch-1970 instant that passes the downstream `> 0` prediction gate and reproduces the
+        // garbage ETA this fix removes; the scheduled>0 guard must fall back to the absolute value.
+        val absolute = 1_783_119_500_000L
+        val ad = ArrivalDeparture(
+            stopSequence = 0,
+            predicted = true,
+            scheduledDepartureTime = 0L, // absent scheduled anchor
+            predictedDepartureTime = absolute, // valid absolute prediction still present
+            tripStatus = TripStatus(predicted = true, scheduleDeviation = 60),
+        ).asArrivalData()
+
+        assertEquals(absolute, ad.predictedDepartureTime.epochMs)
+    }
+
+    @Test
+    fun `an unpredicted arrival keeps the sentinel-normalized absolute time`() {
+        // predicted=false: even with a tripStatus present we do not synthesize scheduled+deviation;
+        // there is no prediction, so the absolute (here absent) instant collapses to 0.
+        val ad = ArrivalDeparture(
+            stopSequence = 5,
+            predicted = false,
+            scheduledArrivalTime = 1_783_119_110_000L,
+            predictedArrivalTime = 0L,
+            tripStatus = TripStatus(scheduleDeviation = 300),
+        ).asArrivalData()
+
+        assertEquals(0L, ad.predictedArrivalTime.epochMs)
+    }
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/ArrivalInfoTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/ArrivalInfoTest.kt
@@ -19,6 +19,9 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.onebusaway.android.api.adapters.asArrivalData
+import org.onebusaway.android.api.contract.ArrivalDeparture
+import org.onebusaway.android.api.contract.TripStatus
 import org.onebusaway.android.models.ArrivalData
 import org.onebusaway.android.models.FrequencyWindow
 import org.onebusaway.android.models.Occupancy
@@ -117,6 +120,40 @@ class ArrivalInfoTest {
         val info = infoFor(arrival(predicted = true, predictedArrivalTime = 1_783_119_500_000L))
 
         assertTrue("a genuine prediction stays real-time in the report", info.toTripReportContext().predicted)
+    }
+
+    /**
+     * Issue #1688: end-to-end through the real wire→domain adapter. WSF "Seattle" terminal origin
+     * departure (stopSequence 0) whose absolute predictedDepartureTime is ~15h stale but whose
+     * scheduleDeviation is a sane +60s. The adapter derives predicted = scheduled + scheduleDeviation,
+     * so the ETA is a sane near-future value instead of the reported ~ -900 min garbage.
+     */
+    @Test
+    fun `a stale absolute predicted departure yields a sane ETA via scheduleDeviation`() {
+        val nowWsf = ServerTime(1_783_117_313_123L)
+        val scheduledDeparture = 1_783_120_500_000L
+        val data = ArrivalDeparture(
+            stopSequence = 0,
+            predicted = true,
+            scheduledDepartureTime = scheduledDeparture,
+            predictedDepartureTime = 1_783_062_899_000L, // garbage, ~15h in the past
+            tripStatus = TripStatus(predicted = true, scheduleDeviation = 60),
+        ).asArrivalData()
+
+        val info = ArrivalInfo(
+            context = null,
+            data = data,
+            now = nowWsf,
+            includeArrivalDepartureInStatusLabel = false,
+            favorite = false,
+        )
+
+        assertTrue("still a real-time prediction", info.predicted)
+        assertFalse("origin-terminal sailing shows the departure", info.isArrival)
+        val derived = scheduledDeparture + 60_000L
+        assertEquals("displayTime is the derived predicted departure", derived, info.displayTime)
+        assertEquals(derived / 60_000 - nowWsf.epochMs / 60_000, info.eta)
+        assertTrue("ETA is a sane ~+54 min, never the -900 min garbage", info.eta in 50..60)
     }
 }
 


### PR DESCRIPTION
Fixes #1688.

## Problem

At the Washington State Ferries **"Seattle" terminal** (stop `95_7`), origin-terminal ferry departures showed a long list of garbage negative ETAs — `-906 min`, `-901 min`, etc. The server's absolute `predictedDepartureTime` for these sailings is pinned ~15h stale near the service-day start, and the app trusted it verbatim. (Same theme as #1687, but the `predictedTime > 0` guard doesn't catch this — the bad value is a large *positive* number.)

## Root cause

An OBA-server data defect, provable from the server's own `scheduleDeviation`. OBA's canonical relationship is `predicted = scheduled + scheduleDeviation`. The server applies it **correctly for the arrival leg** and **incorrectly for the departure leg of the same trip**:

- Arrival leg: `scheduledArrivalTime + scheduleDeviation` == reported `predictedArrivalTime` — exact match.
- Departure leg: reported `predictedDepartureTime` is garbage (~15h stale), disagreeing with both `scheduleDeviation` and the same trip's `predictedArrivalTime`.

The vessel real-time data is healthy (`phase=in_progress`, small `scheduleDeviation`, ~20s-old `lastUpdateTime`); only the absolute predicted **departure** timestamp is corrupt.

## Fix

At the wire→domain boundary (`DtoArrivalData`), when a trip is tracked (`predicted` + a `tripStatus`) **and** has a real scheduled anchor, derive the predicted instant as `scheduled + scheduleDeviation` — the exact formula the server already applies correctly for the arrival leg — instead of trusting the absolute `predicted{Arrival,Departure}Time`.

Because the server computes both the absolute predicted times and `tripStatus.scheduleDeviation` from the same deviation, this is a **no-op for healthy agencies** and only repairs the corrupt WSF value. It's the canonical OBA relationship, **not a heuristic** (no magnitude thresholds or magnitude-based unit guessing, per `CLAUDE.md`).

Applied uniformly to arrival and departure, so downstream consumers that also read the corrupt absolute value — the reminder alarm time (`reminderDepartureTime`) and the report context — are corrected too, not just the ETA badge.

The `scheduled > 0` guard falls back to the sentinel-normalized absolute value when no scheduled anchor is present (the wire defaults an absent scheduled time to `0`), so the derivation can't itself synthesize a ~epoch-1970 instant that would pass the downstream `> 0` prediction gate and reproduce the garbage ETA.

## Tests

JVM unit tests (no device needed):
- `ArrivalAdaptersTest` — corrupt departure repaired, healthy arrival no-op, early/negative deviation, no-`tripStatus` and zero-anchor fallbacks, sentinel collapse.
- `ArrivalInfoTest` — end-to-end case routing the exact issue #1688 WSF numbers through the real adapter → sane ~+54 min ETA, never ~−900.

## Acceptance
- ✅ WSF Seattle-terminal departures show sane ETAs consistent with `scheduled + scheduleDeviation`, not ~−900 min.
- ✅ JVM unit test covering `predicted=true` where the absolute predicted timestamp disagrees with `scheduled + scheduleDeviation`.

## Follow-up (out of scope for this repo)
The defect should also be **reported upstream** to the OneBusAway / WSF server — the `predictedDepartureTime` it computes for ferry departures is internally inconsistent with both `scheduleDeviation` and the same trip's `predictedArrivalTime`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved arrival and departure time calculations so predicted times are derived more reliably from scheduled time plus delay information when available.
  * Prevented stale or invalid predicted times from showing as large negative or otherwise incorrect ETAs.
  * Kept unpredicted or missing values safely normalized to zero instead of displaying garbage values.

* **Tests**
  * Added coverage for predicted-time calculation edge cases, including early/late delays, missing prediction data, and stale timestamps.
  * Added an end-to-end check to confirm arrival estimates remain sensible in real-world scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->