### PR TITLE
Lint cleanup: resolve the final compiler warnings (when-else, confirmValueChange, Room index)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/database/survey/entity/Survey.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/database/survey/entity/Survey.kt
@@ -3,10 +3,15 @@ package org.onebusaway.android.database.survey.entity
 import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.PrimaryKey
+import androidx.room.RoomWarnings
 
 /**
  * Entity class representing a Survey, linked to a Study via a foreign key, with fields for ID, study ID, name, and state.
  */
+// Adding indices = [Index("study_id")] is the right fix, but it's a schema change (DB version bump +
+// migration + regenerated schema JSON), deferred to https://github.com/OneBusAway/onebusaway-android/issues/1739.
+// The surveys table is tiny, so the missing child index has no practical impact today.
+@SuppressWarnings(RoomWarnings.MISSING_INDEX_ON_FOREIGN_KEY_CHILD)
 @Entity(
     tableName = "surveys", foreignKeys = [ForeignKey(
         entity = Study::class,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/DirectionsGenerator.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/DirectionsGenerator.kt
@@ -573,10 +573,9 @@ class DirectionsGenerator(
                 RelativeDirection.SLIGHTLY_RIGHT -> R.drawable.ic_turn_slight_right
                 RelativeDirection.UTURN_LEFT -> R.drawable.ic_uturn_left
                 RelativeDirection.UTURN_RIGHT -> R.drawable.ic_uturn_right
-                else -> {
-                    Log.d(TAG, "No icon for direction: $relDir")
-                    -1
-                }
+                // No else: the when is exhaustive over RelativeDirection, so a future OTP enum
+                // addition surfaces as a compile error here rather than a silent missing icon.
+                // (The caller's -1 initializer still covers the "icon not set" case.)
             }
         }
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsScreen.kt
@@ -573,9 +573,10 @@ private fun AlertList(
  */
 @Composable
 private fun SwipeToHide(onHide: () -> Unit, content: @Composable () -> Unit) {
-    val dismissState = rememberSwipeToDismissBoxState(
-        confirmValueChange = { it == SwipeToDismissBoxValue.StartToEnd }
-    )
+    // Which swipe directions are allowed is expressed by the box's enableDismissFromStartToEnd /
+    // enableDismissFromEndToStart flags below (the modern "leave disallowed anchors out" approach),
+    // replacing the deprecated confirmValueChange veto callback.
+    val dismissState = rememberSwipeToDismissBoxState()
     val rowVisible = remember { MutableTransitionState(true) }
     // Once the row settles in the dismissed position, start the collapse.
     LaunchedEffect(dismissState.currentValue) {


### PR DESCRIPTION
Resolves the last compiler warnings that #1728's cleanup didn't already cover. **With #1736, this brings the codebase to zero Kotlin compiler warnings**, unblocking `allWarningsAsErrors` (#1692).

### Changes
- **`DirectionsGenerator.getRelativeDirectionIcon`** — removed the unreachable `else -> -1` from the exhaustive `when` over `RelativeDirection`. No behavior change: the `-1` "no icon" sentinel comes from the caller's initializer (`var subdirectionIcon = -1`), not this dead branch. Upside: a future OTP enum addition now fails to compile here instead of silently returning a missing icon.
- **`ArrivalsScreen.SwipeToHide`** — the alert-row swipe-to-hide used the deprecated `confirmValueChange` veto to permit only start-to-end. That restriction is already expressed by the box's `enableDismissFromStartToEnd = true` / `enableDismissFromEndToStart = false` (the sanctioned "leave disallowed anchors out" pattern), so the callback is dropped.
- **`Survey` entity** — the Room `study_id` foreign-key-child index warning is silenced with `@SuppressWarnings(RoomWarnings.MISSING_INDEX_ON_FOREIGN_KEY_CHILD)`, pointing at **#1739**. Adding the index is a schema change (version bump + migration + regenerated schema JSON), deferred there; the surveys table is tiny so there's no practical impact today.

### Verification
- `compileObaGoogleDebug{,UnitTest,AndroidTest}Kotlin` + `compileObaMaplibreDebugKotlin` build clean; all three warnings gone.
- ⚠️ **`SwipeToHide` is a gesture interaction — needs on-device verification**: on the arrivals alerts, confirm a full right-swipe hides the row and collapses the space (list glides up), a partial swipe snaps back, and a left-swipe does nothing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved swipe-to-hide behavior so only the intended swipe direction dismisses items, making the interaction more reliable.
  * Tightened direction handling to prevent unexpected fallback behavior.
* **Chores**
  * Updated internal warning handling to reduce unnecessary build warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->