### PR TITLE
Don't auto-zoom the map when a stop is tapped

### DIFF
--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleCameraCommands.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleCameraCommands.kt
@@ -74,16 +74,6 @@ fun applyCameraCommand(
             if (cmd.animate) map.animateCamera(update) else map.moveCamera(update)
         }
 
-        is CameraCommand.CenterOnStopTap -> {
-            val pos = LatLng(cmd.lat, cmd.lon)
-            val update = if (map.cameraPosition.zoom < CAMERA_DEFAULT_ZOOM) {
-                CameraUpdateFactory.newLatLngZoom(pos, CAMERA_DEFAULT_ZOOM)
-            } else {
-                CameraUpdateFactory.newLatLng(pos)
-            }
-            map.animateCamera(update)
-        }
-
         is CameraCommand.SetZoom -> map.moveCamera(CameraUpdateFactory.zoomTo(cmd.zoom))
 
         CameraCommand.ZoomIn -> map.animateCamera(CameraUpdateFactory.zoomIn())

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/StopsMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/StopsMapController.kt
@@ -233,15 +233,17 @@ class StopsMapController(
     }
 
     // ----- Focus -----
-    // This owns only the *render* focus (the 1.5x icon, via renderState.focusedStopId) and the camera
-    // move. The home-side focus (the arrivals sheet + analytics) is driven directly by the owner's tap
-    // callback, so a re-tap of the same stop isn't swallowed by state-dedup.
+    // This owns only the *render* focus (the 1.5x icon, via renderState.focusedStopId). The home-side
+    // focus (the arrivals sheet + analytics) is driven directly by the owner's tap callback, so a re-tap
+    // of the same stop isn't swallowed by state-dedup.
 
-    /** A stop marker was tapped: render-focus it + center on it (the old GoogleMapHost.onStopClick). */
+    /**
+     * A stop marker was tapped: render-focus it (the old GoogleMapHost.onStopClick). Deliberately does
+     * *not* move the camera — a tapped marker is already on screen, so recentering/zooming would only
+     * throw away the user's pre-tap view with no way back.
+     */
     fun onStopTapped(stop: ObaStop) {
         setFocusedStopId(stop.id)
-        val loc = stop.location
-        host.dispatchGesture(CameraCommand.CenterOnStopTap(loc.latitude, loc.longitude))
     }
 
     /** A tap away from any marker clears the stop render focus (the old onMapClick). */

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/CameraCommand.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/CameraCommand.kt
@@ -51,9 +51,6 @@ sealed interface CameraCommand {
         val animate: Boolean,
     ) : CameraCommand
 
-    /** Center on a tapped stop, bumping to the default zoom only if currently zoomed out past it. */
-    data class CenterOnStopTap(val lat: Double, val lon: Double) : CameraCommand
-
     /** Set the zoom level (preserving the current center). */
     data class SetZoom(val zoom: Float) : CameraCommand
 

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreCameraCommands.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreCameraCommands.kt
@@ -65,16 +65,6 @@ fun applyCameraCommand(cmd: CameraCommand, map: MapLibreMap) {
             if (cmd.animate) map.animateCamera(update) else map.moveCamera(update)
         }
 
-        is CameraCommand.CenterOnStopTap -> {
-            val pos = LatLng(cmd.lat, cmd.lon)
-            val update = if (map.cameraPosition.zoom < CAMERA_DEFAULT_ZOOM) {
-                CameraUpdateFactory.newLatLngZoom(pos, CAMERA_DEFAULT_ZOOM)
-            } else {
-                CameraUpdateFactory.newLatLng(pos)
-            }
-            map.animateCamera(update)
-        }
-
         is CameraCommand.SetZoom -> map.moveCamera(CameraUpdateFactory.zoomTo(cmd.zoom.toDouble()))
 
         CameraCommand.ZoomIn -> map.animateCamera(CameraUpdateFactory.zoomIn())


### PR DESCRIPTION
## Problem

Tapping a stop marker on the map recentered on the stop and, whenever the map was zoomed out past the default level (16), **zoomed in**. That threw away the user's pre-tap view — their surrounding context — with no way to return to it. A tapped marker is already on screen, so there was never a reason to move the camera in the first place.

## Change

`StopsMapController.onStopTapped` now only sets the render focus (the enlarged stop icon). The arrivals sheet still opens via the existing tap callback, and the zoom/center stay exactly where the user left them.

The now-dead `CameraCommand.CenterOnStopTap` and its Google/MapLibre camera-command handlers are removed. The programmatic deep-link / rotation-restore path (`focusStop`) was already zoom-neutral and is untouched.

## Verification

- `compileObaGoogleDebugKotlin` and `compileObaMaplibreDebugKotlin` both clean under `-PwarningsAsErrors=true`.
- Installed on device; tapping a stop now holds the view still.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tapping a stop now updates focus without automatically moving the map camera.
  * Removed the extra stop-tap centering animation, resulting in more predictable map behavior when selecting stops.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->