### PR TITLE
Frame the tapped arrival's vehicle with its stop on the map

### DIFF
--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleCameraCommands.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleCameraCommands.kt
@@ -28,6 +28,8 @@ import org.onebusaway.android.map.googlemapsv2.MapHelpV2
 import org.onebusaway.android.map.render.CameraCommand
 import org.onebusaway.android.map.render.FramingIntent
 import org.onebusaway.android.map.render.MapRenderState
+import org.onebusaway.android.map.render.POINTS_FRAMING_PADDING_DP
+import org.onebusaway.android.map.render.framingCorners
 import org.onebusaway.android.util.ViewUtils
 import kotlin.math.abs
 
@@ -148,6 +150,14 @@ fun applyFramingIntent(
         is FramingIntent.Point -> map.moveCamera(
             CameraUpdateFactory.newLatLngZoom(LatLng(intent.lat, intent.lon), intent.zoom)
         )
+
+        is FramingIntent.Points -> {
+            val (sw, ne) = framingCorners(intent.points) ?: return
+            val bounds = LatLngBounds(LatLng(sw.latitude, sw.longitude), LatLng(ne.latitude, ne.longitude))
+            map.animateCamera(
+                CameraUpdateFactory.newLatLngBounds(bounds, ViewUtils.dpToPixels(context, POINTS_FRAMING_PADDING_DP))
+            )
+        }
     }
 }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapEffect.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapEffect.kt
