### PR TITLE
Move pure-logic util tests from instrumented to JVM unit tests

### DIFF
--- a/onebusaway-android/src/test/java/org/onebusaway/android/util/test/MathUtilTest.java
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/util/test/MathUtilTest.java
@@ -17,17 +17,13 @@
 package org.onebusaway.android.util.test;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.onebusaway.android.util.MathUtils;
-
-import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import static junit.framework.Assert.assertEquals;
 
 /**
  * Tests to evaluate utility methods related to math conversions
  */
-@RunWith(AndroidJUnit4.class)
 public class MathUtilTest {
 
     /**

--- a/onebusaway-android/src/test/java/org/onebusaway/android/util/test/MyTextUtilsTest.java
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/util/test/MyTextUtilsTest.java
@@ -16,16 +16,12 @@
 package org.onebusaway.android.util.test;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.onebusaway.android.util.MyTextUtils;
-
-import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertTrue;
 
-@RunWith(AndroidJUnit4.class)
 public class MyTextUtilsTest {
 
     @Test


### PR DESCRIPTION
### Summary

`MathUtilTest` and `MyTextUtilsTest` live under `src/androidTest` but neither the tests nor the classes they exercise (`MathUtils.toDirection`, `MyTextUtils` string casing) touch any Android framework code at runtime. Requiring an emulator to run them is pure overhead.

This moves both to `src/test` so they run on the JVM as part of the unit-test suite, and drops the now-unnecessary `@RunWith(AndroidJUnit4)` runner. No test logic changes — the assertions are untouched.

### Why these two only

I audited the rest of `src/androidTest`. Every other instrumented test genuinely needs the device: Room DAOs/migrations, `android.location.Location` construction in the extrapolation tests, `org.json.JSONObject` (globally excluded per #849 so it's stubbed off-device), Google Play Services, `Context`/resources, `Bitmap`, `Intent` flags, etc. These two were the only ones instrumented for no reason.

### Verification

Both pass under `./gradlew testObaGoogleDebugUnitTest`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified a few utility test setups to use standard JUnit testing directly.
  * No app behavior changed; this helps keep the test suite cleaner and easier to maintain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->