### PR TITLE
Fix periodic WorkManager jobs stacking (BadPeriodicWorkRequestEnqueue)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/nav/FeedbackReceiver.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/nav/FeedbackReceiver.java
@@ -36,6 +36,7 @@ import java.util.concurrent.TimeUnit;
 
 import androidx.core.app.NotificationCompat;
 import androidx.core.app.RemoteInput;
+import androidx.work.ExistingPeriodicWorkPolicy;
 import androidx.work.PeriodicWorkRequest;
 import androidx.work.WorkManager;
 
@@ -170,8 +171,12 @@ public class FeedbackReceiver extends BroadcastReceiver {
         // Create the actual work object:
         PeriodicWorkRequest uploadCheckWork = uploadLogsBuilder.build();
 
-        // Then enqueue the recurring task:
-        WorkManager.getInstance().enqueue(uploadCheckWork);
+        // Then enqueue the recurring task under a unique name so repeated feedback submissions keep
+        // a single upload chain instead of stacking one each time:
+        WorkManager.getInstance().enqueueUniquePeriodicWork(
+                NavigationUploadWorker.UNIQUE_WORK_NAME,
+                ExistingPeriodicWorkPolicy.KEEP,
+                uploadCheckWork);
     }
 
     private void logFeedback(Context context, String feedbackText, String userResponse) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/nav/NavigationCleanupWorker.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/nav/NavigationCleanupWorker.java
@@ -33,6 +33,12 @@ public class NavigationCleanupWorker extends Worker {
 
     public static final String TAG = "NavigationCleanupWorker";
 
+    /**
+     * Unique name for the periodic cleanup work so WorkManager keeps a single recurring chain
+     * instead of stacking a new one each time navigation starts.
+     */
+    public static final String UNIQUE_WORK_NAME = "navigation_log_cleanup";
+
     public NavigationCleanupWorker(@NonNull Context context, @NonNull WorkerParameters workerParams) {
         super(context, workerParams);
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/nav/NavigationService.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/nav/NavigationService.kt
@@ -30,6 +30,7 @@ import android.util.Log
 import androidx.core.app.NotificationCompat
 import androidx.core.app.PendingIntentCompat
 import androidx.core.app.RemoteInput
+import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.PeriodicWorkRequest
 import androidx.work.WorkManager
 import com.google.firebase.auth.FirebaseAuth
@@ -485,8 +486,13 @@ class NavigationService : Service() {
         // Create the actual work object:
         val cleanUpCheckWork = cleanupLogsBuilder.build()
 
-        // Then enqueue the recurring task:
-        WorkManager.getInstance().enqueue(cleanUpCheckWork)
+        // Then enqueue the recurring task under a unique name so repeated navigation starts keep a
+        // single cleanup chain instead of stacking one each time:
+        WorkManager.getInstance().enqueueUniquePeriodicWork(
+            NavigationCleanupWorker.UNIQUE_WORK_NAME,
+            ExistingPeriodicWorkPolicy.KEEP,
+            cleanUpCheckWork
+        )
     }
 
     companion object {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/nav/NavigationUploadWorker.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/nav/NavigationUploadWorker.java
@@ -45,6 +45,12 @@ public class NavigationUploadWorker extends Worker {
 
     public static final String TAG = "NavigationUploadWorker";
 
+    /**
+     * Unique name for the periodic upload work, shared by every enqueue site so WorkManager keeps a
+     * single recurring chain instead of stacking a new one per feedback submission.
+     */
+    public static final String UNIQUE_WORK_NAME = "navigation_log_upload";
+
 
     public NavigationUploadWorker(@NonNull Context context, @NonNull WorkerParameters workerParams) {
         super(context, workerParams);

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/feedback/Feedback.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/feedback/Feedback.kt
@@ -49,6 +49,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.PeriodicWorkRequest
 import androidx.work.WorkManager
 import java.io.File
@@ -173,7 +174,11 @@ class FeedbackSubmitter(
         val uploadCheckWork = PeriodicWorkRequest
             .Builder(NavigationUploadWorker::class.java, 24, TimeUnit.HOURS)
             .build()
-        WorkManager.getInstance().enqueue(uploadCheckWork)
+        WorkManager.getInstance().enqueueUniquePeriodicWork(
+            NavigationUploadWorker.UNIQUE_WORK_NAME,
+            ExistingPeriodicWorkPolicy.KEEP,
+            uploadCheckWork
+        )
     }
 
     private fun logFeedback(liked: Boolean, feedbackText: String) {


### PR DESCRIPTION
Part of the #1704 lint-warning cleanup — surfaced by the `BadPeriodicWorkRequestEnqueue` lint check (×3).

**Bug:** The log-upload and log-cleanup periodic jobs were scheduled with plain `WorkManager.enqueue()`, which does **not** dedupe periodic work. So:
- every feedback submission (`Feedback.kt`, `FeedbackReceiver.java`) enqueued a new 24h `NavigationUploadWorker` chain, and
- every navigation start (`NavigationService.kt`) enqueued a new 24h `NavigationCleanupWorker` chain.

Identical periodic workers stack up and run forever in parallel — repeated uploads/cleanups, wasted battery/network.

**Fix:** All three sites now use `enqueueUniquePeriodicWork(name, ExistingPeriodicWorkPolicy.KEEP, request)`. The unique names are constants on `NavigationUploadWorker` / `NavigationCleanupWorker`, so the two upload call sites share one name and dedupe against each other. `KEEP` leaves an already-scheduled chain running rather than resetting its 24h timer on every event.

**Verified:** `./gradlew :onebusaway-android:lintObaGoogleDebug` → `BadPeriodicWorkRequestEnqueue` 3 → 0; compile + lint green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate navigation log upload and cleanup tasks from stacking up over time.
  * Kept existing scheduled background work in place when feedback is submitted or navigation starts, improving reliability and reducing repeated uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->