### PR TITLE
Pin the trip-map data dot to the extrapolation anchor, not raw position

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/extrapolation/test/TripExtrapolationBuilderTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/extrapolation/test/TripExtrapolationBuilderTest.kt
@@ -28,6 +28,9 @@ import org.onebusaway.android.extrapolation.ExtrapolationResult
 import org.onebusaway.android.extrapolation.buildTripExtrapolation
 import org.onebusaway.android.extrapolation.data.TripState
 import org.onebusaway.android.extrapolation.math.prob.ProbDistribution
+import org.onebusaway.android.models.ObaTripStatus
+import org.onebusaway.android.models.Occupancy
+import org.onebusaway.android.models.Status
 import org.onebusaway.android.util.Polyline
 
 /**
@@ -50,6 +53,34 @@ class TripExtrapolationBuilderTest {
         latitude = lat
         longitude = lng
     }
+
+    /** A minimal predicted [ObaTripStatus] anchor carrying only the fields the data-age marker reads. */
+    private fun anchorStatus(position: Location?, distanceAlongTrip: Double?): ObaTripStatus =
+        object : ObaTripStatus {
+            override val serviceDate = 0L
+            override val isPredicted = true
+            override val scheduleDeviation = 0L
+            override val vehicleId: String? = null
+            override val closestStop: String? = null
+            override val closestStopTimeOffset = 0L
+            override val position = position
+            override val activeTripId: String? = "t"
+            override val distanceAlongTrip = distanceAlongTrip
+            override val scheduledDistanceAlongTrip: Double? = null
+            override val totalDistanceAlongTrip: Double? = null
+            override val orientation: Double? = null
+            override val nextStop: String? = null
+            override val nextStopTimeOffset: Long? = null
+            override val phase: String? = null
+            override val status: Status? = null
+            override val lastUpdateTime = 0L
+            override val lastKnownLocation = position
+            override val lastLocationUpdateTime = 0L
+            override val lastKnownDistanceAlongTrip: Double? = null
+            override val lastKnownOrientation: Double? = null
+            override val blockTripSequence = 0
+            override val occupancyStatus: Occupancy? = null
+        }
 
     /** A straight ~3.3 km line heading north along longitude -122. */
     private fun northLine() = Polyline(
@@ -79,6 +110,53 @@ class TripExtrapolationBuilderTest {
             assertTrue(it.points.size >= 2)
         }
         assertNull("no anchor -> no data-age marker", extrapolation.dataAge)
+    }
+
+    @Test
+    fun dataAgeMarkerFollowsProjectedAnchorDistanceNotRawPosition() {
+        // Anchor's raw position is well OFF the shape (lng -122.5), but its distanceAlongTrip places it
+        // mid-line (1500 m ~ lat 47.015 on the north line). The dot must follow the projected distance —
+        // the same value the glide is seeded from — so it can't float ahead of the glide (regression from
+        // a821321a8, which pinned the dot to the raw `position`).
+        val extrapolation = buildTripExtrapolation(
+            TripState(
+                "t",
+                anchor = anchorStatus(position = loc(47.5, -122.5), distanceAlongTrip = 1500.0),
+                anchorLocalTimeMs = WallTime(1_000L),
+                polyline = northLine(),
+            ),
+            ExtrapolationResult.Success(UniformDist(3000.0)),
+            nowMs = WallTime(6_000L),
+        )!!
+
+        val dot = extrapolation.dataAge!!
+        assertEquals("dot rides the shape (projected distance), not the off-route raw position",
+            -122.0, dot.point.longitude, 1e-6)
+        assertTrue(dot.point.latitude > 47.0 && dot.point.latitude < 47.03)
+        // The projected dot coincides with the glide's origin: the median (q0.50 of the uniform over the
+        // remaining shape) is at or ahead of it, never behind.
+        assertTrue("glide median is not behind the data dot",
+            extrapolation.vehiclePoint!!.latitude >= dot.point.latitude - 1e-9)
+        assertEquals(5_000L, dot.ageMillis)
+    }
+
+    @Test
+    fun dataAgeMarkerFallsBackToRawPositionWithoutDistance() {
+        // No distanceAlongTrip to project (and no shape placement possible) → fall back to raw position.
+        val extrapolation = buildTripExtrapolation(
+            TripState(
+                "t",
+                anchor = anchorStatus(position = loc(47.5, -122.5), distanceAlongTrip = null),
+                anchorLocalTimeMs = WallTime(1_000L),
+                polyline = northLine(),
+            ),
+            ExtrapolationResult.NoData,
+            nowMs = WallTime(1_000L),
+        )!!
+
+        val dot = extrapolation.dataAge!!
+        assertEquals(-122.5, dot.point.longitude, 1e-6)
+        assertEquals(47.5, dot.point.latitude, 1e-6)
     }
 
     @Test