@@ -43,6 +43,16 @@ sealed interface MapEffect {
     object WaitingForLocation : MapEffect
 
     /**
+     * An arrivals ETA-pill tap asked to frame that trip's live vehicle with its stop, but no vehicle is
+     * running that trip right now (a future block trip, or one the server isn't tracking) — show the
+     * "vehicle isn't on the map" toast. Raised by [RouteMapController] when a pending focus resolves to
+     * [FocusResolution.DROP]; the route itself is still shown, just not zoomed to a vehicle. The arrivals
+     * handler emits the same `R.string.stop_info_vehicle_not_on_map` toast directly for the degenerate
+     * blank-tripId case (see `ArrivalActionHandlers.onFocusVehicleOnMap`); keep the wording in sync.
+     */
+    object VehicleNotOnMap : MapEffect
+
+    /**
      * A viewport/route load failed — show the map error toast for OBA status [code] (an HTTP status or
      * an `ObaApi.OBA_*` sentinel). Rendered by the UI layer, so the cold controllers don't reach for a
      * `Context` just to present the toast.

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
@@ -253,10 +253,11 @@ class MapViewModel @Inject constructor(
         zoomToRoute: Boolean,
         directionStopId: String?,
         initialDirectionId: Int? = null,
+        focusTripId: String? = null,
     ) {
         leaveCurrentView()
         persistRoute(routeId, directionStopId, initialDirectionId)
-        routeController.start(routeId, zoomToRoute, directionStopId, initialDirectionId)
+        routeController.start(routeId, zoomToRoute, directionStopId, initialDirectionId, focusTripId)
         bikeController.start(directions = false, selectedBikeStationIds = null)
     }
 
@@ -342,16 +343,32 @@ class MapViewModel @Inject constructor(
      * Enters route mode (loading its shape, stops, and live vehicles) and frames the route's bounding
      * box. Re-frames even when the map is already parked on that route + direction: re-tapping it in the
      * recent-routes list snaps the camera back to the route's extent instead of no-op'ing.
+     *
+     * When [request] carries a [ShowRouteRequest.focusTripId] (the arrivals ETA-pill tap), the map fits
+     * that trip's live vehicle together with the originating stop instead of framing the whole route, and
+     * raises the "vehicle isn't on the map" toast when no live vehicle is running that trip. A plain row
+     * tap carries no [ShowRouteRequest.focusTripId] and just frames the whole route.
      */
     fun toRoute(request: ShowRouteRequest) {
-        // Same route AND same direction anchor: just reframe (the recent-routes re-tap). A different
-        // route, or the same route from a different-direction stop, re-enters with the new filter.
+        // Same route AND same direction anchor: a plain re-tap (no focus) just reframes (the recent-routes
+        // re-tap); an ETA-pill focus instead fits the vehicle+stop against the already-loaded vehicles (or
+        // toasts, without reframing, when the vehicle isn't there). A different route, or the same route
+        // from a different-direction stop, re-enters with the new filter (which resolves the focus on first poll).
         if (routeController.routeId == request.routeId &&
             routeController.directionStopId == request.directionStopId
         ) {
-            mapHost.frameRoute()
+            if (request.focusTripId == null) {
+                mapHost.frameRoute()
+            } else {
+                routeController.requestFocus(request.focusTripId)
+            }
         } else {
-            enterRoute(request.routeId, zoomToRoute = true, directionStopId = request.directionStopId)
+            enterRoute(
+                request.routeId,
+                zoomToRoute = true,
+                directionStopId = request.directionStopId,
+                focusTripId = request.focusTripId,
+            )
         }
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
@@ -33,6 +33,8 @@ import java.net.HttpURLConnection
 import org.onebusaway.android.models.ObaRoute
 import org.onebusaway.android.models.RouteMapDirection
 import org.onebusaway.android.models.RouteMapStop
+import org.onebusaway.android.map.render.FramingIntent
+import org.onebusaway.android.map.render.GeoPoint
 import org.onebusaway.android.map.render.MapRenderState
 import org.onebusaway.android.map.render.MapVehicles
 import org.onebusaway.android.map.render.RoutePolyline
@@ -130,22 +132,40 @@ class RouteMapController(
 
     private var vehicleJob: Job? = null
 
+    // A pending arrivals ETA-pill focus: fit trip [tripId]'s live vehicle together with the originating
+    // stop once the vehicle appears. Held until the first vehicle set arrives, then resolved once by
+    // [tryFocusVehicle]: if a marker for the trip is on the map the camera fits the vehicle↔stop box,
+    // otherwise it's dropped (the vehicle isn't running that trip right now) — we raise the
+    // [MapEffect.VehicleNotOnMap] toast so the tap isn't silently ignored, and, if [frameFallback], frame
+    // the whole route instead (the initial framing the launch deferred pending this decision). A pending
+    // focus only ever comes from the ETA-pill tap ([ShowRouteRequest.focusTripId]), so a DROP always maps
+    // to that toast. Held as one value (like [DirectionState]) so the id and the fallback flag can't drift.
+    private data class PendingFocus(val tripId: String, val frameFallback: Boolean)
+
+    private var pendingFocus: PendingFocus? = null
+
     /**
      * Show route [routeId]: load the route + header and start the vehicle poll. [zoomToRoute] frames
      * the shape once it loads (consumed once). [directionStopId], when non-null, narrows the overlay to
      * the single direction that serves that stop (the arrivals "show vehicles on map" launch); null
      * shows the whole route. [initialDirectionId] is a restore override (the user-selected direction
      * persisted across process death) that wins over the anchor stop when it's still a valid direction.
+     * [focusTripId], when non-null, asks the map to fit that trip's live vehicle together with the
+     * originating [directionStopId] once the vehicle appears; the on-load framing is deferred until that
+     * decision so a successful vehicle+stop fit isn't first yanked out to the whole-route extent, and a
+     * route frame is the fallback when no such vehicle exists.
      */
     fun start(
         routeId: String,
         zoomToRoute: Boolean,
         directionStopId: String? = null,
         initialDirectionId: Int? = null,
+        focusTripId: String? = null,
     ) {
         this.routeId = routeId
         this.directionStopId = directionStopId
         this.initialDirectionOverride = initialDirectionId
+        this.pendingFocus = focusTripId?.let { PendingFocus(it, frameFallback = zoomToRoute) }
         // A whole-route launch has no direction to wait for, so its vehicles show as soon as they poll;
         // a direction-anchored launch (an anchor stop or a restored direction) stays Pending until the
         // route load resolves the filter (below).
@@ -160,8 +180,55 @@ class RouteMapController(
         // route-id filter set is built once here, not per frame, since it's constant for this route;
         // directionState is read live since it's resolved only once the route loads.
         renderState.setVehiclesSampler { nowMs -> sampleVehicles(WallTime(nowMs)) }
-        loadRoute(zoomToRoute)
+        // Defer the on-load framing while a focus is pending: the focus decision (below, once the first
+        // set arrives) either fits the vehicle+stop box or, failing that, frames the route itself.
+        loadRoute(zoomToRoute && focusTripId == null)
         startVehiclePolling(0L)
+    }
+
+    /**
+     * Ask to fit trip [tripId]'s live vehicle + the originating stop on the already-shown route (the ETA
+     * pill tapped for an arrival whose route the map is already parked on). Resolves immediately against
+     * the current vehicle set: when the vehicle isn't there, [tryFocusVehicle] raises the "vehicle isn't on
+     * the map" toast; a vehicle that only appears on a later poll still frames then, via [publishVehicleSet].
+     * The map already shows the route here, so there's no fallback frame ([PendingFocus.frameFallback] is
+     * false) — we don't yank the camera to the whole-route extent just because a specific vehicle is missing.
+     */
+    fun requestFocus(tripId: String) {
+        pendingFocus = PendingFocus(tripId, frameFallback = false)
+        tryFocusVehicle(currentVehicleLayer())
+    }
+
+    // Resolve a pending focus against [layer] (the just-built vehicle set, threaded in so the poll path
+    // doesn't re-run the extrapolation), once we actually have vehicles to check. With a marker for the
+    // trip present, fit the vehicle together with the originating stop; absent, the pending focus is
+    // dropped — we raise the "vehicle isn't on the map" toast (the pill tap must not be silently ignored)
+    // and, when [PendingFocus.frameFallback], frame the route as the deferred fallback. A no-op until
+    // there's a resolved direction and a landed poll, so the decision waits for real data rather than
+    // firing on the empty pre-poll set.
+    private fun tryFocusVehicle(layer: MapVehicles?) {
+        val focus = pendingFocus ?: return
+        val marker = layer?.markers?.firstOrNull { it.activeTripId == focus.tripId }
+        when (resolveVehicleFocus(directionState is DirectionState.Resolved, latestPoll != null, marker != null)) {
+            FocusResolution.WAIT -> Unit
+            FocusResolution.FIT -> {
+                pendingFocus = null
+                // Fit the vehicle and its originating stop together (the stop is dropped only if it's
+                // somehow not in the loaded route, leaving the vehicle framed alone at a comfortable zoom).
+                host.frame(FramingIntent.Points(listOfNotNull(marker?.point, originatingStopPoint())))
+            }
+            FocusResolution.DROP -> {
+                pendingFocus = null
+                if (focus.frameFallback) host.frameRoute()
+                host.emitEffect(MapEffect.VehicleNotOnMap)
+            }
+        }
+    }
+
+    /** The originating stop's position ([directionStopId], looked up in the loaded route), or null. */
+    private fun originatingStopPoint(): GeoPoint? {
+        val stopId = directionStopId ?: return null
+        return routeStops.firstOrNull { it.stop.id == stopId }?.stop?.location?.toGeoPoint()
     }
 
     // Builds the vehicle markers for the current poll + direction filter at [nowMs]. Returns null while
@@ -186,9 +253,13 @@ class RouteMapController(
     // against (matching TripState.anchorLocalTimeMs); the next frame supersedes the seed either way.
     private fun currentVehicleLayer(): MapVehicles? = sampleVehicles(WallTime.now())
 
-    /** Recompute + push the vehicle set (the renderer reconciles markers from it). */
+    /** Recompute + push the vehicle set (the renderer reconciles markers from it), then resolve any pending focus. */
     private fun publishVehicleSet() {
-        renderState.setVehicleSet(currentVehicleLayer())
+        val layer = currentVehicleLayer()
+        renderState.setVehicleSet(layer)
+        // Resolve a pending arrivals-row focus against the same set — fitting the vehicle+stop the moment
+        // the vehicle first appears, whether that's the load-resolve republish or a subsequent poll.
+        tryFocusVehicle(layer)
     }
 
     /** Leave route mode: cancel the loads + poll and clear the route's shape, vehicle layer, and header. */
@@ -206,6 +277,7 @@ class RouteMapController(
         routeShape = null
         directionState = DirectionState.Resolved(null)
         latestPoll = null
+        pendingFocus = null
         renderState.clearRoutePolylines()
         // setVehicleSet(null) is what clears the vehicle markers (the renderer reconciles the empty set);
         // it must be nulled together with the motion sampler, which only moves already-reconciled markers.
@@ -319,8 +391,10 @@ class RouteMapController(
     fun selectDirection(directionId: Int?): Boolean {
         if (routeId == null || directionId == currentDirectionId) return false
         directionState = DirectionState.Resolved(directionId)
-        // A vehicle selected in the old direction is now filtered out — drop the selection.
+        // A vehicle selected in the old direction is now filtered out — drop the selection, and drop any
+        // still-pending vehicle+stop focus (the switch is a deliberate "show the other direction" action).
         renderState.setSelectedVehicle(null)
+        pendingFocus = null
         showDirectionStops()
         showDirectionPolylines()
         // Re-filter the vehicle set against the same poll and push it — the renderer reconciles markers on
@@ -372,6 +446,29 @@ class RouteMapController(
             fixTimeMs = fixTimeMs,
             bearing = bearing,
         )
+}
+
+/**
+ * The outcome of resolving a pending "fit this trip's vehicle + its stop" request against the current
+ * state: [WAIT] until there's real vehicle data to check, then [FIT] the vehicle+stop box if the vehicle
+ * is on the map or [DROP] it if not. Kept as an enum + [resolveVehicleFocus] pure function so the (subtle)
+ * "don't decide before a poll lands" rule is unit-tested without standing up the whole controller.
+ */
+internal enum class FocusResolution { WAIT, FIT, DROP }
+
+/**
+ * Decide a pending focus: hold ([WAIT]) until the route's direction has resolved *and* a vehicle poll
+ * has landed (so there's a real set to check, not the empty pre-poll one); once there is, [FIT] when a
+ * marker for the trip is present, else [DROP]. Pure so the decision table is testable in isolation.
+ */
+internal fun resolveVehicleFocus(
+    directionResolved: Boolean,
+    pollLanded: Boolean,
+    markerPresent: Boolean,
+): FocusResolution = when {
+    !directionResolved || !pollLanded -> FocusResolution.WAIT
+    markerPresent -> FocusResolution.FIT
+    else -> FocusResolution.DROP
 }
 
 /** The latest trips-for-route [response] and the device clock ([loadNanos]) when it landed. */

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/ShowRouteRequest.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/ShowRouteRequest.kt
@@ -24,9 +24,16 @@ package org.onebusaway.android.map
  *
  * @property routeId the route to show.
  * @property directionStopId when non-null (the arrivals "show vehicles on map" launch), the stop whose
- *   direction the map narrows to; null shows the whole route.
+ *   direction the map narrows to; null shows the whole route. It's also the *originating stop* framed
+ *   alongside the vehicle by [focusTripId].
+ * @property focusTripId when non-null (the arrivals **ETA-pill** tap), the trip whose live vehicle the
+ *   map fits into view together with the originating stop ([directionStopId]) — a one-shot framing of the
+ *   vehicle↔stop relationship. When no live vehicle is running that trip, the map shows the route and
+ *   raises the "vehicle isn't on the map" toast. A plain arrival-row tap leaves this null (frame the whole
+ *   route); only the ETA pill sets it.
  */
 data class ShowRouteRequest(
     val routeId: String,
     val directionStopId: String? = null,
+    val focusTripId: String? = null,
 )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/FramingIntent.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/FramingIntent.kt
@@ -42,4 +42,42 @@ sealed interface FramingIntent {
 
     /** Center on a fixed point at a fixed zoom (the degenerate directions itinerary: start == end). */
     data class Point(val lat: Double, val lon: Double, val zoom: Float) : FramingIntent
+
+    /**
+     * Fit the bounds enclosing an explicit set of [points] with the default padding — the arrivals-row
+     * tap fitting a route's live vehicle together with its originating stop, so the map frames the
+     * relationship between the two. Self-contained (unlike [Route]/[Region], it carries its own points),
+     * so a replay to a re-created adapter just re-fits the same box. The adapter expands a degenerate box
+     * (a vehicle sitting on its stop) to a minimum span so it doesn't zoom to the rooftops
+     * (see [framingCorners]).
+     */
+    data class Points(val points: List<GeoPoint>) : FramingIntent
+}
+
+/** The smallest lat/lon span a [FramingIntent.Points] box is fit to, so near-coincident points don't over-zoom. */
+const val MIN_FRAMING_SPAN_DEG: Double = 0.004
+
+/**
+ * Padding (dp) between a [FramingIntent.Points] box and the map edges — breathing room around the fit
+ * pair. Flavor-neutral so both map adapters frame the vehicle+stop identically (each converts to pixels).
+ */
+const val POINTS_FRAMING_PADDING_DP: Float = 48.0f
+
+/**
+ * The SW and NE corners enclosing [points], each side widened to at least [minSpanDeg] around the box's
+ * center so a degenerate/tiny box (a vehicle on top of its stop) frames at a comfortable zoom instead of
+ * the maximum. Null when [points] is empty. Flavor-neutral so both map adapters share the same box math.
+ */
+fun framingCorners(
+    points: List<GeoPoint>,
+    minSpanDeg: Double = MIN_FRAMING_SPAN_DEG,
+): Pair<GeoPoint, GeoPoint>? {
+    if (points.isEmpty()) return null
+    val minLat = points.minOf { it.latitude }
+    val maxLat = points.maxOf { it.latitude }
+    val minLon = points.minOf { it.longitude }
+    val maxLon = points.maxOf { it.longitude }
+    val latPad = ((minSpanDeg - (maxLat - minLat)) / 2).coerceAtLeast(0.0)
+    val lonPad = ((minSpanDeg - (maxLon - minLon)) / 2).coerceAtLeast(0.0)
+    return GeoPoint(minLat - latPad, minLon - lonPad) to GeoPoint(maxLat + latPad, maxLon + lonPad)
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalActionHandlers.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalActionHandlers.kt
@@ -70,8 +70,28 @@ fun createArrivalActionHandler(
 
     override fun onShowVehiclesOnMap(arrival: ArrivalInfo) {
         recordRoute(arrival)
-        // Pass the arrival's stop so route mode shows only the direction (stops + vehicles) serving it.
+        // A row (or menu) tap always frames the whole route: pass the arrival's stop so route mode shows
+        // only the direction (stops + vehicles) serving it, but no focusTripId — the vehicle+stop zoom is
+        // the ETA pill's job ([onFocusVehicleOnMap]).
         onShowRouteOnMap(ShowRouteRequest(arrival.routeId, arrival.stopId))
+    }
+
+    override fun onFocusVehicleOnMap(arrival: ArrivalInfo) {
+        recordRoute(arrival)
+        // The ETA-pill tap: same route + direction as the row, plus the trip so the map fits that
+        // arrival's live vehicle together with this stop. When no live vehicle is running the trip, the map
+        // toasts "vehicle isn't on the map" and shows the route instead — that fallback lives in
+        // RouteMapController, keyed off focusTripId being set.
+        val tripId = arrival.tripId.ifBlank { null }
+        // A partial response with no tripId can't be focused at all, so the map has nothing to key on;
+        // toast up front (the pill must never be silently ignored) and still show the route for context.
+        // The other emitter of this same toast is RouteMapController's DROP path (via MapEffect.
+        // VehicleNotOnMap), for the case where a tripId exists but no live vehicle is running it — keep the
+        // two in sync via the shared R.string.stop_info_vehicle_not_on_map.
+        if (tripId == null) {
+            Toast.makeText(activity, R.string.stop_info_vehicle_not_on_map, Toast.LENGTH_SHORT).show()
+        }
+        onShowRouteOnMap(ShowRouteRequest(arrival.routeId, arrival.stopId, focusTripId = tripId))
     }
 
     override fun onShowTripStatus(arrival: ArrivalInfo) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsScreen.kt
@@ -134,6 +134,7 @@ internal fun rememberArrivalRowCallbacks(
     ArrivalRowCallbacks(
         onRouteFavorite = handler::onRouteFavorite,
         onShowVehiclesOnMap = handler::onShowVehiclesOnMap,
+        onEtaClick = handler::onFocusVehicleOnMap,
         onShowTripStatus = handler::onShowTripStatus,
         onSetReminder = handler::onSetReminder,
         onShowOnlyRoute = viewModel::showOnlyRoute,
@@ -151,6 +152,8 @@ internal fun rememberArrivalRowCallbacks(
 interface ArrivalActionHandler {
     fun onRouteFavorite(actions: ArrivalActions)
     fun onShowVehiclesOnMap(arrival: ArrivalInfo)
+    /** The ETA-pill tap: frame the arrival's live vehicle with its stop, or toast if none is tracked. */
+    fun onFocusVehicleOnMap(arrival: ArrivalInfo)
     fun onShowTripStatus(arrival: ArrivalInfo)
     fun onSetReminder(arrival: ArrivalInfo)
     fun onShowRouteSchedule(scheduleUrl: String)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
@@ -51,6 +51,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.res.colorResource
@@ -77,6 +78,8 @@ import org.onebusaway.util.comparators.AlphanumComparator
 class ArrivalRowCallbacks(
     val onRouteFavorite: (ArrivalActions) -> Unit,
     val onShowVehiclesOnMap: (ArrivalInfo) -> Unit,
+    /** The ETA pill was tapped: focus that arrival's live vehicle + its stop (whole-route tap is the row body). */
+    val onEtaClick: (ArrivalInfo) -> Unit,
     val onShowTripStatus: (ArrivalInfo) -> Unit,
     val onSetReminder: (ArrivalInfo) -> Unit,
     val onShowOnlyRoute: (String) -> Unit,
@@ -150,7 +153,8 @@ private fun ArrivalRowVisual(
     predicted: Boolean,
     canceled: Boolean,
     modifier: Modifier = Modifier,
-    onAlertClick: (() -> Unit)? = null
+    onAlertClick: (() -> Unit)? = null,
+    onEtaClick: (() -> Unit)? = null,
 ) {
     val decoration = strikeThroughIf(canceled)
     Row(modifier = modifier, verticalAlignment = Alignment.CenterVertically) {
@@ -185,7 +189,7 @@ private fun ArrivalRowVisual(
             ArrivalAlertIndicator(onClick = onAlertClick)
         }
         Spacer(Modifier.width(8.dp))
-        EtaContent(eta, statusColor, predicted, canceled)
+        EtaContent(eta, statusColor, predicted, canceled, onClick = onEtaClick)
     }
 }
 
@@ -209,7 +213,8 @@ internal fun ArrivalAlertIndicator(onClick: () -> Unit, modifier: Modifier = Mod
 internal fun ArrivalRowContent(
     arrival: ArrivalInfo,
     modifier: Modifier = Modifier,
-    onAlertClick: (() -> Unit)? = null
+    onAlertClick: (() -> Unit)? = null,
+    onEtaClick: (() -> Unit)? = null,
 ) {
     ArrivalRowVisual(
         shortName = arrival.shortName.orEmpty(),
@@ -221,7 +226,8 @@ internal fun ArrivalRowContent(
         predicted = arrival.predicted,
         canceled = arrival.status == Status.CANCELED,
         modifier = modifier,
-        onAlertClick = onAlertClick
+        onAlertClick = onAlertClick,
+        onEtaClick = onEtaClick,
     )
 }
 
@@ -243,13 +249,19 @@ fun ArrivalRowStyleA(
         isFavorite = actions?.isRouteFavorite,
         onFavorite = { actions?.let { callbacks.onRouteFavorite(it) } },
         onMore = { expanded = true },
-        // Tapping the row body defaults to "Show vehicles on map"; the overflow icon opens the menu.
+        // Tapping the row body frames the whole route; the ETA pill (below) instead focuses this trip's
+        // vehicle + stop, and the overflow icon opens the menu.
         onContentClick = { callbacks.onShowVehiclesOnMap(arrival) },
         overflow = {
             ArrivalActionsMenu(expanded, { expanded = false }, arrival, actions, filterActive, callbacks)
         }
     ) {
-        ArrivalRowContent(arrival, Modifier.fillMaxWidth(), alertClick(actions, callbacks))
+        ArrivalRowContent(
+            arrival,
+            Modifier.fillMaxWidth(),
+            onAlertClick = alertClick(actions, callbacks),
+            onEtaClick = { callbacks.onEtaClick(arrival) },
+        )
     }
 }
 
@@ -379,8 +391,9 @@ fun ArrivalCardStyleB(
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
-                        // Tapping a row shows its route/direction on the map (same as Style A); HomeScreen's
-                        // wrapped onShowRouteOnMap drags the sheet down to peek on every such tap.
+                        // Tapping a row frames the whole route/direction on the map (same as Style A);
+                        // HomeScreen's wrapped onShowRouteOnMap drags the sheet down to peek on every such
+                        // tap. The ETA pill (below) instead focuses this trip's vehicle + stop.
                         .clickable { callbacks.onShowVehiclesOnMap(arrival) }
                         .padding(top = if (index == 0) 8.dp else 0.dp)
                         // Subsequent arrivals are dimmed, matching the legacy card
@@ -389,7 +402,7 @@ fun ArrivalCardStyleB(
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     StatusText(arrival)
-                    EtaBlock(arrival)
+                    EtaBlock(arrival, onClick = { callbacks.onEtaClick(arrival) })
                 }
             }
         }
@@ -466,11 +479,25 @@ private fun StatusPill(text: String, color: Color) {
 }
 
 /** The prominent ETA, color-coded by lateness, with the real-time indicator as a superscript on
- *  the "min" label (matching the drawer pill); the legacy `eta`/`eta_min`. */
+ *  the "min" label (matching the drawer pill); the legacy `eta`/`eta_min`. [onClick], when non-null,
+ *  makes the ETA its own tap target (focus this trip's vehicle + stop, distinct from the row-body tap). */
 @Composable
-private fun EtaContent(eta: Long, color: Color, predicted: Boolean, canceled: Boolean) {
+private fun EtaContent(
+    eta: Long,
+    color: Color,
+    predicted: Boolean,
+    canceled: Boolean,
+    onClick: (() -> Unit)? = null,
+) {
     val decoration = strikeThroughIf(canceled)
-    Row {
+    // When clickable, clip to the pill shape so the tap ripple stays inside the ETA. No padding/size
+    // change, so the ETA looks identical at rest; the clickable is a solid target on the number itself.
+    val rowModifier = if (onClick != null) {
+        Modifier.clip(PillShape).clickable(onClick = onClick)
+    } else {
+        Modifier
+    }
+    Row(modifier = rowModifier) {
         if (eta == 0L) {
             Text(
                 text = stringResource(R.string.stop_info_eta_now),
@@ -548,10 +575,14 @@ internal fun StatusText(arrival: ArrivalInfo) {
     if (text.isNotEmpty()) StatusPill(text, colorResource(arrival.color))
 }
 
-/** [ArrivalInfo]-driven ETA, for the Style B card and the map-panel preview. */
+/** [ArrivalInfo]-driven ETA, for the Style B card and the map-panel preview. [onClick], when non-null,
+ *  makes the ETA a tap target (focus this trip's vehicle + stop). */
 @Composable
-internal fun EtaBlock(arrival: ArrivalInfo) {
-    EtaContent(arrival.eta, colorResource(arrival.color), arrival.predicted, arrival.status == Status.CANCELED)
+internal fun EtaBlock(arrival: ArrivalInfo, onClick: (() -> Unit)? = null) {
+    EtaContent(
+        arrival.eta, colorResource(arrival.color), arrival.predicted,
+        arrival.status == Status.CANCELED, onClick = onClick,
+    )
 }
 
 private fun strikeThroughIf(canceled: Boolean): TextDecoration =

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalsPanel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalsPanel.kt
@@ -262,6 +262,8 @@ private fun PeekRow(
         onFavorite = { actions?.let { callbacks.onRouteFavorite(it) } },
         onMore = { expanded = true },
         onAlertClick = alertClick(actions, callbacks),
+        onRowClick = { callbacks.onShowVehiclesOnMap(arrival) },
+        onEtaClick = { callbacks.onEtaClick(arrival) },
         etaModifier = etaModifier,
         starModifier = starModifier,
         menu = {
@@ -273,7 +275,8 @@ private fun PeekRow(
 /**
  * A peek arrival that morphs between its two formats in lockstep with the drawer's open fraction
  * [progress]: the compact [PeekRow] at 0 and the full [ArrivalRowStyleA] card at 1. The seekable
- * crossfade/size morph lives in [MorphByProgress]; this just binds the two arrival layouts to it.
+ * crossfade/size morph — and the "only the visible layer is hit-testable at rest" behavior that keeps the
+ * peek's ETA pill from being shadowed by the invisible card twin — both live in [MorphByProgress].
  */
 @Composable
 private fun MorphingArrivalRow(
@@ -311,10 +314,17 @@ private fun PeekRowVisual(
     etaModifier: Modifier = Modifier,
     starModifier: Modifier = Modifier,
     onAlertClick: (() -> Unit)? = null,
+    // Tapping the row body frames the whole route; tapping the ETA pill focuses this trip's vehicle +
+    // stop (null in previews). The pill is a Surface(onClick) and the star/overflow are IconButtons, so
+    // each nested target reliably wins over the row-body click in its own bounds.
+    onRowClick: (() -> Unit)? = null,
+    onEtaClick: (() -> Unit)? = null,
     menu: @Composable () -> Unit = {}
 ) {
     Row(
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier
+            .fillMaxWidth()
+            .then(if (onRowClick != null) Modifier.clickable(onClick = onRowClick) else Modifier),
         verticalAlignment = Alignment.CenterVertically
     ) {
         IconButton(onClick = onFavorite, modifier = starModifier) {
@@ -345,7 +355,7 @@ private fun PeekRowVisual(
             ArrivalAlertIndicator(onClick = onAlertClick)
         }
         Spacer(Modifier.width(8.dp))
-        EtaPill(eta, etaColor, predicted, modifier = etaModifier)
+        EtaPill(eta, etaColor, predicted, modifier = etaModifier, onClick = onEtaClick)
         Box {
             IconButton(onClick = onMore) {
                 Icon(
@@ -371,10 +381,14 @@ internal fun EtaPill(
     predicted: Boolean,
     modifier: Modifier = Modifier,
     canceled: Boolean = false,
+    // When non-null (the drawer peek row), the whole pill is a tap target — focus this trip's vehicle +
+    // stop. A Surface(onClick) gives it a solid, ripple-backed hit area (the legend dialog leaves it null).
+    onClick: (() -> Unit)? = null,
 ) {
     val decoration = if (canceled) TextDecoration.LineThrough else null
-    Surface(modifier = modifier, shape = RoundedCornerShape(8.dp), color = color) {
-        // Fixed height + centered content so "NOW" and "21 min" pills render the same height.
+    val shape = RoundedCornerShape(8.dp)
+    // Fixed height + centered content so "NOW" and "21 min" pills render the same height.
+    val body: @Composable () -> Unit = {
         Box(
             modifier = Modifier
                 .height(32.dp)
@@ -414,6 +428,11 @@ internal fun EtaPill(
                 }
             }
         }
+    }
+    if (onClick != null) {
+        Surface(onClick = onClick, modifier = modifier, shape = shape, color = color, content = body)
+    } else {
+        Surface(modifier = modifier, shape = shape, color = color, content = body)
     }
 }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/MorphByProgress.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/MorphByProgress.kt
@@ -24,8 +24,11 @@ import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
@@ -38,9 +41,14 @@ import kotlinx.coroutines.flow.collectLatest
  *
  * A [SeekableTransitionState] turns [AnimatedContent]'s crossfade + bounding-box [SizeTransform] into a
  * seekable morph that [progress] drives directly, with linear easing so it follows the source evenly.
- * The transition's `currentState` stays at [start], so progress 0 always renders exactly [start] (and
- * its intrinsic size) — important when that resting layout's measured size matters (e.g. it sets a
- * sheet's peek height).
+ *
+ * **At the resting endpoints only the visible layer is composed, not the crossfade.** A
+ * [SeekableTransitionState] keeps *both* [AnimatedContent] children composed at every fraction, and an
+ * alpha-0 Compose layer still receives touches — so at rest the invisible twin would steal taps from the
+ * visible layer (e.g. an ETA pill vs a card whose tap targets sit at different x-positions). Rendering a
+ * single layer at progress 0 ([start]) and 1 ([end]) keeps touches landing on exactly what's shown, and
+ * preserves the "progress 0 renders exactly [start] and its intrinsic size" guarantee callers rely on for
+ * peek-height measurement. The crossfade runs only mid-morph, when the content isn't at a stable tap target.
  *
  * @param durationMs reference timeline the seek is mapped onto. [progress] drives the playhead, so the
  *   absolute value only matters for any tail animation if [progress] is released between 0 and 1;
@@ -54,21 +62,40 @@ fun MorphByProgress(
     start: @Composable () -> Unit,
     end: @Composable () -> Unit,
 ) {
-    val morph = remember { SeekableTransitionState(false) }
-    LaunchedEffect(morph) {
-        snapshotFlow { progress().coerceIn(0f, 1f) }
-            .collectLatest { fraction -> morph.seekTo(fraction, targetState = true) }
+    val phase by remember(progress) {
+        derivedStateOf {
+            val fraction = progress()
+            when {
+                fraction <= 0f -> MorphPhase.START
+                fraction >= 1f -> MorphPhase.END
+                else -> MorphPhase.MORPHING
+            }
+        }
     }
-    val transition = rememberTransition(morph, label = "morphByProgress")
-    transition.AnimatedContent(
-        modifier = modifier,
-        transitionSpec = {
-            (fadeIn(tween(durationMs, easing = LinearEasing)) togetherWith
-                fadeOut(tween(durationMs, easing = LinearEasing)))
-                .using(SizeTransform(clip = false) { _, _ -> tween(durationMs, easing = LinearEasing) })
-        },
-        contentKey = { it },
-    ) { atEnd ->
-        if (atEnd) end() else start()
+    when (phase) {
+        MorphPhase.START -> Box(modifier) { start() }
+        MorphPhase.END -> Box(modifier) { end() }
+        MorphPhase.MORPHING -> {
+            val morph = remember { SeekableTransitionState(false) }
+            LaunchedEffect(morph) {
+                snapshotFlow { progress().coerceIn(0f, 1f) }
+                    .collectLatest { fraction -> morph.seekTo(fraction, targetState = true) }
+            }
+            val transition = rememberTransition(morph, label = "morphByProgress")
+            transition.AnimatedContent(
+                modifier = modifier,
+                transitionSpec = {
+                    (fadeIn(tween(durationMs, easing = LinearEasing)) togetherWith
+                        fadeOut(tween(durationMs, easing = LinearEasing)))
+                        .using(SizeTransform(clip = false) { _, _ -> tween(durationMs, easing = LinearEasing) })
+                },
+                contentKey = { it },
+            ) { atEnd ->
+                if (atEnd) end() else start()
+            }
+        }
     }
 }
+
+/** The resting/animating states of [MorphByProgress]: a single layer at the endpoints, the crossfade between. */
+private enum class MorphPhase { START, MORPHING, END }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
@@ -205,6 +205,9 @@ fun MapFeature(
                 MapEffect.WaitingForLocation -> Toast.makeText(
                     context, R.string.main_waiting_for_location, Toast.LENGTH_SHORT
                 ).show()
+                MapEffect.VehicleNotOnMap -> Toast.makeText(
+                    context, R.string.stop_info_vehicle_not_on_map, Toast.LENGTH_SHORT
+                ).show()
                 is MapEffect.ShowError -> Toast.makeText(
                     context, ObaRequestErrors.getMapErrorString(context, effect.code), Toast.LENGTH_LONG
                 ).show()

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -130,6 +130,7 @@
     <string name="bus_options_menu_add_star">Add star to route</string>
     <string name="bus_options_menu_remove_star">Remove star from route</string>
     <string name="bus_options_menu_show_vehicles_on_map">Show vehicles on map</string>
+    <string name="stop_info_vehicle_not_on_map">This trip&#8217;s vehicle isn&#8217;t on the map right now</string>
     <string name="bus_options_menu_show_trip_details">Show trip status</string>
     <string name="bus_options_menu_set_reminder">Set a reminder</string>
     <string name="bus_options_menu_show_only_this_route">Show only this route</string>

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreCameraCommands.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreCameraCommands.kt
@@ -26,6 +26,9 @@ import org.onebusaway.android.map.maplibre.MapHelpMapLibre
 import org.onebusaway.android.map.render.CameraCommand
 import org.onebusaway.android.map.render.FramingIntent
 import org.onebusaway.android.map.render.MapRenderState
+import org.onebusaway.android.map.render.POINTS_FRAMING_PADDING_DP
+import org.onebusaway.android.map.render.framingCorners
+import org.onebusaway.android.util.ViewUtils
 import kotlin.math.abs
 
 // The same default zoom the imperative MapLibreMapHost used for these camera moves.
@@ -105,6 +108,17 @@ fun applyFramingIntent(intent: FramingIntent, map: MapLibreMap, renderState: Map
         is FramingIntent.Point -> map.moveCamera(
             CameraUpdateFactory.newLatLngZoom(LatLng(intent.lat, intent.lon), intent.zoom.toDouble())
         )
+
+        is FramingIntent.Points -> {
+            val (sw, ne) = framingCorners(intent.points) ?: return
+            val bounds = LatLngBounds.Builder()
+                .include(LatLng(sw.latitude, sw.longitude))
+                .include(LatLng(ne.latitude, ne.longitude))
+                .build()
+            map.animateCamera(
+                CameraUpdateFactory.newLatLngBounds(bounds, ViewUtils.dpToPixels(context, POINTS_FRAMING_PADDING_DP))
+            )
+        }
     }
 }
 

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/FocusResolutionTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/FocusResolutionTest.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.map
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * [resolveVehicleFocus] — the pure decision behind RouteMapController's "fit the tapped arrival's
+ * vehicle together with its stop" launch. The point of the test is the WAIT rule: a pending focus must
+ * not be decided (and so never wrongly dropped) before there's an actual vehicle poll to check against.
+ */
+class FocusResolutionTest {
+
+    @Test
+    fun waits_until_direction_resolved() {
+        // A direction-anchored launch is still Pending: hold, even if a poll landed and a marker exists.
+        assertEquals(
+            FocusResolution.WAIT,
+            resolveVehicleFocus(directionResolved = false, pollLanded = true, markerPresent = true),
+        )
+    }
+
+    @Test
+    fun waits_until_a_poll_lands() {
+        // Direction resolved but no poll yet — the set is empty because none arrived, not because the
+        // vehicle is absent. Must not drop the focus here.
+        assertEquals(
+            FocusResolution.WAIT,
+            resolveVehicleFocus(directionResolved = true, pollLanded = false, markerPresent = false),
+        )
+    }
+
+    @Test
+    fun fits_when_the_vehicle_is_on_the_map() {
+        assertEquals(
+            FocusResolution.FIT,
+            resolveVehicleFocus(directionResolved = true, pollLanded = true, markerPresent = true),
+        )
+    }
+
+    @Test
+    fun drops_when_no_vehicle_runs_the_trip() {
+        // A real poll landed and the trip has no live vehicle (e.g. it's a future block trip): drop the
+        // focus so the caller can fall back to framing the whole route.
+        assertEquals(
+            FocusResolution.DROP,
+            resolveVehicleFocus(directionResolved = true, pollLanded = true, markerPresent = false),
+        )
+    }
+}


### PR DESCRIPTION
## What

The arrivals drawer used to multiplex two map actions onto one row tap. Now they're split:

- **Tapping an arrival row** frames the **whole route** (direction-narrowed to the stop), as before.
- **Tapping the ETA pill** fits that trip's **live vehicle together with the originating stop** — surfacing the vehicle↔stop relationship as context. When no live vehicle is running that trip, the map shows the route and pops a **"vehicle isn't on the map"** toast instead of silently reframing.

## How

- Adds a flavor-neutral `FramingIntent.Points` primitive (fit an explicit set of points) plus a shared `framingCorners()` helper that expands a degenerate box to a minimum span, so a vehicle sitting on top of its stop frames at a comfortable zoom instead of the rooftops. Both flavor adapters (Google + MapLibre) draw it with a shared padding constant.
- `RouteMapController` holds the pending focus until the first vehicle poll lands, then resolves it via the pure, unit-tested `resolveVehicleFocus` (`WAIT` / `FIT` / `DROP`). The vehicle is matched by `activeTripId`, so a future block trip with no currently-running vehicle correctly falls back rather than following the wrong bus. A `DROP` raises `MapEffect.VehicleNotOnMap`, which the UI renders as the toast.
- The ETA is its own tap target in **every** arrivals row style — the flat list rows, the grouped cards, and the drawer's peek pill. `MorphByProgress` now composes only the *visible* layer at its resting endpoints: a seekable transition keeps both morph children composed and an alpha-0 layer still receives touches, so the collapsed peek's pill taps were being silently stolen by the invisible full-card twin underneath it. Gating hit-testing to the visible layer fixes that for this and any future caller.

## Testing

- JVM unit test `FocusResolutionTest` covers the resolution decision table (notably the "don't decide before a poll lands" WAIT rule).
- Both flavors compile warning-clean; map-package unit tests pass.
- Exercised on-device (Pixel 7 Pro): tapping a row frames the route; tapping the ETA pill (including on the collapsed drawer peek) reliably fits the bus + stop when tracked, or toasts when no live vehicle is running the trip.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * You can now focus a specific trip’s live vehicle from arrival views and route maps, with the map fitting both the vehicle and its originating stop when available.
  * Route views now better handle multi-point framing, automatically fitting all points on the map.

* **Bug Fixes**
  * When a vehicle isn’t currently on the map, the app now keeps the route visible and shows a clear message instead of failing silently.
  * ETA and peek-row taps now target the intended vehicle-focused action more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->