### PR TITLE
Radiating ping on the vehicle when an ETA pill recontextualizes the map (#1764)

### DIFF
--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
@@ -395,26 +395,27 @@ class GoogleMapRenderer(
     fun renderDynamic(overlay: TripOverlay?, vehicles: MapVehicles?, nowMs: Long) {
         moveVehicles(vehicles, nowMs)
         updateTripOverlay(overlay, nowMs)
-        updatePing(nowMs)
     }
 
-    /** Start a one-shot ping ripple at [point]; the frame loop animates it (#1764). */
+    /** Start a one-shot ping ripple at [point]; the adapter drives [tickPing] to animate it (#1764). */
     fun startPing(point: GeoPoint) {
         clearPing()
         pingPoint = point
-        pingStartMs = 0L // stamped on the first frame that draws it
+        pingStartMs = 0L // stamped on the first tick
     }
 
-    // Advance the ping ripple: grow the Circle's radius (from a target screen size via the current zoom, so
-    // it reads at a consistent on-screen size) and fade its stroke, removing it when the ripple completes.
-    // Circles draw beneath all markers in gms, so the vehicle icon stays crisp on top.
-    private fun updatePing(nowMs: Long) {
-        val point = pingPoint ?: return
+    // Advance the ping ripple one frame: grow the Circle's radius (from a target screen size via the current
+    // zoom, so it reads at a consistent on-screen size) and fade its stroke. Returns false — and removes the
+    // Circle — when the ripple completes. Driven by the adapter's own full-rate frame loop (not the 20Hz
+    // vehicle loop) so the ripple is smooth. Circles draw beneath all markers in gms, so the vehicle icon
+    // stays crisp on top.
+    fun tickPing(nowMs: Long): Boolean {
+        val point = pingPoint ?: return false
         if (pingStartMs == 0L) pingStartMs = nowMs
         val elapsed = nowMs - pingStartMs
         if (MapPing.isDone(elapsed)) {
             clearPing()
-            return
+            return false
         }
         val progress = MapPing.progress(elapsed)
         val radiusPx = MapPing.MAX_RADIUS_DP * density * MapPing.radiusFraction(progress)
@@ -438,6 +439,7 @@ class GoogleMapRenderer(
             existing.radius = radiusMeters
             existing.strokeColor = color
         }
+        return true
     }
 
     private fun clearPing() {

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
@@ -60,6 +60,7 @@ import org.onebusaway.android.map.render.VehicleBitmaps
 import org.onebusaway.android.map.render.VehicleMarker
 import org.onebusaway.android.map.render.bikeZoomBand
 import org.onebusaway.android.map.render.stopIconKind
+import org.onebusaway.android.time.WallTime
 import org.onebusaway.android.util.MyTextUtils
 import org.onebusaway.android.util.getRouteDisplayName
 import java.util.concurrent.TimeUnit
@@ -152,12 +153,12 @@ class GoogleMapRenderer(
     // data" + fix-age info window (the SDK's default title/snippet). Null when nothing is selected.
     private var mostRecentDataMarker: Marker? = null
 
-    // The one-shot "ping" ripple (#1764): a native Circle grown + faded over [MapPing.DURATION_MS], centered
-    // each frame on trip [pingTripId]'s vehicle marker (so it follows the icon as it settles). [pingStartMs]
-    // is 0 until the first tick stamps it (the animation clock is the frame clock); null id means no ping.
+    // The one-shot "ping" ripple (#1764): a native Circle grown + faded over [MapPing.DURATION], centered
+    // each frame on trip [pingTripId]'s vehicle marker (so it follows the icon as it settles). [pingStart]
+    // is null until the first tick stamps it (the animation clock is the frame's wall clock); null id = no ping.
     private var pingCircle: Circle? = null
     private var pingTripId: String? = null
-    private var pingStartMs: Long = 0L
+    private var pingStart: WallTime? = null
     private val pingColor by lazy { ContextCompat.getColor(context, R.color.theme_primary) }
 
     private val bikeIcons by lazy { BikeIcons(context) }
@@ -402,8 +403,11 @@ class GoogleMapRenderer(
     override fun startPing(tripId: String) {
         clearPing()
         pingTripId = tripId
-        pingStartMs = 0L // stamped on the first tick
+        pingStart = null // stamped on the first tick
     }
+
+    /** Remove any in-flight ping ripple (a superseded/cancelled ping). */
+    override fun cancelPing() = clearPing()
 
     // Advance the ping ripple one frame: recenter on the vehicle marker's live position (so it follows the
     // icon as it slides from its raw fallback onto its shape-projected spot), grow the Circle's radius (from
@@ -411,11 +415,11 @@ class GoogleMapRenderer(
     // stroke. Returns false — and removes the Circle — when the ripple completes or the vehicle is gone.
     // Driven by the driver's own full-rate frame loop (not the 20Hz vehicle loop) so the ripple is smooth.
     // Circles draw beneath all markers in gms, so the vehicle icon stays crisp on top.
-    override fun tickPing(nowMs: Long): Boolean {
+    override fun tickPing(now: WallTime): Boolean {
         val tripId = pingTripId ?: return false
         val center = vehicleMarkersByTripId[tripId]?.position ?: run { clearPing(); return false }
-        if (pingStartMs == 0L) pingStartMs = nowMs
-        val elapsed = nowMs - pingStartMs
+        val start = pingStart ?: now.also { pingStart = it }
+        val elapsed = now - start
         if (MapPing.isDone(elapsed)) {
             clearPing()
             return false
@@ -450,7 +454,7 @@ class GoogleMapRenderer(
         pingCircle?.remove()
         pingCircle = null
         pingTripId = null
-        pingStartMs = 0L
+        pingStart = null
     }
 
     /**

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
@@ -48,6 +48,7 @@ import org.onebusaway.android.map.render.GeoPoint
 import org.onebusaway.android.map.render.MapPing
 import org.onebusaway.android.map.render.MapRenderState
 import org.onebusaway.android.map.render.MarkerRendering
+import org.onebusaway.android.map.render.PingTarget
 import org.onebusaway.android.map.render.MapVehicles
 import org.onebusaway.android.map.render.StopBand
 import org.onebusaway.android.map.render.StopIconKind
@@ -86,7 +87,7 @@ class GoogleMapRenderer(
     private val map: GoogleMap,
     private val context: Context,
     private val renderState: MapRenderState,
-) {
+) : PingTarget {
     private val stopByMarker = HashMap<Marker, StopMarker>()
 
     // Stop markers tracked by stop id so [reconcileStopMarkers] can diff them in place (add new,
@@ -397,8 +398,8 @@ class GoogleMapRenderer(
         updateTripOverlay(overlay, nowMs)
     }
 
-    /** Start a one-shot ping ripple at [point]; the adapter drives [tickPing] to animate it (#1764). */
-    fun startPing(point: GeoPoint) {
+    /** Start a one-shot ping ripple at [point]; the driver calls [tickPing] to animate it (#1764). */
+    override fun startPing(point: GeoPoint) {
         clearPing()
         pingPoint = point
         pingStartMs = 0L // stamped on the first tick
@@ -409,7 +410,7 @@ class GoogleMapRenderer(
     // Circle — when the ripple completes. Driven by the adapter's own full-rate frame loop (not the 20Hz
     // vehicle loop) so the ripple is smooth. Circles draw beneath all markers in gms, so the vehicle icon
     // stays crisp on top.
-    fun tickPing(nowMs: Long): Boolean {
+    override fun tickPing(nowMs: Long): Boolean {
         val point = pingPoint ?: return false
         if (pingStartMs == 0L) pingStartMs = nowMs
         val elapsed = nowMs - pingStartMs

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
@@ -152,11 +152,11 @@ class GoogleMapRenderer(
     // data" + fix-age info window (the SDK's default title/snippet). Null when nothing is selected.
     private var mostRecentDataMarker: Marker? = null
 
-    // The one-shot "ping" ripple (#1764): a native Circle grown + faded over [MapPing.DURATION_MS] from a
-    // just-focused vehicle. [pingStartMs] is 0 until the first frame stamps it (so the animation clock is
-    // the renderer's own frame clock); null circle means no ping in flight.
+    // The one-shot "ping" ripple (#1764): a native Circle grown + faded over [MapPing.DURATION_MS], centered
+    // each frame on trip [pingTripId]'s vehicle marker (so it follows the icon as it settles). [pingStartMs]
+    // is 0 until the first tick stamps it (the animation clock is the frame clock); null id means no ping.
     private var pingCircle: Circle? = null
-    private var pingPoint: GeoPoint? = null
+    private var pingTripId: String? = null
     private var pingStartMs: Long = 0L
     private val pingColor by lazy { ContextCompat.getColor(context, R.color.theme_primary) }
 
@@ -398,20 +398,22 @@ class GoogleMapRenderer(
         updateTripOverlay(overlay, nowMs)
     }
 
-    /** Start a one-shot ping ripple at [point]; the driver calls [tickPing] to animate it (#1764). */
-    override fun startPing(point: GeoPoint) {
+    /** Start a one-shot ping ripple on trip [tripId]'s vehicle; the driver calls [tickPing] to animate it (#1764). */
+    override fun startPing(tripId: String) {
         clearPing()
-        pingPoint = point
+        pingTripId = tripId
         pingStartMs = 0L // stamped on the first tick
     }
 
-    // Advance the ping ripple one frame: grow the Circle's radius (from a target screen size via the current
-    // zoom, so it reads at a consistent on-screen size) and fade its stroke. Returns false — and removes the
-    // Circle — when the ripple completes. Driven by the adapter's own full-rate frame loop (not the 20Hz
-    // vehicle loop) so the ripple is smooth. Circles draw beneath all markers in gms, so the vehicle icon
-    // stays crisp on top.
+    // Advance the ping ripple one frame: recenter on the vehicle marker's live position (so it follows the
+    // icon as it slides from its raw fallback onto its shape-projected spot), grow the Circle's radius (from
+    // a target screen size via the current zoom, so it reads at a consistent on-screen size), and fade its
+    // stroke. Returns false — and removes the Circle — when the ripple completes or the vehicle is gone.
+    // Driven by the driver's own full-rate frame loop (not the 20Hz vehicle loop) so the ripple is smooth.
+    // Circles draw beneath all markers in gms, so the vehicle icon stays crisp on top.
     override fun tickPing(nowMs: Long): Boolean {
-        val point = pingPoint ?: return false
+        val tripId = pingTripId ?: return false
+        val center = vehicleMarkersByTripId[tripId]?.position ?: run { clearPing(); return false }
         if (pingStartMs == 0L) pingStartMs = nowMs
         val elapsed = nowMs - pingStartMs
         if (MapPing.isDone(elapsed)) {
@@ -421,14 +423,14 @@ class GoogleMapRenderer(
         val progress = MapPing.progress(elapsed)
         val radiusPx = MapPing.MAX_RADIUS_DP * density * MapPing.radiusFraction(progress)
         val metersPerPx =
-            156543.03392 * cos(Math.toRadians(point.latitude)) / 2.0.pow(map.cameraPosition.zoom.toDouble())
+            156543.03392 * cos(Math.toRadians(center.latitude)) / 2.0.pow(map.cameraPosition.zoom.toDouble())
         val radiusMeters = radiusPx * metersPerPx
         val color = MapPing.withAlpha(pingColor, MapPing.alpha(progress))
         val existing = pingCircle
         if (existing == null) {
             pingCircle = map.addCircle(
                 CircleOptions()
-                    .center(point.toLatLng())
+                    .center(center)
                     .radius(radiusMeters)
                     .strokeColor(color)
                     .strokeWidth(MapPing.STROKE_DP * density)
@@ -437,6 +439,7 @@ class GoogleMapRenderer(
                     .zIndex(PING_Z_INDEX)
             )
         } else {
+            existing.center = center
             existing.radius = radiusMeters
             existing.strokeColor = color
         }
@@ -446,7 +449,7 @@ class GoogleMapRenderer(
     private fun clearPing() {
         pingCircle?.remove()
         pingCircle = null
-        pingPoint = null
+        pingTripId = null
         pingStartMs = 0L
     }
 

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
@@ -18,9 +18,14 @@ package org.onebusaway.android.map.googlemapsv2
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.Color
+import androidx.core.content.ContextCompat
+import kotlin.math.cos
+import kotlin.math.pow
 import com.google.android.gms.maps.GoogleMap
 import com.google.android.gms.maps.model.BitmapDescriptor
 import com.google.android.gms.maps.model.BitmapDescriptorFactory
+import com.google.android.gms.maps.model.Circle
+import com.google.android.gms.maps.model.CircleOptions
 import com.google.android.gms.maps.model.LatLng
 import com.google.android.gms.maps.model.Marker
 import com.google.android.gms.maps.model.MarkerOptions
@@ -40,6 +45,7 @@ import org.onebusaway.android.map.render.BikeBand
 import org.onebusaway.android.map.render.BikeMarker
 import org.onebusaway.android.map.render.CorrectionSmoother
 import org.onebusaway.android.map.render.GeoPoint
+import org.onebusaway.android.map.render.MapPing
 import org.onebusaway.android.map.render.MapRenderState
 import org.onebusaway.android.map.render.MarkerRendering
 import org.onebusaway.android.map.render.MapVehicles
@@ -144,6 +150,14 @@ class GoogleMapRenderer(
     // live estimate was last corrected from), shown while a vehicle is selected, with a "Most recent
     // data" + fix-age info window (the SDK's default title/snippet). Null when nothing is selected.
     private var mostRecentDataMarker: Marker? = null
+
+    // The one-shot "ping" ripple (#1764): a native Circle grown + faded over [MapPing.DURATION_MS] from a
+    // just-focused vehicle. [pingStartMs] is 0 until the first frame stamps it (so the animation clock is
+    // the renderer's own frame clock); null circle means no ping in flight.
+    private var pingCircle: Circle? = null
+    private var pingPoint: GeoPoint? = null
+    private var pingStartMs: Long = 0L
+    private val pingColor by lazy { ContextCompat.getColor(context, R.color.theme_primary) }
 
     private val bikeIcons by lazy { BikeIcons(context) }
 
@@ -363,6 +377,8 @@ class GoogleMapRenderer(
         mostRecentDataMarker?.remove()
         mostRecentDataMarker = null
 
+        clearPing()
+
         fastEstimate.dispose()
 
         // Drop our wrapped descriptors so their native textures are released once the markers using them
@@ -379,6 +395,56 @@ class GoogleMapRenderer(
     fun renderDynamic(overlay: TripOverlay?, vehicles: MapVehicles?, nowMs: Long) {
         moveVehicles(vehicles, nowMs)
         updateTripOverlay(overlay, nowMs)
+        updatePing(nowMs)
+    }
+
+    /** Start a one-shot ping ripple at [point]; the frame loop animates it (#1764). */
+    fun startPing(point: GeoPoint) {
+        clearPing()
+        pingPoint = point
+        pingStartMs = 0L // stamped on the first frame that draws it
+    }
+
+    // Advance the ping ripple: grow the Circle's radius (from a target screen size via the current zoom, so
+    // it reads at a consistent on-screen size) and fade its stroke, removing it when the ripple completes.
+    // Circles draw beneath all markers in gms, so the vehicle icon stays crisp on top.
+    private fun updatePing(nowMs: Long) {
+        val point = pingPoint ?: return
+        if (pingStartMs == 0L) pingStartMs = nowMs
+        val elapsed = nowMs - pingStartMs
+        if (MapPing.isDone(elapsed)) {
+            clearPing()
+            return
+        }
+        val progress = MapPing.progress(elapsed)
+        val radiusPx = MapPing.MAX_RADIUS_DP * density * MapPing.radiusFraction(progress)
+        val metersPerPx =
+            156543.03392 * cos(Math.toRadians(point.latitude)) / 2.0.pow(map.cameraPosition.zoom.toDouble())
+        val radiusMeters = radiusPx * metersPerPx
+        val color = MapPing.withAlpha(pingColor, MapPing.alpha(progress))
+        val existing = pingCircle
+        if (existing == null) {
+            pingCircle = map.addCircle(
+                CircleOptions()
+                    .center(point.toLatLng())
+                    .radius(radiusMeters)
+                    .strokeColor(color)
+                    .strokeWidth(MapPing.STROKE_DP * density)
+                    .fillColor(Color.TRANSPARENT)
+                    .clickable(false)
+                    .zIndex(PING_Z_INDEX)
+            )
+        } else {
+            existing.radius = radiusMeters
+            existing.strokeColor = color
+        }
+    }
+
+    private fun clearPing() {
+        pingCircle?.remove()
+        pingCircle = null
+        pingPoint = null
+        pingStartMs = 0L
     }
 
     /**
@@ -649,6 +715,10 @@ class GoogleMapRenderer(
         // The uncertainty band draws above the static route line; the fast-estimate marker above the band.
         private const val TRIP_BAND_Z_INDEX = 2f
         private const val FAST_ESTIMATE_Z_INDEX = 4f
+
+        // The ping ripple draws above the route line/band (gms always draws Circles beneath markers, so it
+        // never covers the vehicle icon regardless of this value).
+        private const val PING_Z_INDEX = 3f
 
         // The (arbitrary, constant) ease key for a TripEstimateMarker's single-marker easer.
         private const val ESTIMATE_EASE_KEY = "estimate"

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleComposeAdapter.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleComposeAdapter.kt
@@ -231,6 +231,10 @@ class GoogleComposeAdapter : ObaComposeMapAdapter {
                         }
                     }
             }
+            // One-shot vehicle pings: hand each to the renderer, which animates it over the frame loop above.
+            LaunchedEffect(activeRenderer) {
+                renderState.mapPings.collect { activeRenderer.startPing(it) }
+            }
         }
 
         val map = googleMap

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleComposeAdapter.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleComposeAdapter.kt
@@ -48,10 +48,7 @@ import com.google.android.gms.maps.model.MapStyleOptions
 import com.google.android.gms.maps.model.Marker
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.filterNotNull
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.withTimeoutOrNull
 import org.onebusaway.android.R
 import org.onebusaway.android.map.MapHost
 import org.onebusaway.android.time.WallTime
@@ -60,9 +57,9 @@ import org.onebusaway.android.map.compose.ObaComposeMapAdapter
 import org.onebusaway.android.map.compose.ObaMapCallbacks
 import org.onebusaway.android.map.compose.VehicleInfoWindow
 import org.onebusaway.android.map.googlemapsv2.GoogleMapRenderer
+import org.onebusaway.android.map.compose.drivePings
 import org.onebusaway.android.map.render.CameraSnapshot
 import org.onebusaway.android.map.render.GeoPoint
-import org.onebusaway.android.map.render.MapPing
 import org.onebusaway.android.map.render.MapProjector
 import org.onebusaway.android.map.render.ScreenOffset
 import org.onebusaway.android.ui.compose.findActivity
@@ -235,17 +232,10 @@ class GoogleComposeAdapter : ObaComposeMapAdapter {
                         }
                     }
             }
-            // One-shot vehicle pings: fire strictly after the framing pan settles (await the next camera
-            // idle, bounded in case the fit didn't move the camera), then animate at the full display rate —
-            // off the vehicle loop's 20Hz cap — so the ripple is smooth (#1764).
+            // One-shot vehicle pings — the flavor-neutral driver waits for the pan to settle then animates
+            // the ripple at the full display rate (#1764).
             LaunchedEffect(activeRenderer) {
-                renderState.mapPings.collectLatest { point ->
-                    withTimeoutOrNull(MapPing.SETTLE_TIMEOUT_MS) { host.camera.drop(1).first() }
-                    activeRenderer.startPing(point)
-                    while (activeRenderer.tickPing(WallTime.now().epochMs)) {
-                        withFrameNanos { }
-                    }
-                }
+                drivePings(renderState.mapPings, host.camera, activeRenderer)
             }
         }
 

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleComposeAdapter.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleComposeAdapter.kt
@@ -48,7 +48,10 @@ import com.google.android.gms.maps.model.MapStyleOptions
 import com.google.android.gms.maps.model.Marker
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withTimeoutOrNull
 import org.onebusaway.android.R
 import org.onebusaway.android.map.MapHost
 import org.onebusaway.android.time.WallTime
@@ -59,6 +62,7 @@ import org.onebusaway.android.map.compose.VehicleInfoWindow
 import org.onebusaway.android.map.googlemapsv2.GoogleMapRenderer
 import org.onebusaway.android.map.render.CameraSnapshot
 import org.onebusaway.android.map.render.GeoPoint
+import org.onebusaway.android.map.render.MapPing
 import org.onebusaway.android.map.render.MapProjector
 import org.onebusaway.android.map.render.ScreenOffset
 import org.onebusaway.android.ui.compose.findActivity
@@ -231,9 +235,17 @@ class GoogleComposeAdapter : ObaComposeMapAdapter {
                         }
                     }
             }
-            // One-shot vehicle pings: hand each to the renderer, which animates it over the frame loop above.
+            // One-shot vehicle pings: fire strictly after the framing pan settles (await the next camera
+            // idle, bounded in case the fit didn't move the camera), then animate at the full display rate —
+            // off the vehicle loop's 20Hz cap — so the ripple is smooth (#1764).
             LaunchedEffect(activeRenderer) {
-                renderState.mapPings.collect { activeRenderer.startPing(it) }
+                renderState.mapPings.collectLatest { point ->
+                    withTimeoutOrNull(MapPing.SETTLE_TIMEOUT_MS) { host.camera.drop(1).first() }
+                    activeRenderer.startPing(point)
+                    while (activeRenderer.tickPing(WallTime.now().epochMs)) {
+                        withFrameNanos { }
+                    }
+                }
             }
         }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
@@ -234,6 +234,8 @@ class RouteMapController(
                 // Fit the vehicle and its originating stop together (the stop is dropped only if it's
                 // somehow not in the loaded route, leaving the vehicle framed alone at a comfortable zoom).
                 host.frame(FramingIntent.Points(listOfNotNull(marker?.point, originatingStopPoint())))
+                // Radiate a ping from the vehicle so it's clear which one this arrival is querying (#1764).
+                marker?.point?.let { renderState.emitPing(it) }
             }
             FocusResolution.DROP -> {
                 pendingFocus = null

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
@@ -234,8 +234,9 @@ class RouteMapController(
                 // Fit the vehicle and its originating stop together (the stop is dropped only if it's
                 // somehow not in the loaded route, leaving the vehicle framed alone at a comfortable zoom).
                 host.frame(FramingIntent.Points(listOfNotNull(marker?.point, originatingStopPoint())))
-                // Radiate a ping from the vehicle so it's clear which one this arrival is querying (#1764).
-                marker?.point?.let { renderState.emitPing(it) }
+                // Radiate a ping from the vehicle so it's clear which one this arrival is querying (#1764);
+                // keyed by trip id so the ripple follows the marker as it settles onto its projected spot.
+                renderState.emitPing(focus.tripId)
             }
             FocusResolution.DROP -> {
                 pendingFocus = null

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/compose/MapPingDriver.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/compose/MapPingDriver.kt
@@ -41,10 +41,16 @@ suspend fun drivePings(
     target: PingTarget,
 ) {
     pings.collectLatest { tripId ->
-        withTimeoutOrNull(MapPing.SETTLE_TIMEOUT_MS) { camera.drop(1).first() }
-        target.startPing(tripId)
-        while (target.tickPing(WallTime.now().epochMs)) {
-            withFrameNanos { }
+        // collectLatest cancels this block when a newer ping arrives; clear any in-flight ripple in the
+        // finally so a superseded ping doesn't linger frozen on screen through the next one's settle wait.
+        try {
+            withTimeoutOrNull(MapPing.SETTLE_TIMEOUT) { camera.drop(1).first() }
+            target.startPing(tripId)
+            while (target.tickPing(WallTime.now())) {
+                withFrameNanos { }
+            }
+        } finally {
+            target.cancelPing()
         }
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/compose/MapPingDriver.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/compose/MapPingDriver.kt
@@ -23,7 +23,6 @@ import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withTimeoutOrNull
 import org.onebusaway.android.map.render.CameraSnapshot
-import org.onebusaway.android.map.render.GeoPoint
 import org.onebusaway.android.map.render.MapPing
 import org.onebusaway.android.map.render.PingTarget
 import org.onebusaway.android.time.WallTime
@@ -37,13 +36,13 @@ import org.onebusaway.android.time.WallTime
  * so a newer ping supersedes one still waiting/animating. Call from each adapter's `LaunchedEffect`.
  */
 suspend fun drivePings(
-    pings: SharedFlow<GeoPoint>,
+    pings: SharedFlow<String>,
     camera: StateFlow<CameraSnapshot?>,
     target: PingTarget,
 ) {
-    pings.collectLatest { point ->
+    pings.collectLatest { tripId ->
         withTimeoutOrNull(MapPing.SETTLE_TIMEOUT_MS) { camera.drop(1).first() }
-        target.startPing(point)
+        target.startPing(tripId)
         while (target.tickPing(WallTime.now().epochMs)) {
             withFrameNanos { }
         }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/compose/MapPingDriver.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/compose/MapPingDriver.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.map.compose
+
+import androidx.compose.runtime.withFrameNanos
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withTimeoutOrNull
+import org.onebusaway.android.map.render.CameraSnapshot
+import org.onebusaway.android.map.render.GeoPoint
+import org.onebusaway.android.map.render.MapPing
+import org.onebusaway.android.map.render.PingTarget
+import org.onebusaway.android.time.WallTime
+
+/**
+ * Drive one-shot vehicle pings onto [target] (#1764) — the flavor-neutral orchestration both compose
+ * adapters share (they differ only in the SDK draw, which lives behind [PingTarget]). For each point from
+ * [pings]: wait for the framing pan to settle (the next [camera] idle, bounded by [MapPing.SETTLE_TIMEOUT_MS]
+ * in case the fit didn't move the camera) so the ripple plays on the settled map, then animate it at the
+ * full display rate via [withFrameNanos] — off the vehicle loop's throttle, so it's smooth. `collectLatest`
+ * so a newer ping supersedes one still waiting/animating. Call from each adapter's `LaunchedEffect`.
+ */
+suspend fun drivePings(
+    pings: SharedFlow<GeoPoint>,
+    camera: StateFlow<CameraSnapshot?>,
+    target: PingTarget,
+) {
+    pings.collectLatest { point ->
+        withTimeoutOrNull(MapPing.SETTLE_TIMEOUT_MS) { camera.drop(1).first() }
+        target.startPing(point)
+        while (target.tickPing(WallTime.now().epochMs)) {
+            withFrameNanos { }
+        }
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapPing.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapPing.kt
@@ -15,16 +15,11 @@
  */
 package org.onebusaway.android.map.render
 
-import android.graphics.Bitmap
-import android.graphics.Canvas
-import android.graphics.Paint
-import androidx.core.graphics.createBitmap
-
 /**
- * The animation model for a one-shot map "ping" — a ring that radiates out from a point and fades, played
- * once to draw the eye to a just-focused vehicle (#1764). The timing/easing is pure (unit-tested); the
- * ring bitmap (for the maplibre flavor, whose classic annotation API has no circle) lives here too so both
- * flavors share the geometry. The Google flavor draws a native `Circle` from the same fractions.
+ * The pure animation model for a one-shot map "ping" — a ring that radiates out from a point and fades,
+ * played once to draw the eye to a just-focused vehicle (#1764). Just timing/easing/color (unit-tested);
+ * each flavor's renderer draws with its own SDK primitive from these fractions (Google a native `Circle`,
+ * maplibre a stroked-ring bitmap marker).
  */
 object MapPing {
 
@@ -64,21 +59,4 @@ object MapPing {
     /** Applies [alpha01] (`0..1`) to the low 24 bits of [baseColor], producing an ARGB color. */
     fun withAlpha(baseColor: Int, alpha01: Float): Int =
         ((alpha01.coerceIn(0f, 1f) * 255f).toInt() shl 24) or (baseColor and 0x00FFFFFF)
-
-    /**
-     * A stroked ring of [radiusPx] in [colorArgb], centered in a `2*[maxRadiusPx]` square — the maplibre
-     * ping marker's icon. The square is a constant size (the max) so the marker stays centered on the
-     * point as the ring grows inside it; the caller regenerates it each frame with a larger radius.
-     */
-    fun ringBitmap(maxRadiusPx: Int, radiusPx: Float, strokeWidthPx: Float, colorArgb: Int): Bitmap {
-        val size = (maxRadiusPx * 2).coerceAtLeast(1)
-        val bitmap = createBitmap(size, size)
-        val center = size / 2f
-        Canvas(bitmap).drawCircle(center, center, radiusPx.coerceAtLeast(0f), Paint(Paint.ANTI_ALIAS_FLAG).apply {
-            style = Paint.Style.STROKE
-            strokeWidth = strokeWidthPx
-            color = colorArgb
-        })
-        return bitmap
-    }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapPing.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapPing.kt
@@ -15,22 +15,26 @@
  */
 package org.onebusaway.android.map.render
 
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+
 /**
  * The pure animation model for a one-shot map "ping" — a ring that radiates out from a point and fades,
  * played once to draw the eye to a just-focused vehicle (#1764). Just timing/easing/color (unit-tested);
  * each flavor's renderer draws with its own SDK primitive from these fractions (Google a native `Circle`,
- * maplibre a stroked-ring bitmap marker).
+ * maplibre a stroked-ring bitmap marker). Timing is expressed as a [Duration] elapsed since the ping
+ * started (the renderer subtracts two `WallTime`s), so no raw-millis time math leaks in.
  */
 object MapPing {
 
     /** How long a single ping ripple lasts. */
-    const val DURATION_MS = 700L
+    val DURATION: Duration = 700.milliseconds
 
     /**
      * The most the ping waits for the framing pan to settle (the next camera idle) before playing anyway.
      * A fallback for a fit that doesn't actually move the camera (already framed); a real pan settles first.
      */
-    const val SETTLE_TIMEOUT_MS = 1500L
+    val SETTLE_TIMEOUT: Duration = 1500.milliseconds
 
     /** The ring's maximum radius (dp) at the end of the ripple. */
     const val MAX_RADIUS_DP = 44f
@@ -38,11 +42,11 @@ object MapPing {
     /** The ring stroke width (dp). */
     const val STROKE_DP = 3f
 
-    /** Animation progress in `0..1` for [elapsedMs] since the ping started (clamped). */
-    fun progress(elapsedMs: Long): Float = (elapsedMs.toFloat() / DURATION_MS).coerceIn(0f, 1f)
+    /** Animation progress in `0..1` for [elapsed] since the ping started (clamped). */
+    fun progress(elapsed: Duration): Float = (elapsed / DURATION).toFloat().coerceIn(0f, 1f)
 
     /** Whether the ping has run its course (so the renderer can remove it). */
-    fun isDone(elapsedMs: Long): Boolean = elapsedMs >= DURATION_MS
+    fun isDone(elapsed: Duration): Boolean = elapsed >= DURATION
 
     /**
      * The ring radius as a fraction (`0..1`) of the max, easing out (decelerating) so it shoots out then

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapPing.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapPing.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.map.render
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Paint
+import androidx.core.graphics.createBitmap
+
+/**
+ * The animation model for a one-shot map "ping" — a ring that radiates out from a point and fades, played
+ * once to draw the eye to a just-focused vehicle (#1764). The timing/easing is pure (unit-tested); the
+ * ring bitmap (for the maplibre flavor, whose classic annotation API has no circle) lives here too so both
+ * flavors share the geometry. The Google flavor draws a native `Circle` from the same fractions.
+ */
+object MapPing {
+
+    /** How long a single ping ripple lasts. */
+    const val DURATION_MS = 700L
+
+    /** The ring's maximum radius (dp) at the end of the ripple. */
+    const val MAX_RADIUS_DP = 44f
+
+    /** The ring stroke width (dp). */
+    const val STROKE_DP = 3f
+
+    /** Animation progress in `0..1` for [elapsedMs] since the ping started (clamped). */
+    fun progress(elapsedMs: Long): Float = (elapsedMs.toFloat() / DURATION_MS).coerceIn(0f, 1f)
+
+    /** Whether the ping has run its course (so the renderer can remove it). */
+    fun isDone(elapsedMs: Long): Boolean = elapsedMs >= DURATION_MS
+
+    /**
+     * The ring radius as a fraction (`0..1`) of the max, easing out (decelerating) so it shoots out then
+     * settles — the ripple's characteristic quick expansion.
+     */
+    fun radiusFraction(progress: Float): Float {
+        val t = progress.coerceIn(0f, 1f)
+        return 1f - (1f - t) * (1f - t)
+    }
+
+    /** The ring alpha (`0..1`): full at the start, fading to 0, so the ripple dissolves as it expands. */
+    fun alpha(progress: Float): Float = (1f - progress).coerceIn(0f, 1f)
+
+    /** Applies [alpha01] (`0..1`) to the low 24 bits of [baseColor], producing an ARGB color. */
+    fun withAlpha(baseColor: Int, alpha01: Float): Int =
+        ((alpha01.coerceIn(0f, 1f) * 255f).toInt() shl 24) or (baseColor and 0x00FFFFFF)
+
+    /**
+     * A stroked ring of [radiusPx] in [colorArgb], centered in a `2*[maxRadiusPx]` square — the maplibre
+     * ping marker's icon. The square is a constant size (the max) so the marker stays centered on the
+     * point as the ring grows inside it; the caller regenerates it each frame with a larger radius.
+     */
+    fun ringBitmap(maxRadiusPx: Int, radiusPx: Float, strokeWidthPx: Float, colorArgb: Int): Bitmap {
+        val size = (maxRadiusPx * 2).coerceAtLeast(1)
+        val bitmap = createBitmap(size, size)
+        val center = size / 2f
+        Canvas(bitmap).drawCircle(center, center, radiusPx.coerceAtLeast(0f), Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            style = Paint.Style.STROKE
+            strokeWidth = strokeWidthPx
+            color = colorArgb
+        })
+        return bitmap
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapPing.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapPing.kt
@@ -31,6 +31,12 @@ object MapPing {
     /** How long a single ping ripple lasts. */
     const val DURATION_MS = 700L
 
+    /**
+     * The most the ping waits for the framing pan to settle (the next camera idle) before playing anyway.
+     * A fallback for a fit that doesn't actually move the camera (already framed); a real pan settles first.
+     */
+    const val SETTLE_TIMEOUT_MS = 1500L
+
     /** The ring's maximum radius (dp) at the end of the ripple. */
     const val MAX_RADIUS_DP = 44f
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
@@ -240,20 +240,21 @@ class MapRenderState {
         _cameraGestures.tryEmit(command)
     }
 
-    // Transient one-shot "ping" ripples: a circle radiating out from a point, played once to draw the eye
-    // to a just-focused vehicle (#1764). Transient like [cameraGestures] — replay=0 so a ping emitted with
-    // no map subscribed is discarded (it carries no lasting intent), buffered so the synchronous emit never
-    // suspends or drops under a burst. The renderer animates each over a fixed short duration off its
-    // per-frame clock.
-    private val _mapPings = MutableSharedFlow<GeoPoint>(
+    // Transient one-shot "ping" ripples: a circle radiating out from a vehicle, played once to draw the eye
+    // to a just-focused one (#1764). Carries the vehicle's **trip id** (not a fixed point) so the renderer
+    // can center the ripple on the vehicle marker's live position each frame — the marker slides from its
+    // raw fallback to its shape-projected spot once the trip's shape loads, and the ripple must follow it
+    // rather than stay planted where the vehicle was when focused. Transient like [cameraGestures] —
+    // replay=0 so a ping emitted with no map subscribed is discarded, buffered so the emit never drops.
+    private val _mapPings = MutableSharedFlow<String>(
         extraBufferCapacity = 8,
         onBufferOverflow = BufferOverflow.DROP_OLDEST,
     )
 
-    val mapPings: SharedFlow<GeoPoint> = _mapPings.asSharedFlow()
+    val mapPings: SharedFlow<String> = _mapPings.asSharedFlow()
 
-    fun emitPing(point: GeoPoint) {
-        _mapPings.tryEmit(point)
+    fun emitPing(tripId: String) {
+        _mapPings.tryEmit(tripId)
     }
 
     // The map's retained framing intent (fit route / itinerary / region / a fixed point), or null for no

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
@@ -240,6 +240,22 @@ class MapRenderState {
         _cameraGestures.tryEmit(command)
     }
 
+    // Transient one-shot "ping" ripples: a circle radiating out from a point, played once to draw the eye
+    // to a just-focused vehicle (#1764). Transient like [cameraGestures] — replay=0 so a ping emitted with
+    // no map subscribed is discarded (it carries no lasting intent), buffered so the synchronous emit never
+    // suspends or drops under a burst. The renderer animates each over a fixed short duration off its
+    // per-frame clock.
+    private val _mapPings = MutableSharedFlow<GeoPoint>(
+        extraBufferCapacity = 8,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
+
+    val mapPings: SharedFlow<GeoPoint> = _mapPings.asSharedFlow()
+
+    fun emitPing(point: GeoPoint) {
+        _mapPings.tryEmit(point)
+    }
+
     // The map's retained framing intent (fit route / itinerary / region / a fixed point), or null for no
     // framing. A replay=1 SharedFlow rather than a StateFlow, for two reasons a plain StateFlow can't
     // serve at once: (1) a fresh adapter — a config-change or process-restore recompose, or the map

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/PingTarget.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/PingTarget.kt
@@ -16,12 +16,13 @@
 package org.onebusaway.android.map.render
 
 /**
- * A renderer that can play a one-shot ping ripple (#1764). [startPing] arms a ripple at [point];
- * [tickPing] advances it one frame (at the frame's [nowMs]) and returns false once the ripple is done.
- * Each flavor's map renderer implements this so the flavor-neutral `drivePings` loop can drive the
- * animation without knowing the SDK draw primitive.
+ * A renderer that can play a one-shot ping ripple on a vehicle (#1764). [startPing] arms a ripple for the
+ * vehicle on trip [tripId]; [tickPing] advances it one frame (at the frame's [nowMs]), centering it on that
+ * vehicle's live marker position, and returns false once the ripple is done (or the vehicle is gone). Each
+ * flavor's map renderer implements this so the flavor-neutral `drivePings` loop can drive the animation
+ * without knowing the SDK draw primitive.
  */
 interface PingTarget {
-    fun startPing(point: GeoPoint)
+    fun startPing(tripId: String)
     fun tickPing(nowMs: Long): Boolean
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/PingTarget.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/PingTarget.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.map.render
+
+/**
+ * A renderer that can play a one-shot ping ripple (#1764). [startPing] arms a ripple at [point];
+ * [tickPing] advances it one frame (at the frame's [nowMs]) and returns false once the ripple is done.
+ * Each flavor's map renderer implements this so the flavor-neutral `drivePings` loop can drive the
+ * animation without knowing the SDK draw primitive.
+ */
+interface PingTarget {
+    fun startPing(point: GeoPoint)
+    fun tickPing(nowMs: Long): Boolean
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/PingTarget.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/PingTarget.kt
@@ -15,14 +15,18 @@
  */
 package org.onebusaway.android.map.render
 
+import org.onebusaway.android.time.WallTime
+
 /**
  * A renderer that can play a one-shot ping ripple on a vehicle (#1764). [startPing] arms a ripple for the
- * vehicle on trip [tripId]; [tickPing] advances it one frame (at the frame's [nowMs]), centering it on that
- * vehicle's live marker position, and returns false once the ripple is done (or the vehicle is gone). Each
- * flavor's map renderer implements this so the flavor-neutral `drivePings` loop can drive the animation
- * without knowing the SDK draw primitive.
+ * vehicle on trip [tripId]; [tickPing] advances it one frame (at the frame's wall-clock [now]), centering
+ * it on that vehicle's live marker position, and returns false once the ripple is done (or the vehicle is
+ * gone); [cancelPing] removes any in-flight ripple (so a superseded ping doesn't linger). Each flavor's map
+ * renderer implements this so the flavor-neutral `drivePings` loop can drive the animation without knowing
+ * the SDK draw primitive.
  */
 interface PingTarget {
     fun startPing(tripId: String)
-    fun tickPing(nowMs: Long): Boolean
+    fun tickPing(now: WallTime): Boolean
+    fun cancelPing()
 }

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
@@ -20,7 +20,11 @@
 package org.onebusaway.android.map.maplibre
 
 import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Paint
 import androidx.core.content.ContextCompat
+import androidx.core.graphics.createBitmap
 import java.util.concurrent.TimeUnit
 import org.maplibre.android.annotations.Annotation
 import org.maplibre.android.annotations.Icon
@@ -41,6 +45,7 @@ import org.onebusaway.android.map.render.CorrectionSmoother
 import org.onebusaway.android.map.render.GeoPoint
 import org.onebusaway.android.map.render.MapPing
 import org.onebusaway.android.map.render.MapRenderState
+import org.onebusaway.android.map.render.PingTarget
 import org.onebusaway.android.map.render.MapVehicles
 import org.onebusaway.android.map.render.StopBand
 import org.onebusaway.android.map.render.StopIconKind
@@ -83,7 +88,7 @@ class MapLibreRenderer(
     private val map: MapLibreMap,
     private val context: Context,
     private val renderState: MapRenderState,
-) {
+) : PingTarget {
     private val stopByMarker = HashMap<Marker, StopMarker>()
 
     // Stop markers tracked by stop id so [reconcileStopMarkers] can diff them in place (add new,
@@ -149,6 +154,10 @@ class MapLibreRenderer(
     private var pingStartMs: Long = 0L
     private val pingColor by lazy { ContextCompat.getColor(context, R.color.theme_primary) }
     private val density = context.resources.displayMetrics.density
+    // Reused across the ripple's frames — redrawn in place rather than reallocated each frame (the ring
+    // is a bitmap because the classic annotation API has no circle). Freed with the ping in clearPing.
+    private var pingBitmap: Bitmap? = null
+    private val pingPaint by lazy { Paint(Paint.ANTI_ALIAS_FLAG).apply { style = Paint.Style.STROKE } }
 
     /** Redraw the static layer (everything but the live vehicles + trip-focus overlay). */
     fun renderStatic() {
@@ -285,8 +294,8 @@ class MapLibreRenderer(
         updateTripOverlay(overlay, nowMs)
     }
 
-    /** Start a one-shot ping ripple at [point]; the adapter drives [tickPing] to animate it (#1764). */
-    fun startPing(point: GeoPoint) {
+    /** Start a one-shot ping ripple at [point]; the driver calls [tickPing] to animate it (#1764). */
+    override fun startPing(point: GeoPoint) {
         clearPing()
         pingPoint = point
         pingStartMs = 0L // stamped on the first tick
@@ -294,9 +303,9 @@ class MapLibreRenderer(
 
     // Advance the ping ripple one frame: regrow the ring bitmap (bigger radius, fading color) and re-set the
     // marker icon. Returns false — and removes the marker — when the ripple completes. Driven by the
-    // adapter's own full-rate frame loop (not the vehicle loop) so the ripple is smooth. The bitmap is a
+    // driver's own full-rate frame loop (not the vehicle loop) so the ripple is smooth. The bitmap is a
     // constant max-size square so the marker stays centered on the vehicle as the ring grows inside it.
-    fun tickPing(nowMs: Long): Boolean {
+    override fun tickPing(nowMs: Long): Boolean {
         val point = pingPoint ?: return false
         if (pingStartMs == 0L) pingStartMs = nowMs
         val elapsed = nowMs - pingStartMs
@@ -307,10 +316,15 @@ class MapLibreRenderer(
         val progress = MapPing.progress(elapsed)
         val maxRadiusPx = (MapPing.MAX_RADIUS_DP * density).toInt()
         val radiusPx = maxRadiusPx * MapPing.radiusFraction(progress)
-        val color = MapPing.withAlpha(pingColor, MapPing.alpha(progress))
-        val icon = iconFactory.fromBitmap(
-            MapPing.ringBitmap(maxRadiusPx, radiusPx, MapPing.STROKE_DP * density, color)
-        )
+        // A constant max-size square (so the marker stays centered as the ring grows inside it), reused
+        // and redrawn in place each frame.
+        val size = maxRadiusPx * 2
+        val bitmap = pingBitmap?.takeIf { it.width == size } ?: createBitmap(size, size).also { pingBitmap = it }
+        bitmap.eraseColor(0)
+        pingPaint.color = MapPing.withAlpha(pingColor, MapPing.alpha(progress))
+        pingPaint.strokeWidth = MapPing.STROKE_DP * density
+        Canvas(bitmap).drawCircle(size / 2f, size / 2f, radiusPx.coerceAtLeast(0f), pingPaint)
+        val icon = iconFactory.fromBitmap(bitmap)
         val existing = pingMarker
         if (existing == null) {
             pingMarker = map.addMarker(MarkerOptions().position(point.toLatLng()).icon(icon))
@@ -325,6 +339,7 @@ class MapLibreRenderer(
         pingMarker = null
         pingPoint = null
         pingStartMs = 0L
+        pingBitmap = null
     }
 
     /**

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
@@ -146,11 +146,11 @@ class MapLibreRenderer(
 
     private val iconFactory = IconFactory.getInstance(context)
 
-    // The one-shot "ping" ripple (#1764): a ring-bitmap marker grown + faded over [MapPing.DURATION_MS]
-    // from a just-focused vehicle (the classic annotation API has no circle). [pingStartMs] is 0 until the
-    // first frame stamps it; null marker means no ping in flight.
+    // The one-shot "ping" ripple (#1764): a ring-bitmap marker grown + faded over [MapPing.DURATION_MS],
+    // recentered each frame on trip [pingTripId]'s vehicle marker so it follows the icon as it settles (the
+    // classic annotation API has no circle). [pingStartMs] is 0 until the first tick stamps it; null id = no ping.
     private var pingMarker: Marker? = null
-    private var pingPoint: GeoPoint? = null
+    private var pingTripId: String? = null
     private var pingStartMs: Long = 0L
     private val pingColor by lazy { ContextCompat.getColor(context, R.color.theme_primary) }
     private val density = context.resources.displayMetrics.density
@@ -294,19 +294,21 @@ class MapLibreRenderer(
         updateTripOverlay(overlay, nowMs)
     }
 
-    /** Start a one-shot ping ripple at [point]; the driver calls [tickPing] to animate it (#1764). */
-    override fun startPing(point: GeoPoint) {
+    /** Start a one-shot ping ripple on trip [tripId]'s vehicle; the driver calls [tickPing] to animate it (#1764). */
+    override fun startPing(tripId: String) {
         clearPing()
-        pingPoint = point
+        pingTripId = tripId
         pingStartMs = 0L // stamped on the first tick
     }
 
-    // Advance the ping ripple one frame: regrow the ring bitmap (bigger radius, fading color) and re-set the
-    // marker icon. Returns false — and removes the marker — when the ripple completes. Driven by the
-    // driver's own full-rate frame loop (not the vehicle loop) so the ripple is smooth. The bitmap is a
-    // constant max-size square so the marker stays centered on the vehicle as the ring grows inside it.
+    // Advance the ping ripple one frame: recenter on the vehicle marker's live position (so it follows the
+    // icon as it settles onto its shape-projected spot), regrow the ring bitmap (bigger radius, fading
+    // color) and re-set the marker icon. Returns false — and removes the marker — when the ripple completes
+    // or the vehicle is gone. Driven by the driver's own full-rate frame loop so the ripple is smooth. The
+    // bitmap is a constant max-size square so the ring stays centered as it grows inside it.
     override fun tickPing(nowMs: Long): Boolean {
-        val point = pingPoint ?: return false
+        val tripId = pingTripId ?: return false
+        val center = vehicleMarkersByTripId[tripId]?.position ?: run { clearPing(); return false }
         if (pingStartMs == 0L) pingStartMs = nowMs
         val elapsed = nowMs - pingStartMs
         if (MapPing.isDone(elapsed)) {
@@ -316,8 +318,6 @@ class MapLibreRenderer(
         val progress = MapPing.progress(elapsed)
         val maxRadiusPx = (MapPing.MAX_RADIUS_DP * density).toInt()
         val radiusPx = maxRadiusPx * MapPing.radiusFraction(progress)
-        // A constant max-size square (so the marker stays centered as the ring grows inside it), reused
-        // and redrawn in place each frame.
         val size = maxRadiusPx * 2
         val bitmap = pingBitmap?.takeIf { it.width == size } ?: createBitmap(size, size).also { pingBitmap = it }
         bitmap.eraseColor(0)
@@ -327,8 +327,9 @@ class MapLibreRenderer(
         val icon = iconFactory.fromBitmap(bitmap)
         val existing = pingMarker
         if (existing == null) {
-            pingMarker = map.addMarker(MarkerOptions().position(point.toLatLng()).icon(icon))
+            pingMarker = map.addMarker(MarkerOptions().position(center).icon(icon))
         } else {
+            existing.position = center
             existing.icon = icon
         }
         return true
@@ -337,7 +338,7 @@ class MapLibreRenderer(
     private fun clearPing() {
         pingMarker?.let { map.removeAnnotation(it) }
         pingMarker = null
-        pingPoint = null
+        pingTripId = null
         pingStartMs = 0L
         pingBitmap = null
     }

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
@@ -283,26 +283,26 @@ class MapLibreRenderer(
     fun renderDynamic(overlay: TripOverlay?, vehicles: MapVehicles?, nowMs: Long) {
         moveVehicles(vehicles, nowMs)
         updateTripOverlay(overlay, nowMs)
-        updatePing(nowMs)
     }
 
-    /** Start a one-shot ping ripple at [point]; the frame loop animates it (#1764). */
+    /** Start a one-shot ping ripple at [point]; the adapter drives [tickPing] to animate it (#1764). */
     fun startPing(point: GeoPoint) {
         clearPing()
         pingPoint = point
-        pingStartMs = 0L // stamped on the first frame that draws it
+        pingStartMs = 0L // stamped on the first tick
     }
 
-    // Advance the ping ripple: regrow the ring bitmap (bigger radius, fading color) and re-set the marker
-    // icon each frame, removing it when the ripple completes. The bitmap is a constant max-size square so
-    // the marker stays centered on the vehicle as the ring grows inside it.
-    private fun updatePing(nowMs: Long) {
-        val point = pingPoint ?: return
+    // Advance the ping ripple one frame: regrow the ring bitmap (bigger radius, fading color) and re-set the
+    // marker icon. Returns false — and removes the marker — when the ripple completes. Driven by the
+    // adapter's own full-rate frame loop (not the vehicle loop) so the ripple is smooth. The bitmap is a
+    // constant max-size square so the marker stays centered on the vehicle as the ring grows inside it.
+    fun tickPing(nowMs: Long): Boolean {
+        val point = pingPoint ?: return false
         if (pingStartMs == 0L) pingStartMs = nowMs
         val elapsed = nowMs - pingStartMs
         if (MapPing.isDone(elapsed)) {
             clearPing()
-            return
+            return false
         }
         val progress = MapPing.progress(elapsed)
         val maxRadiusPx = (MapPing.MAX_RADIUS_DP * density).toInt()
@@ -317,6 +317,7 @@ class MapLibreRenderer(
         } else {
             existing.icon = icon
         }
+        return true
     }
 
     private fun clearPing() {

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
@@ -57,6 +57,7 @@ import org.onebusaway.android.map.render.VehicleBitmaps
 import org.onebusaway.android.map.render.VehicleMarker
 import org.onebusaway.android.map.render.bikeZoomBand
 import org.onebusaway.android.map.render.stopIconKind
+import org.onebusaway.android.time.WallTime
 import org.onebusaway.android.util.MyTextUtils
 import org.onebusaway.android.util.getRouteDisplayName
 
@@ -146,12 +147,12 @@ class MapLibreRenderer(
 
     private val iconFactory = IconFactory.getInstance(context)
 
-    // The one-shot "ping" ripple (#1764): a ring-bitmap marker grown + faded over [MapPing.DURATION_MS],
+    // The one-shot "ping" ripple (#1764): a ring-bitmap marker grown + faded over [MapPing.DURATION],
     // recentered each frame on trip [pingTripId]'s vehicle marker so it follows the icon as it settles (the
-    // classic annotation API has no circle). [pingStartMs] is 0 until the first tick stamps it; null id = no ping.
+    // classic annotation API has no circle). [pingStart] is null until the first tick stamps it; null id = no ping.
     private var pingMarker: Marker? = null
     private var pingTripId: String? = null
-    private var pingStartMs: Long = 0L
+    private var pingStart: WallTime? = null
     private val pingColor by lazy { ContextCompat.getColor(context, R.color.theme_primary) }
     private val density = context.resources.displayMetrics.density
     // Reused across the ripple's frames — redrawn in place rather than reallocated each frame (the ring
@@ -298,19 +299,22 @@ class MapLibreRenderer(
     override fun startPing(tripId: String) {
         clearPing()
         pingTripId = tripId
-        pingStartMs = 0L // stamped on the first tick
+        pingStart = null // stamped on the first tick
     }
+
+    /** Remove any in-flight ping ripple (a superseded/cancelled ping). */
+    override fun cancelPing() = clearPing()
 
     // Advance the ping ripple one frame: recenter on the vehicle marker's live position (so it follows the
     // icon as it settles onto its shape-projected spot), regrow the ring bitmap (bigger radius, fading
     // color) and re-set the marker icon. Returns false — and removes the marker — when the ripple completes
     // or the vehicle is gone. Driven by the driver's own full-rate frame loop so the ripple is smooth. The
     // bitmap is a constant max-size square so the ring stays centered as it grows inside it.
-    override fun tickPing(nowMs: Long): Boolean {
+    override fun tickPing(now: WallTime): Boolean {
         val tripId = pingTripId ?: return false
         val center = vehicleMarkersByTripId[tripId]?.position ?: run { clearPing(); return false }
-        if (pingStartMs == 0L) pingStartMs = nowMs
-        val elapsed = nowMs - pingStartMs
+        val start = pingStart ?: now.also { pingStart = it }
+        val elapsed = now - start
         if (MapPing.isDone(elapsed)) {
             clearPing()
             return false
@@ -339,7 +343,7 @@ class MapLibreRenderer(
         pingMarker?.let { map.removeAnnotation(it) }
         pingMarker = null
         pingTripId = null
-        pingStartMs = 0L
+        pingStart = null
         pingBitmap = null
     }
 
@@ -568,6 +572,15 @@ class MapLibreRenderer(
     fun bikeForMarker(marker: Marker): BikeMarker? = bikeByMarker[marker]
 
     fun vehicleForMarker(marker: Marker): VehicleMarker? = vehicleByMarker[marker]
+
+    /**
+     * If [marker] is the ping ripple, the vehicle marker it's centered on (else null) — so a tap on the
+     * ripple selects the vehicle underneath rather than being swallowed. maplibre's classic Marker has no
+     * `clickable(false)` (Google draws the ping as a non-clickable Circle), so the click listener routes a
+     * ping tap through to its vehicle via this (#1764).
+     */
+    fun vehicleMarkerUnderPing(marker: Marker): Marker? =
+        if (marker == pingMarker) pingTripId?.let { vehicleMarkersByTripId[it] } else null
 
     /** The current trips-for-route response, needed to render a vehicle's info window. */
     fun vehicleResponse(): RouteTrips? = lastVehicleResponse

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
@@ -20,6 +20,7 @@
 package org.onebusaway.android.map.maplibre
 
 import android.content.Context
+import androidx.core.content.ContextCompat
 import java.util.concurrent.TimeUnit
 import org.maplibre.android.annotations.Annotation
 import org.maplibre.android.annotations.Icon
@@ -38,6 +39,7 @@ import org.onebusaway.android.map.render.BikeBitmaps
 import org.onebusaway.android.map.render.BikeMarker
 import org.onebusaway.android.map.render.CorrectionSmoother
 import org.onebusaway.android.map.render.GeoPoint
+import org.onebusaway.android.map.render.MapPing
 import org.onebusaway.android.map.render.MapRenderState
 import org.onebusaway.android.map.render.MapVehicles
 import org.onebusaway.android.map.render.StopBand
@@ -138,6 +140,15 @@ class MapLibreRenderer(
     private var dotAgeSeconds: Long = -1L
 
     private val iconFactory = IconFactory.getInstance(context)
+
+    // The one-shot "ping" ripple (#1764): a ring-bitmap marker grown + faded over [MapPing.DURATION_MS]
+    // from a just-focused vehicle (the classic annotation API has no circle). [pingStartMs] is 0 until the
+    // first frame stamps it; null marker means no ping in flight.
+    private var pingMarker: Marker? = null
+    private var pingPoint: GeoPoint? = null
+    private var pingStartMs: Long = 0L
+    private val pingColor by lazy { ContextCompat.getColor(context, R.color.theme_primary) }
+    private val density = context.resources.displayMetrics.density
 
     /** Redraw the static layer (everything but the live vehicles + trip-focus overlay). */
     fun renderStatic() {
@@ -272,6 +283,47 @@ class MapLibreRenderer(
     fun renderDynamic(overlay: TripOverlay?, vehicles: MapVehicles?, nowMs: Long) {
         moveVehicles(vehicles, nowMs)
         updateTripOverlay(overlay, nowMs)
+        updatePing(nowMs)
+    }
+
+    /** Start a one-shot ping ripple at [point]; the frame loop animates it (#1764). */
+    fun startPing(point: GeoPoint) {
+        clearPing()
+        pingPoint = point
+        pingStartMs = 0L // stamped on the first frame that draws it
+    }
+
+    // Advance the ping ripple: regrow the ring bitmap (bigger radius, fading color) and re-set the marker
+    // icon each frame, removing it when the ripple completes. The bitmap is a constant max-size square so
+    // the marker stays centered on the vehicle as the ring grows inside it.
+    private fun updatePing(nowMs: Long) {
+        val point = pingPoint ?: return
+        if (pingStartMs == 0L) pingStartMs = nowMs
+        val elapsed = nowMs - pingStartMs
+        if (MapPing.isDone(elapsed)) {
+            clearPing()
+            return
+        }
+        val progress = MapPing.progress(elapsed)
+        val maxRadiusPx = (MapPing.MAX_RADIUS_DP * density).toInt()
+        val radiusPx = maxRadiusPx * MapPing.radiusFraction(progress)
+        val color = MapPing.withAlpha(pingColor, MapPing.alpha(progress))
+        val icon = iconFactory.fromBitmap(
+            MapPing.ringBitmap(maxRadiusPx, radiusPx, MapPing.STROKE_DP * density, color)
+        )
+        val existing = pingMarker
+        if (existing == null) {
+            pingMarker = map.addMarker(MarkerOptions().position(point.toLatLng()).icon(icon))
+        } else {
+            existing.icon = icon
+        }
+    }
+
+    private fun clearPing() {
+        pingMarker?.let { map.removeAnnotation(it) }
+        pingMarker = null
+        pingPoint = null
+        pingStartMs = 0L
     }
 
     /**

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreComposeAdapter.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreComposeAdapter.kt
@@ -54,17 +54,14 @@ import org.onebusaway.android.map.compose.ObaComposeMapAdapter
 import org.onebusaway.android.map.compose.ObaMapCallbacks
 import org.onebusaway.android.map.compose.VehicleInfoWindow
 import org.onebusaway.android.map.maplibre.MapLibreRenderer
+import org.onebusaway.android.map.compose.drivePings
 import org.onebusaway.android.map.render.CameraSnapshot
 import org.onebusaway.android.map.render.GeoPoint
-import org.onebusaway.android.map.render.MapPing
 import org.onebusaway.android.util.PermissionUtils
 import org.onebusaway.android.util.ThemeUtils
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.filterNotNull
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.withTimeoutOrNull
 import kotlin.math.abs
 
 private const val STYLE_URL_LIGHT = "https://tiles.openfreemap.org/styles/liberty"
@@ -205,17 +202,10 @@ class MapLibreComposeAdapter : ObaComposeMapAdapter {
                         }
                     }
             }
-            // One-shot vehicle pings: fire strictly after the framing pan settles (await the next camera
-            // idle, bounded in case the fit didn't move the camera), then animate at the full display rate
-            // so the ripple is smooth (#1764).
+            // One-shot vehicle pings — the flavor-neutral driver waits for the pan to settle then animates
+            // the ripple at the full display rate (#1764).
             LaunchedEffect(activeRenderer) {
-                renderState.mapPings.collectLatest { point ->
-                    withTimeoutOrNull(MapPing.SETTLE_TIMEOUT_MS) { host.camera.drop(1).first() }
-                    activeRenderer.startPing(point)
-                    while (activeRenderer.tickPing(System.currentTimeMillis())) {
-                        withFrameNanos { }
-                    }
-                }
+                drivePings(renderState.mapPings, host.camera, activeRenderer)
             }
             val myLocationEnabled by host.myLocationEnabled.collectAsState()
             val map = mapLibreMap

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreComposeAdapter.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreComposeAdapter.kt
@@ -201,6 +201,10 @@ class MapLibreComposeAdapter : ObaComposeMapAdapter {
                         }
                     }
             }
+            // One-shot vehicle pings: hand each to the renderer, which animates it over the frame loop above.
+            LaunchedEffect(activeRenderer) {
+                renderState.mapPings.collect { activeRenderer.startPing(it) }
+            }
             val myLocationEnabled by host.myLocationEnabled.collectAsState()
             val map = mapLibreMap
             val style = loadedStyle

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreComposeAdapter.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreComposeAdapter.kt
@@ -255,7 +255,10 @@ private fun wireClicks(
         callbacks.onMapClick(null)
         false
     }
-    map.setOnMarkerClickListener { marker ->
+    map.setOnMarkerClickListener { tapped ->
+        // A tap on the ping ripple routes through to the vehicle it's centered on (maplibre classic markers
+        // can't be made non-interactive like Google's Circle), so it doesn't swallow the vehicle tap (#1764).
+        val marker = renderer.vehicleMarkerUnderPing(tapped) ?: tapped
         val stop = renderer.stopForMarker(marker)
         if (stop != null) {
             infoWindows.clear()

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreComposeAdapter.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreComposeAdapter.kt
@@ -56,11 +56,15 @@ import org.onebusaway.android.map.compose.VehicleInfoWindow
 import org.onebusaway.android.map.maplibre.MapLibreRenderer
 import org.onebusaway.android.map.render.CameraSnapshot
 import org.onebusaway.android.map.render.GeoPoint
+import org.onebusaway.android.map.render.MapPing
 import org.onebusaway.android.util.PermissionUtils
 import org.onebusaway.android.util.ThemeUtils
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlin.math.abs
 
 private const val STYLE_URL_LIGHT = "https://tiles.openfreemap.org/styles/liberty"
@@ -201,9 +205,17 @@ class MapLibreComposeAdapter : ObaComposeMapAdapter {
                         }
                     }
             }
-            // One-shot vehicle pings: hand each to the renderer, which animates it over the frame loop above.
+            // One-shot vehicle pings: fire strictly after the framing pan settles (await the next camera
+            // idle, bounded in case the fit didn't move the camera), then animate at the full display rate
+            // so the ripple is smooth (#1764).
             LaunchedEffect(activeRenderer) {
-                renderState.mapPings.collect { activeRenderer.startPing(it) }
+                renderState.mapPings.collectLatest { point ->
+                    withTimeoutOrNull(MapPing.SETTLE_TIMEOUT_MS) { host.camera.drop(1).first() }
+                    activeRenderer.startPing(point)
+                    while (activeRenderer.tickPing(System.currentTimeMillis())) {
+                        withFrameNanos { }
+                    }
+                }
             }
             val myLocationEnabled by host.myLocationEnabled.collectAsState()
             val map = mapLibreMap

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/render/MapPingTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/render/MapPingTest.kt
@@ -15,6 +15,8 @@
  */
 package org.onebusaway.android.map.render
 
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -25,18 +27,18 @@ class MapPingTest {
 
     @Test
     fun `progress runs 0 to 1 and clamps past the duration`() {
-        assertEquals(0f, MapPing.progress(0L), 1e-6f)
-        assertEquals(0.5f, MapPing.progress(MapPing.DURATION_MS / 2), 1e-3f)
-        assertEquals(1f, MapPing.progress(MapPing.DURATION_MS), 1e-6f)
-        assertEquals(1f, MapPing.progress(MapPing.DURATION_MS * 5), 1e-6f)
+        assertEquals(0f, MapPing.progress(Duration.ZERO), 1e-6f)
+        assertEquals(0.5f, MapPing.progress(MapPing.DURATION / 2), 1e-3f)
+        assertEquals(1f, MapPing.progress(MapPing.DURATION), 1e-6f)
+        assertEquals(1f, MapPing.progress(MapPing.DURATION * 5), 1e-6f)
     }
 
     @Test
     fun `isDone flips at the duration`() {
-        assertFalse(MapPing.isDone(0L))
-        assertFalse(MapPing.isDone(MapPing.DURATION_MS - 1))
-        assertTrue(MapPing.isDone(MapPing.DURATION_MS))
-        assertTrue(MapPing.isDone(MapPing.DURATION_MS + 100))
+        assertFalse(MapPing.isDone(Duration.ZERO))
+        assertFalse(MapPing.isDone(MapPing.DURATION - 1.milliseconds))
+        assertTrue(MapPing.isDone(MapPing.DURATION))
+        assertTrue(MapPing.isDone(MapPing.DURATION + 100.milliseconds))
     }
 
     @Test

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/render/MapPingTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/render/MapPingTest.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.map.render
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Pure-logic tests for the ping ripple's timing + easing (the bitmap/circle draw is exercised on device). */
+class MapPingTest {
+
+    @Test
+    fun `progress runs 0 to 1 and clamps past the duration`() {
+        assertEquals(0f, MapPing.progress(0L), 1e-6f)
+        assertEquals(0.5f, MapPing.progress(MapPing.DURATION_MS / 2), 1e-3f)
+        assertEquals(1f, MapPing.progress(MapPing.DURATION_MS), 1e-6f)
+        assertEquals(1f, MapPing.progress(MapPing.DURATION_MS * 5), 1e-6f)
+    }
+
+    @Test
+    fun `isDone flips at the duration`() {
+        assertFalse(MapPing.isDone(0L))
+        assertFalse(MapPing.isDone(MapPing.DURATION_MS - 1))
+        assertTrue(MapPing.isDone(MapPing.DURATION_MS))
+        assertTrue(MapPing.isDone(MapPing.DURATION_MS + 100))
+    }
+
+    @Test
+    fun `radius eases out - starts at 0, ends at 1, past the midpoint by half-time`() {
+        assertEquals(0f, MapPing.radiusFraction(0f), 1e-6f)
+        assertEquals(1f, MapPing.radiusFraction(1f), 1e-6f)
+        // Decelerating: at half progress the ring is already more than halfway out.
+        assertTrue("eases out (fraction > progress mid-way)", MapPing.radiusFraction(0.5f) > 0.5f)
+        // Monotonic increasing.
+        assertTrue(MapPing.radiusFraction(0.25f) < MapPing.radiusFraction(0.75f))
+    }
+
+    @Test
+    fun `alpha fades from full to zero`() {
+        assertEquals(1f, MapPing.alpha(0f), 1e-6f)
+        assertEquals(0.5f, MapPing.alpha(0.5f), 1e-6f)
+        assertEquals(0f, MapPing.alpha(1f), 1e-6f)
+    }
+
+    @Test
+    fun `withAlpha stamps the alpha byte and keeps the rgb`() {
+        val rgb = 0x123456
+        assertEquals(0xFF123456.toInt(), MapPing.withAlpha(0xFF000000.toInt() or rgb, 1f))
+        assertEquals(0x00123456, MapPing.withAlpha(0xFF000000.toInt() or rgb, 0f))
+        // Half alpha -> 0x7F, rgb preserved regardless of the input's alpha byte.
+        assertEquals((0x7F shl 24) or rgb, MapPing.withAlpha(rgb, 0.5f))
+    }
+}


### PR DESCRIPTION
Closes #1764.

When a user taps an arrivals **ETA pill** that recontextualizes the map onto a specific vehicle, a circle now radiates out from that vehicle — a one-shot ping — so it's unmistakable which one the arrival is querying. On a busy route with several markers, the plain pan/zoom didn't make that obvious.

## How it works

- **Trigger** — `RouteMapController` emits `renderState.emitPing(point)` from the single `FIT` branch of `tryFocusVehicle` (covers both the route-already-shown and pending-focus-on-load paths), using the located vehicle's point.
- **Signal** — a transient `MapRenderState.mapPings` `SharedFlow` (mirrors the existing `cameraGestures`: `replay=0`, buffered — a ping with no map subscribed is dropped) + `emitPing`.
- **Driver** — a flavor-neutral `drivePings(pings, camera, PingTarget)` (in `map.compose`): for each ping it waits for the framing **pan to settle** (the next `host.camera` idle, bounded by a timeout in case the fit didn't move the camera), then animates the ripple at the **full display rate** via `withFrameNanos` — deliberately off the vehicle loop's ~20Hz cap (which exists for marker tap hit-testing, #551) so the ripple is smooth. Both adapters just call it; each renderer implements the tiny `PingTarget` (`startPing`/`tickPing`).
- **Draw** — Google uses a native `Circle` (radius derived from a target screen size via the current zoom, so it reads at a consistent on-screen size; Circles sit under markers, so the vehicle icon stays crisp on top). MapLibre uses a stroked ring-bitmap `Marker` (the classic annotation API has no circle), reusing one bitmap redrawn in place. Timing/easing/color is the shared, unit-tested `MapPing`.

## Verification

- ✅ Both flavors + unit + Google `androidTest` compile clean, and lint passes, under `-PwarningsAsErrors=true`. `MapPingTest` (pure timing/easing) passes.
- ✅ Google flavor device-verified (ripple fires after the pan, smooth, centered on the vehicle, doesn't steal taps).
- ⚠️ MapLibre build-verified but not device-verified (same appId, not installed alongside Google).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added one-shot animated “vehicle ping” ripples keyed to the focused vehicle, shown on both map experiences.
  * Pings now start after the map camera/pan settles and follow the vehicle marker position.
* **Bug Fixes**
  * Improved ripple lifecycle so pings cancel/clear automatically when superseded, disposed, or when the vehicle marker is no longer available.
  * Ping taps now route to the underlying vehicle marker so the normal vehicle tap behavior continues.
* **Tests**
  * Added unit tests covering ping timing, easing/radius, fade, and color/alpha handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->