### PR TITLE
Enlarge the selected stop 1.5x while a route is shown

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/TripStopBitmaps.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/TripStopBitmaps.kt
@@ -20,12 +20,15 @@ import android.graphics.Canvas
 import android.graphics.Color
 import android.graphics.Paint
 import androidx.core.graphics.createBitmap
+import kotlin.math.roundToInt
 
 /**
- * The trip-focus map's scheduled-stop dot bitmaps: a white disc with a gray stroke, plus a
- * filled-center variant for the selected stop (ported from the feature's TripRouteOverlay). Resource-
- * free and flavor-neutral, so the Google adapter wraps it in a `BitmapDescriptor` and maplibre in an
- * `Icon`; the two variants are cached.
+ * The route/trip map's scheduled-stop dot bitmaps: a white disc with a gray stroke, plus a
+ * filled-center variant for the selected stop (ported from the feature's TripRouteOverlay). The
+ * selected (focused) stop is also drawn [FOCUSED_SCALE]× larger — circle, stroke, and center dot
+ * scale together — so a selection stands out while a route is shown, matching the focus enlargement
+ * nearby stops get ([StopBitmaps.FOCUSED_DOT_SCALE]). Resource-free and flavor-neutral, so the Google
+ * adapter wraps it in a `BitmapDescriptor` and maplibre in an `Icon`; the two variants are cached.
  */
 object TripStopBitmaps {
 
@@ -33,16 +36,24 @@ object TripStopBitmaps {
     private const val STROKE_PX = 6f
     private val STROKE_COLOR = TripMarkerBitmaps.STROKE_COLOR
 
+    /** The selected (focused) route stop's size multiplier — the app-wide focus enlargement. */
+    private const val FOCUSED_SCALE = StopBitmaps.FOCUSED_DOT_SCALE
+
     private val cache = HashMap<Boolean, Bitmap>()
 
-    /** The dot bitmap for a stop; [selected] adds a filled inner dot. */
+    /** The dot bitmap for a stop; [selected] adds a filled inner dot and enlarges it [FOCUSED_SCALE]×. */
     fun dot(selected: Boolean): Bitmap = cache.getOrPut(selected) { draw(selected) }
 
     private fun draw(selected: Boolean): Bitmap {
-        val bitmap = createBitmap(SIZE_PX, SIZE_PX)
+        // Scale the whole marker (circle + stroke + center dot) uniformly when selected, so the
+        // enlargement is a clean 1.5× of the base rather than a bigger circle with the same-width ring.
+        val scale = if (selected) FOCUSED_SCALE else 1f
+        val sizePx = (SIZE_PX * scale).roundToInt()
+        val strokePx = STROKE_PX * scale
+        val bitmap = createBitmap(sizePx, sizePx)
         val canvas = Canvas(bitmap)
-        val center = SIZE_PX / 2f
-        val radius = center - STROKE_PX / 2f
+        val center = sizePx / 2f
+        val radius = center - strokePx / 2f
 
         canvas.drawCircle(center, center, radius, Paint(Paint.ANTI_ALIAS_FLAG).apply {
             color = Color.WHITE
@@ -51,7 +62,7 @@ object TripStopBitmaps {
         canvas.drawCircle(center, center, radius, Paint(Paint.ANTI_ALIAS_FLAG).apply {
             color = STROKE_COLOR
             style = Paint.Style.STROKE
-            strokeWidth = STROKE_PX
+            strokeWidth = strokePx
         })
         if (selected) {
             canvas.drawCircle(center, center, radius * 0.4f, Paint(Paint.ANTI_ALIAS_FLAG).apply {


### PR DESCRIPTION
## Summary

Small UX refinement: while a route is shown on the map, the **selected (tapped) stop** now renders **1.5× larger** — the circle, its stroke, and the center dot scale together — so the selection stands out against the route's other stops. This matches the 1.5× focus enlargement that nearby stops already get (`FOCUS_ICON_SCALE` / `FOCUSED_DOT_SCALE`); route stops were the one variant that didn't scale on focus (they only toggled a filled center dot).

## Implementation

One shared file: `TripStopBitmaps.dot(selected)` now draws the `selected` variant uniformly scaled by `FOCUSED_SCALE` (= the existing `StopBitmaps.FOCUSED_DOT_SCALE`, reused so there's no new magic number). Both the Google (`tripStopIcon(selected = true)`) and MapLibre (`tripStopSelectedIcon`) renderers already route the focused route stop through this one helper, so both flavors pick it up with no renderer changes. Route circles anchor at center, so the larger bitmap grows around the stop point.

Scoped: `routeStop` markers are produced only by the route-overview loader and `TripStopBitmaps.dot` is reached only via `ROUTE_CIRCLE_FOCUSED`, so this affects only the focused stop on a shown route (the trip-focus map renders through a separate overlay path).

## Testing

- Compiles clean on both platform flavors (`obaGoogle` + `obaMaplibre`) under `-PwarningsAsErrors=true`.
- Verified on-device (Pixel 7 Pro): showing a route and tapping a stop enlarges just that stop; the enlargement moves with the selection. It's a bitmap-drawing tweak, so it's device-verified rather than unit-tested (consistent with the other marker drawing).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Selected scheduled-stop markers are now displayed larger and more prominently on the map.
  * The marker’s circle, outline, and center dot scale together for a consistent appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->