### PR TITLE
Frame the ETA-pill vehicle+stop clear of the map overlays

### DIFF
--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleCameraCommands.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleCameraCommands.kt
@@ -27,6 +27,7 @@ import org.onebusaway.android.app.di.RegionEntryPoint
 import org.onebusaway.android.map.googlemapsv2.MapHelpV2
 import org.onebusaway.android.map.render.CameraCommand
 import org.onebusaway.android.map.render.FramingIntent
+import org.onebusaway.android.map.render.MapPadding
 import org.onebusaway.android.map.render.MapRenderState
 import org.onebusaway.android.map.render.POINTS_FRAMING_PADDING_DP
 import org.onebusaway.android.map.render.framingCorners
@@ -144,12 +145,27 @@ fun applyFramingIntent(
         is FramingIntent.Points -> {
             val (sw, ne) = framingCorners(intent.points) ?: return
             val bounds = LatLngBounds(LatLng(sw.latitude, sw.longitude), LatLng(ne.latitude, ne.longitude))
+            // Google's newLatLngBounds fits the box inside the map's content padding, so this fit must see
+            // the current route-header (top) + arrivals-sheet (bottom) insets. The padding collector
+            // (GoogleComposeAdapter) is a *separate* coroutine with no ordering guarantee against this
+            // framing collector: an ETA tap emits the padding update and the framing intent together, and
+            // if this runs first the box is fit against the map's stale padding and lands under the
+            // overlays that are open right after the tap. Apply the current padding here so the fit is
+            // self-sufficient (idempotent with the collector — setPadding is absolute, not additive).
+            map.applyMapPadding(renderState.padding.value)
             map.animateCamera(
                 CameraUpdateFactory.newLatLngBounds(bounds, ViewUtils.dpToPixels(context, POINTS_FRAMING_PADDING_DP))
             )
         }
     }
 }
