### PR TITLE
Nav upload worker: drop a stray debug println

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/nav/NavigationUploadWorker.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/nav/NavigationUploadWorker.java
@@ -80,11 +80,9 @@ public class NavigationUploadWorker extends Worker {
                 Log.d(TAG, "Location : " + response + logFileName);
 
                 String sCurrentLine, feedbackText = "";
-                ;
                 try {
                     BufferedReader br = new BufferedReader(new FileReader(lFile.getAbsolutePath()));
                     while ((sCurrentLine = br.readLine()) != null) {
-                        System.out.println(sCurrentLine);
                         feedbackText = sCurrentLine;
                     }
                 } catch (IOException e) {


### PR DESCRIPTION
Small cleanup spotted while looking over `main`.

`NavigationUploadWorker.uploadLog()` had a leftover `System.out.println(sCurrentLine)` inside the log-reading loop that dumped every line of every uploaded feedback log to stderr in production. Removed it, along with an adjacent stray empty-statement semicolon (`;` on its own line).

No behavior change: the loop's actual purpose — capturing the file's last line into `feedbackText` for the upload metadata — is untouched.

Compiles clean (`compileObaGoogleDebugJavaWithJavac`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed an unintended debug print from the navigation log upload flow.
  * Improved how uploaded log text is read and displayed during processing, while keeping upload, cleanup, and success/failure handling unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->