### PR TITLE
Route-map header: square route roundel + inline enlarged favorite star

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
@@ -63,6 +63,9 @@ data class RouteHeader(
     val shortName: String,
     val longName: String,
     val agency: String,
+    /** The route's GTFS color (ARGB), or null when the agency didn't set one — the header's route
+     *  badge chip takes its hue, matching the arrival rows. */
+    val routeColor: Int? = null,
     val directions: List<RouteMapDirection> = emptyList(),
     val currentDirectionId: Int? = null,
 )
@@ -260,6 +263,7 @@ class MapViewModel @Inject constructor(
             shortName = MyTextUtils.formatDisplayText(getRouteDisplayName(route))!!,
             longName = MyTextUtils.formatDisplayText(getRouteDescription(route))!!,
             agency = agencyName ?: "",
+            routeColor = route.color,
             directions = directions,
             currentDirectionId = currentDirectionId,
         )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/FavoriteStarButton.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/FavoriteStarButton.kt
@@ -15,6 +15,7 @@
  */
 package org.onebusaway.android.ui.compose.components
 
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LocalContentColor
@@ -23,11 +24,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import org.onebusaway.android.R
 
 /**
  * A star toggle button for favoriting/unfavoriting a route: a filled star when [isFavorite], an outline
- * otherwise, with the matching add/remove-star content description. [onClick] fires on tap.
+ * otherwise, with the matching add/remove-star content description. [onClick] fires on tap. [iconSize]
+ * sizes the star (the Material default 24dp when unset).
  *
  * The shared form of the filled-vs-outline star that several screens (arrivals rows/panel, search
  * results) currently spell out inline; new call sites should use this rather than repeat the ternary.
@@ -38,6 +42,7 @@ fun FavoriteStarButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     tint: Color = LocalContentColor.current,
+    iconSize: Dp = 24.dp,
 ) {
     IconButton(onClick = onClick, modifier = modifier) {
         Icon(
@@ -49,6 +54,7 @@ fun FavoriteStarButton(
                 else R.string.bus_options_menu_add_star
             ),
             tint = tint,
+            modifier = Modifier.size(iconSize),
         )
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/LineBadge.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/LineBadge.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
@@ -120,10 +121,10 @@ fun rememberRouteBadgeColors(routeColor: Int?): Pair<Color, Color> {
  * Drop it anywhere a route short name sits in a constrained slot (list rows, headers, map callouts).
  * [color] defaults to [Color.Unspecified] so the badge inherits the ambient content color. Pass a
  * [containerColor] (e.g. from [rememberRouteBadgeColors]) to draw the name on a rounded colored chip
- * that hugs the text and stays centered in the fixed-width slot (so neighboring columns still align);
- * leave it unspecified for the bare-text badge.
+ * filling the fixed-width slot; leave it unspecified for the bare-text badge. Set [square] to make the
+ * chip a [width]×[width] square tile (a route roundel) with the text shrunk to fit inside it.
  *
- * @param width the fixed width of the badge rectangle
+ * @param width the fixed width of the badge rectangle (also its height when [square])
  * @param maxHeight the height cap for the rectangle; the text also shrinks to fit it (in addition to
  *   [maxLines]). Defaults to roughly two lines at [maxFontSize], so a single big number isn't capped
  *   but a tall multi-line name can't blow up the row. Pass [Dp.Unspecified] to leave it unbounded.
@@ -143,6 +144,7 @@ fun LineBadge(
     maxLines: Int = 2,
     color: Color = Color.Unspecified,
     containerColor: Color = Color.Unspecified,
+    square: Boolean = false,
     textDecoration: TextDecoration = TextDecoration.None
 ) {
     val measurer = rememberTextMeasurer()
@@ -150,6 +152,9 @@ fun LineBadge(
     // On a chip the text sits inside horizontal padding, so shrink-fit against the reduced width so the
     // chip never grows past the fixed slot (which would collide with the neighboring column).
     val textWidth = if (containerColor.isSpecified) width - CHIP_H_PADDING * 2 else width
+    // A square tile is [width]×[width]; the text must also fit that height (minus vertical padding),
+    // so it shrinks to sit inside the square rather than being capped only by [maxHeight].
+    val fitHeight = if (square) width - CHIP_V_PADDING * 2 else maxHeight
     // Bold and centered; line height tracks the font (a fixed line height would keep two lines the
     // same height as the font shrinks, so a multi-line block could never fit maxHeight).
     val titleLarge = MaterialTheme.typography.titleLarge
@@ -161,10 +166,10 @@ fun LineBadge(
 
     // Largest font in [minFontSize, maxFontSize] whose measured text fits the width × maxHeight /
     // maxLines box; measured here (not via onTextLayout) so it's right on the first frame and in @Preview.
-    val fontSize = remember(text, textWidth, maxHeight, maxFontSize, minFontSize, maxLines, density, baseStyle) {
+    val fontSize = remember(text, textWidth, fitHeight, maxFontSize, minFontSize, maxLines, density, baseStyle) {
         with(density) {
-            val constraints = if (maxHeight.isSpecified) {
-                Constraints(maxWidth = textWidth.roundToPx(), maxHeight = maxHeight.roundToPx())
+            val constraints = if (fitHeight.isSpecified) {
+                Constraints(maxWidth = textWidth.roundToPx(), maxHeight = fitHeight.roundToPx())
             } else {
                 Constraints(maxWidth = textWidth.roundToPx())
             }
@@ -180,7 +185,13 @@ fun LineBadge(
     }
     val boxModifier = modifier
         .width(width)
-        .let { if (maxHeight.isSpecified) it.heightIn(max = maxHeight) else it }
+        .let {
+            when {
+                square -> it.height(width)
+                maxHeight.isSpecified -> it.heightIn(max = maxHeight)
+                else -> it
+            }
+        }
     Box(boxModifier, contentAlignment = Alignment.Center) {
         val label = @Composable {
             Text(
@@ -192,9 +203,11 @@ fun LineBadge(
             )
         }
         if (containerColor.isSpecified) {
-            // A rounded chip filling the badge's fixed-width slot (a standard size across rows, not
-            // hugging each name), with the text centered inside.
-            Surface(color = containerColor, shape = CHIP_SHAPE, modifier = Modifier.fillMaxWidth()) {
+            // A rounded chip filling the badge's fixed slot (a standard size across rows, not hugging
+            // each name) — the full square when [square], otherwise the width with wrapped height — with
+            // the text centered inside.
+            val chipModifier = if (square) Modifier.fillMaxSize() else Modifier.fillMaxWidth()
+            Surface(color = containerColor, shape = CHIP_SHAPE, modifier = chipModifier) {
                 Box(
                     Modifier.padding(horizontal = CHIP_H_PADDING, vertical = CHIP_V_PADDING),
                     contentAlignment = Alignment.Center,
@@ -225,8 +238,8 @@ private fun LineBadgePreview() {
                     }
                 }
                 Spacer(Modifier.height(16.dp))
-                // On a colored chip: the name hugs the text inside a rounded surface, still centered in
-                // the fixed-width slot. First a GTFS-colored route, then the neutral no-color fallback.
+                // On a colored chip: the name sits on a rounded surface filling the fixed-width slot,
+                // centered. First a GTFS-colored route, then the neutral no-color fallback.
                 Text("On a route-color chip:", color = MaterialTheme.colorScheme.onSurfaceVariant)
                 Row(Modifier.padding(top = 6.dp), verticalAlignment = Alignment.CenterVertically) {
                     val (green, onGreen) = rememberRouteBadgeColors(0x00A651)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/RouteHeaderOverlay.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/RouteHeaderOverlay.kt
@@ -15,12 +15,12 @@
  */
 package org.onebusaway.android.ui.home.map
 
