### PR TITLE
Lint cleanup: remaining Compose/graphics idiom warnings

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/compose/VehicleInfoWindow.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/compose/VehicleInfoWindow.kt
@@ -40,7 +40,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -68,7 +68,7 @@ import java.util.concurrent.TimeUnit
  */
 @Composable
 fun VehicleInfoWindow(status: ObaTripStatus, isRealtime: Boolean, response: RouteTrips) {
-    val res = LocalContext.current.resources
+    val res = LocalResources.current
     // "Now" in the server clock domain: the age is measured against the vehicle's last real-time fix
     // (status.lastLocationUpdateTime, falling back to lastUpdateTime) — both server AVL timestamps —
     // so a skewed device clock must not leak into it (#1612).

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/StopBitmaps.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/StopBitmaps.kt
@@ -23,6 +23,7 @@ import android.graphics.Paint
 import android.graphics.Path
 import android.graphics.Shader
 import androidx.core.graphics.createBitmap
+import androidx.core.graphics.withRotation
 import kotlin.math.ceil
 import kotlin.math.cos
 import kotlin.math.max
@@ -230,24 +231,23 @@ object StopBitmaps {
                 lineTo(center, center - tipDistance)
                 close()
             }
-            canvas.save()
-            canvas.rotate(directionAngleDeg, center, center)
-            val fill = Paint(Paint.ANTI_ALIAS_FLAG).apply {
-                style = Paint.Style.FILL
-                // Darkest at the tip, matching the plain markers' arrow shading.
-                shader = LinearGradient(
-                    center, center - tipDistance, center, center - tipDistance + arrowHeight,
-                    arrowTipColor, arrowBaseColor, Shader.TileMode.MIRROR
-                )
+            canvas.withRotation(directionAngleDeg, center, center) {
+                val fill = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+                    style = Paint.Style.FILL
+                    // Darkest at the tip, matching the plain markers' arrow shading.
+                    shader = LinearGradient(
+                        center, center - tipDistance, center, center - tipDistance + arrowHeight,
+                        arrowTipColor, arrowBaseColor, Shader.TileMode.MIRROR
+                    )
+                }
+                drawPath(path, fill)
+                val stroke = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+                    style = Paint.Style.STROKE
+                    strokeWidth = 1f
+                    color = Color.WHITE
+                }
+                drawPath(path, stroke)
             }
-            canvas.drawPath(path, fill)
-            val stroke = Paint(Paint.ANTI_ALIAS_FLAG).apply {
-                style = Paint.Style.STROKE
-                strokeWidth = 1f
-                color = Color.WHITE
-            }
-            canvas.drawPath(path, stroke)
-            canvas.restore()
         }
         return bm
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsScreen.kt
@@ -64,6 +64,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -532,7 +533,7 @@ private fun AlertList(
     onShowAlert: (String) -> Unit,
     onHideAlert: (AlertItem) -> Unit
 ) {
-    var visibleCount by rememberSaveable { mutableStateOf(ALERT_PAGE_SIZE) }
+    var visibleCount by rememberSaveable { mutableIntStateOf(ALERT_PAGE_SIZE) }
     val visible = alerts.take(visibleCount)
     Column {
         for (alert in visible) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/dialogs/RouteFavoriteDialog.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/dialogs/RouteFavoriteDialog.kt
@@ -21,6 +21,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -70,7 +71,7 @@ private fun RouteFavoriteDialog(
         routeTitle
     )
     val options = stringArrayResource(R.array.route_favorite_options)
-    var selected by remember { mutableStateOf(SELECTION_THIS_STOP) }
+    var selected by remember { mutableIntStateOf(SELECTION_THIS_STOP) }
     AlertDialog(
         onDismissRequest = onDismiss,
         title = { Text(title) },

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -45,6 +45,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -236,7 +237,7 @@ fun HomeScreen(
         // the screen, since the panel and the sheet both live here (no need to round-trip the VM). Seeded
         // at the two-arrivals height so the first reveal doesn't flash undersized (legacy default), and
         // arrivalsReady gates the peek open until the focused stop's arrivals load (reset on focus change).
-        var peekArrivalCount by remember { mutableStateOf(2) }
+        var peekArrivalCount by remember { mutableIntStateOf(2) }
         var routeFiltering by remember { mutableStateOf(false) }
         var arrivalsReady by remember { mutableStateOf(false) }
         LaunchedEffect(state.focusedStop?.id) { arrivalsReady = false }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanScreen.kt
@@ -53,6 +53,7 @@ import androidx.compose.material3.rememberStandardBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -460,7 +461,7 @@ private fun AdvancedSettingsDialog(
     }
     val current = remember { viewModel.formState.value }
     var selectedMode by remember {
-        mutableStateOf(options.firstOrNull { it.second == current.modeId }?.second ?: options.first().second)
+        mutableIntStateOf(options.firstOrNull { it.second == current.modeId }?.second ?: options.first().second)
     }
     var minimizeTransfers by remember { mutableStateOf(current.optimizeTransfers) }
     var wheelchair by remember { mutableStateOf(current.wheelchair) }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tutorial/SpotlightTutorial.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tutorial/SpotlightTutorial.kt
@@ -54,6 +54,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -106,7 +107,7 @@ data class TutorialStep(
 class TutorialState {
     var steps by mutableStateOf<List<TutorialStep>>(emptyList())
         private set
-    var index by mutableStateOf(0)
+    var index by mutableIntStateOf(0)
         private set
 
     private val bounds = mutableStateMapOf<String, Rect>()


### PR DESCRIPTION
Clears the last three lint idiom warnings (verified 0 after; build + lint green). No behavior change.

- **`AutoboxingStateCreation` (×5):** `mutableStateOf(Int)` → `mutableIntStateOf` in `ArrivalsScreen`, `HomeScreen`, `RouteFavoriteDialog`, `SpotlightTutorial`, and `TripPlanScreen` — avoids boxing `Int` in snapshot state.
- **`LocalContextResourcesRead` (×1):** `VehicleInfoWindow` now reads resources via `LocalResources.current` instead of `LocalContext.current.resources`, so it recomposes on configuration/locale changes.
- **`UseKtx` (×1):** `StopBitmaps` wraps the arrow `canvas.save()/rotate()/restore()` in the `androidx.core.graphics.withRotation { }` KTX extension.

With this plus #1724 (`BadPeriodicWorkRequestEnqueue`) and #1725 (`SourceLockedOrientationActivity` + `AndroidGradlePluginVersion`), the `obaGoogleDebug` lint report reaches **0 warnings**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal state handling across several screens and dialogs for more efficient integer-based UI updates.
  * Updated map drawing behavior to use a cleaner rotation approach, keeping marker rendering consistent.
  * Adjusted one info window to use Compose-provided resources, aligning it better with the UI framework.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->