### PR TITLE
Lint cleanup: BundleCompat, NotificationCompat flags, dead assertions (#1728)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/realtime/RealtimeChecker.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/realtime/RealtimeChecker.kt
@@ -17,7 +17,6 @@ package org.onebusaway.android.directions.realtime
 
 import android.app.Activity
 import android.app.AlarmManager
-import android.app.Notification
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
@@ -26,6 +25,7 @@ import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import androidx.core.app.NotificationCompat
+import androidx.core.os.BundleCompat
 import org.onebusaway.android.R
 import org.onebusaway.android.app.di.TripPlanRepositoryEntryPoint
 import org.onebusaway.android.directions.model.ItineraryDescription
@@ -265,16 +265,17 @@ class RealtimeChecker(private val context: Context) {
             .setContentText(messageText)
             .setPriority(NotificationCompat.PRIORITY_MAX)
             .setContentIntent(openPendingIntent)
+            .setAutoCancel(true)
+            // Sound/vibration/lights for pre-O; on O+ the TRIP_PLAN_UPDATES channel governs these and
+            // NotificationCompat ignores the defaults. (Replaces the deprecated raw Notification.defaults
+            // / FLAG_SHOW_LIGHTS — DEFAULT_ALL already includes lights.)
+            .setDefaults(NotificationCompat.DEFAULT_ALL)
 
         val notificationManager =
             context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-        val notification = mBuilder.build()
-        notification.defaults = Notification.DEFAULT_ALL
-        notification.flags =
-            notification.flags or Notification.FLAG_AUTO_CANCEL or Notification.FLAG_SHOW_LIGHTS
 
         val notificationId = description.id
-        notificationManager.notify(notificationId, notification)
+        notificationManager.notify(notificationId, mBuilder.build())
     }
 
     // If the end time for this itinerary has passed, disable trip updates.
@@ -320,7 +321,8 @@ class RealtimeChecker(private val context: Context) {
     fun getItinerary(bundle: Bundle): Itinerary? {
         @Suppress("UNCHECKED_CAST")
         val itineraries =
-            bundle.getSerializable(OTPConstants.ITINERARIES) as? ArrayList<Itinerary>
+            BundleCompat.getSerializable(bundle, OTPConstants.ITINERARIES, ArrayList::class.java)
+                as? ArrayList<Itinerary>
         if (itineraries.isNullOrEmpty()) {
             return null
         }
@@ -387,9 +389,9 @@ class RealtimeChecker(private val context: Context) {
 
         val ids = idList.toTypedArray()
         extras.putStringArray(ITINERARY_DESC, ids)
-        extras.putLong(ITINERARY_END_DATE, desc.endDate!!.toEpochMilli())
+        extras.putLong(ITINERARY_END_DATE, desc.endDate.toEpochMilli())
 
-        val source = params.getSerializable(OTPConstants.NOTIFICATION_TARGET) as? Class<*>
+        val source = BundleCompat.getSerializable(params, OTPConstants.NOTIFICATION_TARGET, Class::class.java)
         if (source == null) {
             Log.e(
                 TAG, "getSimplifiedBundle: NOTIFICATION_TARGET is missing from params, " +

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/TripRequestBuilder.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/TripRequestBuilder.kt
@@ -17,6 +17,7 @@ package org.onebusaway.android.directions.util
 
 import android.content.Context
 import android.os.Bundle
+import androidx.core.os.BundleCompat
 import android.text.TextUtils
 import android.util.Log
 import org.onebusaway.android.R
@@ -66,10 +67,10 @@ class TripRequestBuilder(context: Context, private val mBundle: Bundle) {
     }
 
     val from: CustomAddress?
-        get() = mBundle.getParcelable(FROM_ADDRESS)
+        get() = BundleCompat.getParcelable(mBundle, FROM_ADDRESS, CustomAddress::class.java)
 
     val to: CustomAddress?
-        get() = mBundle.getParcelable(TO_ADDRESS)
+        get() = BundleCompat.getParcelable(mBundle, TO_ADDRESS, CustomAddress::class.java)
 
     fun setTo(to: CustomAddress): TripRequestBuilder {
         mBundle.putParcelable(TO_ADDRESS, to)
@@ -84,7 +85,7 @@ class TripRequestBuilder(context: Context, private val mBundle: Bundle) {
     }
 
     private fun getOptimizeType(): OptimizeType {
-        val type = mBundle.getSerializable(OPTIMIZE_TRANSFERS) as? OptimizeType
+        val type = BundleCompat.getSerializable(mBundle, OPTIMIZE_TRANSFERS, OptimizeType::class.java)
         return type ?: OptimizeType.QUICK
     }
 

--- a/onebusaway-android/src/test/java/org/onebusaway/android/api/ArrivalsDecodeTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/api/ArrivalsDecodeTest.kt
@@ -102,7 +102,7 @@ class ArrivalsDecodeTest {
         assertEquals("MANY_SEATS_AVAILABLE", arrival.occupancyStatus)
         assertEquals(listOf("1_sit"), arrival.situationIds)
         assertEquals("default", arrival.tripStatus!!.status)
-        assertEquals(47.6, arrival.tripStatus!!.lastKnownLocation!!.lat, 0.0)
+        assertEquals(47.6, arrival.tripStatus.lastKnownLocation!!.lat, 0.0)
     }
 
     @Test

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripdetails/TripDetailsDecodeTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripdetails/TripDetailsDecodeTest.kt
@@ -86,8 +86,8 @@ class TripDetailsDecodeTest {
         assertEquals("1_s2", status.nextStop)
 
         assertEquals(2, entry.schedule!!.stopTimes.size)
-        assertEquals("1_s1", entry.schedule!!.stopTimes[0].stopId)
-        assertEquals(60180L, entry.schedule!!.stopTimes[0].arrivalTime)
+        assertEquals("1_s1", entry.schedule.stopTimes[0].stopId)
+        assertEquals(60180L, entry.schedule.stopTimes[0].arrivalTime)
 
         // Trip ref uses the wire names tripHeadsign / tripShortName.
         val trip = data.references.trip("1_t")!!


### PR DESCRIPTION
Clears the remaining **actionable** compiler warnings from #1728 — down to just 3 deferred-by-design items (see below). Behavior-preserving.

### Changes
- **BundleCompat** for the deprecated typed `Bundle` getters: `getSerializable`/`getParcelable` → `BundleCompat.getSerializable`/`getParcelable(bundle, key, Class)` in `RealtimeChecker` (itineraries, notification target) and `TripRequestBuilder` (from/to addresses, optimize type). The sanctioned, type-safe replacement.
- **NotificationCompat flags**: `RealtimeChecker`'s trip-update notification set `DEFAULT_ALL` + `FLAG_AUTO_CANCEL`/`FLAG_SHOW_LIGHTS` on the raw built `Notification` (deprecated). Moved onto the `NotificationCompat.Builder` (`setDefaults(DEFAULT_ALL)` + `setAutoCancel(true)`), which applies them pre-O and defers to the notification channel on O+. `DEFAULT_ALL` already includes lights, so the separate `FLAG_SHOW_LIGHTS` is dropped as redundant — no behavior change.
- **Dead `!!`**: removed non-null assertions the compiler flags as redundant — `RealtimeChecker`'s `desc.endDate` (smart-cast non-null after its `== null` guard) and the repeated receiver `!!` in `ArrivalsDecodeTest` / `TripDetailsDecodeTest` (the prior line's `!!` already establishes non-null).

### Remaining (deferred by design, not in this PR)
1. **Room `Survey.study_id` FK index** — a schema change (AppDatabase version bump + `MIGRATION_3_4` + regenerated `4.json`), warrants its own PR alongside the storage-modernization work.
2. **`DirectionsGenerator:576` exhaustive-`when` `else`** — deliberately kept; the `else -> -1` is a caller-facing sentinel.
3. **`ArrivalsScreen:576` `confirmValueChange`** — a real Compose rework (dynamic anchors); the veto approach was previously evaluated and rejected.

### Verification
`compileObaGoogleDebug{,UnitTest,AndroidTest}Kotlin` + `compileObaMaplibreDebugKotlin` build clean; only the 3 deferred warnings above remain across the codebase.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification handling for better compatibility with newer Android versions.
  * Made saved trip and address data loading more reliable, reducing crashes from older/invalid stored values.
  * Tightened arrival and trip-details parsing so data is handled more safely in edge cases.
* **Tests**
  * Updated automated checks to match the safer data-handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->