### PR TITLE
Persist a map stop cache so stops render instantly (#1754)

### DIFF
--- a/onebusaway-android/schemas/org.onebusaway.android.database.AppDatabase/5.json
+++ b/onebusaway-android/schemas/org.onebusaway.android.database.AppDatabase/5.json
@@ -1,0 +1,894 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 5,
+    "identityHash": "8c151954b48bd7c35009e3d938181f8c",
+    "entities": [
+      {
+        "tableName": "studies",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`study_id` INTEGER NOT NULL, `name` TEXT NOT NULL, `description` TEXT NOT NULL, `is_subscribed` INTEGER NOT NULL, PRIMARY KEY(`study_id`))",
+        "fields": [
+          {
+            "fieldPath": "study_id",
+            "columnName": "study_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "is_subscribed",
+            "columnName": "is_subscribed",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "study_id"
+          ]
+        }
+      },
+      {
+        "tableName": "surveys",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`survey_id` INTEGER NOT NULL, `study_id` INTEGER NOT NULL, `name` TEXT NOT NULL, `state` INTEGER NOT NULL, PRIMARY KEY(`survey_id`), FOREIGN KEY(`study_id`) REFERENCES `studies`(`study_id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "survey_id",
+            "columnName": "survey_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "study_id",
+            "columnName": "study_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "survey_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_surveys_study_id",
+            "unique": false,
+            "columnNames": [
+              "study_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_surveys_study_id` ON `${TABLE_NAME}` (`study_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "studies",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "study_id"
+            ],
+            "referencedColumns": [
+              "study_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "alerts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "stops",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` TEXT NOT NULL, `code` TEXT NOT NULL, `name` TEXT NOT NULL, `direction` TEXT NOT NULL, `use_count` INTEGER NOT NULL, `latitude` REAL NOT NULL, `longitude` REAL NOT NULL, `user_name` TEXT, `access_time` INTEGER, `favorite` INTEGER, `region_id` INTEGER, PRIMARY KEY(`_id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "code",
+            "columnName": "code",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "direction",
+            "columnName": "direction",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "useCount",
+            "columnName": "use_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userName",
+            "columnName": "user_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "accessTime",
+            "columnName": "access_time",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "favorite",
+            "columnName": "favorite",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "regionId",
+            "columnName": "region_id",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "_id"
+          ]
+        }
+      },
+      {
+        "tableName": "routes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` TEXT NOT NULL, `short_name` TEXT NOT NULL, `long_name` TEXT, `use_count` INTEGER NOT NULL, `user_name` TEXT, `access_time` INTEGER, `favorite` INTEGER, `url` TEXT, `region_id` INTEGER, PRIMARY KEY(`_id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shortName",
+            "columnName": "short_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longName",
+            "columnName": "long_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "useCount",
+            "columnName": "use_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userName",
+            "columnName": "user_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "accessTime",
+            "columnName": "access_time",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "favorite",
+            "columnName": "favorite",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "regionId",
+            "columnName": "region_id",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "_id"
+          ]
+        }
+      },
+      {
+        "tableName": "trips",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` TEXT NOT NULL, `stop_id` TEXT NOT NULL, `route_id` TEXT, `departure` INTEGER NOT NULL, `headsign` TEXT, `name` TEXT NOT NULL, `reminder` INTEGER NOT NULL, `alarm_delete_path` TEXT NOT NULL, `service_date` INTEGER NOT NULL, `stop_sequence` INTEGER NOT NULL, `trip_id` TEXT NOT NULL, `vehicle_id` TEXT, PRIMARY KEY(`_id`, `stop_id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stopId",
+            "columnName": "stop_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "routeId",
+            "columnName": "route_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "departure",
+            "columnName": "departure",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "headsign",
+            "columnName": "headsign",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reminder",
+            "columnName": "reminder",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "alarmDeletePath",
+            "columnName": "alarm_delete_path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serviceDate",
+            "columnName": "service_date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stopSequence",
+            "columnName": "stop_sequence",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tripId",
+            "columnName": "trip_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vehicleId",
+            "columnName": "vehicle_id",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "_id",
+            "stop_id"
+          ]
+        }
+      },
+      {
+        "tableName": "stop_routes_filter",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `stop_id` TEXT NOT NULL, `route_id` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stopId",
+            "columnName": "stop_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "routeId",
+            "columnName": "route_id",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "_id"
+          ]
+        }
+      },
+      {
+        "tableName": "trip_alerts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `trip_id` TEXT NOT NULL, `stop_id` TEXT NOT NULL, `start_time` INTEGER NOT NULL, `state` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tripId",
+            "columnName": "trip_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stopId",
+            "columnName": "stop_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startTime",
+            "columnName": "start_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "_id"
+          ]
+        }
+      },
+      {
+        "tableName": "service_alerts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` TEXT NOT NULL, `marked_read_time` INTEGER, `hidden` INTEGER, PRIMARY KEY(`_id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "markedReadTime",
+            "columnName": "marked_read_time",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "hidden",
+            "columnName": "hidden",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "_id"
+          ]
+        }
+      },
+      {
+        "tableName": "regions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER NOT NULL, `name` TEXT NOT NULL, `oba_base_url` TEXT NOT NULL, `siri_base_url` TEXT NOT NULL, `lang` TEXT NOT NULL, `contact_email` TEXT NOT NULL, `supports_api_discovery` INTEGER NOT NULL, `supports_api_realtime` INTEGER NOT NULL, `supports_siri_realtime` INTEGER NOT NULL, `twitter_url` TEXT, `experimental` INTEGER, `stop_info_url` TEXT, `otp_base_url` TEXT, `otp_contact_email` TEXT, `supports_otp_bikeshare` INTEGER, `supports_embedded_social` INTEGER, `payment_android_app_id` TEXT, `payment_warning_title` TEXT, `payment_warning_body` TEXT, `sidecar_base_url` TEXT DEFAULT 'https://onebusaway.co', `plausible_analytics_server_url` TEXT, `umami_analytics_url` TEXT, `umami_analytics_id` TEXT, PRIMARY KEY(`_id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "obaBaseUrl",
+            "columnName": "oba_base_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "siriBaseUrl",
+            "columnName": "siri_base_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "lang",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contactEmail",
+            "columnName": "contact_email",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "supportsObaDiscovery",
+            "columnName": "supports_api_discovery",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "supportsObaRealtime",
+            "columnName": "supports_api_realtime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "supportsSiriRealtime",
+            "columnName": "supports_siri_realtime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "twitterUrl",
+            "columnName": "twitter_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "experimental",
+            "columnName": "experimental",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "stopInfoUrl",
+            "columnName": "stop_info_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "otpBaseUrl",
+            "columnName": "otp_base_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "otpContactEmail",
+            "columnName": "otp_contact_email",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "supportsOtpBikeshare",
+            "columnName": "supports_otp_bikeshare",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "supportsEmbeddedSocial",
+            "columnName": "supports_embedded_social",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "paymentAndroidAppId",
+            "columnName": "payment_android_app_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "paymentWarningTitle",
+            "columnName": "payment_warning_title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "paymentWarningBody",
+            "columnName": "payment_warning_body",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sidecarBaseUrl",
+            "columnName": "sidecar_base_url",
+            "affinity": "TEXT",
+            "defaultValue": "'https://onebusaway.co'"
+          },
+          {
+            "fieldPath": "plausibleAnalyticsServerUrl",
+            "columnName": "plausible_analytics_server_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "umamiAnalyticsUrl",
+            "columnName": "umami_analytics_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "umamiAnalyticsId",
+            "columnName": "umami_analytics_id",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "_id"
+          ]
+        }
+      },
+      {
+        "tableName": "region_bounds",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `region_id` INTEGER NOT NULL, `lat` REAL NOT NULL, `lon` REAL NOT NULL, `lat_span` REAL NOT NULL, `lon_span` REAL NOT NULL, FOREIGN KEY(`region_id`) REFERENCES `regions`(`_id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "regionId",
+            "columnName": "region_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "lat",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "lon",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "latSpan",
+            "columnName": "lat_span",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lonSpan",
+            "columnName": "lon_span",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_region_bounds_region_id",
+            "unique": false,
+            "columnNames": [
+              "region_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_region_bounds_region_id` ON `${TABLE_NAME}` (`region_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "regions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "region_id"
+            ],
+            "referencedColumns": [
+              "_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "open311_servers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `region_id` INTEGER NOT NULL, `jurisdiction` TEXT, `api_key` TEXT NOT NULL, `open311_base_url` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "regionId",
+            "columnName": "region_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "jurisdiction",
+            "columnName": "jurisdiction",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "apiKey",
+            "columnName": "api_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "baseUrl",
+            "columnName": "open311_base_url",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "_id"
+          ]
+        }
+      },
+      {
+        "tableName": "nav_stops",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `nav_id` TEXT NOT NULL, `start_time` INTEGER NOT NULL, `trip_id` TEXT NOT NULL, `destination_id` TEXT NOT NULL, `before_id` TEXT NOT NULL, `seq_num` INTEGER NOT NULL, `is_active` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "navId",
+            "columnName": "nav_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startTime",
+            "columnName": "start_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tripId",
+            "columnName": "trip_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "destinationId",
+            "columnName": "destination_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "beforeId",
+            "columnName": "before_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sequence",
+            "columnName": "seq_num",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "active",
+            "columnName": "is_active",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "_id"
+          ]
+        }
+      },
+      {
+        "tableName": "cached_stops",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` TEXT NOT NULL, `code` TEXT, `name` TEXT, `direction` TEXT, `latitude` REAL NOT NULL, `longitude` REAL NOT NULL, `location_type` INTEGER NOT NULL, `route_ids` TEXT NOT NULL, `region_id` INTEGER NOT NULL, `last_seen` INTEGER NOT NULL, PRIMARY KEY(`_id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "code",
+            "columnName": "code",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "direction",
+            "columnName": "direction",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "locationType",
+            "columnName": "location_type",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "routeIds",
+            "columnName": "route_ids",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "regionId",
+            "columnName": "region_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSeen",
+            "columnName": "last_seen",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cached_stops_region_id_latitude_longitude",
+            "unique": false,
+            "columnNames": [
+              "region_id",
+              "latitude",
+              "longitude"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_stops_region_id_latitude_longitude` ON `${TABLE_NAME}` (`region_id`, `latitude`, `longitude`)"
+          },
+          {
+            "name": "index_cached_stops_region_id_last_seen",
+            "unique": false,
+            "columnNames": [
+              "region_id",
+              "last_seen"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_stops_region_id_last_seen` ON `${TABLE_NAME}` (`region_id`, `last_seen`)"
+          }
+        ]
+      },
+      {
+        "tableName": "cached_route_types",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` TEXT NOT NULL, `type` INTEGER NOT NULL, `region_id` INTEGER NOT NULL, `last_seen` INTEGER NOT NULL, PRIMARY KEY(`_id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "regionId",
+            "columnName": "region_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSeen",
+            "columnName": "last_seen",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cached_route_types_region_id_last_seen",
+            "unique": false,
+            "columnNames": [
+              "region_id",
+              "last_seen"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_route_types_region_id_last_seen` ON `${TABLE_NAME}` (`region_id`, `last_seen`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '8c151954b48bd7c35009e3d938181f8c')"
+    ]
+  }
+}

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/database/AppDatabaseMigrationTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/database/AppDatabaseMigrationTest.kt
@@ -112,6 +112,35 @@ class AppDatabaseMigrationTest {
         db.close()
     }
 
+    @Test
+    fun migrate4To5_createsCacheTables() {
+        helper.createDatabase(TEST_DB, 4).close()
+
+        // runMigrationsAndValidate asserts the resulting schema matches the exported 5.json.
+        val db = helper.runMigrationsAndValidate(TEST_DB, 5, true, MIGRATION_4_5)
+
+        // Both cache tables exist and are empty.
+        for (table in listOf("cached_stops", "cached_route_types")) {
+            db.query("SELECT count(*) FROM $table").use { c ->
+                c.moveToFirst()
+                assertEquals("expected empty $table", 0, c.getInt(0))
+            }
+        }
+        // And accept a row each (columns resolve).
+        db.execSQL(
+            "INSERT INTO cached_stops " +
+                "(_id, code, name, direction, latitude, longitude, location_type, route_ids, region_id, last_seen) " +
+                "VALUES ('1_1', '1', 'A', 'N', 47.6, -122.3, 0, '', 1, 123)"
+        )
+        db.execSQL(
+            "INSERT INTO cached_route_types (_id, type, region_id, last_seen) VALUES ('r1', 3, 1, 123)"
+        )
+        db.query("SELECT count(*) FROM cached_stops").use { c ->
+            c.moveToFirst(); assertEquals(1, c.getInt(0))
+        }
+        db.close()
+    }
+
     private fun favoriteOf(
         db: androidx.sqlite.db.SupportSQLiteDatabase,
         routeId: String

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/database/oba/MapStopCacheDaoTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/database/oba/MapStopCacheDaoTest.kt
@@ -1,0 +1,192 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.database.oba
+
+import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.onebusaway.android.database.AppDatabase
+
+/**
+ * Verifies [MapStopCacheDao] against a real Room DB: the bounding-box viewport query (region + TTL
+ * scoped), the route-type lookup, and the TTL + size-cap eviction.
+ */
+@RunWith(AndroidJUnit4::class)
+class MapStopCacheDaoTest {
+
+    private lateinit var db: AppDatabase
+    private lateinit var dao: MapStopCacheDao
+
+    @Before
+    fun setUp() {
+        db = Room.inMemoryDatabaseBuilder(
+            InstrumentationRegistry.getInstrumentation().targetContext, AppDatabase::class.java
+        ).build()
+        dao = db.mapStopCacheDao()
+    }
+
+    @After
+    fun tearDown() = db.close()
+
+    @Test
+    fun stopsInBounds_filtersByBoundingBox() = runBlocking {
+        dao.upsertStops(
+            listOf(
+                stop("in", lat = 47.60, lon = -122.30, regionId = 1L, lastSeen = 100),
+                stop("outLat", lat = 47.90, lon = -122.30, regionId = 1L, lastSeen = 100),
+                stop("outLon", lat = 47.60, lon = -121.90, regionId = 1L, lastSeen = 100),
+            )
+        )
+        val rows = dao.stopsInBounds(
+            regionId = 1L, minLat = 47.55, maxLat = 47.65, minLon = -122.35, maxLon = -122.25,
+            centerLat = 47.60, centerLon = -122.30, ttlCutoff = 0, limit = 100,
+        )
+        assertEquals(setOf("in"), rows.map { it.id }.toSet())
+    }
+
+    @Test
+    fun stopsInBounds_excludesOtherRegionsAndStaleRows() = runBlocking {
+        dao.upsertStops(
+            listOf(
+                stop("fresh", lat = 47.60, lon = -122.30, regionId = 1L, lastSeen = 1_000),
+                stop("otherRegion", lat = 47.60, lon = -122.30, regionId = 2L, lastSeen = 1_000),
+                stop("stale", lat = 47.60, lon = -122.30, regionId = 1L, lastSeen = 100),
+            )
+        )
+        val rows = dao.stopsInBounds(
+            regionId = 1L, minLat = 47.5, maxLat = 47.7, minLon = -122.4, maxLon = -122.2,
+            centerLat = 47.60, centerLon = -122.30, ttlCutoff = 500, limit = 100,
+        )
+        assertEquals(setOf("fresh"), rows.map { it.id }.toSet())
+    }
+
+    @Test
+    fun stopsInBounds_whenOverLimit_returnsNearestToCenterFirst() = runBlocking {
+        // Three stops north of a shared center at increasing distance; a limit of 2 must drop the
+        // farthest, so the render is centred on the viewport rather than an arbitrary edge.
+        dao.upsertStops(
+            listOf(
+                stop("near", lat = 47.61, lon = -122.30, regionId = 1L, lastSeen = 100),
+                stop("mid", lat = 47.64, lon = -122.30, regionId = 1L, lastSeen = 100),
+                stop("far", lat = 47.69, lon = -122.30, regionId = 1L, lastSeen = 100),
+            )
+        )
+        val rows = dao.stopsInBounds(
+            regionId = 1L, minLat = 47.5, maxLat = 47.7, minLon = -122.4, maxLon = -122.2,
+            centerLat = 47.60, centerLon = -122.30, ttlCutoff = 0, limit = 2,
+        )
+        assertEquals(listOf("near", "mid"), rows.map { it.id })   // nearest first, farthest dropped
+    }
+
+    @Test
+    fun routeTypes_returnsRequestedSubset() = runBlocking {
+        dao.upsertRouteTypes(
+            listOf(
+                CachedRouteTypeRecord("r1", type = 3, regionId = 1L, lastSeen = 1),
+                CachedRouteTypeRecord("r2", type = 2, regionId = 1L, lastSeen = 1),
+                CachedRouteTypeRecord("r3", type = 4, regionId = 1L, lastSeen = 1),
+            )
+        )
+        val types = dao.routeTypes(listOf("r1", "r3")).associate { it.id to it.type }
+        assertEquals(mapOf("r1" to 3, "r3" to 4), types)
+    }
+
+    @Test
+    fun evictStaleStops_dropsOnlyRowsBeforeCutoff() = runBlocking {
+        dao.upsertStops(
+            listOf(
+                stop("old", lat = 1.0, lon = 1.0, regionId = 1L, lastSeen = 100),
+                stop("new", lat = 1.0, lon = 1.0, regionId = 1L, lastSeen = 900),
+            )
+        )
+        dao.evictStaleStops(regionId = 1L, ttlCutoff = 500)
+
+        val remaining = dao.stopsInBounds(1L, 0.0, 2.0, 0.0, 2.0, centerLat = 1.0, centerLon = 1.0, ttlCutoff = 0, limit = 100)
+        assertEquals(setOf("new"), remaining.map { it.id }.toSet())
+    }
+
+    @Test
+    fun evictBeyondCap_keepsTheMostRecentlySeen() = runBlocking {
+        dao.upsertStops(
+            (1..5).map { i ->
+                stop("s$i", lat = 1.0, lon = 1.0, regionId = 1L, lastSeen = i.toLong())
+            }
+        )
+        dao.evictBeyondCap(regionId = 1L, cap = 2)
+
+        val remaining = dao.stopsInBounds(1L, 0.0, 2.0, 0.0, 2.0, centerLat = 1.0, centerLon = 1.0, ttlCutoff = 0, limit = 100)
+        assertEquals(setOf("s4", "s5"), remaining.map { it.id }.toSet())   // newest two by last_seen
+        assertEquals(2, dao.countStops(1L))
+    }
+
+    @Test
+    fun evictBeyondCap_isScopedToRegion() = runBlocking {
+        dao.upsertStops(
+            listOf(
+                stop("a1", lat = 1.0, lon = 1.0, regionId = 1L, lastSeen = 1),
+                stop("a2", lat = 1.0, lon = 1.0, regionId = 1L, lastSeen = 2),
+                stop("b1", lat = 1.0, lon = 1.0, regionId = 2L, lastSeen = 1),
+            )
+        )
+        dao.evictBeyondCap(regionId = 1L, cap = 1)
+
+        assertEquals(1, dao.countStops(1L))   // region 1 trimmed to 1
+        assertEquals(1, dao.countStops(2L))   // region 2 untouched
+    }
+
+    @Test
+    fun saveAndEvict_upsertsBothTablesAndTrims() = runBlocking {
+        // Pre-seed a stale row that saveAndEvict should drop.
+        dao.upsertStops(listOf(stop("stale", 1.0, 1.0, regionId = 1L, lastSeen = 1)))
+
+        dao.saveAndEvict(
+            stops = (1..3).map { stop("s$it", 1.0, 1.0, regionId = 1L, lastSeen = 1_000) },
+            types = listOf(CachedRouteTypeRecord("r1", 3, regionId = 1L, lastSeen = 1_000)),
+            regionId = 1L, ttlCutoff = 500, cap = 100,
+        )
+
+        val remaining = dao.stopsInBounds(1L, 0.0, 2.0, 0.0, 2.0, centerLat = 1.0, centerLon = 1.0, ttlCutoff = 0, limit = 100)
+        assertEquals(setOf("s1", "s2", "s3"), remaining.map { it.id }.toSet())   // stale gone
+        assertEquals(listOf(3), dao.routeTypes(listOf("r1")).map { it.type })
+    }
+
+    @Test
+    fun zeroRouteStop_roundTrips() = runBlocking {
+        dao.upsertStops(listOf(stop("s1", 1.0, 1.0, regionId = 1L, lastSeen = 1, routeIds = "")))
+        val row = dao.stopsInBounds(1L, 0.0, 2.0, 0.0, 2.0, centerLat = 1.0, centerLon = 1.0, ttlCutoff = 0, limit = 100).single()
+        assertEquals("", row.routeIds)
+        assertEquals(emptyList<String>(), splitRouteIds(row.routeIds).toList())
+    }
+
+    private fun stop(
+        id: String,
+        lat: Double,
+        lon: Double,
+        regionId: Long,
+        lastSeen: Long,
+        routeIds: String = "r1",
+    ) = CachedStopRecord(
+        id = id, code = "code", name = "name", direction = "N",
+        latitude = lat, longitude = lon, locationType = 0,
+        routeIds = routeIds, regionId = regionId, lastSeen = lastSeen,
+    )
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/app/di/DatabaseModule.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/app/di/DatabaseModule.kt
@@ -27,10 +27,12 @@ import org.onebusaway.android.database.AppDatabase
 import org.onebusaway.android.database.MIGRATION_1_2
 import org.onebusaway.android.database.MIGRATION_2_3
 import org.onebusaway.android.database.MIGRATION_3_4
+import org.onebusaway.android.database.MIGRATION_4_5
 import org.onebusaway.android.database.oba.DefaultImportGate
 import org.onebusaway.android.database.oba.ImportGate
 import org.onebusaway.android.database.oba.LegacyDataImporter
 import org.onebusaway.android.database.oba.LegacyImportDao
+import org.onebusaway.android.database.oba.MapStopCacheDao
 import org.onebusaway.android.database.oba.NavStopDao
 import org.onebusaway.android.database.oba.RegionDao
 import org.onebusaway.android.database.oba.RouteDao
@@ -61,7 +63,7 @@ object DatabaseModule {
             context.applicationContext,
             AppDatabase::class.java,
             AppDatabase.DATABASE_NAME
-        ).addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4).build()
+        ).addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5).build()
 
     @Provides
     fun provideLegacyImportDao(db: AppDatabase): LegacyImportDao = db.legacyImportDao()
@@ -86,6 +88,9 @@ object DatabaseModule {
 
     @Provides
     fun provideNavStopDao(db: AppDatabase): NavStopDao = db.navStopDao()
+
+    @Provides
+    fun provideMapStopCacheDao(db: AppDatabase): MapStopCacheDao = db.mapStopCacheDao()
 
     @Provides
     fun provideStudiesDao(db: AppDatabase): StudiesDao = db.studiesDao()

--- a/onebusaway-android/src/main/java/org/onebusaway/android/database/AppDatabase.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/database/AppDatabase.kt
@@ -2,7 +2,10 @@ package org.onebusaway.android.database
 
 import androidx.room.Database
 import androidx.room.RoomDatabase
+import org.onebusaway.android.database.oba.CachedRouteTypeRecord
+import org.onebusaway.android.database.oba.CachedStopRecord
 import org.onebusaway.android.database.oba.LegacyImportDao
+import org.onebusaway.android.database.oba.MapStopCacheDao
 import org.onebusaway.android.database.oba.NavStopDao
 import org.onebusaway.android.database.oba.NavStopRecord
 import org.onebusaway.android.database.oba.RegionDao
@@ -38,6 +41,10 @@ import org.onebusaway.android.database.widealerts.entity.AlertEntity
  * v4 retires the two-tier route-favorite model (#1751): the `route_headsign_favorites` table is dropped
  * and `routes.favorite` becomes the single source of truth, matching `stops.favorite`. It also adds the
  * missing foreign-key child index on `surveys.study_id` (#1739).
+ *
+ * v5 adds the map stop cache (#1754): `cached_stops` + `cached_route_types`, a region-scoped spatial
+ * cache of nearby-stops loads (separate from the user-state `stops` table) so the map renders stops
+ * instantly on a slow/cold-start load.
  */
 @Database(
     entities = [
@@ -54,8 +61,10 @@ import org.onebusaway.android.database.widealerts.entity.AlertEntity
         RegionBoundRecord::class,
         Open311ServerRecord::class,
         NavStopRecord::class,
+        CachedStopRecord::class,
+        CachedRouteTypeRecord::class,
     ],
-    version = 4,
+    version = 5,
     exportSchema = true,
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -77,6 +86,9 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun tripDao(): TripDao
     abstract fun regionDao(): RegionDao
     abstract fun navStopDao(): NavStopDao
+
+    // Map stop cache (#1754).
+    abstract fun mapStopCacheDao(): MapStopCacheDao
 
     companion object {
         /** The Room database filename (also the backup target). */

--- a/onebusaway-android/src/main/java/org/onebusaway/android/database/Migrations.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/database/Migrations.kt
@@ -122,3 +122,37 @@ val MIGRATION_3_4 = object : Migration(3, 4) {
         db.execSQL("CREATE INDEX IF NOT EXISTS `index_surveys_study_id` ON `surveys` (`study_id`)")
     }
 }
+
+/**
+ * Adds the map stop cache (#1754): `cached_stops` (a region-scoped spatial cache of nearby-stops loads,
+ * separate from the user-state `stops` table) + `cached_route_types` (the icon-colour lookup). Purely
+ * additive — no v4 table is touched (v4 is a frozen, released schema). The CREATE statements must match
+ * the exported `5.json` verbatim or Room's identity validation fails (see AppDatabaseMigrationTest).
+ */
+val MIGRATION_4_5 = object : Migration(4, 5) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            "CREATE TABLE IF NOT EXISTS `cached_stops` (`_id` TEXT NOT NULL, `code` TEXT, " +
+                "`name` TEXT, `direction` TEXT, `latitude` REAL NOT NULL, `longitude` REAL NOT NULL, " +
+                "`location_type` INTEGER NOT NULL, `route_ids` TEXT NOT NULL, " +
+                "`region_id` INTEGER NOT NULL, `last_seen` INTEGER NOT NULL, PRIMARY KEY(`_id`))"
+        )
+        db.execSQL(
+            "CREATE INDEX IF NOT EXISTS `index_cached_stops_region_id_latitude_longitude` " +
+                "ON `cached_stops` (`region_id`, `latitude`, `longitude`)"
+        )
+        db.execSQL(
+            "CREATE INDEX IF NOT EXISTS `index_cached_stops_region_id_last_seen` " +
+                "ON `cached_stops` (`region_id`, `last_seen`)"
+        )
+        db.execSQL(
+            "CREATE TABLE IF NOT EXISTS `cached_route_types` (`_id` TEXT NOT NULL, " +
+                "`type` INTEGER NOT NULL, `region_id` INTEGER NOT NULL, `last_seen` INTEGER NOT NULL, " +
+                "PRIMARY KEY(`_id`))"
+        )
+        db.execSQL(
+            "CREATE INDEX IF NOT EXISTS `index_cached_route_types_region_id_last_seen` " +
+                "ON `cached_route_types` (`region_id`, `last_seen`)"
+        )
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/database/oba/MapStopCacheDao.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/database/oba/MapStopCacheDao.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.database.oba
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Transaction
+
+/**
+ * Room access for the map stop cache ([CachedStopRecord] + [CachedRouteTypeRecord]). Only SQL lives
+ * here; the bounding-box math and TTL cutoff are pure helpers in [MapStopCacheMappers]
+ * ([boundsFor]/[ttlCutoff]). See [StopCacheRepository] for the caller-facing API.
+ */
+@Dao
+interface MapStopCacheDao {
+
+    // --- reads (bounding box + region + TTL) ---
+
+    /**
+     * Cached stops within the viewport bounds, for the region, seen no earlier than [ttlCutoff]. When
+     * more than [limit] match (a dense/zoomed-out view), returns the [limit] nearest the viewport centre
+     * ([centerLat]/[centerLon]) — so the render is centred on what the user is looking at, mirroring the
+     * server's centre-biased result, rather than an arbitrary corner of the box. Squared planar distance
+     * is enough to rank within one small viewport (no need for great-circle accuracy).
+     */
+    @Query(
+        "SELECT * FROM cached_stops WHERE region_id = :regionId AND last_seen >= :ttlCutoff " +
+            "AND latitude BETWEEN :minLat AND :maxLat AND longitude BETWEEN :minLon AND :maxLon " +
+            "ORDER BY (latitude - :centerLat) * (latitude - :centerLat) + " +
+            "(longitude - :centerLon) * (longitude - :centerLon) ASC LIMIT :limit"
+    )
+    suspend fun stopsInBounds(
+        regionId: Long,
+        minLat: Double,
+        maxLat: Double,
+        minLon: Double,
+        maxLon: Double,
+        centerLat: Double,
+        centerLon: Double,
+        ttlCutoff: Long,
+        limit: Int,
+    ): List<CachedStopRecord>
+
+    /** The cached route types for the given route ids (the icon-colour lookup). */
+    @Query("SELECT * FROM cached_route_types WHERE _id IN (:routeIds)")
+    suspend fun routeTypes(routeIds: List<String>): List<CachedRouteTypeRecord>
+
+    // --- writes ---
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsertStops(stops: List<CachedStopRecord>)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsertRouteTypes(types: List<CachedRouteTypeRecord>)
+
+    // --- eviction ---
+
+    @Query("DELETE FROM cached_stops WHERE region_id = :regionId AND last_seen < :ttlCutoff")
+    suspend fun evictStaleStops(regionId: Long, ttlCutoff: Long)
+
+    @Query("DELETE FROM cached_route_types WHERE region_id = :regionId AND last_seen < :ttlCutoff")
+    suspend fun evictStaleRouteTypes(regionId: Long, ttlCutoff: Long)
+
+    /** Keeps only the [cap] most-recently-seen stops in the region, dropping the rest. */
+    @Query(
+        "DELETE FROM cached_stops WHERE region_id = :regionId AND _id NOT IN " +
+            "(SELECT _id FROM cached_stops WHERE region_id = :regionId ORDER BY last_seen DESC LIMIT :cap)"
+    )
+    suspend fun evictBeyondCap(regionId: Long, cap: Int)
+
+    /**
+     * Upserts a viewport's stops + route types then evicts, in one transaction, so a concurrent
+     * [stopsInBounds] never observes a partially-written viewport. [ttlCutoff] drops stale rows;
+     * [cap] bounds the stop count per region.
+     */
+    @Transaction
+    suspend fun saveAndEvict(
+        stops: List<CachedStopRecord>,
+        types: List<CachedRouteTypeRecord>,
+        regionId: Long,
+        ttlCutoff: Long,
+        cap: Int,
+    ) {
+        upsertStops(stops)
+        upsertRouteTypes(types)
+        evictStaleStops(regionId, ttlCutoff)
+        evictStaleRouteTypes(regionId, ttlCutoff)
+        // The cap delete's `NOT IN (SELECT … LIMIT cap)` scans the whole region even when it would
+        // delete nothing, so gate it on a cheap indexed COUNT — the common (under-cap) pan skips it.
+        if (countStops(regionId) > cap) evictBeyondCap(regionId, cap)
+    }
+
+    /** The number of cached stops for a region. */
+    @Query("SELECT COUNT(*) FROM cached_stops WHERE region_id = :regionId")
+    suspend fun countStops(regionId: Long): Int
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/database/oba/MapStopCacheEntities.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/database/oba/MapStopCacheEntities.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.database.oba
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+/**
+ * A bus stop cached from a nearby-stops load, so a viewport can render its stops instantly (before —
+ * or without — a network response) and reconcile once the network returns (#1754). This is a spatial
+ * cache keyed by stop id and scoped per [regionId]; it is deliberately SEPARATE from the user-state
+ * `stops` table ([StopRecord]), which only holds favorites/recents/renames and must not be polluted
+ * with transient viewport stops.
+ *
+ * [lastSeen] (device wall-clock millis, stamped on every network upsert) is both the LRU key and the
+ * TTL staleness clock — reads never bump it, so it means "last network-confirmed". [direction] is
+ * nullable and stored verbatim (it is often the literal string `"null"`; see [CachedStopRecord.toObaStop]).
+ * [routeIds] is a delimited string (see [joinRouteIds]/[splitRouteIds]); `""` for a stop with no routes.
+ *
+ * The `(region_id, latitude, longitude)` index serves the bounding-box viewport query; the
+ * `(region_id, last_seen)` index serves the TTL + size-cap eviction.
+ */
+@Entity(
+    tableName = "cached_stops",
+    indices = [
+        Index(value = ["region_id", "latitude", "longitude"]),
+        Index(value = ["region_id", "last_seen"]),
+    ],
+)
+data class CachedStopRecord(
+    @PrimaryKey @ColumnInfo(name = "_id") val id: String,
+    @ColumnInfo(name = "code") val code: String?,
+    @ColumnInfo(name = "name") val name: String?,
+    @ColumnInfo(name = "direction") val direction: String?,
+    @ColumnInfo(name = "latitude") val latitude: Double,
+    @ColumnInfo(name = "longitude") val longitude: Double,
+    @ColumnInfo(name = "location_type") val locationType: Int,
+    @ColumnInfo(name = "route_ids") val routeIds: String,
+    @ColumnInfo(name = "region_id") val regionId: Long,
+    @ColumnInfo(name = "last_seen") val lastSeen: Long,
+)
+
+/**
+ * The GTFS route type ([org.onebusaway.android.models.ObaRoute.TYPE_BUS], etc.) for a route id, cached
+ * alongside [CachedStopRecord] so a cache-rendered stop marker gets its correct icon colour without a
+ * network response. Region-scoped; [lastSeen] drives the TTL eviction (no size cap — the routes-per-
+ * region count is small and bounded).
+ */
+@Entity(
+    tableName = "cached_route_types",
+    indices = [Index(value = ["region_id", "last_seen"])],
+)
+data class CachedRouteTypeRecord(
+    @PrimaryKey @ColumnInfo(name = "_id") val id: String,
+    @ColumnInfo(name = "type") val type: Int,
+    @ColumnInfo(name = "region_id") val regionId: Long,
+    @ColumnInfo(name = "last_seen") val lastSeen: Long,
+)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/database/oba/MapStopCacheMappers.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/database/oba/MapStopCacheMappers.kt
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.database.oba
+
+import android.location.Location
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.days
+import org.onebusaway.android.models.ObaStop
+import org.onebusaway.android.time.WallTime
+import org.onebusaway.android.util.locationOf
+
+/**
+ * Pure mapping + decision helpers for the map stop cache ([CachedStopRecord] ⇄ [ObaStop], the viewport
+ * bounding box, and the TTL cutoff). Kept free of Room/coroutines/clock reads so they are JVM-unit-
+ * testable; the clock ("now") is always passed in, never read here
+ * (see feedback_no_currenttimemillis_in_helpers).
+ */
+
+/** How long a cached stop stays servable before it is treated as stale and evicted. */
+val STOP_CACHE_TTL: Duration = 7.days
+
+/**
+ * The delimiter joining a stop's route ids into the [CachedStopRecord.routeIds] column. ASCII Unit
+ * Separator: OBA route ids contain `_`/`:`/`-`/digits but never a control character, so this can never
+ * collide with an id, unlike a comma/space.
+ */
+private const val ROUTE_ID_DELIM = '\u001F'
+
+/** Joins route ids for storage; an empty list becomes `""` (round-trips back to an empty array). */
+fun joinRouteIds(ids: Array<String>): String = ids.joinToString(ROUTE_ID_DELIM.toString())
+
+/** Splits the stored [CachedStopRecord.routeIds]; `""` becomes an empty array (not `arrayOf("")`). */
+fun splitRouteIds(joined: String): Array<String> =
+    if (joined.isEmpty()) emptyArray() else joined.split(ROUTE_ID_DELIM).toTypedArray()
+
+/** A viewport's latitude/longitude bounds for the cache bounding-box query. */
+data class LatLonBounds(
+    val minLat: Double,
+    val maxLat: Double,
+    val minLon: Double,
+    val maxLon: Double,
+)
+
+/**
+ * The bounds of the viewport centred on ([centerLat], [centerLon]) spanning [latSpan]/[lonSpan] (full
+ * spans, matching how [org.onebusaway.android.api.data.MapDataSource.nearbyStops] interprets them):
+ * centre ± span/2.
+ */
+fun boundsFor(centerLat: Double, centerLon: Double, latSpan: Double, lonSpan: Double): LatLonBounds =
+    LatLonBounds(
+        minLat = centerLat - latSpan / 2,
+        maxLat = centerLat + latSpan / 2,
+        minLon = centerLon - lonSpan / 2,
+        maxLon = centerLon + lonSpan / 2,
+    )
+
+/** Instants before this cutoff are stale — cached older than [STOP_CACHE_TTL] relative to [now]. */
+fun ttlCutoff(now: WallTime): WallTime = now - STOP_CACHE_TTL
+
+/**
+ * A cached stop presented as the [ObaStop] model interface. A dedicated impl (not
+ * [org.onebusaway.android.api.adapters.ObaStopElement], which coerces [direction] to a non-null `""`)
+ * so the nullable [direction] — often the literal `"null"` sentinel — and nullable [stopCode]/[name]
+ * round-trip verbatim; [org.onebusaway.android.map.StopsMapController.toStopMarker] relies on the exact
+ * `direction ?: "null"` behaviour.
+ */
+private class CachedObaStop(private val record: CachedStopRecord) : ObaStop {
+    override val id: String get() = record.id
+    override val stopCode: String? get() = record.code
+    override val name: String? get() = record.name
+    override val location: Location get() = locationOf(record.latitude, record.longitude)
+    override val latitude: Double get() = record.latitude
+    override val longitude: Double get() = record.longitude
+    override val direction: String? get() = record.direction
+    override val locationType: Int get() = record.locationType
+    override val routeIds: Array<String> get() = splitRouteIds(record.routeIds)
+}
+
+/** Presents this cached row as an [ObaStop] for the map overlay. */
+fun CachedStopRecord.toObaStop(): ObaStop = CachedObaStop(this)
+
+/** Maps a freshly-loaded [ObaStop] into a cache row, stamping [regionId]/[now]. */
+fun ObaStop.toCachedRecord(regionId: Long, now: Long): CachedStopRecord = CachedStopRecord(
+    id = id,
+    code = stopCode,
+    name = name,
+    direction = direction,
+    latitude = latitude,
+    longitude = longitude,
+    locationType = locationType,
+    routeIds = joinRouteIds(routeIds),
+    regionId = regionId,
+    lastSeen = now,
+)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/database/oba/StopCacheRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/database/oba/StopCacheRepository.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.database.oba
+
+import javax.inject.Inject
+import javax.inject.Singleton
+import org.onebusaway.android.models.NearbyStops
+import org.onebusaway.android.models.ObaStop
+import org.onebusaway.android.time.WallTime
+
+/** Cached stops for a viewport plus the route-id → GTFS-type lookup for their marker colours. */
+data class CachedViewport(val stops: List<ObaStop>, val routeTypes: Map<String, Int>)
+
+/**
+ * Persists and serves the map stop cache (#1754): the read-through store behind
+ * [org.onebusaway.android.map.StopsMapController]. [stopsFor] returns the cached stops overlapping a
+ * viewport (so the map can render before/without a network response); [save] upserts a network result
+ * and evicts, so the cache stays fresh and bounded. All cache rows are scoped by region — the caller
+ * must have a resolved region id (never a region-less query, which would mix feeds).
+ *
+ * [now] is the device wall clock ([WallTime] — the cache TTL is a purely local timer, per the CLAUDE.md
+ * time-domain rule); it's passed in by the caller so this never reads the clock directly, and unwrapped
+ * to epoch millis only at the DAO boundary.
+ */
+@Singleton
+class StopCacheRepository @Inject constructor(private val dao: MapStopCacheDao) {
+
+    /**
+     * The cached stops overlapping the viewport centred on ([centerLat], [centerLon]) spanning
+     * [latSpan]/[lonSpan], for [regionId], not older than the TTL relative to [now], capped at [limit].
+     * Empty (no [routeTypes] fetch) when nothing is cached.
+     */
+    suspend fun stopsFor(
+        centerLat: Double,
+        centerLon: Double,
+        latSpan: Double,
+        lonSpan: Double,
+        regionId: Long,
+        now: WallTime,
+        limit: Int,
+    ): CachedViewport {
+        val bounds = boundsFor(centerLat, centerLon, latSpan, lonSpan)
+        val rows = dao.stopsInBounds(
+            regionId, bounds.minLat, bounds.maxLat, bounds.minLon, bounds.maxLon,
+            centerLat, centerLon, ttlCutoff(now).epochMs, limit,
+        )
+        if (rows.isEmpty()) return CachedViewport(emptyList(), emptyMap())
+        val routeIds = rows.flatMapTo(mutableSetOf()) { splitRouteIds(it.routeIds).asIterable() }
+        val types = dao.routeTypes(routeIds.toList()).associate { it.id to it.type }
+        return CachedViewport(rows.map { it.toObaStop() }, types)
+    }
+
+    /** Upserts a network [nearby] load into the cache for [regionId] (stamped [now]) and evicts. */
+    suspend fun save(nearby: NearbyStops, regionId: Long, now: WallTime) {
+        val stopRows = nearby.stops.map { it.toCachedRecord(regionId, now.epochMs) }
+        val typeRows = nearby.routes.map { CachedRouteTypeRecord(it.id, it.type, regionId, now.epochMs) }
+        dao.saveAndEvict(stopRows, typeRows, regionId, ttlCutoff(now).epochMs, MAX_CACHED_STOPS_PER_REGION)
+    }
+
+    companion object {
+        /** The per-region stop cap; an order of magnitude above the in-memory viewport LRU (200). */
+        const val MAX_CACHED_STOPS_PER_REGION = 4000
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapDecisions.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapDecisions.kt
@@ -21,6 +21,7 @@ import androidx.lifecycle.SavedStateHandle
 import org.onebusaway.android.map.render.CameraSnapshot
 import org.onebusaway.android.map.render.GeoPoint
 import org.onebusaway.android.map.render.StopMarker
+import org.onebusaway.android.map.render.haversineMeters
 import org.onebusaway.android.util.locationOf
 import org.onebusaway.android.util.PreferenceUtils
 import java.util.concurrent.TimeUnit
@@ -110,21 +111,55 @@ internal fun retainOnlyFocusedStop(accum: LinkedHashMap<String, StopMarker>, foc
 }
 
 /**
- * The stop-accumulation LRU trim: evicts least-recently-used stops until [accum] holds at most [cap],
- * in place. [accum] is access-ordered, so its iterator walks eldest (least-recently-used) first; the
- * entry for [focusedId] is always skipped so the focused stop is never evicted. No-op at/under the
- * cap. Replaces the old clear-everything cap; pure, so the keep-the-focused-stop eviction is
- * unit-testable.
+ * Bounds the stop accumulation to the [cap] markers nearest [center], removing the rest in place;
+ * [focusedId] (when present) is always kept and counts toward the cap. No-op at/under the cap.
+ *
+ * Proximity, not recency (the old LRU): so a stop load that returns an incomplete sample over the whole
+ * viewport can never evict the centred "core" the user is looking at (#1754) — only far-edge stops are
+ * dropped. Pure, so the keep-nearest eviction is unit-testable.
  */
-internal fun trimStopCache(
+internal fun trimToNearest(
     accum: LinkedHashMap<String, StopMarker>,
-    focusedId: String?,
+    center: GeoPoint,
     cap: Int,
+    focusedId: String?,
 ) {
     if (accum.size <= cap) return
+    val keep = LinkedHashSet<String>()
+    if (focusedId != null && accum.containsKey(focusedId)) keep.add(focusedId)
+    // Precompute each marker's distance once (sortedBy's comparator would otherwise recompute it per
+    // comparison). haversineMeters ranks correctly at any latitude, unlike a raw degree-plane metric.
+    val byDistance = accum.values
+        .map { it.id to haversineMeters(it.point, center) }
+        .sortedBy { it.second }
+    for ((id, _) in byDistance) {
+        if (keep.size >= cap) break
+        keep.add(id)
+    }
+    accum.keys.retainAll(keep)
+}
+
+/**
+ * The authoritative-response cache-bust (#1754): removes accumulated stops inside the viewport
+ * [southWest]..[northEast] that a **complete** load omitted ([present] = the load's stop ids), in place;
+ * [focusedId] is never removed. Only safe for a complete response — an incomplete one is a sample and
+ * says nothing about which stops are absent, so it must not remove anything.
+ */
+internal fun evictStaleInViewport(
+    accum: LinkedHashMap<String, StopMarker>,
+    southWest: GeoPoint,
+    northEast: GeoPoint,
+    present: Set<String>,
+    focusedId: String?,
+) {
     val it = accum.entries.iterator()
-    while (accum.size > cap && it.hasNext()) {
-        if (it.next().key != focusedId) it.remove()
+    while (it.hasNext()) {
+        val (id, marker) = it.next()
+        if (id == focusedId || id in present) continue
+        val p = marker.point
+        val inside = p.latitude in southWest.latitude..northEast.latitude &&
+            p.longitude in southWest.longitude..northEast.longitude
+        if (inside) it.remove()
     }
 }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapHost.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapHost.kt
@@ -40,6 +40,18 @@ import org.onebusaway.android.region.RegionRepository
 import org.onebusaway.android.util.PermissionUtils
 import org.onebusaway.android.util.PreferenceUtils
 
+/** The informational strip shown across the top of the nearby-stops map (see [MapHost.stopsBanner]). */
+sealed interface StopsBanner {
+    /** No banner. */
+    data object None : StopsBanner
+
+    /** The load was truncated (the API's `limitExceeded`): prompt the user to zoom in for more stops. */
+    data object MoreStopsAvailable : StopsBanner
+
+    /** A load failed with cached stops on screen (offline, #1754): the map is showing saved stops. */
+    data object ShowingSavedStops : StopsBanner
+}
+
 /**
  * The flavor-neutral **map surface**: everything a map screen needs regardless of *what* it shows.
  * It owns the shared [MapRenderState], the live camera read-back + seed + cross-process persistence,
@@ -120,18 +132,19 @@ class MapHost(
         _progress.value = inProgress
     }
 
-    private val _moreStopsAvailable = MutableStateFlow(false)
+    private val _stopsBanner = MutableStateFlow<StopsBanner>(StopsBanner.None)
 
     /**
-     * Whether the last viewport stop load was truncated (the API's `limitExceeded`): more stops match
-     * the viewport than were returned, so the UI can prompt the user to zoom in. Set by the stop
+     * The informational strip across the top of the nearby-stops map: prompt to zoom in when the load
+     * was truncated ([StopsBanner.MoreStopsAvailable]), or a "showing saved stops" notice when a load
+     * failed with cached stops on screen ([StopsBanner.ShowingSavedStops], #1754). Set by the stop
      * loader on each load; cleared when leaving the nearby-stops view.
      */
-    val moreStopsAvailable: StateFlow<Boolean> = _moreStopsAvailable.asStateFlow()
+    val stopsBanner: StateFlow<StopsBanner> = _stopsBanner.asStateFlow()
 
-    /** Set by the stop loader to the last response's `limitExceeded`; cleared on view changes. */
-    fun setMoreStopsAvailable(available: Boolean) {
-        _moreStopsAvailable.value = available
+    /** Set by the stop loader per load; cleared ([StopsBanner.None]) on view changes. */
+    fun setStopsBanner(banner: StopsBanner) {
+        _stopsBanner.value = banner
     }
 
     private val _effects = MutableSharedFlow<MapEffect>(extraBufferCapacity = 8)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
@@ -37,6 +37,7 @@ import org.onebusaway.android.models.ObaStop
 import org.onebusaway.android.models.RouteMapDirection
 import org.onebusaway.android.api.data.MapDataSource
 import org.onebusaway.android.database.oba.RouteFavoritesRepository
+import org.onebusaway.android.database.oba.StopCacheRepository
 import org.onebusaway.android.database.oba.StopDao
 import org.onebusaway.android.extrapolation.data.TripObservationRepository
 import org.onebusaway.android.models.ObaTripStatus
@@ -107,6 +108,7 @@ class MapViewModel @Inject constructor(
     private val prefsRepository: PreferencesRepository,
     private val tripObservationRepository: TripObservationRepository,
     private val stopDao: StopDao,
+    private val stopCache: StopCacheRepository,
     private val routeFavorites: RouteFavoritesRepository,
     @param:ApplicationContext private val context: Context,
 ) : ViewModel() {
@@ -149,6 +151,9 @@ class MapViewModel @Inject constructor(
         // The home map stars the user's favorite stops (#1680). Room runs the query off the main thread
         // and re-emits on any favorite change, so starring a stop updates the map immediately.
         favoriteStopIds = stopDao.favoriteStopIds().map { it.toSet() },
+        // The home map reads through the persistent stop cache (#1754) so stops appear instantly on a
+        // slow/cold-start load.
+        stopCache = stopCache,
     )
 
     // ----- Map-host surface (delegated) -----
@@ -163,8 +168,8 @@ class MapViewModel @Inject constructor(
     /** Whether a viewport/route load is in flight (the old `Callback.showProgress`). */
     val progress: StateFlow<Boolean> get() = mapHost.progress
 
-    /** Whether the last nearby-stops load was truncated (drives the "zoom in to see more stops" banner). */
-    val moreStopsAvailable: StateFlow<Boolean> get() = mapHost.moreStopsAvailable
+    /** The nearby-stops info banner state — "zoom in for more stops" or "showing saved stops" (#1754). */
+    val stopsBanner: StateFlow<StopsBanner> get() = mapHost.stopsBanner
 
     /** One-shot events that need an Activity (e.g. the out-of-range prompt). */
     val effects: SharedFlow<MapEffect> get() = mapHost.effects
@@ -328,7 +333,7 @@ class MapViewModel @Inject constructor(
         bikeController.stop()
         stopsController.clearStops(false)
         mapHost.setProgress(false)
-        mapHost.setMoreStopsAvailable(false)
+        mapHost.setStopsBanner(StopsBanner.None)
         // Drop any retained framing (route/itinerary/region fit) so it isn't replayed onto the next view
         // — e.g. a stale route fit re-applied when a re-created adapter re-subscribes in nearby-stops
         // mode. The view we enter next sets its own framing (or none, for nearby stops).

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/StopsMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/StopsMapController.kt
@@ -16,6 +16,7 @@
 package org.onebusaway.android.map
 
 import android.util.Log
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
@@ -31,6 +32,8 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import org.onebusaway.android.api.data.MapDataSource
+import org.onebusaway.android.database.oba.CachedViewport
+import org.onebusaway.android.database.oba.StopCacheRepository
 import org.onebusaway.android.models.NearbyStops
 import org.onebusaway.android.models.ObaRoute
 import org.onebusaway.android.models.ObaStop
@@ -42,6 +45,7 @@ import org.onebusaway.android.map.render.StopMarker
 import org.onebusaway.android.map.render.primaryRouteType
 import org.onebusaway.android.map.render.stopZoomBand
 import org.onebusaway.android.region.RegionRepository
+import org.onebusaway.android.time.WallTime
 import org.onebusaway.android.util.RegionUtils
 
 /**
@@ -64,20 +68,29 @@ class StopsMapController(
     private val locationRepository: LocationRepository,
     private val scope: CoroutineScope,
     private val routeActive: () -> Boolean = { false },
-    // The LRU cache size, read on each load so a change in advanced settings applies on the next pan.
+    // The in-memory stop cap, read on each load so a change in advanced settings applies on the next pan.
     private val cacheSize: () -> Int = { DEFAULT_STOP_CACHE_SIZE },
     // The ids of the user's starred (favorite) stops, live: starring/unstarring re-flags the drawn
     // markers so their star icon + tap preference appear immediately (#1680). Defaults to no favorites
     // for the slim stop maps (the report/picker) that don't surface starred stops.
     private val favoriteStopIds: Flow<Set<String>> = flowOf(emptySet()),
+    // The persistent stop cache (#1754): each viewport renders cached stops first, then reconciles
+    // with the network. Null disables read-through (the slim report/picker maps, which are transient
+    // and would only add write churn), mirroring the favoriteStopIds no-op default.
+    private val stopCache: StopCacheRepository? = null,
+    // The device wall clock for the cache TTL (a purely local timer). Read once per load; injectable so
+    // tests pin it. The default is the sanctioned WallTime.now() mint (inert for the slim maps, whose
+    // cache is disabled so it's never read).
+    private val now: () -> WallTime = { WallTime.now() },
 ) {
 
     private val renderState get() = host.renderState
 
-    // Stop accumulation across pans, as an access-ordered LRU (a re-seen stop bumps to most-recently-
-    // used; once over the configured [cacheSize] the least-recently-seen non-focused stops evict) + the
-    // routes cache used to resolve a stop's icon route type and to report a stop's routes to listeners.
-    private val stopAccum = LinkedHashMap<String, StopMarker>(16, 0.75f, true)
+    // Stop accumulation across pans: bounded to the [cacheSize] stops nearest the viewport centre (see
+    // trimToNearest), never by recency — so an incomplete load can't evict the centred core. Plain
+    // insertion order; nothing consumes access order. Alongside the routes cache used to resolve a
+    // stop's icon route type and to report a stop's routes to listeners.
+    private val stopAccum = LinkedHashMap<String, StopMarker>()
 
     private val cachedRoutes = HashMap<String, ObaRoute>()
 
@@ -157,11 +170,37 @@ class StopsMapController(
             .filterNot { next -> stopRequestFulfilled(lastLoad, lastHadResponse, lastLimitExceeded, next) }
             .flatMapLatest { snapshot ->
                 // flatMapLatest cancels an in-flight load when a newer viewport arrives, matching the
-                // controller's `loadJob?.cancel()`; a cancelled load leaves lastLoad untouched.
+                // controller's `loadJob?.cancel()`; a cancelled load leaves lastLoad untouched (and
+                // skips a superseded viewport's cache save).
                 flow {
+                    val regionId = regionRepo.region.value?.id
+                    // Read the (prefs-backed) cache size and clock once — the cache read, the network
+                    // request, and the cache save all share the same viewport's values.
+                    val maxStops = cacheSize()
+                    val loadTime = now()
+
+                    // 1. Serve the cache first so stops render before (or without) the network. Skipped
+                    // when there's no cache (slim maps) or no region resolved yet (cold start); never a
+                    // region-less query, which would mix feeds. Best-effort: a cache read failure must
+                    // fall through to the network, not kill the loader (guardCache below).
+                    var servedCache = false
+                    if (stopCache != null && regionId != null) {
+                        val cached = guardCache("read") {
+                            stopCache.stopsFor(
+                                snapshot.center.latitude, snapshot.center.longitude,
+                                snapshot.latSpan, snapshot.lonSpan, regionId, loadTime, maxStops,
+                            )
+                        }
+                        if (cached != null && cached.stops.isNotEmpty()) {
+                            servedCache = true
+                            emit(StopLoad.Cached(cached, snapshot))
+                        }
+                    }
+
+                    // 2. Network — the unchanged request + fulfillment-gate update.
                     host.setProgress(true)
                     val result = mapDataSource
-                        .nearbyStops(snapshot.center.latitude, snapshot.center.longitude, snapshot.latSpan, snapshot.lonSpan, cacheSize())
+                        .nearbyStops(snapshot.center.latitude, snapshot.center.longitude, snapshot.latSpan, snapshot.lonSpan, maxStops)
                     // Only a usable load updates the fulfillment gate: a success — OK stops, or a null
                     // no-op (e.g. no stops endpoint, which intentionally fulfills future same-center
                     // viewports). A failure (error code / transport) showed no stops, so leave the gate
@@ -172,23 +211,89 @@ class StopsMapController(
                         lastHadResponse = nearby != null
                         lastLimitExceeded = nearby?.limitExceeded ?: false
                     }
-                    emit(result)
+
+                    // 3. Persist a usable, in-range, non-empty result (upsert + evict) for next time.
+                    // Best-effort: a save failure must not abort the flow (leaving the spinner stuck).
+                    if (stopCache != null && regionId != null) {
+                        result.getOrNull()?.let { nearby ->
+                            if (!nearby.outOfRange && nearby.stops.isNotEmpty()) {
+                                guardCache("save") { stopCache.save(nearby, regionId, loadTime) }
+                            }
+                        }
+                    }
+
+                    emit(StopLoad.Network(result, servedCache, snapshot))
                 }
             }
-            .collect { result ->
-                host.setProgress(false)
-                onStopsLoaded(result)
+            .collect { load ->
+                when (load) {
+                    // A cache emission renders immediately and deliberately bypasses onStopsLoaded, so
+                    // the out-of-range / limit-exceeded / progress machinery stays network-only.
+                    is StopLoad.Cached -> showCachedStops(load.viewport, load.snapshot)
+                    is StopLoad.Network -> {
+                        host.setProgress(false)
+                        onStopsLoaded(load.result, load.servedCache, load.snapshot)
+                    }
+                }
             }
     }
 
-    private fun onStopsLoaded(result: Result<NearbyStops?>) {
-        // Default the "more stops" banner off for this load; only a successful in-region result with
-        // limitExceeded turns it back on below. Clearing once up front means every early-out (error,
-        // null, out-of-range) leaves it cleared without having to remember to — the class of bug that
-        // previously left the banner stuck on after a truncated load was followed by a null one.
-        host.setMoreStopsAvailable(false)
+    /**
+     * Runs a persistent-cache [block] best-effort: a Room/SQLite failure is logged and swallowed
+     * (returning null) so it can't escape the loader flow and cancel future viewport loads — the cache
+     * is a nice-to-have, the network path is authoritative. Cancellation is rethrown so flatMapLatest
+     * can still abandon a superseded viewport.
+     */
+    private suspend fun <T> guardCache(op: String, block: suspend () -> T): T? =
+        try {
+            block()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Log.e(TAG, "Stop cache $op failed", e)
+            null
+        }
+
+    /**
+     * One viewport's emission: a [Cached] render (served instantly from the persistent cache) followed
+     * by the [Network] result. The two are keyed by stop id in [stopAccum], so the network render
+     * merges/replaces the cached markers automatically (no separate reconciliation).
+     */
+    private sealed interface StopLoad {
+        data class Cached(val viewport: CachedViewport, val snapshot: CameraSnapshot) : StopLoad
+
+        /** [servedCache] = whether a [Cached] render preceded this in the same viewport load. */
+        data class Network(
+            val result: Result<NearbyStops?>,
+            val servedCache: Boolean,
+            val snapshot: CameraSnapshot,
+        ) : StopLoad
+    }
+
+    /**
+     * Render cached stops immediately: seed only the icon route-type lookup (never [cachedRoutes],
+     * which feeds stop-tap route reporting and must reflect real loaded routes), then accumulate + publish
+     * like [showStops]. A cache render is provisional (no cache-bust, [complete] = false); it deliberately
+     * skips the out-of-range / limit-exceeded handling in [onStopsLoaded] — a cache render makes no claim
+     * about the region or truncation.
+     */
+    private fun showCachedStops(cached: CachedViewport, snapshot: CameraSnapshot) {
+        routeTypeById.putAll(cached.routeTypes)
+        accumulateAndPublish(cached.stops, viewport = snapshot, complete = false)
+    }
+
+    private fun onStopsLoaded(result: Result<NearbyStops?>, servedCache: Boolean, snapshot: CameraSnapshot) {
+        // Default the banner off for this load; the branches below turn it back on. Clearing once up
+        // front means every early-out (error, null, out-of-range) leaves it cleared without having to
+        // remember to — the class of bug that previously left the banner stuck on after a truncated
+        // load was followed by a null one.
+        host.setStopsBanner(StopsBanner.None)
         val nearby = result.getOrElse {
-            host.emitEffect(MapEffect.ShowError.from(it))
+            // The load failed. If the cache already rendered stops for this viewport (offline), show the
+            // "showing saved stops" banner instead of the generic error toast — the user has stops on
+            // screen, and a per-pan toast would spam. A genuine failure with nothing cached still toasts.
+            if (servedCache) host.setStopsBanner(StopsBanner.ShowingSavedStops)
+            else host.emitEffect(MapEffect.ShowError.from(it))
             return
         }
         if (nearby == null) {
@@ -223,13 +328,17 @@ class StopsMapController(
             }
         }
 
-        // More stops match the viewport than the API returned: prompt the user to zoom in.
-        host.setMoreStopsAvailable(nearby.limitExceeded)
-        showStops(nearby.stops, nearby.routes)
+        // More stops match the viewport than the API returned: prompt the user to zoom in, and treat
+        // the response as an incomplete sample — merge it in (bounded to the nearest to centre) but do
+        // NOT let it evict the cached stops it omitted. A complete response is authoritative, so it also
+        // cache-busts stale stops the response dropped inside the viewport (#1754).
+        val complete = !nearby.limitExceeded
+        if (!complete) host.setStopsBanner(StopsBanner.MoreStopsAvailable)
+        showStops(nearby.stops, nearby.routes, viewport = snapshot, complete = complete)
     }
 
     private fun notifyOutOfRange() {
-        host.setMoreStopsAvailable(false)
+        host.setStopsBanner(StopsBanner.None)
         host.emitEffect(MapEffect.OutOfRange)
     }
 
@@ -283,26 +392,60 @@ class StopsMapController(
      * geometry out of this generic controller). Null (the nearby-stops loader) keeps the normal
      * direction-anchored icons at the stop's own location.
      */
-    fun showStops(stops: List<ObaStop>, routes: List<ObaRoute>, projectedPoints: Map<String, GeoPoint>? = null) {
+    fun showStops(
+        stops: List<ObaStop>,
+        routes: List<ObaRoute>,
+        projectedPoints: Map<String, GeoPoint>? = null,
+        viewport: CameraSnapshot? = null,
+        complete: Boolean = false,
+    ) {
         cacheRoutes(routes)
+        accumulateAndPublish(stops, projectedPoints, viewport, complete)
+    }
+
+    /**
+     * Merge [stops] into [stopAccum], reconcile against [viewport], and publish — the tail shared by the
+     * nearby-stops loader ([showStops]) and the cache render ([showCachedStops]); the caller seeds the
+     * route lookup first.
+     *
+     * [viewport], when non-null (the nearby-stops modes), bounds the accumulation to the stops nearest its
+     * centre. [complete] additionally marks an authoritative response: stops it omitted inside the viewport
+     * are cache-busted. Route mode passes `viewport = null` — the whole route's stops arrive in one batch
+     * and aren't capped against each other. (`complete` is a no-op without a viewport.)
+     */
+    private fun accumulateAndPublish(
+        stops: List<ObaStop>,
+        projectedPoints: Map<String, GeoPoint>? = null,
+        viewport: CameraSnapshot? = null,
+        complete: Boolean = false,
+    ) {
         for (stop in stops) {
             val marker = toStopMarker(stop, projectedPoints)
             val existing = stopAccum[stop.id]
             // Reuse the existing instance when its style + position are unchanged, so a stationary re-poll
-            // of the same set yields an equal list the StateFlow conflates and the renderer never runs
-            // (a hit bumps the entry to most-recently-used under access order, same as before). Replace it
-            // when a mode switch flipped the stop's route-circle vs nearby style/point — otherwise a
-            // retained (focused) stop would keep its pre-switch icon. (Favorites are re-synced separately
-            // by applyFavorites, so they're not part of this reuse test.)
+            // of the same set yields an equal list the StateFlow conflates and the renderer never runs.
+            // Replace it when a mode switch flipped the stop's route-circle vs nearby style/point —
+            // otherwise a retained (focused) stop would keep its pre-switch icon. (Favorites are re-synced
+            // separately by applyFavorites, so they're not part of this reuse test.)
             stopAccum[stop.id] =
                 if (existing != null && existing.routeStop == marker.routeStop && existing.point == marker.point) existing
                 else marker
         }
-        // Route mode feeds the whole route's stops in one batch, so don't evict them against each
-        // other; the viewport loader (the only capped accumulator) is stopped while a route shows.
-        if (!routeActive()) {
-            trimStopCache(stopAccum, renderState.snapshot.value.focusedStopId, cacheSize())
+        if (viewport == null) {
+            // Route mode: the whole batch stays; just publish.
+            renderState.setStops(ArrayList(stopAccum.values))
+            return
         }
+        val focusedId = renderState.snapshot.value.focusedStopId
+        // An authoritative (complete) response drops stops it omitted inside the viewport. An incomplete
+        // one is a sample, so it evicts nothing (#1754).
+        if (complete) {
+            evictStaleInViewport(
+                stopAccum, viewport.southWest, viewport.northEast, stops.mapTo(HashSet()) { it.id }, focusedId,
+            )
+        }
+        // Bound to the nearest to centre (never evicting the centred core against an incomplete sample).
+        trimToNearest(stopAccum, viewport.center, cacheSize(), focusedId)
         renderState.setStops(ArrayList(stopAccum.values))
     }
 
@@ -362,7 +505,7 @@ class StopsMapController(
     companion object {
         private const val TAG = "StopsMapController"
 
-        /** Default map stop LRU cache size; overridable via the advanced settings cache-size option. */
+        /** Default in-memory stop cap (nearest-to-centre); overridable via the advanced cache-size option. */
         const val DEFAULT_STOP_CACHE_SIZE = 200
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
@@ -65,6 +65,7 @@ import org.onebusaway.android.models.ObaTripStatus
 import org.onebusaway.android.map.MapEffect
 import org.onebusaway.android.map.MapNavigation
 import org.onebusaway.android.map.MapViewModel
+import org.onebusaway.android.map.StopsBanner
 import org.onebusaway.android.map.compose.ObaMap
 import org.onebusaway.android.map.compose.ObaMapCallbacks
 import org.onebusaway.android.map.render.GeoPoint
@@ -280,9 +281,10 @@ fun MapFeature(
         initialZoom = seed.zoom,
     )
 
-    // "Zoom in to see more stops" — shown when the viewport stop load was truncated (the API's
-    // limitExceeded), i.e. more stops match the viewport than were returned. Driven purely by map state.
-    val moreStops by mapViewModel.moreStopsAvailable.collectAsStateWithLifecycle()
+    // The nearby-stops info strip: "zoom in to see more stops" when the load was truncated (the API's
+    // limitExceeded), or "showing saved stops" when a load failed with cached stops on screen (offline,
+    // #1754). Driven purely by map state.
+    val stopsBanner by mapViewModel.stopsBanner.collectAsStateWithLifecycle()
     // The map sits below HomeTopBar (which already consumes the status-bar inset), so the banner is
     // flush at the map's top edge — no extra inset. clipToBounds clips the upward slide at that edge so
     // the bar tucks up behind the title bar instead of drawing over it.
@@ -291,8 +293,8 @@ fun MapFeature(
             .fillMaxSize()
             .clipToBounds()
     ) {
-        MoreStopsBanner(
-            visible = moreStops,
+        StopsInfoBanner(
+            banner = stopsBanner,
             modifier = Modifier.align(Alignment.TopCenter).fillMaxWidth(),
         )
     }
@@ -355,16 +357,25 @@ fun MapFeature(
 }
 
 /**
- * The "zoom in to see more stops" hint: a full-width, text-height bar at the top edge of the map that
- * slides down to appear and up (tucking behind the home top bar) to disappear. Shown while the last
- * viewport stop load was truncated by the API; purely state-driven, no dismiss button. The status-bar
- * inset is already consumed by HomeTopBar above the map, so the caller's slot adds no inset — only the
- * slide clipping (clipToBounds).
+ * The nearby-stops info strip: a full-width, text-height bar at the top edge of the map that slides
+ * down to appear and up (tucking behind the home top bar) to disappear. Shows either "zoom in to see
+ * more stops" (a truncated load) or "showing saved stops" (a failed load with cached stops on screen,
+ * #1754); hidden on [StopsBanner.None]. Purely state-driven, no dismiss button. The status-bar inset is
+ * already consumed by HomeTopBar above the map, so the caller's slot adds no inset — only the slide
+ * clipping (clipToBounds).
  */
 @Composable
-private fun MoreStopsBanner(visible: Boolean, modifier: Modifier = Modifier) {
+private fun StopsInfoBanner(banner: StopsBanner, modifier: Modifier = Modifier) {
+    // Retain the last shown banner so its label stays put during the slide-out (when banner -> None),
+    // instead of blanking mid-animation. Seeded with the more-stops case; only ever set to a real one.
+    var lastShown by remember { mutableStateOf<StopsBanner>(StopsBanner.MoreStopsAvailable) }
+    if (banner != StopsBanner.None) lastShown = banner
+    val labelRes = when (lastShown) {
+        StopsBanner.ShowingSavedStops -> R.string.map_showing_cached_stops
+        else -> R.string.map_zoom_in_for_more_stops
+    }
     AnimatedVisibility(
-        visible = visible,
+        visible = banner != StopsBanner.None,
         modifier = modifier,
         enter = slideInVertically(initialOffsetY = { -it }),
         exit = slideOutVertically(targetOffsetY = { -it }),
@@ -381,7 +392,7 @@ private fun MoreStopsBanner(visible: Boolean, modifier: Modifier = Modifier) {
                 .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.9f)),
         ) {
             Text(
-                text = stringResource(R.string.map_zoom_in_for_more_stops),
+                text = stringResource(labelRes),
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = 16.dp, vertical = 8.dp),

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -73,6 +73,8 @@
     <!-- Note: %1$s is replaced with app_name for white-label support -->
     <string name="bad_gateway_error">%1$s\'s servers are overloaded. Please excuse us!</string>
     <string name="map_generic_error">Unable to get stops.</string>
+    <!-- Shown when a stop load fails (e.g. offline) but cached stops are already on screen. -->
+    <string name="map_showing_cached_stops">Showing saved stops</string>
     <string name="no_network_error">You appear to be offline or are not connected to the network.
     </string>
     <string name="airplane_mode_error">You are not connected to the network.\nTurn off Airplane
@@ -651,7 +653,7 @@
     <string name="preferences_experimental_regions_title">Experimental regions</string>
     <string name="preferences_experimental_regions_summary">Enables regions that may be unstable
     </string>
-    <string name="map_zoom_in_for_more_stops">Zoom in to see more stops</string>
+    <string name="map_zoom_in_for_more_stops">Zoom in to see all stops</string>
     <string name="preferences_map_stop_cache_size_title">Map stop cache size</string>
     <string name="preferences_map_stop_cache_size_summary">Max bus stops kept on the map while panning (currently %1$d)</string>
     <!-- Not a plural candidate: "%1$d and %2$d" are the bounds of a range, not a count that inflects. -->

--- a/onebusaway-android/src/test/java/org/onebusaway/android/database/oba/MapStopCacheMappersTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/database/oba/MapStopCacheMappersTest.kt
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.database.oba
+
+import android.location.Location
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.onebusaway.android.models.ObaStop
+import org.onebusaway.android.time.WallTime
+
+/** JVM unit tests for the pure map-stop-cache mappers ([MapStopCacheMappers]). */
+class MapStopCacheMappersTest {
+
+    // --- route-id join/split ---
+
+    @Test
+    fun routeIds_emptyRoundTripsToEmptyArray() {
+        assertEquals("", joinRouteIds(emptyArray()))
+        assertArrayEquals(emptyArray<String>(), splitRouteIds(""))
+    }
+
+    @Test
+    fun routeIds_singleAndManyRoundTrip() {
+        val one = arrayOf("1_100")
+        assertArrayEquals(one, splitRouteIds(joinRouteIds(one)))
+
+        // Ids containing the characters that a comma/space delimiter would have collided with.
+        val many = arrayOf("1_100", "40_A-Line", "MTA NYCT_M15", "agency:route")
+        assertArrayEquals(many, splitRouteIds(joinRouteIds(many)))
+    }
+
+    // --- viewport bounds ---
+
+    @Test
+    fun boundsFor_isCenterPlusMinusHalfSpan() {
+        val b = boundsFor(centerLat = 47.6, centerLon = -122.3, latSpan = 0.02, lonSpan = 0.04)
+        assertEquals(47.59, b.minLat, 1e-9)
+        assertEquals(47.61, b.maxLat, 1e-9)
+        assertEquals(-122.32, b.minLon, 1e-9)
+        assertEquals(-122.28, b.maxLon, 1e-9)
+    }
+
+    // --- TTL cutoff (pure; now passed in) ---
+
+    @Test
+    fun ttlCutoff_subtractsTtlFromNow() {
+        val now = WallTime(1_000_000_000_000L)
+        assertEquals(now - STOP_CACHE_TTL, ttlCutoff(now))
+        assertEquals(now.epochMs - STOP_CACHE_TTL.inWholeMilliseconds, ttlCutoff(now).epochMs)
+    }
+
+    // --- record <-> ObaStop round trip ---
+
+    @Test
+    fun toCachedRecord_thenToObaStop_preservesFields() {
+        val stop = fakeStop(
+            id = "1_75403", code = "75403", name = "Pine St & 5th Ave",
+            direction = "NW", locationType = ObaStop.LOCATION_STOP,
+            lat = 47.61, lon = -122.34, routeIds = arrayOf("1_100", "1_101"),
+        )
+
+        val record = stop.toCachedRecord(regionId = 3L, now = 500L)
+        assertEquals(3L, record.regionId)
+        assertEquals(500L, record.lastSeen)
+
+        val back = record.toObaStop()
+        assertEquals("1_75403", back.id)
+        assertEquals("75403", back.stopCode)
+        assertEquals("Pine St & 5th Ave", back.name)
+        assertEquals("NW", back.direction)
+        assertEquals(ObaStop.LOCATION_STOP, back.locationType)
+        assertEquals(47.61, back.latitude, 1e-9)
+        assertEquals(-122.34, back.longitude, 1e-9)
+        assertArrayEquals(arrayOf("1_100", "1_101"), back.routeIds)
+    }
+
+    @Test
+    fun roundTrip_preservesNullDirectionSentinel_nullCodeName_andZeroRoutes() {
+        // The wire "no direction" sentinel is the literal string "null"; must survive verbatim.
+        val sentinel = fakeStop(
+            id = "s1", code = null, name = null, direction = "null",
+            locationType = ObaStop.LOCATION_STATION, lat = 1.0, lon = 2.0, routeIds = emptyArray(),
+        )
+        val back = sentinel.toCachedRecord(regionId = 1L, now = 1L).toObaStop()
+
+        assertEquals("null", back.direction)
+        assertEquals(null, back.stopCode)
+        assertEquals(null, back.name)
+        assertEquals(ObaStop.LOCATION_STATION, back.locationType)
+        assertArrayEquals(emptyArray<String>(), back.routeIds)
+    }
+
+    private fun fakeStop(
+        id: String,
+        code: String?,
+        name: String?,
+        direction: String?,
+        locationType: Int,
+        lat: Double,
+        lon: Double,
+        routeIds: Array<String>,
+    ): ObaStop = object : ObaStop {
+        override val id = id
+        override val stopCode = code
+        override val name = name
+        override val direction = direction
+        override val locationType = locationType
+        override val latitude = lat
+        override val longitude = lon
+        override val routeIds = routeIds
+
+        // Never touched by the mappers (would need Android); guard so a regression is loud.
+        override val location: Location get() = throw UnsupportedOperationException()
+    }
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/StopAccumulationTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/StopAccumulationTest.kt
@@ -25,69 +25,75 @@ import org.onebusaway.android.map.render.StopMarker
 
 /**
  * Unit tests for the stop-accumulation logic [StopsMapController.showStops] / [StopsMapController.clearStops]
- * delegate to — the easily-broken part of the data-shaping: the LRU trim evicts least-recently-used
- * stops down to the 200-cap *but never the focused stop*, and the same focus-retention drives
- * `clearStops(false)`. Split into pure functions ([trimStopCache] / [retainOnlyFocusedStop]) over
- * plain [StopMarker]s so it runs on the JVM — the per-stop marker build (which touches an Android
- * `Location`) is exercised on device.
+ * delegate to — the easily-broken part of the data-shaping: [trimToNearest] bounds the accumulation to
+ * the stops nearest the viewport centre (never the focused stop), [evictStaleInViewport] cache-busts
+ * stops a complete response omitted (#1754), and the same focus-retention drives `clearStops(false)`.
+ * Split into pure functions over plain [StopMarker]s so it runs on the JVM — the per-stop marker build
+ * (which touches an Android `Location`) is exercised on device.
  */
 class StopAccumulationTest {
 
-    private fun marker(id: String): StopMarker =
-        StopMarker(id, GeoPoint(0.0, 0.0), "null", ObaRoute.TYPE_BUS, ObaStopElement(id, 0.0, 0.0, id, id))
+    private fun marker(id: String, lat: Double = 0.0, lon: Double = 0.0): StopMarker =
+        StopMarker(id, GeoPoint(lat, lon), "null", ObaRoute.TYPE_BUS, ObaStopElement(id, lat, lon, id, id))
 
     private fun accumOf(vararg ids: String): LinkedHashMap<String, StopMarker> =
         LinkedHashMap<String, StopMarker>().apply { ids.forEach { put(it, marker(it)) } }
 
+    private fun accumOf(vararg markers: StopMarker): LinkedHashMap<String, StopMarker> =
+        LinkedHashMap<String, StopMarker>().apply { markers.forEach { put(it.id, it) } }
+
     private fun LinkedHashMap<String, StopMarker>.ids() = keys.toSet()
 
-    // --- trimStopCache (the LRU eviction; accumOf is insertion- = eldest-first order) ---
+    // --- trimToNearest (bound to the cap nearest the viewport centre) ---
 
     @Test
     fun `at or below the cap is a no-op`() {
         val accum = accumOf("a", "b", "c")
-        trimStopCache(accum, focusedId = "a", cap = 3)
+        trimToNearest(accum, GeoPoint(0.0, 0.0), cap = 3, focusedId = "a")
         assertEquals(setOf("a", "b", "c"), accum.ids())
     }
 
     @Test
-    fun `over the cap evicts eldest-first down to the cap`() {
-        val accum = accumOf("a", "b", "c", "d")
-        trimStopCache(accum, focusedId = null, cap = 2)
-        assertEquals(setOf("c", "d"), accum.ids())
+    fun `over the cap keeps the stops nearest the center`() {
+        // center at (0,0): near < mid < far by longitude distance.
+        val accum = accumOf(marker("near", 0.0, 1.0), marker("mid", 0.0, 3.0), marker("far", 0.0, 9.0))
+        trimToNearest(accum, GeoPoint(0.0, 0.0), cap = 2, focusedId = null)
+        assertEquals(setOf("near", "mid"), accum.ids())   // the farthest is dropped
     }
 
     @Test
-    fun `over the cap never evicts the focused stop`() {
-        val accum = accumOf("a", "b", "c", "d")
-        // "a" is the eldest, but being focused it's skipped; the next-eldest evict instead.
-        trimStopCache(accum, focusedId = "a", cap = 2)
-        assertEquals(setOf("a", "d"), accum.ids())
+    fun `over the cap never evicts the focused stop even when it is farthest`() {
+        val accum = accumOf(marker("near", 0.0, 1.0), marker("mid", 0.0, 3.0), marker("far", 0.0, 9.0))
+        // "far" would be dropped by distance, but being focused it's kept and counts toward the cap.
+        trimToNearest(accum, GeoPoint(0.0, 0.0), cap = 2, focusedId = "far")
+        assertEquals(setOf("near", "far"), accum.ids())
+    }
+
+    // --- evictStaleInViewport (the complete-response cache-bust) ---
+
+    @Test
+    fun `evicts in-viewport stops the complete response omitted`() {
+        val accum = accumOf(marker("kept", 0.0, 0.0), marker("stale", 1.0, 1.0))
+        // Viewport covers both; the response only carried "kept" — "stale" is dropped.
+        evictStaleInViewport(
+            accum, southWest = GeoPoint(-2.0, -2.0), northEast = GeoPoint(2.0, 2.0),
+            present = setOf("kept"), focusedId = null,
+        )
+        assertEquals(setOf("kept"), accum.ids())
     }
 
     @Test
-    fun `over the cap with no focus evicts pure eldest`() {
-        val accum = accumOf("a", "b", "c")
-        trimStopCache(accum, focusedId = null, cap = 1)
-        assertEquals(setOf("c"), accum.ids())
-    }
-
-    @Test
-    fun `the access-ordered LRU bumps a re-seen stop so it outlives an untouched eldest`() {
-        // The eviction is only "least-recently-USED" because stopAccum is access-ordered and showStops
-        // re-touches each fetched stop. Build the map exactly as StopsMapController.stopAccum (access
-        // order) and re-see the insertion-eldest "a" the way showStops does (getOrPut's get() on a hit
-        // bumps it to most-recently-used), leaving "b" the eldest.
-        val accum = LinkedHashMap<String, StopMarker>(16, 0.75f, true)
-        listOf("a", "b", "c").forEach { accum[it] = marker(it) }
-        accum.getOrPut("a") { marker("a") }
-
-        trimStopCache(accum, focusedId = null, cap = 2)
-
-        // LRU: the now-eldest "b" is evicted and the bumped "a" survives. A plain (insertion-ordered)
-        // map — or dropping the getOrPut bump — would instead evict the first-inserted "a" and keep "b",
-        // so this test fails if stopAccum loses its access-order config or showStops stops re-touching.
-        assertEquals(setOf("a", "c"), accum.ids())
+    fun `keeps omitted stops outside the viewport, and the focused stop`() {
+        val accum = accumOf(
+            marker("outside", 10.0, 10.0),   // omitted but out of the box → not the response's concern
+            marker("focused", 1.0, 1.0),     // omitted + in the box, but focused → kept
+            marker("stale", 0.5, 0.5),       // omitted + in the box → dropped
+        )
+        evictStaleInViewport(
+            accum, southWest = GeoPoint(-2.0, -2.0), northEast = GeoPoint(2.0, 2.0),
+            present = emptySet(), focusedId = "focused",
+        )
+        assertEquals(setOf("outside", "focused"), accum.ids())
     }
 
     // --- retainOnlyFocusedStop (the clearStops(false) path) ---


### PR DESCRIPTION
## Summary

Fixes the confusing "blank map while stops load" experience from #1754 (fix 1, the stops cache). On a slow connection or a cold start, the map now paints stops immediately from a persistent cache instead of showing nothing, then reconciles against the network. The stop the user cares about has very likely been loaded before.

(Fix 2 from that issue — the loading indicator — already exists: `MapHost.progress` → the `MapChrome` loading bar.)

## What changed

- **New `cached_stops` + `cached_route_types` tables** (`AppDatabase` v5 + additive `MIGRATION_4_5`) — a region-scoped spatial cache, deliberately **separate** from the user-state `stops` table (favorites/recents/custom names), which must not be polluted with transient viewport stops.
- **`StopCacheRepository`** serves a viewport's cached stops (bounding-box query, region- and TTL-scoped) and saves each network load (upsert + evict; **4000/region** size cap, **7-day** TTL). Route types are cached alongside so cached markers get correct icon colours immediately, without reconstructing full route objects.
- **`StopsMapController`** reads through the cache in its viewport loader: it emits cached stops first (instant render), then the network result. The in-memory `stopAccum` already dedups by stop id, so the network render merges over the cached markers with **no extra reconciliation**. Cache emissions bypass the out-of-range / limit-exceeded / "zoom in for more stops" handling, which stays strictly network-driven.
- The **home map opts in**; the transient picker / report maps stay uncached.

## Design notes

- `route_ids` is stored as a delimited string split in a pure mapper (no Room `TypeConverter` — the DB has none, and we never query by individual route id).
- The cache TTL uses the device wall clock (a purely local timer) sourced from the existing injected `TimeProvider`.
- `evictBeyondCap` is gated behind an indexed `COUNT` so the common under-cap pan doesn't scan the region.

## Testing

- ✅ Compiles clean on both platform flavors (`obaGoogle` + `obaMaplibre`) under `-PwarningsAsErrors=true`; lint clean (no new issues).
- ✅ JVM unit tests for the pure mappers (route-id codec, bounds, TTL, record⇄`ObaStop` round-trip incl. the `"null"` direction sentinel / null code+name / zero-route stops).
- ✅ Instrumented DAO tests (bbox + region + TTL filtering, eviction) and a `4→5` migration test are included; the generated `5.json` matches the migration DDL verbatim.
- ⏳ On-device acceptance (load stops → go offline / cold start → cached markers appear instantly, then reconcile) still to be run on hardware.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a persistent, region-scoped nearby-stop cache backed by Room, including route-type metadata, TTL expiration, and per-region size limits.
  * Map nearby-stops can now render cached results immediately (best-effort) and then refresh from the network.
  * Added database migration support for the new cache schema.
* **UI Improvements**
  * Updated the “nearby stops” banner to support multiple states (including showing cached stops) and refreshed related copy.
* **Tests**
  * Added/updated migration, DAO, mapper, and map stop-accumulation tests to cover caching, eviction/trimming, and banner behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->