+
+/**
+ * Push a [MapPadding] onto the [GoogleMap] as content padding — the single place the top/bottom insets
+ * map onto `setPadding`'s slots (left/right stay 0). Shared by the [GoogleComposeAdapter] padding
+ * collector and the Points framing, so both agree on the mapping.
+ */
+internal fun GoogleMap.applyMapPadding(padding: MapPadding) = setPadding(0, padding.topPx, 0, padding.bottomPx)
 
 /** Bounds enclosing the current route/itinerary polylines, or null if there are no points. */
 private fun routePolylineBounds(renderState: MapRenderState): LatLngBounds? {

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleComposeAdapter.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleComposeAdapter.kt
@@ -242,7 +242,7 @@ class GoogleComposeAdapter : ObaComposeMapAdapter {
             }
             // Declarative map padding (route-header top + arrivals-sheet bottom).
             LaunchedEffect(map) {
-                renderState.padding.collect { map.setPadding(0, it.topPx, 0, it.bottomPx) }
+                renderState.padding.collect { map.applyMapPadding(it) }
             }
             // Declarative camera. Transient gestures apply as they arrive (dropped if none pending when
             // the map wasn't subscribed). The retained framing intent is replayed to this collector when

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
@@ -207,7 +207,10 @@ class MapRenderState {
     val snapshot: StateFlow<MapRenderSnapshot> = _snapshot.asStateFlow()
 
     // Map content padding (route-header top + arrivals-sheet bottom), in its own flow so a padding
-    // change doesn't redraw the overlay content. The renderer applies it (both flavors: map.setPadding).
+    // change doesn't redraw the overlay content. The Google adapter applies it globally via
+    // map.setPadding (which its newLatLngBounds framing then honors); maplibre's newLatLngBounds ignores
+    // persistent padding, so its Points framing reads this value and folds the insets into the fit
+    // directly (see MapLibreCameraCommands.applyFramingIntent).
     private val _padding = MutableStateFlow(MapPadding())
 
     val padding: StateFlow<MapPadding> = _padding.asStateFlow()

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -241,7 +241,7 @@ fun HomeScreen(
         LaunchedEffect(state.focusedStop?.id) { arrivalsReady = false }
 
         // The measured collapsed-peek content (header + boxed peek rows), as dp (no drag handle) for the
-        // peek anchor below. The raw px goes to the activity as the map's bottom padding (onSheetSettled).
+        // peek anchor below.
         val peekContentDp = with(density) { peekContentPx.toDp() }
 
         // Grow the sheet peek by the system navigation-bar inset (height varies by handset) so the
@@ -250,9 +250,15 @@ fun HomeScreen(
         val peekBottomPadding = navigationBarBottomPadding()
 
         // The full collapsed-sheet peek: the measured header+rows content, plus the real scaffold drag
-        // handle above it, plus the navigation-bar inset below. Both the scaffold's peek height and the FAB
-        // lift use this, so the FABs clear the whole collapsed sheet (handle included), not just the content.
+        // handle above it, plus the navigation-bar inset below. The scaffold's peek height, the FAB
+        // lift, and the map's bottom inset all use this, so the FABs and the map-framed content clear the
+        // whole collapsed sheet (handle + nav-bar inset included), not just the header+rows content.
         val collapsedPeekDp = peekContentDp + DRAG_HANDLE_HEIGHT + peekBottomPadding
+
+        // The full collapsed peek in px — the map's bottom inset (onSheetSettled). Must match the sheet's
+        // on-screen height, or map-framed content (the ETA-tap vehicle+stop fit) lands under the handle +
+        // nav-bar strip the header+rows px alone omits.
+        val collapsedPeekPx = with(density) { collapsedPeekDp.roundToPx() }
 
         // The drawer's live open fraction (0 = collapsed peek, 1 = fully expanded), read each frame by
         // the arrivals panel to morph the peek rows in lockstep with the drag. measureModifier feeds it
@@ -297,12 +303,14 @@ fun HomeScreen(
 
         // Report the resting position back to the activity (map padding / recenter / arrivals preview).
         // While hidden the sheet still rests at `PartiallyExpanded` (just with a 0 peek), so fold the
-        // shown flag in: a hidden sheet reports `Hidden` (map padding 0), else its live expansion.
-        LaunchedEffect(sheetState) {
+        // shown flag in: a hidden sheet reports `Hidden` (map padding 0), else its live expansion. Keyed
+        // on collapsedPeekPx too so a late peek measurement (or nav-bar inset resolving) re-emits the
+        // resting state with the corrected map inset rather than sticking at the stale height.
+        LaunchedEffect(sheetState, collapsedPeekPx) {
             snapshotFlow {
                 if (!sheetShown) ArrivalsSheetState.Hidden else sheetState.currentValue.toArrivalsSheetState()
             }.collect { value ->
-                onSheetSettled(value, peekContentPx)
+                onSheetSettled(value, collapsedPeekPx)
             }
         }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
@@ -183,18 +183,18 @@ class HomeViewModel @Inject constructor(
     fun onSheetSettled(state: ArrivalsSheetState, peekPx: Int) {
         val previous = settledSheet
         settledSheet = state
-        // The FAB lift is computed locally in HomeScreen now; this method only drives the map's bottom
-        // padding + the on-expand recenter. The initial reveal (from Hidden) is skipped.
-        if (previous == ArrivalsSheetState.Hidden) {
-            return
+        // The FAB lift is computed locally in HomeScreen now; this method drives the map's bottom padding
+        // + the on-expand recenter. The map inset must track the sheet's resting height on *every* settle,
+        // including the initial reveal (from Hidden) — otherwise an ETA tap right after focusing a stop
+        // (the sheet's first appearance) frames the vehicle+stop against a stale 0 inset and lands them
+        // under the drawer. Only the on-expand recenter is skipped on that initial reveal (matching the
+        // legacy behavior: don't yank the camera onto the focused stop just because the sheet appeared).
+        _mapBottomPadding.value = when (state) {
+            ArrivalsSheetState.Expanded, ArrivalsSheetState.Collapsed -> peekPx
+            ArrivalsSheetState.Hidden -> 0
         }
-        when (state) {
-            ArrivalsSheetState.Expanded -> {
-                _mapBottomPadding.value = peekPx
-                recenterOnFocusedStop()
-            }
-            ArrivalsSheetState.Collapsed -> _mapBottomPadding.value = peekPx
-            ArrivalsSheetState.Hidden -> _mapBottomPadding.value = 0
+        if (state == ArrivalsSheetState.Expanded && previous != ArrivalsSheetState.Hidden) {
+            recenterOnFocusedStop()
         }
     }
 

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreCameraCommands.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreCameraCommands.kt
@@ -105,8 +105,15 @@ fun applyFramingIntent(intent: FramingIntent, map: MapLibreMap, renderState: Map
                 .include(LatLng(sw.latitude, sw.longitude))
                 .include(LatLng(ne.latitude, ne.longitude))
                 .build()
+            // maplibre's newLatLngBounds fits the box against *only* the padding passed here — unlike the
+            // Google flavor it does NOT consult the map's persistent setPadding (its CameraBoundsUpdate
+            // fits against its own padding array). So the route-header (top) + arrivals-sheet (bottom)
+            // insets have to be folded into the fit explicitly, on top of the symmetric breathing room,
+            // or the vehicle+stop pair lands under one of the two overlays that are open after an ETA tap.
+            val pad = ViewUtils.dpToPixels(context, POINTS_FRAMING_PADDING_DP)
+            val overlay = renderState.padding.value
             map.animateCamera(
-                CameraUpdateFactory.newLatLngBounds(bounds, ViewUtils.dpToPixels(context, POINTS_FRAMING_PADDING_DP))
+                CameraUpdateFactory.newLatLngBounds(bounds, pad, overlay.topPx + pad, pad, overlay.bottomPx + pad)
             )
         }
     }


### PR DESCRIPTION
## Problem

Tapping an ETA pill frames the trip's live vehicle together with its originating stop so the map shows the relationship between the two. But the fit didn't account for the two overlays that are always open right after the tap — the route-mode header (top) and the arrivals sheet (bottom) — so the stop/vehicle pair could end up hidden underneath them. Observed on the Google flavor; MapLibre was affected too.

## Root causes

Three independent gaps combined here:

1. **Bottom inset was never applied on the common path.** `onSheetSettled` returned early before setting the map's bottom padding on the sheet's *initial* reveal (`previous == Hidden`). So the ordinary flow — focus a stop (sheet reveals `Hidden → Collapsed`), then immediately tap an ETA pill — framed against a stale `0` bottom inset. The early-return was only meant to suppress the on-expand recenter, not the padding. Now the inset is tracked on **every** settle; only the recenter is skipped on the initial reveal.

2. **Bottom inset undercounted the sheet.** It used the measured header+rows content px, but the collapsed sheet also occupies the drag handle and the navigation-bar inset. Now it uses the full `collapsedPeekPx` — the same height the scaffold peek and the FAB lift already use.

3. **Framing didn't see the current insets at fit time.**
   - **Google:** the padding collector and the framing collector are separate coroutines with no ordering guarantee, so an ETA tap could run the fit against stale map padding. The Points fit now applies the current `MapPadding` synchronously before `animateCamera` (idempotent with the collector — `setPadding` is absolute).
   - **MapLibre:** its `newLatLngBounds` fits against only the padding passed in the call and never consults the map's persistent `setPadding` (and the MapLibre adapter had no padding collector at all). The Points fit now folds the top/bottom insets into the asymmetric `newLatLngBounds(bounds, left, top, right, bottom)` overload.

Both flavors read `renderState.padding.value` **live at fit time**, so a framing replayed to a re-created adapter re-fits correctly. A small `GoogleMap.applyMapPadding` extension is extracted so the padding collector and the Points framing share one `MapPadding → setPadding` mapping.

## Testing

- Device-verified on the Google flavor (Pixel 7 Pro): focus a stop, tap an ETA pill — the vehicle/stop pair now clears both the route header and the arrivals drawer.
- Builds clean on both `obaGoogle` and `obaMaplibre` with `-PwarningsAsErrors=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)