### PR TITLE
Search results: tap a row to go straight to the map

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/nav/ExtraDestinations.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/nav/ExtraDestinations.kt
@@ -92,8 +92,8 @@ fun NavGraphBuilder.extraDestinations(navController: NavHostController) {
         }
     }
     // Search results (system ACTION_SEARCH + the home top-bar search field). The query is a
-    // nav-arg; result taps route to the in-NavHost destinations (route info / arrivals) or
-    // the map. Re-search when the query arg changes (a fresh search reuses this entry).
+    // nav-arg; tapping a result reveals it on the map. Re-search when the query arg changes
+    // (a fresh search reuses this entry).
     composable(
         NavRoutes.SEARCH,
         arguments = listOf(
@@ -116,18 +116,10 @@ fun NavGraphBuilder.extraDestinations(navController: NavHostController) {
             SearchResultsRoute(
                 viewModel = searchVm,
                 onBack = { navController.popBackStack() },
-                onRouteListStops = { route ->
-                    DatabaseEntryPoint.get(activity).routeRecorder()
-                        .recordDetails(route.id, route.shortName, route.longName, route.url)
-                    navController.navigate(NavRoutes.routeInfo(route.id))
-                },
                 onRouteShowOnMap = { route ->
                     DatabaseEntryPoint.get(activity).routeRecorder()
                         .recordDetails(route.id, route.shortName, route.longName, route.url)
                     navController.revealRouteOnMap(route.id)
-                },
-                onStopArrivals = { stop ->
-                    navController.navigate(NavRoutes.arrivals(stop.id))
                 },
                 onStopShowOnMap = { stop ->
                     navController.revealStopOnMap(stop.id, stop.latitude, stop.longitude)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/searchresults/SearchResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/searchresults/SearchResultsScreen.kt
@@ -16,23 +16,16 @@
 package org.onebusaway.android.ui.searchresults
 
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringArrayResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -41,22 +34,19 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import org.onebusaway.android.R
 import org.onebusaway.android.ui.compose.ListUiState
 import org.onebusaway.android.ui.compose.components.ListScreenScaffold
-import org.onebusaway.android.ui.compose.components.MenuHeader
 import org.onebusaway.android.ui.compose.components.RouteRowContent
 import org.onebusaway.android.ui.compose.components.StopRowContent
 import org.onebusaway.android.ui.compose.theme.ObaTheme
 
 /**
- * Stateful entry point: collects the ViewModel's query (title) and results, and forwards each
- * result's chosen action to the host.
+ * Stateful entry point: collects the ViewModel's query (title) and results, and reveals each
+ * tapped result on the map via the host.
  */
 @Composable
 fun SearchResultsRoute(
     viewModel: SearchResultsViewModel,
     onBack: () -> Unit,
-    onRouteListStops: (SearchResultItem.Route) -> Unit,
     onRouteShowOnMap: (SearchResultItem.Route) -> Unit,
-    onStopArrivals: (SearchResultItem.Stop) -> Unit,
     onStopShowOnMap: (SearchResultItem.Stop) -> Unit
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
@@ -65,9 +55,7 @@ fun SearchResultsRoute(
         state = state,
         onRetry = viewModel::retry,
         onBack = onBack,
-        onRouteListStops = onRouteListStops,
         onRouteShowOnMap = onRouteShowOnMap,
-        onStopArrivals = onStopArrivals,
         onStopShowOnMap = onStopShowOnMap
     )
 }
@@ -79,9 +67,7 @@ fun SearchResultsScreen(
     state: ListUiState<SearchResultItem>,
     onRetry: () -> Unit,
     onBack: () -> Unit,
-    onRouteListStops: (SearchResultItem.Route) -> Unit,
     onRouteShowOnMap: (SearchResultItem.Route) -> Unit,
-    onStopArrivals: (SearchResultItem.Stop) -> Unit,
     onStopShowOnMap: (SearchResultItem.Stop) -> Unit
 ) {
     ListScreenScaffold(
@@ -108,8 +94,8 @@ fun SearchResultsScreen(
         }
     ) { item ->
         when (item) {
-            is SearchResultItem.Route -> RouteResultRow(item, onRouteListStops, onRouteShowOnMap)
-            is SearchResultItem.Stop -> StopResultRow(item, onStopArrivals, onStopShowOnMap)
+            is SearchResultItem.Route -> RouteResultRow(item, onRouteShowOnMap)
+            is SearchResultItem.Stop -> StopResultRow(item, onStopShowOnMap)
         }
     }
 }
@@ -117,33 +103,17 @@ fun SearchResultsScreen(
 @Composable
 private fun RouteResultRow(
     route: SearchResultItem.Route,
-    onListStops: (SearchResultItem.Route) -> Unit,
     onShowOnMap: (SearchResultItem.Route) -> Unit
 ) {
-    var menuExpanded by remember { mutableStateOf(false) }
-    val options = stringArrayResource(R.array.search_route_options)
     Column {
-        Box {
-            RouteRowContent(
-                shortName = route.shortName,
-                longName = route.longName,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clickable { menuExpanded = true }
-                    .padding(horizontal = 16.dp, vertical = 12.dp)
-            )
-            DropdownMenu(expanded = menuExpanded, onDismissRequest = { menuExpanded = false }) {
-                MenuHeader(route.longName ?: route.shortName)
-                DropdownMenuItem(
-                    text = { Text(options[0]) },
-                    onClick = { menuExpanded = false; onListStops(route) }
-                )
-                DropdownMenuItem(
-                    text = { Text(options[1]) },
-                    onClick = { menuExpanded = false; onShowOnMap(route) }
-                )
-            }
-        }
+        RouteRowContent(
+            shortName = route.shortName,
+            longName = route.longName,
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable { onShowOnMap(route) }
+                .padding(horizontal = 16.dp, vertical = 12.dp)
+        )
         HorizontalDivider()
     }
 }
@@ -151,34 +121,18 @@ private fun RouteResultRow(
 @Composable
 private fun StopResultRow(
     stop: SearchResultItem.Stop,
-    onArrivals: (SearchResultItem.Stop) -> Unit,
     onShowOnMap: (SearchResultItem.Stop) -> Unit
 ) {
-    var menuExpanded by remember { mutableStateOf(false) }
-    val options = stringArrayResource(R.array.search_stop_options)
     Column {
-        Box {
-            StopRowContent(
-                name = stop.name,
-                direction = stop.direction,
-                isFavorite = stop.isFavorite,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clickable { menuExpanded = true }
-                    .padding(horizontal = 16.dp, vertical = 12.dp)
-            )
-            DropdownMenu(expanded = menuExpanded, onDismissRequest = { menuExpanded = false }) {
-                MenuHeader(stop.name)
-                DropdownMenuItem(
-                    text = { Text(options[0]) },
-                    onClick = { menuExpanded = false; onArrivals(stop) }
-                )
-                DropdownMenuItem(
-                    text = { Text(options[1]) },
-                    onClick = { menuExpanded = false; onShowOnMap(stop) }
-                )
-            }
-        }
+        StopRowContent(
+            name = stop.name,
+            direction = stop.direction,
+            isFavorite = stop.isFavorite,
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable { onShowOnMap(stop) }
+                .padding(horizontal = 16.dp, vertical = 12.dp)
+        )
         HorizontalDivider()
     }
 }
@@ -197,7 +151,7 @@ private fun SearchResultsScreenSuccessPreview() {
                 )
             ),
             onRetry = {}, onBack = {},
-            onRouteListStops = {}, onRouteShowOnMap = {}, onStopArrivals = {}, onStopShowOnMap = {}
+            onRouteShowOnMap = {}, onStopShowOnMap = {}
         )
     }
 }
@@ -210,7 +164,7 @@ private fun SearchResultsScreenEmptyPreview() {
             title = "zzzz",
             state = ListUiState.Success(emptyList()),
             onRetry = {}, onBack = {},
-            onRouteListStops = {}, onRouteShowOnMap = {}, onStopArrivals = {}, onStopShowOnMap = {}
+            onRouteShowOnMap = {}, onStopShowOnMap = {}
         )
     }
 }
@@ -223,7 +177,7 @@ private fun SearchResultsScreenLoadingPreview() {
             title = "8",
             state = ListUiState.Loading,
             onRetry = {}, onBack = {},
-            onRouteListStops = {}, onRouteShowOnMap = {}, onStopArrivals = {}, onStopShowOnMap = {}
+            onRouteShowOnMap = {}, onStopShowOnMap = {}
         )
     }
 }

