### PR TITLE
Route-badge chip: show the route short name on an HCT-normalized route color

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsRepository.kt
@@ -390,7 +390,6 @@ class DefaultArrivalsRepository @Inject constructor(
             routeShortName = route?.shortName,
             routeLongName = arrival.routeLongName,
             routeColor = route?.color,
-            routeTextColor = route?.textColor,
             scheduleUrl = route?.url,
             agencyName = route?.agencyId?.let { snapshot.agencyName(it) },
             blockId = snapshot.trip(arrival.tripId)?.blockId,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsRepository.kt
@@ -389,6 +389,8 @@ class DefaultArrivalsRepository @Inject constructor(
             routeId = arrival.routeId,
             routeShortName = route?.shortName,
             routeLongName = arrival.routeLongName,
+            routeColor = route?.color,
+            routeTextColor = route?.textColor,
             scheduleUrl = route?.url,
             agencyName = route?.agencyId?.let { snapshot.agencyName(it) },
             blockId = snapshot.trip(arrival.tripId)?.blockId,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsUiState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsUiState.kt
@@ -35,6 +35,10 @@ data class ArrivalActions(
     val routeId: String,
     val routeShortName: String?,
     val routeLongName: String?,
+    /** The route's GTFS color / text color (ARGB), or null when the agency didn't set one — drives the
+     *  route-badge chip. */
+    val routeColor: Int? = null,
+    val routeTextColor: Int? = null,
     /** Route schedule URL; null/blank hides the "show route schedule" menu item. */
     val scheduleUrl: String?,
     val agencyName: String?,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsUiState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsUiState.kt
@@ -35,10 +35,9 @@ data class ArrivalActions(
     val routeId: String,
     val routeShortName: String?,
     val routeLongName: String?,
-    /** The route's GTFS color / text color (ARGB), or null when the agency didn't set one — drives the
-     *  route-badge chip. */
+    /** The route's GTFS color (ARGB), or null when the agency didn't set one — we take its hue to
+     *  derive the route-badge chip. */
     val routeColor: Int? = null,
-    val routeTextColor: Int? = null,
     /** Route schedule URL; null/blank hides the "show route schedule" menu item. */
     val scheduleUrl: String?,
     val agencyName: String?,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
@@ -254,8 +254,7 @@ fun ArrivalRowStyleA(
     modifier: Modifier = Modifier
 ) {
     var expanded by remember { mutableStateOf(false) }
-    val (badgeContainer, badgeContent) =
-        rememberRouteBadgeColors(actions?.routeColor, actions?.routeTextColor)
+    val (badgeContainer, badgeContent) = rememberRouteBadgeColors(actions?.routeColor)
     StyleACard(
         modifier = modifier,
         onMore = { expanded = true },

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
@@ -67,6 +67,7 @@ import org.onebusaway.android.models.Status
 import org.onebusaway.android.ui.arrivals.ArrivalActions
 import org.onebusaway.android.ui.arrivals.ArrivalInfo
 import org.onebusaway.android.ui.compose.components.LineBadge
+import org.onebusaway.android.ui.compose.components.rememberRouteBadgeColors
 import org.onebusaway.android.ui.compose.theme.ObaTheme
 import org.onebusaway.util.comparators.AlphanumComparator
 
@@ -153,6 +154,8 @@ private fun ArrivalRowVisual(
     predicted: Boolean,
     canceled: Boolean,
     modifier: Modifier = Modifier,
+    badgeContainer: Color = Color.Unspecified,
+    badgeContent: Color = Color.Unspecified,
     onAlertClick: (() -> Unit)? = null,
     onEtaClick: (() -> Unit)? = null,
 ) {
@@ -161,6 +164,8 @@ private fun ArrivalRowVisual(
         LineBadge(
             text = shortName,
             maxFontSize = 36.sp,
+            color = badgeContent,
+            containerColor = badgeContainer,
             textDecoration = decoration
         )
         Spacer(Modifier.width(12.dp))
@@ -213,6 +218,8 @@ internal fun ArrivalAlertIndicator(onClick: () -> Unit, modifier: Modifier = Mod
 internal fun ArrivalRowContent(
     arrival: ArrivalInfo,
     modifier: Modifier = Modifier,
+    badgeContainer: Color = Color.Unspecified,
+    badgeContent: Color = Color.Unspecified,
     onAlertClick: (() -> Unit)? = null,
     onEtaClick: (() -> Unit)? = null,
 ) {
@@ -226,6 +233,8 @@ internal fun ArrivalRowContent(
         predicted = arrival.predicted,
         canceled = arrival.status == Status.CANCELED,
         modifier = modifier,
+        badgeContainer = badgeContainer,
+        badgeContent = badgeContent,
         onAlertClick = onAlertClick,
         onEtaClick = onEtaClick,
     )
@@ -245,6 +254,8 @@ fun ArrivalRowStyleA(
     modifier: Modifier = Modifier
 ) {
     var expanded by remember { mutableStateOf(false) }
+    val (badgeContainer, badgeContent) =
+        rememberRouteBadgeColors(actions?.routeColor, actions?.routeTextColor)
     StyleACard(
         modifier = modifier,
         onMore = { expanded = true },
@@ -258,6 +269,8 @@ fun ArrivalRowStyleA(
         ArrivalRowContent(
             arrival,
             Modifier.fillMaxWidth(),
+            badgeContainer = badgeContainer,
+            badgeContent = badgeContent,
             onAlertClick = alertClick(actions, callbacks),
             onEtaClick = { callbacks.onEtaClick(arrival) },
         )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalsPanel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalsPanel.kt
@@ -78,6 +78,7 @@ import org.onebusaway.android.ui.arrivals.dialogs.StopDetailsHost
 import org.onebusaway.android.ui.arrivals.rememberArrivalRowCallbacks
 import org.onebusaway.android.ui.compose.MorphByProgress
 import org.onebusaway.android.ui.compose.components.LineBadge
+import org.onebusaway.android.ui.compose.components.rememberRouteBadgeColors
 import org.onebusaway.android.ui.compose.navigationBarBottomPadding
 import org.onebusaway.android.util.BuildFlavorUtils
 import org.onebusaway.android.ui.compose.theme.ObaTheme
@@ -278,6 +279,8 @@ private fun PeekRow(
     etaModifier: Modifier = Modifier,
 ) {
     var expanded by remember { mutableStateOf(false) }
+    val (badgeContainer, badgeContent) =
+        rememberRouteBadgeColors(actions?.routeColor, actions?.routeTextColor)
     // Wrap the peek row in the same surfaceContainer box as the expanded Style-A card it morphs into,
     // so the box is present at rest and the morph is a pure size change (see MorphingArrivalRow).
     ArrivalCard {
@@ -287,6 +290,8 @@ private fun PeekRow(
             eta = arrival.eta,
             etaColor = colorResource(arrival.color),
             predicted = arrival.predicted,
+            badgeContainer = badgeContainer,
+            badgeContent = badgeContent,
             onMore = { expanded = true },
             onAlertClick = alertClick(actions, callbacks),
             onRowClick = { callbacks.onShowVehiclesOnMap(arrival) },
@@ -337,6 +342,8 @@ private fun PeekRowVisual(
     onMore: () -> Unit,
     modifier: Modifier = Modifier,
     etaModifier: Modifier = Modifier,
+    badgeContainer: Color = Color.Unspecified,
+    badgeContent: Color = Color.Unspecified,
     onAlertClick: (() -> Unit)? = null,
     // Tapping the row body frames the whole route; tapping the ETA pill focuses this trip's vehicle +
     // stop (null in previews). The pill is a Surface(onClick) and the overflow is an IconButton, so
@@ -352,9 +359,14 @@ private fun PeekRowVisual(
             .padding(start = 4.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        // The shared auto-shrinking route badge (sized down for the condensed peek), so a long short
-        // name fits its slot instead of crowding out the headsign.
-        LineBadge(text = shortName, maxFontSize = 28.sp)
+        // The shared auto-shrinking route badge (sized down for the condensed peek), on its GTFS-colored
+        // chip, so a long short name fits its slot instead of crowding out the headsign.
+        LineBadge(
+            text = shortName,
+            maxFontSize = 28.sp,
+            color = badgeContent,
+            containerColor = badgeContainer,
+        )
         Spacer(Modifier.width(10.dp))
         Text(
             text = headsign,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalsPanel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalsPanel.kt
@@ -279,8 +279,7 @@ private fun PeekRow(
     etaModifier: Modifier = Modifier,
 ) {
     var expanded by remember { mutableStateOf(false) }
-    val (badgeContainer, badgeContent) =
-        rememberRouteBadgeColors(actions?.routeColor, actions?.routeTextColor)
+    val (badgeContainer, badgeContent) = rememberRouteBadgeColors(actions?.routeColor)
     // Wrap the peek row in the same surfaceContainer box as the expanded Style-A card it morphs into,
     // so the box is present at rest and the morph is a pure size change (see MorphingArrivalRow).
     ArrivalCard {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/LineBadge.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/LineBadge.kt
@@ -68,11 +68,14 @@ private val CHIP_V_PADDING = 2.dp
 // in HCT (a perceptual space) at a fixed tone + capped chroma, so the agency can't hand us an
 // over-saturated or too-dark/too-light color — every chip lands at a consistent, legible brightness,
 // and the tone flips lighter for dark theme. Fidget with these to taste.
-private const val CHIP_TONE_LIGHT = 42.0        // container tone in light theme (0=black … 100=white)
-private const val CHIP_TONE_DARK = 78.0         // lighter container tone for dark theme
-private const val CHIP_ON_TONE_LIGHT = 100.0    // text tone on the light-theme chip (→ white)
+private const val CHIP_TONE_LIGHT = 80.0        // container tone in light theme (0=black … 100=white)
+private const val CHIP_TONE_DARK = 78.0         // container tone for dark theme
+private const val CHIP_ON_TONE_LIGHT = 30.0     // text tone on the light-theme (pastel) chip (→ dark)
 private const val CHIP_ON_TONE_DARK = 20.0      // text tone on the dark-theme chip (→ near-black)
-private const val CHIP_MAX_CHROMA = 40.0        // cap the saturation the agency color can reach
+private const val CHIP_MAX_CHROMA_LIGHT = 30.0  // saturation cap in light theme (soft pastel)
+private const val CHIP_MAX_CHROMA_DARK = 60.0   // saturation cap in dark theme
+                                                // (each hue still clamps to its own sRGB gamut limit;
+                                                //  low caps mute vivid hues — e.g. orange → brown)
 private const val ACHROMATIC_CHROMA = 5.0       // below this the source is grey/black/white (no hue)
 
 /**
@@ -94,7 +97,7 @@ fun rememberRouteBadgeColors(routeColor: Int?): Pair<Color, Color> {
         if (source == null || source.chroma < ACHROMATIC_CHROMA) {
             neutralContainer to neutralContent
         } else {
-            val chroma = min(source.chroma, CHIP_MAX_CHROMA)
+            val chroma = min(source.chroma, if (dark) CHIP_MAX_CHROMA_DARK else CHIP_MAX_CHROMA_LIGHT)
             val containerTone = if (dark) CHIP_TONE_DARK else CHIP_TONE_LIGHT
             val contentTone = if (dark) CHIP_ON_TONE_DARK else CHIP_ON_TONE_LIGHT
             Color(Hct.from(source.hue, chroma, containerTone).toInt()) to

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/LineBadge.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/LineBadge.kt
@@ -15,11 +15,13 @@
  */
 package org.onebusaway.android.ui.compose.components
 
+import android.annotation.SuppressLint
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
@@ -47,6 +49,8 @@ import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.isSpecified
 import androidx.compose.ui.unit.sp
+import com.google.android.material.color.utilities.Hct
+import kotlin.math.min
 import org.onebusaway.android.ui.compose.theme.ObaTheme
 
 /** Line height as a multiple of the font size, so multi-line badges shrink with the font. */
@@ -60,25 +64,42 @@ private val CHIP_SHAPE = RoundedCornerShape(8.dp)
 private val CHIP_H_PADDING = 8.dp
 private val CHIP_V_PADDING = 2.dp
 
+// Route-badge color tokens. We take only the *hue* of the agency's GTFS color and re-derive the chip
+// in HCT (a perceptual space) at a fixed tone + capped chroma, so the agency can't hand us an
+// over-saturated or too-dark/too-light color — every chip lands at a consistent, legible brightness,
+// and the tone flips lighter for dark theme. Fidget with these to taste.
+private const val CHIP_TONE_LIGHT = 42.0        // container tone in light theme (0=black … 100=white)
+private const val CHIP_TONE_DARK = 78.0         // lighter container tone for dark theme
+private const val CHIP_ON_TONE_LIGHT = 100.0    // text tone on the light-theme chip (→ white)
+private const val CHIP_ON_TONE_DARK = 20.0      // text tone on the dark-theme chip (→ near-black)
+private const val CHIP_MAX_CHROMA = 40.0        // cap the saturation the agency color can reach
+private const val ACHROMATIC_CHROMA = 5.0       // below this the source is grey/black/white (no hue)
+
 /**
- * Resolves the (container, content) colors for a route badge chip from the route's GTFS colors. When
- * the route carries a color it fills the chip, with the GTFS text color if present or an auto black/
- * white for legibility; a route with no color falls back to a neutral theme chip. Callers pass the
- * pair straight to [LineBadge]'s `containerColor` / `color`.
+ * Resolves the (container, content) colors for a route-badge chip from the route's GTFS color. We keep
+ * only its hue and regenerate the chip at a fixed HCT tone + capped chroma (see the tokens above), so
+ * the result is a consistent brightness in the active theme regardless of what the agency picked; the
+ * text tone is paired to the container for guaranteed contrast. An achromatic source (grey/black/white)
+ * or a route with no color falls back to a neutral theme chip. Callers pass the pair straight to
+ * [LineBadge]'s `containerColor` / `color`.
  */
+@SuppressLint("RestrictedApi") // Hct is Material Components' vendored color-science util (LIBRARY_GROUP)
 @Composable
-fun rememberRouteBadgeColors(routeColor: Int?, routeTextColor: Int?): Pair<Color, Color> {
+fun rememberRouteBadgeColors(routeColor: Int?): Pair<Color, Color> {
     val neutralContainer = MaterialTheme.colorScheme.surfaceVariant
     val neutralContent = MaterialTheme.colorScheme.onSurfaceVariant
-    return remember(routeColor, routeTextColor, neutralContainer, neutralContent) {
-        val container = routeColor?.let { Color(it or 0xFF000000.toInt()) } ?: neutralContainer
-        val content = when {
-            routeColor == null -> neutralContent
-            routeTextColor != null -> Color(routeTextColor or 0xFF000000.toInt())
-            container.luminance() > 0.5f -> Color.Black
-            else -> Color.White
+    val dark = MaterialTheme.colorScheme.surface.luminance() < 0.5f
+    return remember(routeColor, dark, neutralContainer, neutralContent) {
+        val source = routeColor?.let { Hct.fromInt(it or 0xFF000000.toInt()) }
+        if (source == null || source.chroma < ACHROMATIC_CHROMA) {
+            neutralContainer to neutralContent
+        } else {
+            val chroma = min(source.chroma, CHIP_MAX_CHROMA)
+            val containerTone = if (dark) CHIP_TONE_DARK else CHIP_TONE_LIGHT
+            val contentTone = if (dark) CHIP_ON_TONE_DARK else CHIP_ON_TONE_LIGHT
+            Color(Hct.from(source.hue, chroma, containerTone).toInt()) to
+                Color(Hct.from(source.hue, chroma, contentTone).toInt())
         }
-        container to content
     }
 }
 
@@ -168,8 +189,9 @@ fun LineBadge(
             )
         }
         if (containerColor.isSpecified) {
-            // A rounded chip that hugs the text (wraps content), centered in the fixed-width slot.
-            Surface(color = containerColor, shape = CHIP_SHAPE) {
+            // A rounded chip filling the badge's fixed-width slot (a standard size across rows, not
+            // hugging each name), with the text centered inside.
+            Surface(color = containerColor, shape = CHIP_SHAPE, modifier = Modifier.fillMaxWidth()) {
                 Box(
                     Modifier.padding(horizontal = CHIP_H_PADDING, vertical = CHIP_V_PADDING),
                     contentAlignment = Alignment.Center,
@@ -204,10 +226,10 @@ private fun LineBadgePreview() {
                 // the fixed-width slot. First a GTFS-colored route, then the neutral no-color fallback.
                 Text("On a route-color chip:", color = MaterialTheme.colorScheme.onSurfaceVariant)
                 Row(Modifier.padding(top = 6.dp), verticalAlignment = Alignment.CenterVertically) {
-                    val (green, onGreen) = rememberRouteBadgeColors(0x00A651, null)
+                    val (green, onGreen) = rememberRouteBadgeColors(0x00A651)
                     LineBadge("40", containerColor = green, color = onGreen)
                     Spacer(Modifier.width(12.dp))
-                    val (neutral, onNeutral) = rememberRouteBadgeColors(null, null)
+                    val (neutral, onNeutral) = rememberRouteBadgeColors(null)
                     LineBadge("RapidRide A", containerColor = neutral, color = onNeutral)
                 }
                 Spacer(Modifier.height(16.dp))

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/LineBadge.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/LineBadge.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -32,6 +33,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.isSpecified
+import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.rememberTextMeasurer
@@ -52,6 +55,33 @@ private const val LINE_HEIGHT_RATIO = 1.1f
 /** Each shrink step multiplies the font size by this until the text fits. */
 private const val SHRINK_STEP = 0.9f
 
+/** The chip's corner radius + inner padding when the badge is drawn on a colored surface. */
+private val CHIP_SHAPE = RoundedCornerShape(8.dp)
+private val CHIP_H_PADDING = 8.dp
+private val CHIP_V_PADDING = 2.dp
+
+/**
+ * Resolves the (container, content) colors for a route badge chip from the route's GTFS colors. When
+ * the route carries a color it fills the chip, with the GTFS text color if present or an auto black/
+ * white for legibility; a route with no color falls back to a neutral theme chip. Callers pass the
+ * pair straight to [LineBadge]'s `containerColor` / `color`.
+ */
+@Composable
+fun rememberRouteBadgeColors(routeColor: Int?, routeTextColor: Int?): Pair<Color, Color> {
+    val neutralContainer = MaterialTheme.colorScheme.surfaceVariant
+    val neutralContent = MaterialTheme.colorScheme.onSurfaceVariant
+    return remember(routeColor, routeTextColor, neutralContainer, neutralContent) {
+        val container = routeColor?.let { Color(it or 0xFF000000.toInt()) } ?: neutralContainer
+        val content = when {
+            routeColor == null -> neutralContent
+            routeTextColor != null -> Color(routeTextColor or 0xFF000000.toInt())
+            container.luminance() > 0.5f -> Color.Black
+            else -> Color.White
+        }
+        container to content
+    }
+}
+
 /**
  * A transit "line" identifier badge (a route short name) shown in a fixed-width rectangle: centered,
  * bold, wrapping to at most [maxLines] lines, and auto-shrunk just enough to fit. So a multi-word
@@ -64,7 +94,10 @@ private const val SHRINK_STEP = 0.9f
  * frame (no flash) and resolves even in a static @Preview — an onTextLayout shrink loop would not.
  *
  * Drop it anywhere a route short name sits in a constrained slot (list rows, headers, map callouts).
- * [color] defaults to [Color.Unspecified] so the badge inherits the ambient content color.
+ * [color] defaults to [Color.Unspecified] so the badge inherits the ambient content color. Pass a
+ * [containerColor] (e.g. from [rememberRouteBadgeColors]) to draw the name on a rounded colored chip
+ * that hugs the text and stays centered in the fixed-width slot (so neighboring columns still align);
+ * leave it unspecified for the bare-text badge.
  *
  * @param width the fixed width of the badge rectangle
  * @param maxHeight the height cap for the rectangle; the text also shrinks to fit it (in addition to
@@ -85,10 +118,14 @@ fun LineBadge(
     minFontSize: TextUnit = 12.sp,
     maxLines: Int = 2,
     color: Color = Color.Unspecified,
+    containerColor: Color = Color.Unspecified,
     textDecoration: TextDecoration = TextDecoration.None
 ) {
     val measurer = rememberTextMeasurer()
     val density = LocalDensity.current
+    // On a chip the text sits inside horizontal padding, so shrink-fit against the reduced width so the
+    // chip never grows past the fixed slot (which would collide with the neighboring column).
+    val textWidth = if (containerColor.isSpecified) width - CHIP_H_PADDING * 2 else width
     // Bold and centered; line height tracks the font (a fixed line height would keep two lines the
     // same height as the font shrinks, so a multi-line block could never fit maxHeight).
     val titleLarge = MaterialTheme.typography.titleLarge
@@ -100,12 +137,12 @@ fun LineBadge(
 
     // Largest font in [minFontSize, maxFontSize] whose measured text fits the width × maxHeight /
     // maxLines box; measured here (not via onTextLayout) so it's right on the first frame and in @Preview.
-    val fontSize = remember(text, width, maxHeight, maxFontSize, minFontSize, maxLines, density, baseStyle) {
+    val fontSize = remember(text, textWidth, maxHeight, maxFontSize, minFontSize, maxLines, density, baseStyle) {
         with(density) {
             val constraints = if (maxHeight.isSpecified) {
-                Constraints(maxWidth = width.roundToPx(), maxHeight = maxHeight.roundToPx())
+                Constraints(maxWidth = textWidth.roundToPx(), maxHeight = maxHeight.roundToPx())
             } else {
-                Constraints(maxWidth = width.roundToPx())
+                Constraints(maxWidth = textWidth.roundToPx())
             }
             var size = maxFontSize
             while (size.value > minFontSize.value &&
@@ -121,13 +158,26 @@ fun LineBadge(
         .width(width)
         .let { if (maxHeight.isSpecified) it.heightIn(max = maxHeight) else it }
     Box(boxModifier, contentAlignment = Alignment.Center) {
-        Text(
-            text = text,
-            color = color,
-            style = styleAt(fontSize),
-            maxLines = maxLines,
-            textDecoration = textDecoration
-        )
+        val label = @Composable {
+            Text(
+                text = text,
+                color = color,
+                style = styleAt(fontSize),
+                maxLines = maxLines,
+                textDecoration = textDecoration
+            )
+        }
+        if (containerColor.isSpecified) {
+            // A rounded chip that hugs the text (wraps content), centered in the fixed-width slot.
+            Surface(color = containerColor, shape = CHIP_SHAPE) {
+                Box(
+                    Modifier.padding(horizontal = CHIP_H_PADDING, vertical = CHIP_V_PADDING),
+                    contentAlignment = Alignment.Center,
+                ) { label() }
+            }
+        } else {
+            label()
+        }
     }
 }
 
@@ -148,6 +198,17 @@ private fun LineBadgePreview() {
                         Spacer(Modifier.width(16.dp))
                         Text("\"$label\"", color = MaterialTheme.colorScheme.onSurfaceVariant)
                     }
+                }
+                Spacer(Modifier.height(16.dp))
+                // On a colored chip: the name hugs the text inside a rounded surface, still centered in
+                // the fixed-width slot. First a GTFS-colored route, then the neutral no-color fallback.
+                Text("On a route-color chip:", color = MaterialTheme.colorScheme.onSurfaceVariant)
+                Row(Modifier.padding(top = 6.dp), verticalAlignment = Alignment.CenterVertically) {
+                    val (green, onGreen) = rememberRouteBadgeColors(0x00A651, null)
+                    LineBadge("40", containerColor = green, color = onGreen)
+                    Spacer(Modifier.width(12.dp))
+                    val (neutral, onNeutral) = rememberRouteBadgeColors(null, null)
+                    LineBadge("RapidRide A", containerColor = neutral, color = onNeutral)
                 }
                 Spacer(Modifier.height(16.dp))
                 // The same name forced into shorter rectangles shrinks further to fit the height.


### PR DESCRIPTION
## Summary

Puts each arrival row's route short name on a **rounded chip** colored from the route's GTFS color — but *normalized* so the agency can't hand us an over-saturated or too-dark/too-light color. We keep only the **hue** and regenerate the chip in **HCT** (Material's perceptual Hue-Chroma-Tone space) at a fixed tone with a capped chroma, so every chip lands at a consistent, legible brightness and reads as one system.

## What it does

- **`LineBadge`** gains an optional `containerColor`: when set it draws the short name on a rounded chip that fills the badge's fixed-width slot (a standard size across rows), centered; unset keeps the bare-text badge, so the other `LineBadge` callers are unchanged.
- **`rememberRouteBadgeColors(routeColor)`** resolves the (container, content) pair:
  - Take the GTFS color's HCT **hue**, discard its tone, and rebuild at a fixed **tone** with a **chroma cap** — per theme.
  - **Light:** soft pastel (tone 80, chroma ≤ 30) with dark tinted text.
  - **Dark:** deeper chip (tone 78, chroma ≤ 60) with near-black text.
  - Text tone is paired to the container for guaranteed contrast; an achromatic source (grey/black/white) or a route with no color falls back to a neutral theme chip. Each hue still clamps to its own sRGB gamut limit, so vivid hues (e.g. King County Metro orange) stay themselves instead of muddying to brown.
- **`ArrivalActions`** carries the route's GTFS color (from the route reference in `buildActions`); the Style-A and peek rows resolve the chip colors and pass them to `LineBadge`.

All the tone/chroma tokens are constants at the top of `LineBadge.kt`, easy to tune.

Note: `Hct` lives in Material Components' vendored `color.utilities` package (`@RestrictTo`), suppressed at the one call site with a rationale.

## Testing

`compileObaGoogleDebugKotlin -PwarningsAsErrors=true`, `lintObaGoogleDebug -PwarningsAsErrors=true`, and `testObaGoogleDebugUnitTest` all clean; iterated on device in both light and dark themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Route badges in arrival views now adapt to the route’s color when available.
  * Badge text can appear on a colored chip-style background for better visual distinction.

* **Bug Fixes**
  * Arrival rows and peek rows now consistently use route-specific badge colors instead of default styling.
  * Routes without a provided color continue to use a neutral fallback appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->