### PR TITLE
CI: strict warnings gate — Kotlin + full-catalog Lint (baseline) (#1692)

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -39,7 +39,7 @@ jobs:
       # compile + API-33 tests can't see (#1692). Runs on the host before the emulator so it
       # fails fast; `check` below keeps skipping lint (-x lint) to avoid running it twice.
       - name: Android Lint
-        run: ./gradlew :onebusaway-android:lintObaGoogleDebug --stacktrace
+        run: ./gradlew :onebusaway-android:lintObaGoogleDebug -PwarningsAsErrors=true --stacktrace
 
       - name: AVD cache
         uses: actions/cache@v4
@@ -71,4 +71,4 @@ jobs:
           target: google_apis
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
-          script: ./gradlew test check connectedObaGoogleDebugAndroidTest -x lint --stacktrace
+          script: ./gradlew test check connectedObaGoogleDebugAndroidTest -x lint -PwarningsAsErrors=true --stacktrace

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,9 +39,14 @@ only prints them. The codebase is kept at **zero** compiler warnings (#1692); do
 - **Android Lint is gated the same way.** Lint *errors* always fail the build (`abortOnError`) —
   notably `NewApi`/minSdk violations the API-33 tests can't catch. Under `-PwarningsAsErrors=true`,
   lint *warnings* fail too (`warningsAsErrors`), so keep lint clean. Reproduce locally with
-  `./gradlew :onebusaway-android:lintObaGoogleDebug -PwarningsAsErrors=true`. Only the default-enabled
-  checks are gated (no `checkAllWarnings`); if an AGP/lint bump floods new warnings, fix them or add a
-  `lint-baseline.xml`.
+  `./gradlew :onebusaway-android:lintObaGoogleDebug -PwarningsAsErrors=true`.
+  - Lint runs the **full catalog** (`checkAllWarnings true`), and the ~760 pre-existing findings are
+    grandfathered in `onebusaway-android/lint-baseline.xml`. Only **new** issues (not in the baseline)
+    are reported — so don't introduce new ones, and prefer fixing over baselining.
+  - After an AGP/lint bump that adds or changes checks, **regenerate the baseline**: delete
+    `lint-baseline.xml` and run `./gradlew :onebusaway-android:lintObaGoogleDebug` (it recreates the
+    file and intentionally fails that one run; the next run passes). Then review the diff before
+    committing so genuinely new issues aren't silently absorbed.
 
 ## Automated Publishing (gradle-play-publisher)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,8 +36,12 @@ only prints them. The codebase is kept at **zero** compiler warnings (#1692); do
 - **Fix the warning at its source.** Only reach for `@Suppress` / `@SuppressWarnings` when the migration
   genuinely can't be done here (e.g. a replacement API that needs a higher `minSdk`, or a schema change),
   and then always add a one-line rationale **and a tracking-issue link** at the suppression site.
-- **Android Lint also fails the build** (`lint { abortOnError true }`) — notably `NewApi`/minSdk
-  violations the API-33 tests can't catch — so keep lint clean too.
+- **Android Lint is gated the same way.** Lint *errors* always fail the build (`abortOnError`) —
+  notably `NewApi`/minSdk violations the API-33 tests can't catch. Under `-PwarningsAsErrors=true`,
+  lint *warnings* fail too (`warningsAsErrors`), so keep lint clean. Reproduce locally with
+  `./gradlew :onebusaway-android:lintObaGoogleDebug -PwarningsAsErrors=true`. Only the default-enabled
+  checks are gated (no `checkAllWarnings`); if an AGP/lint bump floods new warnings, fix them or add a
+  `lint-baseline.xml`.
 
 ## Automated Publishing (gradle-play-publisher)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,20 @@ OneBusAway for Android is a real-time transit information app providing bus arri
 adb shell am start -n com.joulespersecond.seattlebusbot/org.onebusaway.android.ui.HomeActivity
 ```
 
+### CI is strict — warnings fail the build
+
+CI passes `-PwarningsAsErrors=true`, so **every Kotlin compiler warning (`w:`) is a hard error** in CI —
+deprecations, redundant/dead code, unnecessary `!!`, etc. — even though a plain local `./gradlew` build
+only prints them. The codebase is kept at **zero** compiler warnings (#1692); don't regress it.
+
+- Before pushing, compile clean. To reproduce the CI gate locally:
+  `./gradlew :onebusaway-android:compileObaGoogleDebugKotlin -PwarningsAsErrors=true`
+- **Fix the warning at its source.** Only reach for `@Suppress` / `@SuppressWarnings` when the migration
+  genuinely can't be done here (e.g. a replacement API that needs a higher `minSdk`, or a schema change),
+  and then always add a one-line rationale **and a tracking-issue link** at the suppression site.
+- **Android Lint also fails the build** (`lint { abortOnError true }`) — notably `NewApi`/minSdk
+  violations the API-33 tests can't catch — so keep lint clean too.
+
 ## Automated Publishing (gradle-play-publisher)
 
 Uses [gradle-play-publisher](https://github.com/Triple-T/gradle-play-publisher) to auto-increment `versionCode`, build, and upload to Google Play.
@@ -122,7 +136,8 @@ Tests are in `onebusaway-android/src/androidTest/java/`. Key test classes:
 - Region functionality tests (RegionsTest)
 - Utility tests (LocationUtilsTest, RegionUtilTest)
 
-CI runs on API level 33 emulator via GitHub Actions.
+CI runs on API level 33 emulator via GitHub Actions, and is **strict** — Kotlin warnings and Android
+Lint errors both fail the build (see "CI is strict" under Build Commands).
 
 ## Time domains: server clock vs device clock (#1612)
 

--- a/onebusaway-android/build.gradle
+++ b/onebusaway-android/build.gradle
@@ -145,6 +145,12 @@ android {
     kotlin {
         compilerOptions {
             jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+            // Promote Kotlin warnings to errors, but only when -PwarningsAsErrors=true is passed (CI
+            // does; see .github/workflows/android.yml). Local builds default to off, so a Kotlin/AGP
+            // bump that introduces new warnings can't block day-to-day work — it surfaces in CI
+            // instead, where it's addressed. The codebase is at zero warnings as of #1692.
+            allWarningsAsErrors = providers.gradleProperty("warningsAsErrors")
+                .map { it.toBoolean() }.orElse(false)
         }
     }
     testOptions {

--- a/onebusaway-android/build.gradle
+++ b/onebusaway-android/build.gradle
@@ -165,6 +165,13 @@ android {
         // Fail the build (and CI, #1692) on any lint error — notably NewApi minSdk violations,
         // which compile + API-33 instrumented tests can't catch.
         abortOnError true
+        // Under -PwarningsAsErrors=true (CI passes it; see .github/workflows/android.yml), promote lint
+        // warnings to errors too, matching the Kotlin-compiler gate above. Local builds default to off so
+        // an AGP/lint bump that adds new checks surfaces in CI rather than blocking day-to-day work. Kept
+        // WITHOUT checkAllWarnings on purpose — only the default-enabled checks are gated, not lint's full
+        // (opinionated) catalog. If a bump floods new warnings, either fix them or add a lint-baseline.xml.
+        warningsAsErrors = project.hasProperty('warningsAsErrors') &&
+            project.property('warningsAsErrors') == 'true'
     }
 
     useLibrary 'android.test.runner'

--- a/onebusaway-android/build.gradle
+++ b/onebusaway-android/build.gradle
@@ -162,14 +162,22 @@ android {
         // a library-preference nudge, not a correctness signal, and its ~190 hits drown out the
         // actionable warnings, so we opt out of it rather than suppress each call site.
         disable 'MissingTranslation', 'ExtraTranslation', 'LogNotTimber'
+        // Run the FULL lint catalog — including checks that are off by default and library-provided
+        // ones (Compose, UseKtx, …) — so the checked set is comprehensive and current for the installed
+        // lint, not just its (drifting) default-enabled subset. Pre-existing hits are grandfathered by
+        // the baseline below; only NEW issues are reported.
+        checkAllWarnings true
+        // Checked-in record of the issues present when it was generated. New issues aren't in it, so
+        // they're reported (and, under -PwarningsAsErrors, fail the build). After an AGP/lint bump that
+        // adds/changes checks, regenerate it: delete the file and re-run lint (it recreates + passes).
+        baseline = file('lint-baseline.xml')
         // Fail the build (and CI, #1692) on any lint error — notably NewApi minSdk violations,
         // which compile + API-33 instrumented tests can't catch.
         abortOnError true
         // Under -PwarningsAsErrors=true (CI passes it; see .github/workflows/android.yml), promote lint
         // warnings to errors too, matching the Kotlin-compiler gate above. Local builds default to off so
-        // an AGP/lint bump that adds new checks surfaces in CI rather than blocking day-to-day work. Kept
-        // WITHOUT checkAllWarnings on purpose — only the default-enabled checks are gated, not lint's full
-        // (opinionated) catalog. If a bump floods new warnings, either fix them or add a lint-baseline.xml.
+        // an AGP/lint bump that adds new (non-baselined) warnings surfaces in CI rather than blocking
+        // day-to-day work.
         warningsAsErrors = project.hasProperty('warningsAsErrors') &&
             project.property('warningsAsErrors') == 'true'
     }

--- a/onebusaway-android/lint-baseline.xml
+++ b/onebusaway-android/lint-baseline.xml
@@ -1,0 +1,9306 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 9.2.0" type="baseline" client="gradle" dependencies="false" name="AGP (9.2.0)" variant="all" version="9.2.0">
+
+    <issue
+        id="InvalidPackage"
+        message="Invalid package reference in library; not included in Android: `javax.naming.directory`. Referenced from `io.grpc.internal.JndiResourceResolverFactory.JndiRecordFetcher`.">
+        <location
+            file="$GRADLE_USER_HOME/caches/modules-2/files-2.1/io.grpc/grpc-core/1.62.2/5808049a5e33eba6f248a68d58e75399a68f2784/grpc-core-1.62.2.jar"/>
+    </issue>
+
+    <issue
+        id="InvalidPackage"
+        message="Invalid package reference in library; not included in Android: `javax.naming`. Referenced from `io.grpc.internal.JndiResourceResolverFactory.JndiRecordFetcher`.">
+        <location
+            file="$GRADLE_USER_HOME/caches/modules-2/files-2.1/io.grpc/grpc-core/1.62.2/5808049a5e33eba6f248a68d58e75399a68f2784/grpc-core-1.62.2.jar"/>
+    </issue>
+
+    <issue
+        id="MemberExtensionConflict"
+        message="`isActive` is defined both as a member in class `kotlinx.coroutines.Job` and an extension in package `kotlinx.coroutines`. The defined behavior for this is to use the member, but since the extension is explicitly imported into this file, there&apos;s a chance that this was not expected. (One common way this happens is for members to be added to a class after code was already written to use an extension)."
+        errorLine1="        if (routeId != null &amp;&amp; vehicleJob?.isActive != true) {"
+        errorLine2="                                           ~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/map/RouteMapController.kt"
+            line="220"
+            column="44"/>
+    </issue>
+
+    <issue
+        id="ComposableLambdaParameterNaming"
+        message="Composable lambda parameter should be named `content`"
+        errorLine1="    menu: @Composable () -> Unit = {}"
+        errorLine2="    ~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalsPanel.kt"
+            line="314"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ComposableLambdaParameterNaming"
+        message="Composable lambda parameter should be named `content`"
+        errorLine1="    body: @Composable () -> Unit,"
+        errorLine2="    ~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/ui/home/HomeListsDestinations.kt"
+            line="137"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ComposableLambdaParameterNaming"
+        message="Composable lambda parameter should be named `content`"
+        errorLine1="    actions: @Composable RowScope.() -> Unit = {}"
+        errorLine2="    ~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/ui/compose/components/ObaTopAppBar.kt"
+            line="42"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ComposableLambdaParameterNaming"
+        message="Composable lambda parameter should be named `content`"
+        errorLine1="    control: @Composable () -> Unit"
+        errorLine2="    ~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/ui/report/open311/Open311Screen.kt"
+            line="239"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ComposableLambdaParameterNaming"
+        message="Composable lambda parameter should be named `content`"
+        errorLine1="    trailing: (@Composable () -> Unit)? = null,"
+        errorLine2="    ~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/ui/settings/components/PreferenceItems.kt"
+            line="96"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ComposableLambdaParameterNaming"
+        message="Composable lambda parameter should be named `content`"
+        errorLine1="private fun OptionRow(text: String, onClick: () -> Unit, control: @Composable () -> Unit) {"
+        errorLine2="                                                         ~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/ui/survey/SurveyOverlay.kt"
+            line="326"
+            column="58"/>
+    </issue>
+
+    <issue
+        id="PermissionNamingConvention"
+        message="`${applicationId}.permission.TRIP_SERVICE does not follow recommended naming convention`"
+        errorLine1="        android:name=&quot;${applicationId}.permission.TRIP_SERVICE&quot;"
+        errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/AndroidManifest.xml"
+            line="22"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="LogConditional"
+        message="The log call Log.d(...) should be conditional: surround with `if (Log.isLoggable(...))` or `if (BuildConfig.DEBUG) { ... }`"
+        errorLine1="            Log.d(TAG, &quot;Database backup saved successfully to: $uri&quot;)"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/backup/Backup.kt"
+            line="65"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="LogConditional"
+        message="The log call Log.d(...) should be conditional: surround with `if (Log.isLoggable(...))` or `if (BuildConfig.DEBUG) { ... }`"
+        errorLine1="                    Log.d(TAG, &quot;No icon for mode set: $mode&quot;)"
+        errorLine2="                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/directions/util/DirectionsGenerator.kt"
+            line="540"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="LogConditional"
+        message="The log call Log.d(...) should be conditional: surround with `if (Log.isLoggable(...))` or `if (BuildConfig.DEBUG) { ... }`"
+        errorLine1="                    Log.d(TAG, &quot;No icon for mode set: $mode&quot;)"
+        errorLine2="                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/directions/util/DirectionsGenerator.kt"
+            line="540"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="LogConditional"
+        message="The log call Log.d(...) should be conditional: surround with `if (Log.isLoggable(...))` or `if (BuildConfig.DEBUG) { ... }`"
+        errorLine1="        Log.d(FeedbackLauncher.TAG, &quot;Log deleted $deleted&quot;)"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/ui/feedback/Feedback.kt"
+            line="170"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="LogConditional"
+        message="The log call Log.d(...) should be conditional: surround with `if (Log.isLoggable(...))` or `if (BuildConfig.DEBUG) { ... }`"
+        errorLine1="            Log.d(TAG, &quot;sourceLocation: &quot; + lFile);"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/nav/FeedbackReceiver.java"
+            line="140"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="LogConditional"
+        message="The log call Log.d(...) should be conditional: surround with `if (Log.isLoggable(...))` or `if (BuildConfig.DEBUG) { ... }`"
+        errorLine1="            Log.d(TAG, &quot;targetLocation: &quot; + destFolder);"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/nav/FeedbackReceiver.java"
+            line="141"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="LogConditional"
+        message="The log call Log.v(...) should be conditional: surround with `if (Log.isLoggable(...))` or `if (BuildConfig.DEBUG) { ... }`"
+        errorLine1="        Log.v(TAG, &quot;Log deleted &quot; + deleted);"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/nav/FeedbackReceiver.java"
+            line="163"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="LogConditional"
+        message="The log call Log.d(...) should be conditional: surround with `if (Log.isLoggable(...))` or `if (BuildConfig.DEBUG) { ... }`"
+        errorLine1="        Log.d(TAG, &quot;User feedback logged to Firebase Analytics :: wasGoodReminder - &quot;"
+        errorLine2="        ^">
+        <location
+            file="src/main/java/org/onebusaway/android/nav/FeedbackReceiver.java"
+            line="191"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="LogConditional"
+        message="The log call Log.d(...) should be conditional: surround with `if (Log.isLoggable(...))` or `if (BuildConfig.DEBUG) { ... }`"
+        errorLine1="        Log.d(TAG, &quot;fetchAlerts for region: &quot; + regionId);"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/widealerts/GtfsAlerts.java"
+            line="53"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="LogConditional"
+        message="The log call Log.d(...) should be conditional: surround with `if (Log.isLoggable(...))` or `if (BuildConfig.DEBUG) { ... }`"
+        errorLine1="            Log.d(TAG, &quot;Alert: &quot; + id + &quot; - &quot; + title + &quot; - &quot; + description + &quot; - &quot; + url);"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/widealerts/GtfsAlerts.java"
+            line="93"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="LogConditional"
+        message="The log call Log.d(...) should be conditional: surround with `if (Log.isLoggable(...))` or `if (BuildConfig.DEBUG) { ... }`"
+        errorLine1="        Log.d(TAG, &quot;Received reminder for stopId: $stopId&quot;)"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/tripservice/MyFirebaseMessagingService.kt"
+            line="55"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="LogConditional"
+        message="The log call Log.d(...) should be conditional: surround with `if (Log.isLoggable(...))` or `if (BuildConfig.DEBUG) { ... }`"
+        errorLine1="        Log.d(TAG, &quot;Directory - &quot; + getApplicationContext()"
+        errorLine2="        ^">
+        <location
+            file="src/main/java/org/onebusaway/android/nav/NavigationCleanupWorker.java"
+            line="56"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="LogConditional"
+        message="The log call Log.d(...) should be conditional: surround with `if (Log.isLoggable(...))` or `if (BuildConfig.DEBUG) { ... }`"
+        errorLine1="        Log.d(TAG, &quot;Time threshold - &quot; + time.getTime().toString());"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/nav/NavigationCleanupWorker.java"
+            line="60"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="LogConditional"
+        message="The log call Log.d(...) should be conditional: surround with `if (Log.isLoggable(...))` or `if (BuildConfig.DEBUG) { ... }`"
+        errorLine1="            Log.d(TAG, &quot;:&quot; + file.absolutePath)"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/nav/NavigationService.kt"
+            line="305"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="LogConditional"
+        message="The log call Log.d(...) should be conditional: surround with `if (Log.isLoggable(...))` or `if (BuildConfig.DEBUG) { ... }`"
+        errorLine1="        Log.d(TAG, &quot;Number of path links: &quot; + mPath.getPathLinks().size());"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/nav/NavigationServiceProvider.java"
+            line="166"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="LogConditional"
+        message="The log call Log.d(...) should be conditional: surround with `if (Log.isLoggable(...))` or `if (BuildConfig.DEBUG) { ... }`"
+        errorLine1="            Log.d(TAG, &quot;Detecting stop. distance_d=&quot; +"
+        errorLine2="            ^">
+        <location
+            file="src/main/java/org/onebusaway/android/nav/NavigationServiceProvider.java"
+            line="438"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="LogConditional"
+        message="The log call Log.d(...) should be conditional: surround with `if (Log.isLoggable(...))` or `if (BuildConfig.DEBUG) { ... }`"
+        errorLine1="                        Log.d(TAG, logFileName + &quot; uploaded successful&quot;);"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/nav/NavigationUploadWorker.java"
+            line="108"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="LogConditional"
+        message="The log call Log.d(...) should be conditional: surround with `if (Log.isLoggable(...))` or `if (BuildConfig.DEBUG) { ... }`"
+        errorLine1="                        Log.d(TAG, &quot;Response - &quot; + userResponse);"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/nav/NavigationUploadWorker.java"
+            line="112"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="LogConditional"
+        message="The log call Log.d(...) should be conditional: surround with `if (Log.isLoggable(...))` or `if (BuildConfig.DEBUG) { ... }`"
+        errorLine1="                        Log.d(TAG, &quot;FeedbackText - &quot; + feedbackText);"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/nav/NavigationUploadWorker.java"
+            line="113"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="LogConditional"
+        message="The log call Log.d(...) should be conditional: surround with `if (Log.isLoggable(...))` or `if (BuildConfig.DEBUG) { ... }`"
+        errorLine1="                        Log.d(TAG, &quot;Download URL - &quot; + fileURL);"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/nav/NavigationUploadWorker.java"
+            line="114"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="LogConditional"
+        message="The log call Log.v(...) should be conditional: surround with `if (Log.isLoggable(...))` or `if (BuildConfig.DEBUG) { ... }`"
+        errorLine1="                        Log.v(TAG, logFileName + &quot; deleted : &quot; + deleted);"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/nav/NavigationUploadWorker.java"
+            line="117"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="LogConditional"
+        message="The log call Log.d(...) should be conditional: surround with `if (Log.isLoggable(...))` or `if (BuildConfig.DEBUG) { ... }`"
+        errorLine1="        Log.d(TAG, &quot;User feedback logged to Firebase Analytics :: wasGoodReminder - &quot;"
+        errorLine2="        ^">
+        <location
+            file="src/main/java/org/onebusaway/android/nav/NavigationUploadWorker.java"
+            line="133"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="LogConditional"
+        message="The log call Log.d(...) should be conditional: surround with `if (Log.isLoggable(...))` or `if (BuildConfig.DEBUG) { ... }`"
+        errorLine1="        Log.d(TAG, &quot;Finding region closest to &quot; + loc.getLatitude() + &quot;,&quot; + loc.getLongitude());"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/RegionUtils.java"
+            line="86"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="LogConditional"
+        message="The log call Log.d(...) should be conditional: surround with `if (Log.isLoggable(...))` or `if (BuildConfig.DEBUG) { ... }`"
+        errorLine1="            Log.d(TAG, &quot;Region &apos;&quot; + region.getName() + &quot;&apos; is &quot; + fmt.format(miles) + &quot; miles away&quot;);"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/RegionUtils.java"
+            line="101"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="LogConditional"
+        message="The log call Log.d(...) should be conditional: surround with `if (Log.isLoggable(...))` or `if (BuildConfig.DEBUG) { ... }`"
+        errorLine1="                .onFailure { Log.d(TAG, &quot;Delete request failed: $it&quot;) }"
+        errorLine2="                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/api/bridge/ReminderClient.kt"
+            line="52"
+            column="30"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `predictedOrAbsent` of class `ArrivalAdaptersKt` requires synthetic accessor"
+        errorLine1="    override val predictedArrivalTime get() = ServerTime(predictedOrAbsent(d.predictedArrivalTime))"
+        errorLine2="                                                         ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/api/adapters/ArrivalAdapters.kt"
+            line="51"
+            column="58"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `predictedOrAbsent` of class `ArrivalAdaptersKt` requires synthetic accessor"
+        errorLine1="    override val predictedDepartureTime get() = ServerTime(predictedOrAbsent(d.predictedDepartureTime))"
+        errorLine2="                                                           ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/api/adapters/ArrivalAdapters.kt"
+            line="53"
+            column="60"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `getOrdinal` of class `Companion` requires synthetic accessor"
+        errorLine1="                            val ordinal = getOrdinal("
+        errorLine2="                                          ~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/directions/util/DirectionsGenerator.kt"
+            line="180"
+            column="43"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `regularizedGammaP` of class `Companion` requires synthetic accessor"
+        errorLine1="        return regularizedGammaP(alpha, x / scale)"
+        errorLine2="               ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/extrapolation/math/prob/GammaDistribution.kt"
+            line="45"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `speedAtDistance` of class `GammaExtrapolatorKt` requires synthetic accessor"
+        errorLine1="                schedule?.speedAtDistance(lastStatus.scheduledDistanceAlongTrip ?: return null)"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/extrapolation/GammaExtrapolator.kt"
+            line="72"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `resolveMapStyle` of class `GoogleComposeAdapterKt` requires synthetic accessor"
+        errorLine1="                map.setMapStyle(resolveMapStyle(context))"
+        errorLine2="                                ~~~~~~~~~~~~~~~">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleComposeAdapter.kt"
+            line="157"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `wireClicks` of class `GoogleComposeAdapterKt` requires synthetic accessor"
+        errorLine1="                wireClicks(map, r, windows, cb)"
+        errorLine2="                ~~~~~~~~~~">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleComposeAdapter.kt"
+            line="164"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `snapshot` of class `GoogleComposeAdapterKt` requires synthetic accessor"
+        errorLine1="                map.setOnCameraIdleListener { host.onCameraIdle(snapshot(map)) }"
+        errorLine2="                                                                ~~~~~~~~">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleComposeAdapter.kt"
+            line="166"
+            column="65"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `openVehicleWindow` of class `GoogleComposeAdapterKt` requires synthetic accessor"
+        errorLine1="                            activeInfoWindows.openVehicleWindow(activeRenderer, marker)"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleComposeAdapter.kt"
+            line="210"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `applyMyLocation` of class `GoogleComposeAdapterKt` requires synthetic accessor"
+        errorLine1="                applyMyLocation(map, context, myLocationEnabled)"
+        errorLine2="                ~~~~~~~~~~~~~~~">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleComposeAdapter.kt"
+            line="243"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `toLatLng` of class `GoogleMapRendererKt` requires synthetic accessor"
+        errorLine1="            for (point in polyline.points) options.add(point.toLatLng())"
+        errorLine2="                                                       ~~~~~~~~~~~~~~">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt"
+            line="217"
+            column="56"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `toLatLng` of class `GoogleMapRendererKt` requires synthetic accessor"
+        errorLine1="                        .position(stop.point.toLatLng())"
+        errorLine2="                                  ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt"
+            line="227"
+            column="35"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `toLatLng` of class `GoogleMapRendererKt` requires synthetic accessor"
+        errorLine1="                            .position(bike.point.toLatLng())"
+        errorLine2="                                      ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt"
+            line="251"
+            column="39"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `toLatLng` of class `GoogleMapRendererKt` requires synthetic accessor"
+        errorLine1="            val options = MarkerOptions().position(generic.point.toLatLng())"
+        errorLine2="                                                   ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt"
+            line="262"
+            column="52"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `toLatLng` of class `GoogleMapRendererKt` requires synthetic accessor"
+        errorLine1="                        .position(stop.point.toLatLng())"
+        errorLine2="                                  ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt"
+            line="293"
+            column="35"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `toLatLng` of class `GoogleMapRendererKt` requires synthetic accessor"
+        errorLine1="            marker.position = vehicleSmoother"
+        errorLine2="                              ^">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt"
+            line="409"
+            column="31"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `toLatLng` of class `GoogleMapRendererKt` requires synthetic accessor"
+        errorLine1="            marker.position = vehicleSmoother"
+        errorLine2="                              ^">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt"
+            line="409"
+            column="31"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `toLatLng` of class `GoogleMapRendererKt` requires synthetic accessor"
+        errorLine1="                    .position(target.toLatLng())"
+        errorLine2="                              ~~~~~~~~~~~~~~~">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt"
+            line="455"
+            column="31"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `toLatLng` of class `GoogleMapRendererKt` requires synthetic accessor"
+        errorLine1="                    dotSmoother.displayPosition(selectedId, target, selected.fixTimeMs, nowMs).toLatLng()"
+        errorLine2="                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt"
+            line="474"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `toLatLng` of class `GoogleMapRendererKt` requires synthetic accessor"
+        errorLine1="                    dotSmoother.displayPosition(selectedId, target, selected.fixTimeMs, nowMs).toLatLng()"
+        errorLine2="                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt"
+            line="474"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `toLatLng` of class `GoogleMapRendererKt` requires synthetic accessor"
+        errorLine1="                        .position(vehicle.point.toLatLng())"
+        errorLine2="                                  ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt"
+            line="507"
+            column="35"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `toLatLng` of class `GoogleMapRendererKt` requires synthetic accessor"
+        errorLine1="            val points = segment.points.map { it.toLatLng() }"
+        errorLine2="                                              ~~~~~~~~~~~">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt"
+            line="545"
+            column="47"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `toLatLng` of class `GoogleMapRendererKt` requires synthetic accessor"
+        errorLine1="                        .position(point.toLatLng())"
+        errorLine2="                                  ~~~~~~~~~~~~~~">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt"
+            line="602"
+            column="35"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `toLatLng` of class `GoogleMapRendererKt` requires synthetic accessor"
+        errorLine1="                smoother.displayPosition(ESTIMATE_EASE_KEY, point, fixTimeMs, nowMs).toLatLng()"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt"
+            line="616"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `toLatLng` of class `GoogleMapRendererKt` requires synthetic accessor"
+        errorLine1="                smoother.displayPosition(ESTIMATE_EASE_KEY, point, fixTimeMs, nowMs).toLatLng()"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt"
+            line="616"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `fromIntent` of class `HomeActivityKt` requires synthetic accessor"
+        errorLine1="    private fun setupMapState() = viewModel.applyInitialFocus(FocusedStop.fromIntent(intent))"
+        errorLine2="                                                              ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/ui/HomeActivity.kt"
+            line="319"
+            column="63"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `read` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="                alerts = db.read(&quot;alerts&quot;) { AlertEntity(id = str(&quot;id&quot;) ?: return@read null) },"
+        errorLine2="                         ~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="89"
+            column="26"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="                alerts = db.read(&quot;alerts&quot;) { AlertEntity(id = str(&quot;id&quot;) ?: return@read null) },"
+        errorLine2="                                                              ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="89"
+            column="63"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `read` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="        val studies = db.read(&quot;studies&quot;) {"
+        errorLine2="                      ~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="128"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `int` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="                study_id = int(&quot;study_id&quot;) ?: return@read null,"
+        errorLine2="                           ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="130"
+            column="28"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="                name = str(&quot;name&quot;).orEmpty(),"
+        errorLine2="                       ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="131"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="                description = str(&quot;description&quot;).orEmpty(),"
+        errorLine2="                              ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="132"
+            column="31"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `int` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="                is_subscribed = (int(&quot;is_subscribed&quot;) ?: 0) != 0,"
+        errorLine2="                                 ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="133"
+            column="34"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `read` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="        val surveys = db.read(&quot;surveys&quot;) {"
+        errorLine2="                      ~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="137"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `int` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="                survey_id = int(&quot;survey_id&quot;) ?: return@read null,"
+        errorLine2="                            ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="139"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `int` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="                study_id = int(&quot;study_id&quot;) ?: return@read null,"
+        errorLine2="                           ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="140"
+            column="28"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="                name = str(&quot;name&quot;).orEmpty(),"
+        errorLine2="                       ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="141"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `int` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="                state = int(&quot;state&quot;) ?: 0,"
+        errorLine2="                        ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="142"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `read` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="        stops = db.read(&quot;stops&quot;) {"
+        errorLine2="                ~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="149"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            id = str(&quot;_id&quot;) ?: return@read null,"
+        errorLine2="                 ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="151"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            code = str(&quot;code&quot;).orEmpty(),"
+        errorLine2="                   ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="152"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            name = str(&quot;name&quot;).orEmpty(),"
+        errorLine2="                   ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="153"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            direction = str(&quot;direction&quot;).orEmpty(),"
+        errorLine2="                        ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="154"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `int` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            useCount = int(&quot;use_count&quot;) ?: 0,"
+        errorLine2="                       ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="155"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `dbl` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            latitude = dbl(&quot;latitude&quot;) ?: 0.0,"
+        errorLine2="                       ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="156"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `dbl` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            longitude = dbl(&quot;longitude&quot;) ?: 0.0,"
+        errorLine2="                        ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="157"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            userName = str(&quot;user_name&quot;),"
+        errorLine2="                       ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="158"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `long` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            accessTime = long(&quot;access_time&quot;),"
+        errorLine2="                         ~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="159"
+            column="26"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `int` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            favorite = int(&quot;favorite&quot;),"
+        errorLine2="                       ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="160"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `long` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            regionId = long(&quot;region_id&quot;),"
+        errorLine2="                       ~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="161"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `read` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="        routes = db.read(&quot;routes&quot;) {"
+        errorLine2="                 ~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="164"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            id = str(&quot;_id&quot;) ?: return@read null,"
+        errorLine2="                 ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="166"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            shortName = str(&quot;short_name&quot;).orEmpty(),"
+        errorLine2="                        ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="167"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            longName = str(&quot;long_name&quot;),"
+        errorLine2="                       ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="168"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `int` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            useCount = int(&quot;use_count&quot;) ?: 0,"
+        errorLine2="                       ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="169"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            userName = str(&quot;user_name&quot;),"
+        errorLine2="                       ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="170"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `long` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            accessTime = long(&quot;access_time&quot;),"
+        errorLine2="                         ~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="171"
+            column="26"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `int` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            favorite = int(&quot;favorite&quot;),"
+        errorLine2="                       ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="172"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            url = str(&quot;url&quot;),"
+        errorLine2="                  ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="173"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `long` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            regionId = long(&quot;region_id&quot;),"
+        errorLine2="                       ~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="174"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `read` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="        trips = db.read(&quot;trips&quot;) {"
+        errorLine2="                ~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="177"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            id = str(&quot;_id&quot;) ?: return@read null,"
+        errorLine2="                 ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="179"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            stopId = str(&quot;stop_id&quot;) ?: return@read null,"
+        errorLine2="                     ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="180"
+            column="22"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            routeId = str(&quot;route_id&quot;),"
+        errorLine2="                      ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="181"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `int` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            departure = int(&quot;departure&quot;) ?: 0,"
+        errorLine2="                        ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="182"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            headsign = str(&quot;headsign&quot;),"
+        errorLine2="                       ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="183"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            name = str(&quot;name&quot;).orEmpty(),"
+        errorLine2="                   ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="184"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `int` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            reminder = int(&quot;reminder&quot;) ?: 0,"
+        errorLine2="                       ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="185"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            alarmDeletePath = str(&quot;alarm_delete_path&quot;).orEmpty(),"
+        errorLine2="                              ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="186"
+            column="31"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `long` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            serviceDate = long(&quot;service_date&quot;) ?: 0,"
+        errorLine2="                          ~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="187"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `int` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            stopSequence = int(&quot;stop_sequence&quot;) ?: 0,"
+        errorLine2="                           ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="188"
+            column="28"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            tripId = str(&quot;trip_id&quot;).orEmpty(),"
+        errorLine2="                     ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="189"
+            column="22"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            vehicleId = str(&quot;vehicle_id&quot;),"
+        errorLine2="                        ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="190"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `read` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="        stopRouteFilters = db.read(&quot;stop_routes_filter&quot;) {"
+        errorLine2="                           ~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="193"
+            column="28"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            stopId = str(&quot;stop_id&quot;) ?: return@read null,"
+        errorLine2="                     ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="195"
+            column="22"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            routeId = str(&quot;route_id&quot;) ?: return@read null,"
+        errorLine2="                      ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="196"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `read` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="        tripAlerts = db.read(&quot;trip_alerts&quot;) {"
+        errorLine2="                     ~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="199"
+            column="22"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `long` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            id = long(&quot;_id&quot;) ?: 0,"
+        errorLine2="                 ~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="201"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            tripId = str(&quot;trip_id&quot;) ?: return@read null,"
+        errorLine2="                     ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="202"
+            column="22"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            stopId = str(&quot;stop_id&quot;) ?: return@read null,"
+        errorLine2="                     ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="203"
+            column="22"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `long` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            startTime = long(&quot;start_time&quot;) ?: 0,"
+        errorLine2="                        ~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="204"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `int` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            state = int(&quot;state&quot;) ?: 0,"
+        errorLine2="                    ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="205"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `read` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="        serviceAlerts = db.read(&quot;service_alerts&quot;) {"
+        errorLine2="                        ~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="208"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            id = str(&quot;_id&quot;) ?: return@read null,"
+        errorLine2="                 ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="210"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `long` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            markedReadTime = long(&quot;marked_read_time&quot;),"
+        errorLine2="                             ~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="211"
+            column="30"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `int` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            hidden = int(&quot;hidden&quot;),"
+        errorLine2="                     ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="212"
+            column="22"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `read` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="        regions = db.read(&quot;regions&quot;) {"
+        errorLine2="                  ~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="215"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `long` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            id = long(&quot;_id&quot;) ?: return@read null,"
+        errorLine2="                 ~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="217"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            name = str(&quot;name&quot;).orEmpty(),"
+        errorLine2="                   ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="218"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            obaBaseUrl = str(&quot;oba_base_url&quot;).orEmpty(),"
+        errorLine2="                         ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="219"
+            column="26"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            siriBaseUrl = str(&quot;siri_base_url&quot;).orEmpty(),"
+        errorLine2="                          ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="220"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            language = str(&quot;lang&quot;).orEmpty(),"
+        errorLine2="                       ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="221"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            contactEmail = str(&quot;contact_email&quot;).orEmpty(),"
+        errorLine2="                           ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="222"
+            column="28"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `int` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            supportsObaDiscovery = int(&quot;supports_api_discovery&quot;) ?: 0,"
+        errorLine2="                                   ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="223"
+            column="36"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `int` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            supportsObaRealtime = int(&quot;supports_api_realtime&quot;) ?: 0,"
+        errorLine2="                                  ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="224"
+            column="35"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `int` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            supportsSiriRealtime = int(&quot;supports_siri_realtime&quot;) ?: 0,"
+        errorLine2="                                   ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="225"
+            column="36"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            twitterUrl = str(&quot;twitter_url&quot;),"
+        errorLine2="                         ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="226"
+            column="26"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `int` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            experimental = int(&quot;experimental&quot;),"
+        errorLine2="                           ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="227"
+            column="28"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            stopInfoUrl = str(&quot;stop_info_url&quot;),"
+        errorLine2="                          ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="228"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            otpBaseUrl = str(&quot;otp_base_url&quot;),"
+        errorLine2="                         ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="229"
+            column="26"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            otpContactEmail = str(&quot;otp_contact_email&quot;),"
+        errorLine2="                              ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="230"
+            column="31"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `int` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            supportsOtpBikeshare = int(&quot;supports_otp_bikeshare&quot;),"
+        errorLine2="                                   ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="231"
+            column="36"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `int` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            supportsEmbeddedSocial = int(&quot;supports_embedded_social&quot;),"
+        errorLine2="                                     ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="232"
+            column="38"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            paymentAndroidAppId = str(&quot;payment_android_app_id&quot;),"
+        errorLine2="                                  ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="233"
+            column="35"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            paymentWarningTitle = str(&quot;payment_warning_title&quot;),"
+        errorLine2="                                  ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="234"
+            column="35"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            paymentWarningBody = str(&quot;payment_warning_body&quot;),"
+        errorLine2="                                 ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="235"
+            column="34"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            sidecarBaseUrl = str(&quot;sidecar_base_url&quot;),"
+        errorLine2="                             ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="236"
+            column="30"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            plausibleAnalyticsServerUrl = str(&quot;plausible_analytics_server_url&quot;),"
+        errorLine2="                                          ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="237"
+            column="43"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            umamiAnalyticsUrl = str(&quot;umami_analytics_url&quot;),"
+        errorLine2="                                ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="238"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            umamiAnalyticsId = str(&quot;umami_analytics_id&quot;),"
+        errorLine2="                               ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="239"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `read` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="        regionBounds = db.read(&quot;region_bounds&quot;) {"
+        errorLine2="                       ~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="242"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `long` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            id = long(&quot;_id&quot;) ?: 0,"
+        errorLine2="                 ~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="244"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `long` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            regionId = long(&quot;region_id&quot;) ?: return@read null,"
+        errorLine2="                       ~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="245"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `dbl` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            latitude = dbl(&quot;lat&quot;) ?: 0.0,"
+        errorLine2="                       ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="246"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `dbl` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            longitude = dbl(&quot;lon&quot;) ?: 0.0,"
+        errorLine2="                        ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="247"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `dbl` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            latSpan = dbl(&quot;lat_span&quot;) ?: 0.0,"
+        errorLine2="                      ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="248"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `dbl` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            lonSpan = dbl(&quot;lon_span&quot;) ?: 0.0,"
+        errorLine2="                      ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="249"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `read` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="        open311Servers = db.read(&quot;open311_servers&quot;) {"
+        errorLine2="                         ~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="252"
+            column="26"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `long` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            id = long(&quot;_id&quot;) ?: 0,"
+        errorLine2="                 ~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="254"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `long` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            regionId = long(&quot;region_id&quot;) ?: return@read null,"
+        errorLine2="                       ~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="255"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            jurisdiction = str(&quot;jurisdiction&quot;),"
+        errorLine2="                           ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="256"
+            column="28"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            apiKey = str(&quot;api_key&quot;).orEmpty(),"
+        errorLine2="                     ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="257"
+            column="22"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            baseUrl = str(&quot;open311_base_url&quot;).orEmpty(),"
+        errorLine2="                      ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="258"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `read` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="        routeHeadsignFavorites = db.read(&quot;route_headsign_favorites&quot;) {"
+        errorLine2="                                 ~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="261"
+            column="34"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            routeId = str(&quot;route_id&quot;) ?: return@read null,"
+        errorLine2="                      ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="263"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            headsign = str(&quot;headsign&quot;).orEmpty(),"
+        errorLine2="                       ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="264"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            stopId = str(&quot;stop_id&quot;).orEmpty(),"
+        errorLine2="                     ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="265"
+            column="22"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `int` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            exclude = int(&quot;exclude&quot;) ?: 0,"
+        errorLine2="                      ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="266"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `read` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="        navStops = db.read(&quot;nav_stops&quot;) {"
+        errorLine2="                   ~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="269"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `long` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            id = long(&quot;_id&quot;) ?: 0,"
+        errorLine2="                 ~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="271"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            navId = str(&quot;nav_id&quot;) ?: return@read null,"
+        errorLine2="                    ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="272"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `long` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            startTime = long(&quot;start_time&quot;) ?: 0,"
+        errorLine2="                        ~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="273"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            tripId = str(&quot;trip_id&quot;).orEmpty(),"
+        errorLine2="                     ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="274"
+            column="22"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            destinationId = str(&quot;destination_id&quot;).orEmpty(),"
+        errorLine2="                            ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="275"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            beforeId = str(&quot;before_id&quot;).orEmpty(),"
+        errorLine2="                       ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="276"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `int` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            sequence = int(&quot;seq_num&quot;) ?: 0,"
+        errorLine2="                       ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="277"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `int` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            active = int(&quot;is_active&quot;) ?: 0,"
+        errorLine2="                     ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="278"
+            column="22"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `accessor` of class `Companion` requires synthetic accessor"
+        errorLine1="            accessor(context).locationRepository()"
+        errorLine2="            ~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/app/di/LocationEntryPoint.kt"
+            line="48"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `accessor` of class `Companion` requires synthetic accessor"
+        errorLine1="            accessor(context).locationSink()"
+        errorLine2="            ~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/app/di/LocationEntryPoint.kt"
+            line="53"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `recentCutoff` of class `MyListRepositoryKt` requires synthetic accessor"
+        errorLine1="        region.flatMapLatest { r -> stopDao.recents(recentCutoff(), r?.id) }"
+        errorLine2="                                                    ~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/ui/mylists/MyListRepository.kt"
+            line="117"
+            column="53"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `toStopItem` of class `MyListRepositoryKt` requires synthetic accessor"
+        errorLine1="            .map { rows -> rows.map { it.toStopItem(context) } }"
+        errorLine2="                                      ~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/ui/mylists/MyListRepository.kt"
+            line="118"
+            column="39"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `recentCutoff` of class `MyListRepositoryKt` requires synthetic accessor"
+        errorLine1="        region.flatMapLatest { r -> routeDao.recents(recentCutoff(), r?.id) }"
+        errorLine2="                                                     ~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/ui/mylists/MyListRepository.kt"
+            line="144"
+            column="54"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `toRouteItem` of class `MyListRepositoryKt` requires synthetic accessor"
+        errorLine1="            .map { rows -> rows.map { it.toRouteItem() } }"
+        errorLine2="                                      ~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/ui/mylists/MyListRepository.kt"
+            line="145"
+            column="39"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `saveSortOrder` of class `MyListRepositoryKt` requires synthetic accessor"
+        errorLine1="        saveSortOrder(context, order, R.array.sort_stops, R.string.preference_key_default_stop_sort)"
+        errorLine2="        ~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/ui/mylists/MyListRepository.kt"
+            line="175"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `toStopItem` of class `MyListRepositoryKt` requires synthetic accessor"
+        errorLine1="                rows.map { list -> list.map { it.toStopItem(context).copy(arrivals = StopArrivals.Loading) } }"
+        errorLine2="                                              ~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/ui/mylists/MyListRepository.kt"
+            line="188"
+            column="47"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `arrivalsPoll` of class `MyListRepositoryKt` requires synthetic accessor"
+        errorLine1="                    arrivalsPoll(context, stops.map { it.id })"
+        errorLine2="                    ~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/ui/mylists/MyListRepository.kt"
+            line="196"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `saveSortOrder` of class `MyListRepositoryKt` requires synthetic accessor"
+        errorLine1="        saveSortOrder(context, order, R.array.sort_stops, R.string.preference_key_default_stop_sort)"
+        errorLine2="        ~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/ui/mylists/MyListRepository.kt"
+            line="227"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `toRouteItem` of class `MyListRepositoryKt` requires synthetic accessor"
+        errorLine1="            .map { rows -> rows.map { it.toRouteItem() } }"
+        errorLine2="                                      ~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/ui/mylists/MyListRepository.kt"
+            line="241"
+            column="39"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `saveSortOrder` of class `MyListRepositoryKt` requires synthetic accessor"
+        errorLine1="        saveSortOrder(context, order, R.array.sort_reminders, R.string.preference_key_default_reminder_sort)"
+        errorLine2="        ~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/ui/mylists/MyListRepository.kt"
+            line="267"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `toReminderItem` of class `MyListRepositoryKt` requires synthetic accessor"
+        errorLine1="            .map { rows -> rows.map { it.toReminderItem(context) } }"
+        errorLine2="                                      ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/ui/mylists/MyListRepository.kt"
+            line="276"
+            column="39"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` field `mReady` of class `ProximityCalculator` requires synthetic accessor"
+        errorLine1="        mProxCalculator.mReady = false;"
+        errorLine2="                        ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/nav/NavigationServiceProvider.java"
+            line="178"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` field `mTrigger` of class `ProximityCalculator` requires synthetic accessor"
+        errorLine1="        mProxCalculator.mTrigger = false;"
+        errorLine2="                        ~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/nav/NavigationServiceProvider.java"
+            line="179"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `checkProximityAll` of class `ProximityCalculator` requires synthetic accessor"
+        errorLine1="        mProxCalculator.checkProximityAll(mCurrentLocation);"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/nav/NavigationServiceProvider.java"
+            line="250"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` field `mWaitingForConfirm` of class `NavigationServiceProvider` requires synthetic accessor"
+        errorLine1="                            mWaitingForConfirm = true;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/nav/NavigationServiceProvider.java"
+            line="357"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `navigateNextPathLink` of class `NavigationServiceProvider` requires synthetic accessor"
+        errorLine1="                            mNavProvider.navigateNextPathLink();"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/nav/NavigationServiceProvider.java"
+            line="365"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` field `mWaitingForConfirm` of class `NavigationServiceProvider` requires synthetic accessor"
+        errorLine1="                            mWaitingForConfirm = true;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/nav/NavigationServiceProvider.java"
+            line="375"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` field `mPath` of class `NavigationServiceProvider` requires synthetic accessor"
+        errorLine1="                            mNavProvider.mPath = null;"
+        errorLine2="                                         ~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/nav/NavigationServiceProvider.java"
+            line="381"
+            column="42"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` field `mPathLinkIndex` of class `NavigationServiceProvider` requires synthetic accessor"
+        errorLine1="                            mNavProvider.mPathLinkIndex = 0;"
+        errorLine2="                                         ~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/nav/NavigationServiceProvider.java"
+            line="382"
+            column="42"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` field `mWaitingForConfirm` of class `NavigationServiceProvider` requires synthetic accessor"
+        errorLine1="            if (!mWaitingForConfirm) {"
+        errorLine2="                 ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/nav/NavigationServiceProvider.java"
+            line="487"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `updateUi` of class `NavigationServiceProvider` requires synthetic accessor"
+        errorLine1="                mNavProvider.updateUi(EVENT_TYPE_UPDATE_DISTANCE);                 // Update distance notification"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/nav/NavigationServiceProvider.java"
+            line="499"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `updateUi` of class `NavigationServiceProvider` requires synthetic accessor"
+        errorLine1="                        mNavProvider.updateUi(EVENT_TYPE_GET_READY);"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/nav/NavigationServiceProvider.java"
+            line="504"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` field `mContext` of class `NavigationServiceProvider` requires synthetic accessor"
+        errorLine1="                        AnalyticsEntryPoint.get(mContext).reportUiEvent(PlausibleAnalytics.REPORT_DESTINATION_REMINDER_EVENT_URL, mContext.getString(R.string.analytics_label_destination_reminder), mContext.getString(R.string.analytics_label_destination_reminder_variant_get_ready));"
+        errorLine2="                                                ~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/nav/NavigationServiceProvider.java"
+            line="506"
+            column="49"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` field `mContext` of class `NavigationServiceProvider` requires synthetic accessor"
+        errorLine1="                        AnalyticsEntryPoint.get(mContext).reportUiEvent(PlausibleAnalytics.REPORT_DESTINATION_REMINDER_EVENT_URL, mContext.getString(R.string.analytics_label_destination_reminder), mContext.getString(R.string.analytics_label_destination_reminder_variant_get_ready));"
+        errorLine2="                                                                                                                                  ~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/nav/NavigationServiceProvider.java"
+            line="506"
+            column="131"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` field `mContext` of class `NavigationServiceProvider` requires synthetic accessor"
+        errorLine1="                        AnalyticsEntryPoint.get(mContext).reportUiEvent(PlausibleAnalytics.REPORT_DESTINATION_REMINDER_EVENT_URL, mContext.getString(R.string.analytics_label_destination_reminder), mContext.getString(R.string.analytics_label_destination_reminder_variant_get_ready));"
+        errorLine2="                                                                                                                                                                                                     ~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/nav/NavigationServiceProvider.java"
+            line="506"
+            column="198"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `updateUi` of class `NavigationServiceProvider` requires synthetic accessor"
+        errorLine1="                        mNavProvider.updateUi(EVENT_TYPE_PULL_CORD);"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/nav/NavigationServiceProvider.java"
+            line="514"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` field `mContext` of class `NavigationServiceProvider` requires synthetic accessor"
+        errorLine1="                        AnalyticsEntryPoint.get(mContext).reportUiEvent(PlausibleAnalytics.REPORT_DESTINATION_REMINDER_EVENT_URL, mContext.getString(R.string.analytics_label_destination_reminder), mContext.getString(R.string.analytics_label_destination_reminder_variant_exit_at_next_stop));"
+        errorLine2="                                                ~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/nav/NavigationServiceProvider.java"
+            line="516"
+            column="49"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` field `mContext` of class `NavigationServiceProvider` requires synthetic accessor"
+        errorLine1="                        AnalyticsEntryPoint.get(mContext).reportUiEvent(PlausibleAnalytics.REPORT_DESTINATION_REMINDER_EVENT_URL, mContext.getString(R.string.analytics_label_destination_reminder), mContext.getString(R.string.analytics_label_destination_reminder_variant_exit_at_next_stop));"
+        errorLine2="                                                                                                                                  ~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/nav/NavigationServiceProvider.java"
+            line="516"
+            column="131"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` field `mContext` of class `NavigationServiceProvider` requires synthetic accessor"
+        errorLine1="                        AnalyticsEntryPoint.get(mContext).reportUiEvent(PlausibleAnalytics.REPORT_DESTINATION_REMINDER_EVENT_URL, mContext.getString(R.string.analytics_label_destination_reminder), mContext.getString(R.string.analytics_label_destination_reminder_variant_exit_at_next_stop));"
+        errorLine2="                                                                                                                                                                                                     ~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/nav/NavigationServiceProvider.java"
+            line="516"
+            column="198"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` field `endDistance` of class `ProximityCalculator` requires synthetic accessor"
+        errorLine1="            double distance = mProxCalculator.endDistance;"
+        errorLine2="                                              ~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/nav/NavigationServiceProvider.java"
+            line="623"
+            column="47"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `logFeedback` of class `NavigationUploadWorker` requires synthetic accessor"
+        errorLine1="                        logFeedback(feedbackText, userResponse, fileURL);"
+        errorLine2="                        ~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/nav/NavigationUploadWorker.java"
+            line="115"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `toLocation` of class `TripAdaptersKt` requires synthetic accessor"
+        errorLine1="    override val position: Location? get() = dto.position?.toLocation()"
+        errorLine2="                                             ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/api/adapters/TripAdapters.kt"
+            line="49"
+            column="46"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `toLocation` of class `TripAdaptersKt` requires synthetic accessor"
+        errorLine1="    override val lastKnownLocation: Location? get() = dto.lastKnownLocation?.toLocation()"
+        errorLine2="                                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/api/adapters/TripAdapters.kt"
+            line="61"
+            column="55"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `dedupeByActiveTripKeepingBestFix` of class `TripVehiclesDataSourceKt` requires synthetic accessor"
+        errorLine1="        entries.dedupeByActiveTripKeepingBestFix().map { DtoTripDetails(it) }"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/api/data/TripVehiclesDataSource.kt"
+            line="48"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `post` of class `UmamiAnalytics` requires synthetic accessor"
+        errorLine1="                post(payload);"
+        errorLine2="                ~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/analytics/UmamiAnalytics.java"
+            line="77"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="UnusedIds"
+        message="The resource `R.id.listContainer` appears to be unused"
+        errorLine1="    &lt;item name=&quot;listContainer&quot; type=&quot;id&quot; />"
+        errorLine2="          ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/ids.xml"
+            line="21"
+            column="11"/>
+    </issue>
+
+    <issue
+        id="UnusedIds"
+        message="The resource `R.id.internalEmpty` appears to be unused"
+        errorLine1="    &lt;item name=&quot;internalEmpty&quot; type=&quot;id&quot; />"
+        errorLine2="          ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/ids.xml"
+            line="22"
+            column="11"/>
+    </issue>
+
+    <issue
+        id="UnusedIds"
+        message="The resource `R.id.loading` appears to be unused"
+        errorLine1="    &lt;item name=&quot;loading&quot; type=&quot;id&quot; />"
+        errorLine2="          ~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/ids.xml"
+            line="23"
+            column="11"/>
+    </issue>
+
+    <issue
+        id="UnusedIds"
+        message="The resource `R.id.refresh_loading` appears to be unused"
+        errorLine1="    &lt;item name=&quot;refresh_loading&quot; type=&quot;id&quot; />"
+        errorLine2="          ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/ids.xml"
+            line="24"
+            column="11"/>
+    </issue>
+
+    <issue
+        id="UnusedIds"
+        message="The resource `R.id.refresh_progress_small` appears to be unused"
+        errorLine1="    &lt;item name=&quot;refresh_progress_small&quot; type=&quot;id&quot; />"
+        errorLine2="          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/ids.xml"
+            line="25"
+            column="11"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Settings`, used in `analytics_label_button_press_settings` and `navdrawer_item_settings`. Use `android:inputType` or `android:capitalize` to treat these as the same and avoid string duplication."
+        errorLine1="    &lt;string name=&quot;analytics_label_button_press_settings&quot;>settings&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/donottranslate.xml"
+            line="113"
+            column="5"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="28"
+            column="5"
+            message="Duplicates value in `analytics_label_button_press_settings` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Help`, used in `analytics_label_button_press_help`, `main_help_title` and `navdrawer_item_help`. Use `android:inputType` or `android:capitalize` to treat these as the same and avoid string duplication."
+        errorLine1="    &lt;string name=&quot;analytics_label_button_press_help&quot;>help&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/donottranslate.xml"
+            line="114"
+            column="5"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="29"
+            column="5"
+            message="Duplicates value in `analytics_label_button_press_help` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="101"
+            column="5"
+            message="Duplicates value in `analytics_label_button_press_help`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Stops`, used in `analytics_label_stop_category` and `my_recent_stops`. Use `android:inputType` or `android:capitalize` to treat these as the same and avoid string duplication."
+        errorLine1="    &lt;string name=&quot;analytics_label_stop_category&quot;>stops&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/donottranslate.xml"
+            line="156"
+            column="5"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="347"
+            column="5"
+            message="Duplicates value in `analytics_label_stop_category` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `OneBusAway`, used in `app_name` and `ri_static_user_name`"
+        errorLine1="    &lt;string name=&quot;ri_static_user_name&quot;>OneBusAway&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/donottranslate.xml"
+            line="193"
+            column="5"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="21"
+            column="5"
+            message="Duplicates value in `ri_static_user_name`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Stop`, used in `ri_selected_service_stop` and `stop_shortcut`. Use `android:inputType` or `android:capitalize` to treat these as the same and avoid string duplication."
+        errorLine1="    &lt;string name=&quot;ri_selected_service_stop&quot;>stop&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/donottranslate.xml"
+            line="197"
+            column="5"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="420"
+            column="5"
+            message="Duplicates value in `ri_selected_service_stop` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `YES`, used in `analytics_label_destination_reminder_yes`, `destination_reminder_confirm`, `feedback_action_reply_yes` and `rt_yes`. Use `android:inputType` or `android:capitalize` to treat these as the same and avoid string duplication."
+        errorLine1="    &lt;string name=&quot;analytics_label_destination_reminder_yes&quot;>yes&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/donottranslate.xml"
+            line="208"
+            column="5"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="287"
+            column="5"
+            message="Duplicates value in `analytics_label_destination_reminder_yes` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="305"
+            column="5"
+            message="Duplicates value in `analytics_label_destination_reminder_yes`"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="746"
+            column="5"
+            message="Duplicates value in `analytics_label_destination_reminder_yes` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `NO`, used in `analytics_label_destination_reminder_no`, `feedback_action_reply_no` and `rt_no`. Use `android:inputType` or `android:capitalize` to treat these as the same and avoid string duplication."
+        errorLine1="    &lt;string name=&quot;analytics_label_destination_reminder_no&quot;>no&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/donottranslate.xml"
+            line="209"
+            column="5"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="304"
+            column="5"
+            message="Duplicates value in `analytics_label_destination_reminder_no` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="747"
+            column="5"
+            message="Duplicates value in `analytics_label_destination_reminder_no` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Ulubione przystanki`, used in `navdrawer_item_starred_stops` and `starred_stops_shortcut`"
+        errorLine1="    &lt;string name=&quot;navdrawer_item_starred_stops&quot;>Ulubione przystanki&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="7"
+            column="5"/>
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="380"
+            column="5"
+            message="Duplicates value in `navdrawer_item_starred_stops`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Pomoc`, used in `main_help_title` and `navdrawer_item_help`"
+        errorLine1="    &lt;string name=&quot;navdrawer_item_help&quot;>Pomoc&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="10"
+            column="5"/>
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="69"
+            column="5"
+            message="Duplicates value in `navdrawer_item_help`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Fermate preferite`, used in `navdrawer_item_starred_stops` and `starred_stops_shortcut`"
+        errorLine1="    &lt;string name=&quot;navdrawer_item_starred_stops&quot;>Fermate preferite&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="24"
+            column="5"/>
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="340"
+            column="5"
+            message="Duplicates value in `navdrawer_item_starred_stops`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Suosikkipysäkit`, used in `navdrawer_item_starred_stops` and `starred_stops_shortcut`"
+        errorLine1="    &lt;string name=&quot;navdrawer_item_starred_stops&quot;>Suosikkipysäkit&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="24"
+            column="5"/>
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="354"
+            column="5"
+            message="Duplicates value in `navdrawer_item_starred_stops`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Starred Stops`, used in `navdrawer_item_starred_stops` and `starred_stops_shortcut`. Use `android:inputType` or `android:capitalize` to treat these as the same and avoid string duplication."
+        errorLine1="    &lt;string name=&quot;navdrawer_item_starred_stops&quot;>Starred stops&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="25"
+            column="5"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="423"
+            column="5"
+            message="Duplicates value in `navdrawer_item_starred_stops` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Paradas favoritas`, used in `navdrawer_item_starred_stops` and `starred_stops_shortcut`"
+        errorLine1="    &lt;string name=&quot;navdrawer_item_starred_stops&quot;>Paradas favoritas&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="26"
+            column="5"/>
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="413"
+            column="5"
+            message="Duplicates value in `navdrawer_item_starred_stops`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Aiuto`, used in `main_help_title` and `navdrawer_item_help`"
+        errorLine1="    &lt;string name=&quot;navdrawer_item_help&quot;>Aiuto&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="28"
+            column="5"/>
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="68"
+            column="5"
+            message="Duplicates value in `navdrawer_item_help`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Ayuda`, used in `main_help_title` and `navdrawer_item_help`"
+        errorLine1="    &lt;string name=&quot;navdrawer_item_help&quot;>Ayuda&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="30"
+            column="5"/>
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="102"
+            column="5"
+            message="Duplicates value in `navdrawer_item_help`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Cerca`, used in `map_option_search` and `my_search_title`"
+        errorLine1="    &lt;string name=&quot;map_option_search&quot;>Cerca&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="67"
+            column="5"/>
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="289"
+            column="5"
+            message="Duplicates value in `map_option_search`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Wyszukaj`, used in `map_option_search` and `my_search_title`"
+        errorLine1="    &lt;string name=&quot;map_option_search&quot;>Wyszukaj&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="67"
+            column="5"/>
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="310"
+            column="5"
+            message="Duplicates value in `map_option_search`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Anuluj`, used in `cancel`, `destination_reminder_cancel`, `donation_dismiss_dialog_cancel_button`, `night_light_cancel` and `stop_info_cancel`"
+        errorLine1="    &lt;string name=&quot;cancel&quot;>Anuluj&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="68"
+            column="5"/>
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="248"
+            column="5"
+            message="Duplicates value in `cancel`"/>
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="258"
+            column="5"
+            message="Duplicates value in `cancel`"/>
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="740"
+            column="5"
+            message="Duplicates value in `cancel`"/>
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="825"
+            column="5"
+            message="Duplicates value in `cancel`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Chiudi`, used in `close` and `main_help_close`"
+        errorLine1="    &lt;string name=&quot;main_help_close&quot;>Chiudi&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="71"
+            column="5"/>
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="314"
+            column="5"
+            message="Duplicates value in `main_help_close`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Zamknij`, used in `close` and `main_help_close`"
+        errorLine1="    &lt;string name=&quot;main_help_close&quot;>Zamknij&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="79"
+            column="5"/>
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="349"
+            column="5"
+            message="Duplicates value in `main_help_close`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `pohjoiseen`, used in `direction_n` and `step_by_step_non_transit_dir_absolute_north`. Use `android:inputType` or `android:capitalize` to treat these as the same and avoid string duplication."
+        errorLine1="    &lt;string name=&quot;direction_n&quot;>Pohjoiseen&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="82"
+            column="5"/>
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="905"
+            column="5"
+            message="Duplicates value in `direction_n` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `koilliseen`, used in `direction_ne` and `step_by_step_non_transit_dir_absolute_northeast`. Use `android:inputType` or `android:capitalize` to treat these as the same and avoid string duplication."
+        errorLine1="    &lt;string name=&quot;direction_ne&quot;>Koilliseen&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="83"
+            column="5"/>
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="906"
+            column="5"
+            message="Duplicates value in `direction_ne` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `itään`, used in `direction_e` and `step_by_step_non_transit_dir_absolute_east`. Use `android:inputType` or `android:capitalize` to treat these as the same and avoid string duplication."
+        errorLine1="    &lt;string name=&quot;direction_e&quot;>Itään&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="84"
+            column="5"/>
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="904"
+            column="5"
+            message="Duplicates value in `direction_e` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `kaakkoon`, used in `direction_se` and `step_by_step_non_transit_dir_absolute_southeast`. Use `android:inputType` or `android:capitalize` to treat these as the same and avoid string duplication."
+        errorLine1="    &lt;string name=&quot;direction_se&quot;>Kaakkoon&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="85"
+            column="5"/>
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="909"
+            column="5"
+            message="Duplicates value in `direction_se` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `etelään`, used in `direction_s` and `step_by_step_non_transit_dir_absolute_south`. Use `android:inputType` or `android:capitalize` to treat these as the same and avoid string duplication."
+        errorLine1="    &lt;string name=&quot;direction_s&quot;>Etelään&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="86"
+            column="5"/>
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="908"
+            column="5"
+            message="Duplicates value in `direction_s` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `norte`, used in `direction_n` and `step_by_step_non_transit_dir_absolute_north`. Use `android:inputType` or `android:capitalize` to treat these as the same and avoid string duplication."
+        errorLine1="    &lt;string name=&quot;direction_n&quot;>Norte&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="86"
+            column="5"/>
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="975"
+            column="5"
+            message="Duplicates value in `direction_n` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Noreste`, used in `direction_ne` and `step_by_step_non_transit_dir_absolute_northwest`"
+        errorLine1="    &lt;string name=&quot;direction_ne&quot;>Noreste&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="87"
+            column="5"/>
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="977"
+            column="5"
+            message="Duplicates value in `direction_ne`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `lounaaseen`, used in `direction_sw` and `step_by_step_non_transit_dir_absolute_southwest`. Use `android:inputType` or `android:capitalize` to treat these as the same and avoid string duplication."
+        errorLine1="    &lt;string name=&quot;direction_sw&quot;>Lounaaseen&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="87"
+            column="5"/>
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="910"
+            column="5"
+            message="Duplicates value in `direction_sw` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `este`, used in `direction_e` and `step_by_step_non_transit_dir_absolute_east`. Use `android:inputType` or `android:capitalize` to treat these as the same and avoid string duplication."
+        errorLine1="    &lt;string name=&quot;direction_e&quot;>Este&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="88"
+            column="5"/>
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="974"
+            column="5"
+            message="Duplicates value in `direction_e` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `länteen`, used in `direction_w` and `step_by_step_non_transit_dir_absolute_west`. Use `android:inputType` or `android:capitalize` to treat these as the same and avoid string duplication."
+        errorLine1="    &lt;string name=&quot;direction_w&quot;>Länteen&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="88"
+            column="5"/>
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="911"
+            column="5"
+            message="Duplicates value in `direction_w` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `luoteeseen`, used in `direction_nw` and `step_by_step_non_transit_dir_absolute_northwest`. Use `android:inputType` or `android:capitalize` to treat these as the same and avoid string duplication."
+        errorLine1="    &lt;string name=&quot;direction_nw&quot;>Luoteeseen&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="89"
+            column="5"/>
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="907"
+            column="5"
+            message="Duplicates value in `direction_nw` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `sureste`, used in `direction_se` and `step_by_step_non_transit_dir_absolute_southwest`. Use `android:inputType` or `android:capitalize` to treat these as the same and avoid string duplication."
+        errorLine1="    &lt;string name=&quot;direction_se&quot;>Sureste&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="89"
+            column="5"/>
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="980"
+            column="5"
+            message="Duplicates value in `direction_se` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `sur`, used in `direction_s` and `step_by_step_non_transit_dir_absolute_south`. Use `android:inputType` or `android:capitalize` to treat these as the same and avoid string duplication."
+        errorLine1="    &lt;string name=&quot;direction_s&quot;>Sur&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="90"
+            column="5"/>
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="978"
+            column="5"
+            message="Duplicates value in `direction_s` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `suroeste`, used in `direction_sw` and `step_by_step_non_transit_dir_absolute_southeast`. Use `android:inputType` or `android:capitalize` to treat these as the same and avoid string duplication."
+        errorLine1="    &lt;string name=&quot;direction_sw&quot;>Suroeste&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="91"
+            column="5"/>
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="979"
+            column="5"
+            message="Duplicates value in `direction_sw` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `oeste`, used in `direction_w` and `step_by_step_non_transit_dir_absolute_west`. Use `android:inputType` or `android:capitalize` to treat these as the same and avoid string duplication."
+        errorLine1="    &lt;string name=&quot;direction_w&quot;>Oeste&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="92"
+            column="5"/>
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="981"
+            column="5"
+            message="Duplicates value in `direction_w` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Noroeste`, used in `direction_nw` and `step_by_step_non_transit_dir_absolute_northeast`"
+        errorLine1="    &lt;string name=&quot;direction_nw&quot;>Noroeste&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="93"
+            column="5"/>
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="976"
+            column="5"
+            message="Duplicates value in `direction_nw`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Haku`, used in `map_option_search` and `my_search_title`"
+        errorLine1="    &lt;string name=&quot;map_option_search&quot;>Haku&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="97"
+            column="5"/>
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="295"
+            column="5"
+            message="Duplicates value in `map_option_search`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Search`, used in `map_option_search` and `my_search_title`"
+        errorLine1="    &lt;string name=&quot;map_option_search&quot;>Search&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="100"
+            column="5"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="350"
+            column="5"
+            message="Duplicates value in `map_option_search`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Buscar`, used in `map_option_search` and `my_search_title`"
+        errorLine1="    &lt;string name=&quot;map_option_search&quot;>Buscar&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="101"
+            column="5"/>
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="345"
+            column="5"
+            message="Duplicates value in `map_option_search`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Sulje`, used in `close` and `main_help_close`"
+        errorLine1="    &lt;string name=&quot;main_help_close&quot;>Sulje&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="101"
+            column="5"/>
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="334"
+            column="5"
+            message="Duplicates value in `main_help_close`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Close`, used in `close` and `main_help_close`"
+        errorLine1="    &lt;string name=&quot;main_help_close&quot;>Close&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="104"
+            column="5"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="395"
+            column="5"
+            message="Duplicates value in `main_help_close`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Cerrar`, used in `close` and `main_help_close`"
+        errorLine1="    &lt;string name=&quot;main_help_close&quot;>Cerrar&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="105"
+            column="5"/>
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="383"
+            column="5"
+            message="Duplicates value in `main_help_close`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Mostra sulla mappa`, used in `my_context_showonmap`, `route_info_context_showonmap` and `stop_info_option_showonmap`"
+        errorLine1="    &lt;string name=&quot;stop_info_option_showonmap&quot;>Mostra sulla mappa&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="182"
+            column="5"/>
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="280"
+            column="5"
+            message="Duplicates value in `stop_info_option_showonmap`"/>
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="305"
+            column="5"
+            message="Duplicates value in `stop_info_option_showonmap`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Przyjedzie o %1s`, used in `stop_info_time_arrived_at` and `stop_info_time_arriving_at`"
+        errorLine1="    &lt;string name=&quot;stop_info_time_arriving_at&quot;>Przyjedzie o %1s&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="183"
+            column="5"/>
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="185"
+            column="5"
+            message="Duplicates value in `stop_info_time_arriving_at`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Aggiorna`, used in `region_option_refresh` and `stop_info_option_refresh`"
+        errorLine1="    &lt;string name=&quot;stop_info_option_refresh&quot;>Aggiorna&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="184"
+            column="5"/>
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="426"
+            column="5"
+            message="Duplicates value in `stop_info_option_refresh`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Odjedzie o %1s`, used in `stop_info_time_departed_at` and `stop_info_time_departing_at`"
+        errorLine1="    &lt;string name=&quot;stop_info_time_departing_at&quot;>Odjedzie o %1s&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="184"
+            column="5"/>
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="186"
+            column="5"
+            message="Duplicates value in `stop_info_time_departing_at`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `%1$d+ min`, used in `stop_info_no_additional_data_minutes_short_format` and `stop_info_nodata_minutes_short_format`"
+        errorLine1="    &lt;string name=&quot;stop_info_nodata_minutes_short_format&quot;>%1$d+ min&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="191"
+            column="5"/>
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="207"
+            column="5"
+            message="Duplicates value in `stop_info_nodata_minutes_short_format`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Pokaż na mapie`, used in `my_context_showonmap`, `route_info_context_showonmap` and `stop_info_option_showonmap`"
+        errorLine1="    &lt;string name=&quot;stop_info_option_showonmap&quot;>Pokaż na mapie&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="201"
+            column="5"/>
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="300"
+            column="5"
+            message="Duplicates value in `stop_info_option_showonmap`"/>
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="340"
+            column="5"
+            message="Duplicates value in `stop_info_option_showonmap`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Odśwież`, used in `region_option_refresh` and `stop_info_option_refresh`"
+        errorLine1="    &lt;string name=&quot;stop_info_option_refresh&quot;>Odśwież&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="203"
+            column="5"/>
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="468"
+            column="5"
+            message="Duplicates value in `stop_info_option_refresh`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Zgłoś problem z przystankiem`, used in `rt_infrastructure_problem`, `rt_stop_problem` and `stop_info_option_report_problem`"
+        errorLine1="    &lt;string name=&quot;stop_info_option_report_problem&quot;>Zgłoś problem z przystankiem&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="206"
+            column="5"/>
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="657"
+            column="5"
+            message="Duplicates value in `stop_info_option_report_problem`"/>
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="659"
+            column="5"
+            message="Duplicates value in `stop_info_option_report_problem`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `%1$d+ min`, used in `stop_info_no_additional_data_minutes_short_format` and `stop_info_nodata_minutes_short_format`"
+        errorLine1="    &lt;string name=&quot;stop_info_nodata_minutes_short_format&quot;>%1$d+ min&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="210"
+            column="5"/>
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="228"
+            column="5"
+            message="Duplicates value in `stop_info_nodata_minutes_short_format`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Näytä kartalla`, used in `my_context_showonmap`, `route_info_context_showonmap` and `stop_info_option_showonmap`"
+        errorLine1="    &lt;string name=&quot;stop_info_option_showonmap&quot;>Näytä kartalla&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="222"
+            column="5"/>
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="285"
+            column="5"
+            message="Duplicates value in `stop_info_option_showonmap`"/>
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="325"
+            column="5"
+            message="Duplicates value in `stop_info_option_showonmap`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Päivitä`, used in `region_option_refresh` and `stop_info_option_refresh`"
+        errorLine1="    &lt;string name=&quot;stop_info_option_refresh&quot;>Päivitä&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="224"
+            column="5"/>
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="426"
+            column="5"
+            message="Duplicates value in `stop_info_option_refresh`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Salva`, used in `stop_info_save` and `trip_info_save`"
+        errorLine1="    &lt;string name=&quot;stop_info_save&quot;>Salva&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="226"
+            column="5"/>
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="349"
+            column="5"
+            message="Duplicates value in `stop_info_save`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Annulla`, used in `alert_hidden_snackbar_action`, `cancel`, `destination_reminder_cancel`, `donation_dismiss_dialog_cancel_button`, `night_light_cancel` and `stop_info_cancel`. Use `android:inputType` or `android:capitalize` to treat these as the same and avoid string duplication."
+        errorLine1="    &lt;string name=&quot;stop_info_cancel&quot;>Annulla&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="227"
+            column="5"/>
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="237"
+            column="5"
+            message="Duplicates value in `stop_info_cancel`"/>
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="317"
+            column="5"
+            message="Duplicates value in `stop_info_cancel` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="642"
+            column="5"
+            message="Duplicates value in `stop_info_cancel` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="912"
+            column="5"
+            message="Duplicates value in `stop_info_cancel`"/>
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="925"
+            column="5"
+            message="Duplicates value in `stop_info_cancel`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `NOW`, used in `starred_stop_arrival_now` and `stop_info_eta_now`"
+        errorLine1="    &lt;string name=&quot;stop_info_eta_now&quot;>NOW&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="227"
+            column="5"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="355"
+            column="5"
+            message="Duplicates value in `stop_info_eta_now`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Show on map`, used in `my_context_showonmap`, `route_info_context_showonmap` and `stop_info_option_showonmap`"
+        errorLine1="    &lt;string name=&quot;stop_info_option_showonmap&quot;>Show on map&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="228"
+            column="5"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="336"
+            column="5"
+            message="Duplicates value in `stop_info_option_showonmap`"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="374"
+            column="5"
+            message="Duplicates value in `stop_info_option_showonmap`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Ilmoita pysäkkiongelma`, used in `rt_infrastructure_problem`, `rt_stop_problem` and `stop_info_option_report_problem`"
+        errorLine1="    &lt;string name=&quot;stop_info_option_report_problem&quot;>Ilmoita pysäkkiongelma&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="229"
+            column="5"/>
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="800"
+            column="5"
+            message="Duplicates value in `stop_info_option_report_problem`"/>
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="802"
+            column="5"
+            message="Duplicates value in `stop_info_option_report_problem`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Refresh`, used in `region_option_refresh` and `stop_info_option_refresh`"
+        errorLine1="    &lt;string name=&quot;stop_info_option_refresh&quot;>Refresh&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="230"
+            column="5"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="512"
+            column="5"
+            message="Duplicates value in `stop_info_option_refresh`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `%1$d+ min`, used in `stop_info_no_additional_data_minutes_short_format` and `stop_info_nodata_minutes_short_format`"
+        errorLine1="    &lt;string name=&quot;stop_info_nodata_minutes_short_format&quot;>%1$d+ min&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="235"
+            column="5"/>
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="253"
+            column="5"
+            message="Duplicates value in `stop_info_nodata_minutes_short_format`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `SÌ`, used in `destination_reminder_confirm`, `feedback_action_reply_yes` and `rt_yes`. Use `android:inputType` or `android:capitalize` to treat these as the same and avoid string duplication."
+        errorLine1="    &lt;string name=&quot;destination_reminder_confirm&quot;>Sì&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="236"
+            column="5"/>
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="254"
+            column="5"
+            message="Duplicates value in `destination_reminder_confirm`"/>
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="591"
+            column="5"
+            message="Duplicates value in `destination_reminder_confirm` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `%1$d+ min`, used in `stop_info_no_additional_data_minutes_short_format` and `stop_info_nodata_minutes_short_format`"
+        errorLine1="    &lt;string name=&quot;stop_info_nodata_minutes_short_format&quot;>%1$d+ min&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="238"
+            column="5"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="256"
+            column="5"
+            message="Duplicates value in `stop_info_nodata_minutes_short_format`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Zapisz`, used in `stop_info_save` and `trip_info_save`"
+        errorLine1="    &lt;string name=&quot;stop_info_save&quot;>Zapisz&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="247"
+            column="5"/>
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="388"
+            column="5"
+            message="Duplicates value in `stop_info_save`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `NO`, used in `feedback_action_reply_no` and `rt_no`. Use `android:inputType` or `android:capitalize` to treat these as the same and avoid string duplication."
+        errorLine1="    &lt;string name=&quot;feedback_action_reply_no&quot;>No&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="253"
+            column="5"/>
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="592"
+            column="5"
+            message="Duplicates value in `feedback_action_reply_no` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `TAK`, used in `destination_reminder_confirm`, `feedback_action_reply_yes` and `rt_yes`. Use `android:inputType` or `android:capitalize` to treat these as the same and avoid string duplication."
+        errorLine1="    &lt;string name=&quot;destination_reminder_confirm&quot;>Tak&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="257"
+            column="5"/>
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="275"
+            column="5"
+            message="Duplicates value in `destination_reminder_confirm`"/>
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="669"
+            column="5"
+            message="Duplicates value in `destination_reminder_confirm` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Mostrar sobre el mapa`, used in `my_context_showonmap`, `route_info_context_showonmap` and `stop_info_option_showonmap`. Use `android:inputType` or `android:capitalize` to treat these as the same and avoid string duplication."
+        errorLine1="    &lt;string name=&quot;stop_info_option_showonmap&quot;>Mostrar sobre el Mapa&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="260"
+            column="5"/>
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="335"
+            column="5"
+            message="Duplicates value in `stop_info_option_showonmap` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="363"
+            column="5"
+            message="Duplicates value in `stop_info_option_showonmap`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Refrescar`, used in `region_option_refresh` and `stop_info_option_refresh`"
+        errorLine1="    &lt;string name=&quot;stop_info_option_refresh&quot;>Refrescar&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="262"
+            column="5"/>
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="517"
+            column="5"
+            message="Duplicates value in `stop_info_option_refresh`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Ocultar alertas`, used in `preferences_hide_alerts_title` and `stop_info_option_hide_alerts`"
+        errorLine1="    &lt;string name=&quot;stop_info_option_hide_alerts&quot;>Ocultar alertas&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="267"
+            column="5"/>
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="667"
+            column="5"
+            message="Duplicates value in `stop_info_option_hide_alerts`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `%1$d+ min`, used in `stop_info_no_additional_data_minutes_short_format` and `stop_info_nodata_minutes_short_format`"
+        errorLine1="    &lt;string name=&quot;stop_info_nodata_minutes_short_format&quot;>%1$d+ min&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="272"
+            column="5"/>
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="296"
+            column="5"
+            message="Duplicates value in `stop_info_nodata_minutes_short_format`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Tallenna`, used in `stop_info_save` and `trip_info_save`"
+        errorLine1="    &lt;string name=&quot;stop_info_save&quot;>Tallenna&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="272"
+            column="5"/>
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="363"
+            column="5"
+            message="Duplicates value in `stop_info_save`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Peruuta`, used in `cancel`, `destination_reminder_cancel`, `donation_dismiss_dialog_cancel_button`, `night_light_cancel` and `stop_info_cancel`"
+        errorLine1="    &lt;string name=&quot;stop_info_cancel&quot;>Peruuta&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="273"
+            column="5"/>
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="463"
+            column="5"
+            message="Duplicates value in `stop_info_cancel`"/>
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="625"
+            column="5"
+            message="Duplicates value in `stop_info_cancel`"/>
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="709"
+            column="5"
+            message="Duplicates value in `stop_info_cancel`"/>
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="952"
+            column="5"
+            message="Duplicates value in `stop_info_cancel`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `NIE`, used in `feedback_action_reply_no` and `rt_no`. Use `android:inputType` or `android:capitalize` to treat these as the same and avoid string duplication."
+        errorLine1="    &lt;string name=&quot;feedback_action_reply_no&quot;>Nie&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="274"
+            column="5"/>
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="670"
+            column="5"
+            message="Duplicates value in `feedback_action_reply_no` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Save`, used in `stop_info_save` and `trip_info_save`"
+        errorLine1="    &lt;string name=&quot;stop_info_save&quot;>Save&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="277"
+            column="5"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="432"
+            column="5"
+            message="Duplicates value in `stop_info_save`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Cancel`, used in `cancel`, `destination_reminder_cancel`, `donation_dismiss_dialog_cancel_button`, `night_light_cancel` and `stop_info_cancel`"
+        errorLine1="    &lt;string name=&quot;stop_info_cancel&quot;>Cancel&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="278"
+            column="5"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="288"
+            column="5"
+            message="Duplicates value in `stop_info_cancel`"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="803"
+            column="5"
+            message="Duplicates value in `stop_info_cancel`"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1116"
+            column="5"
+            message="Duplicates value in `stop_info_cancel`"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1131"
+            column="5"
+            message="Duplicates value in `stop_info_cancel`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Clear`, used in `stop_info_clear` and `trip_plan_clear_endpoint`"
+        errorLine1="    &lt;string name=&quot;stop_info_clear&quot;>Clear&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="279"
+            column="5"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="910"
+            column="5"
+            message="Duplicates value in `stop_info_clear`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Mostra informazioni sull\&apos;arrivo`, used in `my_context_get_stop_info` and `route_info_context_get_stop_info`"
+        errorLine1="    &lt;string name=&quot;route_info_context_get_stop_info&quot;>Mostra informazioni sull\&apos;arrivo&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="279"
+            column="5"/>
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="302"
+            column="5"
+            message="Duplicates value in `route_info_context_get_stop_info`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Guardar`, used in `stop_info_save` and `trip_info_save`"
+        errorLine1="    &lt;string name=&quot;stop_info_save&quot;>Guardar&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="321"
+            column="5"/>
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="422"
+            column="5"
+            message="Duplicates value in `stop_info_save`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Cancelar`, used in `cancel`, `donation_dismiss_dialog_cancel_button` and `stop_info_cancel`"
+        errorLine1="    &lt;string name=&quot;stop_info_cancel&quot;>Cancelar&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="322"
+            column="5"/>
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="567"
+            column="5"
+            message="Duplicates value in `stop_info_cancel`"/>
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="1080"
+            column="5"
+            message="Duplicates value in `stop_info_cancel`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Luo pikakuvake`, used in `my_context_create_shortcut` and `night_light_create_shortcut`"
+        errorLine1="    &lt;string name=&quot;my_context_create_shortcut&quot;>Luo pikakuvake&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="324"
+            column="5"/>
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="623"
+            column="5"
+            message="Duplicates value in `my_context_create_shortcut`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Lisätietoja`, used in `more_info` and `situation_more_details`"
+        errorLine1="    &lt;string name=&quot;situation_more_details&quot;>Lisätietoja&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="331"
+            column="5"/>
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="740"
+            column="5"
+            message="Duplicates value in `situation_more_details`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Mostrar información de llegadas`, used in `my_context_get_stop_info` and `route_info_context_get_stop_info`"
+        errorLine1="    &lt;string name=&quot;route_info_context_get_stop_info&quot;>Mostrar información de llegadas&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="334"
+            column="5"/>
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="360"
+            column="5"
+            message="Duplicates value in `route_info_context_get_stop_info`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Show arrival information`, used in `my_context_get_stop_info` and `route_info_context_get_stop_info`"
+        errorLine1="    &lt;string name=&quot;route_info_context_get_stop_info&quot;>Show arrival information&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="335"
+            column="5"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="371"
+            column="5"
+            message="Duplicates value in `route_info_context_get_stop_info`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Linea`, used in `connector_before_route` and `route_shortcut`"
+        errorLine1="    &lt;string name=&quot;route_shortcut&quot;>Linea&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="336"
+            column="5"/>
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="877"
+            column="5"
+            message="Duplicates value in `route_shortcut`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Utwórz skrót`, used in `my_context_create_shortcut` and `night_light_create_shortcut`"
+        errorLine1="    &lt;string name=&quot;my_context_create_shortcut&quot;>Utwórz skrót&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="339"
+            column="5"/>
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="738"
+            column="5"
+            message="Duplicates value in `my_context_create_shortcut`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Paradas y rutas recientes`, used in `my_recent_menu_title` and `tutorial_recent_stops_routes_title`. Use `android:inputType` or `android:capitalize` to treat these as the same and avoid string duplication."
+        errorLine1="    &lt;string name=&quot;my_recent_menu_title&quot;>Paradas y Rutas recientes&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="341"
+            column="5"/>
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="809"
+            column="5"
+            message="Duplicates value in `my_recent_menu_title` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Linea %s`, used in `route_name` and `trip_info_route`"
+        errorLine1="    &lt;string name=&quot;route_name&quot;>Linea %s&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="342"
+            column="5"/>
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="346"
+            column="5"
+            message="Duplicates value in `route_name`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Mostra linea`, used in `trip_info_option_showroute` and `trip_list_context_showroute`"
+        errorLine1="    &lt;string name=&quot;trip_info_option_showroute&quot;>Mostra linea&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="354"
+            column="5"/>
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="368"
+            column="5"
+            message="Duplicates value in `trip_info_option_showroute`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Mostra fermata`, used in `trip_info_option_showstop` and `trip_list_context_showstop`"
+        errorLine1="    &lt;string name=&quot;trip_info_option_showstop&quot;>Mostra fermata&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="355"
+            column="5"/>
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="367"
+            column="5"
+            message="Duplicates value in `trip_info_option_showstop`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Reitti %s`, used in `route_name` and `trip_info_route`"
+        errorLine1="    &lt;string name=&quot;route_name&quot;>Reitti %s&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="356"
+            column="5"/>
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="360"
+            column="5"
+            message="Duplicates value in `route_name`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Näytä reitti`, used in `trip_info_option_showroute` and `trip_list_context_showroute`"
+        errorLine1="    &lt;string name=&quot;trip_info_option_showroute&quot;>Näytä reitti&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="368"
+            column="5"/>
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="379"
+            column="5"
+            message="Duplicates value in `trip_info_option_showroute`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Näytä pysäkki`, used in `trip_info_option_showstop` and `trip_list_context_showstop`"
+        errorLine1="    &lt;string name=&quot;trip_info_option_showstop&quot;>Näytä pysäkki&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="369"
+            column="5"/>
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="378"
+            column="5"
+            message="Duplicates value in `trip_info_option_showstop`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Trasa %s`, used in `route_name` and `trip_info_route`"
+        errorLine1="    &lt;string name=&quot;route_name&quot;>Trasa %s&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="381"
+            column="5"/>
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="385"
+            column="5"
+            message="Duplicates value in `route_name`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Invia`, used in `report_problem_send` and `submit`"
+        errorLine1="    &lt;string name=&quot;report_problem_send&quot;>Invia&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="382"
+            column="5"/>
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="944"
+            column="5"
+            message="Duplicates value in `report_problem_send`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Lähetä`, used in `report_problem_send` and `submit`"
+        errorLine1="    &lt;string name=&quot;report_problem_send&quot;>Lähetä&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="383"
+            column="5"/>
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="728"
+            column="5"
+            message="Duplicates value in `report_problem_send`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Pokaż trasę`, used in `trip_info_option_showroute` and `trip_list_context_showroute`"
+        errorLine1="    &lt;string name=&quot;trip_info_option_showroute&quot;>Pokaż trasę&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="393"
+            column="5"/>
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="404"
+            column="5"
+            message="Duplicates value in `trip_info_option_showroute`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Pokaż przystanek`, used in `trip_info_option_showstop` and `trip_list_context_showstop`"
+        errorLine1="    &lt;string name=&quot;trip_info_option_showstop&quot;>Pokaż przystanek&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="394"
+            column="5"/>
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="403"
+            column="5"
+            message="Duplicates value in `trip_info_option_showstop`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Ruta`, used in `connector_before_route` and `route_shortcut`"
+        errorLine1="    &lt;string name=&quot;route_shortcut&quot;>Ruta&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="409"
+            column="5"/>
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="1036"
+            column="5"
+            message="Duplicates value in `route_shortcut`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Ruta %s`, used in `route_name` and `trip_info_route`"
+        errorLine1="    &lt;string name=&quot;route_name&quot;>Ruta %s&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="415"
+            column="5"/>
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="419"
+            column="5"
+            message="Duplicates value in `route_name`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Route`, used in `connector_before_route` and `route_shortcut`"
+        errorLine1="    &lt;string name=&quot;route_shortcut&quot;>Route&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="419"
+            column="5"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1080"
+            column="5"
+            message="Duplicates value in `route_shortcut`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `opcjonalnie`, used in `report_problem_comment_hint` and `report_problem_uservehicle_hint`"
+        errorLine1="    &lt;string name=&quot;report_problem_comment_hint&quot;>opcjonalnie&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="423"
+            column="5"/>
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="430"
+            column="5"
+            message="Duplicates value in `report_problem_comment_hint`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Wyślij`, used in `report_problem_send` and `submit`"
+        errorLine1="    &lt;string name=&quot;report_problem_send&quot;>Wyślij&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="424"
+            column="5"/>
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="844"
+            column="5"
+            message="Duplicates value in `report_problem_send`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Route %s`, used in `route_name` and `trip_info_route`"
+        errorLine1="    &lt;string name=&quot;route_name&quot;>Route %s&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="425"
+            column="5"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="429"
+            column="5"
+            message="Duplicates value in `route_name`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Mostrar la ruta`, used in `trip_info_option_showroute` and `trip_list_context_showroute`"
+        errorLine1="    &lt;string name=&quot;trip_info_option_showroute&quot;>Mostrar la ruta&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="427"
+            column="5"/>
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="443"
+            column="5"
+            message="Duplicates value in `trip_info_option_showroute`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Show route`, used in `trip_info_option_showroute` and `trip_list_context_showroute`. Use `android:inputType` or `android:capitalize` to treat these as the same and avoid string duplication."
+        errorLine1="    &lt;string name=&quot;trip_info_option_showroute&quot;>Show Route&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="437"
+            column="5"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="453"
+            column="5"
+            message="Duplicates value in `trip_info_option_showroute` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Show stop`, used in `trip_info_option_showstop` and `trip_list_context_showstop`. Use `android:inputType` or `android:capitalize` to treat these as the same and avoid string duplication."
+        errorLine1="    &lt;string name=&quot;trip_info_option_showstop&quot;>Show Stop&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="438"
+            column="5"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="452"
+            column="5"
+            message="Duplicates value in `trip_info_option_showstop` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Enviar`, used in `report_problem_send` and `submit`"
+        errorLine1="    &lt;string name=&quot;report_problem_send&quot;>Enviar&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="457"
+            column="5"/>
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="1099"
+            column="5"
+            message="Duplicates value in `report_problem_send`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Informazioni`, used in `preferences_about_title`, `preferences_category_about` and `title_activity_about`"
+        errorLine1="    &lt;string name=&quot;preferences_category_about&quot;>Informazioni&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="458"
+            column="5"/>
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="533"
+            column="5"
+            message="Duplicates value in `preferences_category_about`"/>
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="704"
+            column="5"
+            message="Duplicates value in `preferences_category_about`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Lisäasetukset`, used in `preferences_category_advanced` and `trip_plan_advanced_settings`"
+        errorLine1="    &lt;string name=&quot;preferences_category_advanced&quot;>Lisäasetukset&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="470"
+            column="5"/>
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="820"
+            column="5"
+            message="Duplicates value in `preferences_category_advanced`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `O programie`, used in `preferences_about_title` and `preferences_category_about`"
+        errorLine1="    &lt;string name=&quot;preferences_category_about&quot;>O programie&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="519"
+            column="5"/>
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="612"
+            column="5"
+            message="Duplicates value in `preferences_category_about`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Tietoja`, used in `preferences_about_title` and `title_activity_about`"
+        errorLine1="    &lt;string name=&quot;preferences_about_title&quot;>Tietoja&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="532"
+            column="5"/>
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="696"
+            column="5"
+            message="Duplicates value in `preferences_about_title`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `About`, used in `preferences_about_title`, `preferences_category_about` and `title_activity_about`"
+        errorLine1="    &lt;string name=&quot;preferences_category_about&quot;>About&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="573"
+            column="5"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="683"
+            column="5"
+            message="Duplicates value in `preferences_category_about`"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="851"
+            column="5"
+            message="Duplicates value in `preferences_category_about`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Acerca de`, used in `preferences_about_title`, `preferences_category_about` and `title_activity_about`"
+        errorLine1="    &lt;string name=&quot;preferences_category_about&quot;>Acerca de&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="577"
+            column="5"/>
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="660"
+            column="5"
+            message="Duplicates value in `preferences_category_about`"/>
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="861"
+            column="5"
+            message="Duplicates value in `preferences_category_about`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Segnala problema con la fermata`, used in `rt_infrastructure_problem` and `rt_stop_problem`"
+        errorLine1="    &lt;string name=&quot;rt_infrastructure_problem&quot;>Segnala problema con la fermata&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="579"
+            column="5"/>
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="581"
+            column="5"
+            message="Duplicates value in `rt_infrastructure_problem`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `A:`, used in `step_by_step_transit_connector_stop_name` and `trip_plan_to`"
+        errorLine1="    &lt;string name=&quot;trip_plan_to&quot;>A:&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="708"
+            column="5"/>
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="763"
+            column="5"
+            message="Duplicates value in `trip_plan_to`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Reportar un Problema de Parada`, used in `rt_infrastructure_problem` and `rt_stop_problem`"
+        errorLine1="    &lt;string name=&quot;rt_infrastructure_problem&quot;>Reportar un Problema de Parada&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="716"
+            column="5"/>
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="718"
+            column="5"
+            message="Duplicates value in `rt_infrastructure_problem`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Controlla la tua connessione Internet e riprova.`, used in `tripplanner_error_request_timeout` and `tripplanner_error_system`"
+        errorLine1="    &lt;string name=&quot;tripplanner_error_request_timeout&quot;>Controlla la tua connessione Internet e riprova.&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="720"
+            column="5"/>
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="721"
+            column="5"
+            message="Duplicates value in `tripplanner_error_request_timeout`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `No`, used in `feedback_action_reply_no` and `rt_no`. Use `android:inputType` or `android:capitalize` to treat these as the same and avoid string duplication."
+        errorLine1="    &lt;string name=&quot;rt_no&quot;>NO&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="729"
+            column="5"/>
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="1137"
+            column="5"
+            message="Duplicates value in `rt_no` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Report a Stop Problem`, used in `rt_infrastructure_problem` and `rt_stop_problem`"
+        errorLine1="    &lt;string name=&quot;rt_infrastructure_problem&quot;>Report a Stop Problem&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="734"
+            column="5"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="736"
+            column="5"
+            message="Duplicates value in `rt_infrastructure_problem`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `verso`, used in `step_by_step_non_transit_connector_street_name_roundabout`, `step_by_step_non_transit_to` and `step_by_step_transit_connector_headsign`"
+        errorLine1="    &lt;string name=&quot;step_by_step_transit_connector_headsign&quot;>verso&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="766"
+            column="5"/>
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="789"
+            column="5"
+            message="Duplicates value in `step_by_step_transit_connector_headsign`"/>
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="797"
+            column="5"
+            message="Duplicates value in `step_by_step_transit_connector_headsign`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `¡Bienvenido a %1$s!`, used in `about_welcome_title` and `tutorial_welcome_title`"
+        errorLine1="    &lt;string name=&quot;tutorial_welcome_title&quot;>¡Bienvenido a %1$s!&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="785"
+            column="5"/>
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="822"
+            column="5"
+            message="Duplicates value in `tutorial_welcome_title`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `on`, used in `step_by_step_non_transit_connector_street_name` and `time_connector_before_date`"
+        errorLine1="    &lt;string name=&quot;step_by_step_non_transit_connector_street_name&quot;>on&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="796"
+            column="5"/>
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="874"
+            column="5"
+            message="Duplicates value in `step_by_step_non_transit_connector_street_name`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Alla rotonda prendi la`, used in `step_by_step_non_transit_dir_relative_circle_clockwise` and `step_by_step_non_transit_dir_relative_circle_counterclockwise`"
+        errorLine1="    &lt;string name=&quot;step_by_step_non_transit_dir_relative_circle_clockwise&quot;>Alla rotonda prendi la&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="800"
+            column="5"/>
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="801"
+            column="5"
+            message="Duplicates value in `step_by_step_non_transit_dir_relative_circle_clockwise`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Welcome to %1$s!`, used in `about_welcome_title` and `tutorial_welcome_title`"
+        errorLine1="    &lt;string name=&quot;tutorial_welcome_title&quot;>Welcome to %1$s!&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="807"
+            column="5"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="854"
+            column="5"
+            message="Duplicates value in `tutorial_welcome_title`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Kyllä`, used in `destination_reminder_confirm`, `feedback_action_reply_yes` and `rt_yes`. Use `android:inputType` or `android:capitalize` to treat these as the same and avoid string duplication."
+        errorLine1="    &lt;string name=&quot;rt_yes&quot;>KYLLÄ&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="812"
+            column="5"/>
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="951"
+            column="5"
+            message="Duplicates value in `rt_yes` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="959"
+            column="5"
+            message="Duplicates value in `rt_yes`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Ei`, used in `feedback_action_reply_no` and `rt_no`. Use `android:inputType` or `android:capitalize` to treat these as the same and avoid string duplication."
+        errorLine1="    &lt;string name=&quot;rt_no&quot;>EI&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="813"
+            column="5"/>
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="960"
+            column="5"
+            message="Duplicates value in `rt_no` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Przypomnij mi później`, used in `donation_dismiss_dialog_remind_me_later_button` and `remind_me_latter`"
+        errorLine1="    &lt;string name=&quot;donation_dismiss_dialog_remind_me_later_button&quot;>Przypomnij mi później&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="824"
+            column="5"/>
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="1026"
+            column="5"
+            message="Duplicates value in `donation_dismiss_dialog_remind_me_later_button`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Tarkista internetyhteys ja yritä uudelleen.`, used in `tripplanner_error_request_timeout` and `tripplanner_error_system`"
+        errorLine1="    &lt;string name=&quot;tripplanner_error_request_timeout&quot;>Tarkista internetyhteys ja yritä uudelleen.&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="832"
+            column="5"/>
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="833"
+            column="5"
+            message="Duplicates value in `tripplanner_error_request_timeout`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Sprawdź połączenie internetowe i spróbuj ponownie.&#xA;    `, used in `tripplanner_error_request_timeout` and `tripplanner_error_system`"
+        errorLine1="    &lt;string name=&quot;tripplanner_error_request_timeout&quot;>Sprawdź połączenie internetowe i spróbuj ponownie."
+        errorLine2="    ^">
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="873"
+            column="5"/>
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="875"
+            column="5"
+            message="Duplicates value in `tripplanner_error_request_timeout`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Ota liikenneympyrästä`, used in `step_by_step_non_transit_dir_relative_circle_clockwise` and `step_by_step_non_transit_dir_relative_circle_counterclockwise`"
+        errorLine1="    &lt;string name=&quot;step_by_step_non_transit_dir_relative_circle_clockwise&quot;>Ota liikenneympyrästä&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="891"
+            column="5"/>
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="892"
+            column="5"
+            message="Duplicates value in `step_by_step_non_transit_dir_relative_circle_clockwise`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Bike sharing`, used in `layers_speedial_bikeshare_label` and `transit_directions_bikeshare_label`"
+        errorLine1="    &lt;string name=&quot;transit_directions_bikeshare_label&quot;>Bike sharing&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="899"
+            column="5"/>
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="906"
+            column="5"
+            message="Duplicates value in `transit_directions_bikeshare_label`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `na`, used in `step_by_step_non_transit_connector_street_name` and `step_by_step_transit_connector_stop_name`. Use `android:inputType` or `android:capitalize` to treat these as the same and avoid string duplication."
+        errorLine1="    &lt;string name=&quot;step_by_step_transit_connector_stop_name&quot;>Na&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="904"
+            column="5"/>
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="925"
+            column="5"
+            message="Duplicates value in `step_by_step_transit_connector_stop_name` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `do`, used in `step_by_step_non_transit_connector_street_name_roundabout`, `step_by_step_non_transit_to` and `step_by_step_transit_connector_headsign`"
+        errorLine1="    &lt;string name=&quot;step_by_step_transit_connector_headsign&quot;>do&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="905"
+            column="5"/>
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="922"
+            column="5"
+            message="Duplicates value in `step_by_step_transit_connector_headsign`"/>
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="926"
+            column="5"
+            message="Duplicates value in `step_by_step_transit_connector_headsign`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `desde`, used in `step_by_step_non_transit_from` and `step_by_step_transit_connector_stop_name`. Use `android:inputType` or `android:capitalize` to treat these as the same and avoid string duplication."
+        errorLine1="    &lt;string name=&quot;step_by_step_transit_connector_stop_name&quot;>Desde&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="922"
+            column="5"/>
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="947"
+            column="5"
+            message="Duplicates value in `step_by_step_transit_connector_stop_name` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Ricordamelo più tardi`, used in `donation_dismiss_dialog_remind_me_later_button` and `remind_me_latter`. Use `android:inputType` or `android:capitalize` to treat these as the same and avoid string duplication."
+        errorLine1="    &lt;string name=&quot;donation_dismiss_dialog_remind_me_later_button&quot;>Ricordamelo Più Tardi&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="924"
+            column="5"/>
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="949"
+            column="5"
+            message="Duplicates value in `donation_dismiss_dialog_remind_me_later_button` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `hasta`, used in `step_by_step_non_transit_to` and `step_by_step_transit_connector_headsign`"
+        errorLine1="    &lt;string name=&quot;step_by_step_transit_connector_headsign&quot;>hasta&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="925"
+            column="5"/>
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="948"
+            column="5"
+            message="Duplicates value in `step_by_step_transit_connector_headsign`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `polku`, used in `street_type_path` and `street_type_track`"
+        errorLine1="    &lt;string name=&quot;street_type_path&quot;>polku&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="928"
+            column="5"/>
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="941"
+            column="5"
+            message="Duplicates value in `street_type_path`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Na rondzie weź`, used in `step_by_step_non_transit_dir_relative_circle_clockwise` and `step_by_step_non_transit_dir_relative_circle_counterclockwise`"
+        errorLine1="    &lt;string name=&quot;step_by_step_non_transit_dir_relative_circle_clockwise&quot;>Na rondzie weź&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="929"
+            column="5"/>
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="930"
+            column="5"
+            message="Duplicates value in `step_by_step_non_transit_dir_relative_circle_clockwise`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `En la glorieta tomar la`, used in `step_by_step_non_transit_dir_relative_circle_clockwise` and `step_by_step_non_transit_dir_relative_circle_counterclockwise`"
+        errorLine1="    &lt;string name=&quot;step_by_step_non_transit_dir_relative_circle_clockwise&quot;>En la glorieta tomar la&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="959"
+            column="5"/>
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="960"
+            column="5"
+            message="Duplicates value in `step_by_step_non_transit_dir_relative_circle_clockwise`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `at`, used in `step_by_step_transit_connector_stop_name` and `time_connector_before_time`. Use `android:inputType` or `android:capitalize` to treat these as the same and avoid string duplication."
+        errorLine1="    &lt;string name=&quot;step_by_step_transit_connector_stop_name&quot;>At&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="966"
+            column="5"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1076"
+            column="5"
+            message="Duplicates value in `step_by_step_transit_connector_stop_name` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `to`, used in `step_by_step_non_transit_connector_street_name_roundabout`, `step_by_step_non_transit_to` and `step_by_step_transit_connector_headsign`"
+        errorLine1="    &lt;string name=&quot;step_by_step_transit_connector_headsign&quot;>to&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="969"
+            column="5"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="992"
+            column="5"
+            message="Duplicates value in `step_by_step_transit_connector_headsign`"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1000"
+            column="5"
+            message="Duplicates value in `step_by_step_transit_connector_headsign`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `chodnik`, used in `street_type_footpath` and `street_type_sidewalk`"
+        errorLine1="    &lt;string name=&quot;street_type_footpath&quot;>chodnik&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="972"
+            column="5"/>
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="984"
+            column="5"
+            message="Duplicates value in `street_type_footpath`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `on`, used in `step_by_step_non_transit_connector_street_name` and `time_connector_before_date`"
+        errorLine1="    &lt;string name=&quot;step_by_step_non_transit_connector_street_name&quot;>on&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="999"
+            column="5"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1077"
+            column="5"
+            message="Duplicates value in `step_by_step_non_transit_connector_street_name`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `At the roundabout take the`, used in `step_by_step_non_transit_dir_relative_circle_clockwise` and `step_by_step_non_transit_dir_relative_circle_counterclockwise`"
+        errorLine1="    &lt;string name=&quot;step_by_step_non_transit_dir_relative_circle_clockwise&quot;>At the roundabout take the&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1003"
+            column="5"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1004"
+            column="5"
+            message="Duplicates value in `step_by_step_non_transit_dir_relative_circle_clockwise`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Rower miejski`, used in `layers_speedial_bikeshare_label` and `transit_directions_bikeshare_label`"
+        errorLine1="    &lt;string name=&quot;transit_directions_bikeshare_label&quot;>Rower miejski&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="1015"
+            column="5"/>
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="1020"
+            column="5"
+            message="Duplicates value in `transit_directions_bikeshare_label`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Bicicleta Compartida`, used in `layers_speedial_bikeshare_label` and `transit_directions_bikeshare_label`"
+        errorLine1="    &lt;string name=&quot;transit_directions_bikeshare_label&quot;>Bicicleta Compartida&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="1058"
+            column="5"/>
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="1065"
+            column="5"
+            message="Duplicates value in `transit_directions_bikeshare_label`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Bikeshare`, used in `layers_speedial_bikeshare_label` and `transit_directions_bikeshare_label`"
+        errorLine1="    &lt;string name=&quot;transit_directions_bikeshare_label&quot;>Bikeshare&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1102"
+            column="5"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1109"
+            column="5"
+            message="Duplicates value in `transit_directions_bikeshare_label`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Recordatorio de destino (beta)`, used in `destination_reminder_beta_title` and `destination_reminder_dialog_title`"
+        errorLine1="    &lt;string name=&quot;destination_reminder_beta_title&quot;>Recordatorio de destino (beta)&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="1122"
+            column="5"/>
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="1124"
+            column="5"
+            message="Duplicates value in `destination_reminder_beta_title`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Remind Me Later`, used in `donation_dismiss_dialog_remind_me_later_button` and `remind_me_latter`"
+        errorLine1="    &lt;string name=&quot;donation_dismiss_dialog_remind_me_later_button&quot;>Remind Me Later&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1130"
+            column="5"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1157"
+            column="5"
+            message="Duplicates value in `donation_dismiss_dialog_remind_me_later_button`"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="        &lt;item>What\&apos;s New?&lt;/item>"
+        errorLine2="                   ~">
+        <location
+            file="src/main/res/values/arrays.xml"
+            line="21"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="        &lt;item>What\&apos;s New?&lt;/item>"
+        errorLine2="                   ~">
+        <location
+            file="src/main/res/values/arrays.xml"
+            line="29"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="        &lt;item>L\&apos;autobus non è passato&lt;/item>"
+        errorLine2="                ~">
+        <location
+            file="src/main/res/values-it/arrays.xml"
+            line="76"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="        &lt;item>L\&apos;autobus non ferma qui&lt;/item>"
+        errorLine2="                ~">
+        <location
+            file="src/main/res/values-it/arrays.xml"
+            line="80"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="        &lt;item>The bus doesn\&apos;t stop here&lt;/item>"
+        errorLine2="                            ~">
+        <location
+            file="src/main/res/values/arrays.xml"
+            line="81"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
+        errorLine1="    &lt;string name=&quot;route_not_found_error_no_region&quot;>Przepraszamy, dana trasa nie może być znaleziona. Jeśli był to skrót"
+        errorLine2="                                                   ^">
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="25"
+            column="52"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
+        errorLine1="    &lt;string name=&quot;route_not_found_error_with_region_name&quot;>Przepraszamy, wybrana trasa nie może zostać znaleziona. Jeśli był to skrót to możliwe, że jest on nieaktualny, lub został wybrany zły region (Twój obecny region to"
+        errorLine2="                                                          ^">
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="30"
+            column="59"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
+        errorLine1="    &lt;string name=&quot;stop_not_found_error_no_region&quot;>Przepraszamy, wybrana trasa nie może zostać znaleziona. Jeśli był to skrót to możliwe, że jest on nieaktualny, lub region nie został wybrany."
+        errorLine2="                                                  ^">
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="33"
+            column="51"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;trip_service_perm_description&quot;>Consenti all\&apos;applicazione di mostrare i promemoria per gli autobus in arrivo.&lt;/string>"
+        errorLine2="                                                              ~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="36"
+            column="63"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
+        errorLine1="    &lt;string name=&quot;stop_not_found_error_with_region_name&quot;>Przepraszamy, wybrana trasa nie może zostać znaleziona. Jeśli był to skrót to możliwe, że jest on nieaktualny, lub wybrany został zły region (Twój obecny region to"
+        errorLine2="                                                         ^">
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="37"
+            column="58"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;generic_comm_error&quot;>Si è verificato un errore di comunicazione. Quest\&apos;informazione non è disponibile. Prova di nuovo, potrebbe funzionare.&lt;/string>"
+        errorLine2="                                                                                        ~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="39"
+            column="89"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;route_not_found_error_no_region&quot;>Spiacenti, impossibile trovare questa linea. Se si tratta di una scorciatoia, è possibile che il link sia obsoleto o che non sia ancora stata selezionata l\&apos;area. (Cambia in\&amp;quot;Preferenze-&amp;gt;La tua area\&amp;quot;)&lt;/string>"
+        errorLine2="                                                                                                                                                                                                               ~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="40"
+            column="208"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;route_not_found_error_with_region_name&quot;>Spiacenti, impossibile trovare questa linea. Se si tratta di una scorciatoia, è possibile che il link sia obsoleto o che l\&apos;area selezionata sia errata. (La tua area è: %1$s. Cambia in \&amp;quot;Preferenze-&amp;gt;La tua area\&amp;quot;)&lt;/string>"
+        errorLine2="                                                                                                                                                                                     ~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="41"
+            column="182"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;stop_not_found_error_no_region&quot;>Spiacenti, impossibile trovare questa fermata. Se si tratta di una scorciatoia, è possibile che il link sia obsoleto o che non sia ancora stata selezionata l\&apos;area. (Cambia in\&amp;quot;Preferenze-&amp;gt;La tua area\&amp;quot;)&lt;/string>"
+        errorLine2="                                                                                                                                                                                                                ~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="42"
+            column="209"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;generic_comm_error&quot;>Sorry, there was a communication error and we can\&apos;t show this"
+        errorLine2="                                                                                        ~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="42"
+            column="89"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;stop_not_found_error_with_region_name&quot;>Spiacenti, impossibile trovare questa fermata. Se si tratta di una scorciatoia, è possibile che il link sia obsoleto o che l\&apos;area selezionata sia errata. (La tua area è: %1$s. Cambia in \&amp;quot;Preferenze-&amp;gt;La tua area\&amp;quot;)&lt;/string>"
+        errorLine2="                                                                                                                                                                                      ~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="43"
+            column="183"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
+        errorLine1="    &lt;string name=&quot;route_not_found_error_no_region&quot;>Reittiä ei löydy. Jos tämä"
+        errorLine2="                                                   ^">
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="44"
+            column="52"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;route_not_found_error_no_region&quot;>Sorry, that particular route can\&apos;t be found. If"
+        errorLine2="                                                   ^">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="45"
+            column="52"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
+        errorLine1="    &lt;string name=&quot;route_not_found_error_no_region&quot;>Lo sentimos, la ruta especificada no ha sido encontrada. Si"
+        errorLine2="                                                   ^">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="46"
+            column="52"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
+        errorLine1="    &lt;string name=&quot;route_not_found_error_with_region_name&quot;>Reittiä ei löydy."
+        errorLine2="                                                          ^">
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="50"
+            column="59"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;route_not_found_error_with_region_name&quot;>Sorry, that particular route can\&apos;t be"
+        errorLine2="                                                          ^">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="51"
+            column="59"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
+        errorLine1="    &lt;string name=&quot;route_not_found_error_with_region_name&quot;>Lo sentimos, esa ruta especificada no puede ser"
+        errorLine2="                                                          ^">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="52"
+            column="59"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
+        errorLine1="    &lt;string name=&quot;stop_not_found_error_no_region&quot;>Pysäkkiä ei löydy. Jos"
+        errorLine2="                                                  ^">
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="56"
+            column="51"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;stop_not_found_error_no_region&quot;>Sorry, that particular stop can\&apos;t be found. If"
+        errorLine2="                                                  ^">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="57"
+            column="51"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
+        errorLine1="    &lt;string name=&quot;stop_not_found_error_no_region&quot;>Lo sentimos, esa parada especificada no puede ser encontrada. Si"
+        errorLine2="                                                  ^">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="58"
+            column="51"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
+        errorLine1="    &lt;string name=&quot;stop_not_found_error_with_region_name&quot;>Pysäkkiä ei löydy."
+        errorLine2="                                                         ^">
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="62"
+            column="58"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;stop_not_found_error_with_region_name&quot;>Sorry, that particular stop can\&apos;t be"
+        errorLine2="                                                         ^">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="63"
+            column="58"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
+        errorLine1="    &lt;string name=&quot;stop_not_found_error_with_region_name&quot;>Lo sentimos, esa parada especificada no puede ser"
+        errorLine2="                                                         ^">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="64"
+            column="58"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;out_of_memory_error&quot;>Sorry, there isn\&apos;t enough available memory to handle that"
+        errorLine2="                                                        ~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="70"
+            column="57"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
+        errorLine1="    &lt;string name=&quot;main_help_legend_ontime&quot;>Verde significa \&amp;quot;In orario\&amp;quot;&lt;/string>"
+        errorLine2="                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="73"
+            column="44"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;bad_gateway_error&quot;>%1$s\&apos;s servers are overloaded. Please excuse us!&lt;/string>"
+        errorLine2="                                          ~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="74"
+            column="43"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
+        errorLine1="    &lt;string name=&quot;main_help_legend_late&quot;>Blu significa \&amp;quot;In ritardo\&amp;quot;&lt;/string>"
+        errorLine2="                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="74"
+            column="42"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
+        errorLine1="    &lt;string name=&quot;main_help_legend_early&quot;>Rosso significa \&amp;quot;In anticipo\&amp;quot;&lt;/string>"
+        errorLine2="                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="75"
+            column="43"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
+        errorLine1="        - Stuknij na czas przyjazdu i wybierz \&quot;Pokaż trasę na mapie\&quot;!\n&amp;#8226;\u0020"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="75"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;main_help_legend_scheduled&quot;>Grigio significa \&amp;quot;Arrivo previsto\&amp;quot; - Non sappiamo dove sia ora l\&apos;autobus, ma l\&apos;orario indica che l\&apos;arrivo è imminente&lt;/string>"
+        errorLine2="                                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="76"
+            column="47"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
+        errorLine1="        - Stuknij na czas przyjazdu i wybierz \&quot;Pokaż status podróży\&quot;!"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="77"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;no_location_permission&quot;>Impossibile individuare la posizione. Fornisci all\&apos;app l\&apos;accesso alla posizione nelle impostazioni di sistema.&lt;/string>"
+        errorLine2="                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="84"
+            column="43"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;bus_options_menu_report_trip_problem&quot;>Segnala problema con orario d\&apos;arrivo&lt;/string>"
+        errorLine2="                                                                                      ~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="98"
+            column="87"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;main_help_whatsnew_title&quot;>What\&apos;s New?&lt;/string>"
+        errorLine2="                                                 ~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="102"
+            column="50"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
+        errorLine1="    &lt;string name=&quot;main_help_legend_ontime&quot;>Vihreä tarkoittaa \&quot;ajoissa\&quot;&lt;/string>"
+        errorLine2="                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="103"
+            column="44"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
+        errorLine1="    &lt;string name=&quot;main_help_legend_late&quot;>Sininen tarkoittaa \&quot;Myöhässä\&quot;&lt;/string>"
+        errorLine2="                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="104"
+            column="42"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
+        errorLine1="    &lt;string name=&quot;main_help_legend_early&quot;>Punainen tarkoittaa \&quot;juoksu aikaisin\&quot;&lt;/string>"
+        errorLine2="                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="105"
+            column="43"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
+        errorLine1="    &lt;string name=&quot;main_help_legend_scheduled&quot;>Harmaa tarkoittaa \&quot;Suunniteltu saapuminen\&quot; - Emme tiedä"
+        errorLine2="                                              ^">
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="106"
+            column="47"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
+        errorLine1="    &lt;string name=&quot;main_help_legend_ontime&quot;>Green means \&quot;On time\&quot;&lt;/string>"
+        errorLine2="                                           ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="106"
+            column="44"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
+        errorLine1="    &lt;string name=&quot;main_help_legend_ontime&quot;>Verde significa \&quot;A tiempo\&quot;&lt;/string>"
+        errorLine2="                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="107"
+            column="44"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
+        errorLine1="    &lt;string name=&quot;main_help_legend_late&quot;>Blue means \&quot;Running late\&quot;&lt;/string>"
+        errorLine2="                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="107"
+            column="42"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
+        errorLine1="    &lt;string name=&quot;main_help_legend_late&quot;>Azul significa \&quot;Llegando tarde\&quot;&lt;/string>"
+        errorLine2="                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="108"
+            column="42"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
+        errorLine1="    &lt;string name=&quot;main_help_legend_early&quot;>Red means \&quot;Running early\&quot;&lt;/string>"
+        errorLine2="                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="108"
+            column="43"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;main_help_legend_scheduled&quot;>Gray means \&quot;Scheduled arrival\&quot; - We don\&apos;t know"
+        errorLine2="                                                                                        ~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="109"
+            column="89"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
+        errorLine1="    &lt;string name=&quot;main_help_legend_early&quot;>Rojo significa \&quot;Llegando antes\&quot;&lt;/string>"
+        errorLine2="                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="109"
+            column="43"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
+        errorLine1="    &lt;string name=&quot;main_help_legend_scheduled&quot;>Gris significa \&quot;Llegada planificada\&quot; - No sabemos"
+        errorLine2="                                              ^">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="110"
+            column="47"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
+        errorLine1="    &lt;string name=&quot;main_help_legend_canceled&quot;>Negro significa \&quot;Cancelado\&quot; - Este viaje ha sido cancelado&lt;/string>"
+        errorLine2="                                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="113"
+            column="46"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
+        errorLine1="    &lt;string name=&quot;main_changelocationmode&quot;>Laitteesi nykyinen &quot;Sijaintimenetelmä&quot;-asetus ei välttämättä ilmoita sinulle määränpäähän lähestymisestä epätarkan sijaintitiedon vuoksi. Haluatko muuttaa laitteesi &quot;Sijaintimenetelmän&quot; asetukseksi &quot;Korkea tarkkuus&quot; nyt?&lt;/string>"
+        errorLine2="                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="120"
+            column="44"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;main_outofrange&quot;>You\&apos;re looking at a place outside the %1$s service area.\n\nMove"
+        errorLine2="                                       ~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="124"
+            column="40"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
+        errorLine1="    &lt;string name=&quot;feedback_log_guide&quot;>Il tuo feedback sarà inviato a %1$s. Se selezioni \&amp;quot;Includi registro di sistema\&amp;quot;, %1$s riceverà dal dispositivo la posizione in tempo reale mentre arrivi a destinazione. Questo ci aiuterà a migliorare la funzione promemoria di destinazione.\n\nCambia le tue preferenze per la condivisione del registro di sistema su Impostazioni.&lt;/string>"
+        errorLine2="                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="262"
+            column="39"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
+        errorLine1="    &lt;string name=&quot;main_changelocationmode&quot;>Le attuali impostazioni di localizzazione del dispositivo non consentono di rilevare una posizione accurata. Potresti non ricevere notifiche in prossimità della destinazione. Desideri cambiare la &amp;quot;Modalità localizzazione&amp;quot; in &amp;quot;Alta precisione&amp;quot;?&lt;/string>"
+        errorLine2="                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="271"
+            column="44"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;route_info_context_get_stop_info&quot;>Mostra informazioni sull\&apos;arrivo&lt;/string>"
+        errorLine2="                                                                             ~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="279"
+            column="78"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
+        errorLine1="    &lt;string name=&quot;feedback_log_guide&quot;>Twoja opinia zostanie wysłana do %1$s. Jeśli zaznaczysz \&quot;Dołącz dzienniki systemowe\&quot;, informacje o lokalizacji w czasie rzeczywistym z Twojego urządzenia zarejestrowane podczas zbliżania się do przystanku docelowego zostaną udostępnione %1$s, aby deweloperzy mogli ulepszyć funkcję przypomnień o celu podróży.\n\nZmień swoje preferencje dotyczące udostępniania dzienników systemowych w Ustawieniach.&lt;/string>"
+        errorLine2="                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="281"
+            column="39"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
+        errorLine1="    &lt;string name=&quot;main_changelocationmode&quot;>Twoje obecne ustawienie \&quot;Metoda lokalizacji\&quot; na urządzeniu może nie powiadomić Cię o zbliżaniu się do celu z powodu niedokładnych informacji o pozycji. Czy chcesz teraz zmienić \&quot;Metodę lokalizacji\&quot; urządzenia na \&quot;Wysoka dokładność\&quot;?"
+        errorLine2="                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="290"
+            column="44"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
+        errorLine1="    &lt;string name=&quot;route_favorite_options_title_star&quot;>Aggiungi linea \&amp;quot;%s\&amp;quot; ai preferiti per:&lt;/string>"
+        errorLine2="                                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="294"
+            column="54"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
+        errorLine1="    &lt;string name=&quot;route_favorite_options_title_unstar&quot;>Rimuovi \&amp;quot;%s\&amp;quot; dai preferiti per:&lt;/string>"
+        errorLine2="                                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="295"
+            column="56"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;my_context_get_stop_info&quot;>Mostra informazioni sull\&apos;arrivo&lt;/string>"
+        errorLine2="                                                                     ~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="302"
+            column="70"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
+        errorLine1="    &lt;string name=&quot;route_favorite_options_title_star&quot;>Lisää suosikki \&quot;%s\&quot;:&lt;/string>"
+        errorLine2="                                                     ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="302"
+            column="54"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
+        errorLine1="    &lt;string name=&quot;route_favorite_options_title_unstar&quot;>Poista suosikki \&quot;%s\&quot;:&lt;/string>"
+        errorLine2="                                                       ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="303"
+            column="56"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
+        errorLine1="    &lt;string name=&quot;feedback_log_guide&quot;>Your feedback will be sent to %1$s. If you check \&quot;Include system logs\&quot;, real-time location information from your device recorded as you approached your destination stop will be shared with %1$s so developers can improve the destination reminder feature.\n\nChange your preference for sharing system logs in Settings.&lt;/string>"
+        errorLine2="                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="314"
+            column="39"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;alert_hidden_snackbar_text&quot;>L\&apos;avviso è nascosto&lt;/string>"
+        errorLine2="                                                ~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="315"
+            column="49"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
+        errorLine1="    &lt;string name=&quot;route_favorite_options_title_star&quot;>Dodaj do ulubionych \&quot;%s\&quot; do:&lt;/string>"
+        errorLine2="                                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="317"
+            column="54"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
+        errorLine1="    &lt;string name=&quot;route_favorite_options_title_unstar&quot;>Usuń ulubione od \&quot;%s\&quot; do:&lt;/string>"
+        errorLine2="                                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="318"
+            column="56"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
+        errorLine1="    &lt;string name=&quot;main_changelocationmode&quot;>Your current device &quot;Location method&quot; setting may fail to"
+        errorLine2="                                           ^">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="324"
+            column="44"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;route_info_no_shape_data&quot;>Sorry, map information isn\&apos;t available for this route"
+        errorLine2="                                                                       ~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="337"
+            column="72"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
+        errorLine1="    &lt;string name=&quot;route_favorite_options_title_star&quot;>Marcar como favorito a \&quot;%s\&quot; para:&lt;/string>"
+        errorLine2="                                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="352"
+            column="54"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
+        errorLine1="    &lt;string name=&quot;route_favorite_options_title_unstar&quot;>Remover de favoritos a \&quot;%s\&quot; para:&lt;/string>"
+        errorLine2="                                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="353"
+            column="56"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
+        errorLine1="    &lt;string name=&quot;route_favorite_options_title_star&quot;>Star Route \&quot;%s\&quot; for:&lt;/string>"
+        errorLine2="                                                     ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="363"
+            column="54"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
+        errorLine1="    &lt;string name=&quot;route_favorite_options_title_unstar&quot;>Remove star from \&quot;%s\&quot; for:&lt;/string>"
+        errorLine2="                                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="364"
+            column="56"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;region_choose_region&quot;>Scegli l\&apos;area&lt;/string>"
+        errorLine2="                                                 ~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="427"
+            column="50"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;region_disabled_auto_selection&quot;>Selezione automatica dell\&apos;area disattivata. Puoi attivarla in Preferenze.&lt;/string>"
+        errorLine2="                                                                            ~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="428"
+            column="77"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;bug_report_body_trip_plan_fail&quot;>Ti invitiamo a scriverci per reclami, apprezzamenti, e segnalazioni di bug!\n\n\nVersione app: %1$s\nModello: %2$s\nVersione SO: %3$s / %4$d\nApp Google Play Services: %5$s\n Libreria Google Play Services: %6$d\nArea/API: %7$s (%8$s)\nLoc: %9$s\n\n Impossibile pianificare il viaggio utilizzando l\&apos;URL: %10$s\n\n&lt;/string>"
+        errorLine2="                                                                                                                                                                                                                                                                                                                                                            ~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="440"
+            column="349"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;bug_report_body_trip_plan&quot;>Ti invitiamo a scriverci per reclami, apprezzamenti, e segnalazioni di bug!\n\n\nVersione app: %1$s\nModello: %2$s\nVersione SO: %3$s / %4$d\nApp Google Play Services: %5$s\n Libreria Google Play Services: %6$d\nArea/API: %7$s (%8$s)\nLoc: %9$s\n\n Pianificare il viaggio utilizzando l\&apos;URL: %10$s\n\n&lt;/string>"
+        errorLine2="                                                                                                                                                                                                                                                                                                                                           ~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="441"
+            column="332"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;bug_report_body_trip_plan_without_location&quot;>Ti invitiamo a scriverci per reclami, apprezzamenti, e segnalazioni di bug!\n\n\nVersione app: %1$s\nModello: %2$s\nVersione SO: %3$s / %4$d\n\nPianificare il viaggio utilizzando l\&apos;URL: %5$s\n\n&lt;/string>"
+        errorLine2="                                                                                                                                                                                                                                                   ~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="442"
+            column="244"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;bug_report_body_trip_plan_without_location_fail&quot;>Ti invitiamo a scriverci per reclami, apprezzamenti, e segnalazioni di bug!\n\n\nVersione app: %1$s\nModello: %2$s\nVersione SO: %3$s / %4$d\n\nImpossibile pianificare il viaggio utilizzando l\&apos;URL: %5$s\n\n&lt;/string>"
+        errorLine2="                                                                                                                                                                                                                                                                    ~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="443"
+            column="261"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;trip_list_notrips&quot;>You don\&apos;t have any reminders.\n\nYou can create reminders by"
+        errorLine2="                                             ~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="447"
+            column="46"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;no_play_store&quot;>L\&apos;App Play Store non è installata su questo dispositivo. Trova un metodo alternativo per installare Google Maps.&lt;/string>"
+        errorLine2="                                   ~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="448"
+            column="36"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;preferences_show_header_arrivals_summary&quot;>Quando visualizzi i preferiti, mostra informazioni sugli arrivi nell\&apos;intestazione (la visuale della mappa resta invariata)&lt;/string>"
+        errorLine2="                                                                                                                                 ~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="484"
+            column="130"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;preferences_show_tutorial_screens_summary&quot;>Mostra popup informativi sull\&apos;utilizzo delle funzionalità&lt;/string>"
+        errorLine2="                                                                                           ~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="490"
+            column="92"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
+        errorLine1="    &lt;string name=&quot;preferences_restore_summary&quot;>Palauttaa aiemmasta varmuuskopiosta. Vaihtoehdon valitsemisen jälkeen sinua pyydetään valitsemaan tiedosto. Valitse varmuuskopiotiedosto (esim. \&quot;db.backup\&quot; tai \&quot;%1$s.backup\&quot;), joka voi olla \&quot;Tiedostot\&quot;-kansiossasi tai missä tahansa tallensit varmuuskopion.&lt;/string>"
+        errorLine2="                                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="506"
+            column="48"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
+        errorLine1="    &lt;string name=&quot;preferences_restore_summary&quot;>Ripristina da un backup precedente. Dopo aver selezionato questa opzione, ti verrà chiesto di scegliere un file. Seleziona il file di backup (es. \&quot;db.backup\&quot; o \&quot;%1$s.backup\&quot;), che potrebbe trovarsi nella cartella \&quot;Documenti\&quot; o in qualsiasi posizione in cui hai salvato il backup.&lt;/string>"
+        errorLine2="                                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="507"
+            column="48"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;preferences_experimental_regions_disable_warning&quot;>L\&apos;area sperimentale corrente non sarà disponibile! Vuoi procedere?&lt;/string>"
+        errorLine2="                                                                      ~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="517"
+            column="71"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;preferences_analytics_summary&quot;>Aiutaci a migliorare l\&apos;app&lt;/string>"
+        errorLine2="                                                                        ~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="519"
+            column="73"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;region_load_failed_title&quot;>Couldn\&apos;t load regions&lt;/string>"
+        errorLine2="                                                   ~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="520"
+            column="52"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;region_dialog_message&quot;>Ti trovi nell\&apos;area di %1$s?&lt;/string>"
+        errorLine2="                                                       ~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="553"
+            column="56"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
+        errorLine1="    &lt;string name=&quot;preference_region_dialog_message&quot;>La tua area è impostata su: %1$s. Se ci siamo sbagliati, premi su &amp;quot;La tua area&amp;quot; per cambiarla!&lt;/string>"
+        errorLine2="                                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="554"
+            column="53"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&apos;&apos;) with directional quotes (‘’, &amp;#8216; and &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;preference_region_dialog_message&quot;>Alueeksesi on tällä hetkellä asetettu %1$s. Jos tämä on väärin, muuta sitä napauttamalla \&apos;Alueesi\&apos;!&lt;/string>"
+        errorLine2="                                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="560"
+            column="53"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;no_play_store&quot;>Your device doesn\&apos;t have the Play Store installed. Please find"
+        errorLine2="                                                   ~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="561"
+            column="52"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;ri_address_not_found&quot;>Indirizzo non trovato. Controlla l\&apos;indirizzo inserito.&lt;/string>"
+        errorLine2="                                                                           ~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="563"
+            column="76"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;ri_service_trip&quot;>Problema con orario d\&apos;arrivo&lt;/string>"
+        errorLine2="                                                         ~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="568"
+            column="58"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;ri_unsuccessful_submit&quot;>Si è verificato un errore durante l\&apos;invio, riprova più tardi.&lt;/string>"
+        errorLine2="                                                                              ~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="575"
+            column="79"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
+        errorLine1="    &lt;string name=&quot;preferences_restore_summary&quot;>Przywraca z poprzedniej kopii zapasowej. Po wybraniu tej opcji zostaniesz poproszony o wybranie pliku. Wybierz plik kopii zapasowej (np. \&quot;db.backup\&quot; lub \&quot;%1$s.backup\&quot;), który może znajdować się w folderze \&quot;Dokumenty\&quot; lub w dowolnym miejscu, gdzie zapisałeś kopię zapasową.&lt;/string>"
+        errorLine2="                                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="580"
+            column="48"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;rt_arrival_problem&quot;>Segnala problema con l\&apos;orario d\&apos;arrivo&lt;/string>"
+        errorLine2="                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="582"
+            column="39"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;rt_app_feedback&quot;>Invia feedback sull\&apos;app&lt;/string>"
+        errorLine2="                                                       ~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="584"
+            column="56"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="        show arrival info in the header at the top of the screen (doesn\&apos;t affect map view)"
+        errorLine2="                                                                        ~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="608"
+            column="73"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;trip_details_current_bus_position&quot;>L\&apos;autobus si trova qui:&lt;/string>"
+        errorLine2="                                                       ~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="621"
+            column="56"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
+        errorLine1="    &lt;string name=&quot;preference_region_dialog_message&quot;>Twój region jest obecnie ustawiony na %1$s. Jeśli to nieprawidłowe, dotknij \&quot;Twój region\&quot;, aby to zmienić!&lt;/string>"
+        errorLine2="                                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="633"
+            column="53"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
+        errorLine1="    &lt;string name=&quot;preferences_restore_summary&quot;>Restaura desde un respaldo anterior. Después de seleccionar esta opción, se te pedirá que elijas un archivo. Por favor selecciona el archivo de respaldo (por ejemplo, \&quot;db.backup\&quot; o \&quot;%1$s.backup\&quot;), que puede estar en tu carpeta \&quot;Documentos\&quot; o en cualquier ubicación donde guardaste el respaldo.&lt;/string>"
+        errorLine2="                                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="634"
+            column="48"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;vehicle_last_updated_scheduled&quot;>Posizione calcolata in base all\&apos;orario&lt;/string>"
+        errorLine2="                                                                                  ~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="635"
+            column="83"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;tutorial_arrival_header_sliding_panel_title&quot;>Liu\&apos;uta nähdäksesi lisää saapuvia"
+        errorLine2="                                                                   ~">
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="638"
+            column="68"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;night_light_dialog_title&quot;>Non perdere più l\&apos;autobus la sera!&lt;/string>"
+        errorLine2="                                                              ~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="638"
+            column="63"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;night_light_dialog_message&quot;>Non ne puoi più degli autobus che non si fermano perché è notte e l\&apos;autista non ti vede? Usa la Luce notturna intermittente e renditi visibile! \n\nATTENZIONE: Questa funzionalità potrebbe scatenare attacchi epilettici in persone affette da epilessia fotosensibile. Utilizzare con cautela.&lt;/string>"
+        errorLine2="                                                                                                                  ~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="639"
+            column="115"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;preferences_restore_summary&quot;>Restores from a previous backup. After selecting this option, you\&apos;ll be asked to pick a file. Please select the backup file (e.g., &quot;db.backup&quot; or &quot;%1$s.backup&quot;), which may be in your &quot;Documents&quot; folder or any location where you saved the backup.&lt;/string>"
+        errorLine2="                                                                                                                 ~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="642"
+            column="114"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;tutorial_opt_out_dialog_text&quot;>Desideri che vengano mostrati popup informativi per l\&apos;utilizzo di %1$s? Puoi sempre attivare e disattivare i popup nelle impostazioni, o mostrare il tutorial in seguito premendo su Aiuto.&lt;/string>"
+        errorLine2="                                                                                                      ~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="648"
+            column="103"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
+        errorLine1="    &lt;string name=&quot;tutorial_recent_stops_routes_text&quot;>Ruudun oikeasta laidasta löytyvän \&quot;Lisää\&quot; napin "
+        errorLine2="                                                     ^">
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="648"
+            column="54"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;tutorial_arrival_header_arrival_info_title&quot;>Quanto manca all\&apos;arrivo dell\&apos;autobus?&lt;/string>"
+        errorLine2="                                                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="649"
+            column="63"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;tutorial_arrival_header_arrival_info_text&quot;>Tanto così! Lo sfondo colorato ti dice se l\&apos;autobus è in anticipo (rosso) o in ritardo (blu). In orario = sfondo verde. Se non sappiamo dove sia l\&apos;autobus, ti mostriamo l\&apos;orario previsto (sfondo grigio). Grigio con testo barrato significa che il tragitto è stato cancellato.&lt;/string>"
+        errorLine2="                                                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="650"
+            column="62"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
+        errorLine1="    &lt;string name=&quot;tutorial_recent_stops_routes_text&quot;>Per ritrovare le fermate e le linee cercate di recente, tocca il pulsante \&amp;quot;Altro\&amp;quot; in alto a destra.&lt;/string>"
+        errorLine2="                                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="656"
+            column="54"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;location_permissions_message&quot;>Per migliorare la tua esperienza, abilita l\&apos;utilizzo della posizione per:\n  - Visualizzare la tua posizione in tempo reale sulla mappa.\n  - Impostare automaticamente la tua agenzia di transito locale.\n\nI tuoi dati di posizione non vengono raccolti da noi. In alternativa, puoi selezionare manualmente la tua regione senza abilitare i permessi di localizzazione.&lt;/string>"
+        errorLine2="                                                                                            ~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="660"
+            column="93"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="        won\&apos;t be available! Go ahead?"
+        errorLine2="            ~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="664"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;about_contributors_intro&quot;>I nostri dedicati contributori migliorano la funzionalità e l\&apos;esperienza utente dell\&apos;applicazione:&lt;/string>"
+        errorLine2="                                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="669"
+            column="45"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&apos;&apos;) with directional quotes (‘’, &amp;#8216; and &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;preferences_reset_donation_timestamps_summary&quot;>Tämän vaihtoehdon napauttaminen poistaa sekä \&apos;Muistuta minua myöhemmin\&apos; että \&apos;Älä vaivaudu\&apos; aikaleimat, jotka liittyvät lahjoituspyyntöihin.&lt;/string>"
+        errorLine2="                                                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="714"
+            column="66"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;ri_open_camera_problem&quot;>Camera couldn\&apos;t be opened.&lt;/string>"
+        errorLine2="                                                        ~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="719"
+            column="57"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;ri_resize_image_problem&quot;>Image couldn\&apos;t be resized - using full size.&lt;/string>"
+        errorLine2="                                                        ~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="720"
+            column="57"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;tripplanner_no_contact&quot;>Non c\&apos;è un contatto per la pianificazione del viaggio in ques\&apos;area.&lt;/string>"
+        errorLine2="                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="738"
+            column="43"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
+        errorLine1="    &lt;string name=&quot;tutorial_recent_stops_routes_text&quot;>Znajdź przystanki i trasy które ostatnio"
+        errorLine2="                                                     ^">
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="760"
+            column="54"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="        couldn\&apos;t see you in the dark? Hold up your flashing Night Light and make yourself visible!"
+        errorLine2="               ~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="798"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;step_by_step_non_transit_dir_relative_elevator&quot;>Prendi l\&apos;ascensore&lt;/string>"
+        errorLine2="                                                                           ~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="804"
+            column="76"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
+        errorLine1="    &lt;string name=&quot;tutorial_recent_stops_routes_text&quot;>Encuentra las paradas y rutas que recientemente has mirado"
+        errorLine2="                                                     ^">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="810"
+            column="54"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;step_by_step_non_transit_dir_relative_uturn_left&quot;>Fai un\&apos;inversione a sinistra&lt;/string>"
+        errorLine2="                                                                           ~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="811"
+            column="76"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;step_by_step_non_transit_dir_relative_uturn_right&quot;>Fai un\&apos;inversione a destra&lt;/string>"
+        errorLine2="                                                                            ~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="812"
+            column="77"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="        if the bus is early (red) or late (blue). On time = green background. If we don\&apos;t know"
+        errorLine2="                                                                                        ~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="817"
+            column="89"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&apos;&apos;) with directional quotes (‘’, &amp;#8216; and &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;preferences_reset_donation_timestamps_summary&quot;>Dotknięcie tej opcji spowoduje wyczyszczenie znaczników czasu \&apos;Przypomnij mi później\&apos; i \&apos;Nie przeszkadzaj mi\&apos; związanych z prośbami o darowizny.&lt;/string>"
+        errorLine2="                                                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="830"
+            column="66"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;tutorial_recent_stops_routes_text&quot;>Find the stops and routes that you\&apos;ve recently"
+        errorLine2="                                                                                        ~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="831"
+            column="89"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;tutorial_welcome_map_stop_title&quot;>Here\&apos;s a stop&lt;/string>"
+        errorLine2="                                                        ~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="838"
+            column="57"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;about_contributors_intro&quot;>Our dedicated contributors improve the app\&apos;s functionality and user experience:&lt;/string>"
+        errorLine2="                                                                                       ~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="857"
+            column="88"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;donation_dismiss_dialog_body&quot;>%1$s è un\&apos;organizzazione gestita da volontari con quasi nessun finanziamento. Abbiamo bisogno del tuo aiuto per mantenere questa app in funzione.&lt;/string>"
+        errorLine2="                                                          ~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="922"
+            column="59"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;tripplanner_error_path_not_found&quot;>Couldn\&apos;t find a matching route between origin and destination&lt;/string>"
+        errorLine2="                                                           ~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="924"
+            column="60"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;donation_learn_more_explanation&quot; tools:ignore=&quot;TypographyOther&quot;>&quot;Abbiamo grandi piani per migliorare %1$s, ma non possiamo farlo senza il tuo aiuto. Questa app è attualmente sviluppata con il 100%% di lavoro volontario, e abbiamo bisogno del tuo aiuto per finanziare lo sviluppo futuro.\n\nCome progetto chiave della Open Transit Software Foundation, un&apos;organizzazione non profit 501(c)(3), ci affidiamo alla buona volontà di utenti come te per continuare a funzionare e migliorare questo software.\n\nOgni anno, solo una piccola frazione dei nostri utenti dona, ma ogni contributo, grande o piccolo, aiuta a garantire che %1$s rimanga gratuito, aggiornato e accessibile a tutti. Una piccola donazione, anche solo il costo di una settimana di pendolarismo, $27.50, può fare tutta la differenza.\n\nIl tuo contributo deducibile dalle tasse assicura che %1$s rimanga libero e accessibile per tutti. Modelliamo insieme il futuro del trasporto pubblico!\n\nGrazie,\nIl Team di %1$s&quot;&lt;/string>"
+        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                   ~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="928"
+            column="372"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&apos;&apos;) with directional quotes (‘’, &amp;#8216; and &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;preferences_reset_donation_timestamps_summary&quot;>Toccando questa opzione verranno cancellati i timestamp di \&apos;Ricordamelo più tardi\&apos; e \&apos;Non disturbarmi\&apos; associati alle richieste di donazione.&lt;/string>"
+        errorLine2="                                                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="930"
+            column="66"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;preferences_show_available_studies_body&quot;>Partecipa agli studi per aiutare a migliorare la tua esperienza di trasporto e con l\&apos;app.&lt;/string>"
+        errorLine2="                                                                                                                                                ~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="939"
+            column="145"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;dismiss_survey_dialog_body&quot;>Il tuo feedback aiuta a migliorare i servizi di trasporto e le esperienze con l\&apos;app.&lt;/string>"
+        errorLine2="                                                                                                                              ~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="951"
+            column="127"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
+        errorLine1="    &lt;string name=&quot;feedback_log_guide&quot;>Palautteesi lähetetään %1$slle. Jos valitset &quot;Sisällytä järjestelmälokit&quot;, laitteestasi tallennettu reaaliaikainen sijaintitieto määränpääpysäkille lähestyttäessä jaetaan %1$sn kanssa, jotta kehittäjät voivat parantaa määränpäämuistutusominaisuutta.\n\nVoit muuttaa järjestelmälokien jakamisasetusta Asetuksissa.&lt;/string>"
+        errorLine2="                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="965"
+            column="39"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&apos;&apos;) with directional quotes (‘’, &amp;#8216; and &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;preferences_reset_donation_timestamps_summary&quot;>Al tocar esta opción se borrarán las marcas de tiempo de \&apos;Recuérdame más tarde\&apos; y \&apos;No me molestes\&apos; asociadas con las solicitudes de donación.&lt;/string>"
+        errorLine2="                                                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="1085"
+            column="66"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;donation_dismiss_dialog_title&quot;>Please don\&apos;t dismiss this request&lt;/string>"
+        errorLine2="                                                            ~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1126"
+            column="61"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;donation_dismiss_dialog_dont_want_to_help_button&quot;>I Don\&apos;t Want to Help&lt;/string>"
+        errorLine2="                                                                          ~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1129"
+            column="75"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;donation_learn_more_explanation&quot; tools:ignore=&quot;TypographyOther&quot;>We have big plans to improve %1$s, but we can\&apos;t do it without your help. This app is currently built with 100%% volunteer labor, and we need you to help us fund future development.\n\nAs a key project of the Open Transit Software Foundation, a 501(c)(3) non-profit, we rely on the goodwill of users like you to keep running and making this software better.\n\nEvery year, only a small fraction of our users donate, but every contribution, big or small, helps ensure that %1$s remains free, updated, and accessible to everyone. A small donation, even just the cost of one week of commuting, $27.50, can make all the difference.\n\nYour tax-deductible contribution ensures that %1$s remains free and accessible for everyone. Let\&apos;s shape the future of transit together!\n\nThank you,\nThe %1$s Team&lt;/string>"
+        errorLine2="                                                                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1135"
+            column="83"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&apos;&apos;) with directional quotes (‘’, &amp;#8216; and &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;preferences_reset_donation_timestamps_summary&quot;>Tapping this option will clear both the \&apos;Remind Me Later\&apos; and \&apos;Don\&apos;t Bother Me\&apos; timestamps associated with donation requests.&lt;/string>"
+        errorLine2="                                                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1137"
+            column="66"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
+        errorLine1="    &lt;string name=&quot;feedback_log_guide&quot;>Tus comentarios serán enviados a %1$s. Si marcas \&quot;Incluir registros del sistema\&quot;, la información de ubicación en tiempo real de tu dispositivo registrada al acercarte a tu parada de destino será compartida con %1$s para que los desarrolladores puedan mejorar la función de recordatorio de destino.\n\nCambia tu preferencia para compartir registros del sistema en Configuración.&lt;/string>"
+        errorLine2="                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="1142"
+            column="39"/>
+    </issue>
+
+    <issue
+        id="ConvertToWebp"
+        message="One or more images in this project can be converted to the WebP format which typically results in smaller file sizes, even for lossless conversion">
+        <location
+            file="src/main/res/drawable-nodpi/wmata.jpg"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static int findFirstNonNegativeArrival(ArrayList&lt;ArrivalInfo> infoList) {"
+        errorLine2="                                                  ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/ArrivalInfoUtils.java"
+            line="47"
+            column="51"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static ArrayList&lt;Integer> findPreferredArrivalIndexes(ArrayList&lt;ArrivalInfo> infoList) {"
+        errorLine2="                  ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/ArrivalInfoUtils.java"
+            line="70"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static ArrayList&lt;Integer> findPreferredArrivalIndexes(ArrayList&lt;ArrivalInfo> infoList) {"
+        errorLine2="                                                                 ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/ArrivalInfoUtils.java"
+            line="70"
+            column="66"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static String computeArrivalLabelFromDelay(Resources res, long delay) {"
+        errorLine2="                  ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/ArrivalInfoUtils.java"
+            line="170"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static String computeArrivalLabelFromDelay(Resources res, long delay) {"
+        errorLine2="                                                      ~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/ArrivalInfoUtils.java"
+            line="170"
+            column="55"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static void restore(Context activityContext, Uri uri, Runnable onRestored) {"
+        errorLine2="                               ~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/backup/BackupUtils.java"
+            line="47"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static void restore(Context activityContext, Uri uri, Runnable onRestored) {"
+        errorLine2="                                                        ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/backup/BackupUtils.java"
+            line="47"
+            column="57"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static void restore(Context activityContext, Uri uri, Runnable onRestored) {"
+        errorLine2="                                                                 ~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/backup/BackupUtils.java"
+            line="47"
+            column="66"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static void save(Context activityContext,Uri uri) {"
+        errorLine2="                            ~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/backup/BackupUtils.java"
+            line="101"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static void save(Context activityContext,Uri uri) {"
+        errorLine2="                                                    ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/backup/BackupUtils.java"
+            line="101"
+            column="53"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static Intent buildCreateBackupFileIntent() {"
+        errorLine2="                  ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/backup/BackupUtils.java"
+            line="115"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static Intent buildSelectBackupFileIntent() {"
+        errorLine2="                  ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/backup/BackupUtils.java"
+            line="134"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static String getPreferenceOptionForArrivalInfoBuildFlavorStyle(Context context, int buildFlavorStyle) {"
+        errorLine2="                  ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/BuildFlavorUtils.java"
+            line="52"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static String getPreferenceOptionForArrivalInfoBuildFlavorStyle(Context context, int buildFlavorStyle) {"
+        errorLine2="                                                                           ~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/BuildFlavorUtils.java"
+            line="52"
+            column="76"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static void applyDefaultArrivalInfoStyleIfUnset(Context context) {"
+        errorLine2="                                                           ~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/BuildFlavorUtils.java"
+            line="72"
+            column="60"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static int getArrivalInfoStyleFromPreferences(Context context) {"
+        errorLine2="                                                         ~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/BuildFlavorUtils.java"
+            line="91"
+            column="58"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static void setArrivalInfoStyle(Context context, int style) {"
+        errorLine2="                                           ~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/BuildFlavorUtils.java"
+            line="120"
+            column="44"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="            @ApplicationContext Context context,"
+        errorLine2="                                ~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/donations/DonationsManager.java"
+            line="38"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="            PreferencesRepository preferences) {"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/donations/DonationsManager.java"
+            line="39"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public Date getDonationRequestDismissedDate() {"
+        errorLine2="           ~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/donations/DonationsManager.java"
+            line="68"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public void setDonationRequestDismissedDate(Date date) {"
+        errorLine2="                                                ~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/donations/DonationsManager.java"
+            line="81"
+            column="49"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public Date getDonationRequestReminderDate() {"
+        errorLine2="           ~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/donations/DonationsManager.java"
+            line="102"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public void setDonationRequestReminderDate(Date date) {"
+        errorLine2="                                               ~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/donations/DonationsManager.java"
+            line="111"
+            column="48"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public String donateUrl() {"
+        errorLine2="           ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/donations/DonationsManager.java"
+            line="166"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public Intent buildOpenDonationsPageIntent() {"
+        errorLine2="           ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/donations/DonationsManager.java"
+            line="175"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static Bundle getIntentArgs(Intent intent) {"
+        errorLine2="                  ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/FragmentUtils.java"
+            line="28"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static Bundle getIntentArgs(Intent intent) {"
+        errorLine2="                                       ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/FragmentUtils.java"
+            line="28"
+            column="40"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public CustomAddress getCustomAddressFromPlacesIntent(Context context, Intent intent) {"
+        errorLine2="           ~~~~~~~~~~~~~">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleProprietaryMapHelper.java"
+            line="35"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public CustomAddress getCustomAddressFromPlacesIntent(Context context, Intent intent) {"
+        errorLine2="                                                          ~~~~~~~">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleProprietaryMapHelper.java"
+            line="35"
+            column="59"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public CustomAddress getCustomAddressFromPlacesIntent(Context context, Intent intent) {"
+        errorLine2="                                                                           ~~~~~~">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleProprietaryMapHelper.java"
+            line="35"
+            column="76"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public View.OnClickListener createPlacesAutocompleteOnClick(int requestCode, Fragment fragment, Region region) {"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleProprietaryMapHelper.java"
+            line="40"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public View.OnClickListener createPlacesAutocompleteOnClick(int requestCode, Fragment fragment, Region region) {"
+        errorLine2="                                                                                 ~~~~~~~~">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleProprietaryMapHelper.java"
+            line="40"
+            column="82"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public View.OnClickListener createPlacesAutocompleteOnClick(int requestCode, Fragment fragment, Region region) {"
+        errorLine2="                                                                                                    ~~~~~~">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleProprietaryMapHelper.java"
+            line="40"
+            column="101"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    void onAlert(String title, String message, String url);"
+        errorLine2="                 ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/widealerts/GtfsAlertCallBack.java"
+            line="5"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    void onAlert(String title, String message, String url);"
+        errorLine2="                               ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/widealerts/GtfsAlertCallBack.java"
+            line="5"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    void onAlert(String title, String message, String url);"
+        errorLine2="                                               ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/widealerts/GtfsAlertCallBack.java"
+            line="5"
+            column="48"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public GtfsAlerts(@ApplicationContext Context context) {"
+        errorLine2="                                          ~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/widealerts/GtfsAlerts.java"
+            line="34"
+            column="43"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public void fetchAlerts(String regionId, GtfsAlertCallBack callback) {"
+        errorLine2="                            ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/widealerts/GtfsAlerts.java"
+            line="44"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public void fetchAlerts(String regionId, GtfsAlertCallBack callback) {"
+        errorLine2="                                             ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/widealerts/GtfsAlerts.java"
+            line="44"
+            column="46"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public void processAlerts(List&lt;GtfsRealtime.FeedEntity> alerts, long nowMs, GtfsAlertCallBack callback) {"
+        errorLine2="                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/widealerts/GtfsAlerts.java"
+            line="82"
+            column="31"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public void processAlerts(List&lt;GtfsRealtime.FeedEntity> alerts, long nowMs, GtfsAlertCallBack callback) {"
+        errorLine2="                                                                                ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/widealerts/GtfsAlerts.java"
+            line="82"
+            column="81"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public String getGtfsAlertsUrl(String regionId) {"
+        errorLine2="           ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/widealerts/GtfsAlerts.java"
+            line="107"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public String getGtfsAlertsUrl(String regionId) {"
+        errorLine2="                                   ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/widealerts/GtfsAlerts.java"
+            line="107"
+            column="36"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static String getAlertTitle(GtfsRealtime.Alert alert) {"
+        errorLine2="                  ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/widealerts/GtfsAlertsHelper.java"
+            line="25"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static String getAlertTitle(GtfsRealtime.Alert alert) {"
+        errorLine2="                                       ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/widealerts/GtfsAlertsHelper.java"
+            line="25"
+            column="40"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static String getAlertDescription(GtfsRealtime.Alert alert) {"
+        errorLine2="                  ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/widealerts/GtfsAlertsHelper.java"
+            line="47"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static String getAlertDescription(GtfsRealtime.Alert alert) {"
+        errorLine2="                                             ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/widealerts/GtfsAlertsHelper.java"
+            line="47"
+            column="46"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static String getAlertUrl(GtfsRealtime.Alert alert) {"
+        errorLine2="                  ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/widealerts/GtfsAlertsHelper.java"
+            line="69"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static String getAlertUrl(GtfsRealtime.Alert alert) {"
+        errorLine2="                                     ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/widealerts/GtfsAlertsHelper.java"
+            line="69"
+            column="38"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static boolean isValidEntity(Context context, GtfsRealtime.FeedEntity entity, long nowMs) {"
+        errorLine2="                                        ~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/widealerts/GtfsAlertsHelper.java"
+            line="93"
+            column="41"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static boolean isValidEntity(Context context, GtfsRealtime.FeedEntity entity, long nowMs) {"
+        errorLine2="                                                         ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/widealerts/GtfsAlertsHelper.java"
+            line="93"
+            column="58"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static boolean isAgencyWideAlert(GtfsRealtime.Alert alert) {"
+        errorLine2="                                            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/widealerts/GtfsAlertsHelper.java"
+            line="103"
+            column="45"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static boolean isHighSeverity(GtfsRealtime.Alert alert) {"
+        errorLine2="                                         ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/widealerts/GtfsAlertsHelper.java"
+            line="118"
+            column="42"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static boolean isStartDateWithin24Hours(GtfsRealtime.Alert alert, long nowMs) {"
+        errorLine2="                                                   ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/widealerts/GtfsAlertsHelper.java"
+            line="133"
+            column="52"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static boolean isAlertRead(Context context, GtfsRealtime.FeedEntity entity) {"
+        errorLine2="                                      ~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/widealerts/GtfsAlertsHelper.java"
+            line="156"
+            column="39"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static boolean isAlertRead(Context context, GtfsRealtime.FeedEntity entity) {"
+        errorLine2="                                                       ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/widealerts/GtfsAlertsHelper.java"
+            line="156"
+            column="56"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static void markAlertAsRead(Context context, GtfsRealtime.FeedEntity entity) {"
+        errorLine2="                                       ~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/widealerts/GtfsAlertsHelper.java"
+            line="166"
+            column="40"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static void markAlertAsRead(Context context, GtfsRealtime.FeedEntity entity) {"
+        errorLine2="                                                        ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/widealerts/GtfsAlertsHelper.java"
+            line="166"
+            column="57"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static String getCurrentAppLanguageCode() {"
+        errorLine2="                  ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/widealerts/GtfsAlertsHelper.java"
+            line="178"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static boolean isBikeshareLayerVisible(Context context) {"
+        errorLine2="                                                  ~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/LayerUtils.java"
+            line="35"
+            column="51"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="        void onLocationChanged(Location location);"
+        errorLine2="                               ~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/LocationHelper.java"
+            line="51"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public LocationHelper(Context context) {"
+        errorLine2="                          ~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/LocationHelper.java"
+            line="75"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public LocationHelper(Context context, int interval) {"
+        errorLine2="                          ~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/LocationHelper.java"
+            line="84"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public synchronized boolean registerListener(Listener listener) {"
+        errorLine2="                                                 ~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/LocationHelper.java"
+            line="105"
+            column="50"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public synchronized void unregisterListener(Listener listener) {"
+        errorLine2="                                                ~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/LocationHelper.java"
+            line="122"
+            column="49"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public void onLocationChanged(Location location) {"
+        errorLine2="                                  ~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/LocationHelper.java"
+            line="160"
+            column="35"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public void onProviderEnabled(String provider) {"
+        errorLine2="                                  ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/LocationHelper.java"
+            line="183"
+            column="35"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public void onProviderDisabled(String provider) {"
+        errorLine2="                                   ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/LocationHelper.java"
+            line="188"
+            column="36"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static Location getDefaultSearchCenter(Context context) {"
+        errorLine2="                  ~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/LocationUtils.java"
+            line="66"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static Location getDefaultSearchCenter(Context context) {"
+        errorLine2="                                                  ~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/LocationUtils.java"
+            line="66"
+            column="51"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static Location getSearchCenter(Context context) {"
+        errorLine2="                  ~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/LocationUtils.java"
+            line="81"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static Location getSearchCenter(Context context) {"
+        errorLine2="                                           ~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/LocationUtils.java"
+            line="81"
+            column="44"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static boolean compareLocationsByTime(Location a, Location b) {"
+        errorLine2="                                                 ~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/LocationUtils.java"
+            line="96"
+            column="50"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static boolean compareLocationsByTime(Location a, Location b) {"
+        errorLine2="                                                             ~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/LocationUtils.java"
+            line="96"
+            column="62"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static boolean compareLocations(Location a, Location b) {"
+        errorLine2="                                           ~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/LocationUtils.java"
+            line="110"
+            column="44"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static boolean compareLocations(Location a, Location b) {"
+        errorLine2="                                                       ~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/LocationUtils.java"
+            line="110"
+            column="56"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static boolean isDuplicate(Location a, Location b) {"
+        errorLine2="                                      ~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/LocationUtils.java"
+            line="142"
+            column="39"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static boolean isDuplicate(Location a, Location b) {"
+        errorLine2="                                                  ~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/LocationUtils.java"
+            line="142"
+            column="51"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static Location makeLocation(double lat, double lon) {"
+        errorLine2="                  ~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/LocationUtils.java"
+            line="162"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static boolean fuzzyEquals(Location a, Location b) {"
+        errorLine2="                                      ~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/LocationUtils.java"
+            line="177"
+            column="39"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static boolean fuzzyEquals(Location a, Location b) {"
+        errorLine2="                                                  ~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/LocationUtils.java"
+            line="177"
+            column="51"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static boolean isLocationEnabled(Context context) {"
+        errorLine2="                                            ~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/LocationUtils.java"
+            line="190"
+            column="45"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static int getLocationMode(Context context) {"
+        errorLine2="                                      ~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/LocationUtils.java"
+            line="200"
+            column="39"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static String printLocationDetails(Location loc) {"
+        errorLine2="                  ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/LocationUtils.java"
+            line="217"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static String printLocationDetails(Location loc) {"
+        errorLine2="                                              ~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/LocationUtils.java"
+            line="217"
+            column="47"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static List&lt;CustomAddress> processGooglePlacesGeocoding(Context context, Region region,"
+        errorLine2="                  ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/LocationUtils.java"
+            line="242"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static List&lt;CustomAddress> processGooglePlacesGeocoding(Context context, Region region,"
+        errorLine2="                                                                   ~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/LocationUtils.java"
+            line="242"
+            column="68"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static List&lt;CustomAddress> processGooglePlacesGeocoding(Context context, Region region,"
+        errorLine2="                                                                                    ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/LocationUtils.java"
+            line="242"
+            column="85"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="                                                                   String... reqs) {"
+        errorLine2="                                                                   ~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/LocationUtils.java"
+            line="243"
+            column="68"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static List&lt;CustomAddress> processGeocoding(Context context, Region region, boolean geocodingForMarker, String... reqs) {"
+        errorLine2="                  ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/LocationUtils.java"
+            line="247"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static List&lt;CustomAddress> processGeocoding(Context context, Region region, boolean geocodingForMarker, String... reqs) {"
+        errorLine2="                                                       ~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/LocationUtils.java"
+            line="247"
+            column="56"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static List&lt;CustomAddress> processGeocoding(Context context, Region region, boolean geocodingForMarker, String... reqs) {"
+        errorLine2="                                                                        ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/LocationUtils.java"
+            line="247"
+            column="73"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static List&lt;CustomAddress> processGeocoding(Context context, Region region, boolean geocodingForMarker, String... reqs) {"
+        errorLine2="                                                                                                                   ~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/LocationUtils.java"
+            line="247"
+            column="116"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static List&lt;CustomAddress> processPeliasGeocoding(Context context, Region region,"
+        errorLine2="                  ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/LocationUtils.java"
+            line="362"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static List&lt;CustomAddress> processPeliasGeocoding(Context context, Region region,"
+        errorLine2="                                                             ~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/LocationUtils.java"
+            line="362"
+            column="62"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static List&lt;CustomAddress> processPeliasGeocoding(Context context, Region region,"
+        errorLine2="                                                                              ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/LocationUtils.java"
+            line="362"
+            column="79"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="            String... reqs) {"
+        errorLine2="            ~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/LocationUtils.java"
+            line="363"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static List&lt;CustomAddress> processPeliasGeocoding(Context context, Region region, boolean geocodingForMarker, String... reqs) {"
+        errorLine2="                  ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/LocationUtils.java"
+            line="367"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static List&lt;CustomAddress> processPeliasGeocoding(Context context, Region region, boolean geocodingForMarker, String... reqs) {"
+        errorLine2="                                                             ~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/LocationUtils.java"
+            line="367"
+            column="62"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static List&lt;CustomAddress> processPeliasGeocoding(Context context, Region region, boolean geocodingForMarker, String... reqs) {"
+        errorLine2="                                                                              ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/LocationUtils.java"
+            line="367"
+            column="79"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static List&lt;CustomAddress> processPeliasGeocoding(Context context, Region region, boolean geocodingForMarker, String... reqs) {"
+        errorLine2="                                                                                                                         ~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/LocationUtils.java"
+            line="367"
+            column="122"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static final LatLng makeLatLng(double lat, double lon) {"
+        errorLine2="                        ~~~~~~">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/MapHelpV2.java"
+            line="42"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static final LatLng makeLatLng(Location l) {"
+        errorLine2="                        ~~~~~~">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/MapHelpV2.java"
+            line="52"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static final LatLng makeLatLng(Location l) {"
+        errorLine2="                                          ~~~~~~~~">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/MapHelpV2.java"
+            line="52"
+            column="43"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static final Location makeLocation(LatLng latLng) {"
+        errorLine2="                        ~~~~~~~~">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/MapHelpV2.java"
+            line="62"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static final Location makeLocation(LatLng latLng) {"
+        errorLine2="                                              ~~~~~~">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/MapHelpV2.java"
+            line="62"
+            column="47"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static LatLngBounds getRegionBounds(Region region) {"
+        errorLine2="                  ~~~~~~~~~~~~">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/MapHelpV2.java"
+            line="74"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static LatLngBounds getRegionBounds(Region region) {"
+        errorLine2="                                               ~~~~~~">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/MapHelpV2.java"
+            line="74"
+            column="48"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static boolean isMapsInstalled(Context context) {"
+        errorLine2="                                          ~~~~~~~">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/MapHelpV2.java"
+            line="119"
+            column="43"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static void promptUserInstallMaps(final Context context) {"
+        errorLine2="                                                   ~~~~~~~">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/MapHelpV2.java"
+            line="126"
+            column="52"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    boolean markerClicked(Marker marker);"
+        errorLine2="                          ~~~~~~">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/MarkerListeners.java"
+            line="37"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    void removeMarkerClicked(LatLng latLng);"
+        errorLine2="                             ~~~~~~">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/MarkerListeners.java"
+            line="44"
+            column="30"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static TextToSpeech mTTS;          // TextToSpeech for speaking commands."
+        errorLine2="                  ~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/nav/NavigationServiceProvider.java"
+            line="94"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public NavigationServiceProvider(Context context, String tripId, String stopId) {"
+        errorLine2="                                     ~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/nav/NavigationServiceProvider.java"
+            line="103"
+            column="38"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public NavigationServiceProvider(Context context, String tripId, String stopId) {"
+        errorLine2="                                                      ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/nav/NavigationServiceProvider.java"
+            line="103"
+            column="55"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public NavigationServiceProvider(Context context, String tripId, String stopId) {"
+        errorLine2="                                                                     ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/nav/NavigationServiceProvider.java"
+            line="103"
+            column="70"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public NavigationServiceProvider(Context context, String tripId, String stopId, int flag) {"
+        errorLine2="                                     ~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/nav/NavigationServiceProvider.java"
+            line="114"
+            column="38"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public NavigationServiceProvider(Context context, String tripId, String stopId, int flag) {"
+        errorLine2="                                                      ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/nav/NavigationServiceProvider.java"
+            line="114"
+            column="55"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public NavigationServiceProvider(Context context, String tripId, String stopId, int flag) {"
+        errorLine2="                                                                     ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/nav/NavigationServiceProvider.java"
+            line="114"
+            column="70"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public void navigate(Path path) {"
+        errorLine2="                         ~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/nav/NavigationServiceProvider.java"
+            line="159"
+            column="26"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public void locationUpdated(Location l) {"
+        errorLine2="                                ~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/nav/NavigationServiceProvider.java"
+            line="248"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public Notification getForegroundStartingNotification() {"
+        errorLine2="           ~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/nav/NavigationServiceProvider.java"
+            line="561"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static boolean hasGrantedAllPermissions(Context context, String[] requiredPermissions) {"
+        errorLine2="                                                   ~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/PermissionUtils.java"
+            line="51"
+            column="52"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static boolean hasGrantedAllPermissions(Context context, String[] requiredPermissions) {"
+        errorLine2="                                                                    ~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/PermissionUtils.java"
+            line="51"
+            column="69"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static boolean hasGrantedAtLeastOnePermission(Context context, String[] permissions) {"
+        errorLine2="                                                         ~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/PermissionUtils.java"
+            line="66"
+            column="58"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static boolean hasGrantedAtLeastOnePermission(Context context, String[] permissions) {"
+        errorLine2="                                                                          ~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/PermissionUtils.java"
+            line="66"
+            column="75"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static boolean hasGrantedPermission(Context context, String requiredPermission) {"
+        errorLine2="                                               ~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/PermissionUtils.java"
+            line="81"
+            column="48"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static boolean hasGrantedPermission(Context context, String requiredPermission) {"
+        errorLine2="                                                                ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/PermissionUtils.java"
+            line="81"
+            column="65"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static void saveString(String key, String value) {"
+        errorLine2="                                  ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/PreferenceUtils.java"
+            line="55"
+            column="35"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static void saveString(String key, String value) {"
+        errorLine2="                                              ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/PreferenceUtils.java"
+            line="55"
+            column="47"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static void saveInt(String key, int value) {"
+        errorLine2="                               ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/PreferenceUtils.java"
+            line="59"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static void saveLong(String key, long value) {"
+        errorLine2="                                ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/PreferenceUtils.java"
+            line="63"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static void saveBoolean(String key, boolean value) {"
+        errorLine2="                                   ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/PreferenceUtils.java"
+            line="67"
+            column="36"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static void saveFloat(String key, float value) {"
+        errorLine2="                                 ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/PreferenceUtils.java"
+            line="71"
+            column="34"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static void saveDouble(String key, double value) {"
+        errorLine2="                                  ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/PreferenceUtils.java"
+            line="75"
+            column="35"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static Double getDouble(String key, double defaultValue) {"
+        errorLine2="                  ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/PreferenceUtils.java"
+            line="91"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static Double getDouble(String key, double defaultValue) {"
+        errorLine2="                                   ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/PreferenceUtils.java"
+            line="91"
+            column="36"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static int getStopSortOrderFromPreferences(Context context) {"
+        errorLine2="                                                      ~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/PreferenceUtils.java"
+            line="101"
+            column="55"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static int getReminderSortOrderFromPreferences(Context context){"
+        errorLine2="                                                          ~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/PreferenceUtils.java"
+            line="119"
+            column="59"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static void maybeRestoreMapViewToBundle(Bundle b) {"
+        errorLine2="                                                   ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/PreferenceUtils.java"
+            line="151"
+            column="52"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static String getString(String key) {"
+        errorLine2="                  ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/PreferenceUtils.java"
+            line="162"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static String getString(String key) {"
+        errorLine2="                                   ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/PreferenceUtils.java"
+            line="162"
+            column="36"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static String getString(String key, String defaultValue) {"
+        errorLine2="                  ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/PreferenceUtils.java"
+            line="166"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static String getString(String key, String defaultValue) {"
+        errorLine2="                                   ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/PreferenceUtils.java"
+            line="166"
+            column="36"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static String getString(String key, String defaultValue) {"
+        errorLine2="                                               ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/PreferenceUtils.java"
+            line="166"
+            column="48"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static long getLong(String key, long defaultValue) {"
+        errorLine2="                               ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/PreferenceUtils.java"
+            line="170"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static float getFloat(String key, float defaultValue) {"
+        errorLine2="                                 ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/PreferenceUtils.java"
+            line="174"
+            column="34"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static int getInt(String key, int defaultValue) {"
+        errorLine2="                             ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/PreferenceUtils.java"
+            line="178"
+            column="30"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static boolean getBoolean(String key, boolean defaultValue) {"
+        errorLine2="                                     ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/PreferenceUtils.java"
+            line="182"
+            column="38"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static boolean userDeniedLocationPermission(Context context) {"
+        errorLine2="                                                       ~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/PreferenceUtils.java"
+            line="191"
+            column="56"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static void setUserDeniedLocationPermissions(Context context, boolean value) {"
+        errorLine2="                                                        ~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/PreferenceUtils.java"
+            line="201"
+            column="57"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static boolean getUnitsAreMetricFromPreferences(Context context) {"
+        errorLine2="                                                           ~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/PreferenceUtils.java"
+            line="213"
+            column="60"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static boolean isMapsInstalled(Context context) {"
+        errorLine2="                                          ~~~~~~~">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/ProprietaryMapHelpV2.java"
+            line="55"
+            column="43"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static void promptUserInstallMaps(final Context context) {"
+        errorLine2="                                                   ~~~~~~~">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/ProprietaryMapHelpV2.java"
+            line="68"
+            column="52"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static CustomAddress getCustomAddressFromPlacesIntent(Context context, Intent intent) {"
+        errorLine2="                  ~~~~~~~~~~~~~">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/ProprietaryMapHelpV2.java"
+            line="108"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static CustomAddress getCustomAddressFromPlacesIntent(Context context, Intent intent) {"
+        errorLine2="                                                                 ~~~~~~~">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/ProprietaryMapHelpV2.java"
+            line="108"
+            column="66"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static CustomAddress getCustomAddressFromPlacesIntent(Context context, Intent intent) {"
+        errorLine2="                                                                                  ~~~~~~">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/ProprietaryMapHelpV2.java"
+            line="108"
+            column="83"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="        public StartPlacesAutocompleteOnClick(int requestCode, Fragment fragment, Region region) {"
+        errorLine2="                                                               ~~~~~~~~">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/ProprietaryMapHelpV2.java"
+            line="147"
+            column="64"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="        public StartPlacesAutocompleteOnClick(int requestCode, Fragment fragment, Region region) {"
+        errorLine2="                                                                                  ~~~~~~">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/ProprietaryMapHelpV2.java"
+            line="147"
+            column="83"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static void setZIndex(Marker m, float zIndex) {"
+        errorLine2="                                 ~~~~~~">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/ProprietaryMapHelpV2.java"
+            line="182"
+            column="34"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    CustomAddress getCustomAddressFromPlacesIntent(Context context, Intent intent);"
+        errorLine2="    ~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/map/ProprietaryMapHelper.java"
+            line="38"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    CustomAddress getCustomAddressFromPlacesIntent(Context context, Intent intent);"
+        errorLine2="                                                   ~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/map/ProprietaryMapHelper.java"
+            line="38"
+            column="52"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    CustomAddress getCustomAddressFromPlacesIntent(Context context, Intent intent);"
+        errorLine2="                                                                    ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/map/ProprietaryMapHelper.java"
+            line="38"
+            column="69"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    View.OnClickListener createPlacesAutocompleteOnClick(int requestCode, Fragment fragment, Region region);"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/map/ProprietaryMapHelper.java"
+            line="43"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    View.OnClickListener createPlacesAutocompleteOnClick(int requestCode, Fragment fragment, Region region);"
+        errorLine2="                                                                          ~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/map/ProprietaryMapHelper.java"
+            line="43"
+            column="75"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    View.OnClickListener createPlacesAutocompleteOnClick(int requestCode, Fragment fragment, Region region);"
+        errorLine2="                                                                                             ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/map/ProprietaryMapHelper.java"
+            line="43"
+            column="94"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    static ProprietaryMapHelper getInstance() {"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/map/ProprietaryMapHelper.java"
+            line="48"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static Region getClosestRegion(Context context, List&lt;Region> regions, Location loc,"
+        errorLine2="                  ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/RegionUtils.java"
+            line="71"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static Region getClosestRegion(Context context, List&lt;Region> regions, Location loc,"
+        errorLine2="                                          ~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/RegionUtils.java"
+            line="71"
+            column="43"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static Region getClosestRegion(Context context, List&lt;Region> regions, Location loc,"
+        errorLine2="                                                           ~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/RegionUtils.java"
+            line="71"
+            column="60"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static Region getClosestRegion(Context context, List&lt;Region> regions, Location loc,"
+        errorLine2="                                                                                 ~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/RegionUtils.java"
+            line="71"
+            column="82"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static String getObaRegionName(Context context) {"
+        errorLine2="                  ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/RegionUtils.java"
+            line="124"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static String getObaRegionName(Context context) {"
+        errorLine2="                                          ~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/RegionUtils.java"
+            line="124"
+            column="43"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static Float getDistanceAway(Region region, double lat, double lon) {"
+        errorLine2="                  ~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/RegionUtils.java"
+            line="146"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static Float getDistanceAway(Region region, double lat, double lon) {"
+        errorLine2="                                        ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/RegionUtils.java"
+            line="146"
+            column="41"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static Float getDistanceAway(Region region, Location loc) {"
+        errorLine2="                  ~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/RegionUtils.java"
+            line="162"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static Float getDistanceAway(Region region, Location loc) {"
+        errorLine2="                                        ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/RegionUtils.java"
+            line="162"
+            column="41"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static Float getDistanceAway(Region region, Location loc) {"
+        errorLine2="                                                       ~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/RegionUtils.java"
+            line="162"
+            column="56"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static void getRegionSpan(Region region, double[] results) {"
+        errorLine2="                                     ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/RegionUtils.java"
+            line="175"
+            column="38"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static void getRegionSpan(Region region, double[] results) {"
+        errorLine2="                                                    ~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/RegionUtils.java"
+            line="175"
+            column="53"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static boolean isLocationWithinRegion(Location location, double[] regionSpan) {"
+        errorLine2="                                                 ~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/RegionUtils.java"
+            line="233"
+            column="50"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static boolean isLocationWithinRegion(Location location, double[] regionSpan) {"
+        errorLine2="                                                                    ~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/RegionUtils.java"
+            line="233"
+            column="69"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static boolean isLocationWithinRegion(Location location, Region region) {"
+        errorLine2="                                                 ~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/RegionUtils.java"
+            line="263"
+            column="50"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static boolean isLocationWithinRegion(Location location, Region region) {"
+        errorLine2="                                                                    ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/RegionUtils.java"
+            line="263"
+            column="69"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static boolean isRegionUsable(Context context, Region region) {"
+        errorLine2="                                         ~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/RegionUtils.java"
+            line="279"
+            column="42"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static boolean isRegionUsable(Context context, Region region) {"
+        errorLine2="                                                          ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/RegionUtils.java"
+            line="279"
+            column="59"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static String formatOtpBaseUrl(String baseUrl) {"
+        errorLine2="                  ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/RegionUtils.java"
+            line="308"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static String formatOtpBaseUrl(String baseUrl) {"
+        errorLine2="                                          ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/RegionUtils.java"
+            line="308"
+            column="43"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public synchronized static ArrayList&lt;Region> getRegionsFromServer(Context context) {"
+        errorLine2="                               ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/RegionUtils.java"
+            line="314"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public synchronized static ArrayList&lt;Region> getRegionsFromServer(Context context) {"
+        errorLine2="                                                                      ~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/RegionUtils.java"
+            line="314"
+            column="71"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static ArrayList&lt;Region> getRegionsFromResources(Context context) {"
+        errorLine2="                  ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/RegionUtils.java"
+            line="332"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static ArrayList&lt;Region> getRegionsFromResources(Context context) {"
+        errorLine2="                                                            ~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/RegionUtils.java"
+            line="332"
+            column="61"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static Region getRegionFromBuildFlavor() {"
+        errorLine2="                  ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/RegionUtils.java"
+            line="342"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static String getStopIdFromPayload(String arrivalJson) {"
+        errorLine2="                  ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/ReminderUtils.java"
+            line="51"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static String getStopIdFromPayload(String arrivalJson) {"
+        errorLine2="                                              ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/ReminderUtils.java"
+            line="51"
+            column="47"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static String getTripIdFromPayload(String arrivalJson) {"
+        errorLine2="                  ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/ReminderUtils.java"
+            line="61"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static String getTripIdFromPayload(String arrivalJson) {"
+        errorLine2="                                              ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/ReminderUtils.java"
+            line="61"
+            column="47"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static String[] getReminderTimes(Context context, long departTime) {"
+        errorLine2="                  ~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/ReminderUtils.java"
+            line="83"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static String[] getReminderTimes(Context context, long departTime) {"
+        errorLine2="                                            ~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/ReminderUtils.java"
+            line="83"
+            column="45"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static boolean markTransitServices(Context context, List&lt;Service> serviceList) {"
+        errorLine2="                                              ~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/report/ui/util/ServiceUtils.java"
+            line="39"
+            column="47"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static boolean markTransitServices(Context context, List&lt;Service> serviceList) {"
+        errorLine2="                                                               ~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/report/ui/util/ServiceUtils.java"
+            line="39"
+            column="64"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static boolean isTransitStopServiceByText(Context context, String text) {"
+        errorLine2="                                                     ~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/report/ui/util/ServiceUtils.java"
+            line="136"
+            column="54"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static boolean isTransitStopServiceByText(Context context, String text) {"
+        errorLine2="                                                                      ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/report/ui/util/ServiceUtils.java"
+            line="136"
+            column="71"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static boolean isTransitTripServiceByText(Context context, String text) {"
+        errorLine2="                                                     ~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/report/ui/util/ServiceUtils.java"
+            line="156"
+            column="54"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static boolean isTransitTripServiceByText(Context context, String text) {"
+        errorLine2="                                                                      ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/report/ui/util/ServiceUtils.java"
+            line="156"
+            column="71"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static boolean isTransitStopServiceByType(String type) {"
+        errorLine2="                                                     ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/report/ui/util/ServiceUtils.java"
+            line="172"
+            column="54"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static boolean isTransitTripServiceByType(String type) {"
+        errorLine2="                                                     ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/report/ui/util/ServiceUtils.java"
+            line="181"
+            column="54"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static boolean isTransitServiceByType(String type) {"
+        errorLine2="                                                 ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/report/ui/util/ServiceUtils.java"
+            line="191"
+            column="50"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static boolean isTransitOpen311ServiceByType(String type) {"
+        errorLine2="                                                        ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/report/ui/util/ServiceUtils.java"
+            line="199"
+            column="57"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static boolean isStopIdField(Context context, String desc) {"
+        errorLine2="                                        ~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/report/ui/util/ServiceUtils.java"
+            line="211"
+            column="41"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static boolean isStopIdField(Context context, String desc) {"
+        errorLine2="                                                         ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/report/ui/util/ServiceUtils.java"
+            line="211"
+            column="58"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static synchronized void ensureLoaded(Context context) {"
+        errorLine2="                                                 ~~~~~~~">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/StopIconFactory.java"
+            line="198"
+            column="50"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static synchronized BitmapDescriptor stopIcon(Context context, String direction, int routeType) {"
+        errorLine2="                               ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/StopIconFactory.java"
+            line="206"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static synchronized BitmapDescriptor stopIcon(Context context, String direction, int routeType) {"
+        errorLine2="                                                         ~~~~~~~">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/StopIconFactory.java"
+            line="206"
+            column="58"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static synchronized BitmapDescriptor stopIcon(Context context, String direction, int routeType) {"
+        errorLine2="                                                                          ~~~~~~">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/StopIconFactory.java"
+            line="206"
+            column="75"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static synchronized BitmapDescriptor focusedStopIcon(Context context, String direction, int routeType) {"
+        errorLine2="                               ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/StopIconFactory.java"
+            line="212"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static synchronized BitmapDescriptor focusedStopIcon(Context context, String direction, int routeType) {"
+        errorLine2="                                                                ~~~~~~~">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/StopIconFactory.java"
+            line="212"
+            column="65"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static synchronized BitmapDescriptor focusedStopIcon(Context context, String direction, int routeType) {"
+        errorLine2="                                                                                 ~~~~~~">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/StopIconFactory.java"
+            line="212"
+            column="82"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static synchronized BitmapDescriptor dotStopIcon(Context context) {"
+        errorLine2="                               ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/StopIconFactory.java"
+            line="221"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static synchronized BitmapDescriptor dotStopIcon(Context context) {"
+        errorLine2="                                                            ~~~~~~~">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/StopIconFactory.java"
+            line="221"
+            column="61"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static synchronized BitmapDescriptor focusedDotStopIcon(Context context) {"
+        errorLine2="                               ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/StopIconFactory.java"
+            line="227"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static synchronized BitmapDescriptor focusedDotStopIcon(Context context) {"
+        errorLine2="                                                                   ~~~~~~~">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/StopIconFactory.java"
+            line="227"
+            column="68"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static synchronized BitmapDescriptor favoriteStopIcon(Context context, String direction) {"
+        errorLine2="                               ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/StopIconFactory.java"
+            line="233"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static synchronized BitmapDescriptor favoriteStopIcon(Context context, String direction) {"
+        errorLine2="                                                                 ~~~~~~~">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/StopIconFactory.java"
+            line="233"
+            column="66"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static synchronized BitmapDescriptor favoriteStopIcon(Context context, String direction) {"
+        errorLine2="                                                                                  ~~~~~~">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/StopIconFactory.java"
+            line="233"
+            column="83"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static synchronized BitmapDescriptor focusedFavoriteStopIcon(Context context, String direction) {"
+        errorLine2="                               ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/StopIconFactory.java"
+            line="239"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static synchronized BitmapDescriptor focusedFavoriteStopIcon(Context context, String direction) {"
+        errorLine2="                                                                        ~~~~~~~">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/StopIconFactory.java"
+            line="239"
+            column="73"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static synchronized BitmapDescriptor focusedFavoriteStopIcon(Context context, String direction) {"
+        errorLine2="                                                                                         ~~~~~~">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/StopIconFactory.java"
+            line="239"
+            column="90"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static synchronized BitmapDescriptor favoriteDotStopIcon(Context context) {"
+        errorLine2="                               ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/StopIconFactory.java"
+            line="245"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static synchronized BitmapDescriptor favoriteDotStopIcon(Context context) {"
+        errorLine2="                                                                    ~~~~~~~">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/StopIconFactory.java"
+            line="245"
+            column="69"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static synchronized BitmapDescriptor focusedFavoriteDotStopIcon(Context context) {"
+        errorLine2="                               ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/StopIconFactory.java"
+            line="251"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static synchronized BitmapDescriptor focusedFavoriteDotStopIcon(Context context) {"
+        errorLine2="                                                                           ~~~~~~~">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/StopIconFactory.java"
+            line="251"
+            column="76"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static float anchorX(String direction) {"
+        errorLine2="                                ~~~~~~">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/StopIconFactory.java"
+            line="257"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static float anchorY(String direction) {"
+        errorLine2="                                ~~~~~~">
+        <location
+            file="src/google/java/org/onebusaway/android/map/googlemapsv2/StopIconFactory.java"
+            line="262"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static void waitForLoadFinished(Context context) throws InterruptedException {"
+        errorLine2="                                           ~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/TestUtils.java"
+            line="52"
+            column="44"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static void waitForBroadcast(Context context, String action, String category)"
+        errorLine2="                                        ~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/TestUtils.java"
+            line="56"
+            column="41"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static void waitForBroadcast(Context context, String action, String category)"
+        errorLine2="                                                         ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/TestUtils.java"
+            line="56"
+            column="58"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static void waitForBroadcast(Context context, String action, String category)"
+        errorLine2="                                                                        ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/util/TestUtils.java"
+            line="56"
+            column="73"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public UmamiAnalytics(String serverUrl, String websiteId, String hostname) {"
+        errorLine2="                          ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/analytics/UmamiAnalytics.java"
+            line="46"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public UmamiAnalytics(String serverUrl, String websiteId, String hostname) {"
+        errorLine2="                                            ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/analytics/UmamiAnalytics.java"
+            line="46"
+            column="45"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public UmamiAnalytics(String serverUrl, String websiteId, String hostname) {"
+        errorLine2="                                                              ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/analytics/UmamiAnalytics.java"
+            line="46"
+            column="63"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public void setRegionName(String regionName) {"
+        errorLine2="                              ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/analytics/UmamiAnalytics.java"
+            line="54"
+            column="31"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public void pageView(String pageUrl, Map&lt;String, Object> props) {"
+        errorLine2="                         ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/analytics/UmamiAnalytics.java"
+            line="58"
+            column="26"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public void pageView(String pageUrl, Map&lt;String, Object> props) {"
+        errorLine2="                                         ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/analytics/UmamiAnalytics.java"
+            line="58"
+            column="42"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public void event(String name, String pageUrl, Map&lt;String, Object> props) {"
+        errorLine2="                      ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/analytics/UmamiAnalytics.java"
+            line="62"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public void event(String name, String pageUrl, Map&lt;String, Object> props) {"
+        errorLine2="                                   ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/analytics/UmamiAnalytics.java"
+            line="62"
+            column="36"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public void event(String name, String pageUrl, Map&lt;String, Object> props) {"
+        errorLine2="                                                   ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/analytics/UmamiAnalytics.java"
+            line="62"
+            column="52"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public String buildPayload(String name, String path, Map&lt;String, Object> props) throws JSONException {"
+        errorLine2="           ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/analytics/UmamiAnalytics.java"
+            line="111"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public String buildPayload(String name, String path, Map&lt;String, Object> props) throws JSONException {"
+        errorLine2="                               ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/analytics/UmamiAnalytics.java"
+            line="111"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public String buildPayload(String name, String path, Map&lt;String, Object> props) throws JSONException {"
+        errorLine2="                                            ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/analytics/UmamiAnalytics.java"
+            line="111"
+            column="45"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public String buildPayload(String name, String path, Map&lt;String, Object> props) throws JSONException {"
+        errorLine2="                                                         ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/analytics/UmamiAnalytics.java"
+            line="111"
+            column="58"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static String reducePath(String pageUrl) {"
+        errorLine2="                  ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/analytics/UmamiAnalytics.java"
+            line="135"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static String reducePath(String pageUrl) {"
+        errorLine2="                                    ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/analytics/UmamiAnalytics.java"
+            line="135"
+            column="37"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static boolean isSuccessfulIngest(int httpCode, String body) {"
+        errorLine2="                                                           ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/analytics/UmamiAnalytics.java"
+            line="154"
+            column="60"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static String buildUserAgent() {"
+        errorLine2="                  ~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/analytics/UmamiAnalytics.java"
+            line="168"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static Map&lt;String, Object> sanitizeProps(Map&lt;String, Object> props) {"
+        errorLine2="                  ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/analytics/UmamiAnalytics.java"
+            line="173"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static Map&lt;String, Object> sanitizeProps(Map&lt;String, Object> props) {"
+        errorLine2="                                                    ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/analytics/UmamiAnalytics.java"
+            line="173"
+            column="53"/>
+    </issue>
+
+</issues>

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/BikeBitmaps.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/BikeBitmaps.kt
@@ -19,6 +19,7 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.Color
+import androidx.core.graphics.createBitmap
 import androidx.annotation.DrawableRes
 import org.onebusaway.android.R
 
@@ -70,7 +71,7 @@ object BikeBitmaps {
     private fun bigMarker(context: Context, @DrawableRes glyphRes: Int): Bitmap {
         val scale = context.resources.displayMetrics.density * BIG_SIZE_DP / MarkerRendering.GRID
         val sizePx = (MarkerRendering.GRID * scale).toInt()
-        val bitmap = Bitmap.createBitmap(sizePx, sizePx, Bitmap.Config.ARGB_8888)
+        val bitmap = createBitmap(sizePx, sizePx)
         MarkerRendering.drawPinAndGlyph(
             Canvas(bitmap), context, sizePx, scale, PIN_COLOR, glyphRes, Color.WHITE, GLYPH_SIZE, outline = 0f,
         )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MarkerRendering.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MarkerRendering.kt
@@ -20,6 +20,8 @@ import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.Color
 import android.graphics.drawable.Drawable
+import androidx.core.graphics.createBitmap
+import androidx.core.graphics.withTranslation
 import androidx.annotation.DrawableRes
 import androidx.core.content.ContextCompat
 import org.onebusaway.android.R
@@ -53,7 +55,7 @@ object MarkerRendering {
     fun rasterize(context: Context, @DrawableRes resId: Int, sizePx: Int, tint: Int? = null, insetPx: Int = 0): Bitmap {
         val drawable = ContextCompat.getDrawable(context, resId)!!.mutate()
         if (tint != null) drawable.setTint(tint)
-        val bitmap = Bitmap.createBitmap(sizePx, sizePx, Bitmap.Config.ARGB_8888)
+        val bitmap = createBitmap(sizePx, sizePx)
         drawable.setBounds(insetPx, insetPx, sizePx - insetPx, sizePx - insetPx)
         drawable.draw(Canvas(bitmap))
         return bitmap
@@ -102,10 +104,9 @@ object MarkerRendering {
     /** Runs [draw] once per [OUTLINE_OFFSETS] entry, translated by [outline] — the black-outline dilate. */
     fun stampOffsets(canvas: Canvas, outline: Float, draw: () -> Unit) {
         for (o in OUTLINE_OFFSETS) {
-            canvas.save()
-            canvas.translate(o[0] * outline, o[1] * outline)
-            draw()
-            canvas.restore()
+            canvas.withTranslation(o[0] * outline, o[1] * outline) {
+                draw()
+            }
         }
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/VehicleBitmaps.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/VehicleBitmaps.kt
@@ -21,6 +21,8 @@ import android.graphics.Canvas
 import android.graphics.Color
 import android.graphics.Paint
 import android.graphics.Path
+import androidx.core.graphics.createBitmap
+import androidx.core.graphics.withRotation
 import androidx.annotation.DrawableRes
 import androidx.annotation.VisibleForTesting
 import androidx.collection.LruCache
@@ -173,7 +175,7 @@ object VehicleBitmaps {
         val contentPx = (MarkerRendering.GRID * scale).toInt()
         val sizePx = (MarkerRendering.GRID * scale + 2f * pad).toInt()
         val outline = OUTLINE_GRID * scale
-        val bitmap = Bitmap.createBitmap(sizePx, sizePx, Bitmap.Config.ARGB_8888)
+        val bitmap = createBitmap(sizePx, sizePx)
         val canvas = Canvas(bitmap)
         // Draw inside a [pad] border so the outline halo has room; the grid geometry is relative to
         // this translated content origin.
@@ -184,18 +186,19 @@ object VehicleBitmaps {
 
         // Heading arrow, white, rotated about the head center by the octant (undirected = no arrow).
         if (halfWind != UNDIRECTED) {
-            canvas.save()
-            canvas.rotate(halfWind * 45f, MarkerRendering.HEAD_CX * scale, MarkerRendering.HEAD_CY * scale)
-            val arrow = Path().apply {
-                // Wide chevron, tip grazing the head edge; scaled 0.9 about the tip.
-                moveTo(12f * scale, 0.1f * scale)
-                lineTo(14.16f * scale, 2.44f * scale)
-                lineTo(9.84f * scale, 2.44f * scale)
-                close()
+            canvas.withRotation(
+                halfWind * 45f, MarkerRendering.HEAD_CX * scale, MarkerRendering.HEAD_CY * scale
+            ) {
+                val arrow = Path().apply {
+                    // Wide chevron, tip grazing the head edge; scaled 0.9 about the tip.
+                    moveTo(12f * scale, 0.1f * scale)
+                    lineTo(14.16f * scale, 2.44f * scale)
+                    lineTo(9.84f * scale, 2.44f * scale)
+                    close()
+                }
+                MarkerRendering.stampOffsets(canvas, outline) { canvas.drawPath(arrow, blackPaint) }
+                canvas.drawPath(arrow, whitePaint)
             }
-            MarkerRendering.stampOffsets(canvas, outline) { canvas.drawPath(arrow, blackPaint) }
-            canvas.drawPath(arrow, whitePaint)
-            canvas.restore()
         }
         return bitmap
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/VehicleMarkerPreview.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/VehicleMarkerPreview.kt
@@ -67,6 +67,9 @@ fun VehicleMarkerGrid(color: Color = Color(0xFF2266CC)) {
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Text(name, Modifier.width(56.dp), fontSize = 12.sp)
                 for (dir in 0..8) {
+                    // previewBitmap is @VisibleForTesting; this @Preview catalog is dev-only tooling
+                    // (not a production render path), so calling it here is intentional.
+                    @Suppress("VisibleForTests")
                     val bmp = remember(type, dir, argb) {
                         VehicleBitmaps.previewBitmap(context, type, dir, argb).asImageBitmap()
                     }


### PR DESCRIPTION
The compiler-warning cleanup (#1728) brought the codebase to **zero Kotlin compiler warnings**. This closes the loop for **#1692** — gate CI so warnings (compiler *and* lint) can't creep back — and makes the linted set comprehensive and explicit.

### Kotlin compiler gate
- `allWarningsAsErrors` enabled **only when `-PwarningsAsErrors=true`** (a Gradle property, defaults off). CI passes it; local builds stay lenient so a toolchain bump can't block day-to-day work.

### Lint: full catalog + checked-in baseline
- `lint { checkAllWarnings true }` — runs the **full** catalog (including off-by-default and library checks like `UseKtx`/Compose), not just lint's drifting default-enabled subset.
- `baseline = file('lint-baseline.xml')` — the **~760 pre-existing findings are grandfathered** (checked in). Only **new** issues are reported, and under `-PwarningsAsErrors` they fail. The baseline file is the explicit, versioned record of the known state.
- `warningsAsErrors` honors the same `-PwarningsAsErrors` flag; lint *errors* still always fail (`abortOnError`).
- Regenerate the baseline after an AGP/lint bump (delete + re-run lint) and review the diff — documented in CLAUDE.md.

### CI wiring
`.github/workflows/android.yml` passes `-PwarningsAsErrors=true` to both the host `lintObaGoogleDebug` (fast-fail) and the emulator `test check connectedObaGoogleDebugAndroidTest`.

### Also fixed
The 6 lint warnings that were live on the default set: 5× `UseKtx` (`Bitmap.createBitmap` → `createBitmap`, `Canvas.withTranslation`/`withRotation`) and 1× `VisibleForTests` (`@Suppress`d — the `@Preview` catalog is dev-only tooling). `CLAUDE.md` documents the strict CI.

### Verification
- Full google + maplibre compile surface + `lintObaGoogleDebug` **build clean with the flag on**.
- **Positive controls** (both gates proven to actually fire, not silent no-ops):
  - Compiler: a throwaway `5 as Int` (USELESS_CAST) **fails with the flag on**, passes with it off.
  - Lint: removing a suppress **failed lint with the flag on** (`Error: … [VisibleForTests]`); restored.
- With the baseline in place: lint reports **"no new issues (764 filtered by baseline)"** and passes under the flag.

### Why gated, not always-on
A Kotlin/AGP/lint upgrade can add new warnings; unconditional `= true` would break every local build. Gating behind a CI-only property keeps local builds working while failing any PR that introduces one. **Prefer always-on?** Set `allWarningsAsErrors = true` / `warningsAsErrors = true` directly.

### Out of scope (incidental finding)
`compileObaMaplibreDebugAndroidTestKotlin` fails on a **pre-existing** issue — the shared `VehicleIconAllocationTest` references google-only classes (`googlemapsv2`, `BitmapDescriptorCache`). CI never compiles the maplibre androidTest, so it's latent and unrelated to this PR.

Draft — pending your call on gated-vs-always-on.
