### PR TITLE
Lint cleanup: clear ~93 compiler warnings (safe batch)

### DIFF
--- a/onebusaway-android/build.gradle
+++ b/onebusaway-android/build.gradle
@@ -294,6 +294,7 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.10.1'
     // Unit tests - seems like this is still necessary w/ Android X even though useLibrary is declared earlier
     androidTestImplementation 'androidx.test:runner:1.6.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.2.1'
     androidTestImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.1'
     // WorkManager (Java only)
     implementation 'androidx.work:work-runtime:2.9.1'

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/analytics/test/UmamiAnalyticsTest.java
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/analytics/test/UmamiAnalyticsTest.java
@@ -4,7 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import androidx.test.runner.AndroidJUnit4;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import org.json.JSONObject;
 import org.junit.Test;

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/api/test/LoaderTestCase.java
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/api/test/LoaderTestCase.java
@@ -27,7 +27,7 @@ import java.util.concurrent.ArrayBlockingQueue;
 
 import androidx.loader.content.Loader;
 import androidx.loader.content.Loader.OnLoadCompleteListener;
-import androidx.test.runner.AndroidJUnit4;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 /**
  * A convenience class for testing {@link Loader}s. This test case

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/api/test/ObaTestCase.java
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/api/test/ObaTestCase.java
@@ -23,9 +23,9 @@ import org.onebusaway.android.app.di.PreferencesEntryPoint;
 import org.onebusaway.android.app.di.RegionEntryPoint;
 import org.onebusaway.android.region.Region;
 
-import androidx.test.runner.AndroidJUnit4;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 
-import static androidx.test.InstrumentationRegistry.getTargetContext;
+import androidx.test.platform.app.InstrumentationRegistry;
 
 /**
  * Base test class extended for most OBA unit tests. Sets the OBA theme (needed for {@code attr/?}
@@ -42,12 +42,12 @@ public abstract class ObaTestCase {
     @Before
     public void before() {
         // The theme needs to be set when using "attr/?" elements - see #279
-        getTargetContext().setTheme(R.style.Theme_OneBusAway);
+        InstrumentationRegistry.getInstrumentation().getTargetContext().setTheme(R.style.Theme_OneBusAway);
 
         // Save the current region / custom API URL so the override below can be undone in after().
-        mOldRegion = RegionEntryPoint.get(getTargetContext()).currentRegion();
+        mOldRegion = RegionEntryPoint.get(InstrumentationRegistry.getInstrumentation().getTargetContext()).currentRegion();
         mOldCustomApiUrl = mOldRegion == null
-                ? PreferencesEntryPoint.get(getTargetContext())
+                ? PreferencesEntryPoint.get(InstrumentationRegistry.getInstrumentation().getTargetContext())
                         .getString(R.string.preference_key_oba_api_url, null)
                 : null;
 
@@ -56,21 +56,21 @@ public abstract class ObaTestCase {
          * that were written before multi-region functionality. This is overwritten in some
          * subclasses so multiple regions / APIs can be tested.
          */
-        PreferencesEntryPoint.get(getTargetContext())
+        PreferencesEntryPoint.get(InstrumentationRegistry.getInstrumentation().getTargetContext())
                 .setString(R.string.preference_key_oba_api_url, "api.pugetsound.onebusaway.org");
     }
 
     @After
     public void after() {
         if (mOldRegion != null) {
-            RegionEntryPoint.get(getTargetContext()).applyRegion(mOldRegion, true);
+            RegionEntryPoint.get(InstrumentationRegistry.getInstrumentation().getTargetContext()).applyRegion(mOldRegion, true);
         } else if (mOldCustomApiUrl != null) {
-            PreferencesEntryPoint.get(getTargetContext())
+            PreferencesEntryPoint.get(InstrumentationRegistry.getInstrumentation().getTargetContext())
                     .setString(R.string.preference_key_oba_api_url, mOldCustomApiUrl);
         } else {
-            PreferencesEntryPoint.get(getTargetContext())
+            PreferencesEntryPoint.get(InstrumentationRegistry.getInstrumentation().getTargetContext())
                     .setString(R.string.preference_key_oba_api_url, null);
-            RegionEntryPoint.get(getTargetContext()).applyRegion(null, true);
+            RegionEntryPoint.get(InstrumentationRegistry.getInstrumentation().getTargetContext()).applyRegion(null, true);
         }
     }
 }

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/database/AppDatabaseMigrationTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/database/AppDatabaseMigrationTest.kt
@@ -17,7 +17,7 @@ package org.onebusaway.android.database
 
 import androidx.room.testing.MigrationTestHelper
 import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.runner.AndroidJUnit4
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/database/oba/LegacyDataImporterTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/database/oba/LegacyDataImporterTest.kt
@@ -20,7 +20,7 @@ import android.database.sqlite.SQLiteDatabase
 import androidx.room.Room
 import androidx.sqlite.db.SimpleSQLiteQuery
 import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.runner.AndroidJUnit4
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import java.io.File
 import kotlinx.coroutines.runBlocking
 import org.junit.After

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/database/oba/RegionDaoReplaceAllTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/database/oba/RegionDaoReplaceAllTest.kt
@@ -17,7 +17,7 @@ package org.onebusaway.android.database.oba
 
 import androidx.room.Room
 import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.runner.AndroidJUnit4
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/database/oba/RouteDaoTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/database/oba/RouteDaoTest.kt
@@ -17,7 +17,7 @@ package org.onebusaway.android.database.oba
 
 import androidx.room.Room
 import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.runner.AndroidJUnit4
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/database/oba/RouteHeadsignFavoriteWriterTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/database/oba/RouteHeadsignFavoriteWriterTest.kt
@@ -17,7 +17,7 @@ package org.onebusaway.android.database.oba
 
 import androidx.room.Room
 import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.runner.AndroidJUnit4
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/database/oba/ServiceAlertDaoTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/database/oba/ServiceAlertDaoTest.kt
@@ -17,7 +17,7 @@ package org.onebusaway.android.database.oba
 
 import androidx.room.Room
 import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.runner.AndroidJUnit4
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.junit.After

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/database/oba/StopDaoMergeTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/database/oba/StopDaoMergeTest.kt
@@ -17,7 +17,7 @@ package org.onebusaway.android.database.oba
 
 import androidx.room.Room
 import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.runner.AndroidJUnit4
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.junit.After

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/directions/realtime/RealtimeServiceTest.java
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/directions/realtime/RealtimeServiceTest.java
@@ -32,8 +32,8 @@ import org.opentripplanner.api.model.Leg;
 import java.time.Instant;
 import java.util.ArrayList;
 
-import androidx.test.InstrumentationRegistry;
-import androidx.test.runner.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertFalse;
@@ -54,17 +54,17 @@ public class RealtimeServiceTest {
         mService = new RealtimeService() {
             @Override
             public Context getApplicationContext() {
-                return InstrumentationRegistry.getTargetContext();
+                return InstrumentationRegistry.getInstrumentation().getTargetContext();
             }
 
             @Override
             public String getPackageName() {
-                return InstrumentationRegistry.getTargetContext().getPackageName();
+                return InstrumentationRegistry.getInstrumentation().getTargetContext().getPackageName();
             }
 
             @Override
             public Object getSystemService(String name) {
-                return InstrumentationRegistry.getTargetContext().getSystemService(name);
+                return InstrumentationRegistry.getInstrumentation().getTargetContext().getSystemService(name);
             }
         };
     }