+import androidx.annotation.DrawableRes
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.AlertDialog
@@ -53,7 +53,14 @@ import org.onebusaway.android.models.RouteMapDirection
 import org.onebusaway.android.ui.compose.components.FavoriteStarButton
 import org.onebusaway.android.ui.compose.components.LineBadge
 import org.onebusaway.android.ui.compose.components.RadioOptionList
+import org.onebusaway.android.ui.compose.components.rememberRouteBadgeColors
 import org.onebusaway.android.ui.compose.theme.ObaTheme
+
+// The route-header action icons (favorite / switch-direction / cancel) share one size + tint so they
+// read as one control group: a larger-than-default 36dp icon in a deliberately tightened 40dp touch box
+// (below Material's 48dp default — a conscious trade-off for a compact header banner).
+private val HEADER_ICON_SIZE = 36.dp
+private val HEADER_ICON_BUTTON_SIZE = 40.dp
 
 /**
  * The route-mode header overlay (the Compose replacement for the legacy `route_info_head.xml` /
@@ -101,72 +108,91 @@ fun RouteHeaderOverlay(
             val directionLabel = header.directions
                 .firstOrNull { it.directionId == header.currentDirectionId }
                 ?.labelOr(unnamed)
-            Box(Modifier.fillMaxWidth()) {
-                Row(
-                    Modifier
-                        .fillMaxWidth()
-                        .padding(4.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    // Auto-shrinks (and wraps) a long route short name to fit a fixed slot rather than
-                    // crowding out the long-name/agency column — the shared route-badge style.
-                    LineBadge(
-                        text = header.shortName,
-                        maxFontSize = 45.sp,
-                        width = 96.dp,
-                        modifier = Modifier.padding(horizontal = 10.dp),
-                    )
-                    Column(Modifier.weight(1f)) {
-                        if (header.longName.isNotEmpty()) {
-                            Text(
-                                text = header.longName,
-                                fontSize = 16.sp,
-                                fontWeight = FontWeight.Bold,
-                                maxLines = 2,
-                                overflow = TextOverflow.Ellipsis,
-                            )
-                        }
-                        if (directionLabel != null) {
-                            Text(
-                                text = directionLabel,
-                                color = MaterialTheme.colorScheme.primary,
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis,
-                            )
-                        }
-                        if (header.agency.isNotEmpty()) {
-                            Text(text = header.agency)
-                        }
-                    }
-                    // A route with a single direction has nothing to switch to — the affordance is hidden.
-                    if (header.directions.size >= 2) {
-                        SwitchDirectionAction(
-                            directions = header.directions,
-                            currentDirectionId = header.currentDirectionId,
-                            onSelectDirection = onSelectDirection,
-                        )
-                    }
-                    IconButton(onClick = onCancel) {
-                        Icon(
-                            painter = painterResource(R.drawable.ic_navigation_close),
-                            contentDescription = stringResource(android.R.string.cancel),
-                        )
-                    }
-                }
-                // Favorites star, floated over the banner's upper-left so it occupies no layout space
-                // (it won't shift the badge). The negative offset cancels most of the IconButton's built-in
-                // inset so the star tucks up into the corner.
+            Row(
+                Modifier
+                    .fillMaxWidth()
+                    .padding(4.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                // The favorite star, inline and to the left of the badge — the first of the shared-style
+                // header action icons (larger icon, tightened touch box).
                 FavoriteStarButton(
                     isFavorite = isFavorite,
                     onClick = onToggleFavorite,
-                    // Match the arrival-row star's outline color so the two read as the same control.
                     tint = colorResource(R.color.navdrawer_icon_tint),
-                    modifier = Modifier
-                        .align(Alignment.TopStart)
-                        .offset(x = (-8).dp, y = (-8).dp),
+                    iconSize = HEADER_ICON_SIZE,
+                    modifier = Modifier.size(HEADER_ICON_BUTTON_SIZE),
+                )
+                // A square route roundel: the short name shrinks to fit inside the tile, on the same
+                // HCT-normalized GTFS-color chip as the arrival rows.
+                val (badgeContainer, badgeContent) = rememberRouteBadgeColors(header.routeColor)
+                LineBadge(
+                    text = header.shortName,
+                    maxFontSize = 45.sp,
+                    width = 64.dp,
+                    square = true,
+                    color = badgeContent,
+                    containerColor = badgeContainer,
+                    modifier = Modifier.padding(horizontal = 10.dp),
+                )
+                Column(Modifier.weight(1f)) {
+                    if (header.longName.isNotEmpty()) {
+                        Text(
+                            text = header.longName,
+                            fontSize = 16.sp,
+                            fontWeight = FontWeight.Bold,
+                            maxLines = 2,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
+                    if (directionLabel != null) {
+                        Text(
+                            text = directionLabel,
+                            color = MaterialTheme.colorScheme.primary,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
+                    if (header.agency.isNotEmpty()) {
+                        Text(text = header.agency)
+                    }
+                }
+                // A route with a single direction has nothing to switch to — the affordance is hidden.
+                if (header.directions.size >= 2) {
+                    SwitchDirectionAction(
+                        directions = header.directions,
+                        currentDirectionId = header.currentDirectionId,
+                        onSelectDirection = onSelectDirection,
+                    )
+                }
+                HeaderIconButton(
+                    iconRes = R.drawable.ic_navigation_close,
+                    contentDescription = stringResource(android.R.string.cancel),
+                    onClick = onCancel,
                 )
             }
         }
+    }
+}
+
+/**
+ * A route-header action icon button in the shared header style: the [HEADER_ICON_SIZE] icon tinted with
+ * the nav-drawer icon color, in the tightened [HEADER_ICON_BUTTON_SIZE] box. Used by the switch-direction
+ * and cancel actions; the favorite star ([FavoriteStarButton]) matches these but stays its own toggle.
+ */
+@Composable
+private fun HeaderIconButton(
+    @DrawableRes iconRes: Int,
+    contentDescription: String,
+    onClick: () -> Unit,
+) {
+    IconButton(onClick = onClick, modifier = Modifier.size(HEADER_ICON_BUTTON_SIZE)) {
+        Icon(
+            painter = painterResource(iconRes),
+            contentDescription = contentDescription,
+            tint = colorResource(R.color.navdrawer_icon_tint),
+            modifier = Modifier.size(HEADER_ICON_SIZE),
+        )
     }
 }
 
