### PR TITLE
CI build optimization: prune the variant grid + warm the build cache

### DIFF
--- a/.github/workflows/android-nightly.yml
+++ b/.github/workflows/android-nightly.yml
@@ -31,4 +31,4 @@ jobs:
         uses: gradle/actions/setup-gradle@v3
 
       - name: Full-grid tests + check (all brands)
-        run: ./gradlew test check -PbuildAllBrands=true -x lint -PwarningsAsErrors=true --stacktrace
+        run: ./gradlew test check -PbuildAllBrands=true --build-cache -x lint -PwarningsAsErrors=true --stacktrace

--- a/.github/workflows/android-nightly.yml
+++ b/.github/workflows/android-nightly.yml
@@ -1,0 +1,34 @@
+name: Android Nightly (all brands)
+
+# The PR/push workflow (android.yml) only exercises the shipping `oba` brand's tests to keep the
+# grid small (see the beforeVariants filter in onebusaway-android/build.gradle). This nightly job
+# restores the full brand × platform grid via -PbuildAllBrands=true so that a change breaking the
+# sample white-label brands (agencyX/agencyY) or the third-party `kiedybus` brand is still caught —
+# just off the PR critical path. Unit tests + `check` are JVM-only, so no emulator is needed here;
+# instrumented tests remain oba-only in android.yml.
+
+on:
+  schedule:
+    # 07:00 UTC daily (~midnight US Pacific)
+    - cron: '0 7 * * *'
+  # Allow manual runs from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  all-brands:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          java-version: 21
+          distribution: 'temurin'
+
+      - name: Gradle cache
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Full-grid tests + check (all brands)
+        run: ./gradlew test check -PbuildAllBrands=true -x lint -PwarningsAsErrors=true --stacktrace

--- a/.github/workflows/android-nightly.yml
+++ b/.github/workflows/android-nightly.yml
@@ -14,15 +14,24 @@ on:
   # Allow manual runs from the Actions tab
   workflow_dispatch:
 
+# One nightly run at a time: if a run is still going when the next cron fires (or a manual
+# dispatch overlaps), cancel the stale one so they don't race on the shared Gradle cache.
+concurrency:
+  group: nightly-all-brands
+  cancel-in-progress: true
+
 jobs:
   all-brands:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
         uses: actions/checkout@v4
+        with:
+          # This job only runs tests; it never pushes, so don't leave the token in git config.
+          persist-credentials: false
 
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: 21
           distribution: 'temurin'

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -39,7 +39,11 @@ jobs:
       # compile + API-33 tests can't see (#1692). Runs on the host before the emulator so it
       # fails fast; `check` below keeps skipping lint (-x lint) to avoid running it twice.
       - name: Android Lint
-        run: ./gradlew :onebusaway-android:lintObaGoogleDebug -PwarningsAsErrors=true --stacktrace
+        # --build-cache: store the obaGoogleDebug compile outputs this step produces in the Gradle
+        # build cache so the "run tests" step below reuses them (and setup-gradle persists the cache
+        # across CI runs). Build cache is enabled per-invocation here, NOT in gradle.properties, to
+        # avoid arming a stale-R.jar footgun for local multi-worktree dev (which shares ~/.gradle).
+        run: ./gradlew :onebusaway-android:lintObaGoogleDebug --build-cache -PwarningsAsErrors=true --stacktrace
 
       - name: AVD cache
         uses: actions/cache@v4
