### PR TITLE
Lint: opt out of LogNotTimber (project uses android.util.Log, not Timber)

### DIFF
--- a/onebusaway-android/build.gradle
+++ b/onebusaway-android/build.gradle
@@ -152,7 +152,10 @@ android {
     }
     namespace='org.onebusaway.android'
     lint {
-        disable 'MissingTranslation', 'ExtraTranslation'
+        // LogNotTimber: this project intentionally uses android.util.Log, not Timber. The check is
+        // a library-preference nudge, not a correctness signal, and its ~190 hits drown out the
+        // actionable warnings, so we opt out of it rather than suppress each call site.
+        disable 'MissingTranslation', 'ExtraTranslation', 'LogNotTimber'
         // Fail the build (and CI, #1692) on any lint error — notably NewApi minSdk violations,
         // which compile + API-33 instrumented tests can't catch.
         abortOnError true


### PR DESCRIPTION
Part of the #1704 lint-warning cleanup.

`LogNotTimber` accounts for **~190 of ~206** `obaGoogleDebug` lint warnings. It's a library-preference nudge (use Timber instead of `android.util.Log`), not a correctness signal — and this project deliberately uses `android.util.Log`. Left on, it buries the ~12 genuinely actionable warnings.

This disables the check in the `lint {}` config (alongside the existing translation opt-outs) rather than annotating ~190 call sites. After this, the report drops to ~12 warnings, surfacing the real ones (e.g. `BadPeriodicWorkRequestEnqueue`, addressed separately).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated app quality checks to ignore an additional warning, reducing unnecessary lint noise during builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->