@@ -182,20 +208,17 @@ private fun SwitchDirectionAction(
     onSelectDirection: (Int) -> Unit,
 ) {
     var showPicker by remember { mutableStateOf(false) }
-    IconButton(
+    HeaderIconButton(
+        iconRes = R.drawable.ic_swap_direction,
+        contentDescription = stringResource(R.string.route_header_switch_direction),
         onClick = {
             if (directions.size == 2) {
                 onSelectDirection(directions.first { it.directionId != currentDirectionId }.directionId)
             } else {
                 showPicker = true
             }
-        }
-    ) {
-        Icon(
-            painter = painterResource(R.drawable.ic_swap_direction),
-            contentDescription = stringResource(R.string.route_header_switch_direction),
-        )
-    }
+        },
+    )
     if (showPicker) {
         val unnamed = stringResource(R.string.route_direction_unnamed)
         AlertDialog(


### PR DESCRIPTION
## Summary

Follow-up to #1760. Reuses the arrivals route-badge chip in the **route-mode map header**, and reworks the header's action icons to read as one control group.

## What changes

- **Square route roundel** — the header's route short name is now the same GTFS-colored `LineBadge` chip as the arrival rows, drawn as a square tile. `LineBadge` gains a `square` mode: a `width`×`width` tile with the name shrunk to fit inside it. `RouteHeader` carries the route's GTFS color (mirroring `ArrivalActions.routeColor`), resolved to the theme-aware chip via the shared `rememberRouteBadgeColors`.
- **Inline favorite star** — the star moves out of the floated top-left overlay (dropping the negative-offset corner-tuck hack) into the row as an ordinary item to the left of the badge, ~1.5× the default icon. `FavoriteStarButton` gains an `iconSize` param.
- **Unified header action icons** — the star, switch-direction, and cancel icons share one size + tint (36dp icon in a tightened 40dp box, nav-drawer tint) via `HEADER_ICON_SIZE`/`HEADER_ICON_BUTTON_SIZE` tokens and a small `HeaderIconButton` helper, so they look like one group. (The 40dp box is a deliberate trade-off below Material's 48dp default for a compact header banner.)

## Testing

`compileObaGoogleDebugKotlin -PwarningsAsErrors=true` and `lintObaGoogleDebug -PwarningsAsErrors=true` clean; iterated on device in both light and dark themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Route headers now show route color information and can display a more compact square badge style.
  * Favorite star controls now support adjustable icon sizing for more consistent appearances across screens.

* **UI/UX Improvements**
  * Header action buttons have been standardized for a cleaner, more consistent look and touch target size.
  * The favorite star now appears inline with the route header content for a more polished layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->