--- a/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/TripExtrapolationBuilder.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/TripExtrapolationBuilder.kt
@@ -46,8 +46,8 @@ fun buildTripExtrapolation(
     val distribution = (result as? ExtrapolationResult.Success)?.distribution
 
     return TripExtrapolation(
-        vehiclePoint = distribution?.pointAlong(polyline, distribution.median()),
-        fastEstimatePoint = distribution?.pointAlong(polyline, distribution.quantile(FAST_ESTIMATE_QUANTILE)),
+        vehiclePoint = distribution?.let { polyline.pointAtDistance(it.median()) },
+        fastEstimatePoint = distribution?.let { polyline.pointAtDistance(it.quantile(FAST_ESTIMATE_QUANTILE)) },
         band = distribution?.let { weightedBandSegments(it, polyline) } ?: emptyList(),
         dataAge = dataAgeMarker(state, nowMs),
         // The anchor's instant is constant between fixes; a change means fresh AVL data arrived.
@@ -133,9 +133,9 @@ fun extrapolatedVehicles(
         )
     }
 
-/** The point [distance] along [polyline], or null when [distance] is non-finite or off the shape. */
-private fun ProbDistribution.pointAlong(polyline: Polyline, distance: Double): GeoPoint? =
-    distance.takeIf(Double::isFinite)?.let { polyline.interpolate(it)?.toGeoPoint() }
+/** The point [distance] along this shape, or null when [distance] is non-finite or off the shape. */
+private fun Polyline.pointAtDistance(distance: Double): GeoPoint? =
+    distance.takeIf(Double::isFinite)?.let { interpolate(it)?.toGeoPoint() }
 
 private fun weightedBandSegments(distribution: ProbDistribution, polyline: Polyline): List<WeightedBandSegment> =
     // Draw the band only out to the fast-estimate marker (the optimistic forward bound), not the full
@@ -147,12 +147,22 @@ private fun weightedBandSegments(distribution: ProbDistribution, polyline: Polyl
     }
 
 private fun dataAgeMarker(state: TripState, nowMs: WallTime): DataAgeMarker? {
-    val position = state.anchor?.position ?: return null
+    val anchor = state.anchor ?: return null
     if (state.anchorLocalTimeMs.epochMs <= 0) return null
+    // Plot the dot at the extrapolation's own anchor: the anchor's distanceAlongTrip — the exact value
+    // the glide is seeded from (TripState.extrapolate) — projected onto the shape. This keeps the "data
+    // received" dot pinned to the glide's origin so it can never float ahead of the glide. Drawing it at
+    // the anchor's raw `position` instead (a different, server-extrapolated field than distanceAlongTrip)
+    // let the two disagree, so the dot appeared ahead of the glide when they diverged — the regression
+    // from a821321a8 ("Remove bestLocation — always use position for display"). Fall back to the reported
+    // position only when the fix carries no distance or the shape can't place it.
+    val point = anchor.distanceAlongTrip?.let { dist -> state.polyline?.pointAtDistance(dist) }
+        ?: anchor.position?.toGeoPoint()
+        ?: return null
     // Shown whenever there's a last fix, like the original (no max-age hide); the label is its age.
     // now − anchor is a same-domain (device) Duration; unwrap to raw Long ms for the marker.
     val ageMs = (nowMs - state.anchorLocalTimeMs).inWholeMilliseconds.coerceAtLeast(0L)
-    return DataAgeMarker(position.toGeoPoint(), ageMs)
+    return DataAgeMarker(point, ageMs)
 }
 
 private fun Location.toGeoPoint() = GeoPoint(latitude, longitude)


### PR DESCRIPTION
## Summary

On the trip map, the "data received" dot could sit **ahead of** the extrapolated glide it's supposed to originate from (caught live on a 12 inbound). The dot and the glide were derived from two different fields of the *same* fix:

- **dot** → `anchor.position` (a server-*extrapolated* lat/lng) — `TripExtrapolationBuilder.dataAgeMarker`
- **glide** → `anchor.distanceAlongTrip` (server distance), then dead-reckoned forward — `TripState.extrapolate`

When those two server fields disagree on the shape (or the client median stalls at `distanceAlongTrip` while `position` sits further along), the dot floats ahead of the glide.

## Root cause

Originally **both** the dot and the glide keyed off the *raw* last-known fix (`bestLocation` = `lastKnownLocation ?: position`; `bestDistanceAlongTrip` = `lastKnownDistanceAlongTrip ?: distanceAlongTrip`), so they coincided by construction. Commit **`a821321a8` "Remove bestLocation — always use position for display"** repinned the dot to `position` on the assumption it always agrees with the distance distribution; the later TripState port seeded the glide from `distanceAlongTrip` and dropped `bestDistanceAlongTrip`. That left the dot and glide as two independent server-extrapolated fields whose spatial agreement is only assumed.

## Change

Project the dot from `anchor.distanceAlongTrip` — the exact value the glide is seeded from — onto the route shape, so the dot **is** the glide's origin by construction and can never lead it. Falls back to the reported `position` only when the fix carries no distance or the shape can't place it.

Also consolidates the duplicated shape-projection logic into one `Polyline.pointAtDistance(...)` helper (used by `vehiclePoint`, `fastEstimatePoint`, and the dot).

## Tests

`TripExtrapolationBuilderTest`: an off-route raw `position` with an on-shape `distanceAlongTrip` now plots the dot on the shape (proving it follows the projected distance, not raw position) and the median is never behind it; plus the no-distance fallback. Main + androidTest compile clean.

## Caveat for review

Both `position` and `distanceAlongTrip` are server-extrapolated, so they *usually* agree — a live divergence also implicates the server's two fields disagreeing for that coach, or the client median falling behind its own anchor. This removes the client-side decoupling regardless, but has **not yet been device-verified**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the trip extrapolation display so the marker now follows the route shape when distance information is available.
  * Added a fallback to the vehicle’s reported position when projected placement can’t be calculated.
  * Updated trip position calculations to use a more consistent distance-based interpolation method.

* **Tests**
  * Expanded instrumentation coverage to verify marker placement for both projected and raw-position cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->