### PR TITLE
Animate Google map camera on UI-driven route/itinerary framing (#1719)

### DIFF
--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleCameraCommands.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleCameraCommands.kt
@@ -117,7 +117,9 @@ fun applyFramingIntent(
             if (bounds == null) {
                 Toast.makeText(context, R.string.route_info_no_shape_data, Toast.LENGTH_SHORT).show()
             } else {
-                map.moveCamera(
+                // animateCamera (not moveCamera) so UI-driven route framing eases in, matching the
+                // maplibre adapter's applyFramingIntent (#1719).
+                map.animateCamera(
                     CameraUpdateFactory.newLatLngBounds(bounds, ViewUtils.dpToPixels(context, DEFAULT_MAP_PADDING_DP))
                 )
             }
@@ -126,7 +128,8 @@ fun applyFramingIntent(
         FramingIntent.Itinerary -> {
             val bounds = routePolylineBounds(renderState) ?: return
             val dm = context.resources.displayMetrics
-            map.moveCamera(
+            // animateCamera to match the maplibre adapter (#1719); see Route above.
+            map.animateCamera(
                 CameraUpdateFactory.newLatLngBounds(
                     bounds, dm.widthPixels, dm.heightPixels,
                     ViewUtils.dpToPixels(context, DEFAULT_MAP_PADDING_DP)


### PR DESCRIPTION
## Summary

Fixes #1719. The Google flavor jumped instantly when the UI drove the map to a new bounding box (entering route mode via an arrival-row tap / "show vehicles on map", or framing a trip itinerary), while the MapLibre flavor already eased the same transitions. This makes the Google adapter animate UI-driven route/itinerary framing so both flavors are consistent.

## Change

In `GoogleCameraCommands.applyFramingIntent`:
- `FramingIntent.Route`: `moveCamera` → `animateCamera`
- `FramingIntent.Itinerary`: `moveCamera` → `animateCamera`

`FramingIntent.Region` already animated. This mirrors the MapLibre adapter's `applyFramingIntent`, which animates route/itinerary framing.

## `Point` left instant (deviation from the issue's literal list)

The issue text lists `Point` among the branches to animate, but it's intentionally left as an instant `moveCamera`:
- The MapLibre adapter — the pattern this mirrors — also snaps `Point`, so animating it on Google would make the flavors *diverge*.
- `FramingIntent.Point` also backs the cold-start region seed (`MapHost` `SEED_DEFAULT_ZOOM`), which should not fly in.

If animating `Point` (the degenerate start==end itinerary) is desired, it should be done on both flavors and split from the cold-start seed path — out of scope here.

## Testing

- Google flavor builds and installs.
- Manual: entering route mode from an arrival-row tap eases the camera to the route bounds; trip-plan framing eases to fit the itinerary.

### Note for review

`framingIntent` is a `replay=1` flow, so a re-created adapter (config change / re-attach) re-applies the current framing — now animated. MapLibre already behaves this way without a reported issue; if a fly-in-on-rotate flicker shows up, the animation can be guarded to genuine user-initiated framing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Camera framing now animates smoothly when showing routes or itineraries on the map, instead of jumping instantly.
  * Existing map bounds behavior and error handling remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->