--- a/onebusaway-android/src/main/res/values-es/arrays.xml
+++ b/onebusaway-android/src/main/res/values-es/arrays.xml
@@ -42,14 +42,6 @@
         <item>Llegada estimada</item>
         <item>Ruta</item>
     </string-array>
-    <string-array name="search_stop_options">
-        <item>Mostrar llegadas</item>
-        <item>Mostrar sobre el mapa</item>
-    </string-array>
-    <string-array name="search_route_options">
-        <item>Mostrar la lista de paradas</item>
-        <item>Mostrar sobre el mapa</item>
-    </string-array>
     <string-array name="reminder_time">
         <item>1 minuto</item>
         <item>3 minutos</item>

--- a/onebusaway-android/src/main/res/values-fi/arrays.xml
+++ b/onebusaway-android/src/main/res/values-fi/arrays.xml
@@ -33,14 +33,6 @@
         <item>Nimi</item>
         <item>Useiten käytetty</item>
     </string-array>
-    <string-array name="search_stop_options">
-        <item>Näytä saapuvat</item>
-        <item>Näytä kartalla</item>
-    </string-array>
-    <string-array name="search_route_options">
-        <item>Näytä lista pysäkeistä</item>
-        <item>Näytä kartalla</item>
-    </string-array>
     <string-array name="reminder_time">
         <item>1 minuutti</item>
         <item>3 minuuttia</item>

