### PR TITLE
Lint cleanup: resolve miscellaneous warnings (#1705)

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-all.zip

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/nightlight/NightLightDestination.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/nightlight/NightLightDestination.kt
@@ -17,6 +17,7 @@
 package org.onebusaway.android.ui.nightlight
 
 import org.onebusaway.android.ui.HomeActivity
+import android.annotation.SuppressLint
 import android.content.Intent
 import android.content.pm.ActivityInfo
 import android.view.WindowManager
@@ -79,6 +80,11 @@ private const val PREFERENCE_SHOWED_DIALOG = "showed_night_light_dialog"
  * screen (a [DisposableEffect] adds them on enter and restores them on exit), shows the one-time
  * epilepsy intro, and drives [NightLightScreen]. [onBack] pops the back stack.
  */
+// The night-light screen doubles as a reading light, so it deliberately pins portrait (with the
+// screen kept on at full brightness) while visible; the DisposableEffect below restores the caller's
+// prior orientation on exit. The lock is the intended UX, not an accessibility oversight, so we
+// suppress SourceLockedOrientationActivity here rather than drop it.
+@SuppressLint("SourceLockedOrientationActivity")
 @Composable
 fun NightLightRoute(onBack: () -> Unit) {
     val context = LocalContext.current


### PR DESCRIPTION
Closes #1705 — the two leftover lint warnings.

**`SourceLockedOrientationActivity`** (`NightLightDestination.kt`): the night-light screen doubles as a reading light, so it deliberately pins portrait (with full brightness + keep-screen-on) while visible, and restores the caller's prior orientation on exit via `DisposableEffect.onDispose`. This is intended UX, not an accessibility oversight — annotated `NightLightRoute` with `@SuppressLint("SourceLockedOrientationActivity")` and a justification comment rather than dropping the lock.

**`AndroidGradlePluginVersion`**: bumped the Gradle wrapper `9.4.1 → 9.6.1`.

**Verified:** full build succeeds on Gradle 9.6.1, and `./gradlew :onebusaway-android:lintObaGoogleDebug` reports both `SourceLockedOrientationActivity` and `AndroidGradlePluginVersion` at 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Gradle wrapper to a newer version, which may improve build compatibility and tooling support.
  * Added a lint suppression for the night-light destination’s fixed-orientation behavior, keeping the existing experience unchanged while reducing warning noise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->