@@ -81,7 +81,7 @@ public class RealtimeServiceTest {
         Bundle bundle = new Bundle();
         // Set start time to 2 hours in the future (Query window is 1 hour)
         long futureTime = System.currentTimeMillis() + (OTPConstants.REALTIME_SERVICE_QUERY_WINDOW * 2);
-        new TripRequestBuilder(InstrumentationRegistry.getTargetContext(), bundle).setDateTime(Instant.ofEpochMilli(futureTime));
+        new TripRequestBuilder(InstrumentationRegistry.getInstrumentation().getTargetContext(), bundle).setDateTime(Instant.ofEpochMilli(futureTime));
 
         boolean result = mService.rescheduleRealtimeUpdates(bundle);
         assertTrue("Realtime updates should be rescheduled for future trips", result);
@@ -92,7 +92,7 @@ public class RealtimeServiceTest {
         Bundle bundle = new Bundle();
         // Set start time to 30 minutes in the future (within 1 hour window)
         long nearTime = System.currentTimeMillis() + (OTPConstants.REALTIME_SERVICE_QUERY_WINDOW / 2);
-        new TripRequestBuilder(InstrumentationRegistry.getTargetContext(), bundle).setDateTime(Instant.ofEpochMilli(nearTime));
+        new TripRequestBuilder(InstrumentationRegistry.getInstrumentation().getTargetContext(), bundle).setDateTime(Instant.ofEpochMilli(nearTime));
 
         boolean result = mService.rescheduleRealtimeUpdates(bundle);
         assertFalse("Realtime updates should not be rescheduled if trip starts soon", result);
@@ -172,7 +172,7 @@ public class RealtimeServiceTest {
         CustomAddress to = new CustomAddress();
         to.setLatitude(0);
         to.setLongitude(0);
-        new TripRequestBuilder(InstrumentationRegistry.getTargetContext(), bundle).setFrom(from).setTo(to).setDateTime(Instant.now());
+        new TripRequestBuilder(InstrumentationRegistry.getInstrumentation().getTargetContext(), bundle).setFrom(from).setTo(to).setDateTime(Instant.now());
 
         // Build a valid itinerary with one transit leg so ItineraryDescription succeeds
         // and we actually reach the NOTIFICATION_TARGET check (not the catch block).

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/extrapolation/test/ExtrapolatedVehiclesTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/extrapolation/test/ExtrapolatedVehiclesTest.kt
@@ -18,8 +18,8 @@ package org.onebusaway.android.extrapolation.test
 import org.onebusaway.android.time.WallTime
 import org.onebusaway.android.api.data.asRouteTrips
 
-import androidx.test.InstrumentationRegistry.getTargetContext
-import androidx.test.runner.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.serialization.json.Json
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -57,7 +57,7 @@ class ExtrapolatedVehiclesTest {
 
     // Decode the same fixture through the api/ DTO path the production fetch now uses.
     private fun response(): ObaEnvelope<ListWithReferences<TripDetailsEntry>> =
-        Resources.read(getTargetContext(), Resources.getTestUri("trips_for_route_extrapolation"))
+        Resources.read(InstrumentationRegistry.getInstrumentation().targetContext, Resources.getTestUri("trips_for_route_extrapolation"))
             .use { json.decodeFromString(it.readText()) }
 
     @Test
@@ -107,7 +107,7 @@ class ExtrapolatedVehiclesTest {
     // A trips-for-route response with two vehicles on route_1 heading opposite directions (GTFS
     // directionId 0 vs 1) — the "show vehicles on map" direction filter's fixture.
     private fun directionResponse(): ObaEnvelope<ListWithReferences<TripDetailsEntry>> =
-        Resources.read(getTargetContext(), Resources.getTestUri("trips_for_route_direction_filter"))
+        Resources.read(InstrumentationRegistry.getInstrumentation().targetContext, Resources.getTestUri("trips_for_route_direction_filter"))
             .use { json.decodeFromString(it.readText()) }
 
     @Test
@@ -138,7 +138,7 @@ class ExtrapolatedVehiclesTest {
     // A trips-for-route response listing the same trip twice — a schedule-only entry (position, no
     // fix) and a real-time entry (lastKnownLocation), in each order — the #1667/#50 flicker fixture.
     private fun duplicateResponse(): ObaEnvelope<ListWithReferences<TripDetailsEntry>> =
-        Resources.read(getTargetContext(), Resources.getTestUri("trips_for_route_duplicate_trip"))
+        Resources.read(InstrumentationRegistry.getInstrumentation().targetContext, Resources.getTestUri("trips_for_route_duplicate_trip"))
             .use { json.decodeFromString(it.readText()) }
 
     @Test
@@ -166,7 +166,7 @@ class ExtrapolatedVehiclesTest {
     // Two distinct trips both reporting the same active trip (a vehicle mid-rollover): the ghost
     // predecessor (scheduled) and the real-time successor — collide on activeTripId, not trip id.
     private fun rolloverResponse(): ObaEnvelope<ListWithReferences<TripDetailsEntry>> =
-        Resources.read(getTargetContext(), Resources.getTestUri("trips_for_route_rollover"))
+        Resources.read(InstrumentationRegistry.getInstrumentation().targetContext, Resources.getTestUri("trips_for_route_rollover"))
             .use { json.decodeFromString(it.readText()) }
 
     @Test

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/extrapolation/test/InterpolateAlongPolylineTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/extrapolation/test/InterpolateAlongPolylineTest.kt
@@ -16,7 +16,7 @@
 package org.onebusaway.android.extrapolation.test
 
 import android.location.Location
-import androidx.test.runner.AndroidJUnit4
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/extrapolation/test/TripExtrapolationBuilderTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/extrapolation/test/TripExtrapolationBuilderTest.kt
@@ -17,7 +17,7 @@ package org.onebusaway.android.extrapolation.test
 
 import org.onebusaway.android.time.WallTime
 import android.location.Location
-import androidx.test.runner.AndroidJUnit4
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/extrapolation/test/TripStateCacheTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/extrapolation/test/TripStateCacheTest.kt
@@ -21,7 +21,7 @@ import org.onebusaway.android.api.adapters.StopTimeData
 import org.onebusaway.android.api.adapters.TripScheduleData
 
 import android.location.Location
-import androidx.test.runner.AndroidJUnit4
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/map/VehicleIconAllocationTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/map/VehicleIconAllocationTest.kt
@@ -19,8 +19,8 @@ import org.onebusaway.android.time.WallTime
 import android.content.Context
 import android.graphics.Bitmap
 import android.util.Log
-import androidx.test.InstrumentationRegistry.getTargetContext
-import androidx.test.runner.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.serialization.json.Json
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
@@ -54,7 +54,7 @@ import java.util.concurrent.TimeUnit
 @RunWith(AndroidJUnit4::class)
 class VehicleIconAllocationTest {
 
-    private val context: Context get() = getTargetContext()
+    private val context: Context get() = InstrumentationRegistry.getInstrumentation().targetContext
 
     private val json = Json { ignoreUnknownKeys = true; coerceInputValues = true }
 

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/nav/test/NavigationTest.java
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/nav/test/NavigationTest.java
@@ -15,7 +15,7 @@
  */
 package org.onebusaway.android.nav.test;
 
-import static androidx.test.InstrumentationRegistry.getTargetContext;
+import androidx.test.platform.app.InstrumentationRegistry;
 import static junit.framework.Assert.assertTrue;
 import static junit.framework.Assert.fail;
 import static junit.framework.Assert.assertEquals;
@@ -27,7 +27,7 @@ import android.location.LocationManager;
 import android.os.Build;
 import android.util.Log;
 
-import androidx.test.runner.AndroidJUnit4;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.Assume;
@@ -760,7 +760,7 @@ public class NavigationTest extends ObaTestCase {
         double actualMiles = meters * RegionUtils.METERS_TO_MILES;
         assertEquals("Meters to miles conversion should be accurate", expectedMiles, actualMiles, 0.00001);
 
-        Context context = getTargetContext();
+        Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
         DecimalFormat fmt = new DecimalFormat("0.0");
         
         // Test imperial units (feet for small distances)
@@ -792,7 +792,7 @@ public class NavigationTest extends ObaTestCase {
      * @param expectedPullCordIndex the index for when the "Pull the Cord Now" notification is expected
      */
     private void runSimulation(String csvFileName, int expectedGetReadyIndex, int expectedPullCordIndex) throws IOException {
-        Reader reader = Resources.read(getTargetContext(), Resources.getTestUri(csvFileName));
+        Reader reader = Resources.read(InstrumentationRegistry.getInstrumentation().getTargetContext(), Resources.getTestUri(csvFileName));
         String csv = IOUtils.toString(reader);
         NavigationSimulation trip = new NavigationSimulation(csv);
         trip.runSimulation(expectedGetReadyIndex, expectedPullCordIndex);
@@ -947,7 +947,7 @@ public class NavigationTest extends ObaTestCase {
          * @param expectedPullCordIndex the index for when the "Pull the Cord Now" notification is expected
          */
         void runSimulation(int expectedGetReadyIndex, int expectedPullCordIndex) {
-            NavigationServiceProvider provider = new NavigationServiceProvider(getTargetContext(), mTripId,
+            NavigationServiceProvider provider = new NavigationServiceProvider(InstrumentationRegistry.getInstrumentation().getTargetContext(), mTripId,
                     mDestinationId);
             Location prevLocation = null;
             // Use the first location time as the starting time for this PathLink

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/preferences/PreferencesRepositoryReadYourWritesTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/preferences/PreferencesRepositoryReadYourWritesTest.kt
@@ -20,8 +20,8 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.preferencesOf
 import androidx.datastore.preferences.core.stringPreferencesKey
-import androidx.test.InstrumentationRegistry.getTargetContext
-import androidx.test.runner.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import junit.framework.Assert.assertEquals
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -49,7 +49,7 @@ class PreferencesRepositoryReadYourWritesTest {
     @Test
     fun synchronousReadReflectsLatestWrite_despiteAStaleDataStoreEmission() = runTest {
         val dataStore = FakeDataStore()
-        val repo = DefaultPreferencesRepository(getTargetContext(), dataStore, backgroundScope)
+        val repo = DefaultPreferencesRepository(InstrumentationRegistry.getInstrumentation().targetContext, dataStore, backgroundScope)
         runCurrent() // let the cache machinery subscribe + process the initial (empty) state
 
         repo.setString(key, "first")   // optimistic cache = "first"

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/util/test/LocationUtilsTest.java
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/util/test/LocationUtilsTest.java
@@ -27,6 +27,7 @@ import org.onebusaway.android.util.LocationUtils;
 import org.onebusaway.android.util.PermissionUtils;
 import org.onebusaway.android.util.TestUtils;
 
+import android.content.Context;
 import android.location.Location;
 import android.os.Build;
 import android.os.SystemClock;
@@ -166,9 +167,10 @@ public class LocationUtilsTest extends ObaTestCase {
     @Test
     public void testLocationApiV1() {
         Location loc;
+        Context targetContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
 
         // Make sure we're not running on an emulator, since we'll get a null location there
-        if (!TestUtils.isRunningOnEmulator() && PermissionUtils.hasGrantedAllPermissions(InstrumentationRegistry.getInstrumentation().getTargetContext(), LOCATION_PERMISSIONS)) {
+        if (!TestUtils.isRunningOnEmulator() && PermissionUtils.hasGrantedAllPermissions(targetContext, LOCATION_PERMISSIONS)) {
             /**
              * Retrieves the last known location from any available source - the fused provider
              * when Google Play Services is present, otherwise the framework Location API v1
@@ -176,7 +178,7 @@ public class LocationUtilsTest extends ObaTestCase {
              * (e.g., HTC EVO LTE) have custom framework providers such as "hybrid" that might
              * show up here. So, we can't test for a specific provider.
              */
-            loc = LocationEntryPoint.get(InstrumentationRegistry.getInstrumentation().getTargetContext()).lastKnownLocation();
+            loc = LocationEntryPoint.get(targetContext).lastKnownLocation();
             /**
              * On devices that behave correctly the following non-null test should pass.  However, it's
              * possible that it can fail on some devices (e.g., on a fresh reboot on a device without
@@ -191,17 +193,18 @@ public class LocationUtilsTest extends ObaTestCase {
     @Test
     public void testLocationServices() {
         Location loc;
+        Context targetContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
 
         // Test with Google Play Services, if its supported, and if we're not running on an emulator
         GoogleApiAvailability api = GoogleApiAvailability.getInstance();
-        if (api.isGooglePlayServicesAvailable(InstrumentationRegistry.getInstrumentation().getTargetContext())
+        if (api.isGooglePlayServicesAvailable(targetContext)
                 == ConnectionResult.SUCCESS &&
                 !TestUtils.isRunningOnEmulator() &&
-                PermissionUtils.hasGrantedAllPermissions(InstrumentationRegistry.getInstrumentation().getTargetContext(), LOCATION_PERMISSIONS)) {
+                PermissionUtils.hasGrantedAllPermissions(targetContext, LOCATION_PERMISSIONS)) {
             /**
              * Could return either a fused or Location API v1 location
              */
-            loc = LocationEntryPoint.get(InstrumentationRegistry.getInstrumentation().getTargetContext()).lastKnownLocation();
+            loc = LocationEntryPoint.get(targetContext).lastKnownLocation();
             assertNotNull(loc);
             Log.d(TAG,
                     "Location Provider for Location Services test is '" + loc.getProvider() + "'");

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/util/test/LocationUtilsTest.java
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/util/test/LocationUtilsTest.java
@@ -32,9 +32,9 @@ import android.os.Build;
 import android.os.SystemClock;
 import android.util.Log;
 
-import androidx.test.runner.AndroidJUnit4;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 
-import static androidx.test.InstrumentationRegistry.getTargetContext;
+import androidx.test.platform.app.InstrumentationRegistry;
 import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertTrue;
@@ -168,7 +168,7 @@ public class LocationUtilsTest extends ObaTestCase {
         Location loc;
 
         // Make sure we're not running on an emulator, since we'll get a null location there
-        if (!TestUtils.isRunningOnEmulator() && PermissionUtils.hasGrantedAllPermissions(getTargetContext(), LOCATION_PERMISSIONS)) {
+        if (!TestUtils.isRunningOnEmulator() && PermissionUtils.hasGrantedAllPermissions(InstrumentationRegistry.getInstrumentation().getTargetContext(), LOCATION_PERMISSIONS)) {
             /**
              * Retrieves the last known location from any available source - the fused provider
              * when Google Play Services is present, otherwise the framework Location API v1
@@ -176,7 +176,7 @@ public class LocationUtilsTest extends ObaTestCase {
              * (e.g., HTC EVO LTE) have custom framework providers such as "hybrid" that might
              * show up here. So, we can't test for a specific provider.
              */
-            loc = LocationEntryPoint.get(getTargetContext()).lastKnownLocation();
+            loc = LocationEntryPoint.get(InstrumentationRegistry.getInstrumentation().getTargetContext()).lastKnownLocation();
             /**
              * On devices that behave correctly the following non-null test should pass.  However, it's
              * possible that it can fail on some devices (e.g., on a fresh reboot on a device without
@@ -194,14 +194,14 @@ public class LocationUtilsTest extends ObaTestCase {
 
         // Test with Google Play Services, if its supported, and if we're not running on an emulator
         GoogleApiAvailability api = GoogleApiAvailability.getInstance();
-        if (api.isGooglePlayServicesAvailable(getTargetContext())
+        if (api.isGooglePlayServicesAvailable(InstrumentationRegistry.getInstrumentation().getTargetContext())
                 == ConnectionResult.SUCCESS &&
                 !TestUtils.isRunningOnEmulator() &&
-                PermissionUtils.hasGrantedAllPermissions(getTargetContext(), LOCATION_PERMISSIONS)) {
+                PermissionUtils.hasGrantedAllPermissions(InstrumentationRegistry.getInstrumentation().getTargetContext(), LOCATION_PERMISSIONS)) {
             /**
              * Could return either a fused or Location API v1 location
              */
-            loc = LocationEntryPoint.get(getTargetContext()).lastKnownLocation();
+            loc = LocationEntryPoint.get(InstrumentationRegistry.getInstrumentation().getTargetContext()).lastKnownLocation();
             assertNotNull(loc);
             Log.d(TAG,
                     "Location Provider for Location Services test is '" + loc.getProvider() + "'");

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/util/test/MathUtilTest.java
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/util/test/MathUtilTest.java
@@ -20,7 +20,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.onebusaway.android.util.MathUtils;
 
-import androidx.test.runner.AndroidJUnit4;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import static junit.framework.Assert.assertEquals;
 

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/util/test/MyTextUtilsTest.java
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/util/test/MyTextUtilsTest.java
@@ -19,7 +19,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.onebusaway.android.util.MyTextUtils;
 
-import androidx.test.runner.AndroidJUnit4;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertFalse;

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/util/test/PolylineDecoderTest.java
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/util/test/PolylineDecoderTest.java
@@ -23,7 +23,7 @@ import android.location.Location;
 
 import java.util.List;
 
-import androidx.test.runner.AndroidJUnit4;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNotNull;

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/util/test/RegionUtilTest.java
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/util/test/RegionUtilTest.java
@@ -24,6 +24,7 @@ import org.onebusaway.android.mock.MockRegion;
 import org.onebusaway.android.util.LocationUtils;
 import org.onebusaway.android.util.RegionUtils;
 
+import android.content.Context;
 import android.location.Location;
 
 import java.util.ArrayList;
@@ -58,10 +59,13 @@ public class RegionUtilTest {
 
     Location mZeroZeroLoc;
 
+    Context mTargetContext;
+
     @Before
     public void before() {
-        mPsRegion = MockRegion.getPugetSound(InstrumentationRegistry.getInstrumentation().getTargetContext());
-        mTampaRegion = MockRegion.getTampa(InstrumentationRegistry.getInstrumentation().getTargetContext());
+        mTargetContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        mPsRegion = MockRegion.getPugetSound(mTargetContext);
+        mTampaRegion = MockRegion.getTampa(mTargetContext);
 
         // Region locations
         mSeattleLoc = LocationUtils.makeLocation(47.6097, -122.3331);
@@ -94,14 +98,14 @@ public class RegionUtilTest {
          * it is
          */
         // Close to region
-        Region closestRegion = RegionUtils.getClosestRegion(InstrumentationRegistry.getInstrumentation().getTargetContext(), list, mSeattleLoc, useLimiter);
+        Region closestRegion = RegionUtils.getClosestRegion(mTargetContext, list, mSeattleLoc, useLimiter);
         assertEquals(closestRegion.getId(), RegionUtils.PUGET_SOUND_REGION_ID);
 
-        closestRegion = RegionUtils.getClosestRegion(InstrumentationRegistry.getInstrumentation().getTargetContext(), list, mTampaLoc, useLimiter);
+        closestRegion = RegionUtils.getClosestRegion(mTargetContext, list, mTampaLoc, useLimiter);
         assertEquals(closestRegion.getId(), RegionUtils.TAMPA_REGION_ID);
 
         // Far from region
-        closestRegion = RegionUtils.getClosestRegion(InstrumentationRegistry.getInstrumentation().getTargetContext(), list, mZeroZeroLoc, useLimiter);
+        closestRegion = RegionUtils.getClosestRegion(mTargetContext, list, mZeroZeroLoc, useLimiter);
         assertEquals(closestRegion.getId(), RegionUtils.TAMPA_REGION_ID);
 
         /**
@@ -111,17 +115,17 @@ public class RegionUtilTest {
         useLimiter = true;
 
         // Close to region
-        closestRegion = RegionUtils.getClosestRegion(InstrumentationRegistry.getInstrumentation().getTargetContext(), list, mSeattleLoc, useLimiter);
+        closestRegion = RegionUtils.getClosestRegion(mTargetContext, list, mSeattleLoc, useLimiter);
         assertEquals(closestRegion.getId(), RegionUtils.PUGET_SOUND_REGION_ID);
 
-        closestRegion = RegionUtils.getClosestRegion(InstrumentationRegistry.getInstrumentation().getTargetContext(), list, mTampaLoc, useLimiter);
+        closestRegion = RegionUtils.getClosestRegion(mTargetContext, list, mTampaLoc, useLimiter);
         assertEquals(closestRegion.getId(), RegionUtils.TAMPA_REGION_ID);
 
         // Far from region
-        closestRegion = RegionUtils.getClosestRegion(InstrumentationRegistry.getInstrumentation().getTargetContext(), list, mLondonLoc, useLimiter);
+        closestRegion = RegionUtils.getClosestRegion(mTargetContext, list, mLondonLoc, useLimiter);
         assertNull(closestRegion);
 
-        closestRegion = RegionUtils.getClosestRegion(InstrumentationRegistry.getInstrumentation().getTargetContext(), list, mZeroZeroLoc, useLimiter);
+        closestRegion = RegionUtils.getClosestRegion(mTargetContext, list, mZeroZeroLoc, useLimiter);
         assertNull(closestRegion);
     }
 
@@ -146,11 +150,11 @@ public class RegionUtilTest {
 
     @Test
     public void testIsRegionUsable() {
-        assertTrue(RegionUtils.isRegionUsable(InstrumentationRegistry.getInstrumentation().getTargetContext(), mPsRegion));
-        assertTrue(RegionUtils.isRegionUsable(InstrumentationRegistry.getInstrumentation().getTargetContext(), mTampaRegion));
+        assertTrue(RegionUtils.isRegionUsable(mTargetContext, mPsRegion));
+        assertTrue(RegionUtils.isRegionUsable(mTargetContext, mTampaRegion));
 
-        assertFalse(RegionUtils.isRegionUsable(InstrumentationRegistry.getInstrumentation().getTargetContext(), MockRegion.getRegionWithoutObaApis(InstrumentationRegistry.getInstrumentation().getTargetContext())));
-        assertFalse(RegionUtils.isRegionUsable(InstrumentationRegistry.getInstrumentation().getTargetContext(), MockRegion.getInactiveRegion(InstrumentationRegistry.getInstrumentation().getTargetContext())));
+        assertFalse(RegionUtils.isRegionUsable(mTargetContext, MockRegion.getRegionWithoutObaApis(mTargetContext)));
+        assertFalse(RegionUtils.isRegionUsable(mTargetContext, MockRegion.getInactiveRegion(mTargetContext)));
     }
 
     /**

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/util/test/RegionUtilTest.java
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/util/test/RegionUtilTest.java
@@ -28,9 +28,9 @@ import android.location.Location;
 
 import java.util.ArrayList;
 
-import androidx.test.runner.AndroidJUnit4;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 
-import static androidx.test.InstrumentationRegistry.getTargetContext;
+import androidx.test.platform.app.InstrumentationRegistry;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertNull;
@@ -60,8 +60,8 @@ public class RegionUtilTest {
 
     @Before
     public void before() {
-        mPsRegion = MockRegion.getPugetSound(getTargetContext());
-        mTampaRegion = MockRegion.getTampa(getTargetContext());
+        mPsRegion = MockRegion.getPugetSound(InstrumentationRegistry.getInstrumentation().getTargetContext());
+        mTampaRegion = MockRegion.getTampa(InstrumentationRegistry.getInstrumentation().getTargetContext());
 
         // Region locations
         mSeattleLoc = LocationUtils.makeLocation(47.6097, -122.3331);
@@ -94,14 +94,14 @@ public class RegionUtilTest {
          * it is
          */
         // Close to region
-        Region closestRegion = RegionUtils.getClosestRegion(getTargetContext(), list, mSeattleLoc, useLimiter);
+        Region closestRegion = RegionUtils.getClosestRegion(InstrumentationRegistry.getInstrumentation().getTargetContext(), list, mSeattleLoc, useLimiter);
         assertEquals(closestRegion.getId(), RegionUtils.PUGET_SOUND_REGION_ID);
 
-        closestRegion = RegionUtils.getClosestRegion(getTargetContext(), list, mTampaLoc, useLimiter);
+        closestRegion = RegionUtils.getClosestRegion(InstrumentationRegistry.getInstrumentation().getTargetContext(), list, mTampaLoc, useLimiter);
         assertEquals(closestRegion.getId(), RegionUtils.TAMPA_REGION_ID);
 
         // Far from region
-        closestRegion = RegionUtils.getClosestRegion(getTargetContext(), list, mZeroZeroLoc, useLimiter);
+        closestRegion = RegionUtils.getClosestRegion(InstrumentationRegistry.getInstrumentation().getTargetContext(), list, mZeroZeroLoc, useLimiter);
         assertEquals(closestRegion.getId(), RegionUtils.TAMPA_REGION_ID);
 
         /**
@@ -111,17 +111,17 @@ public class RegionUtilTest {
         useLimiter = true;
 
         // Close to region
-        closestRegion = RegionUtils.getClosestRegion(getTargetContext(), list, mSeattleLoc, useLimiter);
+        closestRegion = RegionUtils.getClosestRegion(InstrumentationRegistry.getInstrumentation().getTargetContext(), list, mSeattleLoc, useLimiter);
         assertEquals(closestRegion.getId(), RegionUtils.PUGET_SOUND_REGION_ID);
 
-        closestRegion = RegionUtils.getClosestRegion(getTargetContext(), list, mTampaLoc, useLimiter);
+        closestRegion = RegionUtils.getClosestRegion(InstrumentationRegistry.getInstrumentation().getTargetContext(), list, mTampaLoc, useLimiter);
         assertEquals(closestRegion.getId(), RegionUtils.TAMPA_REGION_ID);
 
         // Far from region
-        closestRegion = RegionUtils.getClosestRegion(getTargetContext(), list, mLondonLoc, useLimiter);
+        closestRegion = RegionUtils.getClosestRegion(InstrumentationRegistry.getInstrumentation().getTargetContext(), list, mLondonLoc, useLimiter);
         assertNull(closestRegion);
 
-        closestRegion = RegionUtils.getClosestRegion(getTargetContext(), list, mZeroZeroLoc, useLimiter);
+        closestRegion = RegionUtils.getClosestRegion(InstrumentationRegistry.getInstrumentation().getTargetContext(), list, mZeroZeroLoc, useLimiter);
         assertNull(closestRegion);
     }
 
@@ -146,11 +146,11 @@ public class RegionUtilTest {
 
     @Test
     public void testIsRegionUsable() {
-        assertTrue(RegionUtils.isRegionUsable(getTargetContext(), mPsRegion));
-        assertTrue(RegionUtils.isRegionUsable(getTargetContext(), mTampaRegion));
+        assertTrue(RegionUtils.isRegionUsable(InstrumentationRegistry.getInstrumentation().getTargetContext(), mPsRegion));
+        assertTrue(RegionUtils.isRegionUsable(InstrumentationRegistry.getInstrumentation().getTargetContext(), mTampaRegion));
 
-        assertFalse(RegionUtils.isRegionUsable(getTargetContext(), MockRegion.getRegionWithoutObaApis(getTargetContext())));
-        assertFalse(RegionUtils.isRegionUsable(getTargetContext(), MockRegion.getInactiveRegion(getTargetContext())));
+        assertFalse(RegionUtils.isRegionUsable(InstrumentationRegistry.getInstrumentation().getTargetContext(), MockRegion.getRegionWithoutObaApis(InstrumentationRegistry.getInstrumentation().getTargetContext())));
+        assertFalse(RegionUtils.isRegionUsable(InstrumentationRegistry.getInstrumentation().getTargetContext(), MockRegion.getInactiveRegion(InstrumentationRegistry.getInstrumentation().getTargetContext())));
     }
 
     /**

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/util/test/ReportUtilTest.java
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/util/test/ReportUtilTest.java
@@ -21,7 +21,7 @@ import org.onebusaway.android.report.ui.util.ServiceUtils;
 
 import android.test.AndroidTestCase;
 
-import androidx.test.runner.AndroidJUnit4;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 /**
  * Tests to evaluate issue reporting utilities

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/util/test/ShortcutIntentFlagsTest.java
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/util/test/ShortcutIntentFlagsTest.java
@@ -29,8 +29,8 @@ import org.onebusaway.android.ui.common.Shortcuts;
 import java.util.concurrent.atomic.AtomicReference;
 
 import androidx.core.content.pm.ShortcutInfoCompat;
-import androidx.test.InstrumentationRegistry;
-import androidx.test.runner.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertTrue;

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/util/test/UIUtilTest.java
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/util/test/UIUtilTest.java
@@ -18,6 +18,8 @@
 package org.onebusaway.android.util.test;
 
 import androidx.core.util.Pair;
+import android.content.Context;
+
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import org.junit.Test;
@@ -142,6 +144,7 @@ public class UIUtilTest extends ObaTestCase {
 
     @Test
     public void testCreateStopDetailsDialogText() {
+        final Context targetContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
         final String newLine = "\n";
         Pair stopDetails;
         StringBuilder expectedMessage;
@@ -155,7 +158,7 @@ public class UIUtilTest extends ObaTestCase {
         routeDisplayNames.add("5");
 
         // Test without stop nickname or direction
-        stopDetails = StopDetailsDialog.createStopDetailsDialogText(InstrumentationRegistry.getInstrumentation().getTargetContext(),
+        stopDetails = StopDetailsDialog.createStopDetailsDialogText(targetContext,
                 stopName,
                 stopUserName,
                 stopCode,
@@ -170,7 +173,7 @@ public class UIUtilTest extends ObaTestCase {
 
         // Test with stop nickname and without direction
         stopUserName = "My stop nickname";
-        stopDetails = StopDetailsDialog.createStopDetailsDialogText(InstrumentationRegistry.getInstrumentation().getTargetContext(),
+        stopDetails = StopDetailsDialog.createStopDetailsDialogText(targetContext,
                 stopName,
                 stopUserName,
                 stopCode,
@@ -188,7 +191,7 @@ public class UIUtilTest extends ObaTestCase {
         // Test without stop nickname and with direction
         stopUserName = null;
         stopDirection = "S";
-        stopDetails = StopDetailsDialog.createStopDetailsDialogText(InstrumentationRegistry.getInstrumentation().getTargetContext(),
+        stopDetails = StopDetailsDialog.createStopDetailsDialogText(targetContext,
                 stopName,
                 stopUserName,
                 stopCode,
@@ -200,13 +203,13 @@ public class UIUtilTest extends ObaTestCase {
         expectedMessage.append(newLine);
         expectedMessage.append("Routes: " + routeDisplayNames.get(0));
         expectedMessage.append(newLine);
-        expectedMessage.append(InstrumentationRegistry.getInstrumentation().getTargetContext().getString(DisplayFormat.getStopDirectionText(stopDirection)));
+        expectedMessage.append(targetContext.getString(DisplayFormat.getStopDirectionText(stopDirection)));
         assertEquals(expectedMessage.toString(), (String) stopDetails.second);
 
         // Test with stop nickname and direction
         stopUserName = "My stop nickname";
         stopDirection = "S";
-        stopDetails = StopDetailsDialog.createStopDetailsDialogText(InstrumentationRegistry.getInstrumentation().getTargetContext(),
+        stopDetails = StopDetailsDialog.createStopDetailsDialogText(targetContext,
                 stopName,
                 stopUserName,
                 stopCode,
@@ -220,19 +223,20 @@ public class UIUtilTest extends ObaTestCase {
         expectedMessage.append(newLine);
         expectedMessage.append("Routes: " + routeDisplayNames.get(0));
         expectedMessage.append(newLine);
-        expectedMessage.append(InstrumentationRegistry.getInstrumentation().getTargetContext().getString(DisplayFormat.getStopDirectionText(stopDirection)));
+        expectedMessage.append(targetContext.getString(DisplayFormat.getStopDirectionText(stopDirection)));
         assertEquals(expectedMessage.toString(), (String) stopDetails.second);
     }
 
     @Test
     public void testArrivalTimeIndexSearch() throws Exception {
+        final Context targetContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
         // Load a captured arrivals fixture and project it via the production DTO path
-        Region tampa = MockRegion.getTampa(InstrumentationRegistry.getInstrumentation().getTargetContext());
+        Region tampa = MockRegion.getTampa(targetContext);
         assertNotNull(tampa);
-        RegionEntryPoint.get(InstrumentationRegistry.getInstrumentation().getTargetContext()).applyRegion(tampa, true);
+        RegionEntryPoint.get(targetContext).applyRegion(tampa, true);
 
         ObaEnvelope<EntryWithReferences<ArrivalsForStop>> env =
-                ArrivalsFixtures.load(InstrumentationRegistry.getInstrumentation().getTargetContext(), "arrivals_and_departures_for_stop_hart_6497");
+                ArrivalsFixtures.load(targetContext, "arrivals_and_departures_for_stop_hart_6497");
         String stopId = "Hillsborough Area Regional Transit_6497";
 
         // The two favorited route/headsign combos. Favorite state is supplied to convert() directly
@@ -243,7 +247,7 @@ public class UIUtilTest extends ObaTestCase {
                 "Hillsborough Area Regional Transit_6|South to Downtown/MTC"));
 
         // Project the fixture's arrivals via the production path, with those two marked favorite.
-        ArrayList<ArrivalInfo> arrivalInfo = ArrivalsFixtures.convert(InstrumentationRegistry.getInstrumentation().getTargetContext(), env, true,
+        ArrayList<ArrivalInfo> arrivalInfo = ArrivalsFixtures.convert(targetContext, env, true,
                 (routeId, headsign, sid) -> favorites.contains(routeId + "|" + headsign));
 
         // Now confirm that we have the correct number of elements, and values for ETAs for the test
@@ -261,7 +265,7 @@ public class UIUtilTest extends ObaTestCase {
         assertEquals(13, preferredArrivalIndexes.get(1).intValue());
 
         // With no favorites, the first two non-negative arrival times are returned - indexes 5 and 6.
-        arrivalInfo = ArrivalsFixtures.convert(InstrumentationRegistry.getInstrumentation().getTargetContext(), env, true);
+        arrivalInfo = ArrivalsFixtures.convert(targetContext, env, true);
         preferredArrivalIndexes = ArrivalInfoUtils.findPreferredArrivalIndexes(arrivalInfo);
         assertEquals(5, preferredArrivalIndexes.get(0).intValue());
         assertEquals(6, preferredArrivalIndexes.get(1).intValue());
@@ -272,18 +276,19 @@ public class UIUtilTest extends ObaTestCase {
      */
     @Test
     public void testArrivalInfoLabels() throws Exception {
+        final Context targetContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
         // Load a captured arrivals fixture and project it via the production DTO path
-        Region tampa = MockRegion.getTampa(InstrumentationRegistry.getInstrumentation().getTargetContext());
+        Region tampa = MockRegion.getTampa(targetContext);
         assertNotNull(tampa);
-        RegionEntryPoint.get(InstrumentationRegistry.getInstrumentation().getTargetContext()).applyRegion(tampa, true);
+        RegionEntryPoint.get(targetContext).applyRegion(tampa, true);
 
         ObaEnvelope<EntryWithReferences<ArrivalsForStop>> env =
-                ArrivalsFixtures.load(InstrumentationRegistry.getInstrumentation().getTargetContext(), "arrivals_and_departures_for_stop_hart_6497");
+                ArrivalsFixtures.load(targetContext, "arrivals_and_departures_for_stop_hart_6497");
 
         /**
          * Labels *with* arrive/depart included, and time labels
          */
-        ArrayList<ArrivalInfo> arrivalInfo = ArrivalsFixtures.convert(InstrumentationRegistry.getInstrumentation().getTargetContext(), env, true);
+        ArrayList<ArrivalInfo> arrivalInfo = ArrivalsFixtures.convert(targetContext, env, true);
 
         // Now confirm that we have the correct number of elements, and values for ETAs for the test
         validateUatcArrivalInfo(arrivalInfo);
@@ -384,7 +389,7 @@ public class UIUtilTest extends ObaTestCase {
         /**
          * Status labels *without* arrive/depart included
          */
-        arrivalInfo = ArrivalsFixtures.convert(InstrumentationRegistry.getInstrumentation().getTargetContext(), env, false);
+        arrivalInfo = ArrivalsFixtures.convert(targetContext, env, false);
 
         // Now confirm that we have the correct number of elements, and values for ETAs for the test
         validateUatcArrivalInfo(arrivalInfo);
@@ -544,14 +549,15 @@ public class UIUtilTest extends ObaTestCase {
      */
     @Test
     public void testGetAllSituations() throws Exception {
-        PreferencesEntryPoint.get(InstrumentationRegistry.getInstrumentation().getTargetContext())
+        final Context targetContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        PreferencesEntryPoint.get(targetContext)
                 .setString(R.string.preference_key_oba_api_url, "sdmts.onebusway.org/api");
 
         /**
          * Test route-specific alerts only
          */
         ObaEnvelope<EntryWithReferences<ArrivalsForStop>> env = ArrivalsFixtures.load(
-                InstrumentationRegistry.getInstrumentation().getTargetContext(), "arrivals_and_departures_for_stop_mts_11670_route_alerts");
+                targetContext, "arrivals_and_departures_for_stop_mts_11670_route_alerts");
         // No stop-specific alerts; route alerts don't appear in the entry's situations - see #700.
         assertEquals(0, ArrivalsFixtures.stopSituations(env).size());
 
@@ -577,7 +583,7 @@ public class UIUtilTest extends ObaTestCase {
          */
 
         env = ArrivalsFixtures.load(
-                InstrumentationRegistry.getInstrumentation().getTargetContext(), "arrivals_and_departures_for_stop_mts_13353_route_and_stop_alerts");
+                targetContext, "arrivals_and_departures_for_stop_mts_13353_route_and_stop_alerts");
         // One stop alert in the entry; route alerts excluded - see #700.
         assertEquals(1, ArrivalsFixtures.stopSituations(env).size());
 
@@ -601,7 +607,7 @@ public class UIUtilTest extends ObaTestCase {
         Test filtering routes alerts
          */
         env = ArrivalsFixtures.load(
-                InstrumentationRegistry.getInstrumentation().getTargetContext(), "arrivals_and_departures_for_stop_mts_11671_filter_route_alerts");
+                targetContext, "arrivals_and_departures_for_stop_mts_11671_filter_route_alerts");
 
         List<String> routeFilters = new ArrayList<>();
         routeFilters.add("MTS_1");

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/util/test/UIUtilTest.java
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/util/test/UIUtilTest.java
@@ -18,7 +18,7 @@
 package org.onebusaway.android.util.test;
 
 import androidx.core.util.Pair;
-import androidx.test.runner.AndroidJUnit4;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -44,7 +44,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 
-import static androidx.test.InstrumentationRegistry.getTargetContext;
+import androidx.test.platform.app.InstrumentationRegistry;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertNotNull;
@@ -155,7 +155,7 @@ public class UIUtilTest extends ObaTestCase {
         routeDisplayNames.add("5");
 
         // Test without stop nickname or direction
-        stopDetails = StopDetailsDialog.createStopDetailsDialogText(getTargetContext(),
+        stopDetails = StopDetailsDialog.createStopDetailsDialogText(InstrumentationRegistry.getInstrumentation().getTargetContext(),
                 stopName,
                 stopUserName,
                 stopCode,
@@ -170,7 +170,7 @@ public class UIUtilTest extends ObaTestCase {
 
         // Test with stop nickname and without direction
         stopUserName = "My stop nickname";
-        stopDetails = StopDetailsDialog.createStopDetailsDialogText(getTargetContext(),
+        stopDetails = StopDetailsDialog.createStopDetailsDialogText(InstrumentationRegistry.getInstrumentation().getTargetContext(),
                 stopName,
                 stopUserName,
                 stopCode,
@@ -188,7 +188,7 @@ public class UIUtilTest extends ObaTestCase {
         // Test without stop nickname and with direction
         stopUserName = null;
         stopDirection = "S";
-        stopDetails = StopDetailsDialog.createStopDetailsDialogText(getTargetContext(),
+        stopDetails = StopDetailsDialog.createStopDetailsDialogText(InstrumentationRegistry.getInstrumentation().getTargetContext(),
                 stopName,
                 stopUserName,
                 stopCode,
@@ -200,13 +200,13 @@ public class UIUtilTest extends ObaTestCase {
         expectedMessage.append(newLine);
         expectedMessage.append("Routes: " + routeDisplayNames.get(0));
         expectedMessage.append(newLine);
-        expectedMessage.append(getTargetContext().getString(DisplayFormat.getStopDirectionText(stopDirection)));
+        expectedMessage.append(InstrumentationRegistry.getInstrumentation().getTargetContext().getString(DisplayFormat.getStopDirectionText(stopDirection)));
         assertEquals(expectedMessage.toString(), (String) stopDetails.second);
 
         // Test with stop nickname and direction
         stopUserName = "My stop nickname";
         stopDirection = "S";
-        stopDetails = StopDetailsDialog.createStopDetailsDialogText(getTargetContext(),
+        stopDetails = StopDetailsDialog.createStopDetailsDialogText(InstrumentationRegistry.getInstrumentation().getTargetContext(),
                 stopName,
                 stopUserName,
                 stopCode,
@@ -220,19 +220,19 @@ public class UIUtilTest extends ObaTestCase {
         expectedMessage.append(newLine);
         expectedMessage.append("Routes: " + routeDisplayNames.get(0));
         expectedMessage.append(newLine);
-        expectedMessage.append(getTargetContext().getString(DisplayFormat.getStopDirectionText(stopDirection)));
+        expectedMessage.append(InstrumentationRegistry.getInstrumentation().getTargetContext().getString(DisplayFormat.getStopDirectionText(stopDirection)));
         assertEquals(expectedMessage.toString(), (String) stopDetails.second);
     }
 
     @Test
     public void testArrivalTimeIndexSearch() throws Exception {
         // Load a captured arrivals fixture and project it via the production DTO path
-        Region tampa = MockRegion.getTampa(getTargetContext());
+        Region tampa = MockRegion.getTampa(InstrumentationRegistry.getInstrumentation().getTargetContext());
         assertNotNull(tampa);
-        RegionEntryPoint.get(getTargetContext()).applyRegion(tampa, true);
+        RegionEntryPoint.get(InstrumentationRegistry.getInstrumentation().getTargetContext()).applyRegion(tampa, true);
 
         ObaEnvelope<EntryWithReferences<ArrivalsForStop>> env =
-                ArrivalsFixtures.load(getTargetContext(), "arrivals_and_departures_for_stop_hart_6497");
+                ArrivalsFixtures.load(InstrumentationRegistry.getInstrumentation().getTargetContext(), "arrivals_and_departures_for_stop_hart_6497");
         String stopId = "Hillsborough Area Regional Transit_6497";
 
         // The two favorited route/headsign combos. Favorite state is supplied to convert() directly
@@ -243,7 +243,7 @@ public class UIUtilTest extends ObaTestCase {
                 "Hillsborough Area Regional Transit_6|South to Downtown/MTC"));
 
         // Project the fixture's arrivals via the production path, with those two marked favorite.
-        ArrayList<ArrivalInfo> arrivalInfo = ArrivalsFixtures.convert(getTargetContext(), env, true,
+        ArrayList<ArrivalInfo> arrivalInfo = ArrivalsFixtures.convert(InstrumentationRegistry.getInstrumentation().getTargetContext(), env, true,
                 (routeId, headsign, sid) -> favorites.contains(routeId + "|" + headsign));
 
         // Now confirm that we have the correct number of elements, and values for ETAs for the test
@@ -261,7 +261,7 @@ public class UIUtilTest extends ObaTestCase {
         assertEquals(13, preferredArrivalIndexes.get(1).intValue());
 
         // With no favorites, the first two non-negative arrival times are returned - indexes 5 and 6.
-        arrivalInfo = ArrivalsFixtures.convert(getTargetContext(), env, true);
+        arrivalInfo = ArrivalsFixtures.convert(InstrumentationRegistry.getInstrumentation().getTargetContext(), env, true);
         preferredArrivalIndexes = ArrivalInfoUtils.findPreferredArrivalIndexes(arrivalInfo);
         assertEquals(5, preferredArrivalIndexes.get(0).intValue());
         assertEquals(6, preferredArrivalIndexes.get(1).intValue());
@@ -273,17 +273,17 @@ public class UIUtilTest extends ObaTestCase {
     @Test
     public void testArrivalInfoLabels() throws Exception {
         // Load a captured arrivals fixture and project it via the production DTO path
-        Region tampa = MockRegion.getTampa(getTargetContext());
+        Region tampa = MockRegion.getTampa(InstrumentationRegistry.getInstrumentation().getTargetContext());
         assertNotNull(tampa);
-        RegionEntryPoint.get(getTargetContext()).applyRegion(tampa, true);
+        RegionEntryPoint.get(InstrumentationRegistry.getInstrumentation().getTargetContext()).applyRegion(tampa, true);
 
         ObaEnvelope<EntryWithReferences<ArrivalsForStop>> env =
-                ArrivalsFixtures.load(getTargetContext(), "arrivals_and_departures_for_stop_hart_6497");
+                ArrivalsFixtures.load(InstrumentationRegistry.getInstrumentation().getTargetContext(), "arrivals_and_departures_for_stop_hart_6497");
 
         /**
          * Labels *with* arrive/depart included, and time labels
          */
-        ArrayList<ArrivalInfo> arrivalInfo = ArrivalsFixtures.convert(getTargetContext(), env, true);
+        ArrayList<ArrivalInfo> arrivalInfo = ArrivalsFixtures.convert(InstrumentationRegistry.getInstrumentation().getTargetContext(), env, true);
 
         // Now confirm that we have the correct number of elements, and values for ETAs for the test
         validateUatcArrivalInfo(arrivalInfo);
@@ -384,7 +384,7 @@ public class UIUtilTest extends ObaTestCase {
         /**
          * Status labels *without* arrive/depart included
          */
-        arrivalInfo = ArrivalsFixtures.convert(getTargetContext(), env, false);
+        arrivalInfo = ArrivalsFixtures.convert(InstrumentationRegistry.getInstrumentation().getTargetContext(), env, false);
 
         // Now confirm that we have the correct number of elements, and values for ETAs for the test
         validateUatcArrivalInfo(arrivalInfo);
@@ -535,7 +535,7 @@ public class UIUtilTest extends ObaTestCase {
     }
 
     private String formatTime(long time) {
-        return DisplayFormat.formatTime(getTargetContext(), time);
+        return DisplayFormat.formatTime(InstrumentationRegistry.getInstrumentation().getTargetContext(), time);
     }
 
     /**
@@ -544,14 +544,14 @@ public class UIUtilTest extends ObaTestCase {
      */
     @Test
     public void testGetAllSituations() throws Exception {
-        PreferencesEntryPoint.get(getTargetContext())
+        PreferencesEntryPoint.get(InstrumentationRegistry.getInstrumentation().getTargetContext())
                 .setString(R.string.preference_key_oba_api_url, "sdmts.onebusway.org/api");
 
         /**
          * Test route-specific alerts only
          */
         ObaEnvelope<EntryWithReferences<ArrivalsForStop>> env = ArrivalsFixtures.load(
-                getTargetContext(), "arrivals_and_departures_for_stop_mts_11670_route_alerts");
+                InstrumentationRegistry.getInstrumentation().getTargetContext(), "arrivals_and_departures_for_stop_mts_11670_route_alerts");
         // No stop-specific alerts; route alerts don't appear in the entry's situations - see #700.
         assertEquals(0, ArrivalsFixtures.stopSituations(env).size());
 
@@ -577,7 +577,7 @@ public class UIUtilTest extends ObaTestCase {
          */
 
         env = ArrivalsFixtures.load(
-                getTargetContext(), "arrivals_and_departures_for_stop_mts_13353_route_and_stop_alerts");
+                InstrumentationRegistry.getInstrumentation().getTargetContext(), "arrivals_and_departures_for_stop_mts_13353_route_and_stop_alerts");
         // One stop alert in the entry; route alerts excluded - see #700.
         assertEquals(1, ArrivalsFixtures.stopSituations(env).size());
 
@@ -601,7 +601,7 @@ public class UIUtilTest extends ObaTestCase {
         Test filtering routes alerts
          */
         env = ArrivalsFixtures.load(
-                getTargetContext(), "arrivals_and_departures_for_stop_mts_11671_filter_route_alerts");
+                InstrumentationRegistry.getInstrumentation().getTargetContext(), "arrivals_and_departures_for_stop_mts_11671_filter_route_alerts");
 
         List<String> routeFilters = new ArrayList<>();
         routeFilters.add("MTS_1");

--- a/onebusaway-android/src/main/java/org/onebusaway/android/analytics/AnalyticsProvider.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/analytics/AnalyticsProvider.kt
@@ -39,7 +39,7 @@ import org.onebusaway.android.region.RegionRepository
  */
 @Singleton
 class AnalyticsProvider @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
     regionRepository: RegionRepository,
     @AppScope scope: CoroutineScope,
 ) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/analytics/ObaAnalytics.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/analytics/ObaAnalytics.kt
@@ -37,7 +37,7 @@ import org.onebusaway.android.preferences.PreferencesRepository
  */
 @Singleton
 class ObaAnalytics @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
     private val analyticsProvider: AnalyticsProvider,
     private val preferences: PreferencesRepository,
     private val firebase: FirebaseAnalytics,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/net/ObaEndpointResolver.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/net/ObaEndpointResolver.kt
@@ -35,7 +35,7 @@ import org.onebusaway.android.region.RegionRepository
  */
 @Singleton
 class ObaEndpointResolver @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
     private val regionRepository: RegionRepository,
     private val preferences: PreferencesRepository,
 ) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/database/oba/ImportGate.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/database/oba/ImportGate.kt
@@ -61,7 +61,7 @@ interface ImportGate {
 
 @Singleton
 class DefaultImportGate @Inject constructor(
-    @AppScope private val appScope: CoroutineScope,
+    @param:AppScope private val appScope: CoroutineScope,
     private val importer: LegacyDataImporter,
 ) : ImportGate {
     private val ready: Deferred<Unit> by lazy {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/database/oba/RouteRecorder.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/database/oba/RouteRecorder.kt
@@ -30,7 +30,7 @@ import org.onebusaway.android.util.MyTextUtils
  */
 @Singleton
 class RouteRecorder @Inject constructor(
-    @AppScope private val appScope: CoroutineScope,
+    @param:AppScope private val appScope: CoroutineScope,
     private val routeDao: RouteDao,
     private val regionRepository: RegionRepository,
     private val importGate: ImportGate,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/ConversionUtils.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/ConversionUtils.kt
@@ -21,6 +21,7 @@ import android.text.TextUtils
 import android.text.style.ForegroundColorSpan
 import android.text.style.StrikethroughSpan
 import android.util.Log
+import androidx.core.content.ContextCompat
 import org.onebusaway.android.R
 import org.onebusaway.android.util.ArrivalInfoUtils
 import org.onebusaway.android.util.PreferenceUtils
@@ -373,7 +374,8 @@ object ConversionUtils {
             applicationContext.resources.getString(R.string.time_connector_before_time) + " "
         val timezone: CharSequence = noDeviceTimezoneNote
 
-        val color = applicationContext.resources.getColor(
+        val color = ContextCompat.getColor(
+            applicationContext,
             ArrivalInfoUtils.computeColorFromDeviation(newTime - oldTime)
         )
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/DirectionsGenerator.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/DirectionsGenerator.kt
@@ -465,7 +465,6 @@ class DirectionsGenerator(
                         resources.getString(R.string.step_by_step_non_transit_dir_relative_uturn_left)
                     RelativeDirection.UTURN_RIGHT ->
                         resources.getString(R.string.step_by_step_non_transit_dir_relative_uturn_right)
-                    else -> null
                 }
             }
             return null
@@ -491,7 +490,6 @@ class DirectionsGenerator(
                         resources.getString(R.string.step_by_step_non_transit_dir_absolute_southwest)
                     AbsoluteDirection.WEST ->
                         resources.getString(R.string.step_by_step_non_transit_dir_absolute_west)
-                    else -> null
                 }
             }
             return null

--- a/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/ScheduleReplayExtrapolator.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/ScheduleReplayExtrapolator.kt
@@ -61,7 +61,7 @@ fun replaySchedule(
         queryTime: WallTime
 ): Double? {
     val dtSec = (queryTime - lastTime).toDouble(DurationUnit.SECONDS)
-    val stopTimes = schedule.stopTimes ?: return null
+    val stopTimes = schedule.stopTimes
     if (stopTimes.size < 2 || dtSec < 0) return null
 
     val segIdx =

--- a/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/TripExtrapolationBuilder.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/TripExtrapolationBuilder.kt
@@ -118,7 +118,7 @@ fun extrapolatedVehicles(
         // fix's flag, a point taken from the current status uses that status'. This keeps the marker
         // from reading "scheduled" for a vehicle we're actively tracking/extrapolating (#1621).
         val isRealtime = if (projection != null) {
-            state?.anchor?.isLocationRealtime == true
+            state.anchor?.isLocationRealtime == true
         } else {
             status.isLocationRealtime
         }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/location/LocationRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/location/LocationRepository.kt
@@ -115,7 +115,7 @@ interface LocationSink {
  */
 @Singleton
 class DefaultLocationRepository @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
 ) : LocationRepository, LocationSink {
 
     private val _location = MutableStateFlow<Location?>(null)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
@@ -100,7 +100,7 @@ class MapViewModel @Inject constructor(
     private val prefsRepository: PreferencesRepository,
     private val tripObservationRepository: TripObservationRepository,
     private val stopDao: StopDao,
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
 ) : ViewModel() {
 
     // The flavor-neutral map surface: render state + camera + padding + generic markers +

--- a/onebusaway-android/src/main/java/org/onebusaway/android/nav/NavigationService.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/nav/NavigationService.kt
@@ -488,7 +488,7 @@ class NavigationService : Service() {
 
         // Then enqueue the recurring task under a unique name so repeated navigation starts keep a
         // single cleanup chain instead of stacking one each time:
-        WorkManager.getInstance().enqueueUniquePeriodicWork(
+        WorkManager.getInstance(applicationContext).enqueueUniquePeriodicWork(
             NavigationCleanupWorker.UNIQUE_WORK_NAME,
             ExistingPeriodicWorkPolicy.KEEP,
             cleanUpCheckWork

--- a/onebusaway-android/src/main/java/org/onebusaway/android/preferences/PreferencesRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/preferences/PreferencesRepository.kt
@@ -137,9 +137,9 @@ interface PreferencesRepository {
  * read [dataStore]`.data` directly via the `observe*` methods, so they don't need the cache.
  */
 class DefaultPreferencesRepository @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
     private val dataStore: DataStore<Preferences>,
-    @AppScope private val scope: CoroutineScope,
+    @param:AppScope private val scope: CoroutineScope,
 ) : PreferencesRepository {
 
     // Seeded synchronously so the first synchronous read (e.g. from Application.onCreate) sees real

--- a/onebusaway-android/src/main/java/org/onebusaway/android/region/RegionCache.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/region/RegionCache.kt
@@ -34,7 +34,7 @@ import org.onebusaway.android.util.RegionUtils
  */
 @Singleton
 class RegionCache @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
     private val regionDao: RegionDao,
     private val importGate: ImportGate,
     private val prefs: PreferencesRepository,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/region/RegionRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/region/RegionRepository.kt
@@ -142,11 +142,11 @@ private const val TAG = "RegionRepository"
  */
 @Singleton
 class DefaultRegionRepository @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
     private val prefs: PreferencesRepository,
     private val locationRepository: LocationRepository,
     private val regionCache: RegionCache,
-    @AppScope private val appScope: CoroutineScope,
+    @param:AppScope private val appScope: CoroutineScope,
 ) : RegionRepository {
 
     // Seeded null and then asynchronously from the region cache once the one-time import has run — the

--- a/onebusaway-android/src/main/java/org/onebusaway/android/reminders/ReminderRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/reminders/ReminderRepository.kt
@@ -35,8 +35,8 @@ import org.onebusaway.android.util.ReminderUtils
  */
 @Singleton
 class ReminderRepository @Inject constructor(
-    @ApplicationContext private val context: Context,
-    @AppScope private val appScope: CoroutineScope,
+    @param:ApplicationContext private val context: Context,
+    @param:AppScope private val appScope: CoroutineScope,
     private val tripDao: TripDao,
     private val importGate: ImportGate,
 ) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsRepository.kt
@@ -238,7 +238,7 @@ data class AlertDetails(
  * which would share `lastGood` across stops and corrupt per-stop state.
  */
 class DefaultArrivalsRepository @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
     private val regionRepository: RegionRepository,
     private val routeRepository: RouteDataSource,
     private val stopArrivals: StopArrivalsDataSource,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/feedback/Feedback.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/feedback/Feedback.kt
@@ -174,7 +174,7 @@ class FeedbackSubmitter(
         val uploadCheckWork = PeriodicWorkRequest
             .Builder(NavigationUploadWorker::class.java, 24, TimeUnit.HOURS)
             .build()
-        WorkManager.getInstance().enqueueUniquePeriodicWork(
+        WorkManager.getInstance(context).enqueueUniquePeriodicWork(
             NavigationUploadWorker.UNIQUE_WORK_NAME,
             ExistingPeriodicWorkPolicy.KEEP,
             uploadCheckWork

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
@@ -362,7 +362,7 @@ sealed interface HomeAnalyticsEvent {
     data class RegionSelected(val regionName: String) : HomeAnalyticsEvent
 
     /** A nav-drawer / help-menu selection identified by its analytics label string resource. */
-    data class MenuItem(@StringRes val labelRes: Int) : HomeAnalyticsEvent
+    data class MenuItem(@param:StringRes val labelRes: Int) : HomeAnalyticsEvent
 }
 
 /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/weather/WeatherRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/weather/WeatherRepository.kt
@@ -43,7 +43,7 @@ interface WeatherRepository {
  * response without a current forecast all map to [Result.failure] (matching the legacy AsyncTask).
  */
 class DefaultWeatherRepository @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
     private val regionRepository: RegionRepository,
     private val weatherService: WeatherWebService,
 ) : WeatherRepository {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/mylists/MyListModels.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/mylists/MyListModels.kt
@@ -48,7 +48,7 @@ sealed interface StopArrivals {
 /** One "route · ETA" arrival badge; [colorRes] is the lateness color. */
 data class ArrivalBadge(
     val text: String,
-    @ColorRes val colorRes: Int
+    @param:ColorRes val colorRes: Int
 )
 
 /** A route row for the My-tab starred/recent lists. */

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/mylists/MyTabsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/mylists/MyTabsScreen.kt
@@ -48,7 +48,7 @@ import org.onebusaway.android.R
 import org.onebusaway.android.ui.compose.components.ObaTopAppBar
 
 /** A labelled overflow action (the per-tab "Clear" item) for [MyTab]. */
-data class TabAction(@StringRes val labelRes: Int, val onClick: () -> Unit)
+data class TabAction(@param:StringRes val labelRes: Int, val onClick: () -> Unit)
 
 /**
  * One tab in a [MyTabsScreen]: its stable [tag] (deep-link / last-tab persistence), [titleRes] +
@@ -57,8 +57,8 @@ data class TabAction(@StringRes val labelRes: Int, val onClick: () -> Unit)
  */
 data class MyTab(
     val tag: String,
-    @StringRes val titleRes: Int,
-    @DrawableRes val iconRes: Int,
+    @param:StringRes val titleRes: Int,
+    @param:DrawableRes val iconRes: Int,
     val onSort: (() -> Unit)? = null,
     val clear: TabAction? = null,
     val content: @Composable () -> Unit,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/regions/RegionsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/regions/RegionsRepository.kt
@@ -71,7 +71,7 @@ interface RegionsRepository {
  * stays JVM-testable.
  */
 class DefaultRegionsRepository @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
     private val prefs: PreferencesRepository,
     private val regionRepository: RegionRepository,
     private val regionCache: RegionCache,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/report/infrastructure/InfrastructureControls.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/report/infrastructure/InfrastructureControls.kt
@@ -26,7 +26,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.MenuAnchorType
+import androidx.compose.material3.ExposedDropdownMenuAnchorType
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -124,7 +124,7 @@ private fun ServiceSpinner(
             trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
             modifier = Modifier
                 .fillMaxWidth()
-                .menuAnchor(MenuAnchorType.PrimaryNotEditable)
+                .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable)
         )
         ExposedDropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
             services.forEachIndexed { index, item ->

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/report/open311/Open311Screen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/report/open311/Open311Screen.kt
@@ -340,7 +340,7 @@ private fun rememberThumbnail(path: String?): ImageBitmap? {
         } else {
             withContext(Dispatchers.IO) {
                 runCatching {
-                    BitmapUtils.decodeSampledBitmapFromFile(path, 192, 192)?.asImageBitmap()
+                    BitmapUtils.decodeSampledBitmapFromFile(path, 192, 192).asImageBitmap()
                 }.getOrNull()
             }
         }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/report/problem/ProblemReportScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/report/problem/ProblemReportScreen.kt
@@ -27,7 +27,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.MenuAnchorType
+import androidx.compose.material3.ExposedDropdownMenuAnchorType
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -138,7 +138,7 @@ private fun ProblemCodeDropdown(
             trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
             modifier = Modifier
                 .fillMaxWidth()
-                .menuAnchor(MenuAnchorType.PrimaryNotEditable)
+                .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable)
         )
         ExposedDropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
             codes.forEachIndexed { index, code ->

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/report/types/ReportTypeRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/report/types/ReportTypeRepository.kt
@@ -35,7 +35,7 @@ interface ReportTypeRepository {
  * applies the region-email gate via [ReportTypeGate].
  */
 class DefaultReportTypeRepository @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
     private val regionRepository: RegionRepository,
 ) : ReportTypeRepository {
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/routeinfo/RouteInfoRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/routeinfo/RouteInfoRepository.kt
@@ -53,7 +53,7 @@ interface RouteInfoRepository {
  * quarantined here so [RouteInfoViewModel] stays JVM-testable.
  */
 class DefaultRouteInfoRepository @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
     private val regionRepository: RegionRepository,
     private val routeRepository: RouteDataSource,
     private val routeStopsRepository: RouteStopsDataSource,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/searchresults/SearchResultsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/searchresults/SearchResultsRepository.kt
@@ -47,7 +47,7 @@ interface SearchResultsRepository {
  * stays JVM-testable.
  */
 class DefaultSearchResultsRepository @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
     private val search: LocationSearchDataSource,
     private val stopDao: StopDao,
     private val importGate: ImportGate,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/settings/AdvancedSettingsViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/settings/AdvancedSettingsViewModel.kt
@@ -55,7 +55,7 @@ sealed interface AdvancedSettingsEffect {
  */
 @HiltViewModel
 class AdvancedSettingsViewModel @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
     private val prefs: PreferencesRepository,
     private val regionRepository: RegionRepository,
     private val donationsManager: DonationsManager,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/settings/SettingsViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/settings/SettingsViewModel.kt
@@ -59,7 +59,7 @@ sealed interface SettingsEffect {
  */
 @HiltViewModel
 class SettingsViewModel @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
     private val prefs: PreferencesRepository,
     private val regionRepository: RegionRepository,
     private val serviceAlertDao: ServiceAlertDao,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/settings/components/PreferenceItems.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/settings/components/PreferenceItems.kt
@@ -98,7 +98,7 @@ private fun PreferenceRow(
     val clickable = onClick != null && enabled
     val rowModifier = modifier
         .fillMaxWidth()
-        .then(if (clickable) Modifier.clickable(onClick = onClick!!) else Modifier)
+        .then(if (clickable) Modifier.clickable(onClick = onClick) else Modifier)
         .padding(horizontal = 16.dp, vertical = 12.dp)
     val alpha = if (enabled) 1f else DISABLED_ALPHA
     Row(rowModifier, verticalAlignment = Alignment.CenterVertically) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/survey/SurveyPreferences.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/survey/SurveyPreferences.kt
@@ -35,7 +35,7 @@ import org.onebusaway.android.preferences.PreferencesRepository
  */
 @Singleton
 class SurveyPreferences @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
     private val prefs: PreferencesRepository,
 ) {
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/survey/SurveyViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/survey/SurveyViewModel.kt
@@ -85,14 +85,14 @@ sealed interface SurveyEffect {
  */
 @HiltViewModel
 class SurveyViewModel @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
     private val regionRepository: RegionRepository,
     private val prefs: PreferencesRepository,
     private val surveyPreferences: SurveyPreferences,
     private val surveyRepo: SurveyDataSource,
     private val surveyStore: SurveyRepository,
     private val donationsManager: DonationsManager,
-    @AppScope private val appScope: CoroutineScope,
+    @param:AppScope private val appScope: CoroutineScope,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(SurveyUiState())

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/survey/utils/SurveyUtils.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/survey/utils/SurveyUtils.kt
@@ -120,7 +120,7 @@ object SurveyUtils {
         visibleStopsList: List<String>?,
         visibleRouteList: List<String>?
     ): Boolean {
-        if (currentStop == null || currentStop.id == null) return false
+        if (currentStop == null) return false
         // If both visibleStopsList and visibleRouteList are null, show the survey by default.
         if (visibleRouteList == null && visibleStopsList == null) {
             return true
@@ -339,7 +339,7 @@ object SurveyUtils {
      * @return The stop identifier or null if conditions are not met.
      */
     fun getCurrentStopIdentifier(currentStop: ObaStop?, visibleOnStops: Boolean): String? {
-        return if (currentStop != null && currentStop.id != null && visibleOnStops) {
+        return if (currentStop != null && visibleOnStops) {
             currentStop.id
         } else {
             null

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripdetails/TripDetailsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripdetails/TripDetailsRepository.kt
@@ -97,12 +97,12 @@ data class DestinationReminderStops(val beforeStopId: String, val destinationSto
  * deferred (as in the Compose arrivals rows).
  */
 class DefaultTripDetailsRepository @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
     private val tripDetailsDataSource: TripDetailsDataSource,
     private val stopDao: StopDao,
     private val regionRepository: RegionRepository,
     private val importGate: ImportGate,
-    @AppScope private val appScope: CoroutineScope,
+    @param:AppScope private val appScope: CoroutineScope,
 ) : TripDetailsRepository {
 
     private var lastGood: TripDetails? = null

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripdetails/TripDetailsUiState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripdetails/TripDetailsUiState.kt
@@ -33,7 +33,7 @@ data class TripHeader(
     /** Vehicle id label; null when there's no real-time vehicle. */
     val vehicleId: String?,
     val statusText: String,
-    @ColorRes val statusColor: Int,
+    @param:ColorRes val statusColor: Int,
     /** True when the trip has real-time data (drives the pulsing indicator). */
     val isRealtime: Boolean
 )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripinfo/TripInfoRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripinfo/TripInfoRepository.kt
@@ -93,7 +93,7 @@ interface TripInfoRepository {
 }
 
 class DefaultTripInfoRepository @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
     private val regionRepository: RegionRepository,
     private val reminderService: ReminderWebService,
     private val reminderRepository: ReminderRepository,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripinfo/TripInfoScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripinfo/TripInfoScreen.kt
@@ -39,7 +39,7 @@ import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.MenuAnchorType
+import androidx.compose.material3.ExposedDropdownMenuAnchorType
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -267,7 +267,7 @@ private fun ReminderTimeDropdown(
             trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
             modifier = Modifier
                 .fillMaxWidth()
-                .menuAnchor(MenuAnchorType.PrimaryNotEditable)
+                .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable)
         )
         ExposedDropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
             options.forEachIndexed { index, label ->

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/AdvancedSettingsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/AdvancedSettingsRepository.kt
@@ -33,7 +33,7 @@ interface AdvancedSettingsRepository {
  * that with an injected SharedPreferences is broader preferences work.)
  */
 class DefaultAdvancedSettingsRepository @Inject constructor(
-    @ApplicationContext private val context: Context
+    @param:ApplicationContext private val context: Context
 ) : AdvancedSettingsRepository {
 
     override fun load(): AdvancedSettings {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/GeocodeRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/GeocodeRepository.kt
@@ -39,7 +39,7 @@ interface GeocodeRepository {
  * Runs the blocking work on the IO thread and projects onto the JVM-pure [TripEndpoint.Geocoded].
  */
 class DefaultGeocodeRepository @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
     private val regionRepository: RegionRepository,
 ) : GeocodeRepository {
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanForm.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanForm.kt
@@ -34,7 +34,7 @@ import androidx.compose.material3.InputChip
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
-import androidx.compose.material3.MenuAnchorType
+import androidx.compose.material3.ExposedDropdownMenuAnchorType
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.ui.text.input.VisualTransformation
@@ -229,7 +229,7 @@ private fun EditableAddressField(
             modifier = Modifier
                 .fillMaxWidth()
                 .testTag(tagPrefix + TripPlanTestTags.FIELD_SUFFIX)
-                .menuAnchor(MenuAnchorType.PrimaryEditable)
+                .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryEditable)
         )
         ExposedDropdownMenu(expanded = showMenu, onDismissRequest = { expanded = false }) {
             suggestions.forEach { place ->
@@ -388,7 +388,7 @@ private fun LeavingArrivingDropdown(
             trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
             modifier = Modifier
                 .fillMaxWidth()
-                .menuAnchor(MenuAnchorType.PrimaryNotEditable)
+                .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable)
         )
         ExposedDropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
             DropdownMenuItem(text = { Text(leaving) }, onClick = { expanded = false; onSetArriving(false) })

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanRepository.kt
@@ -59,7 +59,7 @@ interface TripPlanRepository {
  * [Result.failure].
  */
 class DefaultTripPlanRepository @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
     private val prefs: PreferencesRepository,
     private val otpWebService: OtpWebService,
 ) : TripPlanRepository {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsRepository.kt
@@ -44,7 +44,7 @@ interface TripResultsRepository {
     suspend fun directionsFor(itinerary: Itinerary): Result<List<DirectionItem>>
 }
 
-class DefaultTripResultsRepository @Inject constructor(@ApplicationContext private val context: Context) : TripResultsRepository {
+class DefaultTripResultsRepository @Inject constructor(@param:ApplicationContext private val context: Context) : TripResultsRepository {
 
     override suspend fun summarize(
         itineraries: List<Itinerary>

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsRepository.kt
@@ -51,7 +51,7 @@ class DefaultTripResultsRepository @Inject constructor(@param:ApplicationContext
     ): Result<List<ItineraryOption>> = withContext(Dispatchers.IO) {
         runCatching {
             itineraries.map { itinerary ->
-                val durationSec = itinerary.duration.toLong()
+                val durationSec = itinerary.duration
                 ItineraryOption(
                     title = DirectionsGenerator(itinerary.legs, context).itineraryTitle,
                     durationText = ConversionUtils

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/render/MapRenderStateFramingTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/render/MapRenderStateFramingTest.kt
@@ -15,6 +15,7 @@
  */
 package org.onebusaway.android.map.render
 
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
@@ -30,6 +31,7 @@ import org.junit.Test
  * results sheet, a re-created map — isn't dropped), re-fires on an identical value (unlike a StateFlow),
  * and can be cleared; transient gestures are dropped when nothing is listening.
  */
+@OptIn(ExperimentalCoroutinesApi::class)
 class MapRenderStateFramingTest {
 
     @Test


### PR DESCRIPTION
Continues the "Lint cleanup" campaign (#1725, #1726) by eliminating a first, **safe** batch of the Kotlin compiler warnings emitted in CI. Baseline was **192 unique** warnings (1047 raw, deduped across flavors); this clears **~93** of them, in five behavior-preserving slices. The remaining warnings are tracked separately in #1728 (they need their own PRs and on-device verification).

Each commit compiles cleanly (`compileObaGoogleDebug{,UnitTest,AndroidTest}Kotlin` + androidTest Java); no runtime behavior changes.

### Slices
1. **Pin annotation use-site target to `@param:`** (38) — `@ApplicationContext`/`@AppScope`/`@Named`/`@StringRes`/`@DrawableRes`/`@ColorRes` on constructor `val`/`var` params now carry an explicit `@param:` target. This pins today's behavior (param-only) — exactly what Hilt constructor injection reads and what lint already checks — so KSP/Hilt still resolve; no binding changes.
2. **Remove dead null-handling / redundant idioms** (8) — K2's stronger flow analysis flags genuinely-dead constructs: a `!!` under `if (clickable)`, a `state?.` where `projection != null` already implies non-null, a `?.` on a non-null `Bitmap` return, a `?:` on a non-null `stopTimes`, a redundant `.toLong()`, two unreachable `else -> null` in exhaustive enum `when`s, and two dead `ObaStop.id == null` checks (`id` is a non-null type). The `DirectionsGenerator` icon-`when` `else -> {log; -1}` is intentionally **kept** as a caller-facing sentinel.
3. **`MenuAnchorType` rename + test `@OptIn`** (11) — `MenuAnchorType` is a deprecated typealias for `ExposedDropdownMenuAnchorType` (import + 8 call sites); `MapRenderStateFramingTest` opts in to `ExperimentalCoroutinesApi` for `UnconfinedTestDispatcher`/`testScheduler`.
4. **Modernize deprecated AndroidX test APIs** (~35) — `androidx.test.runner.AndroidJUnit4` → `androidx.test.ext.junit.runners.AndroidJUnit4` across 26 test classes (adds the `androidx.test.ext:junit:1.2.1` dependency it lives in); deprecated `androidx.test.InstrumentationRegistry` → `androidx.test.platform.app.InstrumentationRegistry.getInstrumentation().(get)targetContext`, mirroring the form the Room DAO tests already use.
5. **Context-aware `WorkManager.getInstance` + `ContextCompat.getColor`** (3) — pass the available context to the deprecated no-arg `WorkManager.getInstance()`; swap `Resources.getColor(int)` for `ContextCompat.getColor`.

### Deferred (tracked in #1728)
MapLibre annotation API migration (~50), `IntentService`/`WakefulBroadcastReceiver` in `directions/realtime` (~9), the `Survey.study_id` Room FK-index (a schema change), and ~10 runtime-risky main-source deprecations (`NetworkInfo`→`NetworkCapabilities`, `setColorFilter`, Settings constants, `TabRow`→`PrimaryTabRow`, `android.R.string.yes/no`, `CustomAddress` `Locale` ctor).

Squash-merge is fine — the five commits are separated by topic for review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated Android instrumentation tests to use newer AndroidX JUnit runner/context APIs for improved compatibility and reliability.
* **Bug Fixes**
  * Improved survey display behavior when a stop ID is missing.
  * Adjusted schedule replay extrapolation to handle missing stop-time data more consistently.
* **UI/Behavior**
  * Updated dropdown menu anchoring to the latest Compose API across affected screens.
  * Refined time coloring and thumbnail decoding behavior to be more consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->