### PR TITLE
Remove the per-arrival-row route-favorite star

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
@@ -247,12 +247,9 @@ fun ArrivalRowStyleA(
     var expanded by remember { mutableStateOf(false) }
     StyleACard(
         modifier = modifier,
-        // Null omits the star entirely when there's no actions to favorite against (defensive).
-        isFavorite = isFavorite.takeIf { actions != null },
-        onFavorite = { actions?.let { callbacks.onRouteFavorite(it) } },
         onMore = { expanded = true },
         // Tapping the row body frames the whole route; the ETA pill (below) instead focuses this trip's
-        // vehicle + stop, and the overflow icon opens the menu.
+        // vehicle + stop, and the overflow icon opens the menu (which hosts the favorite toggle).
         onContentClick = { callbacks.onShowVehiclesOnMap(arrival) },
         overflow = {
             ArrivalActionsMenu(expanded, { expanded = false }, arrival, actions, isFavorite, filterActive, callbacks)
@@ -272,18 +269,16 @@ internal fun alertClick(actions: ArrivalActions?, callbacks: ArrivalRowCallbacks
     actions?.alertSituationId?.let { id -> { callbacks.onShowAlert(id) } }
 
 /**
- * The Style A card scaffold: the row content with a small favorite star tucked into the top-left
- * corner and a horizontal-overflow into the top-right (legacy `route_favorite` / `more_horizontal`).
- * Shared by the live row and its @Preview so the corner layout and padding can't drift apart.
+ * The Style A card scaffold: the row content with a horizontal-overflow into the top-right (legacy
+ * `more_horizontal`). Shared by the live row and its @Preview so the corner layout and padding can't
+ * drift apart. Favoriting a route lives in the overflow menu + the route-map header now, not a per-row
+ * star.
  *
- * @param isFavorite the star's state, or null to omit the star (e.g. when there are no actions)
  * @param onContentClick tap handler for the row body, or null for a non-interactive body (preview)
  * @param overflow the dropdown menu anchored to the top-right overflow icon
  */
 @Composable
 private fun StyleACard(
-    isFavorite: Boolean?,
-    onFavorite: () -> Unit,
     onMore: () -> Unit,
     onContentClick: (() -> Unit)?,
     overflow: @Composable () -> Unit,
@@ -296,22 +291,10 @@ private fun StyleACard(
                 Modifier
                     .fillMaxWidth()
                     .then(if (onContentClick != null) Modifier.clickable(onClick = onContentClick) else Modifier)
-                    // A little top room so the 36sp route/ETA clear the overlaid corner icons
+                    // A little top room so the 36sp route/ETA clear the overlaid overflow icon
                     .padding(start = 10.dp, top = 8.dp, end = 10.dp, bottom = 6.dp)
             ) {
                 content()
-            }
-            if (isFavorite != null) {
-                CornerIcon(
-                    iconRes = if (isFavorite) R.drawable.star else R.drawable.star_outline,
-                    contentDescription = stringResource(
-                        if (isFavorite) R.string.bus_options_menu_remove_star
-                        else R.string.bus_options_menu_add_star
-                    ),
-                    tint = colorResource(R.color.navdrawer_icon_tint),
-                    onClick = onFavorite,
-                    modifier = Modifier.align(Alignment.TopStart)
-                )
             }
             Box(Modifier.align(Alignment.TopEnd)) {
                 CornerIcon(
@@ -597,12 +580,12 @@ private fun canceledDecoration(arrival: ArrivalInfo): TextDecoration =
 private fun ArrivalRowStyleAPreview() {
     ObaTheme {
         Column(Modifier.padding(vertical = 8.dp)) {
-            PreviewStyleACard("8", "Capitol Hill", "2 min late", R.color.stop_info_delayed, "Departing at 4:32 PM", 5, predicted = true, favorite = true)
-            PreviewStyleACard("12", "Downtown Seattle", "On time", R.color.stop_info_ontime, "Departing at 4:27 PM", 0, predicted = true, favorite = false)
-            PreviewStyleACard("40", "Northgate", "3 min early", R.color.stop_info_early, "Arriving at 4:39 PM", 12, predicted = true, favorite = false)
-            PreviewStyleACard("550", "Bellevue Transit Center", "Scheduled", R.color.stop_info_scheduled_time, "Departing at 4:49 PM", 22, predicted = false, favorite = false)
-            PreviewStyleACard("7", "Rainier Beach", "Departed 1 min late", R.color.stop_info_delayed, "Departed at 4:25 PM", -2, predicted = true, favorite = false)
-            PreviewStyleACard("49", "University District", "Canceled", R.color.stop_info_scheduled_time, "", 8, predicted = false, favorite = false, canceled = true)
+            PreviewStyleACard("8", "Capitol Hill", "2 min late", R.color.stop_info_delayed, "Departing at 4:32 PM", 5, predicted = true)
+            PreviewStyleACard("12", "Downtown Seattle", "On time", R.color.stop_info_ontime, "Departing at 4:27 PM", 0, predicted = true)
+            PreviewStyleACard("40", "Northgate", "3 min early", R.color.stop_info_early, "Arriving at 4:39 PM", 12, predicted = true)
+            PreviewStyleACard("550", "Bellevue Transit Center", "Scheduled", R.color.stop_info_scheduled_time, "Departing at 4:49 PM", 22, predicted = false)
+            PreviewStyleACard("7", "Rainier Beach", "Departed 1 min late", R.color.stop_info_delayed, "Departed at 4:25 PM", -2, predicted = true)
+            PreviewStyleACard("49", "University District", "Canceled", R.color.stop_info_scheduled_time, "", 8, predicted = false, canceled = true)
         }
     }
 }
@@ -617,12 +600,9 @@ private fun PreviewStyleACard(
     timeText: String,
     eta: Long,
     predicted: Boolean,
-    favorite: Boolean,
     canceled: Boolean = false
 ) {
     StyleACard(
-        isFavorite = favorite,
-        onFavorite = {},
         onMore = {},
         onContentClick = null,
         overflow = {}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalsPanel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalsPanel.kt
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-// This panel threads named per-element anchor modifiers (etaAnchor/starAnchor) a host attaches to
-// specific sub-elements for the onboarding spotlight — several per composable, none being the root
-// `modifier` — so ModifierParameter's "name it modifier" rule doesn't apply here.
+// This panel threads a named per-element anchor modifier (etaAnchor) a host attaches to a specific
+// sub-element for the onboarding spotlight — not the root `modifier` — so ModifierParameter's "name it
+// modifier" rule doesn't apply here.
 @file:Suppress("ModifierParameter")
 
 package org.onebusaway.android.ui.arrivals.components
@@ -109,10 +109,9 @@ fun ArrivalsPanel(
     // Tapping the pinned stop-name header invokes this (null = not tappable); the drawer host wires it
     // to an animated map recenter on the focused stop.
     onTitleClick: (() -> Unit)? = null,
-    // Opaque anchor modifiers a host may attach to the first peek row's ETA pill + favorite star (e.g.
-    // for an onboarding spotlight). The panel stays ignorant of what they're for.
+    // An opaque anchor modifier a host may attach to the first peek row's ETA pill (e.g. for an
+    // onboarding spotlight). The panel stays ignorant of what it's for.
     etaAnchor: Modifier = Modifier,
-    starAnchor: Modifier = Modifier,
 ) {
     // The system navigation-bar inset (height varies by handset); see the list contentPadding below.
     val navBarInset = navigationBarBottomPadding()
@@ -210,9 +209,8 @@ fun ArrivalsPanel(
                             previewArrivals,
                             key = { index, arrival -> "peek:${arrival.tripId}#$index" }
                         ) { index, arrival ->
-                            // The host's anchors apply to the first peek row only.
+                            // The host's ETA anchor applies to the first peek row only.
                             val etaModifier = if (index == 0) etaAnchor else Modifier
-                            val starModifier = if (index == 0) starAnchor else Modifier
                             val isFavorite = arrival.routeId in content.favoriteRouteIds
                             val row: @Composable () -> Unit = {
                                 if (styleA) {
@@ -224,7 +222,6 @@ fun ArrivalsPanel(
                                         callbacks = rowCallbacks,
                                         progress = expandProgress,
                                         etaModifier = etaModifier,
-                                        starModifier = starModifier,
                                     )
                                 } else {
                                     PeekRow(
@@ -234,7 +231,6 @@ fun ArrivalsPanel(
                                         filterActive = filtering,
                                         callbacks = rowCallbacks,
                                         etaModifier = etaModifier,
-                                        starModifier = starModifier,
                                     )
                                 }
                             }
@@ -270,7 +266,8 @@ private fun ColumnScope.PeekDivider() {
 }
 
 
-/** Adapts an [ArrivalInfo] onto [PeekRowVisual], wiring the favorite star and per-arrival menu. */
+/** Adapts an [ArrivalInfo] onto [PeekRowVisual], wiring the per-arrival overflow menu (which hosts the
+ *  favorite toggle). [isFavorite] drives the menu's star label. */
 @Composable
 private fun PeekRow(
     arrival: ArrivalInfo,
@@ -279,7 +276,6 @@ private fun PeekRow(
     filterActive: Boolean,
     callbacks: ArrivalRowCallbacks,
     etaModifier: Modifier = Modifier,
-    starModifier: Modifier = Modifier,
 ) {
     var expanded by remember { mutableStateOf(false) }
     // Wrap the peek row in the same surfaceContainer box as the expanded Style-A card it morphs into,
@@ -291,14 +287,11 @@ private fun PeekRow(
             eta = arrival.eta,
             etaColor = colorResource(arrival.color),
             predicted = arrival.predicted,
-            isFavorite = isFavorite,
-            onFavorite = { actions?.let { callbacks.onRouteFavorite(it) } },
             onMore = { expanded = true },
             onAlertClick = alertClick(actions, callbacks),
             onRowClick = { callbacks.onShowVehiclesOnMap(arrival) },
             onEtaClick = { callbacks.onEtaClick(arrival) },
             etaModifier = etaModifier,
-            starModifier = starModifier,
             menu = {
                 ArrivalActionsMenu(expanded, { expanded = false }, arrival, actions, isFavorite, filterActive, callbacks)
             }
@@ -321,11 +314,10 @@ private fun MorphingArrivalRow(
     callbacks: ArrivalRowCallbacks,
     progress: () -> Float,
     etaModifier: Modifier = Modifier,
-    starModifier: Modifier = Modifier,
 ) {
     MorphByProgress(
         progress = progress,
-        start = { PeekRow(arrival, actions, isFavorite, filterActive, callbacks, etaModifier, starModifier) },
+        start = { PeekRow(arrival, actions, isFavorite, filterActive, callbacks, etaModifier) },
         end = { ArrivalRowStyleA(arrival, actions, isFavorite, filterActive, callbacks) },
     )
 }
@@ -342,15 +334,12 @@ private fun PeekRowVisual(
     eta: Long,
     etaColor: Color,
     predicted: Boolean,
-    isFavorite: Boolean,
-    onFavorite: () -> Unit,
     onMore: () -> Unit,
     modifier: Modifier = Modifier,
     etaModifier: Modifier = Modifier,
-    starModifier: Modifier = Modifier,
     onAlertClick: (() -> Unit)? = null,
     // Tapping the row body frames the whole route; tapping the ETA pill focuses this trip's vehicle +
-    // stop (null in previews). The pill is a Surface(onClick) and the star/overflow are IconButtons, so
+    // stop (null in previews). The pill is a Surface(onClick) and the overflow is an IconButton, so
     // each nested target reliably wins over the row-body click in its own bounds.
     onRowClick: (() -> Unit)? = null,
     onEtaClick: (() -> Unit)? = null,
@@ -359,22 +348,10 @@ private fun PeekRowVisual(
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .then(if (onRowClick != null) Modifier.clickable(onClick = onRowClick) else Modifier),
+            .then(if (onRowClick != null) Modifier.clickable(onClick = onRowClick) else Modifier)
+            .padding(start = 4.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        IconButton(onClick = onFavorite, modifier = starModifier) {
-            Icon(
-                painter = painterResource(
-                    if (isFavorite) R.drawable.star else R.drawable.star_outline
-                ),
-                contentDescription = stringResource(
-                    if (isFavorite) R.string.bus_options_menu_remove_star
-                    else R.string.bus_options_menu_add_star
-                ),
-                tint = colorResource(R.color.navdrawer_icon_tint),
-                modifier = Modifier.size(28.dp)
-            )
-        }
         // The shared auto-shrinking route badge (sized down for the condensed peek), so a long short
         // name fits its slot instead of crowding out the headsign.
         LineBadge(text = shortName, maxFontSize = 28.sp)
@@ -565,8 +542,6 @@ private fun DrawerCollapsedPreview() {
                         eta = 19,
                         etaColor = colorResource(R.color.stop_info_delayed),
                         predicted = true,
-                        isFavorite = false,
-                        onFavorite = {},
                         onMore = {}
                     )
                 }
@@ -577,8 +552,6 @@ private fun DrawerCollapsedPreview() {
                         eta = 21,
                         etaColor = colorResource(R.color.stop_info_delayed),
                         predicted = true,
-                        isFavorite = false,
-                        onFavorite = {},
                         onMore = {}
                     )
                 }
@@ -604,11 +577,11 @@ private fun DrawerPeekRowPreview() {
     ObaTheme {
         Surface(color = MaterialTheme.colorScheme.surface) {
             Column(Modifier.fillMaxWidth()) {
-                ArrivalCard { PeekRowVisual("8", "Mount Baker Transit Center", 1, colorResource(R.color.stop_info_delayed), true, true, {}, {}) }
-                ArrivalCard { PeekRowVisual("40", "Downtown Seattle", 0, colorResource(R.color.stop_info_ontime), true, false, {}, {}) }
-                ArrivalCard { PeekRowVisual("550", "Bellevue Transit Center", 28, colorResource(R.color.stop_info_scheduled_time), false, false, {}, {}) }
+                ArrivalCard { PeekRowVisual("8", "Mount Baker Transit Center", 1, colorResource(R.color.stop_info_delayed), true, {}) }
+                ArrivalCard { PeekRowVisual("40", "Downtown Seattle", 0, colorResource(R.color.stop_info_ontime), true, {}) }
+                ArrivalCard { PeekRowVisual("550", "Bellevue Transit Center", 28, colorResource(R.color.stop_info_scheduled_time), false, {}) }
                 // A long route short name: it should ellipsize at the capped width, not crowd the headsign.
-                ArrivalCard { PeekRowVisual("Mount Si. Trailhead", "North Bend", 12, colorResource(R.color.stop_info_ontime), true, false, {}, {}) }
+                ArrivalCard { PeekRowVisual("Mount Si. Trailhead", "North Bend", 12, colorResource(R.color.stop_info_ontime), true, {}) }
             }
         }
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/arrivals/ArrivalsSheetHost.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/arrivals/ArrivalsSheetHost.kt
@@ -130,7 +130,6 @@ internal fun ArrivalsSheetHost(
                     onPeekContentHeight = onPeekContentHeight,
                     onTitleClick = onTitleClick,
                     etaAnchor = Modifier.tutorialAnchor(tutorialState, ArrivalTutorial.KEY_ETA),
-                    starAnchor = Modifier.tutorialAnchor(tutorialState, ArrivalTutorial.KEY_STAR),
                     // The onboarding "slide up to see more" spotlight (KEY_PANEL) anchors on the sheet's
                     // drag handle in the host scaffold, not the panel — see ArrivalsDragHandle.
                 )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tutorial/ArrivalTutorial.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tutorial/ArrivalTutorial.kt
@@ -21,8 +21,8 @@ import org.onebusaway.android.preferences.PreferencesRepository
 /**
  * The arrivals-panel onboarding sequence — the Compose successor to the legacy ShowcaseView
  * "arrival header" tutorial chain (which spotlighted XML views removed in the Compose migration).
- * Spotlights, in order, the ETA pill, the slide-up chevron, and the favorite star of the focused
- * stop's peek (see the [Modifier.tutorialAnchor] call sites in `ArrivalsPanel`). Shown once the first
+ * Spotlights, in order, the ETA pill, the slide-up chevron, and the top-bar overflow (see the
+ * [Modifier.tutorialAnchor] call sites in `ArrivalsPanel` / the sheet host). Shown once the first
  * time a stop's arrivals load, gated by [pendingSteps]; "show tutorials again" re-arms it by clearing
  * the [resetKeys] (see `TutorialPrefs.resetAllTutorials`).
  *
@@ -39,9 +39,6 @@ object ArrivalTutorial {
     /** Slide-up chevron — pull the panel up for the full arrivals list. */
     const val KEY_PANEL = ".tutorial_compose_arrival_panel"
 
-    /** Favorite star — pin a route to the top of the panel. */
-    const val KEY_STAR = ".tutorial_compose_arrival_star"
-
     /** Top-bar overflow (⋮) — find recently viewed stops and routes. */
     const val KEY_MORE_MENU = ".tutorial_compose_more_menu"
 
@@ -57,11 +54,6 @@ object ArrivalTutorial {
             id = KEY_PANEL,
             title = R.string.tutorial_arrival_header_sliding_panel_title,
             body = R.string.tutorial_arrival_header_sliding_panel_text,
-        ),
-        TutorialStep(
-            id = KEY_STAR,
-            title = R.string.tutorial_arrival_header_star_route_title,
-            body = R.string.tutorial_arrival_header_star_route_text,
         ),
         TutorialStep(
             id = KEY_MORE_MENU,

--- a/onebusaway-android/src/main/res/values-es/strings.xml
+++ b/onebusaway-android/src/main/res/values-es/strings.xml
@@ -800,10 +800,6 @@
     <string name="tutorial_arrival_header_sliding_panel_text">Toca sobre la flecha o desliza el panel hacia arriba
         para ver mas llegadas de buses en esta parada.
     </string>
-    <string name="tutorial_arrival_header_star_route_title">Agrega rutas a favoritos</string>
-    <string name="tutorial_arrival_header_star_route_text">Toca sobre la estrella para que tus rutas
-        favoritas aparezcan en la parte superior del panel deslizante.
-    </string>
     <string name="tutorial_recent_stops_routes_title">Paradas y rutas recientes</string>
     <string name="tutorial_recent_stops_routes_text">Encuentra las paradas y rutas que recientemente has mirado
         accediendo por medio del botón \"Más\" en la parte superior derecha de la pantalla.

--- a/onebusaway-android/src/main/res/values-fi/strings.xml
+++ b/onebusaway-android/src/main/res/values-fi/strings.xml
@@ -638,10 +638,6 @@
     <string name="tutorial_arrival_header_sliding_panel_text">Napsauta nuolta tai liikuta paneelia ylöspäin
         nähdäksesi lisää tälle pysäkille saapuvia vuoroja.
     </string>
-    <string name="tutorial_arrival_header_star_route_title">Merkkaa suosikkireittisi</string>
-    <string name="tutorial_arrival_header_star_route_text">Napsauta tähteä liittääksesi suosikkireittisi
-        liukupaneelin yläosaan.
-    </string>
     <string name="tutorial_recent_stops_routes_title">Viimeisimmät pysäkit ja reitit</string>
     <string name="tutorial_recent_stops_routes_text">Ruudun oikeasta laidasta löytyvän \"Lisää\" napin 
         avulla löydät pysäkit ja reitit joita olet viimeksi katsellut.

--- a/onebusaway-android/src/main/res/values-it/strings.xml
+++ b/onebusaway-android/src/main/res/values-it/strings.xml
@@ -648,8 +648,6 @@
     <string name="tutorial_arrival_header_arrival_info_text">Tanto così! Lo sfondo colorato ti dice se l\'autobus è in anticipo (rosso) o in ritardo (blu). In orario = sfondo verde. Se non sappiamo dove sia l\'autobus, ti mostriamo l\'orario previsto (sfondo grigio). Grigio con testo barrato significa che il tragitto è stato cancellato.</string>
     <string name="tutorial_arrival_header_sliding_panel_title">Scorri in su per mostrare più arrivi</string>
     <string name="tutorial_arrival_header_sliding_panel_text">Tocca la freccia o trascina il pannello in su per vedere altri arrivi a questa fermata.</string>
-    <string name="tutorial_arrival_header_star_route_title">Salva le tue linee preferite</string>
-    <string name="tutorial_arrival_header_star_route_text">Tocca sulla stella per fissare le tue linee preferite in cima al pannello di scorrimento.</string>
     <string name="tutorial_recent_stops_routes_title">Fermate e linee recenti</string>
     <string name="tutorial_recent_stops_routes_text">Per ritrovare le fermate e le linee cercate di recente, tocca il pulsante \&quot;Altro\&quot; in alto a destra.</string>
 

--- a/onebusaway-android/src/main/res/values-pl/strings.xml
+++ b/onebusaway-android/src/main/res/values-pl/strings.xml
@@ -751,9 +751,6 @@
     <string name="tutorial_arrival_header_sliding_panel_text">Dotknij strzałki i przesuń panel do góry
         by zobaczyć więcej przyjazdów na tym przystanku.
     </string>
-    <string name="tutorial_arrival_header_star_route_title">Dodaj do ulubionych swoje trasy</string>
-    <string name="tutorial_arrival_header_star_route_text">Dotknij gwiazdki by zaznaczyć Twoje ulubione trasy
-    </string>
     <string name="tutorial_recent_stops_routes_title">Ostatnie przystanki i trasy</string>
     <string name="tutorial_recent_stops_routes_text">Znajdź przystanki i trasy które ostatnio
         przeglądając klikając przycisk \"Więcej\" u góry ekranu.

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -822,10 +822,6 @@
     <string name="tutorial_arrival_header_sliding_panel_text">Drag the panel up
         to see more arrivals for this stop.
     </string>
-    <string name="tutorial_arrival_header_star_route_title">Star your favorite routes</string>
-    <string name="tutorial_arrival_header_star_route_text">Tap on the star to pin your favorite
-        routes to the top of the sliding panel.
-    </string>
     <string name="tutorial_recent_stops_routes_title">Recent stops and routes</string>
     <string name="tutorial_recent_stops_routes_text">Find the stops and routes that you\'ve recently
         looked at via the \"More\" button at the top right of the screen.

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tutorial/ArrivalTutorialTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tutorial/ArrivalTutorialTest.kt
@@ -37,7 +37,6 @@ class ArrivalTutorialTest {
             listOf(
                 ArrivalTutorial.KEY_ETA,
                 ArrivalTutorial.KEY_PANEL,
-                ArrivalTutorial.KEY_STAR,
                 ArrivalTutorial.KEY_MORE_MENU,
             ),
             pending.map { it.id },
@@ -58,7 +57,7 @@ class ArrivalTutorialTest {
         prefs.setBoolean(ArrivalTutorial.KEY_ETA, true)
 
         assertEquals(
-            listOf(ArrivalTutorial.KEY_PANEL, ArrivalTutorial.KEY_STAR, ArrivalTutorial.KEY_MORE_MENU),
+            listOf(ArrivalTutorial.KEY_PANEL, ArrivalTutorial.KEY_MORE_MENU),
             ArrivalTutorial.pendingSteps(prefs).map { it.id },
         )
     }


### PR DESCRIPTION
## Summary

Follow-up to #1727. Now that a route can be starred from the **route-map header** (and still from each row's overflow menu), drop the redundant per-row route-favorite **star icons** on the arrival rows — the small star tucked into the Style-A card corner and the one leading each collapsed peek row.

This was explicitly deferred in #1727 ("Removing the arrivals-row star is also deferred to that follow-up").

## What changes

- **Style-A rows** — remove the favorite star from the card's top-left corner (and its `isFavorite`/`onFavorite` plumbing on `StyleACard`).
- **Peek rows** — remove the star icon leading each peek row (`PeekRowVisual`), plus the now-unused `starModifier`/`starAnchor` plumbing threaded through `PeekRow`/`MorphingArrivalRow`/`ArrivalsPanel`.
- **Overflow menu kept** — each row's "⋮" still offers "Add/Remove star", so a route can still be favorited from the list (as well as from the map header).
- **Promotion unchanged** — favorited routes still float to the top of the drawer (the reactive `favoriteRouteIds` overlay is untouched).
- **Tutorial** — retire the onboarding star spotlight (`ArrivalTutorial.KEY_STAR`, its anchor in `ArrivalsSheetHost`, and the unused strings across all locales), since the star it pointed at is gone. The sequence is now ETA → slide-up → overflow. `ArrivalTutorialTest` updated accordingly.

`isFavorite` is still threaded to the rows for the overflow menu's star label.

## Testing

`compileObaGoogleDebugKotlin -PwarningsAsErrors=true`, `lintObaGoogleDebug -PwarningsAsErrors=true`, and `testObaGoogleDebugUnitTest` all clean; exercised on device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the arrivals tutorial to focus on the ETA pill, slide-up control, and overflow menu.

* **Bug Fixes**
  * Removed the per-row favorite/star element from arrival cards and peek rows for a cleaner, simpler layout.
  * Simplified tutorial anchors so the ETA highlight is used consistently.

* **Documentation**
  * Revised tutorial text in supported languages to match the updated onboarding flow.

* **Tests**
  * Updated tutorial tests to reflect the shorter step sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->