--- a/onebusaway-android/src/main/res/values-it/arrays.xml
+++ b/onebusaway-android/src/main/res/values-it/arrays.xml
@@ -41,14 +41,6 @@
         <item>Arrivo stimato</item>
         <item>Linea</item>
     </string-array>
-    <string-array name="search_stop_options">
-        <item>Mostra arrivi</item>
-        <item>Mostra sulla mappa</item>
-    </string-array>
-    <string-array name="search_route_options">
-        <item>Mostra lista fermate</item>
-        <item>Mostra sulla mappa</item>
-    </string-array>
     <string-array name="reminder_time">
         <item>1 minuto</item>
         <item>3 minuti</item>

--- a/onebusaway-android/src/main/res/values-pl/arrays.xml
+++ b/onebusaway-android/src/main/res/values-pl/arrays.xml
@@ -42,14 +42,6 @@
         <item>Szacowany przyjazd</item>
         <item>Linia</item>
     </string-array>
-    <string-array name="search_stop_options">
-        <item>Pokaż przyjazdy</item>
-        <item>Pokaż na mapie</item>
-    </string-array>
-    <string-array name="search_route_options">
-        <item>Pokaż listę przystanków</item>
-        <item>Pokaż na mapie</item>
-    </string-array>
     <string-array name="reminder_time">
         <item>1 minuta</item>
         <item>3 minuty</item>

--- a/onebusaway-android/src/main/res/values/arrays.xml
+++ b/onebusaway-android/src/main/res/values/arrays.xml
@@ -42,14 +42,6 @@
         <item>Estimated arrival</item>
         <item>Route</item>
     </string-array>
-    <string-array name="search_stop_options">
-        <item>Show arrivals</item>
-        <item>Show on map</item>
-    </string-array>
-    <string-array name="search_route_options">
-        <item>Show list of stops</item>
-        <item>Show on map</item>
-    </string-array>
     <string-array name="reminder_time">
         <item>1 minute</item>
         <item>3 minutes</item>


### PR DESCRIPTION
## What

In the search results pane, tapping a result row now **reveals it on the map directly** instead of opening a dropdown menu. The menu is removed entirely, along with its secondary actions ("Show list of stops" for routes, "Show arrivals" for stops). A tap now does exactly what the old **Show on map** item did.

## Why

Simplifies the search-result interaction to a single, predictable gesture — from the map you can still tap through to a route's stops or a stop's arrivals.

## Changes

- **`SearchResultsScreen.kt`** — each row calls `onShowOnMap(...)` on tap; removed the `DropdownMenu`, its per-row `menuExpanded` state, the `MenuHeader`, and the now-unused list-stops/arrivals callback parameters (through `SearchResultsRoute`, `SearchResultsScreen`, and the previews). Dropped the orphaned imports.
- **`ExtraDestinations.kt`** — removed the `onRouteListStops` / `onStopArrivals` callback wiring. The route path still records the route into recents (`recordDetails`) before `revealRouteOnMap`, matching the old "Show on map" behavior; the stop path calls `revealStopOnMap`.
- **`arrays.xml` (values + es/fi/it/pl)** — removed the now-unused `search_stop_options` / `search_route_options` string arrays across all five locales (they would otherwise trip the `UnusedResources` lint gate).

## Verification

- `compileObaGoogleDebugKotlin -PwarningsAsErrors=true` → BUILD SUCCESSFUL (zero warnings)
- `lintObaGoogleDebug -PwarningsAsErrors=true` → no new issues
- Built and installed `obaGoogleDebug` on a physical device.

## Note

The legacy search UI (`ui/search/RouteSearchContent.kt`, `StopSearchContent.kt`) still uses the same dropdown-over-a-row pattern; giving those the same treatment is a natural follow-up but out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)