### PR TITLE
Typed time: complete the affine algebra + type-first schedule/service-day/deviation migration

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/extrapolation/test/TripExtrapolationBuilderTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/extrapolation/test/TripExtrapolationBuilderTest.kt
@@ -17,6 +17,7 @@ package org.onebusaway.android.extrapolation.test
 
 import org.onebusaway.android.time.WallTime
 import android.location.Location
+import kotlin.time.Duration
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -59,7 +60,7 @@ class TripExtrapolationBuilderTest {
         object : ObaTripStatus {
             override val serviceDate = 0L
             override val isPredicted = true
-            override val scheduleDeviation = 0L
+            override val scheduleDeviation = Duration.ZERO
             override val vehicleId: String? = null
             override val closestStop: String? = null
             override val closestStopTimeOffset = 0L

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/extrapolation/test/TripStateCacheTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/extrapolation/test/TripStateCacheTest.kt
@@ -15,8 +15,12 @@
  */
 package org.onebusaway.android.extrapolation.test
 
+import org.onebusaway.android.time.ScheduleTime
 import org.onebusaway.android.time.ServerTime
+import org.onebusaway.android.time.ServiceDate
 import org.onebusaway.android.time.WallTime
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 import org.onebusaway.android.api.adapters.StopTimeData
 import org.onebusaway.android.api.adapters.TripScheduleData
 
@@ -270,7 +274,7 @@ class TripStateCacheTest {
                         longArrayOf(100, 300)
                 )
         cache.putSchedule("trip1", schedule)
-        cache.putServiceDate("trip1", serviceDate)
+        cache.putServiceDate("trip1", ServiceDate(serviceDate))
 
         val status1 = createStatus("v1", "trip1", 47.0, -122.0, 100.0, 100.0, 5000.0, 170_000L)
         val status2 = createStatus("v1", "trip1", 47.001, -122.0, 400.0, 400.0, 5000.0, queryTime)
@@ -312,7 +316,7 @@ class TripStateCacheTest {
                         longArrayOf(0, 500, 1000)
                 )
         cache.putSchedule("trip1", schedule)
-        cache.putServiceDate("trip1", serviceDate)
+        cache.putServiceDate("trip1", ServiceDate(serviceDate))
 
         // Record 5 position updates, each 30 seconds apart, 300m apart (~10 m/s)
         for (i in 0 until 5) {
@@ -359,7 +363,7 @@ class TripStateCacheTest {
                             status.activeTripId!!,
                             status,
                             ServerTime(serverTimeMs),
-                            serviceDate = 0,
+                            serviceDate = null,
                             routeType = null
                     ),
                     WallTime(localTimeMs)
@@ -409,8 +413,8 @@ class TripStateCacheTest {
             Array<ObaTripSchedule.StopTime>(distances.size) { i ->
                 StopTimeData(
                     stopId = "stop_$i",
-                    arrivalTime = arrivalTimes[i],
-                    departureTime = departureTimes[i],
+                    arrivalTime = ScheduleTime(arrivalTimes[i].seconds),
+                    departureTime = ScheduleTime(departureTimes[i].seconds),
                     distanceAlongTrip = distances[i],
                 )
             },
@@ -434,7 +438,7 @@ private class TestTripStatus(
 ) : ObaTripStatus {
     override val serviceDate: Long = 0L
     override val isPredicted: Boolean = predicted
-    override val scheduleDeviation: Long = scheduleDeviation
+    override val scheduleDeviation: Duration = scheduleDeviation.seconds
     override val vehicleId: String? = vehicleId
     override val closestStop: String? = null
     override val closestStopTimeOffset: Long = 0L

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/map/VehicleIconAllocationTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/map/VehicleIconAllocationTest.kt
@@ -17,6 +17,8 @@ package org.onebusaway.android.map
 
 import org.onebusaway.android.time.WallTime
 import android.content.Context
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 import android.graphics.Bitmap
 import android.util.Log
 import androidx.test.platform.app.InstrumentationRegistry
@@ -271,7 +273,7 @@ class VehicleIconAllocationTest {
             isRealtime = true,
             bearing = 0f,
             status = object : ObaTripStatus by vehicle.status {
-                override val scheduleDeviation: Long = deviationSeconds
+                override val scheduleDeviation: Duration = deviationSeconds.seconds
             },
         )
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/adapters/TripAdapters.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/adapters/TripAdapters.kt
@@ -27,7 +27,10 @@ import org.onebusaway.android.models.ObaTripSchedule
 import org.onebusaway.android.models.ObaTripStatus
 import org.onebusaway.android.models.Occupancy
 import org.onebusaway.android.models.Status
+import org.onebusaway.android.time.ScheduleTime
 import org.onebusaway.android.util.LocationUtils
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 
 /*
  * Adapters that present the api/ trip DTOs as the `models` domain interfaces
@@ -42,7 +45,8 @@ private fun Position.toLocation(): Location = LocationUtils.makeLocation(lat, lo
 internal class DtoTripStatus(private val dto: TripStatus) : ObaTripStatus {
     override val serviceDate: Long get() = dto.serviceDate
     override val isPredicted: Boolean get() = dto.predicted
-    override val scheduleDeviation: Long get() = dto.scheduleDeviation
+    // Wire sends schedule deviation as raw seconds; mint the domain Duration here.
+    override val scheduleDeviation: Duration get() = dto.scheduleDeviation.seconds
     override val vehicleId: String? get() = dto.vehicleId
     override val closestStop: String? get() = dto.closestStop
     override val closestStopTimeOffset: Long get() = dto.closestStopTimeOffset
@@ -92,8 +96,11 @@ fun TripSchedule.toObaTripSchedule(): ObaTripSchedule {
         StopTimeData(
             it.stopId,
             it.stopHeadsign,
-            it.arrivalTime,
-            it.departureTime,
+            // Wire units: the trip-details schedule sends stop times as seconds since the service day
+            // start (verified against sample payloads — NOT epoch millis, despite the sibling
+            // ScheduleStopTime DTO). Mint the domain here, once.
+            ScheduleTime(it.arrivalTime.seconds),
+            ScheduleTime(it.departureTime.seconds),
             Occupancy.fromString(it.historicalOccupancy),
             Occupancy.fromString(it.predictedOccupancy),
             it.distanceAlongTrip,
@@ -124,8 +131,8 @@ class TripScheduleData(
 class StopTimeData(
     override val stopId: String = "",
     override val headsign: String? = null,
-    override val arrivalTime: Long = 0,
-    override val departureTime: Long = 0,
+    override val arrivalTime: ScheduleTime = ScheduleTime(Duration.ZERO),
+    override val departureTime: ScheduleTime = ScheduleTime(Duration.ZERO),
     override val historicalOccupancy: Occupancy? = null,
     override val predictedOccupancy: Occupancy? = null,
     override val distanceAlongTrip: Double = 0.0,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/contract/ObaApiModels.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/contract/ObaApiModels.kt
@@ -276,8 +276,10 @@ data class TripSchedule(
 )
 
 /**
- * One scheduled stop on a trip; [arrivalTime]/[departureTime] are epoch millis and
- * [distanceAlongTrip] is meters (used by the schedule-replay extrapolator).
+ * One scheduled stop on a trip; [arrivalTime]/[departureTime] are **seconds since the service day
+ * start** (verified against sample payloads — e.g. 60180 = 16:43, not epoch millis; contrast the
+ * epoch-millis [ScheduleStopTime] below) and [distanceAlongTrip] is meters. The adapter mints these
+ * into the domain-typed `ObaTripSchedule.StopTime.arrivalTime` (a `ScheduleTime`).
  */
 @Serializable
 data class StopTime(
@@ -413,7 +415,12 @@ data class DirectionSchedule(
     val scheduleStopTimes: List<ScheduleStopTime> = emptyList(),
 )
 
-/** One scheduled visit of a trip to the stop; [arrivalTime]/[departureTime] are epoch millis. */
+/**
+ * One scheduled visit of a trip to the stop; [arrivalTime]/[departureTime] are **epoch millis**
+ * (verified against sample payloads — e.g. 1343663220000 = 2012-07-30, genuinely millis here, unlike
+ * the seconds-based [StopTime] above). Not yet domain-typed — this schedule-for-stop cluster has no
+ * ScheduleTime/ServerTime consumer yet; mint at its adapter when one lands.
+ */
 @Serializable
 data class ScheduleStopTime(
     val tripId: String = "",

--- a/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/GammaExtrapolator.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/GammaExtrapolator.kt
@@ -24,6 +24,7 @@ import org.onebusaway.android.extrapolation.math.prob.GammaMixtureDistribution
 import org.onebusaway.android.extrapolation.math.prob.ProbDistribution
 import org.onebusaway.android.models.ObaTripSchedule
 import org.onebusaway.android.time.WallTime
+import kotlin.time.Duration
 import kotlin.time.DurationUnit
 
 // H34 two-gamma mixture parameters, fitted on span-weighted King County Metro data (in mph).
@@ -135,9 +136,11 @@ private fun ObaTripSchedule.speedAtDistance(distanceAlongTrip: Double): Double? 
 
     val distDelta =
         stopTimes[segmentStart + 1].distanceAlongTrip - stopTimes[segmentStart].distanceAlongTrip
-    val timeDelta = stopTimes[segmentStart + 1].arrivalTime - stopTimes[segmentStart].departureTime
+    val timeDelta: Duration = stopTimes[segmentStart + 1].arrivalTime - stopTimes[segmentStart].departureTime
 
-    return if (distDelta > 0 && timeDelta > 0) distDelta / timeDelta else null
+    return if (distDelta > 0 && timeDelta > Duration.ZERO)
+        distDelta / timeDelta.toDouble(DurationUnit.SECONDS)
+    else null
 }
 
 private fun sigmoid(x: Double): Double = 1.0 / (1.0 + exp(-x))

--- a/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/ScheduleReplayExtrapolator.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/ScheduleReplayExtrapolator.kt
@@ -18,8 +18,9 @@ package org.onebusaway.android.extrapolation
 import org.onebusaway.android.extrapolation.data.TripState
 import org.onebusaway.android.extrapolation.math.prob.DiracDistribution
 import org.onebusaway.android.models.ObaTripSchedule
+import org.onebusaway.android.time.ScheduleTime
 import org.onebusaway.android.time.WallTime
-import kotlin.time.DurationUnit
+import kotlin.time.Duration
 
 /**
  * Per-trip extrapolator for grade-separated transit (rail, subway) that replays the schedule
@@ -60,9 +61,9 @@ fun replaySchedule(
         lastTime: WallTime,
         queryTime: WallTime
 ): Double? {
-    val dtSec = (queryTime - lastTime).toDouble(DurationUnit.SECONDS)
+    val dt: Duration = queryTime - lastTime
     val stopTimes = schedule.stopTimes
-    if (stopTimes.size < 2 || dtSec < 0) return null
+    if (stopTimes.size < 2 || dt < Duration.ZERO) return null
 
     val segIdx =
             try {
@@ -74,25 +75,25 @@ fun replaySchedule(
     val segEnd = stopTimes[segIdx + 1]
 
     val segDist = segEnd.distanceAlongTrip - segStart.distanceAlongTrip
-    val travelTimeSec = (segEnd.arrivalTime - segStart.departureTime).toDouble()
-    if (segDist <= 0 || travelTimeSec <= 0) return null
+    val travelTime: Duration = segEnd.arrivalTime - segStart.departureTime
+    if (segDist <= 0 || travelTime <= Duration.ZERO) return null
 
-    // Interpolate the schedule time at startDist within this segment
+    // Interpolate the schedule time at startDist within this segment, then advance it by the
+    // wall-clock elapsed interval (the schedule-time group action).
     val fraction = (startDist - segStart.distanceAlongTrip) / segDist
-    val schedTimeAtStart = segStart.departureTime + fraction * travelTimeSec
-    val targetSchedTime = schedTimeAtStart + dtSec
+    val targetSchedTime: ScheduleTime = segStart.departureTime + travelTime * fraction + dt
 
     return walkForward(stopTimes, segIdx, targetSchedTime)
 }
 
 /**
  * Walks the schedule timeline forward from segment [startSegIdx] to find the distance corresponding
- * to [targetTime] (in seconds since service date).
+ * to [targetTime] (a schedule time).
  */
 private fun walkForward(
         stopTimes: Array<ObaTripSchedule.StopTime>,
         startSegIdx: Int,
-        targetTime: Double
+        targetTime: ScheduleTime
 ): Double {
     // Check if still within the starting segment's travel phase
     val segEnd = stopTimes[startSegIdx + 1]
@@ -126,11 +127,11 @@ private fun walkForward(
 private fun interpolateInSegment(
         from: ObaTripSchedule.StopTime,
         to: ObaTripSchedule.StopTime,
-        targetTime: Double
+        targetTime: ScheduleTime
 ): Double {
-    val travelTime = to.arrivalTime - from.departureTime
-    if (travelTime <= 0) return to.distanceAlongTrip
-    val elapsed = targetTime - from.departureTime
+    val travelTime: Duration = to.arrivalTime - from.departureTime
+    if (travelTime <= Duration.ZERO) return to.distanceAlongTrip
+    val elapsed: Duration = targetTime - from.departureTime
     val fraction = (elapsed / travelTime).coerceIn(0.0, 1.0)
     val segDist = to.distanceAlongTrip - from.distanceAlongTrip
     return from.distanceAlongTrip + fraction * segDist

--- a/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/data/Adapters.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/data/Adapters.kt
@@ -21,6 +21,7 @@ import org.onebusaway.android.models.ObaTrip
 import org.onebusaway.android.models.ObaTripStatus
 import org.onebusaway.android.models.RouteTrips
 import org.onebusaway.android.time.ServerTime
+import org.onebusaway.android.time.ServiceDate
 
 /*
  * The adapter between a trips-for-route / trip-details fetch and the trip store's standard
@@ -32,22 +33,31 @@ import org.onebusaway.android.time.ServerTime
 
 /**
  * What one API response said about one trip's vehicle: the standard object the trip store
- * records. [serviceDate] is 0 and [routeType] null when the response doesn't carry them.
+ * records. [serviceDate] and [routeType] are null when the response doesn't carry them.
  */
 data class TripObservation(
         val tripId: String,
         val status: ObaTripStatus,
         /** The server's currentTime when the status was fetched. */
         val serverTimeMs: ServerTime,
-        val serviceDate: Long,
+        val serviceDate: ServiceDate?,
         val routeType: Int?
 )
+
+/**
+ * Decodes the OBA service-date wire sentinel — 0 means "the response didn't carry one" — into the
+ * domain type. The wire convention lives here in the data layer, not on [ServiceDate] itself, which
+ * stays a pure domain wrapper (CLAUDE.md: unit/sentinel normalization belongs at the wire boundary).
+ */
+internal fun serviceDateOrNull(epochMs: Long): ServiceDate? =
+        epochMs.takeIf { it > 0 }?.let(::ServiceDate)
 
 /** One observation per active trip in the route's vehicles (one for a single trip-details poll). */
 fun RouteTrips.toObservations(): List<TripObservation> = buildList {
     forEachActiveTrip { tripId, status, _ ->
-        // currentTimeMs is the server's currentTime, already epoch millis.
-        add(TripObservation(tripId, status, ServerTime(currentTimeMs), status.serviceDate, routeTypeForTrip(tripId)))
+        // currentTimeMs is the server's currentTime, already epoch millis. Decode the service-date
+        // sentinel (0 = absent) into ServiceDate? exactly here, at the mint boundary.
+        add(TripObservation(tripId, status, ServerTime(currentTimeMs), serviceDateOrNull(status.serviceDate), routeTypeForTrip(tripId)))
     }
 }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/data/TripObservationFetcher.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/data/TripObservationFetcher.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.withContext
 import org.onebusaway.android.models.ObaTripSchedule
 import org.onebusaway.android.models.RouteTrips
+import org.onebusaway.android.time.ServiceDate
 import org.onebusaway.android.util.Polyline
 import org.onebusaway.android.util.SingleFlight
 
@@ -64,7 +65,7 @@ interface TripObservationFetcher {
 data class TripDetails(
     val observations: List<TripObservation>,
     val schedule: ObaTripSchedule?,
-    val serviceDate: Long,
+    val serviceDate: ServiceDate?,
     val vehicleActiveTripId: String?,
     val shapeId: String?,
 )
@@ -104,7 +105,7 @@ class DefaultTripObservationFetcher @Inject constructor(
                 TripDetails(
                     observations = routeTrips.toObservations(),
                     schedule = details?.schedule,
-                    serviceDate = details?.status?.serviceDate ?: 0,
+                    serviceDate = serviceDateOrNull(details?.status?.serviceDate ?: 0),
                     vehicleActiveTripId = details?.status?.activeTripId,
                     shapeId = routeTrips.trip(tripId)?.shapeId?.takeIf { it.isNotEmpty() },
                 )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/data/TripState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/data/TripState.kt
@@ -24,6 +24,7 @@ import org.onebusaway.android.models.ObaTripSchedule
 import org.onebusaway.android.models.ObaTripStatus
 import org.onebusaway.android.time.WallTime
 import org.onebusaway.android.time.ServerTime
+import org.onebusaway.android.time.ServiceDate
 import org.onebusaway.android.util.Polyline
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
@@ -74,8 +75,8 @@ data class TripState(
          */
         val anchorLocalTimeMs: WallTime = WallTime(0L),
         val schedule: ObaTripSchedule? = null,
-        /** Service date in ms since the epoch, or 0 when not yet known. */
-        val serviceDate: Long = 0L,
+        /** The trip's service day, or null when not yet known. */
+        val serviceDate: ServiceDate? = null,
         val polyline: Polyline? = null,
         val routeType: Int? = null,
         /**
@@ -161,9 +162,9 @@ data class TripState(
                     .withServiceDate(observation.serviceDate)
                     .withRouteType(observation.routeType)
 
-    /** Returns the state with [serviceDate] applied, or `this` when it is unknown or unchanged. */
-    fun withServiceDate(serviceDate: Long): TripState =
-            if (serviceDate > 0 && serviceDate != this.serviceDate) copy(serviceDate = serviceDate)
+    /** Returns the state with [serviceDate] applied, or `this` when it is null (unknown) or unchanged. */
+    fun withServiceDate(serviceDate: ServiceDate?): TripState =
+            if (serviceDate != null && serviceDate != this.serviceDate) copy(serviceDate = serviceDate)
             else this
 
     /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/data/TripStateCache.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/data/TripStateCache.kt
@@ -17,6 +17,7 @@ package org.onebusaway.android.extrapolation.data
 
 import androidx.annotation.VisibleForTesting
 import org.onebusaway.android.models.ObaTripSchedule
+import org.onebusaway.android.time.ServiceDate
 import org.onebusaway.android.time.WallTime
 import org.onebusaway.android.util.Polyline
 
@@ -72,8 +73,8 @@ internal class TripStateCache {
         }
     }
 
-    fun putServiceDate(tripId: String?, serviceDate: Long) {
-        if (tripId != null && serviceDate > 0) {
+    fun putServiceDate(tripId: String?, serviceDate: ServiceDate?) {
+        if (tripId != null && serviceDate != null) {
             update(tripId) { it.withServiceDate(serviceDate) }
         }
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/compose/VehicleInfoWindow.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/compose/VehicleInfoWindow.kt
@@ -77,7 +77,7 @@ fun VehicleInfoWindow(status: ObaTripStatus, isRealtime: Boolean, response: Rout
     // guard the unreachable null instead of dereferencing (the legacy getTrip/getRoute would NPE).
     val trip = response.trip(status.activeTripId) ?: return
     val route = response.route(trip.routeId) ?: return
-    val deviationMin = TimeUnit.SECONDS.toMinutes(status.scheduleDeviation)
+    val deviationMin = status.scheduleDeviation.inWholeMinutes
 
     // [isRealtime] is the drawn marker's live-vs-scheduled flag (from the renderer), so the window can't
     // disagree with the icon; the arrival listings share the scheduled-vs-deviation coloring via ArrivalInfoUtils.

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/VehicleBitmaps.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/VehicleBitmaps.kt
@@ -32,7 +32,6 @@ import org.onebusaway.android.models.ObaRoute
 import org.onebusaway.android.models.RouteTrips
 import org.onebusaway.android.util.ArrivalInfoUtils
 import org.onebusaway.android.util.MathUtils
-import java.util.concurrent.TimeUnit
 
 /**
  * Flavor-neutral generation of vehicle marker bitmaps. Lives in `src/main` so both the Google flavor
@@ -120,7 +119,7 @@ object VehicleBitmaps {
 
     /** The schedule-deviation color (realtime) or the scheduled color — constant between polls. */
     private fun colorResource(vehicle: VehicleMarker): Int {
-        val deviationMin = TimeUnit.SECONDS.toMinutes(vehicle.status.scheduleDeviation)
+        val deviationMin = vehicle.status.scheduleDeviation.inWholeMinutes
         return ArrivalInfoUtils.statusColor(vehicle.isRealtime, deviationMin)
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/models/ObaTripSchedule.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/models/ObaTripSchedule.kt
@@ -15,6 +15,8 @@
  */
 package org.onebusaway.android.models
 
+import org.onebusaway.android.time.ScheduleTime
+
 /**
  * The schedule for a trip: the ordered stop times plus the neighboring trips in the block. The
  * concrete holder lives in `api`; the schedule-geometry logic lives in `extrapolation`.
@@ -42,11 +44,11 @@ interface ObaTripSchedule {
         /** The passenger-facing headsign at this stop, or null. */
         val headsign: String?
 
-        /** The scheduled arrival time, in seconds since the service start date. */
-        val arrivalTime: Long
+        /** The scheduled arrival time, as an offset from the service day start. */
+        val arrivalTime: ScheduleTime
 
-        /** The scheduled departure time, in seconds since the service start date. */
-        val departureTime: Long
+        /** The scheduled departure time, as an offset from the service day start. */
+        val departureTime: ScheduleTime
 
         /** The average historical occupancy when the vehicle arrives at this stop, or null. */
         val historicalOccupancy: Occupancy?

--- a/onebusaway-android/src/main/java/org/onebusaway/android/models/ObaTripStatus.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/models/ObaTripStatus.kt
@@ -16,6 +16,7 @@
 package org.onebusaway.android.models
 
 import android.location.Location
+import kotlin.time.Duration
 
 interface ObaTripStatus {
 
@@ -29,10 +30,11 @@ interface ObaTripStatus {
     val isPredicted: Boolean
 
     /**
-     * If real-time arrival info is available, the deviation from the schedule in seconds (positive =
-     * running late, negative = early); zero if no real-time info is available.
+     * If real-time arrival info is available, the deviation from the schedule (positive = running
+     * late, negative = early); zero when no real-time info is available. Minted from the wire's raw
+     * seconds in the adapter.
      */
-    val scheduleDeviation: Long
+    val scheduleDeviation: Duration
 
     /** If real-time info is available, the id of the transit vehicle currently running the trip. */
     val vehicleId: String?

--- a/onebusaway-android/src/main/java/org/onebusaway/android/time/ScheduleTime.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/time/ScheduleTime.kt
@@ -16,7 +16,6 @@
 package org.onebusaway.android.time
 
 import kotlin.time.Duration
-import kotlin.time.Duration.Companion.seconds
 
 /*
  * Civil (schedule) time — the third kind of time, distinct from the clock instants in TypedTime.kt.
@@ -26,10 +25,10 @@ import kotlin.time.Duration.Companion.seconds
  * has no clock domain until it is resolved against a concrete service day — it is the recurring civil
  * label, the service day is the interpretation context, and [ScheduleTime.resolve] is the one place
  * that pairs them to land on the [ServerTime] timeline. (This is the same split java.time draws between
- * `LocalTime` and `Instant`, specialized to GTFS's "seconds since the service day start".)
+ * `LocalTime` and `Instant`, specialized to GTFS's "time since the service day start".)
  *
  * These are pure domain wrappers, mirroring TypedTime.kt: mint at the boundary, unwrap only at a
- * platform edge (formatting, a plotting coordinate). The seconds↔millis and DST conventions live in
+ * platform edge (formatting, a plotting coordinate). The offset→millis and DST conventions live in
  * exactly one place — [ScheduleTime.resolve] — so no other site re-derives them.
  */
 
@@ -62,30 +61,40 @@ value class ServiceDate(val epochMs: Long) {
 }
 
 /**
- * A **schedule time**: a whole-second offset from a [ServiceDate], i.e. GTFS "seconds since the service
- * day start" (`ObaTripSchedule.StopTime.arrivalTime`/`departureTime`). Recurring civil time, not an
- * instant — it carries no clock domain until [resolve]d against a concrete service day.
+ * A **schedule time**: the offset from a [ServiceDate] to a scheduled event, i.e. GTFS "time since the
+ * service day start" (`ObaTripSchedule.StopTime.arrivalTime`/`departureTime`). Recurring civil time,
+ * not an instant — it carries no clock domain until [resolve]d against a concrete service day.
  *
- * Same-domain subtraction yields the **scheduled interval** between two schedule points (e.g. a stop's
- * dwell, or the run time between two stops) as a [Duration]. There is deliberately no addition of two
- * schedule times and no comparison against any clock instant — the only bridge to the timeline is
- * [resolve].
+ * Unlike the clock instants (torsors, with no canonical zero), schedule time has a real origin — the
+ * service-day start — so it is represented literally as its [Duration] offset from that origin. That
+ * choice also buys the interpolation algebra for free: [Duration] scales by a `Double` and divides to
+ * a `Double`, exactly the two operations walking a fractional point between whole-second stop times
+ * needs (see `ScheduleReplayExtrapolator`). Same-domain subtraction yields the **scheduled interval**
+ * between two points; the group action ([plus]/[minus] a [Duration]) shifts a point by an elapsed
+ * interval. There is deliberately no addition of two schedule times and no comparison against any clock
+ * instant — the only bridge to the timeline is [resolve].
  */
 @JvmInline
-value class ScheduleTime(val secondsIntoServiceDay: Long) : Comparable<ScheduleTime> {
+value class ScheduleTime(val sinceServiceDayStart: Duration) : Comparable<ScheduleTime> {
 
     override fun compareTo(other: ScheduleTime): Int =
-        secondsIntoServiceDay.compareTo(other.secondsIntoServiceDay)
+        sinceServiceDayStart.compareTo(other.sinceServiceDayStart)
 
     /** The scheduled interval from [other] to this schedule point. Same-domain only. */
     operator fun minus(other: ScheduleTime): Duration =
-        (secondsIntoServiceDay - other.secondsIntoServiceDay).seconds
+        sinceServiceDayStart - other.sinceServiceDayStart
+
+    /** This schedule point shifted later by [elapsed] (the group action); still schedule time. */
+    operator fun plus(elapsed: Duration): ScheduleTime = ScheduleTime(sinceServiceDayStart + elapsed)
+
+    /** This schedule point shifted earlier by [elapsed]. Distinct from `minus(ScheduleTime)` by type. */
+    operator fun minus(elapsed: Duration): ScheduleTime = ScheduleTime(sinceServiceDayStart - elapsed)
 
     /**
      * Resolves this recurring schedule time to a concrete server-clock instant on [day].
      *
      * The single sanctioned schedule→instant adapter — the civil-time analogue of the API layer's
-     * `situationEpochToMillis`. `day.epochMs + seconds` is DST-correct **only** because the OBA server
+     * `situationEpochToMillis`. `day.epochMs + offset` is DST-correct **only** because the OBA server
      * defines the service date as the GTFS noon-minus-12h anchor and has already done the timezone
      * arithmetic upstream, so a fixed 86 400-second day plus the raw offset lands on the right wall
      * instant even across a DST transition. The client trusts that server convention here rather than
@@ -94,5 +103,5 @@ value class ScheduleTime(val secondsIntoServiceDay: Long) : Comparable<ScheduleT
      * always compared against the server's "now", never the device clock (CLAUDE.md "Time domains").
      */
     fun resolve(day: ServiceDate): ServerTime =
-        ServerTime(day.epochMs + secondsIntoServiceDay * 1000L)
+        ServerTime(day.epochMs + sinceServiceDayStart.inWholeMilliseconds)
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/time/ScheduleTime.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/time/ScheduleTime.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.time
+
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+/*
+ * Civil (schedule) time — the third kind of time, distinct from the clock instants in TypedTime.kt.
+ *
+ * A clock instant (`ServerTime`/`WallTime`/`ElapsedTime`) is a point on a timeline. A schedule time is
+ * *not*: "the 08:15 to Ballard" denotes a different instant on every service day. So a schedule time
+ * has no clock domain until it is resolved against a concrete service day — it is the recurring civil
+ * label, the service day is the interpretation context, and [ScheduleTime.resolve] is the one place
+ * that pairs them to land on the [ServerTime] timeline. (This is the same split java.time draws between
+ * `LocalTime` and `Instant`, specialized to GTFS's "seconds since the service day start".)
+ *
+ * These are pure domain wrappers, mirroring TypedTime.kt: mint at the boundary, unwrap only at a
+ * platform edge (formatting, a plotting coordinate). The seconds↔millis and DST conventions live in
+ * exactly one place — [ScheduleTime.resolve] — so no other site re-derives them.
+ */
+
+/**
+ * A **service-day anchor**: the OBA server's service date, as epoch millis at that day's start.
+ *
+ * Opaque on purpose. The only thing the client does with it is anchor a [ScheduleTime]; it is never
+ * subtracted or ordered as an instant (it is a calendar date, not a point on the clock), so it exposes
+ * no arithmetic. The primary constructor takes the value the **server** sends as the service date —
+ * the GTFS "noon minus 12 hours" anchor — which is what makes [ScheduleTime.resolve] DST-correct. The
+ * one off-contract source (device-local midnight, for the schedule-only path) is minted through the
+ * named [ServiceDate.approximateFromDeviceMidnight] instead, so the two provenances stay distinguishable
+ * at a grep.
+ */
+@JvmInline
+value class ServiceDate(val epochMs: Long) {
+    companion object {
+        /**
+         * A **fallback** anchor for the schedule-only path (no vehicle, so the server sent no service
+         * date): device-local civil midnight, taken from the device clock. Named apart from the plain
+         * constructor because it does **not** meet the server-anchor contract above — it is a
+         * device-clock quantity, so it carries the device's clock skew, and on the two DST-transition
+         * days a year it sits an hour off the GTFS noon-minus-12h anchor. Schedule times
+         * [ScheduleTime.resolve]d against it inherit that slop. Use only where an approximate day is
+         * better than none; never treat its result as interchangeable with a server-sent date.
+         */
+        fun approximateFromDeviceMidnight(deviceMidnightMs: Long): ServiceDate =
+            ServiceDate(deviceMidnightMs)
+    }
+}
+
+/**
+ * A **schedule time**: a whole-second offset from a [ServiceDate], i.e. GTFS "seconds since the service
+ * day start" (`ObaTripSchedule.StopTime.arrivalTime`/`departureTime`). Recurring civil time, not an
+ * instant — it carries no clock domain until [resolve]d against a concrete service day.
+ *
+ * Same-domain subtraction yields the **scheduled interval** between two schedule points (e.g. a stop's
+ * dwell, or the run time between two stops) as a [Duration]. There is deliberately no addition of two
+ * schedule times and no comparison against any clock instant — the only bridge to the timeline is
+ * [resolve].
+ */
+@JvmInline
+value class ScheduleTime(val secondsIntoServiceDay: Long) : Comparable<ScheduleTime> {
+
+    override fun compareTo(other: ScheduleTime): Int =
+        secondsIntoServiceDay.compareTo(other.secondsIntoServiceDay)
+
+    /** The scheduled interval from [other] to this schedule point. Same-domain only. */
+    operator fun minus(other: ScheduleTime): Duration =
+        (secondsIntoServiceDay - other.secondsIntoServiceDay).seconds
+
+    /**
+     * Resolves this recurring schedule time to a concrete server-clock instant on [day].
+     *
+     * The single sanctioned schedule→instant adapter — the civil-time analogue of the API layer's
+     * `situationEpochToMillis`. `day.epochMs + seconds` is DST-correct **only** because the OBA server
+     * defines the service date as the GTFS noon-minus-12h anchor and has already done the timezone
+     * arithmetic upstream, so a fixed 86 400-second day plus the raw offset lands on the right wall
+     * instant even across a DST transition. The client trusts that server convention here rather than
+     * re-deriving it from a timezone; its failure mode is a schedule drawn one hour off if a server
+     * ever emitted a non-GTFS-conformant service date. Lands in [ServerTime] because schedules are
+     * always compared against the server's "now", never the device clock (CLAUDE.md "Time domains").
+     */
+    fun resolve(day: ServiceDate): ServerTime =
+        ServerTime(day.epochMs + secondsIntoServiceDay * 1000L)
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/time/TypedTime.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/time/TypedTime.kt
@@ -24,9 +24,20 @@ import kotlin.time.Duration.Companion.milliseconds
  * silent until a user sees a wrong number: a server timestamp minus the device clock (#27/#1612), an
  * alert window in seconds compared against a millis "now", a wall-clock delta corrupted by an NTP
  * correction. A raw `Long` carries no record of which clock it came from, so the mistake passes review
- * and compiles. These wrappers make the clock **domain** part of the type: the only arithmetic defined
- * is same-domain subtraction (yielding a unit-safe `kotlin.time.Duration`), so a cross-domain subtraction
- * fails to *compile* rather than misbehaving at runtime.
+ * and compiles. These wrappers make the clock **domain** part of the type.
+ *
+ * Algebraically each domain is an *affine space* (a torsor) over `kotlin.time.Duration`: the instants
+ * are points with no zero and no addition-to-each-other, and `Duration` is the vector between them. The
+ * defined arithmetic is exactly the affine signature —
+ *
+ *   - `Point − Point → Duration`  (same-domain only; the elapsed interval)
+ *   - `Point + Duration → Point`  and  `Point − Duration → Point`  (the group action: shift an instant)
+ *
+ * — so a cross-domain subtraction (`ServerTime − WallTime`) or adding two instants fails to *compile*
+ * rather than misbehaving at runtime. Note the group action shares one `Duration` type across all three
+ * domains, which quietly assumes every clock ticks at unit rate (they differ only by offset, never by
+ * drift/rate). That holds over the minutes-long horizons this app reasons about; it would not for
+ * multi-hour extrapolation, where clock drift becomes a real affine `a·t + b` rather than a translation.
  *
  * They are `@JvmInline value class`es — at runtime each is just its underlying `Long`, so the safety is
  * free. These are pure domain types: they carry no wire/unit knowledge. Mint one at the wire/Android
@@ -48,6 +59,12 @@ value class ServerTime(val epochMs: Long) : Comparable<ServerTime> {
 
     /** Elapsed time from [other] to this instant. Same-domain only — this is the point. */
     operator fun minus(other: ServerTime): Duration = (epochMs - other.epochMs).milliseconds
+
+    /** This instant shifted later by [elapsed] (the affine group action); still server-clock. */
+    operator fun plus(elapsed: Duration): ServerTime = ServerTime(epochMs + elapsed.inWholeMilliseconds)
+
+    /** This instant shifted earlier by [elapsed]. Distinct from `minus(ServerTime)` by argument type. */
+    operator fun minus(elapsed: Duration): ServerTime = ServerTime(epochMs - elapsed.inWholeMilliseconds)
 }
 
 /**
@@ -61,6 +78,12 @@ value class WallTime(val epochMs: Long) : Comparable<WallTime> {
     override fun compareTo(other: WallTime): Int = epochMs.compareTo(other.epochMs)
 
     operator fun minus(other: WallTime): Duration = (epochMs - other.epochMs).milliseconds
+
+    /** This instant shifted later by [elapsed] (the affine group action); still device-clock. */
+    operator fun plus(elapsed: Duration): WallTime = WallTime(epochMs + elapsed.inWholeMilliseconds)
+
+    /** This instant shifted earlier by [elapsed]. Distinct from `minus(WallTime)` by argument type. */
+    operator fun minus(elapsed: Duration): WallTime = WallTime(epochMs - elapsed.inWholeMilliseconds)
 
     companion object {
         fun now(): WallTime = WallTime(System.currentTimeMillis())
@@ -77,6 +100,12 @@ value class ElapsedTime(val ms: Long) : Comparable<ElapsedTime> {
     override fun compareTo(other: ElapsedTime): Int = ms.compareTo(other.ms)
 
     operator fun minus(other: ElapsedTime): Duration = (ms - other.ms).milliseconds
+
+    /** This reading shifted later by [elapsed] (the affine group action); still monotonic-clock. */
+    operator fun plus(elapsed: Duration): ElapsedTime = ElapsedTime(ms + elapsed.inWholeMilliseconds)
+
+    /** This reading shifted earlier by [elapsed]. Distinct from `minus(ElapsedTime)` by argument type. */
+    operator fun minus(elapsed: Duration): ElapsedTime = ElapsedTime(ms - elapsed.inWholeMilliseconds)
 
     companion object {
         fun now(): ElapsedTime = ElapsedTime(SystemClock.elapsedRealtime())

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/dataview/TripTrajectory.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/dataview/TripTrajectory.kt
@@ -17,19 +17,19 @@ package org.onebusaway.android.ui.dataview
 
 import org.onebusaway.android.extrapolation.ExtrapolationResult
 import org.onebusaway.android.extrapolation.data.TripState
-import org.onebusaway.android.time.ScheduleTime
-import org.onebusaway.android.time.ServiceDate
+import org.onebusaway.android.time.ServerTime
 import org.onebusaway.android.time.WallTime
 import org.onebusaway.android.extrapolation.math.prob.ProbDistribution
+import kotlin.time.Duration.Companion.seconds
 
-/** A plotted point: distance along the trip (meters) at a server-clock time (ms since epoch). */
-data class TrajectoryPoint(val distanceMeters: Double, val timeMs: Long)
+/** A plotted point: distance along the trip (meters) at a server-clock time. */
+data class TrajectoryPoint(val distanceMeters: Double, val timeMs: ServerTime)
 
 /** One scheduled stop: its distance, plus arrival/departure server-clock times (the dwell bar). */
 data class ScheduleStop(
     val distanceMeters: Double,
-    val arrivalMs: Long,
-    val departureMs: Long,
+    val arrivalMs: ServerTime,
+    val departureMs: ServerTime,
     val stopId: String?,
 )
 
@@ -38,38 +38,38 @@ data class PdfBin(val distanceMeters: Double, val normalizedHeight: Double)
 
 /**
  * The extrapolation overlay at [nowMs]: the median estimate and the 80% CI bounds projected from the
- * [anchor], plus the position PDF histogram. Distances in meters, times in server-clock ms.
+ * [anchor], plus the position PDF histogram. Distances in meters, times on the server clock.
  *
  * [scheduleAtMedianMs] is the server-clock time the schedule says the vehicle should reach the
- * median distance — the schedule-deviation reference. 0 when the median falls outside the schedule's
- * interpolatable span (no deviation to draw).
+ * median distance — the schedule-deviation reference. Null when the median falls outside the
+ * schedule's interpolatable span (no deviation to draw).
  */
 data class ExtrapolationSeries(
     val anchor: TrajectoryPoint,
-    val nowMs: Long,
+    val nowMs: ServerTime,
     val medianMeters: Double,
     val lowMeters: Double,
     val highMeters: Double,
     val pdf: List<PdfBin>,
-    val scheduleAtMedianMs: Long = 0L,
+    val scheduleAtMedianMs: ServerTime? = null,
 )
 
 /** The full data extent of a trajectory, for the viewport's initial fit. */
-data class DataBounds(val minDist: Double, val maxDist: Double, val minTime: Long, val maxTime: Long)
+data class DataBounds(val minDist: Double, val maxDist: Double, val minTime: ServerTime, val maxTime: ServerTime)
 
 /** Everything the trajectory graph plots for one trip at one instant. All distance-vs-time. */
 data class TripTrajectory(
     val observations: List<TrajectoryPoint> = emptyList(),
     val schedule: List<ScheduleStop> = emptyList(),
     val extrapolation: ExtrapolationSeries? = null,
-    val bounds: DataBounds = DataBounds(0.0, 0.0, 0L, 0L),
+    val bounds: DataBounds = DataBounds(0.0, 0.0, ServerTime(0L), ServerTime(0L)),
     /**
      * "Now" the graph was built at — the horizontal now line, rising over time. Already in the
      * server-clock domain the time axis is laid out in: [buildTrajectory] converts the caller's
      * local clock using the anchor's server/local skew, so the now line tracks the latest
      * observation even when the device clock drifts from the server's.
      */
-    val nowMs: Long = 0L,
+    val nowMs: ServerTime = ServerTime(0L),
 )
 
 /** Lower bound of the position-PDF histogram window (quantile). */
@@ -116,13 +116,13 @@ fun pdfBins(
  * the outermost points aren't drawn on the axes. Pure. A degenerate (empty or zero-extent) input
  * yields a unit-extent box so the viewport never divides by zero.
  */
-fun dataBounds(distances: List<Double>, times: List<Long>, padFraction: Double = 0.05): DataBounds {
+fun dataBounds(distances: List<Double>, times: List<ServerTime>, padFraction: Double = 0.05): DataBounds {
     val minD = distances.minOrNull() ?: 0.0
     val maxD = distances.maxOrNull() ?: 0.0
-    val minT = times.minOrNull() ?: 0L
-    val maxT = times.maxOrNull() ?: 0L
+    val minT = times.minOrNull() ?: ServerTime(0L)
+    val maxT = times.maxOrNull() ?: ServerTime(0L)
     val distPad = ((maxD - minD) * padFraction).coerceAtLeast(1.0)
-    val timePad = ((maxT - minT) * padFraction).toLong().coerceAtLeast(1_000L)
+    val timePad = ((maxT - minT) * padFraction).coerceAtLeast(1.seconds)
     return DataBounds(minD - distPad, maxD + distPad, minT - timePad, maxT + timePad)
 }
 
@@ -138,26 +138,25 @@ fun dataBounds(distances: List<Double>, times: List<Long>, padFraction: Double =
  * local clock).
  */
 fun buildTrajectory(state: TripState, nowMs: WallTime): TripTrajectory {
-    // Plot on the server-clock axis; unwrap to raw Long for the graph's time coordinates.
-    val serverNowMs = state.toServerClock(nowMs).epochMs
+    // Plot on the server-clock axis: reconcile the caller's local "now" via the anchor skew.
+    val serverNow = state.toServerClock(nowMs)
 
     val observations = state.history.mapNotNull { entry ->
         val dist = entry.status.distanceAlongTrip ?: return@mapNotNull null
-        val time = entry.status.lastUpdateTime.takeIf { it > 0 } ?: entry.serverTimeMs.epochMs
+        val time = entry.status.lastUpdateTime.takeIf { it > 0 }?.let { ServerTime(it) } ?: entry.serverTimeMs
         TrajectoryPoint(dist, time)
     }
 
-    // serviceDate defaults to 0 (unknown); resolving against it would plot every stop near the 1970
-    // epoch. Skip the schedule overlay until a real date arrives rather than draw that decoy.
-    val serviceDate = state.serviceDate.takeIf { it > 0 }?.let { ServiceDate(it) }
-    val schedule = serviceDate?.let { day ->
+    // The schedule overlay needs a concrete service day to resolve its stop times onto the server
+    // clock. Skip it while the date is unknown (null) rather than plot a decoy — the type makes the
+    // unknown case impossible to forget.
+    val schedule = state.serviceDate?.let { day ->
         state.schedule?.stopTimes.orEmpty().map { st ->
             ScheduleStop(
                 distanceMeters = st.distanceAlongTrip,
-                // Resolve each recurring schedule offset onto the server-clock axis, then unwrap to the
-                // raw Long the graph's time coordinates use.
-                arrivalMs = ScheduleTime(st.arrivalTime).resolve(day).epochMs,
-                departureMs = ScheduleTime(st.departureTime).resolve(day).epochMs,
+                // Resolve each recurring schedule offset onto the server-clock axis.
+                arrivalMs = st.arrivalTime.resolve(day),
+                departureMs = st.departureTime.resolve(day),
                 stopId = st.stopId,
             )
         }
@@ -171,13 +170,13 @@ fun buildTrajectory(state: TripState, nowMs: WallTime): TripTrajectory {
         extrapolation?.let { add(it.anchor.distanceMeters); add(it.medianMeters); add(it.highMeters) }
     }
     val times = buildList {
-        add(serverNowMs) // keep the now line in-bounds even before any extrapolation exists
+        add(serverNow) // keep the now line in-bounds even before any extrapolation exists
         observations.forEach { add(it.timeMs) }
         schedule.forEach { add(it.arrivalMs); add(it.departureMs) }
         extrapolation?.let { add(it.anchor.timeMs); add(it.nowMs) }
     }
 
-    return TripTrajectory(observations, schedule, extrapolation, dataBounds(distances, times), serverNowMs)
+    return TripTrajectory(observations, schedule, extrapolation, dataBounds(distances, times), serverNow)
 }
 
 private fun extrapolationSeries(state: TripState, schedule: List<ScheduleStop>, nowMs: WallTime): ExtrapolationSeries? {
@@ -188,8 +187,8 @@ private fun extrapolationSeries(state: TripState, schedule: List<ScheduleStop>, 
     val high = distribution.quantile(CI_HIGH_QUANTILE)
     if (!median.isFinite() || !low.isFinite() || !high.isFinite()) return null
     return ExtrapolationSeries(
-        anchor = TrajectoryPoint(anchorDist, state.anchorTimeMs.epochMs),
-        nowMs = state.toServerClock(nowMs).epochMs,
+        anchor = TrajectoryPoint(anchorDist, state.anchorTimeMs),
+        nowMs = state.toServerClock(nowMs),
         medianMeters = median,
         lowMeters = low,
         highMeters = high,
@@ -203,7 +202,7 @@ private fun extrapolationSeries(state: TripState, schedule: List<ScheduleStop>, 
  * arrival time [t1] at [d1]. Boundary ownership (which segment claims a distance exactly on [d0]/[d1])
  * is not a property of the segment — it lives in [interpolateScheduleTime].
  */
-internal data class ScheduleSegment(val d0: Double, val d1: Double, val t0: Long, val t1: Long) {
+internal data class ScheduleSegment(val d0: Double, val d1: Double, val t0: ServerTime, val t1: ServerTime) {
     init {
         require(d1 > d0) { "ScheduleSegment requires strictly increasing distance, got d0=$d0 d1=$d1" }
     }
@@ -233,27 +232,27 @@ internal fun scheduleSegments(schedule: List<ScheduleStop>): List<ScheduleSegmen
 /**
  * The server-clock time the [schedule] says the vehicle reaches [distanceMeters], linearly
  * interpolated within the bracketing stop pair (previous stop's departure to next stop's arrival).
- * Pure, so it is unit-testable. Returns 0 when fewer than two stops exist or the distance falls
+ * Pure, so it is unit-testable. Returns null when fewer than two stops exist or the distance falls
  * outside every interpolatable segment.
  *
  * Each segment is half-open `[d0, d1)`, so a distance exactly on a stop boundary lands in a single
  * segment (the next one) instead of being ambiguously claimed by both. The trip's final distance,
  * which every half-open span excludes, is mapped after the scan to the last segment's arrival so the
- * end of the trip still resolves rather than dropping to the 0 sentinel. Operating on
+ * end of the trip still resolves rather than dropping to null. Operating on
  * [scheduleSegments] (strictly increasing by construction) means there is no degenerate case left to
  * handle here.
  */
-fun interpolateScheduleTime(schedule: List<ScheduleStop>, distanceMeters: Double): Long {
+fun interpolateScheduleTime(schedule: List<ScheduleStop>, distanceMeters: Double): ServerTime? {
     val segments = scheduleSegments(schedule)
     for (s in segments) {
         if (distanceMeters >= s.d0 && distanceMeters < s.d1) {
             val fraction = (distanceMeters - s.d0) / (s.d1 - s.d0)
-            return s.t0 + (fraction * (s.t1 - s.t0)).toLong()
+            return s.t0 + (s.t1 - s.t0) * fraction
         }
     }
     // Half-open spans exclude the trip's final distance; map that exact endpoint to the last arrival.
-    val last = segments.lastOrNull() ?: return 0L
-    return if (distanceMeters == last.d1) last.t1 else 0L
+    val last = segments.lastOrNull() ?: return null
+    return if (distanceMeters == last.d1) last.t1 else null
 }
 
 /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/dataview/TripTrajectory.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/dataview/TripTrajectory.kt
@@ -17,6 +17,8 @@ package org.onebusaway.android.ui.dataview
 
 import org.onebusaway.android.extrapolation.ExtrapolationResult
 import org.onebusaway.android.extrapolation.data.TripState
+import org.onebusaway.android.time.ScheduleTime
+import org.onebusaway.android.time.ServiceDate
 import org.onebusaway.android.time.WallTime
 import org.onebusaway.android.extrapolation.math.prob.ProbDistribution
 
@@ -145,14 +147,21 @@ fun buildTrajectory(state: TripState, nowMs: WallTime): TripTrajectory {
         TrajectoryPoint(dist, time)
     }
 
-    val schedule = state.schedule?.stopTimes.orEmpty().map { st ->
-        ScheduleStop(
-            distanceMeters = st.distanceAlongTrip,
-            arrivalMs = state.serviceDate + st.arrivalTime * 1000L,
-            departureMs = state.serviceDate + st.departureTime * 1000L,
-            stopId = st.stopId,
-        )
-    }
+    // serviceDate defaults to 0 (unknown); resolving against it would plot every stop near the 1970
+    // epoch. Skip the schedule overlay until a real date arrives rather than draw that decoy.
+    val serviceDate = state.serviceDate.takeIf { it > 0 }?.let { ServiceDate(it) }
+    val schedule = serviceDate?.let { day ->
+        state.schedule?.stopTimes.orEmpty().map { st ->
+            ScheduleStop(
+                distanceMeters = st.distanceAlongTrip,
+                // Resolve each recurring schedule offset onto the server-clock axis, then unwrap to the
+                // raw Long the graph's time coordinates use.
+                arrivalMs = ScheduleTime(st.arrivalTime).resolve(day).epochMs,
+                departureMs = ScheduleTime(st.departureTime).resolve(day).epochMs,
+                stopId = st.stopId,
+            )
+        }
+    }.orEmpty()
 
     val extrapolation = extrapolationSeries(state, schedule, nowMs)
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/dataview/TripTrajectoryScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/dataview/TripTrajectoryScreen.kt
@@ -173,7 +173,7 @@ private fun TrajectoryGraph(trajectory: TripTrajectory, modifier: Modifier) {
         invalidations // read so gesture mutations recompose this draw
         viewport.setDataBounds(
             trajectory.bounds.minDist, trajectory.bounds.maxDist,
-            trajectory.bounds.minTime, trajectory.bounds.maxTime,
+            trajectory.bounds.minTime.epochMs, trajectory.bounds.maxTime.epochMs,
         )
         if (!viewport.setupVisibleWindow(size.width, size.height)) return@Canvas
 
@@ -181,7 +181,7 @@ private fun TrajectoryGraph(trajectory: TripTrajectory, modifier: Modifier) {
         drawSchedule(viewport, trajectory.schedule)
         drawObservations(viewport, trajectory.observations)
         trajectory.extrapolation?.let { drawExtrapolation(viewport, it, labelPaint, deviationLabelPaint) }
-        drawNowLine(viewport, trajectory.nowMs, nowLabelPaint, timeFormat)
+        drawNowLine(viewport, trajectory.nowMs.epochMs, nowLabelPaint, timeFormat)
     }
 }
 
@@ -205,8 +205,8 @@ private fun DrawScope.drawSchedule(viewport: GraphViewport, schedule: List<Sched
     if (schedule.isEmpty()) return
     var prev: Offset? = null
     schedule.forEach { stop ->
-        val arrival = Offset(viewport.toPixelX(stop.distanceMeters), viewport.toPixelY(stop.arrivalMs))
-        val departure = Offset(viewport.toPixelX(stop.distanceMeters), viewport.toPixelY(stop.departureMs))
+        val arrival = Offset(viewport.toPixelX(stop.distanceMeters), viewport.toPixelY(stop.arrivalMs.epochMs))
+        val departure = Offset(viewport.toPixelX(stop.distanceMeters), viewport.toPixelY(stop.departureMs.epochMs))
         prev?.let { drawLine(ScheduleColor, it, arrival, 4f) }
         if (stop.departureMs != stop.arrivalMs) {
             drawLine(ScheduleColor, arrival, departure, 8f, cap = StrokeCap.Round) // dwell
@@ -219,7 +219,7 @@ private fun DrawScope.drawSchedule(viewport: GraphViewport, schedule: List<Sched
 private fun DrawScope.drawObservations(viewport: GraphViewport, observations: List<TrajectoryPoint>) {
     var prev: Offset? = null
     observations.forEach { point ->
-        val p = Offset(viewport.toPixelX(point.distanceMeters), viewport.toPixelY(point.timeMs))
+        val p = Offset(viewport.toPixelX(point.distanceMeters), viewport.toPixelY(point.timeMs.epochMs))
         prev?.let { drawLine(TrajectoryColor, it, p, 6f) }
         drawCircle(TrajectoryColor, radius = 6f, center = p)
         prev = p
@@ -232,12 +232,12 @@ private fun DrawScope.drawExtrapolation(
     labelPaint: Paint,
     deviationLabelPaint: Paint,
 ) {
-    val anchor = Offset(viewport.toPixelX(series.anchor.distanceMeters), viewport.toPixelY(series.anchor.timeMs))
-    val median = Offset(viewport.toPixelX(series.medianMeters), viewport.toPixelY(series.nowMs))
+    val anchor = Offset(viewport.toPixelX(series.anchor.distanceMeters), viewport.toPixelY(series.anchor.timeMs.epochMs))
+    val median = Offset(viewport.toPixelX(series.medianMeters), viewport.toPixelY(series.nowMs.epochMs))
 
     // 80% CI: dashed lines from the anchor to the low/high bounds at "now".
-    val low = Offset(viewport.toPixelX(series.lowMeters), viewport.toPixelY(series.nowMs))
-    val high = Offset(viewport.toPixelX(series.highMeters), viewport.toPixelY(series.nowMs))
+    val low = Offset(viewport.toPixelX(series.lowMeters), viewport.toPixelY(series.nowMs.epochMs))
+    val high = Offset(viewport.toPixelX(series.highMeters), viewport.toPixelY(series.nowMs.epochMs))
     drawLine(ConfidenceColor, anchor, low, 3f, pathEffect = CiDashes)
     drawLine(ConfidenceColor, anchor, high, 3f, pathEffect = CiDashes)
 
@@ -271,11 +271,11 @@ private fun DrawScope.drawExtrapolation(
 
     // Schedule deviation: an orange marker at the time the schedule says the vehicle reaches the
     // median distance, linked up to "now" by a dashed line; the gap is how early/late it's running.
-    if (series.scheduleAtMedianMs > 0L) {
-        val schedY = viewport.toPixelY(series.scheduleAtMedianMs)
+    series.scheduleAtMedianMs?.let { scheduleAtMedian ->
+        val schedY = viewport.toPixelY(scheduleAtMedian.epochMs)
         drawLine(DeviationColor, Offset(median.x, schedY), median, 3f, pathEffect = DeviationDashes)
         drawCircle(DeviationColor, radius = 10f, center = Offset(median.x, schedY))
-        val devLabel = formatDeviationLabel((series.nowMs - series.scheduleAtMedianMs) / 1000)
+        val devLabel = formatDeviationLabel((series.nowMs - scheduleAtMedian).inWholeSeconds)
         drawContext.canvas.nativeCanvas.drawText(
             devLabel,
             median.x + 5f,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripdetails/TripDetailsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripdetails/TripDetailsRepository.kt
@@ -36,6 +36,9 @@ import org.onebusaway.android.models.ObaTrip
 import org.onebusaway.android.models.ObaTripSchedule
 import org.onebusaway.android.models.ObaTripStatus
 import org.onebusaway.android.models.Status
+import org.onebusaway.android.time.ScheduleTime
+import org.onebusaway.android.time.ServiceDate
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import org.onebusaway.android.app.di.AppScope
@@ -170,15 +173,19 @@ class DefaultTripDetailsRepository @Inject constructor(
         val stopIndex = findIndexForStop(stopTimes, stopId)
         val destinationIndex = findIndexForStop(stopTimes, destinationId)
 
-        // Time base: real-time service date + deviation, or midnight today for schedule-only.
-        val deviation = status?.scheduleDeviation ?: 0L
-        val serviceDate = status?.serviceDate ?: midnightToday()
+        // Time base: real-time service date + deviation, or (schedule-only) an approximate device
+        // midnight — minted through the named factory so the off-contract provenance stays visible.
+        val deviation = (status?.scheduleDeviation ?: 0L).seconds
+        val serviceDate = status?.serviceDate?.let { ServiceDate(it) }
+            ?: ServiceDate.approximateFromDeviceMidnight(midnightToday())
         val canceled = status != null && status.status == Status.CANCELED
 
         val lastIndex = stopTimes.lastIndex
         val stops = stopTimes.mapIndexed { i, stopTime ->
             val stop = td.stop(stopTime.stopId)
-            val millis = serviceDate + stopTime.arrivalTime * 1000 + deviation * 1000
+            // Resolve the scheduled stop time onto the server clock, then shift by the live schedule
+            // deviation (a server-clock ServerTime + Duration group action).
+            val millis = (ScheduleTime(stopTime.arrivalTime).resolve(serviceDate) + deviation).epochMs
             TripStopItem(
                 stopId = stopTime.stopId,
                 name = MyTextUtils.formatDisplayText(stop?.name).orEmpty(),

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripdetails/TripDetailsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripdetails/TripDetailsRepository.kt
@@ -23,9 +23,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import java.io.IOException
 import java.util.Calendar
 import java.util.GregorianCalendar
-import java.util.concurrent.TimeUnit
 import javax.inject.Inject
-import kotlin.math.abs
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.onebusaway.android.R
@@ -36,8 +34,8 @@ import org.onebusaway.android.models.ObaTrip
 import org.onebusaway.android.models.ObaTripSchedule
 import org.onebusaway.android.models.ObaTripStatus
 import org.onebusaway.android.models.Status
-import org.onebusaway.android.time.ScheduleTime
 import org.onebusaway.android.time.ServiceDate
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -175,7 +173,7 @@ class DefaultTripDetailsRepository @Inject constructor(
 
         // Time base: real-time service date + deviation, or (schedule-only) an approximate device
         // midnight — minted through the named factory so the off-contract provenance stays visible.
-        val deviation = (status?.scheduleDeviation ?: 0L).seconds
+        val deviation = status?.scheduleDeviation ?: Duration.ZERO
         val serviceDate = status?.serviceDate?.let { ServiceDate(it) }
             ?: ServiceDate.approximateFromDeviceMidnight(midnightToday())
         val canceled = status != null && status.status == Status.CANCELED
@@ -185,7 +183,7 @@ class DefaultTripDetailsRepository @Inject constructor(
             val stop = td.stop(stopTime.stopId)
             // Resolve the scheduled stop time onto the server clock, then shift by the live schedule
             // deviation (a server-clock ServerTime + Duration group action).
-            val millis = (ScheduleTime(stopTime.arrivalTime).resolve(serviceDate) + deviation).epochMs
+            val millis = (stopTime.arrivalTime.resolve(serviceDate) + deviation).epochMs
             TripStopItem(
                 stopId = stopTime.stopId,
                 name = MyTextUtils.formatDisplayText(stop?.name).orEmpty(),
@@ -225,11 +223,11 @@ class DefaultTripDetailsRepository @Inject constructor(
         status: ObaTripStatus?,
         isRealtime: Boolean
     ): TripHeader {
-        val deviation = status?.scheduleDeviation ?: 0L
+        val deviation = status?.scheduleDeviation ?: Duration.ZERO
         val statusColor = when {
             status == null || !status.isPredicted -> R.color.stop_info_scheduled_time
             else -> {
-                val c = ArrivalInfoUtils.computeColorFromDeviation(TimeUnit.SECONDS.toMinutes(deviation))
+                val c = ArrivalInfoUtils.computeColorFromDeviation(deviation.inWholeMinutes)
                 if (c == R.color.stop_info_ontime) R.color.theme_primary else c
             }
         }
@@ -247,7 +245,7 @@ class DefaultTripDetailsRepository @Inject constructor(
 
     private fun headerStatusText(
         status: ObaTripStatus?,
-        deviation: Long
+        deviation: Duration
     ): String = when {
         status == null -> context.getString(R.string.trip_details_scheduled_data)
         !status.isPredicted ->
@@ -255,15 +253,16 @@ class DefaultTripDetailsRepository @Inject constructor(
             else context.getString(R.string.trip_details_scheduled_data)
 
         else -> {
-            val minutes = abs(deviation) / 60
-            val seconds = abs(deviation) % 60
+            val absDev = deviation.absoluteValue
+            val minutes = absDev.inWholeMinutes
+            val seconds = absDev.inWholeSeconds % 60
             val lastUpdate = DisplayFormat.formatTime(context, status.lastUpdateTime)
             when {
-                deviation >= 0 && deviation < 60 ->
+                deviation >= Duration.ZERO && deviation < 60.seconds ->
                     context.resources.getQuantityString(R.plurals.trip_details_real_time_sec_late, seconds.toInt(), seconds, lastUpdate)
-                deviation >= 0 ->
+                deviation >= Duration.ZERO ->
                     context.resources.getQuantityString(R.plurals.trip_details_real_time_min_sec_late, seconds.toInt(), minutes, seconds, lastUpdate)
-                deviation > -60 ->
+                deviation > -(60.seconds) ->
                     context.resources.getQuantityString(R.plurals.trip_details_real_time_sec_early, seconds.toInt(), seconds, lastUpdate)
                 else ->
                     context.resources.getQuantityString(R.plurals.trip_details_real_time_min_sec_early, seconds.toInt(), minutes, seconds, lastUpdate)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripdetails/TripDetailsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripdetails/TripDetailsRepository.kt
@@ -33,6 +33,7 @@ import org.onebusaway.android.models.ObaRoute
 import org.onebusaway.android.models.ObaTrip
 import org.onebusaway.android.models.ObaTripSchedule
 import org.onebusaway.android.models.ObaTripStatus
+import org.onebusaway.android.extrapolation.data.serviceDateOrNull
 import org.onebusaway.android.models.Status
 import org.onebusaway.android.time.ServiceDate
 import kotlin.time.Duration
@@ -171,10 +172,12 @@ class DefaultTripDetailsRepository @Inject constructor(
         val stopIndex = findIndexForStop(stopTimes, stopId)
         val destinationIndex = findIndexForStop(stopTimes, destinationId)
 
-        // Time base: real-time service date + deviation, or (schedule-only) an approximate device
-        // midnight — minted through the named factory so the off-contract provenance stays visible.
+        // Time base: real-time service date + deviation, or an approximate device midnight when the
+        // server sent none. Decode the "0 = absent" sentinel through the one shared decoder so a
+        // present-but-zero serviceDate falls through to the fallback instead of resolving to 1970,
+        // matching the observation path (rather than a second, divergent inline decode).
         val deviation = status?.scheduleDeviation ?: Duration.ZERO
-        val serviceDate = status?.serviceDate?.let { ServiceDate(it) }
+        val serviceDate = serviceDateOrNull(status?.serviceDate ?: 0)
             ?: ServiceDate.approximateFromDeviceMidnight(midnightToday())
         val canceled = status != null && status.status == Status.CANCELED
 

--- a/onebusaway-android/src/test/java/org/onebusaway/android/extrapolation/ScheduleReplayExtrapolatorTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/extrapolation/ScheduleReplayExtrapolatorTest.kt
@@ -15,7 +15,9 @@
  */
 package org.onebusaway.android.extrapolation
 
+import org.onebusaway.android.time.ScheduleTime
 import org.onebusaway.android.time.WallTime
+import kotlin.time.Duration.Companion.seconds
 import org.onebusaway.android.api.adapters.StopTimeData
 import org.onebusaway.android.api.adapters.TripScheduleData
 
@@ -147,8 +149,8 @@ class ScheduleReplayExtrapolatorTest {
             val (dist, arrive, depart) = stops[i]
             StopTimeData(
                 stopId = "stop_$i",
-                arrivalTime = arrive,
-                departureTime = depart,
+                arrivalTime = ScheduleTime(arrive.seconds),
+                departureTime = ScheduleTime(depart.seconds),
                 distanceAlongTrip = dist,
             )
         }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/extrapolation/data/TripDetailsObservationsTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/extrapolation/data/TripDetailsObservationsTest.kt
@@ -16,6 +16,7 @@
 package org.onebusaway.android.extrapolation.data
 
 import org.onebusaway.android.api.data.asRouteTrips
+import org.onebusaway.android.time.ServiceDate
 
 import kotlinx.serialization.json.Json
 import org.junit.Assert.assertEquals
@@ -46,7 +47,7 @@ class TripDetailsObservationsTest {
         assertEquals(1, observations.size)
         val observation = observations[0]
         assertEquals("Hillsborough Area Regional Transit_1389962", observation.tripId)
-        assertEquals(1545886800000L, observation.serviceDate)
+        assertEquals(ServiceDate(1545886800000L), observation.serviceDate)
         // Resolved through the refs: trip 1389962 -> route 16 -> type 3 (bus).
         assertEquals(3, observation.routeType)
     }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/extrapolation/data/TripStateTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/extrapolation/data/TripStateTest.kt
@@ -15,8 +15,10 @@
  */
 package org.onebusaway.android.extrapolation.data
 
+import org.onebusaway.android.time.ScheduleTime
 import org.onebusaway.android.time.ServerTime
 import org.onebusaway.android.time.WallTime
+import kotlin.time.Duration.Companion.seconds
 import org.onebusaway.android.api.adapters.StopTimeData
 import org.onebusaway.android.api.adapters.TripScheduleData
 import org.junit.Assert.assertEquals
@@ -526,8 +528,8 @@ class TripStateTest {
             val (dist, arrive, depart) = stops[i]
             StopTimeData(
                 stopId = "stop_$i",
-                arrivalTime = arrive,
-                departureTime = depart,
+                arrivalTime = ScheduleTime(arrive.seconds),
+                departureTime = ScheduleTime(depart.seconds),
                 distanceAlongTrip = dist,
             )
         }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/extrapolation/data/TripsForRouteDecodeTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/extrapolation/data/TripsForRouteDecodeTest.kt
@@ -16,6 +16,7 @@
 package org.onebusaway.android.extrapolation.data
 
 import org.onebusaway.android.api.data.asRouteTrips
+import org.onebusaway.android.time.ServiceDate
 
 import kotlinx.serialization.json.Json
 import org.junit.Assert.assertEquals
@@ -49,7 +50,7 @@ class TripsForRouteDecodeTest {
         val first = observations[0]
         assertEquals("Hillsborough Area Regional Transit_101446", first.tripId)
         assertEquals(1444073094612L, first.serverTimeMs.epochMs)
-        assertEquals(1444017600000L, first.serviceDate)
+        assertEquals(ServiceDate(1444017600000L), first.serviceDate)
         // Resolved through the refs: trip -> route -> type 3 (bus).
         assertEquals(3, first.routeType)
         // Each observation is keyed by the trip its vehicle reported as active.

--- a/onebusaway-android/src/test/java/org/onebusaway/android/testing/TestTripStatus.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/testing/TestTripStatus.kt
@@ -17,6 +17,7 @@ package org.onebusaway.android.testing
 
 import android.location.Location
 import org.onebusaway.android.models.ObaTripStatus
+import kotlin.time.Duration
 import org.onebusaway.android.models.Occupancy
 import org.onebusaway.android.models.Status
 
@@ -59,7 +60,7 @@ private class TestTripStatus(
 ) : ObaTripStatus {
     override val serviceDate: Long = 0L
     override val isPredicted: Boolean = predicted
-    override val scheduleDeviation: Long = 0L
+    override val scheduleDeviation: Duration = Duration.ZERO
     override val vehicleId: String? = vehicleId
     override val closestStop: String? = null
     override val closestStopTimeOffset: Long = 0L

--- a/onebusaway-android/src/test/java/org/onebusaway/android/time/ScheduleTimeTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/time/ScheduleTimeTest.kt
@@ -33,20 +33,26 @@ class ScheduleTimeTest {
     @Test
     fun `subtraction yields the scheduled interval`() {
         // 08:20:00 minus 08:15:00 into the service day = 5 minutes of scheduled run time.
-        assertEquals(5.minutes, ScheduleTime(30_000L) - ScheduleTime(29_700L))
+        assertEquals(5.minutes, ScheduleTime(30_000.seconds) - ScheduleTime(29_700.seconds))
+    }
+
+    @Test
+    fun `the group action shifts a schedule point and stays in-domain`() {
+        assertEquals(ScheduleTime(30_030.seconds), ScheduleTime(30_000.seconds) + 30.seconds)
+        assertEquals(ScheduleTime(29_970.seconds), ScheduleTime(30_000.seconds) - 30.seconds)
     }
 
     @Test
     fun `Comparable orders schedule times`() {
-        assertTrue(ScheduleTime(29_700L) < ScheduleTime(30_000L))
-        assertEquals(ScheduleTime(30_000L), ScheduleTime(30_000L))
+        assertTrue(ScheduleTime(29_700.seconds) < ScheduleTime(30_000.seconds))
+        assertEquals(ScheduleTime(30_000.seconds), ScheduleTime(30_000.seconds))
     }
 
     @Test
     fun `resolve lands on the server clock at day-anchor plus offset`() {
         val day = ServiceDate(1_700_000_000_000L)
         // 3600 s into the service day = one hour of millis after the anchor.
-        assertEquals(ServerTime(1_700_000_000_000L + 3_600_000L), ScheduleTime(3_600L).resolve(day))
+        assertEquals(ServerTime(1_700_000_000_000L + 3_600_000L), ScheduleTime(3_600.seconds).resolve(day))
     }
 
     @Test
@@ -60,7 +66,7 @@ class ScheduleTimeTest {
     fun `resolve composes with the ServerTime group action`() {
         // The TripDetailsRepository path: resolve a scheduled stop, then shift by schedule deviation.
         val day = ServiceDate(1_700_000_000_000L)
-        val scheduled = ScheduleTime(3_600L).resolve(day)
+        val scheduled = ScheduleTime(3_600.seconds).resolve(day)
         val withDeviation = scheduled + 90.seconds // 90 s late
         assertEquals(90.seconds, withDeviation - scheduled)
         assertEquals(ServerTime(1_700_000_000_000L + 3_600_000L + 90_000L), withDeviation)

--- a/onebusaway-android/src/test/java/org/onebusaway/android/time/ScheduleTimeTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/time/ScheduleTimeTest.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.time
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Guards the civil/schedule-time types: [ScheduleTime] is recurring (no clock domain) and only reaches
+ * the timeline through [ScheduleTime.resolve], which is the single place the seconds→millis and
+ * service-day-anchor conventions live. Same-domain subtraction yields the scheduled interval as a
+ * [kotlin.time.Duration]. The absence of a `ScheduleTime`↔clock-instant comparison is enforced by the
+ * compiler, so its proof is that the app compiles.
+ */
+class ScheduleTimeTest {
+
+    @Test
+    fun `subtraction yields the scheduled interval`() {
+        // 08:20:00 minus 08:15:00 into the service day = 5 minutes of scheduled run time.
+        assertEquals(5.minutes, ScheduleTime(30_000L) - ScheduleTime(29_700L))
+    }
+
+    @Test
+    fun `Comparable orders schedule times`() {
+        assertTrue(ScheduleTime(29_700L) < ScheduleTime(30_000L))
+        assertEquals(ScheduleTime(30_000L), ScheduleTime(30_000L))
+    }
+
+    @Test
+    fun `resolve lands on the server clock at day-anchor plus offset`() {
+        val day = ServiceDate(1_700_000_000_000L)
+        // 3600 s into the service day = one hour of millis after the anchor.
+        assertEquals(ServerTime(1_700_000_000_000L + 3_600_000L), ScheduleTime(3_600L).resolve(day))
+    }
+
+    @Test
+    fun `the device-midnight fallback wraps its value without transforming it`() {
+        // The named factory only exists to make the off-contract provenance greppable; it must not
+        // re-derive or shift the anchor, so its result equals the plain constructor's.
+        assertEquals(ServiceDate(1_700_000_000_000L), ServiceDate.approximateFromDeviceMidnight(1_700_000_000_000L))
+    }
+
+    @Test
+    fun `resolve composes with the ServerTime group action`() {
+        // The TripDetailsRepository path: resolve a scheduled stop, then shift by schedule deviation.
+        val day = ServiceDate(1_700_000_000_000L)
+        val scheduled = ScheduleTime(3_600L).resolve(day)
+        val withDeviation = scheduled + 90.seconds // 90 s late
+        assertEquals(90.seconds, withDeviation - scheduled)
+        assertEquals(ServerTime(1_700_000_000_000L + 3_600_000L + 90_000L), withDeviation)
+    }
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/time/TypedTimeTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/time/TypedTimeTest.kt
@@ -20,6 +20,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * Guards the domain-tagged time types: same-domain arithmetic yields a [kotlin.time.Duration] and stays
@@ -47,5 +48,31 @@ class TypedTimeTest {
         assertTrue(ServerTime(1_000L) < ServerTime(2_000L))
         assertTrue(WallTime(2_000L) > WallTime(1_000L))
         assertEquals(ServerTime(1_000L), ServerTime(1_000L))
+    }
+
+    @Test
+    fun `group action shifts an instant and stays in-domain`() {
+        assertEquals(ServerTime(360_000L), ServerTime(300_000L) + 1.minutes)
+        assertEquals(WallTime(240_000L), WallTime(300_000L) - 1.minutes)
+        assertEquals(ElapsedTime(360_000L), ElapsedTime(300_000L) + 1.minutes)
+    }
+
+    @Test
+    fun `affine laws hold`() {
+        val p = ServerTime(1_000_000L)
+        val d = 90.seconds
+        // (p + d) − p == d : the group action is the inverse of subtraction.
+        assertEquals(d, (p + d) - p)
+        // p + d − d == p : plus and minus by the same vector cancel.
+        assertEquals(p, (p + d) - d)
+    }
+
+    @Test
+    fun `both minus overloads coexist by argument type`() {
+        // minus(Point) yields a Duration; minus(Duration) yields a Point — resolved by argument type.
+        val elapsed: kotlin.time.Duration = ServerTime(5_000L) - ServerTime(2_000L)
+        val shifted: ServerTime = ServerTime(5_000L) - 3.seconds
+        assertEquals(3.seconds, elapsed)
+        assertEquals(ServerTime(2_000L), shifted)
     }
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/dataview/TripTrajectoryTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/dataview/TripTrajectoryTest.kt
@@ -15,8 +15,11 @@
  */
 package org.onebusaway.android.ui.dataview
 
+import org.onebusaway.android.time.ScheduleTime
 import org.onebusaway.android.time.ServerTime
+import org.onebusaway.android.time.ServiceDate
 import org.onebusaway.android.time.WallTime
+import kotlin.time.Duration.Companion.seconds
 import kotlin.math.sqrt
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -97,11 +100,11 @@ class TripTrajectoryTest {
 
     @Test
     fun `data bounds pad the extent of the points`() {
-        val bounds = dataBounds(distances = listOf(100.0, 500.0, 300.0), times = listOf(1_000L, 5_000L))
+        val bounds = dataBounds(distances = listOf(100.0, 500.0, 300.0), times = listOf(ServerTime(1_000L), ServerTime(5_000L)))
         assertEquals(80.0, bounds.minDist, 1e-9) // 100 - 5% of 400
         assertEquals(520.0, bounds.maxDist, 1e-9) // 500 + 5% of 400
-        assertEquals(0L, bounds.minTime) // 1000 - max(5% of 4000, 1000) = 1000 - 1000
-        assertEquals(6_000L, bounds.maxTime) // 5000 + 1000
+        assertEquals(ServerTime(0L), bounds.minTime) // 1000 - max(5% of 4000, 1000) = 1000 - 1000
+        assertEquals(ServerTime(6_000L), bounds.maxTime) // 5000 + 1000
     }
 
     @Test
@@ -127,7 +130,7 @@ class TripTrajectoryTest {
     fun `the now line is left on the local clock when no anchor skew is known`() {
         // No anchor yet (anchorLocalTimeMs == 0) -> no measurable skew -> nowMs unshifted.
         val trajectory = buildTrajectory(TripState("trip1"), nowMs = WallTime(10_000L))
-        assertEquals(10_000L, trajectory.nowMs)
+        assertEquals(ServerTime(10_000L), trajectory.nowMs)
     }
 
     @Test
@@ -136,15 +139,15 @@ class TripTrajectoryTest {
         val state = TripState("trip1").copy(anchorTimeMs = ServerTime(1_005_000L), anchorLocalTimeMs = WallTime(1_000_000L))
         val trajectory = buildTrajectory(state, nowMs = WallTime(1_002_000L))
         // The local "now" (1_002_000) is plotted at its server-clock equivalent (+5s skew).
-        assertEquals(1_007_000L, trajectory.nowMs)
+        assertEquals(ServerTime(1_007_000L), trajectory.nowMs)
     }
 
     @Test
     fun `the schedule overlay is withheld while the service date is unknown`() {
-        // The rail state carries a schedule but no service date (defaults to 0). Resolving against 0
-        // would plot every stop near the 1970 epoch, so the overlay is skipped rather than drawn.
+        // The rail state carries a schedule but no service date (null). With no day to resolve stop
+        // times against, the overlay is skipped rather than drawn.
         val state = skewedRailState(anchorServerTime = 105_000L, anchorLocalMs = 100_000L)
-        assertEquals(0L, state.serviceDate)
+        assertNull(state.serviceDate)
         assertTrue(buildTrajectory(state, nowMs = WallTime(102_000L)).schedule.isEmpty())
     }
 
@@ -152,12 +155,12 @@ class TripTrajectoryTest {
     fun `a known service date resolves schedule stops onto the server clock`() {
         val day = 1_700_000_000_000L
         val state = skewedRailState(anchorServerTime = 105_000L, anchorLocalMs = 100_000L)
-            .withServiceDate(day)
+            .withServiceDate(ServiceDate(day))
         val schedule = buildTrajectory(state, nowMs = WallTime(102_000L)).schedule
         // railSchedule's stops arrive at 0s / 100s / 330s into the service day.
         assertEquals(3, schedule.size)
-        assertEquals(day, schedule.first().arrivalMs)
-        assertEquals(day + 330L * 1000L, schedule.last().arrivalMs)
+        assertEquals(ServerTime(day), schedule.first().arrivalMs)
+        assertEquals(ServerTime(day + 330L * 1000L), schedule.last().arrivalMs)
     }
 
     // --- buildTrajectory: extrapolation-overlay now line (clock skew) ---
@@ -193,7 +196,7 @@ class TripTrajectoryTest {
     private fun makeSchedule(vararg stops: Triple<Double, Long, Long>): ObaTripSchedule {
         val stopTimes: Array<ObaTripSchedule.StopTime> = Array(stops.size) { i ->
             val (dist, arrive, depart) = stops[i]
-            StopTimeData(stopId = "stop_$i", arrivalTime = arrive, departureTime = depart, distanceAlongTrip = dist)
+            StopTimeData(stopId = "stop_$i", arrivalTime = ScheduleTime(arrive.seconds), departureTime = ScheduleTime(depart.seconds), distanceAlongTrip = dist)
         }
         return TripScheduleData(stopTimes)
     }
@@ -209,7 +212,7 @@ class TripTrajectoryTest {
         }
         // Local "now" (102_000) plotted at its server-clock equivalent (+5s skew). Reverting the
         // toServerClock lift in extrapolationSeries() to `nowMs = nowMs` would leave this at 102_000.
-        assertEquals(107_000L, extrapolation.nowMs)
+        assertEquals(ServerTime(107_000L), extrapolation.nowMs)
     }
 
     @Test
@@ -233,46 +236,46 @@ class TripTrajectoryTest {
 
         val extrapolation = requireNotNull(trajectory.extrapolation)
         // toServerClock(102_000) = 102_000 + (97_000 - 100_000) = 99_000.
-        assertEquals(99_000L, extrapolation.nowMs)
+        assertEquals(ServerTime(99_000L), extrapolation.nowMs)
     }
 
     // --- interpolateScheduleTime ---
 
     private fun stop(dist: Double, arriveMs: Long, departMs: Long = arriveMs) =
-        ScheduleStop(distanceMeters = dist, arrivalMs = arriveMs, departureMs = departMs, stopId = null)
+        ScheduleStop(distanceMeters = dist, arrivalMs = ServerTime(arriveMs), departureMs = ServerTime(departMs), stopId = null)
 
     @Test
     fun `schedule time interpolates linearly within the bracketing stops`() {
         val schedule = listOf(stop(0.0, 1_000L), stop(100.0, 3_000L))
         // 75% of the way to the next stop -> 75% of the way through the time span.
-        assertEquals(2_500L, interpolateScheduleTime(schedule, 75.0))
+        assertEquals(ServerTime(2_500L), interpolateScheduleTime(schedule, 75.0))
     }
 
     @Test
     fun `schedule time interpolates from the prior departure across a dwell`() {
         val schedule = listOf(stop(0.0, 1_000L, departMs = 2_000L), stop(100.0, 6_000L))
         // Segment runs from stop0's departure (2000) to stop1's arrival (6000).
-        assertEquals(4_000L, interpolateScheduleTime(schedule, 50.0))
+        assertEquals(ServerTime(4_000L), interpolateScheduleTime(schedule, 50.0))
     }
 
     @Test
-    fun `schedule time is zero outside the interpolatable span or with too few stops`() {
+    fun `schedule time is null outside the interpolatable span or with too few stops`() {
         val schedule = listOf(stop(0.0, 1_000L), stop(100.0, 3_000L))
-        assertEquals(0L, interpolateScheduleTime(schedule, 150.0))
-        assertEquals(0L, interpolateScheduleTime(listOf(stop(0.0, 1_000L)), 0.0))
-        assertEquals(0L, interpolateScheduleTime(emptyList(), 0.0))
+        assertNull(interpolateScheduleTime(schedule, 150.0))
+        assertNull(interpolateScheduleTime(listOf(stop(0.0, 1_000L)), 0.0))
+        assertNull(interpolateScheduleTime(emptyList(), 0.0))
     }
 
     @Test
-    fun `a distance below the first stop returns the sentinel, not a negative-fraction time`() {
+    fun `a distance below the first stop returns null, not a negative-fraction time`() {
         // Guards the lower-bound check: without it, -10 on a [0,100] schedule would compute a negative
-        // fraction and return a time before the first departure instead of the 0 sentinel.
+        // fraction and return a time before the first departure instead of null.
         val schedule = listOf(stop(0.0, 1_000L), stop(100.0, 3_000L))
-        assertEquals(0L, interpolateScheduleTime(schedule, -10.0))
+        assertNull(interpolateScheduleTime(schedule, -10.0))
 
         // Same below-origin case when the first stop is not at distance 0.
         val offsetSchedule = listOf(stop(50.0, 1_000L), stop(150.0, 3_000L))
-        assertEquals(0L, interpolateScheduleTime(offsetSchedule, 40.0))
+        assertNull(interpolateScheduleTime(offsetSchedule, 40.0))
     }
 
     @Test
@@ -285,7 +288,7 @@ class TripTrajectoryTest {
         // Exactly at the middle stop, the half-open [d0, d1) segments give it to the *next* segment,
         // so it reads the departure (7000) deterministically rather than ambiguously matching the
         // prior segment's arrival (6000).
-        assertEquals(7_000L, interpolateScheduleTime(schedule, 100.0))
+        assertEquals(ServerTime(7_000L), interpolateScheduleTime(schedule, 100.0))
     }
 
     @Test
@@ -296,8 +299,8 @@ class TripTrajectoryTest {
             stop(200.0, 10_000L),
         )
         // The trip's end distance is excluded by the half-open segments, so it's mapped to the last
-        // segment's arrival (the final stop, 10000) rather than falling through to the 0 sentinel.
-        assertEquals(10_000L, interpolateScheduleTime(schedule, 200.0))
+        // segment's arrival (the final stop, 10000) rather than falling through to null.
+        assertEquals(ServerTime(10_000L), interpolateScheduleTime(schedule, 200.0))
     }
 
     @Test
@@ -308,16 +311,16 @@ class TripTrajectoryTest {
             stop(100.0, 10_000L), // trailing zero-length pair (shared shape_dist_traveled)
         )
         // The last *interpolatable* pair is 0 -> 100 (the trailing 100 -> 100 pair forms no segment),
-        // so the max distance maps to that segment's arrival (6000) instead of falling through to 0.
-        assertEquals(6_000L, interpolateScheduleTime(schedule, 100.0))
+        // so the max distance maps to that segment's arrival (6000) instead of falling through to null.
+        assertEquals(ServerTime(6_000L), interpolateScheduleTime(schedule, 100.0))
     }
 
     @Test
     fun `a distance exactly at the first stop interpolates to the start time`() {
         val schedule = listOf(stop(0.0, 1_000L, departMs = 2_000L), stop(100.0, 6_000L))
         // The span is lower-inclusive, so the trip origin resolves to the first segment's start
-        // (stop0's departure, 2000) rather than the sentinel.
-        assertEquals(2_000L, interpolateScheduleTime(schedule, 0.0))
+        // (stop0's departure, 2000) rather than null.
+        assertEquals(ServerTime(2_000L), interpolateScheduleTime(schedule, 0.0))
     }
 
     @Test
@@ -330,7 +333,7 @@ class TripTrajectoryTest {
         )
         // 150 lands in the 100 -> 200 segment (departure 8000 to arrival 12000), proving the loop
         // advances past the degenerate middle pair.
-        assertEquals(10_000L, interpolateScheduleTime(schedule, 150.0))
+        assertEquals(ServerTime(10_000L), interpolateScheduleTime(schedule, 150.0))
     }
 
     @Test
@@ -344,20 +347,20 @@ class TripTrajectoryTest {
             stop(150.0, 12_000L),
         )
         // 75 lies in both segments; first-match gives it to (0 -> 100): 2000 + 0.75 * (6000 - 2000).
-        assertEquals(5_000L, interpolateScheduleTime(schedule, 75.0))
+        assertEquals(ServerTime(5_000L), interpolateScheduleTime(schedule, 75.0))
         // 120 lies only in (50 -> 150), so the later overlapping segment is still reachable:
         // 9000 + 0.7 * (12000 - 9000).
-        assertEquals(11_100L, interpolateScheduleTime(schedule, 120.0))
+        assertEquals(ServerTime(11_100L), interpolateScheduleTime(schedule, 120.0))
     }
 
     @Test
-    fun `a non-finite distance degrades to the sentinel rather than the divide`() {
+    fun `a non-finite distance degrades to null rather than the divide`() {
         // The production caller guards finiteness, but the function itself must not feed NaN/Infinity
-        // into the fraction: each fails every half-open comparison and the endpoint check, so 0L.
+        // into the fraction: each fails every half-open comparison and the endpoint check, so null.
         val schedule = listOf(stop(0.0, 1_000L), stop(100.0, 3_000L))
-        assertEquals(0L, interpolateScheduleTime(schedule, Double.NaN))
-        assertEquals(0L, interpolateScheduleTime(schedule, Double.POSITIVE_INFINITY))
-        assertEquals(0L, interpolateScheduleTime(schedule, Double.NEGATIVE_INFINITY))
+        assertNull(interpolateScheduleTime(schedule, Double.NaN))
+        assertNull(interpolateScheduleTime(schedule, Double.POSITIVE_INFINITY))
+        assertNull(interpolateScheduleTime(schedule, Double.NEGATIVE_INFINITY))
     }
 
     // --- scheduleSegments ---
@@ -365,7 +368,7 @@ class TripTrajectoryTest {
     @Test
     fun `segments span each stop pair from the prior departure to the next arrival`() {
         val schedule = listOf(stop(0.0, 1_000L, departMs = 2_000L), stop(100.0, 6_000L))
-        assertEquals(listOf(ScheduleSegment(0.0, 100.0, 2_000L, 6_000L)), scheduleSegments(schedule))
+        assertEquals(listOf(ScheduleSegment(0.0, 100.0, ServerTime(2_000L), ServerTime(6_000L))), scheduleSegments(schedule))
     }
 
     @Test
@@ -378,7 +381,7 @@ class TripTrajectoryTest {
     fun `a trailing zero-length stop pair is dropped`() {
         val schedule = listOf(stop(0.0, 1_000L), stop(100.0, 6_000L), stop(100.0, 10_000L))
         // The degenerate 100 -> 100 pair produces no segment; the real 0 -> 100 segment remains the last.
-        assertEquals(listOf(ScheduleSegment(0.0, 100.0, 1_000L, 6_000L)), scheduleSegments(schedule))
+        assertEquals(listOf(ScheduleSegment(0.0, 100.0, ServerTime(1_000L), ServerTime(6_000L))), scheduleSegments(schedule))
     }
 
     @Test
@@ -391,8 +394,8 @@ class TripTrajectoryTest {
         )
         assertEquals(
             listOf(
-                ScheduleSegment(0.0, 100.0, 1_000L, 6_000L),
-                ScheduleSegment(100.0, 200.0, 8_000L, 12_000L),
+                ScheduleSegment(0.0, 100.0, ServerTime(1_000L), ServerTime(6_000L)),
+                ScheduleSegment(100.0, 200.0, ServerTime(8_000L), ServerTime(12_000L)),
             ),
             scheduleSegments(schedule),
         )
@@ -407,15 +410,15 @@ class TripTrajectoryTest {
             stop(0.0, 3_000L, departMs = 4_000L),
             stop(100.0, 8_000L),
         )
-        assertEquals(listOf(ScheduleSegment(0.0, 100.0, 4_000L, 8_000L)), scheduleSegments(schedule))
+        assertEquals(listOf(ScheduleSegment(0.0, 100.0, ServerTime(4_000L), ServerTime(8_000L))), scheduleSegments(schedule))
     }
 
     @Test
     fun `a ScheduleSegment rejects non-increasing distance`() {
         // The factory never emits a degenerate segment, but the guard catches any future
         // out-of-factory construction with d1 <= d0 loudly instead of dividing by zero downstream.
-        assertThrows(IllegalArgumentException::class.java) { ScheduleSegment(100.0, 100.0, 0L, 1L) }
-        assertThrows(IllegalArgumentException::class.java) { ScheduleSegment(100.0, 50.0, 0L, 1L) }
+        assertThrows(IllegalArgumentException::class.java) { ScheduleSegment(100.0, 100.0, ServerTime(0L), ServerTime(1L)) }
+        assertThrows(IllegalArgumentException::class.java) { ScheduleSegment(100.0, 50.0, ServerTime(0L), ServerTime(1L)) }
     }
 
     // --- formatDeviationLabel ---

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/dataview/TripTrajectoryTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/dataview/TripTrajectoryTest.kt
@@ -139,6 +139,27 @@ class TripTrajectoryTest {
         assertEquals(1_007_000L, trajectory.nowMs)
     }
 
+    @Test
+    fun `the schedule overlay is withheld while the service date is unknown`() {
+        // The rail state carries a schedule but no service date (defaults to 0). Resolving against 0
+        // would plot every stop near the 1970 epoch, so the overlay is skipped rather than drawn.
+        val state = skewedRailState(anchorServerTime = 105_000L, anchorLocalMs = 100_000L)
+        assertEquals(0L, state.serviceDate)
+        assertTrue(buildTrajectory(state, nowMs = WallTime(102_000L)).schedule.isEmpty())
+    }
+
+    @Test
+    fun `a known service date resolves schedule stops onto the server clock`() {
+        val day = 1_700_000_000_000L
+        val state = skewedRailState(anchorServerTime = 105_000L, anchorLocalMs = 100_000L)
+            .withServiceDate(day)
+        val schedule = buildTrajectory(state, nowMs = WallTime(102_000L)).schedule
+        // railSchedule's stops arrive at 0s / 100s / 330s into the service day.
+        assertEquals(3, schedule.size)
+        assertEquals(day, schedule.first().arrivalMs)
+        assertEquals(day + 330L * 1000L, schedule.last().arrivalMs)
+    }
+
     // --- buildTrajectory: extrapolation-overlay now line (clock skew) ---
     //
     // The now-line tests above only exercise TripTrajectory.nowMs. These drive a real anchor so

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripdetails/TripDetailsDecodeTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripdetails/TripDetailsDecodeTest.kt
@@ -87,6 +87,8 @@ class TripDetailsDecodeTest {
 
         assertEquals(2, entry.schedule!!.stopTimes.size)
         assertEquals("1_s1", entry.schedule.stopTimes[0].stopId)
+        // Wire DTO stays a raw Long of seconds-since-service-day (60180 = 16:43); the domain mint to
+        // ScheduleTime happens later, in TripAdapters.toObaTripSchedule.
         assertEquals(60180L, entry.schedule.stopTimes[0].arrivalTime)
 
         // Trip ref uses the wire names tripHeadsign / tripShortName.


### PR DESCRIPTION
## Typed time: complete the affine algebra, then push it through the schedule model

Builds on the domain-tagged instants (`ServerTime`/`WallTime`/`ElapsedTime`, #1620) with two stacked commits.

### 1. Complete the typed-time affine algebra (`65447d90a`)
- Add the missing group action to the instant types: `ServerTime`/`WallTime`/`ElapsedTime` gain `plus`/`minus(Duration)`, completing the torsor structure (`Point − Point → Duration` was already there; `Point + Duration → Point` was not). The header documents the structure and the unit-rate axiom that sharing one `Duration` across domains assumes.
- Introduce the third kind of time — civil/schedule time — as `ScheduleTime` + `ServiceDate`, with a single sanctioned `ScheduleTime.resolve(day): ServerTime` adapter (the civil-time analogue of `situationEpochToMillis`).

### 2. Type-first migration through the schedule model (`5ae0b37fc`)
Push the discipline down so unit claims are discharged once, at the wire boundary, instead of living in comments a raw `Long` can silently contradict.

- **Motivating bug:** the trip-details `StopTime` was documented as "epoch millis" while every consumer treated it as **seconds since the service date** (`serviceDate + arrivalTime * 1000`). Type-first migration forces that claim to be verified once, at the mint site. Both wire comments in `ObaApiModels` are now correct and cite sample payloads (trip-details `StopTime` = seconds; schedule-for-stop `ScheduleStopTime` genuinely = epoch millis).
- `ScheduleTime` is backed by `kotlin.time.Duration` — the one time-kind with a canonical origin — which buys the extrapolator's fractional interpolation for free (`Duration × Double`, `Duration ÷ Duration`).
- `ObaTripSchedule.StopTime.arrivalTime/departureTime` are `ScheduleTime`, minted once in the adapter; both extrapolators (`ScheduleReplay`, `Gamma`) now do typed math.
- `TripState.serviceDate` is `ServiceDate?`; the `0 = absent` wire sentinel is decoded once at the boundary. The trajectory overlay's unknown-date case is a compile-forced skip, not a 1970 decoy.
- The trip-trajectory graph's time axis carries `ServerTime`; `.epochMs` unwraps only at the renderer's pixel edge. `interpolateScheduleTime` returns `ServerTime?` — absence is a type, not a `0`.
- `ObaTripStatus.scheduleDeviation` is a `Duration`, minted in the adapter; the `deviation * 1000` conversion is retired.

## Testing
- Compiles clean under `-PwarningsAsErrors` (main + unit + androidTest); custom `RawClockArithmetic`/`UnwrappedClockValue` lint checks pass.
- Full JVM unit suite and Lint pass.
- Instrumented suite passes on-device (two unrelated environmental flakes — `LocationUtilsTest`/`UmamiAnalyticsTest`, neither touching migrated code — cleared on rerun; `LocationUtilsTest.testLocationServices` is skipped on the CI emulator regardless).

## Note for reviewers
The map vehicle color/info-window and the trip-details header text are device-gated (no JVM coverage) but behavior-preserving. One deliberately-deferred item: `TripDetailsRepository`'s schedule-only fallback decodes a present-but-zero `serviceDate` differently from the shared `serviceDateOrNull` — preserved as pre-existing behavior; flagged for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved schedule deviation calculations and trip stop time rendering for more accurate delay/status labels.
  * Fixed handling of missing/unknown service-day dates so extrapolation and trip details behave consistently when date data isn’t available.
  * Updated trajectory graph interpolation to use consistent schedule-time math, improving overlay accuracy.
* **Refactor**
  * Standardized time and deviation handling across the app using typed schedule-time and duration values to reduce unit-conversion and rounding issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->