### PR TITLE
Suppress deprecated maplibre annotation-API warnings (#1728)

### DIFF
--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
@@ -13,6 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+// Classic annotation API (Marker/Polyline/Icon/IconFactory) is deprecated in maplibre 11.x but still
+// functional; file-level so the deprecated *imports* are covered too. Migration tracked in #1728.
+@file:Suppress("DEPRECATION")
+
 package org.onebusaway.android.map.maplibre
 
 import android.content.Context
@@ -69,6 +73,11 @@ import org.onebusaway.android.util.getRouteDisplayName
  *
  * maplibre markers have no per-marker anchor and the classic info window is title/snippet, so the rich
  * Google Compose info windows degrade to a title + snippet here (a deliberate flavor gap).
+ *
+ * The classic annotation API (Marker/Polyline/Icon/IconFactory) is deprecated in maplibre 11.x but
+ * still fully functional. This whole renderer — and the tap/info-window layer it feeds — is built on
+ * it, and the replacement (SymbolManager/LineManager) has no info-window support, so migrating is a
+ * feature-level rewrite (tracked in #1728), not a lint fix. Suppressed file-wide (see the top).
  */
 class MapLibreRenderer(
     private val map: MapLibreMap,

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreStopIcons.java
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreStopIcons.java
@@ -43,7 +43,11 @@ import java.util.Map;
  * StopOverlay. Holds the 9-direction normal + focused bitmap caches and wraps them as maplibre
  * {@link Icon}s; the declarative MapRenderState renderer asks it for an icon per stop. Built once on
  * first use. (maplibre markers have no per-marker anchor, so the direction offset math is dropped.)
+ *
+ * <p>Wraps bitmaps as the deprecated-but-functional classic {@link Icon}/{@link IconFactory}; the move
+ * to the SymbolManager style-image model is part of the feature-level rewrite tracked in issue #1728.
  */
+@SuppressWarnings("deprecation")
 public final class MapLibreStopIcons {
 
     private MapLibreStopIcons() {

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreComposeAdapter.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreComposeAdapter.kt
@@ -83,7 +83,12 @@ private const val FRAME_INTERVAL_NANOS = 8_333_333L
  * Lifecycle note: `addObserver` on an already-STARTED/RESUMED lifecycle synchronously dispatches the
  * upward events, so the MapView still receives `onStart`/`onResume` when it enters composition late.
  * `onCreate` happens once at [remember] time; `onDestroy` happens once in `onDispose`.
+ *
+ * Uses the deprecated-but-functional classic annotation API (setInfoWindowAdapter, and the marker/
+ * info-window click wiring in [wireClicks]). Migrating to SymbolManager/LineManager is a feature-level
+ * rewrite tracked in #1728; suppress the deprecation until then.
  */
+@Suppress("DEPRECATION")
 class MapLibreComposeAdapter : ObaComposeMapAdapter {
 
     @Composable
@@ -237,6 +242,7 @@ class MapLibreComposeAdapter : ObaComposeMapAdapter {
  * open window deep links. The bike content is wrapped in a white bubble ([VehicleInfoWindow] draws its
  * own card, [BikeInfoWindow] is background-free), matching the Google flavor.
  */
+@Suppress("DEPRECATION") // classic Marker/InfoWindow click API; migration tracked in #1728
 private fun wireClicks(
     map: MapLibreMap,
     renderer: MapLibreRenderer,

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreInfoWindows.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreInfoWindows.kt
@@ -13,6 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+// Classic Marker/InfoWindowAdapter API is deprecated in maplibre 11.x but still functional; file-level
+// so the deprecated *import* is covered too. SymbolManager has no info window; migration tracked in #1728.
+@file:Suppress("DEPRECATION")
+
 package org.onebusaway.android.map.maplibre.compose
 
 import android.app.Activity
@@ -38,6 +42,10 @@ import org.onebusaway.android.map.compose.ComposeBitmapRenderer
  * synchronous size, which maplibre anchors correctly on the first frame. [clear] drops the tracked
  * window (a tap away / another marker). Markers with no content (the trip-focus estimate markers) fall
  * through to the SDK's default title window.
+ *
+ * Built on the deprecated-but-functional classic annotation API (Marker/InfoWindowAdapter/selectMarker);
+ * SymbolManager has no info-window equivalent, so replacing it is the feature-level rewrite tracked in
+ * #1728. Suppressed file-wide (see the top).
  */
 class MapLibreInfoWindows(
     private val activity: Activity,


### PR DESCRIPTION
Clears the **~50 maplibre annotation-API deprecation warnings** (part of #1728) via documented suppression, with **zero behavior change**.

### Why suppress rather than migrate
The maplibre flavor's entire marker / polyline / info-window / tap layer (`MapLibreRenderer`, `MapLibreComposeAdapter`, `MapLibreInfoWindows`, `MapLibreStopIcons`) is built on the classic annotation API — `Marker`/`MarkerOptions`/`Polyline`/`PolylineOptions`/`Icon`/`IconFactory`/`InfoWindowAdapter`/`selectMarker`. It depends on classic-annotation semantics the modern API doesn't offer:

- in-place mutation (`marker.position/icon/title`), `Marker` identity as HashMap keys for tap routing, and 120 Hz per-frame position smoothing;
- **info windows** — the shared Compose vehicle/bike bubbles are pre-rendered to bitmaps and shown via the classic `InfoWindow`. The replacement, `SymbolManager`, has **no info-window support at all**; replicating it means a custom Compose overlay tracking each symbol's projected screen position across camera moves.

So migrating off the classic API is a **feature-level rewrite of the map's interaction layer** with real regression risk (info windows, tap hit-testing, smoothing, icon anchoring), not a lint fix. The classic API is deprecated but still fully functional in maplibre 11.5. That migration stays tracked in #1728 to be sliced up as resources allow.

### This change
Adds `@Suppress("DEPRECATION")` / `@SuppressWarnings("deprecation")` scoped to the four `src/maplibre` files, each with a rationale comment pointing at #1728. File-level in the two Kotlin files that *import* deprecated types (so the import lines are covered too); class-level + one function-level (`wireClicks`) in the adapter, which imports none; class-level in the Java icon factory.

The suppressions live in the shared `src/maplibre` source set, so they cover all four brand×maplibre variants.

Diff is annotations and comments only — no logic touched.

### Verification
`:onebusaway-android:compileObaMaplibreDebugKotlin` + `…JavaWithJavac` build clean; **0** warnings remain under `src/maplibre/`. No runtime surface changed, so no on-device pass needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated in-app mapping component notes to clarify use of legacy map annotation and info-window behavior.
  * Added clearer migration context for future map rendering updates.

* **Chores**
  * Suppressed deprecation warnings related to existing map features to keep builds cleaner without changing app behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->