### PR TITLE
Hide Google map bus-stop icons (redundant with our stop markers)

### DIFF
--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleComposeAdapter.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleComposeAdapter.kt
@@ -389,8 +389,10 @@ private fun resolveMapStyle(context: Context): MapStyleOptions =
     if (ThemeUtils.isInDarkMode(context)) {
         MapStyleOptions.loadRawResourceStyle(context, R.raw.dark_map)
     } else {
-        // Light mode: just hide POIs (ported from GoogleMapHost.onMapReady).
+        // Light mode: hide POIs (ported from GoogleMapHost.onMapReady) and bus-stop icons,
+        // which are redundant with our own stop markers.
         MapStyleOptions(
-            "[{\"featureType\":\"poi\",\"elementType\":\"all\",\"stylers\":[{\"visibility\":\"off\"}]}]"
+            "[{\"featureType\":\"poi\",\"elementType\":\"all\",\"stylers\":[{\"visibility\":\"off\"}]}," +
+                "{\"featureType\":\"transit.station.bus\",\"elementType\":\"all\",\"stylers\":[{\"visibility\":\"off\"}]}]"
         )
     }

--- a/onebusaway-android/src/main/res/raw/dark_map.json
+++ b/onebusaway-android/src/main/res/raw/dark_map.json
@@ -171,6 +171,15 @@
     ]
   },
   {
+    "featureType": "transit.station.bus",
+    "elementType": "all",
+    "stylers": [
+      {
+        "visibility": "off"
+      }
+    ]
+  },
+  {
     "featureType": "water",
     "elementType": "geometry",
     "stylers": [


### PR DESCRIPTION
## Summary

Google map bus stops render as the `transit.station.bus` map feature, which is separate from `poi`. The existing map style only hid `poi` in light mode and colored transit-station labels *on* in dark mode, so Google's built-in bus stops kept drawing right on top of our own stop markers.

This hides `transit.station.bus` in both the light-mode inline style and the `dark_map.json` raw style. It's scoped to bus stations specifically, so rail/ferry station context is preserved.

## Changes
- `GoogleComposeAdapter.kt` — light-mode inline style now hides `transit.station.bus` in addition to `poi`.
- `res/raw/dark_map.json` — added a `transit.station.bus` → `visibility: off` rule (used in dark mode).

## Testing
- Built and installed `obaGoogleDebug`; verified on-device that bus-stop icons no longer appear in both light and dark mode, while our own stop markers remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)