### PR TITLE
Settle map stop/bike queries on drag-end to kill mid-pan jank

### DIFF
--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleComposeAdapter.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleComposeAdapter.kt
@@ -163,6 +163,14 @@ class GoogleComposeAdapter : ObaComposeMapAdapter {
                 map.setInfoWindowAdapter(windows)
                 wireClicks(map, r, windows, cb)
 
+                map.setOnCameraMoveStartedListener { reason ->
+                    // A user gesture (pan/fling/pinch) started: gate the stop/bike loaders until it settles.
+                    // Programmatic camera animations (recenter, zoom-to-route) don't gate — they emit only
+                    // their terminating idle, so there's nothing mid-move to suppress.
+                    if (reason == GoogleMap.OnCameraMoveStartedListener.REASON_GESTURE) {
+                        host.onCameraGestureStarted()
+                    }
+                }
                 map.setOnCameraIdleListener { host.onCameraIdle(snapshot(map)) }
 
                 r.renderStatic()

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/BikeLayerController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/BikeLayerController.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.launch
 import org.onebusaway.android.R
@@ -77,7 +78,10 @@ class BikeLayerController(
         loadJob?.cancel()
         loadJob = scope.launch {
             combine(
-                host.camera.filterNotNull().debounce(STOP_LOAD_DEBOUNCE_MS),
+                // Settle on drag-end, matching the stop loader: hold the station load until the gesture
+                // settles so a pan fires one load at drag-end, not one per intermediate camera-idle.
+                host.camera.filterNotNull().debounce(STOP_LOAD_DEBOUNCE_MS)
+                    .filter { !host.cameraInteracting.value },
                 _bikeshareVisible,
             ) { camera, layerVisible -> camera to layerVisible }
                 // collectLatest so a newer viewport cancels an in-flight station load (the old loadJob?.cancel()).

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapHost.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapHost.kt
@@ -111,15 +111,24 @@ class MapHost(
 
     val cameraInteracting: StateFlow<Boolean> = _cameraInteracting.asStateFlow()
 
-    /** The flavor adapter reports the start of a user camera gesture; cleared by the next [onCameraIdle]. */
+    /** The flavor adapter reports the start of a user camera gesture; cleared by the next [onCameraSettled]. */
     fun onCameraGestureStarted() {
         _cameraInteracting.value = true
     }
 
+    /**
+     * The camera has come to rest, so any in-flight gesture has settled — reopen the loader gate. Its own
+     * method (not just folded into [onCameraIdle]) so an adapter that can't build a snapshot for a given
+     * idle — MapLibre can momentarily report a null camera target — still clears the gate rather than
+     * leaving it stuck true and blocking every future load.
+     */
+    fun onCameraSettled() {
+        _cameraInteracting.value = false
+    }
+
     fun onCameraIdle(snapshot: CameraSnapshot) {
         _camera.value = snapshot
-        // The camera has come to rest, so any in-flight gesture has settled — reopen the loader gate.
-        _cameraInteracting.value = false
+        onCameraSettled()
         // Persist the live viewport so a process-death restore (and MapLibre, which has no rememberSaveable
         // backstop) re-seeds here via [cameraSeed]. Same keys as the intent extras, so they interoperate.
         savedStateHandle[MapParams.CENTER_LAT] = snapshot.center.latitude

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapHost.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapHost.kt
@@ -102,8 +102,24 @@ class MapHost(
 
     val camera: StateFlow<CameraSnapshot?> = _camera.asStateFlow()
 
+    // True while a user camera gesture (pan/fling/pinch) is in flight: raised by the flavor adapter's
+    // gesture-start callback and lowered on the next camera-idle. The stop/bike loaders read this to hold
+    // their query until the gesture settles, so a drag fires one load at drag-end instead of one per
+    // intermediate settle — each of which pays the two-layer stop cache read + a full marker redraw and
+    // stutters the pan.
+    private val _cameraInteracting = MutableStateFlow(false)
+
+    val cameraInteracting: StateFlow<Boolean> = _cameraInteracting.asStateFlow()
+
+    /** The flavor adapter reports the start of a user camera gesture; cleared by the next [onCameraIdle]. */
+    fun onCameraGestureStarted() {
+        _cameraInteracting.value = true
+    }
+
     fun onCameraIdle(snapshot: CameraSnapshot) {
         _camera.value = snapshot
+        // The camera has come to rest, so any in-flight gesture has settled — reopen the loader gate.
+        _cameraInteracting.value = false
         // Persist the live viewport so a process-death restore (and MapLibre, which has no rememberSaveable
         // backstop) re-seeds here via [cameraSeed]. Same keys as the intent extras, so they interoperate.
         savedStateHandle[MapParams.CENTER_LAT] = snapshot.center.latitude

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/StopsMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/StopsMapController.kt
@@ -18,16 +18,19 @@ package org.onebusaway.android.map
 import android.util.Log
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterNot
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
@@ -167,6 +170,12 @@ class StopsMapController(
         host.camera
             .filterNotNull()
             .debounce(STOP_LOAD_DEBOUNCE_MS)
+            // Settle on drag-end: if the debounce elapses while a gesture is still in flight (the user is
+            // mid-pan, or a fling that emitted an intermediate idle is still going), drop this viewport —
+            // the gesture's terminating camera-idle re-arms the debounce and fires one load at the true
+            // drag-end. Combined with the debounce this keeps a whole pan to a single load + redraw
+            // instead of one per intermediate settle, killing the mid-pan jank.
+            .filter { !host.cameraInteracting.value }
             .filterNot { next -> stopRequestFulfilled(lastLoad, lastHadResponse, lastLimitExceeded, next) }
             .flatMapLatest { snapshot ->
                 // flatMapLatest cancels an in-flight load when a newer viewport arrives, matching the
@@ -224,6 +233,11 @@ class StopsMapController(
 
                     emit(StopLoad.Network(result, servedCache, snapshot))
                 }
+                    // Run the query pipeline (cache read + row mapping, network, cache save) off the main
+                    // thread; only the emitted results cross back to the collector, which does the (cheap,
+                    // main-confined) stopAccum merge + publish. flatMapLatest still cancels this on a newer
+                    // viewport.
+                    .flowOn(Dispatchers.Default)
             }
             .collect { load ->
                 when (load) {

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreComposeAdapter.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreComposeAdapter.kt
@@ -152,6 +152,14 @@ class MapLibreComposeAdapter : ObaComposeMapAdapter {
                     val windows = MapLibreInfoWindows(activity, container, map)
                     map.setInfoWindowAdapter(windows)
                     wireClicks(map, r, windows, cb)
+                    map.addOnCameraMoveStartedListener { reason ->
+                        // A user gesture (pan/fling/pinch) started: gate the stop/bike loaders until it
+                        // settles. Programmatic animations emit only their terminating idle, so they're
+                        // left ungated (nothing mid-move to suppress).
+                        if (reason == MapLibreMap.OnCameraMoveStartedListener.REASON_API_GESTURE) {
+                            host.onCameraGestureStarted()
+                        }
+                    }
                     map.addOnCameraIdleListener {
                         map.cameraPosition.target?.let { host.onCameraIdle(snapshot(map, it)) }
                     }

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreComposeAdapter.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreComposeAdapter.kt
@@ -161,7 +161,11 @@ class MapLibreComposeAdapter : ObaComposeMapAdapter {
                         }
                     }
                     map.addOnCameraIdleListener {
-                        map.cameraPosition.target?.let { host.onCameraIdle(snapshot(map, it)) }
+                        // Always settle the gesture gate on idle; publish a snapshot only when the camera
+                        // has a resolved target (MapLibre can momentarily report a null target). Skipping
+                        // the settle on a null target would leave the loader gate stuck shut.
+                        val target = map.cameraPosition.target
+                        if (target != null) host.onCameraIdle(snapshot(map, target)) else host.onCameraSettled()
                     }
                     r.renderStatic()
                 }


### PR DESCRIPTION
## Problem

The nearby-stops loader re-queried on **every camera-idle during a pan**, and each query paid the two-layer (Room + in-memory LRU) stop cache read plus a full marker redraw. With the persistent stop cache now in place (#1754), that per-settle cost is heavy enough to cause noticeable stutter/jank while panning or flinging the map.

Root cause: the flavor-neutral map core only ever had a camera-**idle** signal (`MapHost.onCameraIdle`, the sole writer of `host.camera`). It had no way to distinguish "a gesture is still in flight" from "the camera has settled," so every intermediate settle during a gesture fired a fresh load.

## Fix — settle on drag-end

Give the core the gesture distinction it was missing, on the one seam both loaders and both flavors already share (`MapHost`):

- **`MapHost.cameraInteracting`** — raised on a user camera gesture-start and cleared on the next `onCameraIdle`.
- **Per-flavor gesture-start wiring** — Google `setOnCameraMoveStartedListener` gated to `REASON_GESTURE`, MapLibre `addOnCameraMoveStartedListener` gated to `REASON_API_GESTURE`. Programmatic camera animations (recenter, zoom-to-route) are left ungated — they emit only their terminating idle, so there's nothing mid-move to suppress.
- **Loader gate** — the stop and bike loaders add `.filter { !host.cameraInteracting.value }` after their existing 250 ms debounce. A viewport that debounces through while a gesture is live is dropped; the gesture's terminating idle re-arms the debounce and fires **one** load at the true drag-end.
- **Off-main query** — `StopsMapController` adds `.flowOn(Dispatchers.Default)` to the inner query pipeline so its per-query CPU (cache-row mapping, route-id splits, save prep) runs off the main thread; the cheap, main-confined `stopAccum` merge + publish stays on the collector.

Net effect: a whole pan/fling produces a single stop (and bike) load + redraw at drag-end instead of one per intermediate settle.

## Testing

- Builds clean on both flavors under `-PwarningsAsErrors=true` (the CI gate).
- Map-package JVM unit tests pass.
- Manually verified on a Pixel 7 Pro (Google flavor): slow drag-pause-drag pans, flings, and pinch-zoom now settle/redraw only once the gesture comes to rest; initial load, stop taps, and my-location recenter still load stops correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Map data refreshes only after users finish interacting with the map, reducing updates during dragging.
  - Stop and bike-station results load more reliably once the camera movement settles.
  - Improved gesture vs. programmatic movement handling across supported map providers for consistent behavior.
- **Performance**
  - Map result loading and caching work is processed off the main thread to keep the UI responsive during camera interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->