### PR TITLE
Lint cleanup: runtime-risky main-source deprecations (#1728)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/CustomAddress.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/CustomAddress.kt
@@ -132,8 +132,12 @@ class CustomAddress(locale: Locale) : Address(locale) {
         val CREATOR: Parcelable.Creator<CustomAddress> =
             object : Parcelable.Creator<CustomAddress> {
                 override fun createFromParcel(parcel: Parcel): CustomAddress {
-                    val language = parcel.readString()
+                    val language = parcel.readString().orEmpty()
                     val country = parcel.readString()
+                    // Locale.of(...) requires API 34 (> minSdk 23), and Locale.Builder validates
+                    // strictly — it can throw on the lenient, parcel-sourced language/country the
+                    // legacy constructor accepts — so keep the deprecated-but-lenient constructor. #1728
+                    @Suppress("DEPRECATION")
                     val locale = if (!country.isNullOrEmpty()) {
                         Locale(language, country)
                     } else {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/common/Shortcuts.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/common/Shortcuts.kt
@@ -19,11 +19,12 @@ package org.onebusaway.android.ui.common
 import android.content.Context
 import android.content.Intent
 import android.graphics.Canvas
-import android.graphics.PorterDuff
 import android.graphics.drawable.Drawable
 import android.graphics.drawable.LayerDrawable
 import androidx.annotation.DrawableRes
 import androidx.core.content.ContextCompat
+import androidx.core.graphics.BlendModeColorFilterCompat
+import androidx.core.graphics.BlendModeCompat
 import androidx.core.graphics.createBitmap
 import androidx.core.content.pm.ShortcutInfoCompat
 import androidx.core.content.pm.ShortcutManagerCompat
@@ -110,9 +111,9 @@ object Shortcuts {
 
         val drawableIcon: Drawable = ResourcesCompat
             .getDrawable(context.resources, icon, context.theme)!!
-        drawableIcon.setColorFilter(
+        drawableIcon.colorFilter = BlendModeColorFilterCompat.createBlendModeColorFilterCompat(
             ContextCompat.getColor(context, R.color.shortcut_icon),
-            PorterDuff.Mode.SRC_IN
+            BlendModeCompat.SRC_IN
         )
         val drawableBackground: Drawable = ResourcesCompat
             .getDrawable(context.resources, R.drawable.launcher_background, context.theme)!!

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/mylists/MyListClearDialog.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/mylists/MyListClearDialog.kt
@@ -35,8 +35,10 @@ internal fun AppCompatActivity.confirmClear(
         .setTitle(titleRes)
         .setMessage(messageRes)
         .setIcon(android.R.drawable.ic_dialog_alert)
-        .setPositiveButton(android.R.string.yes) { _, _ -> onConfirm() }
-        .setNegativeButton(android.R.string.no, null)
+        // android.R.string.yes/no are deprecated (they already alias "OK"/"Cancel" on modern
+        // platforms); use the app's ok/cancel, which are translated and match that displayed text.
+        .setPositiveButton(R.string.ok) { _, _ -> onConfirm() }
+        .setNegativeButton(R.string.cancel, null)
         .show()
 }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/mylists/MyTabsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/mylists/MyTabsScreen.kt
@@ -30,8 +30,8 @@ import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.PrimaryTabRow
 import androidx.compose.material3.Tab
-import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -117,7 +117,7 @@ fun MyTabsScreen(
         }
     ) { padding ->
         Column(Modifier.fillMaxSize().padding(padding)) {
-            TabRow(selectedTabIndex = pagerState.currentPage) {
+            PrimaryTabRow(selectedTabIndex = pagerState.currentPage) {
                 tabs.forEachIndexed { index, tab ->
                     Tab(
                         selected = pagerState.currentPage == index,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripdetails/DestinationReminder.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripdetails/DestinationReminder.kt
@@ -158,8 +158,13 @@ internal fun rememberDestinationReminderAction(
             askUserToTurnLocationOn()
             return
         }
+        // LOCATION_MODE_HIGH_ACCURACY: Android's location "modes" were deprecated in API 28 (collapsed
+        // to a simple on/off + per-app precision). Reworking this high-accuracy nudge is a UX decision
+        // (tracked in #1728); the legacy setting still reads on devices, so keep it for now.
+        @Suppress("DEPRECATION")
+        val highAccuracyMode = Settings.Secure.LOCATION_MODE_HIGH_ACCURACY
         if (!prefsRepository.getBoolean(R.string.preference_key_never_show_change_location_mode_dialog, false) &&
-            LocationUtils.getLocationMode(context) != Settings.Secure.LOCATION_MODE_HIGH_ACCURACY
+            LocationUtils.getLocationMode(context) != highAccuracyMode
         ) {
             dialogForLocationModeChanges()
         }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/ObaRequestErrors.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/ObaRequestErrors.kt
@@ -19,6 +19,7 @@ package org.onebusaway.android.util
 
 import android.content.Context
 import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
 import android.provider.Settings
 
 import java.net.HttpURLConnection
@@ -129,7 +130,8 @@ object ObaRequestErrors {
             return false
         }
         val cr = context.contentResolver
-        return Settings.System.getInt(cr, Settings.System.AIRPLANE_MODE_ON, 0) != 0
+        // AIRPLANE_MODE_ON moved from Settings.System to Settings.Global in API 17; same value/semantics.
+        return Settings.Global.getInt(cr, Settings.Global.AIRPLANE_MODE_ON, 0) != 0
     }
 
     /**
@@ -146,7 +148,12 @@ object ObaRequestErrors {
         }
         val cm = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
 
-        val activeNetwork = cm.activeNetworkInfo
-        return activeNetwork != null && activeNetwork.isConnectedOrConnecting
+        // Replaces the deprecated activeNetworkInfo.isConnectedOrConnecting: an active network with
+        // INTERNET capability. NetworkCapabilities has no "connecting" state — an active network is
+        // already connected — so this drops the transient connecting case, which is fine here (this
+        // only decides whether a failure should be reported as a connectivity problem).
+        val network = cm.activeNetwork ?: return false
+        val caps = cm.getNetworkCapabilities(network) ?: return false
+        return caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
     }
 }


### PR DESCRIPTION
Clears the "runtime-risky main-source deprecations" bucket of #1728 — the deprecations that touch actual app behavior or UI, handled per-item rather than mechanically. Three topic-separated commits.

### 1. Modern connectivity / airplane-mode / color-filter APIs (real fixes)
- `ObaRequestErrors`: `Settings.System.AIRPLANE_MODE_ON` → `Settings.Global` (moved in API 17, same value); `NetworkInfo.isConnectedOrConnecting` → an active network with `NET_CAPABILITY_INTERNET`. NetworkCapabilities has no "connecting" state, so this drops the transient case — fine here, as it only decides whether a failure is reported as a connectivity problem.
- `Shortcuts`: `Drawable.setColorFilter(int, PorterDuff.Mode)` → `BlendModeColorFilterCompat.createBlendModeColorFilterCompat(color, SRC_IN)` — identical SRC_IN blend on all API levels.

### 2. Suppressed where the replacement would regress (with rationale, tracked in #1728)
- `CustomAddress`: `Locale.of(...)` requires API 34 (> **minSdk 23**), and `Locale.Builder` validates strictly — it can throw on the lenient, parcel-sourced language/country the legacy constructor accepts. Kept the lenient constructor; also read language as non-null (`.orEmpty()`), which fixes the Java type-mismatch warning **and** removes a latent NPE.
- `DestinationReminder`: `LOCATION_MODE_HIGH_ACCURACY` — Android location "modes" were deprecated in API 28 (collapsed to on/off). Reworking the high-accuracy nudge is a UX decision, not a lint fix; the legacy setting still reads on devices.

### 3. User-facing / visual replacements (real fixes — need a look)
- `MyListClearDialog`: `android.R.string.yes/no` are deprecated (they already alias OK/Cancel on modern platforms) → app `R.string.ok`/`R.string.cancel` (translated, match the displayed text). **Wording change** on the "clear all" confirm buttons: Yes/No → OK/Cancel.
- `MyTabsScreen`: the M3 `TabRow` is deprecated → `PrimaryTabRow` (same `tabs` lambda). The default **indicator style changes subtly** (content-width primary indicator vs. full-width underline).

### Scope
Excludes items owned by open PRs off the same base: `getColor`/`MenuAnchorType`/`WorkManager.getInstance`/idioms (#1729) and the realtime `IntentService`/`WakefulBroadcastReceiver`/notification-constant warnings (#1733). Those reappear when compiling this branch only because those PRs aren't merged yet.

### Verification
- `compileObaGoogleDebugKotlin` + `compileObaMaplibreDebugKotlin` build clean; none of the seven target warnings remain in either flavor.
- ⚠️ **Needs on-device verification** (behavior/UI): the connectivity-error path (turn wifi/data off), the launcher shortcut icon tint, the **My\* tab bar** indicator (Starred stops/routes/reminders), and the **clear-list confirm dialog** button text.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network and airplane-mode detection so connection-related error messages are more accurate.
  * Fixed destination reminder behavior to better handle location settings checks.
  * Made shortcut icons and tab navigation display more consistently with modern Android UI styling.
  * Improved dialog button labels to use the app’s translated text instead of outdated system labels.
  * Enhanced locale handling to reduce issues when saved language data is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->