### PR TITLE
Arrivals drawer: box each row + measure the collapsed peek height

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
@@ -127,9 +127,9 @@ internal fun ArrivalCard(
 ) {
     val base = modifier
         .fillMaxWidth()
-        .padding(horizontal = 12.dp, vertical = 6.dp)
+        .padding(horizontal = 12.dp, vertical = 3.dp)
     val shape = MaterialTheme.shapes.medium
-    val color = MaterialTheme.colorScheme.surfaceContainerLow
+    val color = MaterialTheme.colorScheme.surfaceContainer
     if (onClick != null) {
         Surface(onClick = onClick, modifier = base, shape = shape, color = color, content = content)
     } else {
@@ -355,13 +355,7 @@ fun ArrivalCardStyleB(
 ) {
     val first = group.first()
     var expanded by remember { mutableStateOf(false) }
-    Surface(
-        modifier = modifier
-            .fillMaxWidth()
-            .padding(horizontal = 12.dp, vertical = 6.dp),
-        shape = MaterialTheme.shapes.medium,
-        color = MaterialTheme.colorScheme.surfaceContainerLow
-    ) {
+    ArrivalCard(modifier) {
         Column(Modifier.padding(16.dp)) {
             Row(verticalAlignment = Alignment.Top) {
                 Column(Modifier.weight(1f)) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalsPanel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalsPanel.kt
@@ -47,12 +47,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -88,9 +90,11 @@ import org.onebusaway.android.util.ArrivalInfoUtils
  * supplies the drag handle above this content; tapping/dragging it drives expand/collapse (the header
  * no longer carries a chevron or tap-to-toggle).
  *
- * The peek height is driven by the host: this composable reports the preferred-arrival count +
- * filter state via [onPreferredHeight] so the host can size the collapsed panel. Polling, callbacks,
- * the per-arrival menu, and the expanded list are shared with the standalone screen.
+ * The peek height is driven by the host, sized from real layout rather than hand-tuned dimens: this
+ * composable measures its own collapsed peek (the pinned header plus the leading peek rows) and reports
+ * the total height in px via [onPeekContentHeight], so the host sizes the sheet's peek without knowing
+ * what the peek is made of. Polling, callbacks, the per-arrival menu, and the expanded list are
+ * shared with the standalone screen.
  */
 @Composable
 fun ArrivalsPanel(
@@ -101,7 +105,7 @@ fun ArrivalsPanel(
     expandProgress: () -> Float,
     initialTitle: String,
     handler: ArrivalActionHandler,
-    onPreferredHeight: (previewCount: Int, filtering: Boolean) -> Unit,
+    onPeekContentHeight: (heightPx: Int) -> Unit,
     // Tapping the pinned stop-name header invokes this (null = not tappable); the drawer host wires it
     // to an animated map recenter on the focused stop.
     onTitleClick: (() -> Unit)? = null,
@@ -142,15 +146,23 @@ fun ArrivalsPanel(
     // slides into view with the drag instead of popping in at the settle; at rest it stays hidden so
     // nothing bleeds through the collapsed fold.
     val revealList by remember(expandProgress) { derivedStateOf { expandProgress() > 0f } }
-    // Only report the peek size once arrivals have actually loaded. Reporting the loading skeleton's
-    // 0-count first would shrink the sheet's peek anchor and then grow it when arrivals arrive; that
-    // anchor move, landing mid-open-animation, strands the BottomSheetScaffold's AnchoredDraggable so
-    // the sheet sticks partway up. Holding the peek steady (at its prior/default height) until real
-    // content lands keeps the anchor stable through the open.
-    if (content != null) {
-        LaunchedEffect(previewArrivals.size, filtering) {
-            onPreferredHeight(previewArrivals.size, filtering)
-        }
+    // The collapsed peek's measured pieces (px): the pinned header's height and one peek row's *rest*
+    // height. The host sizes the sheet's peek from these (header + rowCount × row) instead of a
+    // hand-tuned dimen table, so it auto-adapts to content, padding, and font scale.
+    var headerHeightPx by remember { mutableIntStateOf(0) }
+    var peekRowHeightPx by remember { mutableIntStateOf(0) }
+
+    val previewCount = previewArrivals.size
+    // Only report once arrivals have loaded AND the pieces are actually measured — a 0 (loading skeleton,
+    // or a not-yet-laid-out row) would shrink the peek anchor and then grow it when the real height lands.
+    // That anchor move, mid-open-animation, strands the BottomSheetScaffold's AnchoredDraggable so the
+    // sheet sticks partway up. Gating readiness on a real measurement keeps the anchor stable through the
+    // open (the host only reveals the sheet once the height arrives). Peek rows are uniform height, so one
+    // sampled row height sizes them all; the panel owns this "header + rows" formula so the host doesn't.
+    val metricsMeasured = headerHeightPx > 0 && (previewCount == 0 || peekRowHeightPx > 0)
+    if (content != null && metricsMeasured) {
+        val peekContentPx = headerHeightPx + previewCount * peekRowHeightPx
+        LaunchedEffect(peekContentPx) { onPeekContentHeight(peekContentPx) }
     }
 
     Surface(color = MaterialTheme.colorScheme.surface, modifier = Modifier.fillMaxSize()) {
@@ -167,6 +179,8 @@ fun ArrivalsPanel(
                 filtering = filtering,
                 onToggleFavorite = viewModel::toggleFavorite,
                 onTitleClick = onTitleClick,
+                // Feed the pinned header's measured height into the collapsed-peek metrics.
+                modifier = Modifier.onSizeChanged { headerHeightPx = it.height },
             )
             if (content == null) {
                 LinearProgressIndicator(Modifier.fillMaxWidth())
@@ -199,25 +213,39 @@ fun ArrivalsPanel(
                             // The host's anchors apply to the first peek row only.
                             val etaModifier = if (index == 0) etaAnchor else Modifier
                             val starModifier = if (index == 0) starAnchor else Modifier
-                            if (styleA) {
-                                MorphingArrivalRow(
-                                    arrival = arrival,
-                                    actions = content.actions[arrival.tripId],
-                                    filterActive = filtering,
-                                    callbacks = rowCallbacks,
-                                    progress = expandProgress,
-                                    etaModifier = etaModifier,
-                                    starModifier = starModifier,
-                                )
+                            val row: @Composable () -> Unit = {
+                                if (styleA) {
+                                    MorphingArrivalRow(
+                                        arrival = arrival,
+                                        actions = content.actions[arrival.tripId],
+                                        filterActive = filtering,
+                                        callbacks = rowCallbacks,
+                                        progress = expandProgress,
+                                        etaModifier = etaModifier,
+                                        starModifier = starModifier,
+                                    )
+                                } else {
+                                    PeekRow(
+                                        arrival = arrival,
+                                        actions = content.actions[arrival.tripId],
+                                        filterActive = filtering,
+                                        callbacks = rowCallbacks,
+                                        etaModifier = etaModifier,
+                                        starModifier = starModifier,
+                                    )
+                                }
+                            }
+                            // Measure only the first peek row's *rest* height for the collapsed-peek metrics
+                            // (peek rows are uniform height, so one sample sizes them all). The measuring Box
+                            // wraps just that row; the rest attach to the list item directly. Gate on the
+                            // sheet sitting at its collapsed anchor (expandProgress <= 0) so the peek→card
+                            // morph's growth never inflates the measured rest height.
+                            if (index == 0) {
+                                Box(Modifier.onSizeChanged {
+                                    if (expandProgress() <= 0f) peekRowHeightPx = it.height
+                                }) { row() }
                             } else {
-                                PeekRow(
-                                    arrival = arrival,
-                                    actions = content.actions[arrival.tripId],
-                                    filterActive = filtering,
-                                    callbacks = rowCallbacks,
-                                    etaModifier = etaModifier,
-                                    starModifier = starModifier,
-                                )
+                                row()
                             }
                         }
                     },
@@ -250,24 +278,28 @@ private fun PeekRow(
     starModifier: Modifier = Modifier,
 ) {
     var expanded by remember { mutableStateOf(false) }
-    PeekRowVisual(
-        shortName = arrival.shortName.orEmpty(),
-        headsign = arrival.headsign.orEmpty(),
-        eta = arrival.eta,
-        etaColor = colorResource(arrival.color),
-        predicted = arrival.predicted,
-        isFavorite = actions?.isRouteFavorite == true,
-        onFavorite = { actions?.let { callbacks.onRouteFavorite(it) } },
-        onMore = { expanded = true },
-        onAlertClick = alertClick(actions, callbacks),
-        onRowClick = { callbacks.onShowVehiclesOnMap(arrival) },
-        onEtaClick = { callbacks.onEtaClick(arrival) },
-        etaModifier = etaModifier,
-        starModifier = starModifier,
-        menu = {
-            ArrivalActionsMenu(expanded, { expanded = false }, arrival, actions, filterActive, callbacks)
-        }
-    )
+    // Wrap the peek row in the same surfaceContainer box as the expanded Style-A card it morphs into,
+    // so the box is present at rest and the morph is a pure size change (see MorphingArrivalRow).
+    ArrivalCard {
+        PeekRowVisual(
+            shortName = arrival.shortName.orEmpty(),
+            headsign = arrival.headsign.orEmpty(),
+            eta = arrival.eta,
+            etaColor = colorResource(arrival.color),
+            predicted = arrival.predicted,
+            isFavorite = actions?.isRouteFavorite == true,
+            onFavorite = { actions?.let { callbacks.onRouteFavorite(it) } },
+            onMore = { expanded = true },
+            onAlertClick = alertClick(actions, callbacks),
+            onRowClick = { callbacks.onShowVehiclesOnMap(arrival) },
+            onEtaClick = { callbacks.onEtaClick(arrival) },
+            etaModifier = etaModifier,
+            starModifier = starModifier,
+            menu = {
+                ArrivalActionsMenu(expanded, { expanded = false }, arrival, actions, filterActive, callbacks)
+            }
+        )
+    }
 }
 
 /**
@@ -453,10 +485,11 @@ private fun ArrivalsPanelHeader(
     onToggleFavorite: () -> Unit,
     onTitleClick: (() -> Unit)? = null,
     starSize: Dp = 20.dp,
+    modifier: Modifier = Modifier,
 ) {
     val name = if (!direction.isNullOrBlank()) "$title (${direction.trim()})" else title
     Box(
-        Modifier
+        modifier
             .fillMaxWidth()
             .padding(horizontal = 8.dp, vertical = 10.dp)
     ) {
@@ -520,27 +553,30 @@ private fun DrawerCollapsedPreview() {
     ObaTheme {
         Surface(color = MaterialTheme.colorScheme.surface) {
             Column(Modifier.fillMaxWidth()) {
-                PeekRowVisual(
-                    shortName = "12",
-                    headsign = "Interlaken Park Via 19th Ave E",
-                    eta = 19,
-                    etaColor = colorResource(R.color.stop_info_delayed),
-                    predicted = true,
-                    isFavorite = false,
-                    onFavorite = {},
-                    onMore = {}
-                )
-                PeekDivider()
-                PeekRowVisual(
-                    shortName = "12",
-                    headsign = "Interlaken Park Via 19th Ave E",
-                    eta = 21,
-                    etaColor = colorResource(R.color.stop_info_delayed),
-                    predicted = true,
-                    isFavorite = false,
-                    onFavorite = {},
-                    onMore = {}
-                )
+                ArrivalCard {
+                    PeekRowVisual(
+                        shortName = "12",
+                        headsign = "Interlaken Park Via 19th Ave E",
+                        eta = 19,
+                        etaColor = colorResource(R.color.stop_info_delayed),
+                        predicted = true,
+                        isFavorite = false,
+                        onFavorite = {},
+                        onMore = {}
+                    )
+                }
+                ArrivalCard {
+                    PeekRowVisual(
+                        shortName = "12",
+                        headsign = "Interlaken Park Via 19th Ave E",
+                        eta = 21,
+                        etaColor = colorResource(R.color.stop_info_delayed),
+                        predicted = true,
+                        isFavorite = false,
+                        onFavorite = {},
+                        onMore = {}
+                    )
+                }
                 ArrivalsPanelHeader(
                     title = "19th Ave E & E Republican St",
                     direction = "N",
@@ -563,14 +599,11 @@ private fun DrawerPeekRowPreview() {
     ObaTheme {
         Surface(color = MaterialTheme.colorScheme.surface) {
             Column(Modifier.fillMaxWidth()) {
-                PeekRowVisual("8", "Mount Baker Transit Center", 1, colorResource(R.color.stop_info_delayed), true, true, {}, {})
-                PeekDivider()
-                PeekRowVisual("40", "Downtown Seattle", 0, colorResource(R.color.stop_info_ontime), true, false, {}, {})
-                PeekDivider()
-                PeekRowVisual("550", "Bellevue Transit Center", 28, colorResource(R.color.stop_info_scheduled_time), false, false, {}, {})
-                PeekDivider()
+                ArrivalCard { PeekRowVisual("8", "Mount Baker Transit Center", 1, colorResource(R.color.stop_info_delayed), true, true, {}, {}) }
+                ArrivalCard { PeekRowVisual("40", "Downtown Seattle", 0, colorResource(R.color.stop_info_ontime), true, false, {}, {}) }
+                ArrivalCard { PeekRowVisual("550", "Bellevue Transit Center", 28, colorResource(R.color.stop_info_scheduled_time), false, false, {}, {}) }
                 // A long route short name: it should ellipsize at the capped width, not crowd the headsign.
-                PeekRowVisual("Mount Si. Trailhead", "North Bend", 12, colorResource(R.color.stop_info_ontime), true, false, {}, {})
+                ArrivalCard { PeekRowVisual("Mount Si. Trailhead", "North Bend", 12, colorResource(R.color.stop_info_ontime), true, false, {}, {}) }
             }
         }
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -58,9 +58,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.colorResource
-import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -233,30 +231,28 @@ fun HomeScreen(
             { scope.launch { runCatching { sheetState.partialExpand() } } }
         }
 
-        // The arrivals sheet's measurement state, reported by the panel via onPreferredHeight — local to
-        // the screen, since the panel and the sheet both live here (no need to round-trip the VM). Seeded
-        // at the two-arrivals height so the first reveal doesn't flash undersized (legacy default), and
-        // arrivalsReady gates the peek open until the focused stop's arrivals load (reset on focus change).
-        var peekArrivalCount by remember { mutableIntStateOf(2) }
-        var routeFiltering by remember { mutableStateOf(false) }
+        // The collapsed peek's content height (px), measured by the panel and reported via onPeekMetrics:
+        // the pinned header plus rowCount boxed peek rows. Sizing the peek from real layout (instead of a
+        // hand-tuned dimen table) auto-adapts to content, padding, and font scale. Seeded at 0; the sheet
+        // stays hidden until the first real measurement lands (arrivalsReady), so it never reveals at 0.
+        // arrivalsReady also gates the peek open until the focused stop's arrivals load (reset on focus change).
+        var peekContentPx by remember { mutableIntStateOf(0) }
         var arrivalsReady by remember { mutableStateOf(false) }
         LaunchedEffect(state.focusedStop?.id) { arrivalsReady = false }
 
-        // The arrivals header height for the current preview count + filter offset (no drag handle).
-        val peekHeaderDp = arrivalsPeekHeight(peekArrivalCount, routeFiltering)
-        val peekHeaderPx = with(density) { peekHeaderDp.roundToPx() }
+        // The measured collapsed-peek content (header + boxed peek rows), as dp (no drag handle) for the
+        // peek anchor below. The raw px goes to the activity as the map's bottom padding (onSheetSettled).
+        val peekContentDp = with(density) { peekContentPx.toDp() }
 
         // Grow the sheet peek by the system navigation-bar inset (height varies by handset) so the
         // collapsed peek's pinned header clears the bottom chrome. The panel matches this with its own
         // content inset (see ArrivalsPanel), so the revealed gap is empty rather than clipped content.
         val peekBottomPadding = navigationBarBottomPadding()
 
-        // The full collapsed-sheet peek: the reported header (less the phantom in-panel-handle budget its
-        // dimens still bake in — see LEGACY_IN_PANEL_HANDLE_BUDGET), plus the real scaffold drag handle
-        // above it, plus the navigation-bar inset below. Both the scaffold's peek height and the FAB lift
-        // use this, so the FABs clear the whole collapsed sheet (handle included), not just the header.
-        val collapsedPeekDp =
-            peekHeaderDp - LEGACY_IN_PANEL_HANDLE_BUDGET + DRAG_HANDLE_HEIGHT + peekBottomPadding
+        // The full collapsed-sheet peek: the measured header+rows content, plus the real scaffold drag
+        // handle above it, plus the navigation-bar inset below. Both the scaffold's peek height and the FAB
+        // lift use this, so the FABs clear the whole collapsed sheet (handle included), not just the content.
+        val collapsedPeekDp = peekContentDp + DRAG_HANDLE_HEIGHT + peekBottomPadding
 
         // The drawer's live open fraction (0 = collapsed peek, 1 = fully expanded), read each frame by
         // the arrivals panel to morph the peek rows in lockstep with the drag. measureModifier feeds it
@@ -306,7 +302,7 @@ fun HomeScreen(
             snapshotFlow {
                 if (!sheetShown) ArrivalsSheetState.Hidden else sheetState.currentValue.toArrivalsSheetState()
             }.collect { value ->
-                onSheetSettled(value, peekHeaderPx)
+                onSheetSettled(value, peekContentPx)
             }
         }
 
@@ -418,9 +414,8 @@ fun HomeScreen(
                             },
                             onShowTrip = onShowTrip,
                             onEditReminder = onEditReminder,
-                            onPreferredHeight = { count, filtering ->
-                                peekArrivalCount = count
-                                routeFiltering = filtering
+                            onPeekContentHeight = { px ->
+                                peekContentPx = px
                                 arrivalsReady = true
                             },
                             onTitleClick = homeViewModel::recenterOnFocusedStop,
@@ -615,35 +610,12 @@ private fun SheetValue.toArrivalsSheetState() = when (this) {
     SheetValue.Expanded -> ArrivalsSheetState.Expanded
 }
 
-/** Maps the arrivals preview count + route-filter flag to the collapsed peek header height. */
-@Composable
-private fun arrivalsPeekHeight(arrivalCount: Int, filtering: Boolean): Dp {
-    val base = dimensionResource(
-        when (arrivalsPeekTier(arrivalCount)) {
-            ArrivalsPeekTier.TWO_OR_MORE -> R.dimen.arrival_header_height_two_arrivals
-            ArrivalsPeekTier.ONE -> R.dimen.arrival_header_height_one_arrival
-            ArrivalsPeekTier.NONE -> R.dimen.arrival_header_height_no_arrivals
-        }
-    )
-    val offset = if (filtering) {
-        dimensionResource(R.dimen.arrival_header_height_offset_filter_routes)
-    } else {
-        0.dp
-    }
-    return base + offset
-}
-
 // The custom drag handle's geometry — the visible bar plus the vertical padding above and below it.
 // Shared by [ArrivalsDragHandle] (what it draws) and the peek-height math (how much room it needs), so
 // the two can't drift apart.
 private val DRAG_HANDLE_BAR_HEIGHT = 4.dp
 private val DRAG_HANDLE_VERTICAL_PADDING = 9.dp
 private val DRAG_HANDLE_HEIGHT = DRAG_HANDLE_BAR_HEIGHT + DRAG_HANDLE_VERTICAL_PADDING * 2
-
-// The reported arrivals-header dimens (arrival_header_height_*) still bake in this much room for the
-// legacy in-panel handle the scaffold drag handle replaced; collapsedPeekDp subtracts it back out and
-// adds the real DRAG_HANDLE_HEIGHT instead.
-private val LEGACY_IN_PANEL_HANDLE_BUDGET = 20.dp
 
 /**
  * The arrivals sheet's drag handle: a short grab bar tinted to sit on the panel surface (paired with

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeSheetLogic.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeSheetLogic.kt
@@ -46,12 +46,3 @@ internal fun sheetBackAction(current: ArrivalsSheetState): SheetBackAction = whe
     ArrivalsSheetState.Collapsed -> SheetBackAction.CLEAR_FOCUS  // peek -> clear focus (then hides)
     ArrivalsSheetState.Hidden -> SheetBackAction.NONE            // let the system handle back
 }
-
-/** The collapsed-peek size tier for the previewed arrival count (maps to the header-height dimens). */
-enum class ArrivalsPeekTier { NONE, ONE, TWO_OR_MORE }
-
-internal fun arrivalsPeekTier(arrivalCount: Int): ArrivalsPeekTier = when {
-    arrivalCount >= 2 -> ArrivalsPeekTier.TWO_OR_MORE
-    arrivalCount == 1 -> ArrivalsPeekTier.ONE
-    else -> ArrivalsPeekTier.NONE
-}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/arrivals/ArrivalsSheetHost.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/arrivals/ArrivalsSheetHost.kt
@@ -59,8 +59,8 @@ import org.onebusaway.android.ui.tutorial.tutorialAnchor
  *
  * Polling lifecycle is owned by `ArrivalsPanel` itself (`ArrivalsPolling` → `repeatOnLifecycle`), so
  * it also pauses with the screen. Loaded responses are forwarded to the host via [onArrivalsLoaded]
- * (the map recenter / focus marker / tutorials), and the preview size drives the peek height via
- * [onPreferredHeight]. Expand/collapse is driven by the sheet's drag handle (in the host scaffold).
+ * (the map recenter / focus marker / tutorials), and the panel's measured collapsed-peek height drives
+ * the sheet peek via [onPeekContentHeight]. Expand/collapse is driven by the sheet's drag handle (in the host scaffold).
  */
 @Composable
 internal fun ArrivalsSheetHost(
@@ -76,7 +76,7 @@ internal fun ArrivalsSheetHost(
     onShowRouteOnMap: (ShowRouteRequest) -> Unit,
     onShowTrip: (tripId: String, stopId: String) -> Unit,
     onEditReminder: (args: ReminderEditorArgs) -> Unit,
-    onPreferredHeight: (previewCount: Int, filtering: Boolean) -> Unit,
+    onPeekContentHeight: (heightPx: Int) -> Unit,
     // Tapping the drawer's stop-name title — the host recenters the map on the focused stop.
     onTitleClick: () -> Unit,
     showUndoSnackbar: (messageRes: Int, actionRes: Int?, onAction: (() -> Unit)?) -> Unit,
@@ -127,7 +127,7 @@ internal fun ArrivalsSheetHost(
                     expandProgress = expandProgress,
                     initialTitle = stop.name.orEmpty(),
                     handler = handler,
-                    onPreferredHeight = onPreferredHeight,
+                    onPeekContentHeight = onPeekContentHeight,
                     onTitleClick = onTitleClick,
                     etaAnchor = Modifier.tutorialAnchor(tutorialState, ArrivalTutorial.KEY_ETA),
                     starAnchor = Modifier.tutorialAnchor(tutorialState, ArrivalTutorial.KEY_STAR),

--- a/onebusaway-android/src/main/res/values/dimens.xml
+++ b/onebusaway-android/src/main/res/values/dimens.xml
@@ -33,10 +33,6 @@
 
     <!-- Collapsed drawer peek heights = drag handle (~20dp) + N peek rows (~48dp each) + the stop
          header (~40dp). Sized so the panel ends at the header; the full list stays hidden below. -->
-    <dimen name="arrival_header_height_no_arrivals">60dp</dimen>
-    <dimen name="arrival_header_height_one_arrival">108dp</dimen>
-    <dimen name="arrival_header_height_two_arrivals">158dp</dimen>
-    <dimen name="arrival_header_height_offset_filter_routes">25dp</dimen>
 
     <!-- Arrivals Style A -->
 

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeSheetLogicTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeSheetLogicTest.kt
@@ -55,16 +55,4 @@ class HomeSheetLogicTest {
         assertEquals(SheetBackAction.CLEAR_FOCUS, sheetBackAction(ArrivalsSheetState.Collapsed))
         assertEquals(SheetBackAction.NONE, sheetBackAction(ArrivalsSheetState.Hidden))
     }
-
-    // --- arrivalsPeekTier ---
-
-    @Test
-    fun `peek tier follows the previewed arrival count`() {
-        assertEquals(ArrivalsPeekTier.NONE, arrivalsPeekTier(0))
-        assertEquals(ArrivalsPeekTier.ONE, arrivalsPeekTier(1))
-        assertEquals(ArrivalsPeekTier.TWO_OR_MORE, arrivalsPeekTier(2))
-        assertEquals(ArrivalsPeekTier.TWO_OR_MORE, arrivalsPeekTier(5))
-        // Defensive: a negative count falls back to the no-arrivals tier.
-        assertEquals(ArrivalsPeekTier.NONE, arrivalsPeekTier(-1))
-    }
 }


### PR DESCRIPTION
## What

A UX refinement to the home arrivals drawer (`ArrivalsPanel`), plus a supporting cleanup of how the collapsed-peek height is derived.

### Box each row
- Every drawer row now sits in the shared `ArrivalCard` box (`surfaceContainer` fill, `shapes.medium` corners, a tight `3dp` inter-row margin).
- The previously-flat **peek rows are boxed too**, so the peek→card `MorphByProgress` transition is a pure size change (the card is present at both ends of the crossfade).
- `ArrivalCardStyleB` now reuses `ArrivalCard` instead of duplicating the box styling inline.

### Measure the peek height instead of hand-tuning dimens
Previously the collapsed peek was sized from a per-count dimen table (`arrival_header_height_*`) plus a `LEGACY_IN_PANEL_HANDLE_BUDGET` fudge — magic pixels that rot whenever a row's content, padding, or font scale changes.

Now `ArrivalsPanel` measures the pinned header + one peek row's **rest** height (gated on `expandProgress() <= 0f` so the morph's growth can't inflate it), computes `header + rowCount × row`, and reports a single `onPeekContentHeight(px)` up through `ArrivalsSheetHost` to `HomeScreen`. This auto-adapts to content, padding, and font scale.

Deleted: the `arrival_header_height_*` dimens, `arrivalsPeekHeight()`, the `ArrivalsPeekTier` enum, and `LEGACY_IN_PANEL_HANDLE_BUDGET`.

The sheet-anchor **stranding-safety** is preserved: the sheet only reveals once a real measurement lands (`arrivalsReady`), so the peek anchor is correct *before* the open animation starts and is never moved mid-animation.

## Testing
- Compiles clean under `-PwarningsAsErrors=true`.
- Android Lint clean (`lintObaGoogleDebug -PwarningsAsErrors=true`, no new issues).
- Unit tests pass (`HomeSheetLogicTest` updated for the removed tier).
- Installed and exercised on a physical device (peek + expanded rows, collapse/expand, 0/1/2 peek rows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bottom-sheet peek sizing so the arrivals panel now uses measured content height, making the sheet open more consistently.
  * Refined arrivals card spacing and background appearance for a cleaner, more compact layout.
  * Updated the collapsed arrivals preview to better match the expanded card style.

* **Style**
  * Simplified preview and panel rendering so the arrivals screen uses a more consistent visual structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->