### PR TITLE
Arrivals: pull an ETA strip past its end to load more arrivals

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsScreen.kt
@@ -136,7 +136,9 @@ internal fun rememberArrivalRowCallbacks(
         onShowOnlyRoute = viewModel::showOnlyRoute,
         onShowRouteSchedule = handler::onShowRouteSchedule,
         onReportArrivalProblem = handler::onReportArrivalProblem,
-        onShowAlert = handler::onShowAlert
+        onShowAlert = handler::onShowAlert,
+        onLoadMore = viewModel::loadMore,
+        loadMoreState = viewModel.loadMoreState
     )
 }
 
@@ -190,7 +192,6 @@ fun ArrivalsRoute(
         onBack = onBack,
         onRefresh = viewModel::manualRefresh,
         onToggleFavorite = viewModel::toggleFavorite,
-        onLoadMore = viewModel::loadMore,
         rowCallbacks = rowCallbacks,
         handler = handler,
         onSetRouteFilter = viewModel::setRouteFilter,
@@ -210,7 +211,6 @@ fun ArrivalsScreen(
     onBack: () -> Unit,
     onRefresh: () -> Unit,
     onToggleFavorite: () -> Unit,
-    onLoadMore: () -> Unit,
     rowCallbacks: ArrivalRowCallbacks,
     handler: ArrivalActionHandler,
     onSetRouteFilter: (Set<String>) -> Unit,
@@ -283,7 +283,6 @@ fun ArrivalsScreen(
                     content = state,
                     rowCallbacks = rowCallbacks,
                     handler = handler,
-                    onLoadMore = onLoadMore,
                     onShowAllRoutes = onShowAllRoutes,
                     onShowHiddenAlerts = onShowHiddenAlerts
                 )
@@ -348,7 +347,6 @@ internal fun ArrivalsList(
     content: ArrivalsUiState.Content,
     rowCallbacks: ArrivalRowCallbacks,
     handler: ArrivalActionHandler,
-    onLoadMore: () -> Unit,
     onShowAllRoutes: () -> Unit,
     onShowHiddenAlerts: () -> Unit,
     modifier: Modifier = Modifier,
@@ -436,21 +434,12 @@ internal fun ArrivalsList(
                 items(visibleGroups, key = { it.key }) { group ->
                     RouteArrivalRow(
                         group = group,
+                        dataVersion = content.dataVersion,
                         actionsFor = { content.actions[it.tripId] },
                         isFavorite = group.routeId in content.favoriteRouteIds,
                         filterActive = filterActive,
                         callbacks = rowCallbacks
                     )
-                }
-            }
-            item(key = "load_more") {
-                TextButton(
-                    onClick = onLoadMore,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(16.dp)
-                ) {
-                    Text(stringResource(R.string.stop_info_load_more_arrivals))
                 }
             }
         }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsUiState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsUiState.kt
@@ -97,6 +97,9 @@ sealed interface ArrivalsUiState {
         val routeGroups: List<RouteRowGroup>,
         val minutesAfter: Int,
         val isStale: Boolean,
+        /** Monotonic revision of the loaded snapshot; pairs with [LoadMoreState.Finished.dataVersion]
+         *  so the ETA strip can await the layout of the data that completed its load-more request. */
+        val dataVersion: Long = 0,
         val actions: Map<String, ArrivalActions> = emptyMap(),
         /** The starred route ids, live — a row's star + the drawer-header promotion read from this, so a
          *  toggle from any surface re-flags the list without a re-fetch (#1751). */

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsViewModel.kt
@@ -20,6 +20,7 @@ import androidx.lifecycle.viewModelScope
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -30,6 +31,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 import org.onebusaway.android.time.WallTime
 
 /**
@@ -38,6 +40,24 @@ import org.onebusaway.android.time.WallTime
  */
 internal fun collapseRouteFilter(selected: Set<String>, totalRoutes: Int): Set<String> =
     if (selected.size >= totalRoutes) emptySet() else selected
+
+/**
+ * The lifecycle of a pull-to-load-more request (the ETA strip's pull-past-end gesture). One request
+ * is tracked at a time — the load is global to the stop — and the [Loading.token] identifies which
+ * strip fired it, so only that strip animates its spinner/reveal.
+ */
+sealed interface LoadMoreState {
+    data object Idle : LoadMoreState
+    data class Loading(val token: Int) : LoadMoreState
+
+    /**
+     * [dataVersion] is the [ArrivalsUiState.Content.dataVersion] current when this request's load
+     * completed; the firing strip settles once its *layout* reflects a version >= this. [success]
+     * means a fresh network result landed (a stale fallback counts as failure — nothing new could
+     * have arrived).
+     */
+    data class Finished(val token: Int, val success: Boolean, val dataVersion: Long) : LoadMoreState
+}
 
 /**
  * ViewModel for the arrivals screen. The 60-second polling loop lives in the screen (driven by the
@@ -68,8 +88,20 @@ class ArrivalsViewModel @AssistedInject constructor(
     // --- Reactive state sources. The UI [state] is derived from these, so a user action updates the
     // screen by mutating a source rather than imperatively recomputing and assigning the state. -----
 
+    /**
+     * The loaded snapshot paired with a monotonically increasing revision. The revision is stamped
+     * into [ArrivalsUiState.Content.dataVersion] so the UI can tell, purely from state, whether a
+     * given load's data has reached its composition/layout yet. Paired in one object (not two flows)
+     * so the [state] combine can never emit new data with an old version.
+     */
+    private data class VersionedData(val data: ArrivalsData, val version: Long)
+
     /** The latest fetched snapshot (null until the first load). */
-    private val loaded = MutableStateFlow<ArrivalsData?>(null)
+    private val loaded = MutableStateFlow<VersionedData?>(null)
+
+    private fun publish(data: ArrivalsData) {
+        loaded.value = VersionedData(data, (loaded.value?.version ?: 0L) + 1L)
+    }
 
     /** Set only when a load fails with nothing to show; cleared by any successful load. */
     private val fatalError = MutableStateFlow<String?>(null)
@@ -86,7 +118,7 @@ class ArrivalsViewModel @AssistedInject constructor(
             loaded, repository.alertHideState(), repository.favoriteRouteIds(), fatalError
         ) { data, hideState, favoriteRouteIds, error ->
             when {
-                data != null -> data.toContent(hideState, favoriteRouteIds)
+                data != null -> data.data.toContent(hideState, favoriteRouteIds, data.version)
                 error != null -> ArrivalsUiState.Error(error)
                 else -> ArrivalsUiState.Loading
             }
@@ -123,21 +155,27 @@ class ArrivalsViewModel @AssistedInject constructor(
      * 60s interval from completion. A failed refresh keeps any existing content (the repository
      * already returns the last good data as stale); it only surfaces [ArrivalsUiState.Error]
      * when there is nothing to show.
+     *
+     * Returns true when a *fresh* network response landed — a stale fallback (the repository
+     * returns the last good data flagged `isStale` on failure-with-content) or a hard failure
+     * returns false. Consumed by [loadMore]; the poll loop ignores it.
      */
-    suspend fun refresh() {
+    suspend fun refresh(): Boolean {
         val result = repository.getArrivals(stopId, minutesAfter, routeFilter.takeIf { filterLoaded })
         lastResponseTime = WallTime.now()
-        result.fold(
+        return result.fold(
             onSuccess = { data ->
                 minutesAfter = data.minutesAfter
                 routeFilter = data.effectiveRouteFilter
                 filterLoaded = true
                 fatalError.value = null
-                loaded.value = data
+                publish(data)
                 repository.lastLoaded()?.let { _arrivalsLoaded.tryEmit(it) }
+                !data.isStale
             },
             onFailure = { error ->
                 if (loaded.value == null) fatalError.value = error.message.orEmpty()
+                false
             }
         )
     }
@@ -147,17 +185,50 @@ class ArrivalsViewModel @AssistedInject constructor(
         viewModelScope.launch { refresh() }
     }
 
-    /** Widens the time window and reloads (the "load more arrivals" footer). */
-    fun loadMore() {
+    private val _loadMoreState = MutableStateFlow<LoadMoreState>(LoadMoreState.Idle)
+
+    /** The pull-to-load-more lifecycle; the ETA strip that fired the matching token drives its
+     *  spinner/reveal from this. */
+    val loadMoreState: StateFlow<LoadMoreState> = _loadMoreState.asStateFlow()
+
+    private var nextLoadMoreToken = 0
+
+    /** The in-flight load-more refresh, cancelled when a newer load-more supersedes it. */
+    private var loadMoreJob: Job? = null
+
+    /**
+     * Widens the time window and reloads (the ETA strip's pull-past-end gesture). Returns the
+     * request token; [loadMoreState] reports the request's lifecycle under that token.
+     */
+    fun loadMore(): Int {
+        val token = ++nextLoadMoreToken
         minutesAfter += DefaultArrivalsRepository.MINUTES_AFTER_INCREMENT
-        viewModelScope.launch { refresh() }
+        _loadMoreState.value = LoadMoreState.Loading(token)
+        // Cancel any older load-more still in flight so its refresh() can't publish() after this one —
+        // an earlier (narrower-window) response resolving last would otherwise roll the arrivals back.
+        // A cancelled refresh dies on its (cooperative) network call before it reaches publish. Polls
+        // and other refreshes are separate intents and are left alone.
+        loadMoreJob?.cancel()
+        loadMoreJob = viewModelScope.launch {
+            // Safety guard ONLY (not happy-path logic): getArrivals is already bounded by OkHttp's
+            // connect/read timeouts; this caps a pathological trickling response so Finished always
+            // fires and a strip's spinner can't be pinned forever.
+            val fresh = withTimeoutOrNull(LOAD_MORE_SAFETY_TIMEOUT_MS) { refresh() } ?: false
+            // Publish completion only if a later loadMore hasn't superseded this request (its own
+            // Finished will follow; the superseded strip tears down on seeing Loading(other)).
+            if ((_loadMoreState.value as? LoadMoreState.Loading)?.token == token) {
+                _loadMoreState.value =
+                    LoadMoreState.Finished(token, fresh, loaded.value?.version ?: 0L)
+            }
+        }
+        return token
     }
 
     /** Toggles the stop favorite, updating the header optimistically and persisting. */
     fun toggleFavorite() {
         val content = state.value as? ArrivalsUiState.Content ?: return
         val newValue = !content.header.isFavorite
-        loaded.value = loaded.value?.copy(header = content.header.copy(isFavorite = newValue))
+        loaded.value?.let { publish(it.data.copy(header = content.header.copy(isFavorite = newValue))) }
         viewModelScope.launch { repository.setStopFavorite(content.header.stopId, newValue) }
     }
 
@@ -235,7 +306,7 @@ class ArrivalsViewModel @AssistedInject constructor(
 
     /** Every situation id across the currently loaded active alerts (all grouped ids, deduped). */
     private fun activeSituationIds(): List<String> =
-        loaded.value?.activeAlerts.orEmpty().flatMapTo(mutableSetOf()) { it.situationIds }.toList()
+        loaded.value?.data?.activeAlerts.orEmpty().flatMapTo(mutableSetOf()) { it.situationIds }.toList()
 
     /** The service-alert dialog's content for an alert id (read from the last good response). */
     fun alertDetails(id: String): AlertDetails? = repository.alertDetails(id)
@@ -263,11 +334,13 @@ class ArrivalsViewModel @AssistedInject constructor(
     private fun ArrivalsData.toContent(
         hideState: AlertHideState,
         favoriteRouteIds: Set<String>,
+        version: Long,
     ): ArrivalsUiState.Content {
         val shown = activeAlerts.filterNot { hideState.isHidden(it, hideAlertsByDefault) }
         val hiddenCount = activeAlerts.size - shown.size
         return ArrivalsUiState.Content(
             header = header,
+            dataVersion = version,
             arrivals = arrivals,
             // Lift starred routes to the top (each partition stays in departure order). Done here, off
             // the live favorite set, so a star toggle re-orders the list with no re-fetch (#1707/#1751).
@@ -285,5 +358,11 @@ class ArrivalsViewModel @AssistedInject constructor(
             stopLon = stopLon,
             stopUserName = stopUserName
         )
+    }
+
+    private companion object {
+        /** Backstop on a pathological trickling response so [LoadMoreState.Finished] always fires;
+         *  OkHttp's connect/read timeouts bound the normal failure paths well before this. */
+        const val LOAD_MORE_SAFETY_TIMEOUT_MS = 30_000L
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
@@ -17,6 +17,7 @@ package org.onebusaway.android.ui.arrivals.components
 
 import androidx.compose.animation.core.FastOutLinearInEasing
 import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animate
 import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
@@ -37,13 +38,16 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowForward
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
@@ -53,31 +57,63 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.CustomAccessibilityAction
+import androidx.compose.ui.semantics.customActions
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.Velocity
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import kotlin.coroutines.cancellation.CancellationException
+import kotlin.math.roundToInt
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
 import org.onebusaway.android.R
 import org.onebusaway.android.models.Status
 import org.onebusaway.android.ui.arrivals.ArrivalActions
 import org.onebusaway.android.ui.arrivals.ArrivalInfo
+import org.onebusaway.android.ui.arrivals.LoadMoreState
 import org.onebusaway.android.ui.compose.components.LineBadge
 import org.onebusaway.android.ui.compose.components.rememberRouteBadgeColors
 import org.onebusaway.android.ui.arrivals.RouteRowGroup
@@ -99,7 +135,14 @@ class ArrivalRowCallbacks(
     val onShowRouteSchedule: (String) -> Unit,
     val onReportArrivalProblem: (ArrivalActions) -> Unit,
     /** Opens the service-alert dialog for the given situation id (the per-row alert indicator). */
-    val onShowAlert: (String) -> Unit
+    val onShowAlert: (String) -> Unit,
+    /** Fires a widen-window reload — invoked by pulling an ETA strip past its end (replaces the old
+     *  "load more arrivals" footer button). Returns the request token whose lifecycle
+     *  [loadMoreState] reports. */
+    val onLoadMore: () -> Int,
+    /** The stop's shared load-more lifecycle; the strip that fired the matching token drives its
+     *  spinner/reveal from this. */
+    val loadMoreState: StateFlow<LoadMoreState>
 )
 
 /**
@@ -244,6 +287,9 @@ internal fun ArrivalRowContent(
 @Composable
 fun RouteArrivalRow(
     group: RouteRowGroup,
+    // The Content.dataVersion the group came from — MUST be read off the same Content object, so the
+    // ETA strip's load-more reveal can pair its pills with the data generation they render.
+    dataVersion: Long,
     actionsFor: (ArrivalInfo) -> ArrivalActions?,
     isFavorite: Boolean,
     filterActive: Boolean,
@@ -290,6 +336,7 @@ fun RouteArrivalRow(
                     }
                     EtaStrip(
                         trips = group.trips,
+                        dataVersion = dataVersion,
                         actionsFor = actionsFor,
                         callbacks = callbacks,
                         firstPillModifier = etaAnchor,
@@ -348,14 +395,30 @@ private fun DirectionHeader(direction: String) {
     }
 }
 
+// Pull-past-end-to-load tuning. The strip captures a drag that continues past its last pill and, once
+// it crosses [PULL_TO_LOAD_THRESHOLD], loads more arrivals on release (the old footer button's job).
+/** Finger travel maps to pull distance at this ratio, so the pull lags the finger for a rubber-band feel. */
+private const val PULL_RESISTANCE = 0.5f
+/** Pull distance (post-resistance) that arms the load-more trigger. */
+private val PULL_TO_LOAD_THRESHOLD = 48.dp
+/** Pull distance is clamped here so the strip can't be dragged arbitrarily far off its end. */
+private val PULL_TO_LOAD_MAX = 72.dp
 /**
  * The horizontally-scrollable strip of per-trip ETA pills below the direction name. When the pills
  * overflow the row, a right-edge fade + chevron appears to signal there's more to scroll to; it's a
  * pure visual hint (no pointer handling) so it never blocks the strip's own drag-to-scroll.
+ *
+ * Dragging the strip past its last pill (once there's nothing more to scroll) builds a resistive pull
+ * that reveals a trailing load-more affordance; releasing past [PULL_TO_LOAD_THRESHOLD] widens the
+ * arrivals window via [ArrivalRowCallbacks.onLoadMore] — this replaced the drawer's footer button
+ * (issue #1707 follow-up). A TalkBack custom action exposes the same load-more for non-drag users.
  */
 @Composable
 private fun EtaStrip(
     trips: List<ArrivalInfo>,
+    // The Content.dataVersion this strip's trips came from. MUST come from the same Content object as
+    // the trips themselves, so the strip can never see a version ahead of its rendered pills.
+    dataVersion: Long,
     actionsFor: (ArrivalInfo) -> ArrivalActions?,
     callbacks: ArrivalRowCallbacks,
     modifier: Modifier = Modifier,
@@ -363,9 +426,161 @@ private fun EtaStrip(
 ) {
     val scrollState = rememberScrollState()
     val canScrollForward by remember { derivedStateOf { scrollState.canScrollForward } }
-    Box(modifier) {
+    val density = LocalDensity.current
+    val triggerPx = remember(density) { with(density) { PULL_TO_LOAD_THRESHOLD.toPx() } }
+    val maxPullPx = remember(density) { with(density) { PULL_TO_LOAD_MAX.toPx() } }
+    // Current pull distance in px (post-resistance). Written from the nested-scroll callbacks and read
+    // in the layout/graphics phase, so growing it during a drag doesn't recompose the whole strip.
+    val pull = remember { mutableFloatStateOf(0f) }
+    // Whether the pull has crossed the arm threshold. A derivedState kept out of this composable's own
+    // read set so only its reader (the chip) recomposes when it flips — never the whole strip per frame.
+    val armed = remember(triggerPx) { derivedStateOf { pull.floatValue >= triggerPx } }
+    val loadMoreLabel = stringResource(R.string.stop_info_load_more_arrivals)
+    val haptic = LocalHapticFeedback.current
+
+    // The strip's active load-more request: the token returned at fire time, NO_LOAD_REQUEST at rest.
+    // Saveable so a list eviction / recreation mid-load resumes (or cleanly ends) the transaction.
+    val request = rememberSaveable { mutableIntStateOf(NO_LOAD_REQUEST) }
+    val loadMore by callbacks.loadMoreState.collectAsStateWithLifecycle()
+    // The spinner shows from fire until the composition that carries the completing data's version, so
+    // the spinner and the new pills swap in the SAME composition — never a frame where both/neither
+    // show. At rest, request is NO_LOAD_REQUEST, which reads as Superseded → no spinner.
+    val loadingMore = spinnerVisible(loadMoreOutcome(loadMore, request.intValue), dataVersion)
+
+    // Layout acknowledgement: the highest dataVersion whose strip content has been MEASURED. Written in
+    // the measure pass that wraps horizontalScroll — the same pass (and snapshot batch) in which
+    // scrollState.maxValue is brought up to date — so `measuredVersion >= V` GUARANTEES maxValue is
+    // consistent with data version V. Read only from snapshotFlow (never composition), so writing it
+    // per layout pass can't cause recomposition loops.
+    val measuredVersion = remember { mutableLongStateOf(0L) }
+    val versionState = rememberUpdatedState(dataVersion)
+
+    // The reveal transaction for this strip's request: keep the strip pinned to its (moving) right end
+    // — first the spinner slot, then the reloaded pills — and settle once the layout provably reflects
+    // the data that completed the request. Every wait is a level-triggered predicate over monotonic
+    // snapshot/StateFlow state, so a signal that fires before we start listening is still observed.
+    LaunchedEffect(request.intValue) {
+        val token = request.intValue
+        if (token == NO_LOAD_REQUEST) return@LaunchedEffect
+        try {
+            coroutineScope {
+                // FOLLOWER: glides to the current end whenever there is one to reach. Each glide runs
+                // TO COMPLETION and the loop then re-evaluates against current state (never
+                // collectLatest: a change mid-glide is caught by the fresh level-triggered re-await,
+                // so there is no lost-update window).
+                val follower = launch {
+                    while (true) {
+                        snapshotFlow { scrollState.maxValue > scrollState.value }.first { it }
+                        try {
+                            scrollState.animateScrollTo(scrollState.maxValue)
+                        } catch (cause: CancellationException) {
+                            currentCoroutineContext().ensureActive() // real teardown propagates
+                            // Lost the scrollable mutex to a touch. Never contest user input: resume
+                            // the chase only once the strip is fully at rest. (A drag that actually
+                            // travels ends the whole transaction via the nested-scroll hook.)
+                            snapshotFlow { scrollState.isScrollInProgress }.first { !it }
+                        }
+                    }
+                }
+                // AWAIT RESULT: level-triggered on the VM's StateFlow — a Finished that landed before
+                // we started collecting is still observed (StateFlow replays its value).
+                val landed = callbacks.loadMoreState
+                    .map { loadMoreOutcome(it, token) }
+                    .first { it !is LoadMoreOutcome.Pending }
+                if (landed is LoadMoreOutcome.Landed) {
+                    // SETTLE: wait until (a) layout reflects the completing data's version — which,
+                    // via the layout-ack modifier, also means maxValue is current for that data and
+                    // the spinner slot is gone (spinner and new pills swap in the same composition,
+                    // both keyed on dataVersion) — and (b) we are at rest at the true end. Success
+                    // with new pills, success with none for this row, and failure all take this one
+                    // path: the end is wherever layout says it is.
+                    snapshotFlow {
+                        measuredVersion.longValue >= landed.dataVersion &&
+                            scrollState.value == scrollState.maxValue &&
+                            !scrollState.isScrollInProgress
+                    }.first { it }
+                }
+                follower.cancel()
+            }
+        } finally {
+            // Idempotent teardown; guarded so a user-takeover or a re-fire (which already moved
+            // `request`) isn't clobbered.
+            if (request.intValue == token) request.intValue = NO_LOAD_REQUEST
+        }
+    }
+
+    val pullConnection = remember(scrollState, callbacks, triggerPx, maxPullPx, haptic) {
+        object : NestedScrollConnection {
+            // Dragging back toward the pills unwinds an active pull before the strip itself scrolls.
+            override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
+                // Programmatic glides dispatch as SideEffect; only real user input drives the pull and
+                // the take-over below.
+                if (source != NestedScrollSource.UserInput) return Offset.Zero
+                // A real user scroll on this strip while a reveal transaction is active ends it: the
+                // user wins, the transaction effect is cancelled (killing any in-flight glide via the
+                // scrollable mutex), and the spinner is dropped. The load itself continues in the
+                // ViewModel; its pills land unanimated.
+                if (request.intValue != NO_LOAD_REQUEST) request.intValue = NO_LOAD_REQUEST
+                // Dragging back toward the pills unwinds an active pull before the strip itself scrolls.
+                if (available.x > 0f && pull.floatValue > 0f) {
+                    val consumedFinger = (pull.floatValue / PULL_RESISTANCE).coerceAtMost(available.x)
+                    pull.floatValue -= consumedFinger * PULL_RESISTANCE
+                    return Offset(consumedFinger, 0f)
+                }
+                return Offset.Zero
+            }
+
+            // Past the strip's end, a further left-drag (negative x) builds the resistive pull; a light
+            // tick fires the instant it crosses the arm threshold (rising edge only).
+            override fun onPostScroll(consumed: Offset, available: Offset, source: NestedScrollSource): Offset {
+                if (source == NestedScrollSource.UserInput && available.x < 0f && !scrollState.canScrollForward) {
+                    val before = pull.floatValue
+                    pull.floatValue = (before - available.x * PULL_RESISTANCE).coerceAtMost(maxPullPx)
+                    if (before < triggerPx && pull.floatValue >= triggerPx) {
+                        haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                    }
+                    return Offset(available.x, 0f)
+                }
+                return Offset.Zero
+            }
+
+            // Drag released: fire load-more if armed (the reveal transaction, keyed on the request
+            // token, then pins the strip to its end), then spring the pull back.
+            override suspend fun onPreFling(available: Velocity): Velocity {
+                if (pull.floatValue <= 0f) return Velocity.Zero
+                if (pull.floatValue >= triggerPx) {
+                    // The VM sets Loading(token) synchronously inside onLoadMore, so the spinner is
+                    // already visible in the composition this write lands in — no gap.
+                    request.intValue = callbacks.onLoadMore()
+                }
+                animate(pull.floatValue, 0f) { value, _ -> pull.floatValue = value }
+                // Swallow the fling — there's nothing left to scroll to at the strip's end.
+                return available
+            }
+        }
+    }
+
+    Box(
+        modifier
+            .clipToBounds()
+            .nestedScroll(pullConnection)
+            .semantics {
+                customActions = listOf(
+                    // The full transaction, so TalkBack users get the same spinner + reveal.
+                    CustomAccessibilityAction(loadMoreLabel) {
+                        request.intValue = callbacks.onLoadMore(); true
+                    }
+                )
+            }
+    ) {
         Row(
-            modifier = Modifier.horizontalScroll(scrollState),
+            modifier = Modifier
+                // Follow the pull so the pills slide aside, opening the gap the load-more chip fills.
+                .offset { IntOffset(-pull.floatValue.roundToInt(), 0) }
+                // The composition↔layout bridge: measure the scroll content, then record the data
+                // version this layout reflects (see acknowledgeVersion).
+                .acknowledgeVersion(versionState, measuredVersion)
+                .horizontalScroll(scrollState),
             horizontalArrangement = Arrangement.spacedBy(6.dp),
             // Bottom-align so a smaller recent-past pill sits on the same baseline as the full-size ones.
             verticalAlignment = Alignment.Bottom
@@ -378,8 +593,34 @@ private fun EtaStrip(
                     modifier = if (index == 0) firstPillModifier else Modifier,
                 )
             }
+            // While the reload is in flight, the spinner rides as a real tail item so it reserves its
+            // own slot to the right of the last pill (rather than overlaying it); when the completing
+            // data's composition lands it's dropped in the same frame the new pills appear, and the
+            // strip glides left to the new end.
+            if (loadingMore) {
+                Box(
+                    modifier = Modifier.size(width = 28.dp, height = 32.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(20.dp),
+                        strokeWidth = 2.dp,
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                }
+            }
         }
-        if (canScrollForward) {
+        // The pull-revealed load-more chip (invisible at rest, armed as the pull crosses the threshold).
+        // Hidden while loading — the inline spinner above takes over then.
+        if (!loadingMore) {
+            LoadMorePullChip(
+                progress = { (pull.floatValue / triggerPx).coerceIn(0f, 1f) },
+                armed = { armed.value },
+                contentDescription = loadMoreLabel,
+                modifier = Modifier.align(Alignment.CenterEnd),
+            )
+        }
+        if (canScrollForward && !loadingMore) {
             Row(
                 modifier = Modifier
                     .align(Alignment.CenterEnd)
@@ -408,6 +649,45 @@ private fun EtaStrip(
                 )
             }
         }
+    }
+}
+
+/**
+ * The circular load-more affordance uncovered as the ETA strip is pulled past its end. [progress]
+ * (0..1, read in the graphics phase to avoid recomposing on every drag frame) fades and slides it in;
+ * [armed] (progress has reached 1) flips it to the primary color so "release to load" reads at a glance.
+ */
+@Composable
+private fun LoadMorePullChip(
+    progress: () -> Float,
+    armed: () -> Boolean,
+    contentDescription: String,
+    modifier: Modifier = Modifier,
+) {
+    val slidePx = with(LocalDensity.current) { 20.dp.toPx() }
+    // Reading the arm lambda here scopes threshold-crossing recomposition to just this small chip.
+    val isArmed = armed()
+    val container = if (isArmed) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surfaceVariant
+    val content = if (isArmed) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurfaceVariant
+    Box(
+        modifier = modifier
+            .graphicsLayer {
+                val p = progress()
+                alpha = p
+                // Slide in from the right edge as the pull grows (fully seated at p == 1).
+                translationX = (1f - p) * slidePx
+            }
+            .size(30.dp)
+            .clip(CircleShape)
+            .background(container),
+        contentAlignment = Alignment.Center
+    ) {
+        Icon(
+            imageVector = Icons.AutoMirrored.Filled.ArrowForward,
+            contentDescription = contentDescription,
+            tint = content,
+            modifier = Modifier.size(18.dp)
+        )
     }
 }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalsPanel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalsPanel.kt
@@ -170,7 +170,6 @@ fun ArrivalsPanel(
                     content = content,
                     rowCallbacks = rowCallbacks,
                     handler = handler,
-                    onLoadMore = viewModel::loadMore,
                     onShowAllRoutes = viewModel::showAllRoutes,
                     onShowHiddenAlerts = viewModel::showHiddenAlerts,
                     modifier = Modifier.weight(1f),
@@ -202,6 +201,7 @@ fun ArrivalsPanel(
                             Box(Modifier.onSizeChanged { rowHeights[index] = it.height }) {
                                 RouteArrivalRow(
                                     group = group,
+                                    dataVersion = content.dataVersion,
                                     actionsFor = { content.actions[it.tripId] },
                                     isFavorite = group.routeId in content.favoriteRouteIds,
                                     filterActive = filtering,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStripLoadMore.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStripLoadMore.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.arrivals.components
+
+import androidx.compose.runtime.MutableLongState
+import androidx.compose.runtime.State
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.layout
+import org.onebusaway.android.ui.arrivals.LoadMoreState
+
+/**
+ * No active load-more request on this strip. Real tokens start at 1, so 0 is safely "none" (and
+ * survives rememberSaveable without a nullable).
+ */
+internal const val NO_LOAD_REQUEST = 0
+
+/** The stop-shared [LoadMoreState] interpreted from one strip's point of view. */
+internal sealed interface LoadMoreOutcome {
+    /** Our request is still in flight. */
+    data object Pending : LoadMoreOutcome
+
+    /** The shared slot no longer tracks our request — no live request, another strip re-fired, or a
+     *  restored token from a dead process — terminal; tear down without animating. */
+    data object Superseded : LoadMoreOutcome
+
+    /** Our request completed; the strip settles once its layout reflects [dataVersion]. Success vs
+     *  failure isn't distinguished here — both settle wherever layout puts the new end; the fresh-vs-
+     *  stale outcome lives on [LoadMoreState.Finished.success] as a VM concern. */
+    data class Landed(val dataVersion: Long) : LoadMoreOutcome
+}
+
+/** How the shared [state] reads for the strip holding [token] ([NO_LOAD_REQUEST] reads as
+ *  [LoadMoreOutcome.Superseded] — it can never match a live token). */
+internal fun loadMoreOutcome(state: LoadMoreState, token: Int): LoadMoreOutcome = when (state) {
+    LoadMoreState.Idle -> LoadMoreOutcome.Superseded
+    is LoadMoreState.Loading ->
+        if (state.token == token) LoadMoreOutcome.Pending else LoadMoreOutcome.Superseded
+    is LoadMoreState.Finished ->
+        if (state.token == token) LoadMoreOutcome.Landed(state.dataVersion)
+        else LoadMoreOutcome.Superseded
+}
+
+/**
+ * Whether the inline tail spinner shows: from fire until the composition that carries the completing
+ * data's version — so the spinner and the new pills swap in the SAME composition — or immediately on
+ * supersession/teardown.
+ */
+internal fun spinnerVisible(outcome: LoadMoreOutcome, renderedDataVersion: Long): Boolean =
+    when (outcome) {
+        LoadMoreOutcome.Superseded -> false
+        LoadMoreOutcome.Pending -> true
+        is LoadMoreOutcome.Landed -> renderedDataVersion < outcome.dataVersion
+    }
+
+/**
+ * Acknowledges, in the LAYOUT phase, the data [version] this strip's content has been MEASURED for.
+ * Place BEFORE `horizontalScroll` in the chain so measuring the child runs the scroll node's measure
+ * (refreshing its `maxValue`) in the same pass; [into] is then set to [version]'s current value, so
+ * `into >= V` guarantees `maxValue` is consistent with data version V — the composition-vs-layout
+ * bridge the reveal transaction's settle predicate waits on. [version] is read as snapshot [State]
+ * *inside* the measure block, so a version-only change (identical pills, bumped revision) re-runs the
+ * ack without recomposing.
+ */
+internal fun Modifier.acknowledgeVersion(version: State<Long>, into: MutableLongState): Modifier =
+    layout { measurable, constraints ->
+        val placeable = measurable.measure(constraints)
+        into.longValue = version.value
+        layout(placeable.width, placeable.height) { placeable.place(0, 0) }
+    }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/ArrivalsViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/ArrivalsViewModelTest.kt
@@ -16,6 +16,7 @@
 package org.onebusaway.android.ui.arrivals
 
 import java.io.IOException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -47,6 +48,10 @@ private class FakeArrivalsRepository(
 
     val requestedFilters = mutableListOf<Set<String>?>()
 
+    /** When set, [getArrivals] suspends until it completes — lets a test hold a load in flight
+     *  (e.g. to fire a superseding load-more before the first finishes). */
+    var gate: CompletableDeferred<Unit>? = null
+
     var lastFavoriteSet: Pair<String, Boolean>? = null
 
     var lastFavoriteRoute: FavoriteRouteCall? = null
@@ -73,6 +78,7 @@ private class FakeArrivalsRepository(
     ): Result<ArrivalsData> {
         requestedMinutesAfter.add(minutesAfter)
         requestedFilters.add(routeFilter)
+        gate?.await()
         // Echo the effective filter back, like the real repo (persisted when the caller passes null)
         val effective = routeFilter ?: persistedFilter
         return result.map { it.copy(effectiveRouteFilter = effective) }
@@ -224,6 +230,116 @@ class ArrivalsViewModelTest {
 
         // 65 (initial) then 125 (65 + 60 increment)
         assertEquals(listOf(65, 125), repository.requestedMinutesAfter)
+    }
+
+    // --- Pull-to-load-more lifecycle (LoadMoreState) --------------------------------------------
+
+    private fun contentVersion(viewModel: ArrivalsViewModel) =
+        (viewModel.state.value as ArrivalsUiState.Content).dataVersion
+
+    @Test
+    fun `loadMore emits Loading then Finished with success and a bumped dataVersion on a fresh load`() =
+        runTest {
+            val repository = FakeArrivalsRepository(Result.success(data()))
+            val viewModel = ArrivalsViewModel("1_100", false, repository)
+            viewModel.refresh()
+            val versionBefore = contentVersion(viewModel)
+            repository.gate = CompletableDeferred()
+
+            val token = viewModel.loadMore()
+            assertEquals(LoadMoreState.Loading(token), viewModel.loadMoreState.value)
+
+            repository.gate!!.complete(Unit)
+            advanceUntilIdle()
+
+            val finished = viewModel.loadMoreState.value as LoadMoreState.Finished
+            assertEquals(token, finished.token)
+            assertTrue(finished.success)
+            assertTrue(finished.dataVersion > versionBefore)
+            assertEquals(contentVersion(viewModel), finished.dataVersion)
+        }
+
+    @Test
+    fun `loadMore reports failure when the reload falls back to stale data`() = runTest {
+        val repository = FakeArrivalsRepository(Result.success(data()))
+        val viewModel = ArrivalsViewModel("1_100", false, repository)
+        viewModel.refresh()
+        // The repository's failure-with-content path: last good data flagged stale.
+        repository.result = Result.success(data(isStale = true))
+
+        val token = viewModel.loadMore()
+        advanceUntilIdle()
+
+        val finished = viewModel.loadMoreState.value as LoadMoreState.Finished
+        assertEquals(token, finished.token)
+        assertEquals(false, finished.success)
+    }
+
+    @Test
+    fun `loadMore reports failure with an unchanged dataVersion on a hard failure`() = runTest {
+        val repository = FakeArrivalsRepository(Result.success(data()))
+        val viewModel = ArrivalsViewModel("1_100", false, repository)
+        viewModel.refresh()
+        val versionBefore = contentVersion(viewModel)
+        repository.result = Result.failure(IOException("No network"))
+
+        viewModel.loadMore()
+        advanceUntilIdle()
+
+        val finished = viewModel.loadMoreState.value as LoadMoreState.Finished
+        assertEquals(false, finished.success)
+        assertEquals(versionBefore, finished.dataVersion)
+    }
+
+    @Test
+    fun `a second loadMore supersedes the first - only the second request's Finished is published`() =
+        runTest {
+            val repository = FakeArrivalsRepository(Result.success(data()))
+            val viewModel = ArrivalsViewModel("1_100", false, repository)
+            viewModel.refresh()
+            repository.gate = CompletableDeferred()
+
+            val first = viewModel.loadMore()
+            val second = viewModel.loadMore()
+            assertTrue(second > first)
+            assertEquals(LoadMoreState.Loading(second), viewModel.loadMoreState.value)
+
+            repository.gate!!.complete(Unit)
+            advanceUntilIdle()
+
+            // The first request's completion must not clobber the second's lifecycle.
+            val finished = viewModel.loadMoreState.value as LoadMoreState.Finished
+            assertEquals(second, finished.token)
+        }
+
+    @Test
+    fun `a superseded loadMore is cancelled so its refresh cannot publish stale content`() = runTest {
+        val repository = FakeArrivalsRepository(Result.success(data()))
+        val viewModel = ArrivalsViewModel("1_100", false, repository)
+        viewModel.refresh() // dataVersion 1
+        repository.gate = CompletableDeferred() // hold the next getArrivals in flight
+
+        viewModel.loadMore()  // request A: blocks in getArrivals on the gate
+        viewModel.loadMore()  // request B: cancels A, then blocks on the same gate
+
+        repository.gate!!.complete(Unit) // release: A is cancelled, only B reaches publish()
+        advanceUntilIdle()
+
+        // Exactly one further publish (B → version 2); the cancelled A never rolled the window back.
+        assertEquals(2L, contentVersion(viewModel))
+    }
+
+    @Test
+    fun `dataVersion increases on every refresh`() = runTest {
+        val repository = FakeArrivalsRepository(Result.success(data()))
+        val viewModel = ArrivalsViewModel("1_100", false, repository)
+
+        viewModel.refresh()
+        val v1 = contentVersion(viewModel)
+        viewModel.refresh()
+        val v2 = contentVersion(viewModel)
+
+        assertTrue(v2 > v1)
     }
 
     @Test

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/EtaStripLoadMoreTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/EtaStripLoadMoreTest.kt
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.arrivals
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.onebusaway.android.ui.arrivals.components.LoadMoreOutcome
+import org.onebusaway.android.ui.arrivals.components.NO_LOAD_REQUEST
+import org.onebusaway.android.ui.arrivals.components.loadMoreOutcome
+import org.onebusaway.android.ui.arrivals.components.spinnerVisible
+
+/** Truth tables for the ETA strip's pure load-more interpretation (see EtaStripLoadMore.kt). */
+class EtaStripLoadMoreTest {
+
+    private val ours = 7
+    private val theirs = 8
+
+    // --- loadMoreOutcome -------------------------------------------------------------------------
+
+    @Test
+    fun `Idle reads as superseded - the shared slot no longer tracks our request`() {
+        assertEquals(LoadMoreOutcome.Superseded, loadMoreOutcome(LoadMoreState.Idle, ours))
+    }
+
+    @Test
+    fun `Loading with our token is pending`() {
+        assertEquals(LoadMoreOutcome.Pending, loadMoreOutcome(LoadMoreState.Loading(ours), ours))
+    }
+
+    @Test
+    fun `Loading with another strip's token is superseded`() {
+        assertEquals(LoadMoreOutcome.Superseded, loadMoreOutcome(LoadMoreState.Loading(theirs), ours))
+    }
+
+    @Test
+    fun `Finished with our token lands with its dataVersion`() {
+        val landed = loadMoreOutcome(LoadMoreState.Finished(ours, success = true, dataVersion = 42L), ours)
+        assertEquals(LoadMoreOutcome.Landed(dataVersion = 42L), landed)
+    }
+
+    @Test
+    fun `NO_LOAD_REQUEST reads as superseded - it can never match a live token`() {
+        assertEquals(
+            LoadMoreOutcome.Superseded,
+            loadMoreOutcome(LoadMoreState.Loading(ours), NO_LOAD_REQUEST)
+        )
+    }
+
+    @Test
+    fun `Finished with another token is superseded`() {
+        assertEquals(
+            LoadMoreOutcome.Superseded,
+            loadMoreOutcome(LoadMoreState.Finished(theirs, success = true, dataVersion = 42L), ours)
+        )
+    }
+
+    // --- spinnerVisible ----------------------------------------------------------------------------
+
+    @Test
+    fun `a pending request shows the spinner`() {
+        assertTrue(spinnerVisible(LoadMoreOutcome.Pending, renderedDataVersion = 5L))
+    }
+
+    @Test
+    fun `a superseded request drops the spinner immediately`() {
+        assertFalse(spinnerVisible(LoadMoreOutcome.Superseded, renderedDataVersion = 5L))
+    }
+
+    @Test
+    fun `a landed request keeps the spinner until the completing data's composition arrives`() {
+        val landed = LoadMoreOutcome.Landed(dataVersion = 6L)
+        // Still rendering the pre-load data: spinner stays, so it swaps with the new pills atomically.
+        assertTrue(spinnerVisible(landed, renderedDataVersion = 5L))
+        // The completing data's composition (or a later one) has arrived: spinner gone.
+        assertFalse(spinnerVisible(landed, renderedDataVersion = 6L))
+        assertFalse(spinnerVisible(landed, renderedDataVersion = 7L))
+    }
+}


### PR DESCRIPTION
## What

Replaces the arrivals drawer's **"load more arrivals" footer button** with a **pull-past-the-end gesture on a route row's horizontal ETA-pill strip**:

- Drag the strip past its last pill → a resistive rubber-band pull builds; crossing a threshold arms it (a haptic tick + a chip).
- Release while armed → widens the stop's time window (the same `loadMore()` the button used).
- An inline spinner reserves a slot at the strip's right end while the reload is in flight; the strip glides to reveal the spinner.
- When fresh ETAs land, the strip glides to the new end to reveal them. A failed/empty reload snaps back and drops the spinner.
- A TalkBack `CustomAccessibilityAction` exposes the same load-more for non-drag users.

## Why it's built this way (determinism)

"Scroll to the newly-loaded ETAs" is deceptively hard: `trips` updates in Compose's **composition** phase while a `horizontalScroll`'s `maxValue` updates a phase later in **layout**, so any reveal that reads `maxValue` at a moment in time races that skew (it stalls at a random fraction, or no-fires). This PR removes the guesswork:

- **Load lifecycle moves to the ViewModel** — an explicit `LoadMoreState` (`Idle` / `Loading(token)` / `Finished(token, success, dataVersion)`), with a monotonic `dataVersion` stamped on every `Content` snapshot. The requesting strip is identified by a token, so only it animates.
- **The strip acknowledges the measured version in its own layout pass** (`Modifier.acknowledgeVersion`), so `measuredVersion >= V` provably means `maxValue` is consistent with data version `V`.
- **Every wait is a level-triggered predicate over monotonic snapshot/StateFlow state** — no timeouts, polling, or `maxValue`-at-a-moment reads in the happy path. The spinner is *derived* (`spinnerVisible`), so it and the new pills swap in the **same** composition. A single 30s network backstop lives in the ViewModel, off the happy path.

## Tests

- `EtaStripLoadMoreTest` (pure JVM) — truth tables for `loadMoreOutcome` / `spinnerVisible`.
- `ArrivalsViewModelTest` — token issuance, `dataVersion` monotonicity, supersession, and stale-fallback-as-failure.
- On-device verified on a Pixel 7 Pro: pull → spinner → reveal; airplane-mode pull → snap-back; pull-then-drag hand-off; per-row isolation.

## Note

`loadMore()` widens the **whole stop's** window (all route rows gain ETAs), while the gesture/spinner/reveal are per-strip — pulling one row reloads all rows but only that row animates. This mirrors the old footer button's stop-wide action; happy to revisit if a per-route widen is preferred.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added drag-to-load-more for arrivals with progress/chip visuals, inline loading spinner, and a load-more accessibility action.
  * Load-more is now tokenized and coordinated with a per-content revision so the ETA strip waits for the completed update to render.

* **Bug Fixes**
  * Prevented superseded/older load-more requests from updating the arrivals view.
  * Improved readiness so loading indicators appear/disappear correctly as new content completes rendering.

* **Tests**
  * Expanded unit coverage for load-more state transitions, token supersession, dataVersion bumping behavior, and ETA strip spinner rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->