### PR TITLE
Route-map header favorite star (UI scaffolding)

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/database/oba/RouteDaoTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/database/oba/RouteDaoTest.kt
@@ -95,6 +95,30 @@ class RouteDaoTest {
     }
 
     @Test
+    fun ensureRouteDetails_doesNotCountAsAUse() = runBlocking {
+        // A route the user has actually viewed twice.
+        dao.storeRouteDetails("r5", "50", "Route 50", "http://u", regionId = 5L, now = 100)
+        dao.markRouteUsed("r5", "50", "Route 50", regionId = 5L, now = 200)
+        assertEquals(2, dao.getRoute("r5")!!.useCount)
+
+        // Favoriting ensures the row but must not bump use_count / access_time (#1727 review).
+        dao.ensureRouteDetails("r5", "50", "Route 50", url = null, regionId = null)
+
+        val r = dao.getRoute("r5")!!
+        assertEquals(2, r.useCount)               // unchanged — a favorite toggle is not a view
+        assertEquals(200L, r.accessTime)          // unchanged
+        assertEquals("http://u", r.url)           // null url preserves the existing one
+        assertEquals(5L, r.regionId)
+
+        // A brand-new (never-viewed) route starts at use_count 0, so it sorts last by frequency.
+        dao.ensureRouteDetails("r6", "60", "Route 60", url = "http://v", regionId = 6L)
+        val fresh = dao.getRoute("r6")!!
+        assertEquals(0, fresh.useCount)
+        assertNull(fresh.accessTime)
+        assertEquals("http://v", fresh.url)
+    }
+
+    @Test
     fun refreshRouteShortName_onlyTouchesShortName() = runBlocking {
         dao.storeRouteDetails("r3", "30", "Route 30", "http://u", regionId = 3L, now = 100)
 

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/database/oba/RouteDaoTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/database/oba/RouteDaoTest.kt
@@ -18,10 +18,13 @@ package org.onebusaway.android.database.oba
 import androidx.room.Room
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -74,6 +77,21 @@ class RouteDaoTest {
         assertEquals(1L, r.regionId)             // regionId = null keeps the existing region
         assertEquals("10", r.shortName)          // short/long names refreshed
         assertEquals("Route 10 renamed", r.longName)
+    }
+
+    @Test
+    fun isFavorite_reflectsTheFavoriteBit() = runBlocking {
+        // No row yet -> not a favorite (the route-map header's default before a star lands).
+        assertFalse(dao.isFavorite("r4").first())
+
+        dao.storeRouteDetails("r4", "40", "Route 40", "http://u", regionId = 4L, now = 100)
+        assertFalse(dao.isFavorite("r4").first())   // row exists, favorite still unset
+
+        dao.setFavorite("r4", 1)
+        assertTrue(dao.isFavorite("r4").first())
+
+        dao.setFavorite("r4", 0)
+        assertFalse(dao.isFavorite("r4").first())
     }
 
     @Test

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/mock/ArrivalsFixtures.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/mock/ArrivalsFixtures.kt
@@ -48,19 +48,17 @@ object ArrivalsFixtures {
 
     /**
      * The fixture's arrivals projected to display [ArrivalInfo] via the production [convertArrivals].
-     * [favorite] supplies each row's route/headsign favorite state (defaults to none); the favorite
-     * store is no longer a ContentProvider, so tests pass the favorites in directly.
+     * Favorite state is no longer baked into [ArrivalInfo] — it's a live overlay keyed by route id — so
+     * promotion tests pass a favorite-route-id set straight to `findPreferredArrivalIndexes`.
      */
     @JvmStatic
-    @JvmOverloads
     fun convert(
         context: Context,
         env: ObaEnvelope<EntryWithReferences<ArrivalsForStop>>,
         includeArriveDepartLabels: Boolean,
-        favorite: (routeId: String, headsign: String?, stopId: String) -> Boolean = { _, _, _ -> false },
     ): ArrayList<ArrivalInfo> = ArrayList(
         convertArrivals(
-            context, snapshot(env).arrivals, null, ServerTime(env.currentTime), includeArriveDepartLabels, favorite
+            context, snapshot(env).arrivals, null, ServerTime(env.currentTime), includeArriveDepartLabels
         )
     )
 

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/util/test/UIUtilTest.java
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/util/test/UIUtilTest.java
@@ -239,17 +239,13 @@ public class UIUtilTest extends ObaTestCase {
                 ArrivalsFixtures.load(targetContext, "arrivals_and_departures_for_stop_hart_6497");
         String stopId = "Hillsborough Area Regional Transit_6497";
 
-        // Two arrivals marked favorite. Favorite state is supplied to convert() directly (the favorites
-        // store is no longer a ContentProvider); this exercises findPreferredArrivalIndexes' header
-        // promotion regardless of how the boolean was computed. The set below is keyed on route+headsign
-        // purely to pick out two specific rows in the fixture.
-        java.util.Set<String> favorites = new java.util.HashSet<>(java.util.Arrays.asList(
-                "Hillsborough Area Regional Transit_6|North to University Area TC",
-                "Hillsborough Area Regional Transit_6|South to Downtown/MTC"));
+        // Star route 6 (wholesale, #1751): every route-6 arrival is promoted. Favorite state is a live
+        // overlay keyed by route id now, so it's passed straight to findPreferredArrivalIndexes.
+        java.util.Set<String> favoriteRouteIds =
+                new java.util.HashSet<>(java.util.Arrays.asList("Hillsborough Area Regional Transit_6"));
 
-        // Project the fixture's arrivals via the production path, with those two marked favorite.
-        ArrayList<ArrivalInfo> arrivalInfo = ArrivalsFixtures.convert(targetContext, env, true,
-                (routeId, headsign, sid) -> favorites.contains(routeId + "|" + headsign));
+        // Project the fixture's arrivals via the production path.
+        ArrayList<ArrivalInfo> arrivalInfo = ArrivalsFixtures.convert(targetContext, env, true);
 
         // Now confirm that we have the correct number of elements, and values for ETAs for the test
         validateUatcArrivalInfo(arrivalInfo);
@@ -259,15 +255,15 @@ public class UIUtilTest extends ObaTestCase {
         assertEquals(5, firstNonNegativeArrivalIndex);
 
         ArrayList<Integer> preferredArrivalIndexes = ArrivalInfoUtils
-                .findPreferredArrivalIndexes(arrivalInfo);
+                .findPreferredArrivalIndexes(arrivalInfo, favoriteRouteIds);
 
-        // Indexes 11 and 13 should hold the favorites
+        // Indexes 11 and 13 should hold the route-6 favorites
         assertEquals(11, preferredArrivalIndexes.get(0).intValue());
         assertEquals(13, preferredArrivalIndexes.get(1).intValue());
 
         // With no favorites, the first two non-negative arrival times are returned - indexes 5 and 6.
-        arrivalInfo = ArrivalsFixtures.convert(targetContext, env, true);
-        preferredArrivalIndexes = ArrivalInfoUtils.findPreferredArrivalIndexes(arrivalInfo);
+        preferredArrivalIndexes = ArrivalInfoUtils.findPreferredArrivalIndexes(
+                arrivalInfo, java.util.Collections.emptySet());
         assertEquals(5, preferredArrivalIndexes.get(0).intValue());
         assertEquals(6, preferredArrivalIndexes.get(1).intValue());
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/database/oba/RouteDao.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/database/oba/RouteDao.kt
@@ -127,6 +127,40 @@ interface RouteDao {
         )
     }
 
+    /**
+     * Ensures the route row exists with its display name/URL/region (so the Starred Routes folder can
+     * JOIN it) **without counting a use** — `use_count` and `access_time` are left untouched, and a new
+     * row starts at `use_count = 0`. Favoriting/unfavoriting a route is not a "view", so it must not
+     * bump the recents (`access_time`) or the frequency sort (`use_count`) (#1727 review). Null name/URL
+     * arguments preserve any existing value rather than clobbering it (the arrivals path stars first,
+     * with no URL in hand, then backfills the details from the network).
+     */
+    @Transaction
+    suspend fun ensureRouteDetails(
+        routeId: String,
+        shortName: String?,
+        longName: String?,
+        url: String?,
+        regionId: Long?,
+    ) {
+        val existing = getRoute(routeId)
+        upsert(
+            existing?.copy(
+                shortName = shortName?.takeIf { it.isNotEmpty() } ?: existing.shortName,
+                longName = longName ?: existing.longName,
+                url = url ?: existing.url,
+                regionId = regionId ?: existing.regionId,
+            ) ?: RouteRecord(
+                id = routeId,
+                shortName = shortName.orEmpty(),
+                longName = longName,
+                url = url,
+                useCount = 0,
+                regionId = regionId,
+            )
+        )
+    }
+
     /** Refreshes only a route's short name (does not mark it used; leaves other columns untouched). */
     @Transaction
     suspend fun refreshRouteShortName(routeId: String, shortName: String?) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/database/oba/RouteDao.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/database/oba/RouteDao.kt
@@ -50,9 +50,13 @@ interface RouteDao {
     @Query("UPDATE routes SET favorite = :favorite WHERE _id = :routeId")
     suspend fun setFavorite(routeId: String, favorite: Int)
 
-    /** The ids of every starred (favorite) route, for the arrivals drawer-header promotion (#1751). */
+    /**
+     * The ids of every starred (favorite) route, live — the arrivals list overlays this to star rows +
+     * promote favorited routes to the drawer header (#1751), reacting to a star toggle from any surface
+     * (an arrival row, the route-map header) without a re-fetch.
+     */
     @Query("SELECT _id FROM routes WHERE favorite = 1")
-    suspend fun favoriteRouteIds(): List<String>
+    fun favoriteRouteIds(): Flow<List<String>>
 
     /** Whether [routeId] is starred, live — drives the route-map header star toggle (#1727). */
     @Query("SELECT EXISTS(SELECT 1 FROM routes WHERE _id = :routeId AND favorite = 1)")

--- a/onebusaway-android/src/main/java/org/onebusaway/android/database/oba/RouteDao.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/database/oba/RouteDao.kt
@@ -54,6 +54,10 @@ interface RouteDao {
     @Query("SELECT _id FROM routes WHERE favorite = 1")
     suspend fun favoriteRouteIds(): List<String>
 
+    /** Whether [routeId] is starred, live — drives the route-map header star toggle (#1727). */
+    @Query("SELECT EXISTS(SELECT 1 FROM routes WHERE _id = :routeId AND favorite = 1)")
+    fun isFavorite(routeId: String): Flow<Boolean>
+
     // --- Usage/metadata writes (the legacy partial upsert; see RoutesStore) ---
 
     /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/database/oba/RouteFavoritesRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/database/oba/RouteFavoritesRepository.kt
@@ -72,12 +72,9 @@ class RouteFavoritesRepository @Inject constructor(
     ) {
         importGate.awaitReady()
         val regionId = regionRepository.region.value?.id
-        // now passed straight to the DAO write (a consuming API), so it never rests in a bare Long.
-        if (url != null) {
-            routeDao.storeRouteDetails(routeId, shortName, longName, url, regionId, System.currentTimeMillis())
-        } else {
-            routeDao.markRouteUsed(routeId, shortName, longName, regionId, System.currentTimeMillis())
-        }
+        // Ensure the row for the folder JOIN without counting a "use" — a favorite toggle must not bump
+        // the recents / frequency ordering (#1727 review). Passing url=null preserves any existing URL.
+        routeDao.ensureRouteDetails(routeId, shortName, longName, url, regionId)
         routeDao.setFavorite(routeId, if (favorite) 1 else 0)
         reportBookmarkAnalytics(routeId, favorite)
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/database/oba/RouteFavoritesRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/database/oba/RouteFavoritesRepository.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.database.oba
+
+import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onStart
+import org.onebusaway.android.R
+import org.onebusaway.android.analytics.ObaAnalytics
+import org.onebusaway.android.analytics.PlausibleAnalytics
+import org.onebusaway.android.region.RegionRepository
+
+/**
+ * The single owner of route-favorite membership — a wholesale `routes.favorite` bit (#1751). Every
+ * surface that stars a route (the per-arrival star, the route-map header) writes through [setFavorite]
+ * so the import gating, the row-existence guarantee, and the bookmark analytics live in one place
+ * instead of being re-implemented (and drifting) per surface; every surface that shows the star reads
+ * one of the reactive flows below, so a toggle from any surface re-flags the others with no re-fetch.
+ */
+@Singleton
+class RouteFavoritesRepository @Inject constructor(
+    private val routeDao: RouteDao,
+    private val regionRepository: RegionRepository,
+    private val importGate: ImportGate,
+    private val obaAnalytics: ObaAnalytics,
+    @param:ApplicationContext private val context: Context,
+) {
+
+    /** The starred route ids, live: import-gated, and deduped so an unrelated `routes` write (a route
+     *  recorded on an arrivals load) doesn't re-emit an identical set. */
+    fun favoriteRouteIds(): Flow<Set<String>> =
+        routeDao.favoriteRouteIds()
+            .onStart { importGate.awaitReady() }
+            .map { it.toSet() }
+            .distinctUntilChanged()
+
+    /** Whether [routeId] is starred, live — deduped against unrelated `routes` writes. */
+    fun isFavorite(routeId: String): Flow<Boolean> =
+        routeDao.isFavorite(routeId).distinctUntilChanged()
+
+    /**
+     * Stars (or unstars) [routeId] wholesale. Ensures the `routes` row exists (so the Starred Routes
+     * folder can JOIN it for its display name/URL) before flipping the flag, gated on the one-time
+     * import, and reports the bookmark event. Pass [url] when the caller already has the loaded route
+     * (it's stored); pass null to leave any existing URL untouched (the arrivals path backfills the
+     * full details from the network afterward).
+     */
+    suspend fun setFavorite(
+        routeId: String,
+        shortName: String?,
+        longName: String?,
+        url: String?,
+        favorite: Boolean,
+    ) {
+        importGate.awaitReady()
+        val regionId = regionRepository.region.value?.id
+        // now passed straight to the DAO write (a consuming API), so it never rests in a bare Long.
+        if (url != null) {
+            routeDao.storeRouteDetails(routeId, shortName, longName, url, regionId, System.currentTimeMillis())
+        } else {
+            routeDao.markRouteUsed(routeId, shortName, longName, regionId, System.currentTimeMillis())
+        }
+        routeDao.setFavorite(routeId, if (favorite) 1 else 0)
+        reportBookmarkAnalytics(routeId, favorite)
+    }
+
+    private fun reportBookmarkAnalytics(routeId: String, favorite: Boolean) {
+        val event = context.getString(
+            if (favorite) R.string.analytics_label_star_route else R.string.analytics_label_unstar_route
+        )
+        obaAnalytics.reportUiEvent(PlausibleAnalytics.REPORT_BOOKMARK_EVENT_URL, event, routeId)
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
@@ -22,16 +22,23 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.onebusaway.android.R
 import org.onebusaway.android.models.ObaRoute
 import org.onebusaway.android.models.ObaStop
 import org.onebusaway.android.models.RouteMapDirection
 import org.onebusaway.android.api.data.MapDataSource
+import org.onebusaway.android.database.oba.RouteDao
 import org.onebusaway.android.database.oba.StopDao
 import org.onebusaway.android.extrapolation.data.TripObservationRepository
 import org.onebusaway.android.models.ObaTripStatus
@@ -100,6 +107,7 @@ class MapViewModel @Inject constructor(
     private val prefsRepository: PreferencesRepository,
     private val tripObservationRepository: TripObservationRepository,
     private val stopDao: StopDao,
+    private val routeDao: RouteDao,
     @param:ApplicationContext private val context: Context,
 ) : ViewModel() {
 
@@ -208,6 +216,40 @@ class MapViewModel @Inject constructor(
             // save — and it emits only a few times per route session, so the idle collector is free.
             .map { it?.toRouteHeader() }
             .stateIn(viewModelScope, SharingStarted.Eagerly, null)
+
+    /**
+     * Whether the shown route is starred, live — drives the route-mode header's star toggle (#1727).
+     * Flat-maps the loaded route's id into the reactive `routes.favorite` query, so starring/unstarring
+     * (here or from an arrival row) re-flags the header immediately. False while no route is loaded.
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val isRouteFavorite: StateFlow<Boolean> =
+        routeController.loadedRoute
+            .flatMapLatest { loaded ->
+                val id = (loaded as? LoadedRoute.Loaded)?.route?.id
+                if (id == null) flowOf(false) else routeDao.isFavorite(id)
+            }
+            .stateIn(viewModelScope, SharingStarted.Eagerly, false)
+
+    /**
+     * Toggle the shown route's star (the route-mode header star, #1727) — a wholesale single
+     * `routes.favorite` bit (#1751). No-op until the route has loaded. Ensures the route row exists
+     * (name/URL + region, so the Starred Routes folder can list it) before flipping the flag; the route
+     * is already loaded, so no network backfill is needed.
+     */
+    fun toggleRouteFavorite() {
+        val route = (routeController.loadedRoute.value as? LoadedRoute.Loaded)?.route ?: return
+        val favorite = !isRouteFavorite.value
+        viewModelScope.launch {
+            withContext(Dispatchers.IO) {
+                routeDao.storeRouteDetails(
+                    route.id, route.shortName, route.longName, route.url,
+                    regionRepo.region.value?.id, System.currentTimeMillis(),
+                )
+                routeDao.setFavorite(route.id, if (favorite) 1 else 0)
+            }
+        }
+    }
 
     /** The route header reported its measured height; derive the map's top padding (0 clears it). */
     fun setRouteHeaderHeight(heightPx: Int) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
@@ -22,7 +22,6 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -32,13 +31,12 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import org.onebusaway.android.R
 import org.onebusaway.android.models.ObaRoute
 import org.onebusaway.android.models.ObaStop
 import org.onebusaway.android.models.RouteMapDirection
 import org.onebusaway.android.api.data.MapDataSource
-import org.onebusaway.android.database.oba.RouteDao
+import org.onebusaway.android.database.oba.RouteFavoritesRepository
 import org.onebusaway.android.database.oba.StopDao
 import org.onebusaway.android.extrapolation.data.TripObservationRepository
 import org.onebusaway.android.models.ObaTripStatus
@@ -107,7 +105,7 @@ class MapViewModel @Inject constructor(
     private val prefsRepository: PreferencesRepository,
     private val tripObservationRepository: TripObservationRepository,
     private val stopDao: StopDao,
-    private val routeDao: RouteDao,
+    private val routeFavorites: RouteFavoritesRepository,
     @param:ApplicationContext private val context: Context,
 ) : ViewModel() {
 
@@ -222,32 +220,29 @@ class MapViewModel @Inject constructor(
      * Flat-maps the loaded route's id into the reactive `routes.favorite` query, so starring/unstarring
      * (here or from an arrival row) re-flags the header immediately. False while no route is loaded.
      */
+    // WhileSubscribed, not Eagerly (unlike the routeHeader sibling above): this flat-maps into a live
+    // Room query, so keeping it collected while nothing observes it (route mode not shown) would hold a
+    // DB invalidation observer for no reason. The 5s window rides out config changes / brief detaches.
     @OptIn(ExperimentalCoroutinesApi::class)
     val isRouteFavorite: StateFlow<Boolean> =
         routeController.loadedRoute
             .flatMapLatest { loaded ->
                 val id = (loaded as? LoadedRoute.Loaded)?.route?.id
-                if (id == null) flowOf(false) else routeDao.isFavorite(id)
+                if (id == null) flowOf(false) else routeFavorites.isFavorite(id)
             }
-            .stateIn(viewModelScope, SharingStarted.Eagerly, false)
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
 
     /**
      * Toggle the shown route's star (the route-mode header star, #1727) — a wholesale single
-     * `routes.favorite` bit (#1751). No-op until the route has loaded. Ensures the route row exists
-     * (name/URL + region, so the Starred Routes folder can list it) before flipping the flag; the route
-     * is already loaded, so no network backfill is needed.
+     * `routes.favorite` bit (#1751), through the shared [RouteFavoritesRepository] so it gets the same
+     * import gating + analytics as the arrival-row star. No-op until the route has loaded; passes the
+     * loaded route's URL so no network backfill is needed.
      */
     fun toggleRouteFavorite() {
         val route = (routeController.loadedRoute.value as? LoadedRoute.Loaded)?.route ?: return
         val favorite = !isRouteFavorite.value
         viewModelScope.launch {
-            withContext(Dispatchers.IO) {
-                routeDao.storeRouteDetails(
-                    route.id, route.shortName, route.longName, route.url,
-                    regionRepo.region.value?.id, System.currentTimeMillis(),
-                )
-                routeDao.setFavorite(route.id, if (favorite) 1 else 0)
-            }
+            routeFavorites.setFavorite(route.id, route.shortName, route.longName, route.url, favorite)
         }
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalInfo.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalInfo.kt
@@ -38,7 +38,6 @@ class ArrivalInfo(
     private val data: ArrivalData,
     now: ServerTime,
     includeArrivalDepartureInStatusLabel: Boolean,
-    favorite: Boolean,
 ) {
 
     val eta: Long
@@ -65,11 +64,6 @@ class ArrivalInfo(
      * True if this arrival info is for an arrival time, false if it is for a departure time.
      */
     val isArrival: Boolean
-
-    /**
-     * True if this route is a user-designated favorite, false if it is not.
-     */
-    val isRouteFavorite: Boolean
 
     /**
      * The average historical occupancy of the vehicle when it arrives at this stop, or null if the
@@ -188,10 +182,6 @@ class ArrivalInfo(
             includeArrivalDepartureInStatusLabel
         )
         timeText = computeTimeLabel(context)
-
-        // Whether the user starred this route (precomputed by the caller from the favorite-route id
-        // set — a route star is wholesale now, #1751).
-        isRouteFavorite = favorite
 
         notifyText = computeNotifyText(context)
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsRepository.kt
@@ -30,12 +30,11 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.withContext
 import org.onebusaway.android.R
-import org.onebusaway.android.analytics.ObaAnalytics
-import org.onebusaway.android.analytics.PlausibleAnalytics
 import org.onebusaway.android.api.ObaApi
 import org.onebusaway.android.api.ObaApiException
 import org.onebusaway.android.database.oba.ImportGate
 import org.onebusaway.android.database.oba.RouteDao
+import org.onebusaway.android.database.oba.RouteFavoritesRepository
 import org.onebusaway.android.database.oba.ServiceAlertDao
 import org.onebusaway.android.database.oba.StopDao
 import org.onebusaway.android.database.oba.StopRouteFilterDao
@@ -247,9 +246,9 @@ class DefaultArrivalsRepository @Inject constructor(
     private val serviceAlertDao: ServiceAlertDao,
     private val stopDao: StopDao,
     private val routeDao: RouteDao,
+    private val routeFavorites: RouteFavoritesRepository,
     private val importGate: ImportGate,
     private val preferences: PreferencesRepository,
-    private val obaAnalytics: ObaAnalytics,
 ) : ArrivalsRepository {
 
     /** The last good snapshot paired with the monotonic device time it was received, so the
@@ -423,27 +422,11 @@ class DefaultArrivalsRepository @Inject constructor(
         longName: String?,
         favorite: Boolean
     ) {
-        importGate.awaitReady()
-        val regionId = regionRepository.region.value?.id
-        // Ensure the route row exists (stamped with the current region) before marking the favorite —
-        // the starred-routes folder JOINs it for the display name/URL.
-        routeDao.markRouteUsed(routeId, shortName, longName, regionId, System.currentTimeMillis())
-        routeDao.setFavorite(routeId, if (favorite) 1 else 0)
-        reportBookmarkAnalytics(routeId, favorite)
-
-        // Backfill the full route details so the long name can be shown later (was an AsyncTaskLoader).
-        fetchAndStoreRouteDetails(routeId, regionId)
-    }
-
-    private fun reportBookmarkAnalytics(routeId: String, favorite: Boolean) {
-        val event = context.getString(
-            if (favorite) R.string.analytics_label_star_route else R.string.analytics_label_unstar_route
-        )
-        obaAnalytics.reportUiEvent(
-            PlausibleAnalytics.REPORT_BOOKMARK_EVENT_URL,
-            event,
-            routeId,
-        )
+        // The shared write ensures the row (no URL in hand yet — leaves any existing one), flips the
+        // flag, gates on the import, and reports analytics.
+        routeFavorites.setFavorite(routeId, shortName, longName, url = null, favorite = favorite)
+        // Backfill the full route details (incl. URL) so the long name can be shown later.
+        fetchAndStoreRouteDetails(routeId, regionRepository.region.value?.id)
     }
 
     /** Route-details fetch via the modernized client; writes name/url back. */
@@ -475,10 +458,7 @@ class DefaultArrivalsRepository @Inject constructor(
         }
     }
 
-    override fun favoriteRouteIds(): Flow<Set<String>> =
-        routeDao.favoriteRouteIds()
-            .onStart { importGate.awaitReady() }
-            .map { it.toSet() }
+    override fun favoriteRouteIds(): Flow<Set<String>> = routeFavorites.favoriteRouteIds()
 
     override fun alertHideState(): Flow<AlertHideState> =
         serviceAlertDao.hideDecisions()

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsRepository.kt
@@ -442,9 +442,9 @@ class DefaultArrivalsRepository @Inject constructor(
             longName = route.description
         }
 
-        routeDao.storeRouteDetails(
-            route.id, shortName, longName, route.url, regionId, System.currentTimeMillis()
-        )
+        // Backfilling details for a just-starred route is part of the favorite action, not a view, so
+        // ensure the row without bumping use_count / access_time (#1727 review).
+        routeDao.ensureRouteDetails(route.id, shortName, longName, route.url, regionId)
     }
 
     override suspend fun setRouteFilter(stopId: String, filter: Set<String>) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsRepository.kt
@@ -169,6 +169,13 @@ interface ArrivalsRepository {
     suspend fun setArrivalStyle(style: Int)
 
     /**
+     * The starred route ids, live — the ViewModel overlays this onto the loaded arrivals so a row's
+     * star + the drawer-header promotion re-flag on any star toggle (an arrival row, the route-map
+     * header) with no re-fetch. Mirrors [alertHideState]'s reactive-overlay pattern (#1751).
+     */
+    fun favoriteRouteIds(): Flow<Set<String>>
+
+    /**
      * The explicit hide/show decisions recorded in the store, re-emitting on every service-alert
      * change. This is the single source of truth for hidden state: the ViewModel derives the
      * shown/hidden split from it (plus the per-load preference), and a hide/un-hide from any surface
@@ -320,14 +327,11 @@ class DefaultArrivalsRepository @Inject constructor(
         val style = BuildFlavorUtils.getArrivalInfoStyleFromPreferences(context)
         // Style B includes the arrival/departure word in the status label; Style A does not.
         val includeArrivalDepartureLabel = style == BuildFlavorUtils.ARRIVAL_INFO_STYLE_B
-        // One favorite-route query for the whole list; each arrival's star resolves from the set in
-        // memory. A route star is wholesale now (#1751) — headsign/stop no longer matter.
-        val favoriteRouteIds = routeDao.favoriteRouteIds().toHashSet()
+        // Favorite state is a live overlay applied in the ViewModel (from the reactive starred-route
+        // set), not baked here — so a star toggle re-flags the list without this re-fetch.
         val arrivals = convertArrivals(
             context, snapshot.arrivals, routeFilter, ServerTime(now), includeArrivalDepartureLabel
-        ) { routeId, _, _ ->
-            routeId in favoriteRouteIds
-        }
+        )
         val stop = snapshot.stop
         val userInfo = stopDao.userInfo(snapshot.stopId)
         val header = StopHeader(
@@ -389,7 +393,6 @@ class DefaultArrivalsRepository @Inject constructor(
             scheduleUrl = route?.url,
             agencyName = route?.agencyId?.let { snapshot.agencyName(it) },
             blockId = snapshot.trip(arrival.tripId)?.blockId,
-            isRouteFavorite = arrival.isRouteFavorite,
             alertSituationId = activeAlertFor(arrival.situationIds, activeSituationIds)
         )
     }
@@ -471,6 +474,11 @@ class DefaultArrivalsRepository @Inject constructor(
             BuildFlavorUtils.setArrivalInfoStyle(context, style)
         }
     }
+
+    override fun favoriteRouteIds(): Flow<Set<String>> =
+        routeDao.favoriteRouteIds()
+            .onStart { importGate.awaitReady() }
+            .map { it.toSet() }
 
     override fun alertHideState(): Flow<AlertHideState> =
         serviceAlertDao.hideDecisions()

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsScreen.kt
@@ -489,6 +489,7 @@ internal fun ArrivalsList(
                     ArrivalCardStyleB(
                         group = group,
                         actions = content.actions[group.first().tripId],
+                        isFavorite = group.first().routeId in content.favoriteRouteIds,
                         filterActive = filterActive,
                         callbacks = rowCallbacks
                     )
@@ -504,6 +505,7 @@ internal fun ArrivalsList(
                     ArrivalRowStyleA(
                         arrival = arrival,
                         actions = content.actions[arrival.tripId],
+                        isFavorite = arrival.routeId in content.favoriteRouteIds,
                         filterActive = filterActive,
                         callbacks = rowCallbacks
                     )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsUiState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsUiState.kt
@@ -39,7 +39,6 @@ data class ArrivalActions(
     val scheduleUrl: String?,
     val agencyName: String?,
     val blockId: String?,
-    val isRouteFavorite: Boolean,
     /** The representative *active* service-alert id affecting this arrival, or null when none —
      *  drives the per-row alert indicator and the situation it opens on tap (issue #1687 Bug 2). */
     val alertSituationId: String? = null
@@ -95,6 +94,9 @@ sealed interface ArrivalsUiState {
         val style: Int,
         val isStale: Boolean,
         val actions: Map<String, ArrivalActions> = emptyMap(),
+        /** The starred route ids, live — a row's star + the drawer-header promotion read from this, so a
+         *  toggle from any surface re-flags the list without a re-fetch (#1751). */
+        val favoriteRouteIds: Set<String> = emptySet(),
         val alerts: List<AlertItem> = emptyList(),
         val hiddenAlertCount: Int = 0,
         val routeFilterOptions: List<RouteFilterOption> = emptyList(),

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsViewModel.kt
@@ -82,9 +82,11 @@ class ArrivalsViewModel @AssistedInject constructor(
      * See #1593.
      */
     val state: StateFlow<ArrivalsUiState> =
-        combine(loaded, repository.alertHideState(), fatalError) { data, hideState, error ->
+        combine(
+            loaded, repository.alertHideState(), repository.favoriteRouteIds(), fatalError
+        ) { data, hideState, favoriteRouteIds, error ->
             when {
-                data != null -> data.toContent(hideState)
+                data != null -> data.toContent(hideState, favoriteRouteIds)
                 error != null -> ArrivalsUiState.Error(error)
                 else -> ArrivalsUiState.Loading
             }
@@ -170,18 +172,20 @@ class ArrivalsViewModel @AssistedInject constructor(
     }
 
     /**
-     * Toggles the route star wholesale (#1751): stars the route if it isn't already (else unstars),
-     * backfills the route details, then reloads.
+     * Toggles the route star wholesale (#1751): stars the route if it isn't already (else unstars) and
+     * backfills the route details. No reload — the star + drawer promotion re-flag reactively from the
+     * repository's [ArrivalsRepository.favoriteRouteIds] overlay.
      */
     fun toggleRouteFavorite(actions: ArrivalActions) {
+        val starred = (state.value as? ArrivalsUiState.Content)
+            ?.favoriteRouteIds?.contains(actions.routeId) == true
         viewModelScope.launch {
             repository.favoriteRoute(
                 routeId = actions.routeId,
                 shortName = actions.routeShortName,
                 longName = actions.routeLongName,
-                favorite = !actions.isRouteFavorite
+                favorite = !starred
             )
-            refresh()
         }
     }
 
@@ -264,7 +268,10 @@ class ArrivalsViewModel @AssistedInject constructor(
         viewModelScope.launch { repository.hideAllRecordedAlerts() }
     }
 
-    private fun ArrivalsData.toContent(hideState: AlertHideState): ArrivalsUiState.Content {
+    private fun ArrivalsData.toContent(
+        hideState: AlertHideState,
+        favoriteRouteIds: Set<String>,
+    ): ArrivalsUiState.Content {
         val shown = activeAlerts.filterNot { hideState.isHidden(it, hideAlertsByDefault) }
         val hiddenCount = activeAlerts.size - shown.size
         return ArrivalsUiState.Content(
@@ -274,6 +281,7 @@ class ArrivalsViewModel @AssistedInject constructor(
             style = style,
             isStale = isStale,
             actions = actions,
+            favoriteRouteIds = favoriteRouteIds,
             alerts = shown,
             hiddenAlertCount = hiddenCount,
             routeFilterOptions = routeFilterOptions,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ConvertArrivals.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ConvertArrivals.kt
@@ -27,9 +27,9 @@ import org.onebusaway.android.util.ArrivalInfoUtils
  * drops past arrivals unless the user opted in, and sorts by ETA. Callers feed it the [ArrivalData]
  * the api arrivals fetch ([org.onebusaway.android.api.data.StopArrivals.arrivals]) produces.
  *
- * [isFavorite] resolves each arrival's route/headsign favorite state; the caller precomputes it from
- * one favorites query (the legacy per-row ContentProvider lookup is gone). Reminder lists that don't
- * render the favorite star pass a constant `false`.
+ * Favorite state is not baked in here — it's a live overlay the arrivals UI applies from the reactive
+ * starred-route set (so a star toggle from any surface re-flags rows without a re-fetch), keyed by
+ * `ArrivalInfo.routeId`.
  */
 fun convertArrivals(
     context: Context,
@@ -37,18 +37,12 @@ fun convertArrivals(
     filter: Collection<String>?,
     ms: ServerTime,
     includeArrivalDepartureInStatusLabel: Boolean,
-    isFavorite: (routeId: String, headsign: String?, stopId: String) -> Boolean,
 ): List<ArrivalInfo> {
     val showNegativeArrivals = PreferencesEntryPoint.get(context)
         .getBoolean(R.string.preference_key_show_negative_arrivals, true)
     val selected = if (!filter.isNullOrEmpty()) arrivals.filter { it.routeId in filter } else arrivals
     return selected
-        .map {
-            ArrivalInfo(
-                context, it, ms, includeArrivalDepartureInStatusLabel,
-                isFavorite(it.routeId, it.headsign, it.stopId),
-            )
-        }
+        .map { ArrivalInfo(context, it, ms, includeArrivalDepartureInStatusLabel) }
         .filter { it.eta >= 0 || showNegativeArrivals }
         .sortedWith(ArrivalInfoUtils.InfoComparator())
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
@@ -248,7 +248,7 @@ fun ArrivalRowStyleA(
     StyleACard(
         modifier = modifier,
         // Null omits the star entirely when there's no actions to favorite against (defensive).
-        isFavorite = actions?.let { isFavorite },
+        isFavorite = isFavorite.takeIf { actions != null },
         onFavorite = { actions?.let { callbacks.onRouteFavorite(it) } },
         onMore = { expanded = true },
         // Tapping the row body frames the whole route; the ETA pill (below) instead focuses this trip's

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
@@ -239,6 +239,7 @@ internal fun ArrivalRowContent(
 fun ArrivalRowStyleA(
     arrival: ArrivalInfo,
     actions: ArrivalActions?,
+    isFavorite: Boolean,
     filterActive: Boolean,
     callbacks: ArrivalRowCallbacks,
     modifier: Modifier = Modifier
@@ -246,14 +247,15 @@ fun ArrivalRowStyleA(
     var expanded by remember { mutableStateOf(false) }
     StyleACard(
         modifier = modifier,
-        isFavorite = actions?.isRouteFavorite,
+        // Null omits the star entirely when there's no actions to favorite against (defensive).
+        isFavorite = actions?.let { isFavorite },
         onFavorite = { actions?.let { callbacks.onRouteFavorite(it) } },
         onMore = { expanded = true },
         // Tapping the row body frames the whole route; the ETA pill (below) instead focuses this trip's
         // vehicle + stop, and the overflow icon opens the menu.
         onContentClick = { callbacks.onShowVehiclesOnMap(arrival) },
         overflow = {
-            ArrivalActionsMenu(expanded, { expanded = false }, arrival, actions, filterActive, callbacks)
+            ArrivalActionsMenu(expanded, { expanded = false }, arrival, actions, isFavorite, filterActive, callbacks)
         }
     ) {
         ArrivalRowContent(
@@ -349,6 +351,7 @@ private fun CornerIcon(
 fun ArrivalCardStyleB(
     group: List<ArrivalInfo>,
     actions: ArrivalActions?,
+    isFavorite: Boolean,
     filterActive: Boolean,
     callbacks: ArrivalRowCallbacks,
     modifier: Modifier = Modifier
@@ -383,7 +386,7 @@ fun ArrivalCardStyleB(
                             contentDescription = stringResource(R.string.stop_info_item_options_title)
                         )
                     }
-                    ArrivalActionsMenu(expanded, { expanded = false }, first, actions, filterActive, callbacks)
+                    ArrivalActionsMenu(expanded, { expanded = false }, first, actions, isFavorite, filterActive, callbacks)
                 }
             }
             group.forEachIndexed { index, arrival ->
@@ -416,12 +419,13 @@ internal fun ArrivalActionsMenu(
     onDismiss: () -> Unit,
     arrival: ArrivalInfo,
     actions: ArrivalActions?,
+    isFavorite: Boolean,
     filterActive: Boolean,
     callbacks: ArrivalRowCallbacks
 ) {
     DropdownMenu(expanded = expanded, onDismissRequest = onDismiss) {
         if (actions != null) {
-            val favLabel = if (actions.isRouteFavorite) {
+            val favLabel = if (isFavorite) {
                 R.string.bus_options_menu_remove_star
             } else {
                 R.string.bus_options_menu_add_star

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalsPanel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalsPanel.kt
@@ -123,9 +123,9 @@ fun ArrivalsPanel(
     // widens ("load more arrivals"); the collapsed peek only has room for two rows, so cap here. Kept
     // as indexes (not just the arrivals) so the list below can drop these exact rows — when expanded
     // they morph into the pinned cards and listing them again would duplicate them.
-    val previewIndexes = remember(content?.arrivals) {
+    val previewIndexes = remember(content?.arrivals, content?.favoriteRouteIds) {
         val arrivals = content?.arrivals ?: return@remember emptyList<Int>()
-        ArrivalInfoUtils.findPreferredArrivalIndexes(ArrayList(arrivals))
+        ArrivalInfoUtils.findPreferredArrivalIndexes(ArrayList(arrivals), content.favoriteRouteIds)
             ?.take(2)
             ?.filter { it in arrivals.indices }
             .orEmpty()
@@ -199,10 +199,12 @@ fun ArrivalsPanel(
                             // The host's anchors apply to the first peek row only.
                             val etaModifier = if (index == 0) etaAnchor else Modifier
                             val starModifier = if (index == 0) starAnchor else Modifier
+                            val isFavorite = arrival.routeId in content.favoriteRouteIds
                             if (styleA) {
                                 MorphingArrivalRow(
                                     arrival = arrival,
                                     actions = content.actions[arrival.tripId],
+                                    isFavorite = isFavorite,
                                     filterActive = filtering,
                                     callbacks = rowCallbacks,
                                     progress = expandProgress,
@@ -213,6 +215,7 @@ fun ArrivalsPanel(
                                 PeekRow(
                                     arrival = arrival,
                                     actions = content.actions[arrival.tripId],
+                                    isFavorite = isFavorite,
                                     filterActive = filtering,
                                     callbacks = rowCallbacks,
                                     etaModifier = etaModifier,
@@ -244,6 +247,7 @@ private fun ColumnScope.PeekDivider() {
 private fun PeekRow(
     arrival: ArrivalInfo,
     actions: ArrivalActions?,
+    isFavorite: Boolean,
     filterActive: Boolean,
     callbacks: ArrivalRowCallbacks,
     etaModifier: Modifier = Modifier,
@@ -256,7 +260,7 @@ private fun PeekRow(
         eta = arrival.eta,
         etaColor = colorResource(arrival.color),
         predicted = arrival.predicted,
-        isFavorite = actions?.isRouteFavorite == true,
+        isFavorite = isFavorite,
         onFavorite = { actions?.let { callbacks.onRouteFavorite(it) } },
         onMore = { expanded = true },
         onAlertClick = alertClick(actions, callbacks),
@@ -265,7 +269,7 @@ private fun PeekRow(
         etaModifier = etaModifier,
         starModifier = starModifier,
         menu = {
-            ArrivalActionsMenu(expanded, { expanded = false }, arrival, actions, filterActive, callbacks)
+            ArrivalActionsMenu(expanded, { expanded = false }, arrival, actions, isFavorite, filterActive, callbacks)
         }
     )
 }
@@ -280,6 +284,7 @@ private fun PeekRow(
 private fun MorphingArrivalRow(
     arrival: ArrivalInfo,
     actions: ArrivalActions?,
+    isFavorite: Boolean,
     filterActive: Boolean,
     callbacks: ArrivalRowCallbacks,
     progress: () -> Float,
@@ -288,8 +293,8 @@ private fun MorphingArrivalRow(
 ) {
     MorphByProgress(
         progress = progress,
-        start = { PeekRow(arrival, actions, filterActive, callbacks, etaModifier, starModifier) },
-        end = { ArrivalRowStyleA(arrival, actions, filterActive, callbacks) },
+        start = { PeekRow(arrival, actions, isFavorite, filterActive, callbacks, etaModifier, starModifier) },
+        end = { ArrivalRowStyleA(arrival, actions, isFavorite, filterActive, callbacks) },
     )
 }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/FavoriteStarButton.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/FavoriteStarButton.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.compose.components
+
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import org.onebusaway.android.R
+
+/**
+ * A star toggle button for favoriting/unfavoriting a route: a filled star when [isFavorite], an outline
+ * otherwise, with the matching add/remove-star content description. [onClick] fires on tap.
+ *
+ * The shared form of the filled-vs-outline star that several screens (arrivals rows/panel, search
+ * results) currently spell out inline; new call sites should use this rather than repeat the ternary.
+ */
+@Composable
+fun FavoriteStarButton(
+    isFavorite: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    tint: Color = LocalContentColor.current,
+) {
+    IconButton(onClick = onClick, modifier = modifier) {
+        Icon(
+            painter = painterResource(
+                if (isFavorite) R.drawable.star else R.drawable.star_outline
+            ),
+            contentDescription = stringResource(
+                if (isFavorite) R.string.bus_options_menu_remove_star
+                else R.string.bus_options_menu_add_star
+            ),
+            tint = tint,
+        )
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -455,6 +455,7 @@ fun HomeScreen(
                             fabBottomInset = fabInsetTarget,
                             modifier = Modifier.fillMaxSize(),
                         )
+                        val isRouteFavorite by mapViewModel.isRouteFavorite.collectAsStateWithLifecycle()
                         HomeMapOverlays(
                             weatherViewModel = weatherViewModel,
                             donationViewModel = donationViewModel,
@@ -464,6 +465,10 @@ fun HomeScreen(
                             // The switch-direction affordance calls straight into the map VM (which
                             // re-filters stops/vehicles + persists the choice), like the height report below.
                             onSelectRouteDirection = mapViewModel::selectRouteDirection,
+                            // The star reads/writes the route's single favorite bit straight on the map VM,
+                            // like the direction switch — starring here or from an arrival row stays in sync.
+                            isRouteFavorite = isRouteFavorite,
+                            onToggleRouteFavorite = mapViewModel::toggleRouteFavorite,
                             onLearnMore = onLearnMore,
                             onOpenSurvey = onOpenSurvey,
                             // The route header reports its height straight to the map VM (which owns the
@@ -564,6 +569,8 @@ private fun BoxScope.HomeMapOverlays(
     routeHeader: RouteHeader?,
     onCancelRouteMode: () -> Unit,
     onSelectRouteDirection: (Int) -> Unit,
+    isRouteFavorite: Boolean,
+    onToggleRouteFavorite: () -> Unit,
     onLearnMore: () -> Unit,
     onOpenSurvey: (url: String) -> Unit,
     onRouteHeaderHeight: (Int) -> Unit,
@@ -592,6 +599,8 @@ private fun BoxScope.HomeMapOverlays(
             header = routeHeader,
             onCancel = onCancelRouteMode,
             onSelectDirection = onSelectRouteDirection,
+            isFavorite = isRouteFavorite,
+            onToggleFavorite = onToggleRouteFavorite,
             onHeight = onRouteHeaderHeight,
             modifier = Modifier.align(Alignment.TopCenter).fillMaxWidth(),
         )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/RouteHeaderOverlay.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/RouteHeaderOverlay.kt
@@ -39,6 +39,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -158,6 +159,8 @@ fun RouteHeaderOverlay(
                 FavoriteStarButton(
                     isFavorite = isFavorite,
                     onClick = onToggleFavorite,
+                    // Match the arrival-row star's outline color so the two read as the same control.
+                    tint = colorResource(R.color.navdrawer_icon_tint),
                     modifier = Modifier
                         .align(Alignment.TopStart)
                         .offset(x = (-8).dp, y = (-8).dp),

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/RouteHeaderOverlay.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/RouteHeaderOverlay.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.AlertDialog
@@ -48,6 +49,7 @@ import androidx.compose.ui.unit.sp
 import org.onebusaway.android.R
 import org.onebusaway.android.map.RouteHeader
 import org.onebusaway.android.models.RouteMapDirection
+import org.onebusaway.android.ui.compose.components.FavoriteStarButton
 import org.onebusaway.android.ui.compose.components.LineBadge
 import org.onebusaway.android.ui.compose.components.RadioOptionList
 import org.onebusaway.android.ui.compose.theme.ObaTheme
@@ -55,18 +57,24 @@ import org.onebusaway.android.ui.compose.theme.ObaTheme
 /**
  * The route-mode header overlay (the Compose replacement for the legacy `route_info_head.xml` /
  * `RouteMapController.RoutePopup`). Renders the route short/long name + agency (or a spinner while the
- * route loads), the current direction's headsign, a switch-direction affordance (when the route has
- * more than one direction), and a cancel button that exits route mode. It reports its measured height
- * via [onHeight] so the host can set the map's top padding (keeping vehicle markers visible under it).
+ * route loads), the current direction's headsign, a favorite (star) toggle, a switch-direction
+ * affordance (when the route has more than one direction), and a cancel button that exits route mode. It
+ * reports its measured height via [onHeight] so the host can set the map's top padding (keeping vehicle
+ * markers visible under it).
  *
  * [onSelectDirection] switches which direction of the route is shown (the id is one of
  * [RouteHeader.directions]).
+ *
+ * [isFavorite] drives the star's filled/outline state and [onToggleFavorite] toggles the route's star
+ * (a wholesale `routes.favorite` bit, #1751/#1727), kept in sync with the arrival-row star.
  */
 @Composable
 fun RouteHeaderOverlay(
     header: RouteHeader,
     onCancel: () -> Unit,
     onSelectDirection: (Int) -> Unit,
+    isFavorite: Boolean,
+    onToggleFavorite: () -> Unit,
     onHeight: (Int) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -92,56 +100,68 @@ fun RouteHeaderOverlay(
             val directionLabel = header.directions
                 .firstOrNull { it.directionId == header.currentDirectionId }
                 ?.labelOr(unnamed)
-            Row(
-                Modifier
-                    .fillMaxWidth()
-                    .padding(4.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                // Auto-shrinks (and wraps) a long route short name to fit a fixed slot rather than
-                // crowding out the long-name/agency column — the shared route-badge style.
-                LineBadge(
-                    text = header.shortName,
-                    maxFontSize = 45.sp,
-                    width = 96.dp,
-                    modifier = Modifier.padding(horizontal = 10.dp),
+            Box(Modifier.fillMaxWidth()) {
+                Row(
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(4.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    // Auto-shrinks (and wraps) a long route short name to fit a fixed slot rather than
+                    // crowding out the long-name/agency column — the shared route-badge style.
+                    LineBadge(
+                        text = header.shortName,
+                        maxFontSize = 45.sp,
+                        width = 96.dp,
+                        modifier = Modifier.padding(horizontal = 10.dp),
+                    )
+                    Column(Modifier.weight(1f)) {
+                        if (header.longName.isNotEmpty()) {
+                            Text(
+                                text = header.longName,
+                                fontSize = 16.sp,
+                                fontWeight = FontWeight.Bold,
+                                maxLines = 2,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                        }
+                        if (directionLabel != null) {
+                            Text(
+                                text = directionLabel,
+                                color = MaterialTheme.colorScheme.primary,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                        }
+                        if (header.agency.isNotEmpty()) {
+                            Text(text = header.agency)
+                        }
+                    }
+                    // A route with a single direction has nothing to switch to — the affordance is hidden.
+                    if (header.directions.size >= 2) {
+                        SwitchDirectionAction(
+                            directions = header.directions,
+                            currentDirectionId = header.currentDirectionId,
+                            onSelectDirection = onSelectDirection,
+                        )
+                    }
+                    IconButton(onClick = onCancel) {
+                        Icon(
+                            painter = painterResource(R.drawable.ic_navigation_close),
+                            contentDescription = stringResource(android.R.string.cancel),
+                        )
+                    }
+                }
+                // Favorites star, floated over the banner's upper-left so it occupies no layout space
+                // (it won't shift the badge). The negative offset cancels most of the IconButton's built-in
+                // inset so the star tucks up into the corner.
+                FavoriteStarButton(
+                    isFavorite = isFavorite,
+                    onClick = onToggleFavorite,
+                    modifier = Modifier
+                        .align(Alignment.TopStart)
+                        .offset(x = (-8).dp, y = (-8).dp),
                 )
-                Column(Modifier.weight(1f)) {
-                    if (header.longName.isNotEmpty()) {
-                        Text(
-                            text = header.longName,
-                            fontSize = 16.sp,
-                            fontWeight = FontWeight.Bold,
-                            maxLines = 2,
-                            overflow = TextOverflow.Ellipsis,
-                        )
-                    }
-                    if (directionLabel != null) {
-                        Text(
-                            text = directionLabel,
-                            color = MaterialTheme.colorScheme.primary,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                        )
-                    }
-                    if (header.agency.isNotEmpty()) {
-                        Text(text = header.agency)
-                    }
-                }
-                // A route with a single direction has nothing to switch to — the affordance is hidden.
-                if (header.directions.size >= 2) {
-                    SwitchDirectionAction(
-                        directions = header.directions,
-                        currentDirectionId = header.currentDirectionId,
-                        onSelectDirection = onSelectDirection,
-                    )
-                }
-                IconButton(onClick = onCancel) {
-                    Icon(
-                        painter = painterResource(R.drawable.ic_navigation_close),
-                        contentDescription = stringResource(android.R.string.cancel),
-                    )
-                }
             }
         }
     }
@@ -220,6 +240,8 @@ private fun RouteHeaderOverlayPreview() {
                 ),
                 onCancel = {},
                 onSelectDirection = {},
+                isFavorite = true,
+                onToggleFavorite = {},
                 onHeight = {},
             )
             Spacer(Modifier.size(12.dp))
@@ -238,6 +260,8 @@ private fun RouteHeaderOverlayPreview() {
                 ),
                 onCancel = {},
                 onSelectDirection = {},
+                isFavorite = false,
+                onToggleFavorite = {},
                 onHeight = {},
             )
             Spacer(Modifier.size(12.dp))
@@ -257,6 +281,8 @@ private fun RouteHeaderOverlayPreview() {
                 ),
                 onCancel = {},
                 onSelectDirection = {},
+                isFavorite = false,
+                onToggleFavorite = {},
                 onHeight = {},
             )
             Spacer(Modifier.size(12.dp))
@@ -270,6 +296,8 @@ private fun RouteHeaderOverlayPreview() {
                 ),
                 onCancel = {},
                 onSelectDirection = {},
+                isFavorite = false,
+                onToggleFavorite = {},
                 onHeight = {},
             )
             Spacer(Modifier.size(12.dp))
@@ -278,6 +306,8 @@ private fun RouteHeaderOverlayPreview() {
                 header = RouteHeader(loading = true, shortName = "", longName = "", agency = ""),
                 onCancel = {},
                 onSelectDirection = {},
+                isFavorite = false,
+                onToggleFavorite = {},
                 onHeight = {},
             )
         }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/mylists/MyListRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/mylists/MyListRepository.kt
@@ -320,8 +320,8 @@ private suspend fun fetchStopBadges(context: Context, stopId: String): List<Arri
             .arrivals(stopId, ARRIVALS_MINUTES_AFTER)
             .getOrThrow()
         // Server clock as the ETA baseline so badges cancel device clock skew (#1612). These badge
-        // rows don't render the favorite star, so favorite state is always false.
-        convertArrivals(context, snapshot.arrivals, null, ServerTime(snapshot.currentTime), false) { _, _, _ -> false }
+        // rows don't render the favorite star.
+        convertArrivals(context, snapshot.arrivals, null, ServerTime(snapshot.currentTime), false)
             .take(MAX_ARRIVALS_PER_STOP)
             .map { it.toBadge(context) }
     }.getOrDefault(emptyList())

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/ArrivalInfoUtils.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/ArrivalInfoUtils.java
@@ -19,12 +19,15 @@ package org.onebusaway.android.util;
 import android.content.Context;
 import android.content.res.Resources;
 
+import androidx.annotation.NonNull;
+
 import org.onebusaway.android.R;
 import org.onebusaway.android.ui.arrivals.ArrivalInfo;
 
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Set;
 
 public class ArrivalInfoUtils {
 
@@ -56,18 +59,20 @@ public class ArrivalInfoUtils {
     }
 
     /**
-     * Returns the indexes in the provided infoList for the preferred route/headsign combinations
-     * to be prioritized for displayed in the header, or null if no non-negative ETAs exist in the
-     * list.  If no route/headsign combinations are favorited, the indexes returned may simply be
-     * the indexes of the first (and second, if it exists) non-negative arrival times.
+     * Returns the indexes in the provided infoList for the preferred arrivals to be prioritized in the
+     * header, or null if no non-negative ETAs exist in the list. An arrival is preferred when its route
+     * is starred ({@code favoriteRouteIds} contains its route id — a route star is wholesale now, #1751).
+     * If none are favorited, the indexes returned may simply be the indexes of the first (and second,
+     * if it exists) non-negative arrival times.
      *
      * @param infoList list to search for non-negative arrival times, ordered by relative ETA from
      *                 negative infinity to positive infinity
-     * @return the indexes in the provided infoList for the preferred route/headsign combinations
-     * to be prioritized for displayed in the header, or null if no non-negative ETAs exist in the
-     * list
+     * @param favoriteRouteIds the ids of the user's starred routes
+     * @return the indexes in the provided infoList for the preferred arrivals to be prioritized in the
+     * header, or null if no non-negative ETAs exist in the list
      */
-    public static ArrayList<Integer> findPreferredArrivalIndexes(ArrayList<ArrivalInfo> infoList) {
+    public static ArrayList<Integer> findPreferredArrivalIndexes(
+            ArrayList<ArrivalInfo> infoList, @NonNull Set<String> favoriteRouteIds) {
         // Start by getting the index of the first non-negative arrival time
         int firstIndex = findFirstNonNegativeArrival(infoList);
         if (firstIndex == -1) {
@@ -77,7 +82,7 @@ public class ArrivalInfoUtils {
         ArrayList<Integer> preferredIndexes = new ArrayList<>();
         for (int i = firstIndex; i < infoList.size(); i++) {
             ArrivalInfo info = infoList.get(i);
-            if (info.isRouteFavorite()) {
+            if (favoriteRouteIds.contains(info.getRouteId())) {
                 preferredIndexes.add(i);
             }
         }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/ArrivalInfoTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/ArrivalInfoTest.kt
@@ -60,7 +60,6 @@ class ArrivalInfoTest {
         data = data,
         now = now,
         includeArrivalDepartureInStatusLabel = false,
-        favorite = false,
     )
 
     @Test

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/ArrivalsViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/ArrivalsViewModelTest.kt
@@ -62,6 +62,10 @@ private class FakeArrivalsRepository(
      *  mutate it directly to stand in for a hide/un-hide from another surface (the alert dialog). */
     val hideState = MutableStateFlow(initialHideState)
 
+    /** The starred route ids the ViewModel overlays onto the arrivals; a test mutates it to stand in
+     *  for a star toggle from any surface. */
+    val favoriteRoutes = MutableStateFlow<Set<String>>(emptySet())
+
     override suspend fun getArrivals(
         stopId: String,
         minutesAfter: Int,
@@ -97,6 +101,8 @@ private class FakeArrivalsRepository(
     override suspend fun setArrivalStyle(style: Int) {
         lastSetStyle = style
     }
+
+    override fun favoriteRouteIds(): Flow<Set<String>> = favoriteRoutes
 
     override fun alertHideState(): Flow<AlertHideState> = hideState
 
@@ -239,7 +245,7 @@ class ArrivalsViewModelTest {
         assertEquals("1_100" to true, repository.lastFavoriteSet)
     }
 
-    private fun routeActions(isRouteFavorite: Boolean) = ArrivalActions(
+    private val routeActions = ArrivalActions(
         tripId = "t1",
         routeId = "1_5",
         routeShortName = "5",
@@ -247,41 +253,38 @@ class ArrivalsViewModelTest {
         scheduleUrl = null,
         agencyName = null,
         blockId = null,
-        isRouteFavorite = isRouteFavorite
     )
 
     @Test
-    fun `toggleRouteFavorite stars an unstarred route wholesale and reloads`() = runTest {
+    fun `toggleRouteFavorite stars an unstarred route wholesale`() = runTest {
         val repository = FakeArrivalsRepository(Result.success(data()))
         val viewModel = ArrivalsViewModel("1_100", false, repository)
         viewModel.refresh()
+        // Route not in the live favorite set -> toggling stars it.
 
-        val actions = routeActions(isRouteFavorite = false)
-
-        viewModel.toggleRouteFavorite(actions)
+        viewModel.toggleRouteFavorite(routeActions)
         advanceUntilIdle()
 
-        // Wholesale star (#1751): route id + names, favorite = !isRouteFavorite.
+        // Wholesale star (#1751): route id + names, favorite = true.
         assertEquals(
             FavoriteRouteCall("1_5", "5", "Fifth Ave", true),
             repository.lastFavoriteRoute
         )
-        // The write is followed by a reload (initial load + the post-favorite refresh).
-        assertEquals(2, repository.requestedMinutesAfter.size)
+        // No reload — the star re-flags reactively from the favorite overlay (only the initial load).
+        assertEquals(1, repository.requestedMinutesAfter.size)
     }
 
     @Test
     fun `toggleRouteFavorite unstars a starred route`() = runTest {
         val repository = FakeArrivalsRepository(Result.success(data()))
+        repository.favoriteRoutes.value = setOf("1_5")   // already starred (from any surface)
         val viewModel = ArrivalsViewModel("1_100", false, repository)
         viewModel.refresh()
 
-        val actions = routeActions(isRouteFavorite = true)
-
-        viewModel.toggleRouteFavorite(actions)
+        viewModel.toggleRouteFavorite(routeActions)
         advanceUntilIdle()
 
-        // Already starred => unstar (favorite = false).
+        // Already in the live set => unstar (favorite = false).
         assertEquals(
             FavoriteRouteCall("1_5", "5", "Fifth Ave", false),
             repository.lastFavoriteRoute


### PR DESCRIPTION
## Summary

Adds a tappable favorites star to the route-mode map header (`RouteHeaderOverlay`), floated over the banner's **upper-left** so it takes no layout space (doesn't shift the route badge), and wires route favorites to update **reactively everywhere**.

This finishes the star that was previously scaffolded UI-only. Persistence was deferred because route favorites were keyed by `(route, headsign)` — a destination string the map header can't match exactly (its direction labels are stop-group display names, not trip headsigns). #1751 collapsed route favorites to a single wholesale `routes.favorite` bit keyed by `routeId`, which the header has directly — so it now wires straight in.

## Header star

- **`RouteDao.isFavorite(routeId): Flow<Boolean>`** — reactive per-route star state.
- **`MapViewModel`** exposes `isRouteFavorite` (flat-mapping the loaded route's id into that query) and `toggleRouteFavorite()`. The toggle ensures the route row exists (name/URL + region, so the Starred Routes folder can list it) then flips the bit — no network backfill, since the route is already loaded in route mode.
- **`HomeScreen`** collects `isRouteFavorite` and passes it + the toggle to the overlay, mirroring the existing direction-switch wiring.
- The star is tinted with `navdrawer_icon_tint` so its outline matches the arrival-row star.

## Reactive favorites in the arrivals drawer

The arrivals list previously **baked** each row's star state at load time (a one-shot `favoriteRouteIds()` read), so a toggle only took effect on the next network reload. It's now a **live overlay** — the same reactive-overlay pattern the alert hide-state already uses — so starring/unstarring a route from any surface (an arrival row, the route-map header) re-flags every row for that route **and** the drawer-header promotion immediately, with no re-fetch:

- `RouteDao.favoriteRouteIds()` is a `Flow<List<String>>`; `ArrivalsRepository.favoriteRouteIds(): Flow<Set<String>>` exposes it (import-gated, like `alertHideState()`).
- `ArrivalsViewModel` folds it into the state `combine`; `Content` carries the live `favoriteRouteIds`. Favorite state is no longer baked into `ArrivalInfo` / `ArrivalActions` / `convertArrivals` — the rows read `arrival.routeId in favoriteRouteIds`, and `findPreferredArrivalIndexes` takes the set. This makes `ArrivalInfo` a pure display model.
- `toggleRouteFavorite` reads the current state from the live set and drops its post-write `refresh()` (the overlay updates the UI).

## Reusable star button

Extracts **`FavoriteStarButton`** (`ui/compose/components`) — the shared filled/outline star toggle the arrivals rows/panel currently spell out inline. New call sites use it rather than repeating the `if (isFavorite) star else star_outline` ternary; the existing inline sites can adopt it later.

## Testing

- `compileObaGoogleDebugKotlin -PwarningsAsErrors=true`, `lintObaGoogleDebug -PwarningsAsErrors=true`, `testObaGoogleDebugUnitTest` — all clean.
- New `RouteDaoTest.isFavorite_reflectsTheFavoriteBit`; `ArrivalsViewModelTest` toggle tests seed the live favorite set and assert the wholesale toggle; `UIUtilTest` promotion updated to the routeId semantics (starring route 6 promotes its arrivals) — all pass on device.
- Built + installed on device for a manual pass of the header star + reactive drawer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added live star toggles for routes in the map and arrivals views.
  * Introduced a new favorite star button component and updated the route header to display/toggle favorite state.
* **Bug Fixes**
  * Made route-favorite state fully reactive across the app, keeping starred routes, arrivals preview, and arrival selection consistent without forcing reloads.
  * Ensured route-details “star” updates no longer affect usage counters.
* **Tests**
  * Updated and added instrumentation/UI coverage for favorite state transitions and reactive behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->