### PR TITLE
Fix empty long name on starred/recent routes (store-time description resolve)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/database/oba/RouteDao.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/database/oba/RouteDao.kt
@@ -131,9 +131,10 @@ interface RouteDao {
      * Ensures the route row exists with its display name/URL/region (so the Starred Routes folder can
      * JOIN it) **without counting a use** — `use_count` and `access_time` are left untouched, and a new
      * row starts at `use_count = 0`. Favoriting/unfavoriting a route is not a "view", so it must not
-     * bump the recents (`access_time`) or the frequency sort (`use_count`) (#1727 review). Null name/URL
-     * arguments preserve any existing value rather than clobbering it (the arrivals path stars first,
-     * with no URL in hand, then backfills the details from the network).
+     * bump the recents (`access_time`) or the frequency sort (`use_count`) (#1727 review). Null **or
+     * empty** name/URL arguments preserve any existing value rather than clobbering it — a star from a
+     * surface that only has a bare short name (e.g. the route-map header, whose loaded route may carry
+     * an empty long name) must not wipe a good long name; the network backfill fills it in afterward.
      */
     @Transaction
     suspend fun ensureRouteDetails(
@@ -147,8 +148,8 @@ interface RouteDao {
         upsert(
             existing?.copy(
                 shortName = shortName?.takeIf { it.isNotEmpty() } ?: existing.shortName,
-                longName = longName ?: existing.longName,
-                url = url ?: existing.url,
+                longName = longName?.takeIf { it.isNotEmpty() } ?: existing.longName,
+                url = url?.takeIf { it.isNotEmpty() } ?: existing.url,
                 regionId = regionId ?: existing.regionId,
             ) ?: RouteRecord(
                 id = routeId,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/database/oba/RouteFavoritesRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/database/oba/RouteFavoritesRepository.kt
@@ -19,14 +19,19 @@ import android.content.Context
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.launch
 import org.onebusaway.android.R
 import org.onebusaway.android.analytics.ObaAnalytics
 import org.onebusaway.android.analytics.PlausibleAnalytics
+import org.onebusaway.android.api.data.RouteDataSource
+import org.onebusaway.android.app.di.AppScope
 import org.onebusaway.android.region.RegionRepository
+import org.onebusaway.android.util.routeDisplayNames
 
 /**
  * The single owner of route-favorite membership — a wholesale `routes.favorite` bit (#1751). Every
@@ -38,9 +43,11 @@ import org.onebusaway.android.region.RegionRepository
 @Singleton
 class RouteFavoritesRepository @Inject constructor(
     private val routeDao: RouteDao,
+    private val routeDataSource: RouteDataSource,
     private val regionRepository: RegionRepository,
     private val importGate: ImportGate,
     private val obaAnalytics: ObaAnalytics,
+    @param:AppScope private val appScope: CoroutineScope,
     @param:ApplicationContext private val context: Context,
 ) {
 
@@ -59,9 +66,10 @@ class RouteFavoritesRepository @Inject constructor(
     /**
      * Stars (or unstars) [routeId] wholesale. Ensures the `routes` row exists (so the Starred Routes
      * folder can JOIN it for its display name/URL) before flipping the flag, gated on the one-time
-     * import, and reports the bookmark event. Pass [url] when the caller already has the loaded route
-     * (it's stored); pass null to leave any existing URL untouched (the arrivals path backfills the
-     * full details from the network afterward).
+     * import, and reports the bookmark event. Pass whatever [shortName]/[longName]/[url] the caller has
+     * in hand (null/empty values leave any existing value untouched); on a **star** the full details are
+     * then backfilled from the network so the folder always shows a proper long name — regardless of
+     * which surface starred it (the route-map header's loaded route often carries an empty long name).
      */
     suspend fun setFavorite(
         routeId: String,
@@ -73,10 +81,28 @@ class RouteFavoritesRepository @Inject constructor(
         importGate.awaitReady()
         val regionId = regionRepository.region.value?.id
         // Ensure the row for the folder JOIN without counting a "use" — a favorite toggle must not bump
-        // the recents / frequency ordering (#1727 review). Passing url=null preserves any existing URL.
+        // the recents / frequency ordering (#1727 review).
         routeDao.ensureRouteDetails(routeId, shortName, longName, url, regionId)
         routeDao.setFavorite(routeId, if (favorite) 1 else 0)
         reportBookmarkAnalytics(routeId, favorite)
+        // Backfill the full details off the star action's scope, so it completes even if the user
+        // navigates away immediately. Only on a star — an unstar drops the row from the folder anyway.
+        if (favorite) {
+            appScope.launch { backfillRouteDetails(routeId, regionId) }
+        }
+    }
+
+    /**
+     * Fetches the route's full details from the network and writes name/URL back, so a starred route
+     * shows a proper long name in the folder even when the starring surface only had a bare short name.
+     * A no-op if the fetch fails (the row keeps whatever it had). Does not count a "use".
+     */
+    private suspend fun backfillRouteDetails(routeId: String, regionId: Long?) {
+        val route = routeDataSource.getRoute(routeId).getOrNull() ?: return
+        // Resolve the display short/long names with the shared fallbacks (short→long; long→description)
+        // so the folder shows a real name even when the agency ships an empty long_name (e.g. KC Metro).
+        val names = routeDisplayNames(route.shortName, route.longName, route.description)
+        routeDao.ensureRouteDetails(route.id, names.shortName, names.longName, route.url, regionId)
     }
 
     private fun reportBookmarkAnalytics(routeId: String, favorite: Boolean) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsRepository.kt
@@ -17,7 +17,6 @@ package org.onebusaway.android.ui.arrivals
 
 import org.onebusaway.android.api.data.StopArrivalsDataSource
 import org.onebusaway.android.api.data.StopArrivals
-import org.onebusaway.android.api.data.RouteDataSource
 
 import android.content.Context
 import android.os.SystemClock
@@ -33,7 +32,6 @@ import org.onebusaway.android.R
 import org.onebusaway.android.api.ObaApi
 import org.onebusaway.android.api.ObaApiException
 import org.onebusaway.android.database.oba.ImportGate
-import org.onebusaway.android.database.oba.RouteDao
 import org.onebusaway.android.database.oba.RouteFavoritesRepository
 import org.onebusaway.android.database.oba.ServiceAlertDao
 import org.onebusaway.android.database.oba.StopDao
@@ -240,12 +238,10 @@ data class AlertDetails(
 class DefaultArrivalsRepository @Inject constructor(
     @param:ApplicationContext private val context: Context,
     private val regionRepository: RegionRepository,
-    private val routeRepository: RouteDataSource,
     private val stopArrivals: StopArrivalsDataSource,
     private val stopRouteFilterDao: StopRouteFilterDao,
     private val serviceAlertDao: ServiceAlertDao,
     private val stopDao: StopDao,
-    private val routeDao: RouteDao,
     private val routeFavorites: RouteFavoritesRepository,
     private val importGate: ImportGate,
     private val preferences: PreferencesRepository,
@@ -424,28 +420,9 @@ class DefaultArrivalsRepository @Inject constructor(
         favorite: Boolean
     ) {
         // The shared write ensures the row (no URL in hand yet — leaves any existing one), flips the
-        // flag, gates on the import, and reports analytics.
+        // flag, gates on the import, reports analytics, and backfills the full details from the network
+        // on a star so the long name shows in the folder.
         routeFavorites.setFavorite(routeId, shortName, longName, url = null, favorite = favorite)
-        // Backfill the full route details (incl. URL) so the long name can be shown later.
-        fetchAndStoreRouteDetails(routeId, regionRepository.region.value?.id)
-    }
-
-    /** Route-details fetch via the modernized client; writes name/url back. */
-    private suspend fun fetchAndStoreRouteDetails(routeId: String, regionId: Long?) {
-        val route = routeRepository.getRoute(routeId).getOrNull() ?: return
-
-        var shortName = route.shortName
-        var longName = route.longName
-        if (shortName.isNullOrEmpty()) {
-            shortName = longName
-        }
-        if (longName.isNullOrEmpty() || shortName == longName) {
-            longName = route.description
-        }
-
-        // Backfilling details for a just-starred route is part of the favorite action, not a view, so
-        // ensure the row without bumping use_count / access_time (#1727 review).
-        routeDao.ensureRouteDetails(route.id, shortName, longName, route.url, regionId)
     }
 
     override suspend fun setRouteFilter(stopId: String, filter: Set<String>) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/routeinfo/RouteInfoRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/routeinfo/RouteInfoRepository.kt
@@ -88,8 +88,14 @@ class DefaultRouteInfoRepository @Inject constructor(
     /** Records the route in the recents/search table so it appears in recents and search (legacy parity). */
     private suspend fun registerRouteUsage(route: RouteDetails) {
         importGate.awaitReady()
+        // Persist the resolved display names (short→long; long→description fallback), not the raw fields
+        // — legacy DBUtil resolved at store time, and many agencies (e.g. KC Metro) ship an empty
+        // long_name with the real name in description. Storing raw would leave the recents/starred folder
+        // showing only the short-name badge. Uses the same shared resolver as toRouteInfo and the
+        // favorites backfill so every routes-cache write agrees on the display names.
+        val names = routeDisplayNames(route.shortName, route.longName, route.description)
         routeDao.storeRouteDetails(
-            route.id, route.shortName, route.longName, route.url,
+            route.id, names.shortName, names.longName, route.url,
             regionRepository.region.value?.id, System.currentTimeMillis()
         )
     }


### PR DESCRIPTION
## Problem

The **Starred Routes** and **Recent Routes** folders show only the route's short-name badge — no secondary line — for many agencies (e.g. King County Metro).

Root cause is a **data** bug, not a UI trim: the cached `routes.long_name` is persisted **empty**. Those agencies ship an empty `longName` with the real name in `description`. For route 8 (`1_100275`) the API returns:

```
longName:    ""
description: "Seattle Center - Capitol Hill - Rainier Beach"
```

The legacy app resolved `description` → `long_name` **at store time** (`DBUtil.setRouteView`). The storage-modernization port kept that resolve for *display* but persisted the raw empty long name in some write paths, so the folder (which JOINs the cached column) went blank.

## Fix (go-forward write-path resolution)

- **`RouteInfoRepository.registerRouteUsage`** — resolve display names via the shared `routeDisplayNames()` before `storeRouteDetails`, matching `toRouteInfo` and the favorites backfill, instead of persisting raw fields. *(This is the primary root cause.)*
- **`RouteDao.ensureRouteDetails`** — preserve an existing `long_name`/`url` when the incoming value is null **or empty** (was null only; an empty string clobbered good data — a regression from #1727).
- **Centralize the network route-details backfill** into `RouteFavoritesRepository.setFavorite` (on star, fire-and-forget on `@AppScope`) so **both** the arrivals star *and* the route-map header star populate `long_name`. The map-header path previously had **no** backfill at all. Removes the duplicated `fetchAndStoreRouteDetails` and now-unused `RouteDataSource`/`RouteDao` deps from `ArrivalsRepository`.

## Why not a migration?

A SQL migration **cannot** retroactively fix this: the `routes` table has **no `description` column** at any schema version (the data is API-only), and the legacy→Room import (`LegacyDataImporter`) carries the legacy-resolved `long_name` verbatim — so production upgraders already have good names. Existing empty rows self-heal on the next route-info view or re-star.

## Testing

- `./gradlew :onebusaway-android:compileObaGoogleDebugKotlin -PwarningsAsErrors=true` — clean (CI gate).
- JVM unit tests pass (`*RouteDisplay*`, `*RouteInfo*`, `*ArrivalsViewModel*`).
- Installed on device; empty starred routes repopulate after viewing route info / re-starring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Starred routes now keep existing long names and website links when incoming data is missing or empty.
  * Favoriting a route now fills in route details more reliably, improving how starred routes appear later.
  * Recent and route-history entries now use the same display names shown in the app, making route labels more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->