@@ -71,4 +75,4 @@ jobs:
           target: google_apis
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
-          script: ./gradlew test check connectedObaGoogleDebugAndroidTest -x lint -PwarningsAsErrors=true --stacktrace
+          script: ./gradlew test check connectedObaGoogleDebugAndroidTest --build-cache -x lint -PwarningsAsErrors=true --stacktrace

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,19 @@ OneBusAway for Android is a real-time transit information app providing bus arri
 adb shell am start -n com.joulespersecond.seattlebusbot/org.onebusaway.android.ui.HomeActivity
 ```
 
+### Variant grid: `check`/`test` only exercise the `oba` brand by default
+
+The app has two flavor dimensions — **brand** (`oba`, `agencyX`, `agencyY`, `kiedybus`) × **platform**
+(`google`, `maplibre`) — so `test`/`check` would otherwise fan out `testXUnitTest` across all 8 debug
+variants. Only `oba` ships; `agencyX`/`agencyY` are sample white-label rebrands and `kiedybus` is a
+third-party brand, all sharing identical code (they differ only in resources/manifest/appId). So a
+`beforeVariants` filter in `onebusaway-android/build.gradle` **disables unit + Android tests for every
+non-`oba` brand**, shrinking the routine grid to `obaGoogle` + `obaMaplibre`.
+
+- The brand **main** variants stay enabled — `./gradlew assembleAgencyXGoogleDebug` (etc.) still builds
+  on demand to verify rebranding compiles.
+- To run the full 8-variant test grid (nightly / pre-release), pass **`-PbuildAllBrands=true`**.
+
 ### CI is strict — warnings fail the build
 
 CI passes `-PwarningsAsErrors=true`, so **every Kotlin compiler warning (`w:`) is a hard error** in CI —

--- a/onebusaway-android/build.gradle
+++ b/onebusaway-android/build.gradle
@@ -200,6 +200,23 @@ android {
  * content:// stop/route deep-link authority) — historically the ObaProvider ContentProvider authority.
  */
 androidComponents {
+    // Routine `check`/`test` builds only exercise the shipping `oba` brand's test suites. The sample
+    // white-label brands (agencyX/agencyY) and the third-party `kiedybus` brand share identical code —
+    // they differ only in resources/manifest/appId — so running their unit + Android tests on every
+    // build multiplies the KSP + Hilt + compile + test grid ~4x for no added signal. Their MAIN
+    // variants stay enabled, so `assembleAgencyXGoogleDebug` (etc.) still builds on demand to verify
+    // rebranding compiles. Pass -PbuildAllBrands=true (nightly / pre-release) to restore the full grid.
+    def buildAllBrands = providers.gradleProperty("buildAllBrands")
+            .map { it.toBoolean() }.orElse(false).get()
+    if (!buildAllBrands) {
+        beforeVariants(selector().all(), { variantBuilder ->
+            if (!variantBuilder.productFlavors.any { it.second == "oba" }) {
+                variantBuilder.enableUnitTest = false
+                variantBuilder.enableAndroidTest = false
+            }
+        })
+    }
+
     onVariants(selector().all(), { variant ->
         def authority
         // Check if the primary flavor is "oba"


### PR DESCRIPTION
Two independent CI build-speed changes.

## 1. Restrict the routine `check`/`test` grid to the `oba` brand

The app has two flavor dimensions — **brand** (`oba`, `agencyX`, `agencyY`, `kiedybus`) × **platform** (`google`, `maplibre`) — so `test`/`check` fan `testXUnitTest` out across all **8 debug variants**, each with its own `kspXKotlin` + `hiltJavaCompileX` + `compileXKotlin` + `testXUnitTest`. The brands share **identical code** (they differ only in resources/manifest/appId); only `oba` ships, `agencyX`/`agencyY` are sample white-label rebrands, and `kiedybus` is a third-party brand — so the routine grid multiplies the annotation-processing + compile + test work ~4x for no added signal.

- A `beforeVariants` filter in `onebusaway-android/build.gradle` disables unit + Android tests for every non-`oba` brand, shrinking the routine grid from 8 variants to **`obaGoogle` + `obaMaplibre`**.
- Brand **main** variants stay enabled, so `./gradlew assembleAgencyXGoogleDebug` (etc.) still builds on demand to verify rebranding compiles.
- Pass **`-PbuildAllBrands=true`** to restore the full 8-variant grid.
- New **nightly** workflow (`android-nightly.yml`) runs `test check -PbuildAllBrands=true` so the sample/third-party brands stay verified, off the PR critical path.

## 2. Enable the Gradle build cache in CI (`--build-cache`)

The lint step and the test step are separate `./gradlew` invocations. Within a run the daemon + incremental checks already reuse the `obaGoogleDebug` compilation across them, but nothing persisted task outputs to the build cache — so a fresh runner on the next PR recompiled from scratch.

- Pass `--build-cache` on the CI lint, test, and nightly invocations, so the lint step's compile outputs are cached and reused, and `setup-gradle` persists the local build cache across runs (`FROM-CACHE` on subsequent runs).
- Enabled **per-invocation** rather than via `org.gradle.caching` in `gradle.properties` on purpose: a shared `~/.gradle` build cache across local worktrees can serve a stale `R.jar`, so the cache stays CI-only (isolated per run) and local multi-worktree dev is untouched.

## Verification

Via `--dry-run`: default grid = 2 unit-test variants; `-PbuildAllBrands=true` = full 8; `assembleAgencyXGoogleDebug` still resolves on demand. `--build-cache` configures cleanly alongside the (already-enabled) configuration cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a nightly Android CI workflow (manual trigger available) to run full build and test checks across the brand/platform matrix.
* **Documentation**
  * Documented the default flavor/test matrix behavior and how to run the full variant grid, including guidance for non-default brands.
* **CI / Build Improvements**
  * Improved Android CI speed by enabling Gradle build caching during lint and test steps.
* **Quality / Test Scope**
  * Reduced unit and Android test execution for non-shipping brands by default, while keeping the full grid available when explicitly enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->