### PR TITLE
Trip planning: replace vendored OTP1 POJOs with an app-owned domain model

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/adapters/TripPlanAdapters.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/adapters/TripPlanAdapters.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.api.adapters
+
+import org.onebusaway.android.api.contract.OtpItineraryDto
+import org.onebusaway.android.api.contract.OtpLegDto
+import org.onebusaway.android.api.contract.OtpLegGeometryDto
+import org.onebusaway.android.api.contract.OtpPlaceDto
+import org.onebusaway.android.api.contract.OtpWalkStepDto
+import org.onebusaway.android.directions.model.TripAbsoluteDirection
+import org.onebusaway.android.directions.model.TripItinerary
+import org.onebusaway.android.directions.model.TripLeg
+import org.onebusaway.android.directions.model.TripLegGeometry
+import org.onebusaway.android.directions.model.TripMode
+import org.onebusaway.android.directions.model.TripPlace
+import org.onebusaway.android.directions.model.TripRelativeDirection
+import org.onebusaway.android.directions.model.TripStep
+import org.onebusaway.android.directions.model.TripVertexType
+import org.onebusaway.android.time.ServerTime
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Maps the OTP `/plan` wire DTOs (`api/contract/OtpPlanModels.kt`) onto the app-owned trip-plan domain
+ * model (`directions/model/TripItinerary.kt`), replacing the old `to…()` mappers that built
+ * `org.opentripplanner.api.model.*` POJOs directly. Every enum/`ServerTime`/`Duration` value is minted
+ * here, exactly once — see `TripItinerary.kt`'s doc comment for why that matters. This is also the one
+ * place that decides a malformed leg/itinerary (missing a place or a time OTP always sends for a
+ * well-formed response) is an error rather than something for every downstream reader to null-check —
+ * [requireField] throws, which `OtpPlanParser`'s callers already treat the same as any other malformed
+ * response.
+ *
+ * `duration`/`departureDelay`/`arrivalDelay` are seconds on the OTP1 wire (confirmed against the
+ * existing consumers before this migration — e.g. `DirectionsGenerator`'s `leg.departureDelay * 1000L`
+ * and `TripResultsRepository`'s `durationSec * 1000` both multiply by 1000 to reach milliseconds, so the
+ * wire value itself is seconds); only `startTime`/`endTime` are epoch milliseconds.
+ */
+fun OtpItineraryDto.toTripItinerary(): TripItinerary = TripItinerary(
+    duration = (duration?.toLong() ?: 0L).seconds,
+    startTime = requireField("itinerary.startTime", startTime?.toLongOrNull()?.let { ServerTime(it) }),
+    legs = legs.map { it.toTripLeg() },
+)
+
+fun OtpLegDto.toTripLeg(): TripLeg = TripLeg(
+    mode = mode.toEnum<TripMode>(),
+    route = route,
+    routeId = routeId,
+    routeShortName = routeShortName,
+    routeLongName = routeLongName,
+    routeColor = routeColor,
+    agencyName = agencyName,
+    agencyTimeZoneOffset = agencyTimeZoneOffset?.toInt() ?: 0,
+    headsign = headsign,
+    tripId = tripId,
+    realTime = realTime ?: false,
+    distance = distance ?: 0.0,
+    duration = (duration?.toLong() ?: 0L).seconds,
+    departureDelay = (departureDelay?.toInt() ?: 0).seconds,
+    arrivalDelay = (arrivalDelay?.toInt() ?: 0).seconds,
+    startTime = requireField("leg.startTime", startTime?.toLongOrNull()?.let { ServerTime(it) }),
+    endTime = requireField("leg.endTime", endTime?.toLongOrNull()?.let { ServerTime(it) }),
+    from = requireField("leg.from", from?.toTripPlace()),
+    to = requireField("leg.to", to?.toTripPlace()),
+    intermediateStops = intermediateStops?.map { it.toTripPlace() },
+    stop = stop?.map { it.toTripPlace() },
+    steps = steps.map { it.toTripStep() },
+    legGeometry = legGeometry?.toTripLegGeometry(),
+)
+
+/** A field every well-formed OTP leg/itinerary carries; its absence means a malformed response. */
+private fun <T : Any> requireField(name: String, value: T?): T =
+    value ?: error("OTP /plan response missing required field: $name")
+
+fun OtpPlaceDto.toTripPlace(): TripPlace = TripPlace(
+    name = name,
+    stopCode = stopCode,
+    lat = lat,
+    lon = lon,
+    vertexType = vertexType.toEnum<TripVertexType>(),
+    bikeShareId = bikeShareId,
+)
+
+fun OtpWalkStepDto.toTripStep(): TripStep = TripStep(
+    distance = distance ?: 0.0,
+    relativeDirection = relativeDirection.toEnum<TripRelativeDirection>(),
+    absoluteDirection = absoluteDirection.toEnum<TripAbsoluteDirection>(),
+    streetName = streetName,
+    exit = exit,
+    stayOn = stayOn ?: false,
+    lat = lat ?: 0.0,
+    lon = lon ?: 0.0,
+)
+
+fun OtpLegGeometryDto.toTripLegGeometry(): TripLegGeometry =
+    TripLegGeometry(points = points, length = length?.toInt() ?: 0)
+
+/** Decodes an OTP wire enum name, degrading an unknown/absent value to null rather than throwing. */
+private inline fun <reified E : Enum<E>> String?.toEnum(): E? =
+    this?.let { runCatching { enumValueOf<E>(it) }.getOrNull() }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/contract/OtpPlanModels.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/contract/OtpPlanModels.kt
@@ -28,26 +28,14 @@ import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonDecoder
 import kotlinx.serialization.json.jsonPrimitive
-import org.opentripplanner.api.model.AbsoluteDirection
-import org.opentripplanner.api.model.EncodedPolylineBean
-import org.opentripplanner.api.model.Itinerary
-import org.opentripplanner.api.model.Leg
-import org.opentripplanner.api.model.Place
-import org.opentripplanner.api.model.RelativeDirection
-import org.opentripplanner.api.model.TripPlan
-import org.opentripplanner.api.model.VertexType
-import org.opentripplanner.api.model.WalkStep
-import org.opentripplanner.api.model.error.PlannerError
-import org.opentripplanner.api.ws.Response
 
 /**
  * kotlinx.serialization models for the OpenTripPlanner `/plan` response — the replacement for the
- * old Jackson `JacksonConfig`/`ObjectReader` path (the app's last Jackson consumer). Trip planning
- * still flows through the OTP library POJOs (`Itinerary`, `Leg`, `Place`, …) that the directions/
- * UI code reads, so — exactly like [BikeRentalStationsDto] — the DTOs here decode the wire and the
- * `to…()` mappers project onto those POJOs (public fields + no-arg ctors), leaving every downstream
- * consumer untouched. Only the fields the app actually reads are modeled; the rest are dropped via
- * `ignoreUnknownKeys`.
+ * old Jackson `JacksonConfig`/`ObjectReader` path (the app's last Jackson consumer). These DTOs are a
+ * pure mirror of the wire JSON; [org.onebusaway.android.api.adapters.toTripItinerary] (in
+ * `api/adapters/TripPlanAdapters.kt`) maps them onto the app-owned trip-plan domain model
+ * (`directions/model/TripItinerary.kt`) that the rest of the app actually consumes. Only the fields the
+ * app reads are modeled here; the rest are dropped via `ignoreUnknownKeys`.
  *
  * Parse both call sites (the legacy `TripRequest` AsyncTask and `DefaultTripPlanRepository`) through
  * [OtpPlanParser].
@@ -124,7 +112,6 @@ data class OtpWalkStepDto(
     val streetName: String? = null,
     val exit: String? = null,
     val stayOn: Boolean? = null,
-    val bogusName: Boolean? = null,
     val lon: Double? = null,
     val lat: Double? = null,
 )
@@ -132,7 +119,6 @@ data class OtpWalkStepDto(
 @Serializable
 data class OtpLegGeometryDto(
     val points: String? = null,
-    val levels: String? = null,
     val length: Double? = null,
 )
 
@@ -153,88 +139,14 @@ private object WireStringSerializer : KSerializer<String> {
     override fun serialize(encoder: Encoder, value: String) = encoder.encodeString(value)
 }
 
-/** Projects the decoded `/plan` response onto the OTP library [Response] the callers expect. */
-fun OtpResponseDto.toResponse(): Response = Response().also {
-    it.setPlan(plan?.toTripPlan())
-    it.setError(error?.toPlannerError())
-}
-
-private fun OtpTripPlanDto.toTripPlan(): TripPlan = TripPlan().also {
-    it.itineraries = itineraries.map { itinerary -> itinerary.toItinerary() }
-}
-
-private fun OtpErrorDto.toPlannerError(): PlannerError = PlannerError().also {
-    it.id = id
-    it.msg = msg ?: message
-    it.setNoPath(noPath)
-    it.setMissing(missing)
-}
-
-private fun OtpItineraryDto.toItinerary(): Itinerary = Itinerary().also {
-    it.duration = duration?.toLong() ?: 0L
-    it.startTime = startTime
-    it.legs = legs.map { leg -> leg.toLeg() }
-}
-
-private fun OtpLegDto.toLeg(): Leg = Leg().also {
-    it.mode = mode
-    it.route = route
-    it.routeId = routeId
-    it.routeShortName = routeShortName
-    it.routeLongName = routeLongName
-    it.routeColor = routeColor
-    it.agencyName = agencyName
-    it.agencyTimeZoneOffset = agencyTimeZoneOffset?.toInt() ?: 0
-    it.headsign = headsign
-    it.tripId = tripId
-    it.realTime = realTime
-    it.distance = distance
-    it.duration = duration?.toLong() ?: 0L
-    it.departureDelay = departureDelay?.toInt() ?: 0
-    it.arrivalDelay = arrivalDelay?.toInt() ?: 0
-    it.startTime = startTime
-    it.endTime = endTime
-    it.from = from?.toPlace()
-    it.to = to?.toPlace()
-    it.intermediateStops = intermediateStops?.map { place -> place.toPlace() }
-    it.stop = stop?.map { place -> place.toPlace() }
-    it.steps = steps.map { step -> step.toWalkStep() }
-    it.legGeometry = legGeometry?.toBean()
-}
-
-private fun OtpPlaceDto.toPlace(): Place = Place().also {
-    it.name = name
-    it.stopCode = stopCode
-    it.lat = lat
-    it.lon = lon
-    it.vertexType = vertexType.toEnum<VertexType>()
-    it.bikeShareId = bikeShareId
-}
-
-private fun OtpWalkStepDto.toWalkStep(): WalkStep = WalkStep().also {
-    it.distance = distance ?: 0.0
-    it.relativeDirection = relativeDirection.toEnum<RelativeDirection>()
-    it.absoluteDirection = absoluteDirection.toEnum<AbsoluteDirection>()
-    it.streetName = streetName
-    it.exit = exit
-    it.stayOn = stayOn ?: false
-    it.bogusName = bogusName ?: false
-    it.lon = lon ?: 0.0
-    it.lat = lat ?: 0.0
-}
-
-private fun OtpLegGeometryDto.toBean(): EncodedPolylineBean =
-    EncodedPolylineBean(points, levels, length?.toInt() ?: 0)
-
-/** Decodes an OTP enum name, degrading an unknown/absent value to null rather than throwing. */
-private inline fun <reified E : Enum<E>> String?.toEnum(): E? =
-    this?.let { runCatching { enumValueOf<E>(it) }.getOrNull() }
-
 /**
  * The single OTP `/plan` JSON entry point, shared by the legacy Java `TripRequest` AsyncTask and the
  * coroutine [org.onebusaway.android.ui.tripplan.DefaultTripPlanRepository]. Configured like the rest
  * of the modernized stack (`ignoreUnknownKeys` + `coerceInputValues`, mirroring `NetworkModule`), and
- * exposed as a `@JvmStatic` so the remaining Java caller can invoke it directly.
+ * exposed as a `@JvmStatic` so the remaining Java caller can invoke it directly. Returns the decoded
+ * [OtpResponseDto] as-is — callers map `.plan?.itineraries` through
+ * [org.onebusaway.android.api.adapters.toTripItinerary] themselves; there's no OTP-library envelope
+ * type to project onto anymore.
  *
  * A malformed body is rethrown as [IOException] rather than the unchecked
  * [SerializationException] `decodeFromString` raises, so both call sites route it through the same
@@ -250,18 +162,18 @@ object OtpPlanParser {
 
     @JvmStatic
     @Throws(IOException::class)
-    fun parse(body: String): Response =
+    fun parse(body: String): OtpResponseDto =
         try {
-            json.decodeFromString<OtpResponseDto>(body).toResponse()
+            json.decodeFromString<OtpResponseDto>(body)
         } catch (e: SerializationException) {
             throw IOException("Malformed OTP /plan response", e)
         }
 
     /**
-     * Reads [input] fully as UTF-8 and [parse]s it — the single stream→[Response] entry point, so
-     * callers don't each hand-roll the read (and its charset choice).
+     * Reads [input] fully as UTF-8 and [parse]s it — the single stream→[OtpResponseDto] entry point,
+     * so callers don't each hand-roll the read (and its charset choice).
      */
     @JvmStatic
     @Throws(IOException::class)
-    fun parse(input: InputStream): Response = parse(input.readBytes().toString(Charsets.UTF_8))
+    fun parse(input: InputStream): OtpResponseDto = parse(input.readBytes().toString(Charsets.UTF_8))
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/model/ItineraryDescription.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/model/ItineraryDescription.kt
@@ -15,9 +15,6 @@
  */
 package org.onebusaway.android.directions.model
 
-import org.onebusaway.android.directions.util.ConversionUtils
-import org.opentripplanner.api.model.Itinerary
-import org.opentripplanner.routing.core.TraverseMode
 import java.time.Duration
 import java.time.Instant
 
@@ -30,18 +27,12 @@ class ItineraryDescription {
 
     val endDate: Instant?
 
-    constructor(itinerary: Itinerary) {
-        val ids = ArrayList<String>()
-        for (leg in itinerary.legs) {
-            val traverseMode = TraverseMode.valueOf(leg.mode)
-            if (traverseMode.isTransit) {
-                ids.add(leg.tripId)
-            }
-        }
-        tripIds = ids
+    constructor(itinerary: TripItinerary) {
+        tripIds = itinerary.legs
+            .filter { it.mode?.isTransit == true }
+            .mapNotNull { it.tripId }
 
-        val last = itinerary.legs[itinerary.legs.size - 1]
-        endDate = ConversionUtils.parseOtpDate(last.endTime)
+        endDate = itinerary.legs.lastOrNull()?.endTime?.let { Instant.ofEpochMilli(it.epochMs) }
     }
 
     constructor(tripIds: List<String>, endDate: Instant?) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/model/TripItinerary.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/model/TripItinerary.kt
@@ -123,9 +123,15 @@ private val tripItineraryJson = Json { ignoreUnknownKeys = true }
 fun List<TripItinerary>.toJson(): String =
     tripItineraryJson.encodeToString(ListSerializer(TripItinerary.serializer()), this)
 
-/** The read side of [List.toJson]. */
+/**
+ * The read side of [List.toJson]. A corrupted/truncated extra degrades to an empty list — exactly how
+ * [TripPlanScreen.maybeRestoreFromIntent][org.onebusaway.android.ui.tripplan] already treats a missing
+ * extra — rather than crashing the activity on notification re-entry.
+ */
 fun String.toTripItineraries(): List<TripItinerary> =
-    tripItineraryJson.decodeFromString(ListSerializer(TripItinerary.serializer()), this)
+    runCatching {
+        tripItineraryJson.decodeFromString(ListSerializer(TripItinerary.serializer()), this)
+    }.getOrDefault(emptyList())
 
 private object ServerTimeSerializer : KSerializer<ServerTime> {
     override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("ServerTime", PrimitiveKind.LONG)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/model/TripItinerary.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/model/TripItinerary.kt
@@ -1,0 +1,173 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.directions.model
+
+import org.onebusaway.android.time.ServerTime
+import kotlin.time.Duration
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.Json
+
+/**
+ * The app's own trip-plan domain model — replaces direct use of the vendored, unpublished-snapshot
+ * `org.opentripplanner.api.model.*` POJOs (`edu.usf.cutr.opentripplanner.android:opentripplanner-pojos`)
+ * that used to flow, largely unconverted, from the network layer all the way into Compose UI/ViewModel
+ * signatures.
+ *
+ * Minted exactly once, in `api/adapters/TripPlanAdapters.kt`, from the OTP `/plan` wire DTOs
+ * (`api/contract/OtpPlanModels.kt`) — consumers never re-parse a raw wire value (mode strings, epoch
+ * timestamps, delay ints) themselves. `duration`/`departureDelay`/`arrivalDelay` are [Duration] rather
+ * than a raw ms/seconds `Long`, and `startTime`/`endTime` are [ServerTime] (the OTP server's clock,
+ * same "mint at the boundary" domain-typing `org.onebusaway.android.time.TypedTime` uses elsewhere)
+ * rather than an epoch-ms string, so unit confusion between OTP protocol versions (OTP1 ms vs. OTP2
+ * seconds) is no longer possible by construction — there's nothing left to disambiguate.
+ *
+ * `from`/`to`/`startTime`/`endTime` are non-null: a well-formed OTP leg always has two endpoints and an
+ * absolute start/end time (that's the point of a routing response), so the adapter — the one place that
+ * knows whether a response is well-formed — asserts that once, instead of every consumer repeating a
+ * `!!`/null-check whose answer was already known at parse time. Fixture construction (tests) can still
+ * omit them; the field defaults below exist for that convenience only — production code always goes
+ * through the adapter, which never relies on them.
+ *
+ * `@Serializable` (kotlinx.serialization, not a wire concern here) so the trip-plan-monitor notification
+ * path (`TripPlanMonitorService`/`TripPlanScreen`) can JSON-encode a result list into an `Intent` extra
+ * instead of relying on `java.io.Serializable`, which the old OTP1 POJOs got "for free" from the vendored
+ * library and this domain model doesn't.
+ */
+@Serializable
+data class TripItinerary(
+    @Serializable(with = DurationSerializer::class) val duration: Duration = Duration.ZERO,
+    @Serializable(with = ServerTimeSerializer::class) val startTime: ServerTime = ServerTime(0L),
+    val legs: List<TripLeg> = emptyList(),
+)
+
+@Serializable
+data class TripLeg(
+    val mode: TripMode? = null,
+    val route: String? = null,
+    val routeId: String? = null,
+    val routeShortName: String? = null,
+    val routeLongName: String? = null,
+    val routeColor: String? = null,
+    val agencyName: String? = null,
+    val agencyTimeZoneOffset: Int = 0,
+    val headsign: String? = null,
+    val tripId: String? = null,
+    val realTime: Boolean = false,
+    val distance: Double = 0.0,
+    @Serializable(with = DurationSerializer::class) val duration: Duration = Duration.ZERO,
+    @Serializable(with = DurationSerializer::class) val departureDelay: Duration = Duration.ZERO,
+    @Serializable(with = DurationSerializer::class) val arrivalDelay: Duration = Duration.ZERO,
+    @Serializable(with = ServerTimeSerializer::class) val startTime: ServerTime = ServerTime(0L),
+    @Serializable(with = ServerTimeSerializer::class) val endTime: ServerTime = ServerTime(0L),
+    val from: TripPlace = TripPlace(),
+    val to: TripPlace = TripPlace(),
+    val intermediateStops: List<TripPlace>? = null,
+    val stop: List<TripPlace>? = null,
+    val steps: List<TripStep> = emptyList(),
+    val legGeometry: TripLegGeometry? = null,
+)
+
+@Serializable
+data class TripPlace(
+    val name: String? = null,
+    val stopCode: String? = null,
+    val lat: Double? = null,
+    val lon: Double? = null,
+    val vertexType: TripVertexType? = null,
+    val bikeShareId: String? = null,
+)
+
+@Serializable
+data class TripStep(
+    val distance: Double = 0.0,
+    val relativeDirection: TripRelativeDirection? = null,
+    val absoluteDirection: TripAbsoluteDirection? = null,
+    val streetName: String? = null,
+    val exit: String? = null,
+    val stayOn: Boolean = false,
+    val lat: Double = 0.0,
+    val lon: Double = 0.0,
+)
+
+@Serializable
+data class TripLegGeometry(val points: String? = null, val length: Int = 0)
+
+private val tripItineraryJson = Json { ignoreUnknownKeys = true }
+
+/**
+ * JSON-encodes a plan result for the one spot it needs to cross a real Android serialization boundary
+ * (the trip-plan-monitor's "your trip changed" notification `Intent` — see
+ * `TripPlanMonitorService.notifyChange` / `TripPlanScreen.maybeRestoreFromIntent`). Paired with
+ * [String.toTripItineraries].
+ */
+fun List<TripItinerary>.toJson(): String =
+    tripItineraryJson.encodeToString(ListSerializer(TripItinerary.serializer()), this)
+
+/** The read side of [List.toJson]. */
+fun String.toTripItineraries(): List<TripItinerary> =
+    tripItineraryJson.decodeFromString(ListSerializer(TripItinerary.serializer()), this)
+
+private object ServerTimeSerializer : KSerializer<ServerTime> {
+    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("ServerTime", PrimitiveKind.LONG)
+    override fun serialize(encoder: Encoder, value: ServerTime) = encoder.encodeLong(value.epochMs)
+    override fun deserialize(decoder: Decoder): ServerTime = ServerTime(decoder.decodeLong())
+}
+
+private object DurationSerializer : KSerializer<Duration> {
+    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("Duration", PrimitiveKind.STRING)
+    override fun serialize(encoder: Encoder, value: Duration) = encoder.encodeString(value.toIsoString())
+    override fun deserialize(decoder: Decoder): Duration = Duration.parseIsoString(decoder.decodeString())
+}
+
+/**
+ * Mirrors OTP1's `org.opentripplanner.routing.core.TraverseMode` wire vocabulary exactly (verified
+ * against the vendored jar). [isTransit] mirrors `TraverseMode.isTransit()` so callers don't each
+ * re-derive it from the raw mode name.
+ */
+enum class TripMode {
+    WALK, BICYCLE, CAR, TRAM, SUBWAY, RAIL, BUS, FERRY, CABLE_CAR, GONDOLA, FUNICULAR, TRANSIT,
+    TRAINISH, BUSISH, BOARDING, ALIGHTING, TRANSFER;
+
+    val isTransit: Boolean
+        get() = this in TRANSIT_MODES
+
+    /** Mirrors `TraverseMode.isOnStreetNonTransit()`: true only for WALK/BICYCLE/CAR. */
+    val isOnStreetNonTransit: Boolean
+        get() = this == WALK || this == BICYCLE || this == CAR
+
+    private companion object {
+        val TRANSIT_MODES = setOf(TRAM, SUBWAY, RAIL, BUS, FERRY, CABLE_CAR, GONDOLA, FUNICULAR, TRANSIT, TRAINISH, BUSISH)
+    }
+}
+
+/** Mirrors OTP1's `org.opentripplanner.api.model.VertexType` wire vocabulary exactly. */
+enum class TripVertexType { NORMAL, BIKESHARE, BIKEPARK, TRANSIT }
+
+/** Mirrors OTP1's `org.opentripplanner.api.model.RelativeDirection` wire vocabulary exactly. */
+enum class TripRelativeDirection {
+    DEPART, HARD_LEFT, LEFT, SLIGHTLY_LEFT, CONTINUE, SLIGHTLY_RIGHT, RIGHT, HARD_RIGHT,
+    CIRCLE_CLOCKWISE, CIRCLE_COUNTERCLOCKWISE, ELEVATOR, UTURN_LEFT, UTURN_RIGHT,
+}
+
+/** Mirrors OTP1's `org.opentripplanner.api.model.AbsoluteDirection` wire vocabulary exactly. */
+enum class TripAbsoluteDirection { NORTH, NORTHEAST, EAST, SOUTHEAST, SOUTH, SOUTHWEST, WEST, NORTHWEST }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/realtime/TripMonitorDecider.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/realtime/TripMonitorDecider.kt
@@ -16,9 +16,9 @@
 package org.onebusaway.android.directions.realtime
 
 import org.onebusaway.android.directions.model.ItineraryDescription
+import org.onebusaway.android.directions.model.TripItinerary
 import org.onebusaway.android.time.ServerTime
 import org.onebusaway.android.time.WallTime
-import org.opentripplanner.api.model.Itinerary
 import kotlin.math.abs
 import kotlin.time.Duration
 
@@ -63,7 +63,7 @@ object TripMonitorDecider {
     @JvmStatic
     fun decide(
         current: ItineraryDescription,
-        results: List<Itinerary>,
+        results: List<TripItinerary>,
         thresholdSeconds: Long,
     ): MonitorResult {
         if (results.isEmpty()) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/realtime/TripPlanMonitor.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/realtime/TripPlanMonitor.kt
@@ -25,14 +25,13 @@ import android.util.Log
 import androidx.core.content.ContextCompat
 import org.onebusaway.android.BuildConfig
 import org.onebusaway.android.directions.model.ItineraryDescription
-import org.onebusaway.android.directions.util.ConversionUtils
+import org.onebusaway.android.directions.model.TripItinerary
 import org.onebusaway.android.directions.util.OTPConstants
 import org.onebusaway.android.time.ServerTime
 import org.onebusaway.android.time.WallTime
 import org.onebusaway.android.ui.tripplan.TripPlanParams
 import org.onebusaway.android.ui.tripplan.toRequestBuilder
 import org.onebusaway.android.util.PreferenceUtils
-import org.opentripplanner.api.model.Itinerary
 import kotlin.time.Duration.Companion.milliseconds
 
 /**
@@ -80,7 +79,7 @@ object TripPlanMonitor {
     fun start(
         context: Context,
         params: TripPlanParams,
-        itinerary: Itinerary,
+        itinerary: TripItinerary,
         notificationTarget: Class<*>,
     ) {
         val app = context.applicationContext
@@ -110,19 +109,15 @@ object TripPlanMonitor {
             return
         }
 
-        // The itinerary's departure (origin start) is a server-provided instant; mint it into ServerTime
-        // at the read so the clock domain travels with it. Used to stop monitoring once travel begins — a
-        // warning is moot after that. null if unparseable; the service then falls back to the end-time guard.
-        val itineraryDeparture: ServerTime? =
-            ConversionUtils.parseOtpDate(itinerary.startTime)?.let { ServerTime(it.toEpochMilli()) }
+        // The itinerary's departure (origin start) is a server-provided instant, already ServerTime —
+        // used to stop monitoring once travel begins (a warning is moot after that).
+        val itineraryDeparture: ServerTime = itinerary.startTime
 
         val builder = params.toRequestBuilder(app)
         val bundle = Bundle().apply {
             builder.copyIntoBundleSimple(this)
             putStringArray(EXTRA_ITINERARY_DESC, tripIds.toTypedArray())
-            // Only store a real departure; an absent one is the reader's getLong default, never a 0
-            // (1970) instant. The unwrap is passed straight to the putLong sink.
-            itineraryDeparture?.epochMs?.let { putLong(EXTRA_ITINERARY_START_DATE, it) }
+            putLong(EXTRA_ITINERARY_START_DATE, itineraryDeparture.epochMs)
             putLong(EXTRA_ITINERARY_END_DATE, endDate.toEpochMilli())
             putString(OTPConstants.NOTIFICATION_TARGET, notificationTarget.name)
         }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/realtime/TripPlanMonitorService.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/realtime/TripPlanMonitorService.kt
@@ -43,6 +43,8 @@ import kotlinx.coroutines.withContext
 import org.onebusaway.android.BuildConfig
 import org.onebusaway.android.R
 import org.onebusaway.android.directions.model.ItineraryDescription
+import org.onebusaway.android.directions.model.TripItinerary
+import org.onebusaway.android.directions.model.toJson
 import org.onebusaway.android.directions.util.OTPConstants
 import org.onebusaway.android.directions.util.TripRequestBuilder
 import org.onebusaway.android.notifications.NotificationChannels
@@ -50,7 +52,6 @@ import org.onebusaway.android.time.ServerTime
 import org.onebusaway.android.time.WallTime
 import org.onebusaway.android.ui.nav.NavRoutes
 import org.onebusaway.android.ui.tripplan.TripPlanRepository
-import org.opentripplanner.api.model.Itinerary
 import java.time.Instant
 import kotlin.coroutines.coroutineContext
 
@@ -222,7 +223,7 @@ class TripPlanMonitorService : Service() {
         desc: ItineraryDescription,
         target: Class<*>,
         builder: TripRequestBuilder,
-        itineraries: List<Itinerary>,
+        itineraries: List<TripItinerary>,
         @StringRes titleRes: Int,
         @StringRes messageRes: Int,
     ) {
@@ -230,10 +231,13 @@ class TripPlanMonitorService : Service() {
 
         // Reopen the trip-plan screen with enough state to rehydrate the form + fresh results
         // (matches TripPlanScreen.maybeRestoreFromIntent, which reads the simplified request bundle).
+        // The itinerary list is JSON-encoded (kotlinx.serialization), not passed via
+        // Intent.putExtra(String, Serializable) — TripItinerary has no reason to implement
+        // java.io.Serializable itself, unlike the OTP1 POJOs this domain model replaced.
         val requestExtras = Bundle().also { builder.copyIntoBundleSimple(it) }
         val openIntent = Intent(applicationContext, target).apply {
             putExtras(requestExtras)
-            putExtra(OTPConstants.ITINERARIES, ArrayList(itineraries))
+            putExtra(OTPConstants.ITINERARIES, itineraries.toJson())
             putExtra(OTPConstants.INTENT_SOURCE, OTPConstants.Source.NOTIFICATION)
             putExtra(NavRoutes.EXTRA_NAV_ROUTE, NavRoutes.TRIP_PLAN)
             flags = Intent.FLAG_ACTIVITY_SINGLE_TOP

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/ConversionUtils.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/ConversionUtils.kt
@@ -25,8 +25,6 @@ import androidx.core.content.ContextCompat
 import org.onebusaway.android.R
 import org.onebusaway.android.util.ArrivalInfoUtils
 import org.onebusaway.android.util.PreferenceUtils
-import org.opentripplanner.api.model.Itinerary
-import org.opentripplanner.routing.core.TraverseMode
 import java.time.Duration
 import java.time.Instant
 import java.time.LocalDate
@@ -53,51 +51,6 @@ object ConversionUtils {
      * zero-offset zone, so [ZoneOffset.UTC] is equivalent for the day/hour/minute/second fields.
      */
     private val GMT: ZoneId = ZoneOffset.UTC
-
-    /**
-     * Given a date string from an OTP server, parse it into an [Instant].
-     *
-     * @param text string from OTP (epoch milliseconds)
-     * @return parsed instant, or null if there is an error with parsing.
-     */
-    @JvmStatic
-    fun parseOtpDate(text: String): Instant? {
-        return try {
-            Instant.ofEpochMilli(text.toLong())
-        } catch (ex: NumberFormatException) {
-            Log.e(TAG, "Error processing OTP response time text: $text")
-            null
-        }
-    }
-
-    /**
-     * Given start time and end time strings, compute the delta between them.
-     * Strings should be in the OTP server return format, specified in OTPConstants
-     *
-     * @param startTimeText start time
-     * @param endTimeText end time
-     * @param applicationContext context to look up resources
-     * @return duration
-     */
-    @JvmStatic
-    fun getDuration(startTimeText: String, endTimeText: String, applicationContext: Context): Double {
-        var duration = 0.0
-
-        val startTime = parseOtpDate(startTimeText)
-        val endTime = parseOtpDate(endTimeText)
-
-        if (startTime != null && endTime != null) {
-            duration = if (PreferenceUtils.getInt(
-                    OTPConstants.PREFERENCE_KEY_API_VERSION, OTPConstants.API_VERSION_V1
-                ) == OTPConstants.API_VERSION_V1
-            ) {
-                Duration.between(startTime, endTime).toMillis().toDouble()
-            } else {
-                (Duration.between(startTime, endTime).toMillis() / 1000).toDouble()
-            }
-        }
-        return duration
-    }
 
     /**
      * Return a formatted String for a distance. Should be in proper units according to
@@ -198,50 +151,6 @@ object ConversionUtils {
             }
         }
         return text
-    }
-
-    @JvmStatic
-    fun fixTimezoneOffsets(
-        itineraries: List<Itinerary>?,
-        useDeviceTimezone: Boolean,
-    ): List<Itinerary>? {
-        var agencyTimeZoneOffset = 0
-        var containsTransitLegs = false
-
-        if (!itineraries.isNullOrEmpty()) {
-            val itinerariesFixed = ArrayList(itineraries)
-
-            for (it in itinerariesFixed) {
-                for (leg in it.legs) {
-                    if (TraverseMode.valueOf(leg.mode).isTransit) {
-                        containsTransitLegs = true
-                    }
-                    if (leg.agencyTimeZoneOffset != 0) {
-                        agencyTimeZoneOffset = leg.agencyTimeZoneOffset
-                        // If agencyTimeZoneOffset is different from 0, route contains transit legs
-                        containsTransitLegs = true
-                        break
-                    }
-                }
-            }
-
-            if (useDeviceTimezone || !containsTransitLegs) {
-                agencyTimeZoneOffset =
-                    TimeZone.getDefault().getOffset(itinerariesFixed[0].startTime.toLong())
-            }
-
-            if (agencyTimeZoneOffset != 0) {
-                for (it in itinerariesFixed) {
-                    for (leg in it.legs) {
-                        leg.agencyTimeZoneOffset = agencyTimeZoneOffset
-                    }
-                }
-            }
-
-            return itinerariesFixed
-        } else {
-            return itineraries
-        }
     }
 
     @JvmStatic

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/DirectionsGenerator.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/DirectionsGenerator.kt
@@ -22,13 +22,12 @@ import android.text.TextUtils
 import android.util.Log
 import org.onebusaway.android.R
 import org.onebusaway.android.directions.model.Direction
-import org.onebusaway.android.util.PreferenceUtils
-import org.opentripplanner.api.model.AbsoluteDirection
-import org.opentripplanner.api.model.Leg
-import org.opentripplanner.api.model.Place
-import org.opentripplanner.api.model.RelativeDirection
-import org.opentripplanner.routing.core.TraverseMode
-import org.opentripplanner.routing.core.TraverseModeSet
+import org.onebusaway.android.directions.model.TripAbsoluteDirection
+import org.onebusaway.android.directions.model.TripLeg
+import org.onebusaway.android.directions.model.TripMode
+import org.onebusaway.android.directions.model.TripPlace
+import org.onebusaway.android.directions.model.TripRelativeDirection
+import org.onebusaway.android.time.ServerTime
 
 /**
  * Generates a set of step-by-step directions that can be shown to the user from a list of trip
@@ -37,7 +36,7 @@ import org.opentripplanner.routing.core.TraverseModeSet
  * @author Khoa Tran
  */
 class DirectionsGenerator(
-    private val legs: List<Leg>,
+    private val legs: List<TripLeg>,
     private val applicationContext: Context,
 ) {
 
@@ -50,8 +49,6 @@ class DirectionsGenerator(
      * @return the totalDistance
      */
     var totalDistance = 0.0
-
-    private var totalTimeTraveled = 0.0
 
     init {
         convertToDirectionList()
@@ -67,8 +64,7 @@ class DirectionsGenerator(
             index++
             totalDistance += leg.distance
 
-            val traverseMode = TraverseMode.valueOf(leg.mode)
-            if (traverseMode.isOnStreetNonTransit) {
+            if (leg.mode?.isOnStreetNonTransit == true) {
                 val dir = generateNonTransitDirections(leg)
                 dir.directionIndex = index
                 addDirection(dir)
@@ -83,17 +79,17 @@ class DirectionsGenerator(
         }
     }
 
-    private fun generateNonTransitDirections(leg: Leg): Direction {
+    private fun generateNonTransitDirections(leg: TripLeg): Direction {
         val direction = Direction()
 
         // Get appropriate action and icon
         var action =
             applicationContext.getString(R.string.step_by_step_non_transit_mode_walk_action)
-        val mode = TraverseMode.valueOf(leg.mode)
-        val icon = getModeIcon(TraverseModeSet(mode))
-        if (mode == TraverseMode.BICYCLE) {
+        val mode = leg.mode
+        val icon = getModeIcon(mode)
+        if (mode == TripMode.BICYCLE) {
             action = applicationContext.getString(R.string.step_by_step_non_transit_mode_bicycle_action)
-        } else if (mode == TraverseMode.CAR) {
+        } else if (mode == TripMode.CAR) {
             action = applicationContext.getString(R.string.step_by_step_non_transit_mode_car_action)
         }
 
@@ -116,14 +112,7 @@ class DirectionsGenerator(
                 " " + getLocalizedStreetName(toPlace.name, applicationContext.resources)
         }
         val extraStopInformation = toPlace.stopCode
-        val legDuration = if (PreferenceUtils.getInt(
-                OTPConstants.PREFERENCE_KEY_API_VERSION, OTPConstants.API_VERSION_V1
-            ) == OTPConstants.API_VERSION_V1
-        ) {
-            leg.duration
-        } else {
-            leg.duration / 1000
-        }
+        val legDuration = leg.duration.inWholeSeconds
         if (!TextUtils.isEmpty(extraStopInformation)) {
             mainDirectionText += " ($extraStopInformation)"
         }
@@ -134,7 +123,7 @@ class DirectionsGenerator(
         direction.directionText = mainDirectionText
 
         // Sub-direction
-        val walkSteps = leg.steps ?: return direction
+        val walkSteps = leg.steps
 
         val subDirections = ArrayList<Direction>(walkSteps.size)
         // Loop-invariant default; only the roundabout branch overrides it per step.
@@ -160,20 +149,18 @@ class DirectionsGenerator(
                 subDirectionText += "$absoluteDirString "
             } else {
                 // (Turn left)/(Continue)
-                val rDir = RelativeDirection.valueOf(relativeDir.name)
-
-                subdirectionIcon = getRelativeDirectionIcon(rDir, applicationContext.resources)
+                subdirectionIcon = getRelativeDirectionIcon(relativeDir, applicationContext.resources)
 
                 // Do not need TURN Continue
-                if (rDir == RelativeDirection.RIGHT || rDir == RelativeDirection.LEFT) {
+                if (relativeDir == TripRelativeDirection.RIGHT || relativeDir == TripRelativeDirection.LEFT) {
                     subDirectionText += applicationContext
                         .getString(R.string.step_by_step_non_transit_turn) + " "
                 }
 
                 subDirectionText += "$relativeDirString "
 
-                if (rDir == RelativeDirection.CIRCLE_CLOCKWISE ||
-                    rDir == RelativeDirection.CIRCLE_COUNTERCLOCKWISE
+                if (relativeDir == TripRelativeDirection.CIRCLE_CLOCKWISE ||
+                    relativeDir == TripRelativeDirection.CIRCLE_COUNTERCLOCKWISE
                 ) {
                     if (step.exit != null) {
                         try {
@@ -219,25 +206,25 @@ class DirectionsGenerator(
         return direction
     }
 
-    private fun generateTransitDirections(leg: Leg): ArrayList<Direction> {
+    private fun generateTransitDirections(leg: TripLeg): ArrayList<Direction> {
         val directions = ArrayList<Direction>(2)
         directions.add(generateTransitSubdirection(leg, true))
         directions.add(generateTransitSubdirection(leg, false))
         return directions
     }
 
-    fun generateTransitSubdirection(leg: Leg, isOnDirection: Boolean): Direction {
+    fun generateTransitSubdirection(leg: TripLeg, isOnDirection: Boolean): Direction {
         val direction = Direction()
         direction.isRealTimeInfo = leg.realTime
 
         // Set icon
-        val mode = getLocalizedMode(TraverseMode.valueOf(leg.mode), applicationContext.resources)
+        val mode = getLocalizedMode(leg.mode, applicationContext.resources)
         val modeIcon: Int
         val agencyName = leg.agencyName
         val from = leg.from
         val to = leg.to
-        var newTimeMillis = 0L
-        var oldTimeMillis = 0L
+        var newTimeMillis = ServerTime(0L)
+        var oldTimeMillis = ServerTime(0L)
 
         // As a work-around for #662, we always use routeShortName and not tripShortName
         val shortName = leg.routeShortName
@@ -255,20 +242,19 @@ class DirectionsGenerator(
         if (isOnDirection) {
             action = applicationContext.getString(R.string.step_by_step_transit_get_on)
             placeAndHeadsign = from.name
-            val modeSet = TraverseModeSet(leg.mode)
-            modeIcon = getModeIcon(modeSet)
-            newTimeMillis = leg.startTime.toLong()
-            oldTimeMillis = newTimeMillis - leg.departureDelay * 1000L
+            modeIcon = getModeIcon(leg.mode)
+            newTimeMillis = leg.startTime
+            oldTimeMillis = newTimeMillis - leg.departureDelay
 
             // Only onDirection has subdirection (list of stops in between)
-            val stopsInBetween = ArrayList<Place>()
+            val stopsInBetween = ArrayList<TripPlace>()
             if (leg.intermediateStops != null && !leg.intermediateStops.isEmpty()) {
                 stopsInBetween.addAll(leg.intermediateStops)
             } else if (leg.stop != null && !leg.stop.isEmpty()) {
                 stopsInBetween.addAll(leg.stop)
             }
             // sub-direction
-            val stopIcon = getStopIcon(modeSet)
+            val stopIcon = getStopIcon(leg.mode)
             val subDirections = ArrayList<Direction>()
             for (i in stopsInBetween.indices) {
                 val subDirection = Direction()
@@ -304,8 +290,8 @@ class DirectionsGenerator(
             action = applicationContext.getString(R.string.step_by_step_transit_get_off)
             placeAndHeadsign = to.name
             modeIcon = -1
-            newTimeMillis = leg.endTime.toLong()
-            oldTimeMillis = newTimeMillis - leg.arrivalDelay * 1000L
+            newTimeMillis = leg.endTime
+            oldTimeMillis = newTimeMillis - leg.arrivalDelay
         }
 
         direction.icon = modeIcon
@@ -317,14 +303,14 @@ class DirectionsGenerator(
 
         if (leg.realTime) {
             val newTimeString = ConversionUtils.getTimeUpdated(
-                applicationContext, leg.agencyTimeZoneOffset, oldTimeMillis, newTimeMillis
+                applicationContext, leg.agencyTimeZoneOffset, oldTimeMillis.epochMs, newTimeMillis.epochMs
             )
             direction.newTime = newTimeString
         }
 
         val oldTimeString = SpannableString(
             ConversionUtils.getTimeWithContext(
-                applicationContext, leg.agencyTimeZoneOffset, oldTimeMillis, true
+                applicationContext, leg.agencyTimeZoneOffset, oldTimeMillis.epochMs, true
             )
         )
         direction.oldTime = oldTimeString
@@ -332,27 +318,9 @@ class DirectionsGenerator(
         return direction
     }
 
-    /**
-     * @return the totalTimeTraveled
-     */
-    fun getTotalTimeTraveled(context: Context): Double {
-        if (legs.isEmpty()) {
-            return 0.0
-        }
-
-        val legStart = legs[0]
-        val startTimeText = legStart.startTime
-        val legEnd = legs[legs.size - 1]
-        val endTimeText = legEnd.endTime
-
-        totalTimeTraveled = ConversionUtils.getDuration(startTimeText, endTimeText, context)
-
-        return totalTimeTraveled
-    }
-
     /* Added for Trip Plan titles */
 
-    private fun getTransitTitle(leg: Leg): String? {
+    private fun getTransitTitle(leg: TripLeg): String? {
         // As a work-around for #662, we don't use leg.tripShortName
         return arrayOf(leg.routeShortName, leg.route, leg.routeId).firstOrNull { !it.isNullOrEmpty() }
     }
@@ -360,8 +328,8 @@ class DirectionsGenerator(
     val itineraryTitle: String
         get() {
             if (legs.size == 1) {
-                val mode = TraverseMode.valueOf(legs[0].mode)
-                if (!mode.isTransit) {
+                val mode = legs[0].mode
+                if (mode == null || !mode.isTransit) {
                     // getLocalizedMode only names transit modes and WALK; for a lone bicycle/car leg
                     // it returns null, so fall through to the general labeling below (which tags a
                     // bicycle leg with the bikeshare label) rather than crashing.
@@ -372,11 +340,11 @@ class DirectionsGenerator(
             val tokens = ArrayList<String?>()
 
             for (leg in legs) {
-                val traverseMode = TraverseMode.valueOf(leg.mode)
-                if (traverseMode.isTransit) {
+                val mode = leg.mode
+                if (mode?.isTransit == true) {
                     tokens.add(getTransitTitle(leg))
                 } else {
-                    if (traverseMode == TraverseMode.BICYCLE) {
+                    if (mode == TripMode.BICYCLE) {
                         tokens.add(applicationContext.getString(R.string.transit_directions_bikeshare_label))
                     }
                 }
@@ -436,34 +404,34 @@ class DirectionsGenerator(
         }
 
         @JvmStatic
-        fun getLocalizedRelativeDir(relDir: RelativeDirection?, resources: Resources): String? {
+        fun getLocalizedRelativeDir(relDir: TripRelativeDirection?, resources: Resources): String? {
             if (relDir != null) {
                 return when (relDir) {
-                    RelativeDirection.CIRCLE_CLOCKWISE ->
+                    TripRelativeDirection.CIRCLE_CLOCKWISE ->
                         resources.getString(R.string.step_by_step_non_transit_dir_relative_circle_clockwise)
-                    RelativeDirection.CIRCLE_COUNTERCLOCKWISE ->
+                    TripRelativeDirection.CIRCLE_COUNTERCLOCKWISE ->
                         resources.getString(R.string.step_by_step_non_transit_dir_relative_circle_counterclockwise)
-                    RelativeDirection.CONTINUE ->
+                    TripRelativeDirection.CONTINUE ->
                         resources.getString(R.string.step_by_step_non_transit_dir_relative_continue)
-                    RelativeDirection.DEPART ->
+                    TripRelativeDirection.DEPART ->
                         resources.getString(R.string.step_by_step_non_transit_dir_relative_depart)
-                    RelativeDirection.ELEVATOR ->
+                    TripRelativeDirection.ELEVATOR ->
                         resources.getString(R.string.step_by_step_non_transit_dir_relative_elevator)
-                    RelativeDirection.HARD_LEFT ->
+                    TripRelativeDirection.HARD_LEFT ->
                         resources.getString(R.string.step_by_step_non_transit_dir_relative_hard_left)
-                    RelativeDirection.HARD_RIGHT ->
+                    TripRelativeDirection.HARD_RIGHT ->
                         resources.getString(R.string.step_by_step_non_transit_dir_relative_hard_right)
-                    RelativeDirection.LEFT ->
+                    TripRelativeDirection.LEFT ->
                         resources.getString(R.string.step_by_step_non_transit_dir_relative_left)
-                    RelativeDirection.RIGHT ->
+                    TripRelativeDirection.RIGHT ->
                         resources.getString(R.string.step_by_step_non_transit_dir_relative_right)
-                    RelativeDirection.SLIGHTLY_LEFT ->
+                    TripRelativeDirection.SLIGHTLY_LEFT ->
                         resources.getString(R.string.step_by_step_non_transit_dir_relative_slightly_left)
-                    RelativeDirection.SLIGHTLY_RIGHT ->
+                    TripRelativeDirection.SLIGHTLY_RIGHT ->
                         resources.getString(R.string.step_by_step_non_transit_dir_relative_slightly_right)
-                    RelativeDirection.UTURN_LEFT ->
+                    TripRelativeDirection.UTURN_LEFT ->
                         resources.getString(R.string.step_by_step_non_transit_dir_relative_uturn_left)
-                    RelativeDirection.UTURN_RIGHT ->
+                    TripRelativeDirection.UTURN_RIGHT ->
                         resources.getString(R.string.step_by_step_non_transit_dir_relative_uturn_right)
                 }
             }
@@ -471,24 +439,24 @@ class DirectionsGenerator(
         }
 
         @JvmStatic
-        fun getLocalizedAbsoluteDir(absDir: AbsoluteDirection?, resources: Resources): String? {
+        fun getLocalizedAbsoluteDir(absDir: TripAbsoluteDirection?, resources: Resources): String? {
             if (absDir != null) {
                 return when (absDir) {
-                    AbsoluteDirection.EAST ->
+                    TripAbsoluteDirection.EAST ->
                         resources.getString(R.string.step_by_step_non_transit_dir_absolute_east)
-                    AbsoluteDirection.NORTH ->
+                    TripAbsoluteDirection.NORTH ->
                         resources.getString(R.string.step_by_step_non_transit_dir_absolute_north)
-                    AbsoluteDirection.NORTHEAST ->
+                    TripAbsoluteDirection.NORTHEAST ->
                         resources.getString(R.string.step_by_step_non_transit_dir_absolute_northeast)
-                    AbsoluteDirection.NORTHWEST ->
+                    TripAbsoluteDirection.NORTHWEST ->
                         resources.getString(R.string.step_by_step_non_transit_dir_absolute_northwest)
-                    AbsoluteDirection.SOUTH ->
+                    TripAbsoluteDirection.SOUTH ->
                         resources.getString(R.string.step_by_step_non_transit_dir_absolute_south)
-                    AbsoluteDirection.SOUTHEAST ->
+                    TripAbsoluteDirection.SOUTHEAST ->
                         resources.getString(R.string.step_by_step_non_transit_dir_absolute_southeast)
-                    AbsoluteDirection.SOUTHWEST ->
+                    TripAbsoluteDirection.SOUTHWEST ->
                         resources.getString(R.string.step_by_step_non_transit_dir_absolute_southwest)
-                    AbsoluteDirection.WEST ->
+                    TripAbsoluteDirection.WEST ->
                         resources.getString(R.string.step_by_step_non_transit_dir_absolute_west)
                 }
             }
@@ -496,21 +464,21 @@ class DirectionsGenerator(
         }
 
         @JvmStatic
-        fun getLocalizedMode(mode: TraverseMode?, resources: Resources): String? {
+        fun getLocalizedMode(mode: TripMode?, resources: Resources): String? {
             if (mode != null) {
                 return when (mode) {
-                    TraverseMode.TRAM -> resources.getString(R.string.step_by_step_transit_mode_tram)
-                    TraverseMode.SUBWAY -> resources.getString(R.string.step_by_step_transit_mode_subway)
-                    TraverseMode.RAIL -> resources.getString(R.string.step_by_step_transit_mode_rail)
-                    TraverseMode.BUS -> resources.getString(R.string.step_by_step_transit_mode_bus)
-                    TraverseMode.FERRY -> resources.getString(R.string.step_by_step_transit_mode_ferry)
-                    TraverseMode.CABLE_CAR ->
+                    TripMode.TRAM -> resources.getString(R.string.step_by_step_transit_mode_tram)
+                    TripMode.SUBWAY -> resources.getString(R.string.step_by_step_transit_mode_subway)
+                    TripMode.RAIL -> resources.getString(R.string.step_by_step_transit_mode_rail)
+                    TripMode.BUS -> resources.getString(R.string.step_by_step_transit_mode_bus)
+                    TripMode.FERRY -> resources.getString(R.string.step_by_step_transit_mode_ferry)
+                    TripMode.CABLE_CAR ->
                         resources.getString(R.string.step_by_step_transit_mode_cable_car)
-                    TraverseMode.GONDOLA ->
+                    TripMode.GONDOLA ->
                         resources.getString(R.string.step_by_step_transit_mode_gondola)
-                    TraverseMode.FUNICULAR ->
+                    TripMode.FUNICULAR ->
                         resources.getString(R.string.step_by_step_transit_mode_funicular)
-                    TraverseMode.WALK ->
+                    TripMode.WALK ->
                         resources.getString(R.string.step_by_step_non_transit_mode_walk_action)
                     else -> null
                 }
@@ -524,20 +492,19 @@ class DirectionsGenerator(
          * @return the mode icon for the given mode
          */
         @JvmStatic
-        fun getModeIcon(mode: TraverseModeSet): Int {
-            // Order matters: the first matching mode wins (e.g. a SUBWAY+TRAM set resolves to
-            // subway, not railway), so SUBWAY must stay ahead of TRAM.
-            return when {
-                mode.contains(TraverseMode.BUS) -> R.drawable.ic_bus
-                mode.contains(TraverseMode.RAIL) -> R.drawable.ic_directions_railway
-                mode.contains(TraverseMode.FERRY) || mode.contains(TraverseMode.GONDOLA) ->
-                    R.drawable.ic_directions_boat
-                mode.contains(TraverseMode.SUBWAY) -> R.drawable.ic_directions_subway
-                mode.contains(TraverseMode.TRAM) -> R.drawable.ic_directions_railway
-                mode.contains(TraverseMode.WALK) -> R.drawable.ic_directions_walk
-                mode.contains(TraverseMode.BICYCLE) -> R.drawable.ic_directions_bike
+        fun getModeIcon(mode: TripMode?): Int {
+            // Order matters: the first matching mode wins, matching the legacy TraverseModeSet
+            // priority (e.g. a SUBWAY+TRAM set resolved to subway, not railway).
+            return when (mode) {
+                TripMode.BUS -> R.drawable.ic_bus
+                TripMode.RAIL -> R.drawable.ic_directions_railway
+                TripMode.FERRY, TripMode.GONDOLA -> R.drawable.ic_directions_boat
+                TripMode.SUBWAY -> R.drawable.ic_directions_subway
+                TripMode.TRAM -> R.drawable.ic_directions_railway
+                TripMode.WALK -> R.drawable.ic_directions_walk
+                TripMode.BICYCLE -> R.drawable.ic_directions_bike
                 else -> {
-                    Log.d(TAG, "No icon for mode set: $mode")
+                    Log.d(TAG, "No icon for mode: $mode")
                     -1
                 }
             }
@@ -549,8 +516,8 @@ class DirectionsGenerator(
          * @return the transit stop icon for the given mode
          */
         @JvmStatic
-        fun getStopIcon(mode: TraverseModeSet): Int {
-            if (mode.contains(TraverseMode.BUS) || mode.contains(TraverseMode.RAIL)) {
+        fun getStopIcon(mode: TripMode?): Int {
+            if (mode == TripMode.BUS || mode == TripMode.RAIL) {
                 return R.drawable.stop_flag
             }
             // Just use the mode icon
@@ -558,22 +525,22 @@ class DirectionsGenerator(
         }
 
         @JvmStatic
-        fun getRelativeDirectionIcon(relDir: RelativeDirection, resources: Resources): Int {
+        fun getRelativeDirectionIcon(relDir: TripRelativeDirection, resources: Resources): Int {
             return when (relDir) {
-                RelativeDirection.CIRCLE_CLOCKWISE -> R.drawable.ic_rotary_clockwise
-                RelativeDirection.CIRCLE_COUNTERCLOCKWISE -> R.drawable.ic_rotary_counterclockwise
-                RelativeDirection.CONTINUE -> R.drawable.ic_continue
-                RelativeDirection.DEPART -> R.drawable.ic_depart
-                RelativeDirection.ELEVATOR -> R.drawable.ic_elevator
-                RelativeDirection.HARD_LEFT -> R.drawable.ic_turn_sharp_left
-                RelativeDirection.HARD_RIGHT -> R.drawable.ic_turn_sharp_right
-                RelativeDirection.LEFT -> R.drawable.ic_turn_left
-                RelativeDirection.RIGHT -> R.drawable.ic_turn_right
-                RelativeDirection.SLIGHTLY_LEFT -> R.drawable.ic_turn_slight_left
-                RelativeDirection.SLIGHTLY_RIGHT -> R.drawable.ic_turn_slight_right
-                RelativeDirection.UTURN_LEFT -> R.drawable.ic_uturn_left
-                RelativeDirection.UTURN_RIGHT -> R.drawable.ic_uturn_right
-                // No else: the when is exhaustive over RelativeDirection, so a future OTP enum
+                TripRelativeDirection.CIRCLE_CLOCKWISE -> R.drawable.ic_rotary_clockwise
+                TripRelativeDirection.CIRCLE_COUNTERCLOCKWISE -> R.drawable.ic_rotary_counterclockwise
+                TripRelativeDirection.CONTINUE -> R.drawable.ic_continue
+                TripRelativeDirection.DEPART -> R.drawable.ic_depart
+                TripRelativeDirection.ELEVATOR -> R.drawable.ic_elevator
+                TripRelativeDirection.HARD_LEFT -> R.drawable.ic_turn_sharp_left
+                TripRelativeDirection.HARD_RIGHT -> R.drawable.ic_turn_sharp_right
+                TripRelativeDirection.LEFT -> R.drawable.ic_turn_left
+                TripRelativeDirection.RIGHT -> R.drawable.ic_turn_right
+                TripRelativeDirection.SLIGHTLY_LEFT -> R.drawable.ic_turn_slight_left
+                TripRelativeDirection.SLIGHTLY_RIGHT -> R.drawable.ic_turn_slight_right
+                TripRelativeDirection.UTURN_LEFT -> R.drawable.ic_uturn_left
+                TripRelativeDirection.UTURN_RIGHT -> R.drawable.ic_uturn_right
+                // No else: the when is exhaustive over TripRelativeDirection, so a future OTP enum
                 // addition surfaces as a compile error here rather than a silent missing icon.
                 // (The caller's -1 initializer still covers the "icon not set" case.)
             }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/TripRequestBuilder.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/TripRequestBuilder.kt
@@ -78,18 +78,16 @@ class TripRequestBuilder(context: Context, private val mBundle: Bundle) {
     }
 
     fun setOptimizeTransfers(set: Boolean): TripRequestBuilder {
-        mBundle.putSerializable(
-            OPTIMIZE_TRANSFERS, if (set) OptimizeType.TRANSFERS else OptimizeType.QUICK
-        )
+        mBundle.putBoolean(OPTIMIZE_TRANSFERS, set)
         return this
     }
 
-    private fun getOptimizeType(): OptimizeType {
-        val type = BundleCompat.getSerializable(mBundle, OPTIMIZE_TRANSFERS, OptimizeType::class.java)
-        return type ?: OptimizeType.QUICK
-    }
+    fun getOptimizeTransfers(): Boolean = mBundle.getBoolean(OPTIMIZE_TRANSFERS)
 
-    fun getOptimizeTransfers(): Boolean = getOptimizeType() == OptimizeType.TRANSFERS
+    /** The OTP1 wire enum, derived from [getOptimizeTransfers] only where [buildRequest] needs it —
+     * never itself persisted, so it never has to cross a Bundle/Intent serialization boundary. */
+    private fun getOptimizeType(): OptimizeType =
+        if (getOptimizeTransfers()) OptimizeType.TRANSFERS else OptimizeType.QUICK
 
     fun setWheelchairAccessible(wheelchair: Boolean): TripRequestBuilder {
         mBundle.putBoolean(WHEELCHAIR_ACCESSIBLE, wheelchair)
@@ -280,7 +278,7 @@ class TripRequestBuilder(context: Context, private val mBundle: Bundle) {
         target.putBoolean(ARRIVE_BY, arriveBy)
         target.putParcelable(FROM_ADDRESS, from)
         target.putParcelable(TO_ADDRESS, to)
-        target.putSerializable(OPTIMIZE_TRANSFERS, getOptimizeType())
+        target.putBoolean(OPTIMIZE_TRANSFERS, getOptimizeTransfers())
         target.putBoolean(WHEELCHAIR_ACCESSIBLE, getWheelchairAccessible())
         getMaxWalkDistance()?.let { target.putDouble(MAX_WALK_DISTANCE, it) }
         target.putString(MODE_SET, getModeString())
@@ -302,7 +300,7 @@ class TripRequestBuilder(context: Context, private val mBundle: Bundle) {
         target.putDouble(TO_LAT, toAddr!!.latitude)
         target.putDouble(TO_LON, toAddr.longitude)
         target.putString(TO_NAME, toAddr.toString())
-        target.putString(OPTIMIZE_TRANSFERS, getOptimizeType().toString())
+        target.putBoolean(OPTIMIZE_TRANSFERS, getOptimizeTransfers())
         target.putBoolean(WHEELCHAIR_ACCESSIBLE, getWheelchairAccessible())
         getMaxWalkDistance()?.let { target.putDouble(MAX_WALK_DISTANCE, it) }
         target.putString(MODE_SET, getModeString())
@@ -366,11 +364,7 @@ class TripRequestBuilder(context: Context, private val mBundle: Bundle) {
             target.putParcelable(FROM_ADDRESS, from)
             target.putParcelable(TO_ADDRESS, to)
 
-            val optName = bundle.getString(OPTIMIZE_TRANSFERS)
-            if (optName != null) {
-                target.putSerializable(OPTIMIZE_TRANSFERS, OptimizeType.valueOf(optName))
-            }
-
+            target.putBoolean(OPTIMIZE_TRANSFERS, bundle.getBoolean(OPTIMIZE_TRANSFERS))
             target.putBoolean(WHEELCHAIR_ACCESSIBLE, bundle.getBoolean(WHEELCHAIR_ACCESSIBLE))
             target.putDouble(MAX_WALK_DISTANCE, bundle.getDouble(MAX_WALK_DISTANCE))
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/DirectionsMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/DirectionsMapController.kt
@@ -18,16 +18,16 @@ package org.onebusaway.android.map
 import android.graphics.Color
 import android.location.Location
 import android.util.Log
+import org.onebusaway.android.directions.model.TripItinerary
+import org.onebusaway.android.directions.model.TripLeg
+import org.onebusaway.android.directions.model.TripLegGeometry
+import org.onebusaway.android.directions.model.TripMode
+import org.onebusaway.android.directions.model.TripVertexType
 import org.onebusaway.android.directions.util.OTPConstants
 import org.onebusaway.android.models.ObaShape
 import org.onebusaway.android.util.PolylineDecoder
 import org.onebusaway.android.map.render.GeoPoint
 import org.onebusaway.android.map.render.RoutePolyline
-import org.opentripplanner.api.model.EncodedPolylineBean
-import org.opentripplanner.api.model.Itinerary
-import org.opentripplanner.api.model.Leg
-import org.opentripplanner.routing.core.TraverseMode
-import org.opentripplanner.api.model.VertexType
 
 /**
  * The trip-plan directions use case (the legacy `DirectionsMapController`): draws an itinerary's legs
@@ -50,22 +50,25 @@ class DirectionsMapController(private val host: MapHost) {
     private var directionsStart: GeoPoint? = null
 
     /** Draw [itinerary]'s leg polylines + start/end pins and frame it. */
-    fun start(itinerary: Itinerary) {
+    fun start(itinerary: TripItinerary) {
         val legs = itinerary.legs
         if (legs.isEmpty()) {
             return
         }
         val firstLeg = legs.first()
         val lastLeg = legs.last()
-        val startLat = firstLeg.from.lat
-        val startLon = firstLeg.from.lon
-        val endLat = lastLeg.to.lat
-        val endLon = lastLeg.to.lon
+        val startPlace = firstLeg.from
+        val endPlace = lastLeg.to
+        val startLat = startPlace.lat!!
+        val startLon = startPlace.lon!!
+        val endLat = endPlace.lat!!
+        val endLon = endPlace.lon!!
 
         // Build every leg's polyline (each in its own mode color), then append them in one write —
         // matching the legacy per-leg append but without rebuilding the polyline list n times.
         val legPolylines = legs.mapNotNull { leg ->
-            val shape = LegShape(leg.legGeometry)
+            val geometry = leg.legGeometry ?: return@mapNotNull null
+            val shape = LegShape(geometry)
             if (shape.length > 0) {
                 // An itinerary leg is traversed one way; keep its travel-direction chevrons.
                 RoutePolyline(
@@ -110,9 +113,9 @@ class DirectionsMapController(private val host: MapHost) {
         directionsMarkerIds.clear()
     }
 
-    private fun resolveLegColor(leg: Leg): Int {
+    private fun resolveLegColor(leg: TripLeg): Int {
         // Color for transit routes when planning a trip.
-        if (TraverseMode.valueOf(leg.mode).isTransit) {
+        if (leg.mode?.isTransit == true) {
             return OTPConstants.OTP_TRANSIT_COLOR
         }
         // Use the route's custom color if available.
@@ -127,11 +130,12 @@ class DirectionsMapController(private val host: MapHost) {
         return Color.GRAY
     }
 
-    /** An [ObaShape] over an OTP [EncodedPolylineBean] leg geometry (ported from DirectionsMapController). */
-    private class LegShape(private val bean: EncodedPolylineBean) : ObaShape {
-        override val length: Int get() = bean.length
-        override val points: List<Location> get() = PolylineDecoder.decodeLine(bean.points, bean.length)
-        override val rawPoints: String get() = bean.points
+    /** An [ObaShape] over a [TripLegGeometry] (ported from the legacy DirectionsMapController). */
+    private class LegShape(private val geometry: TripLegGeometry) : ObaShape {
+        override val length: Int get() = geometry.length
+        override val points: List<Location> get() =
+            PolylineDecoder.decodeLine(geometry.points.orEmpty(), geometry.length)
+        override val rawPoints: String get() = geometry.points.orEmpty()
     }
 
     companion object {
@@ -147,15 +151,15 @@ class DirectionsMapController(private val host: MapHost) {
          * The bike-share stations an itinerary references, to filter the bike overlay to the trip's own
          * stations (ported from the legacy DirectionsMapController; passed to the bike loader).
          */
-        fun bikeStationIdsFromItinerary(itinerary: Itinerary): List<String> {
+        fun bikeStationIdsFromItinerary(itinerary: TripItinerary): List<String> {
             val ids = ArrayList<String>()
             for (leg in itinerary.legs) {
-                if (TraverseMode.BICYCLE.toString() == leg.mode) {
-                    if (VertexType.BIKESHARE == leg.from.vertexType) {
-                        ids.add(leg.from.bikeShareId)
+                if (leg.mode == TripMode.BICYCLE) {
+                    if (leg.from.vertexType == TripVertexType.BIKESHARE) {
+                        leg.from.bikeShareId?.let { ids.add(it) }
                     }
-                    if (VertexType.BIKESHARE == leg.to.vertexType) {
-                        ids.add(leg.to.bikeShareId)
+                    if (leg.to.vertexType == TripVertexType.BIKESHARE) {
+                        leg.to.bikeShareId?.let { ids.add(it) }
                     }
                 }
             }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/DirectionsMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/DirectionsMapController.kt
@@ -57,12 +57,15 @@ class DirectionsMapController(private val host: MapHost) {
         }
         val firstLeg = legs.first()
         val lastLeg = legs.last()
+        // A place is required on every leg, but its coordinates aren't (e.g. a vertex with no
+        // geographic identity) — degrade to skipping the pin/start-framing for that endpoint rather
+        // than crashing map rendering; the leg polylines below don't depend on either.
         val startPlace = firstLeg.from
         val endPlace = lastLeg.to
-        val startLat = startPlace.lat!!
-        val startLon = startPlace.lon!!
-        val endLat = endPlace.lat!!
-        val endLon = endPlace.lon!!
+        val startLat = startPlace.lat
+        val startLon = startPlace.lon
+        val endLat = endPlace.lat
+        val endLon = endPlace.lon
 
         // Build every leg's polyline (each in its own mode color), then append them in one write —
         // matching the legacy per-leg append but without rebuilding the polyline list n times.
@@ -84,11 +87,15 @@ class DirectionsMapController(private val host: MapHost) {
             host.renderState.setRoutePolylines(host.renderState.getRoutePolylines() + legPolylines)
         }
 
-        directionsMarkerIds.add(host.addMarker(startLat, startLon, HUE_GREEN))
-        directionsMarkerIds.add(host.addMarker(endLat, endLon, HUE_RED))
+        if (startLat != null && startLon != null) {
+            directionsMarkerIds.add(host.addMarker(startLat, startLon, HUE_GREEN))
+        }
+        if (endLat != null && endLon != null) {
+            directionsMarkerIds.add(host.addMarker(endLat, endLon, HUE_RED))
+        }
 
         directionsHasRoute = legPolylines.isNotEmpty()
-        directionsStart = GeoPoint(startLat, startLon)
+        directionsStart = if (startLat != null && startLon != null) GeoPoint(startLat, startLon) else null
         frameDirections()
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/DirectionsMapViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/DirectionsMapViewModel.kt
@@ -22,11 +22,11 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
+import org.onebusaway.android.directions.model.TripItinerary
 import org.onebusaway.android.location.LocationRepository
 import org.onebusaway.android.map.bike.BikeStationsRepository
 import org.onebusaway.android.preferences.PreferencesRepository
 import org.onebusaway.android.region.RegionRepository
-import org.opentripplanner.api.model.Itinerary
 
 /**
  * The map view model for the **trip-plan directions** screen (trip results). It owns a [MapHost] + a
@@ -72,7 +72,7 @@ class DirectionsMapViewModel @Inject constructor(
     )
 
     /** Draw [itinerary]'s legs + start/end pins and load its bike-share stations. */
-    fun showItinerary(itinerary: Itinerary) {
+    fun showItinerary(itinerary: TripItinerary) {
         directionsController.clear()
         mapHost.renderState.clearRoutePolylines()
         directionsController.start(itinerary)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanFormState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanFormState.kt
@@ -15,7 +15,7 @@
  */
 package org.onebusaway.android.ui.tripplan
 
-import org.opentripplanner.api.model.Itinerary
+import org.onebusaway.android.directions.model.TripItinerary
 
 /**
  * A JVM-pure projection of a trip-plan endpoint (a [org.onebusaway.android.directions.util.CustomAddress]),
@@ -145,7 +145,7 @@ sealed interface PlanResult {
      * re-entry (the full request isn't reconstructed there), in which case monitoring isn't re-armed.
      */
     data class Success(
-        val itineraries: List<Itinerary>,
+        val itineraries: List<TripItinerary>,
         val params: TripPlanParams? = null,
     ) : PlanResult
     data class Error(val message: String) : PlanResult

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanRepository.kt
@@ -25,20 +25,21 @@ import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.onebusaway.android.R
+import org.onebusaway.android.api.adapters.toTripItinerary
 import org.onebusaway.android.api.contract.OtpPlanParser
+import org.onebusaway.android.api.contract.OtpResponseDto
 import org.onebusaway.android.api.contract.OtpWebService
+import org.onebusaway.android.directions.model.TripItinerary
 import org.onebusaway.android.directions.util.CustomAddress
 import org.onebusaway.android.directions.util.TripRequestBuilder
-import org.opentripplanner.api.model.Itinerary
 import org.opentripplanner.api.ws.Message
 import org.opentripplanner.api.ws.Request
-import org.opentripplanner.api.ws.Response
 import org.opentripplanner.routing.core.TraverseMode
 import org.onebusaway.android.preferences.PreferencesRepository
 
 /** Plans a trip against the region's OpenTripPlanner server. */
 interface TripPlanRepository {
-    suspend fun plan(params: TripPlanParams): Result<List<Itinerary>>
+    suspend fun plan(params: TripPlanParams): Result<List<TripItinerary>>
 
     /**
      * Blocking OTP plan for a caller that is already on a background thread and has assembled its
@@ -48,7 +49,7 @@ interface TripPlanRepository {
      * Result-free so it stays cleanly callable from the Java service.
      */
     @WorkerThread
-    fun planBlocking(builder: TripRequestBuilder): List<Itinerary>
+    fun planBlocking(builder: TripRequestBuilder): List<TripItinerary>
 }
 
 /**
@@ -64,13 +65,13 @@ class DefaultTripPlanRepository @Inject constructor(
     private val otpWebService: OtpWebService,
 ) : TripPlanRepository {
 
-    override suspend fun plan(params: TripPlanParams): Result<List<Itinerary>> =
+    override suspend fun plan(params: TripPlanParams): Result<List<TripItinerary>> =
         withContext(Dispatchers.IO) {
             runCatching { planInternal(builderFor(params)) }
         }
 
     @WorkerThread
-    override fun planBlocking(builder: TripRequestBuilder): List<Itinerary> =
+    override fun planBlocking(builder: TripRequestBuilder): List<TripItinerary> =
         runCatching { planInternal(builder) }.getOrDefault(emptyList())
 
     /** Assembles a [TripRequestBuilder] from the UI-supplied [params]. */
@@ -81,7 +82,7 @@ class DefaultTripPlanRepository @Inject constructor(
      * Runs the OTP request for an already-assembled [builder] on the calling thread. Throws
      * [IOException] with a user-facing message when no server is selected or the plan is empty/errored.
      */
-    private fun planInternal(builder: TripRequestBuilder): List<Itinerary> {
+    private fun planInternal(builder: TripRequestBuilder): List<TripItinerary> {
         val request = builder.buildRequest()
         val baseUrl = builder.formattedOtpBaseUrl
             ?: throw IOException(context.getString(R.string.tripplanner_no_server_selected_error))
@@ -91,7 +92,7 @@ class DefaultTripPlanRepository @Inject constructor(
             baseUrl,
             oldServer = prefs.getBoolean(R.string.preference_key_otp_api_url_version, false),
         )
-        val itineraries = response.plan?.itinerary
+        val itineraries = response.plan?.itineraries?.map { it.toTripItinerary() }
         if (itineraries.isNullOrEmpty()) {
             throw IOException(errorMessage(response.error?.id ?: -1))
         }
@@ -118,7 +119,7 @@ class DefaultTripPlanRepository @Inject constructor(
         request: Request,
         baseUrl: String,
         oldServer: Boolean
-    ): Response {
+    ): OtpResponseDto {
         val routerRooted = baseUrl.contains(OTP_ROUTERS_SEGMENT)
         // A router-rooted base is unambiguously a modern server, so it can never be the pre-1.0 kind
         // the `oldServer` fallback exists for; force it modern even if a stale flag says otherwise.
@@ -161,7 +162,7 @@ class DefaultTripPlanRepository @Inject constructor(
             return requestPlan(request, baseUrl, oldServer = true)
         }
 
-        val parsed: Response = try {
+        val parsed: OtpResponseDto = try {
             val body = response.body()
             if (!response.isSuccessful || body == null) {
                 throw IOException("OTP /plan returned HTTP ${response.code()}")

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanScreen.kt
@@ -94,9 +94,9 @@ import org.onebusaway.android.time.ElapsedTime
 import org.onebusaway.android.util.BikeshareAvailability
 import org.onebusaway.android.util.ExternalIntents
 import org.onebusaway.android.util.PreferenceUtils
+import org.onebusaway.android.directions.model.toTripItineraries
 import org.onebusaway.android.util.describeLocation
 import org.onebusaway.android.util.locationOf
-import org.opentripplanner.api.model.Itinerary
 
 
 /**
@@ -607,7 +607,7 @@ private fun reportPlanAnalytics(
  * there was nothing to restore.
  */
 // UnwrappedClockValue: the trip-plan time defaults to device "now" when the intent carries none.
-@Suppress("UNCHECKED_CAST", "DEPRECATION", "UnwrappedClockValue")
+@Suppress("DEPRECATION", "UnwrappedClockValue")
 private fun maybeRestoreFromIntent(
     viewModel: TripPlanViewModel,
     context: Context,
@@ -615,8 +615,7 @@ private fun maybeRestoreFromIntent(
 ): Intent? {
     val extras = intent?.extras ?: return null
     if (extras.getSerializable(OTPConstants.INTENT_SOURCE) == null) return null
-    val itineraries =
-        (extras.getSerializable(OTPConstants.ITINERARIES) as? ArrayList<Itinerary>).orEmpty()
+    val itineraries = extras.getString(OTPConstants.ITINERARIES)?.toTripItineraries().orEmpty()
     if (itineraries.isEmpty()) return null
 
     val builder = TripRequestBuilder.initFromBundleSimple(context, extras)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanViewModel.kt
@@ -35,10 +35,10 @@ import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
+import org.onebusaway.android.directions.model.TripItinerary
 import org.onebusaway.android.location.SearchCenter
 import org.onebusaway.android.region.RegionRepository
 import org.onebusaway.android.util.TimeProvider
-import org.opentripplanner.api.model.Itinerary
 
 /**
  * Owns the trip-plan form ([formState]) and plan submission ([planState]). Address autocomplete runs
@@ -221,7 +221,7 @@ class TripPlanViewModel @Inject constructor(
         to: TripEndpoint?,
         dateTimeMillis: Long,
         arriving: Boolean,
-        itineraries: List<Itinerary>
+        itineraries: List<TripItinerary>
     ) {
         _formState.update {
             it.copy(

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsRepository.kt
@@ -24,13 +24,13 @@ import java.util.Locale
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.onebusaway.android.directions.model.Direction
+import org.onebusaway.android.directions.model.TripItinerary
 import org.onebusaway.android.directions.util.ConversionUtils
 import org.onebusaway.android.directions.util.DirectionsGenerator
 import org.onebusaway.android.directions.util.OTPConstants
-import org.opentripplanner.api.model.Itinerary
 
 /**
- * Projects OpenTripPlanner [Itinerary] objects onto the Compose results model. Reuses the legacy
+ * Projects [TripItinerary] objects onto the Compose results model. Reuses the legacy
  * [DirectionsGenerator]/[ConversionUtils] (which need a [Context] for resources/formatting) and the
  * card interval formatting ported from the old TripResultsFragment, all on the IO thread so
  * [TripResultsViewModel] stays JVM-testable.
@@ -38,32 +38,32 @@ import org.opentripplanner.api.model.Itinerary
 interface TripResultsRepository {
 
     /** Summarizes each itinerary into an option card (title, duration, time interval). */
-    suspend fun summarize(itineraries: List<Itinerary>): Result<List<ItineraryOption>>
+    suspend fun summarize(itineraries: List<TripItinerary>): Result<List<ItineraryOption>>
 
     /** Builds the turn-by-turn directions for a single itinerary. */
-    suspend fun directionsFor(itinerary: Itinerary): Result<List<DirectionItem>>
+    suspend fun directionsFor(itinerary: TripItinerary): Result<List<DirectionItem>>
 }
 
 class DefaultTripResultsRepository @Inject constructor(@param:ApplicationContext private val context: Context) : TripResultsRepository {
 
     override suspend fun summarize(
-        itineraries: List<Itinerary>
+        itineraries: List<TripItinerary>
     ): Result<List<ItineraryOption>> = withContext(Dispatchers.IO) {
         runCatching {
             itineraries.map { itinerary ->
-                val durationSec = itinerary.duration
+                val durationSec = itinerary.duration.inWholeSeconds
                 ItineraryOption(
                     title = DirectionsGenerator(itinerary.legs, context).itineraryTitle,
                     durationText = ConversionUtils
                         .getFormattedDurationTextNoSeconds(durationSec, false, context),
-                    intervalText = formatTimeString(itinerary.startTime.toString(), durationSec * 1000)
+                    intervalText = formatTimeString(itinerary.startTime.epochMs, durationSec * 1000)
                 )
             }
         }
     }
 
     override suspend fun directionsFor(
-        itinerary: Itinerary
+        itinerary: TripItinerary
     ): Result<List<DirectionItem>> = withContext(Dispatchers.IO) {
         runCatching {
             DirectionsGenerator(itinerary.legs, context).directions.map { it.toItem() }
@@ -102,10 +102,8 @@ class DefaultTripResultsRepository @Inject constructor(@param:ApplicationContext
     private fun CharSequence?.orEmptyString(): String = this?.toString().orEmpty()
 
     // Ported verbatim from the legacy TripResultsFragment (e.g. "3:45p - 4:30p").
-    private fun formatTimeString(startMs: String, durationMs: Long): String {
-        val start = startMs.toLong()
-        return "${toDateFmt(start)} - ${toDateFmt(start + durationMs)}"
-    }
+    private fun formatTimeString(startMs: Long, durationMs: Long): String =
+        "${toDateFmt(startMs)} - ${toDateFmt(startMs + durationMs)}"
 
     private fun toDateFmt(ms: Long): String {
         val s = SimpleDateFormat(OTPConstants.TRIP_RESULTS_TIME_STRING_FORMAT_SUMMARY, Locale.getDefault())

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
@@ -64,6 +64,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import org.onebusaway.android.R
 import org.onebusaway.android.notifications.NotificationChannels
 import org.onebusaway.android.app.di.PreferencesEntryPoint
+import org.onebusaway.android.directions.model.TripItinerary
 import org.onebusaway.android.directions.realtime.TripPlanMonitor
 import org.onebusaway.android.map.DirectionsMapViewModel
 import org.onebusaway.android.map.compose.NoOpObaMapCallbacks
@@ -72,7 +73,6 @@ import org.onebusaway.android.ui.compose.components.LoadingContent
 import org.onebusaway.android.ui.compose.findActivity
 import org.onebusaway.android.ui.compose.theme.ObaTheme
 import org.onebusaway.android.ui.tripplan.TripPlanParams
-import org.opentripplanner.api.model.Itinerary
 
 /**
  * The results header: the (1–3) itinerary option cards. Shown above the directions list, pinned at the
@@ -185,7 +185,7 @@ fun TripResultsList(state: TripResultsUiState, modifier: Modifier = Modifier) {
  */
 @Composable
 fun TripResultsSheet(
-    itineraries: List<Itinerary>,
+    itineraries: List<TripItinerary>,
     params: TripPlanParams?,
     resultsViewModel: TripResultsViewModel,
     mapViewModel: DirectionsMapViewModel,
@@ -252,7 +252,7 @@ fun TripResultsMap(
 private fun maybeStartTripUpdates(
     activity: Activity,
     params: TripPlanParams?,
-    itineraries: List<Itinerary>,
+    itineraries: List<TripItinerary>,
     index: Int,
 ) {
     val itinerary = itineraries.getOrNull(index) ?: return

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsViewModel.kt
@@ -26,13 +26,13 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
-import org.opentripplanner.api.model.Itinerary
+import org.onebusaway.android.directions.model.TripItinerary
 
 /**
  * Holds the trip-planning results: the option cards, which one is selected, and the selected
- * itinerary's directions. The OTP [Itinerary] objects are kept as opaque tokens (they aren't
- * JVM-pure) and handed back to the repository to re-summarize/re-generate directions on selection.
- * [selectedItinerary] drives a re-point of the declarative map when a different option is selected.
+ * itinerary's directions. The [TripItinerary] objects are kept as opaque tokens and handed back to
+ * the repository to re-summarize/re-generate directions on selection. [selectedItinerary] drives a
+ * re-point of the declarative map when a different option is selected.
  */
 @HiltViewModel
 class TripResultsViewModel @Inject constructor(
@@ -43,14 +43,14 @@ class TripResultsViewModel @Inject constructor(
     val state: StateFlow<TripResultsUiState> = _state.asStateFlow()
 
     /** Emits the selected index (and its itinerary) so the screen can re-point the map. */
-    private val _selectedItinerary = MutableSharedFlow<Pair<Int, Itinerary>>(extraBufferCapacity = 1)
-    val selectedItinerary: SharedFlow<Pair<Int, Itinerary>> = _selectedItinerary.asSharedFlow()
+    private val _selectedItinerary = MutableSharedFlow<Pair<Int, TripItinerary>>(extraBufferCapacity = 1)
+    val selectedItinerary: SharedFlow<Pair<Int, TripItinerary>> = _selectedItinerary.asSharedFlow()
 
-    private var itineraries: List<Itinerary> = emptyList()
+    private var itineraries: List<TripItinerary> = emptyList()
     private var selectedIndex: Int = 0
 
     /** Seeds the results from a completed plan. [initialIndex] restores the prior option selection. */
-    fun setItineraries(itineraries: List<Itinerary>, initialIndex: Int) {
+    fun setItineraries(itineraries: List<TripItinerary>, initialIndex: Int) {
         this.itineraries = itineraries
         this.selectedIndex = initialIndex.coerceIn(0, (itineraries.size - 1).coerceAtLeast(0))
         load()

--- a/onebusaway-android/src/test/java/org/onebusaway/android/api/OtpPlanDecodeTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/api/OtpPlanDecodeTest.kt
@@ -16,32 +16,37 @@
 package org.onebusaway.android.api
 
 import java.io.IOException
+import kotlin.time.Duration.Companion.seconds
+import org.onebusaway.android.api.adapters.toTripItinerary
 import org.onebusaway.android.api.contract.OtpPlanParser
+import org.onebusaway.android.directions.model.TripMode
+import org.onebusaway.android.directions.model.TripRelativeDirection
+import org.onebusaway.android.directions.model.TripVertexType
+import org.onebusaway.android.time.ServerTime
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Test
-import org.opentripplanner.api.model.RelativeDirection
-import org.opentripplanner.api.model.VertexType
 
 /**
- * Covers the OTP `/plan` decode + the mapping onto the OTP library POJOs (`Response`/`TripPlan`/
- * `Itinerary`/`Leg`/…) that the directions + trip-planner UI read — the kotlinx.serialization
- * replacement for the retired Jackson `JacksonConfig` path.
+ * Covers the OTP `/plan` decode ([OtpPlanParser]) and the mapping onto the app-owned trip-plan domain
+ * model ([org.onebusaway.android.directions.model.TripItinerary]/`TripLeg`/…) via
+ * [org.onebusaway.android.api.adapters.toTripItinerary] — the kotlinx.serialization replacement for the
+ * retired Jackson `JacksonConfig` path, now targeting our own domain model instead of the vendored OTP1
+ * POJOs.
  *
- * The pinned case is the epoch-millis timestamps: OTP emits `startTime`/`endTime` as JSON *numbers*,
- * but the POJOs store them as `String` and callers do `Long.parseLong(...)`. Jackson used to coerce
- * number→String; [org.onebusaway.android.api.contract.OtpResponseDto] must preserve that so both a
- * bare number and a quoted string decode to the same literal text.
+ * The pinned case is the epoch-millis timestamps: OTP emits `startTime`/`endTime` as JSON *numbers*, but
+ * some servers quote them as strings; [org.onebusaway.android.api.contract.OtpResponseDto] must preserve
+ * both forms so they decode to the same [ServerTime].
  */
 class OtpPlanDecodeTest {
 
     @Test
     fun decodesAndMapsPlan() {
         // startTime is a bare number (as OTP emits it); the bus leg's endTime is a quoted string —
-        // both must survive as numeric-millis text. `debugOutput` is an unmodeled key that must be
-        // ignored, not rejected.
+        // both must decode to the same Instant. `debugOutput` is an unmodeled key that must be
+        // ignored, not rejected. duration/departureDelay are seconds on the wire.
         val body = """
             {
               "debugOutput": { "totalTime": 42 },
@@ -91,44 +96,49 @@ class OtpPlanDecodeTest {
         val response = OtpPlanParser.parse(body)
         assertNull(response.error)
 
-        val itineraries = response.plan.itinerary
+        val itineraries = response.plan!!.itineraries.map { it.toTripItinerary() }
         assertEquals(1, itineraries.size)
         val itinerary = itineraries[0]
-        assertEquals(1500L, itinerary.duration)
-        // number startTime coerced to its literal millis text
-        assertEquals("1699999999000", itinerary.startTime)
+        assertEquals(1500L, itinerary.duration.inWholeSeconds)
+        assertEquals(ServerTime(1699999999000), itinerary.startTime)
         assertEquals(2, itinerary.legs.size)
 
         val walk = itinerary.legs[0]
-        assertEquals("WALK", walk.mode)
-        assertEquals(123.4, walk.distance!!, 1e-6)
-        assertEquals("1699999999000", walk.startTime)
-        assertEquals("1700000100000", walk.endTime)
-        assertEquals("Origin", walk.from.name)
-        assertEquals(47.6, walk.from.lat!!, 1e-6)
-        assertEquals("1001", walk.to.stopCode)
-        assertEquals(VertexType.TRANSIT, walk.to.vertexType)
-        // legGeometry + walk steps flow through the getter-backed fields
-        assertEquals("abc_def", walk.legGeometry.points)
-        assertEquals(2, walk.legGeometry.length)
+        assertEquals(TripMode.WALK, walk.mode)
+        assertEquals(123.4, walk.distance, 1e-6)
+        assertEquals(ServerTime(1699999999000), walk.startTime)
+        assertEquals(ServerTime(1700000100000), walk.endTime)
+        val walkFrom = walk.from
+        val walkTo = walk.to
+        val walkGeometry = walk.legGeometry!!
+        assertEquals("Origin", walkFrom.name)
+        assertEquals(47.6, walkFrom.lat!!, 1e-6)
+        assertEquals("1001", walkTo.stopCode)
+        assertEquals(TripVertexType.TRANSIT, walkTo.vertexType)
+        // legGeometry + walk steps flow through the mapped fields
+        assertEquals("abc_def", walkGeometry.points)
+        assertEquals(2, walkGeometry.length)
         assertEquals(1, walk.steps.size)
-        assertEquals(RelativeDirection.LEFT, walk.steps[0].relativeDirection)
+        assertEquals(TripRelativeDirection.LEFT, walk.steps[0].relativeDirection)
         assertEquals("Main St", walk.steps[0].streetName)
 
         val bus = itinerary.legs[1]
-        assertEquals("BUS", bus.mode)
+        assertEquals(TripMode.BUS, bus.mode)
         assertTrue(bus.realTime)
         assertEquals(-14400, bus.agencyTimeZoneOffset)
         assertEquals("5", bus.routeShortName)
         assertEquals("0000FF", bus.routeColor)
-        assertEquals(30, bus.departureDelay)
+        assertEquals(30L, bus.departureDelay.inWholeSeconds)
+        assertEquals(30.seconds, bus.departureDelay)
         assertEquals("trip_5", bus.tripId)
-        // quoted-string endTime survives unchanged
-        assertEquals("1700000700000", bus.endTime)
-        assertEquals(VertexType.BIKESHARE, bus.from.vertexType)
-        assertEquals("bs_9", bus.from.bikeShareId)
-        assertEquals(1, bus.intermediateStops.size)
-        assertEquals("Stop Mid", bus.intermediateStops[0].name)
+        // quoted-string endTime decodes the same as a bare number
+        assertEquals(ServerTime(1700000700000), bus.endTime)
+        val busFrom = bus.from
+        val intermediateStops = bus.intermediateStops!!
+        assertEquals(TripVertexType.BIKESHARE, busFrom.vertexType)
+        assertEquals("bs_9", busFrom.bikeShareId)
+        assertEquals(1, intermediateStops.size)
+        assertEquals("Stop Mid", intermediateStops[0].name)
     }
 
     @Test
@@ -137,8 +147,9 @@ class OtpPlanDecodeTest {
 
         val response = OtpPlanParser.parse(body)
         assertNull(response.plan)
-        assertEquals(404, response.error.id)
-        assertEquals("Path not found", response.error.msg)
+        val error = response.error!!
+        assertEquals(404, error.id)
+        assertEquals("Path not found", error.msg)
     }
 
     /** An unknown enum string must degrade to null rather than blow up the whole parse. */
@@ -146,13 +157,31 @@ class OtpPlanDecodeTest {
     fun toleratesUnknownVertexType() {
         val body = """
             { "plan": { "itineraries": [ { "startTime": 1, "legs": [
-              { "mode": "WALK", "from": { "name": "X", "vertexType": "WHO_KNOWS" }, "to": { "name": "Y" } }
+              { "mode": "WALK", "startTime": 1, "endTime": 2,
+                "from": { "name": "X", "vertexType": "WHO_KNOWS" }, "to": { "name": "Y" } }
             ] } ] } }
         """.trimIndent()
 
         val response = OtpPlanParser.parse(body)
-        val leg = response.plan.itinerary[0].legs[0]
+        val leg = response.plan!!.itineraries[0].toTripItinerary().legs[0]
         assertNull(leg.from.vertexType)
+    }
+
+    /**
+     * A leg missing a field every well-formed OTP leg carries (here, `startTime`) must fail loudly at
+     * the adapter boundary rather than silently defaulting — this is the one place that knows the
+     * response is malformed, so every downstream consumer can treat these fields as non-null.
+     */
+    @Test
+    fun missingRequiredLegFieldThrows() {
+        val body = """
+            { "plan": { "itineraries": [ { "startTime": 1, "legs": [
+              { "mode": "WALK", "endTime": 2, "from": { "name": "X" }, "to": { "name": "Y" } }
+            ] } ] } }
+        """.trimIndent()
+
+        val itinerary = OtpPlanParser.parse(body).plan!!.itineraries[0]
+        assertThrows(IllegalStateException::class.java) { itinerary.toTripItinerary() }
     }
 
     /**

--- a/onebusaway-android/src/test/java/org/onebusaway/android/directions/model/TripItineraryJsonTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/directions/model/TripItineraryJsonTest.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.directions.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.onebusaway.android.time.ServerTime
+
+/**
+ * Covers the [List.toJson]/[String.toTripItineraries] round trip used to carry a plan result across
+ * the trip-plan-monitor notification `Intent` ([org.onebusaway.android.directions.realtime.TripPlanMonitorService.notifyChange] /
+ * [org.onebusaway.android.ui.tripplan.TripPlanScreen.maybeRestoreFromIntent]).
+ */
+class TripItineraryJsonTest {
+
+    @Test
+    fun `round-trips an itinerary through JSON`() {
+        val itinerary = TripItinerary(
+            startTime = ServerTime(1_700_000_000_000L),
+            legs = listOf(TripLeg(mode = TripMode.BUS, tripId = "t1")),
+        )
+
+        val decoded = listOf(itinerary).toJson().toTripItineraries()
+
+        assertEquals(listOf(itinerary), decoded)
+    }
+
+    /**
+     * A corrupted/truncated extra (e.g. the app was updated between writing and reading a pending
+     * notification's Intent) must degrade to "nothing to restore", not crash the activity on
+     * notification re-entry.
+     */
+    @Test
+    fun `malformed JSON decodes to an empty list instead of throwing`() {
+        val decoded = "not valid json".toTripItineraries()
+
+        assertTrue(decoded.isEmpty())
+    }
+
+    @Test
+    fun `truncated JSON decodes to an empty list instead of throwing`() {
+        val truncated = listOf(TripItinerary()).toJson().dropLast(10)
+
+        assertTrue(truncated.toTripItineraries().isEmpty())
+    }
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/directions/realtime/TripMonitorDeciderTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/directions/realtime/TripMonitorDeciderTest.kt
@@ -18,8 +18,10 @@ package org.onebusaway.android.directions.realtime
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.onebusaway.android.directions.model.ItineraryDescription
-import org.opentripplanner.api.model.Itinerary
-import org.opentripplanner.api.model.Leg
+import org.onebusaway.android.directions.model.TripItinerary
+import org.onebusaway.android.directions.model.TripLeg
+import org.onebusaway.android.directions.model.TripMode
+import org.onebusaway.android.time.ServerTime
 import java.util.concurrent.TimeUnit
 
 /**
@@ -31,14 +33,14 @@ class TripMonitorDeciderTest {
     private val thresholdSeconds = TimeUnit.MINUTES.toSeconds(2)
 
     /** Builds a single-transit-leg itinerary with the given trip id and end time (epoch millis). */
-    private fun itinerary(tripId: String, endTimeMillis: Long): Itinerary {
-        val leg = Leg().apply {
-            mode = "BUS"
-            realTime = true
-            this.tripId = tripId
-            endTime = endTimeMillis.toString()
-        }
-        return Itinerary().apply { legs = arrayListOf(leg) }
+    private fun itinerary(tripId: String, endTimeMillis: Long): TripItinerary {
+        val leg = TripLeg(
+            mode = TripMode.BUS,
+            realTime = true,
+            tripId = tripId,
+            endTime = ServerTime(endTimeMillis),
+        )
+        return TripItinerary(legs = listOf(leg))
     }
 
     private fun monitoring(tripId: String, endTimeMillis: Long): ItineraryDescription =

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripPlanViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripPlanViewModelTest.kt
@@ -33,7 +33,7 @@ import org.onebusaway.android.region.RegionRepository
 import org.onebusaway.android.region.region
 import org.onebusaway.android.testing.MainDispatcherRule
 import org.onebusaway.android.util.TimeProvider
-import org.opentripplanner.api.model.Itinerary
+import org.onebusaway.android.directions.model.TripItinerary
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class TripPlanViewModelTest {
@@ -53,27 +53,27 @@ class TripPlanViewModelTest {
         }
     }
 
-    private class FakeTripPlanRepository(var result: Result<List<Itinerary>>) : TripPlanRepository {
+    private class FakeTripPlanRepository(var result: Result<List<TripItinerary>>) : TripPlanRepository {
         var calls = 0
-        override suspend fun plan(params: TripPlanParams): Result<List<Itinerary>> {
+        override suspend fun plan(params: TripPlanParams): Result<List<TripItinerary>> {
             calls++
             return result
         }
 
-        override fun planBlocking(builder: TripRequestBuilder): List<Itinerary> =
+        override fun planBlocking(builder: TripRequestBuilder): List<TripItinerary> =
             result.getOrDefault(emptyList())
     }
 
     /** A plan repository whose call suspends until [gate] is completed, to exercise the in-flight race. */
     private class GatedTripPlanRepository : TripPlanRepository {
-        val gate = CompletableDeferred<Result<List<Itinerary>>>()
+        val gate = CompletableDeferred<Result<List<TripItinerary>>>()
         var calls = 0
-        override suspend fun plan(params: TripPlanParams): Result<List<Itinerary>> {
+        override suspend fun plan(params: TripPlanParams): Result<List<TripItinerary>> {
             calls++
             return gate.await()
         }
 
-        override fun planBlocking(builder: TripRequestBuilder): List<Itinerary> = emptyList()
+        override fun planBlocking(builder: TripRequestBuilder): List<TripItinerary> = emptyList()
     }
 
     private inner class FakeAdvancedSettingsRepository : AdvancedSettingsRepository {
@@ -82,7 +82,7 @@ class TripPlanViewModelTest {
 
     private fun viewModel(
         geocode: GeocodeRepository = FakeGeocodeRepository(Result.success(emptyList())),
-        plan: TripPlanRepository = FakeTripPlanRepository(Result.success(listOf(Itinerary()))),
+        plan: TripPlanRepository = FakeTripPlanRepository(Result.success(listOf(TripItinerary()))),
         region: RegionRepository = FakeRegionRepository()
     ) = TripPlanViewModel(
         geocode, plan, region,
@@ -139,7 +139,7 @@ class TripPlanViewModelTest {
 
     @Test
     fun `clearFrom resets the origin to empty FreeText and does not submit`() = runTest {
-        val plan = FakeTripPlanRepository(Result.success(listOf(Itinerary())))
+        val plan = FakeTripPlanRepository(Result.success(listOf(TripItinerary())))
         val vm = viewModel(plan = plan)
         setBothEndpoints(vm)
         advanceUntilIdle()
@@ -155,7 +155,7 @@ class TripPlanViewModelTest {
 
     @Test
     fun `setting both endpoints with coordinates auto-submits the plan`() = runTest {
-        val plan = FakeTripPlanRepository(Result.success(listOf(Itinerary())))
+        val plan = FakeTripPlanRepository(Result.success(listOf(TripItinerary())))
         val vm = viewModel(plan = plan)
 
         vm.setFrom(origin)
@@ -207,7 +207,7 @@ class TripPlanViewModelTest {
         advanceUntilIdle()
         assertEquals(PlanResult.Idle, vm.planState.value)
 
-        plan.gate.complete(Result.success(listOf(Itinerary()))) // late completion of the stale plan
+        plan.gate.complete(Result.success(listOf(TripItinerary()))) // late completion of the stale plan
         advanceUntilIdle()
         assertEquals(PlanResult.Idle, vm.planState.value)
     }
@@ -231,7 +231,7 @@ class TripPlanViewModelTest {
 
     @Test
     fun `an endpoint without coordinates does not enable submit`() = runTest {
-        val plan = FakeTripPlanRepository(Result.success(listOf(Itinerary())))
+        val plan = FakeTripPlanRepository(Result.success(listOf(TripItinerary())))
         val vm = viewModel(plan = plan)
 
         vm.setFrom(TripEndpoint.AddressBook("Contact A", lat = null, lon = null))

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/TripResultsViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/TripResultsViewModelTest.kt
@@ -26,7 +26,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.onebusaway.android.testing.MainDispatcherRule
-import org.opentripplanner.api.model.Itinerary
+import org.onebusaway.android.directions.model.TripItinerary
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class TripResultsViewModelTest {
@@ -44,15 +44,15 @@ class TripResultsViewModelTest {
         var summary: Result<List<ItineraryOption>>,
         var directions: Result<List<DirectionItem>> = Result.success(emptyList())
     ) : TripResultsRepository {
-        val directionsForCalls = mutableListOf<Itinerary>()
-        override suspend fun summarize(itineraries: List<Itinerary>) = summary
-        override suspend fun directionsFor(itinerary: Itinerary): Result<List<DirectionItem>> {
+        val directionsForCalls = mutableListOf<TripItinerary>()
+        override suspend fun summarize(itineraries: List<TripItinerary>) = summary
+        override suspend fun directionsFor(itinerary: TripItinerary): Result<List<DirectionItem>> {
             directionsForCalls.add(itinerary)
             return directions
         }
     }
 
-    private fun itineraries(count: Int): List<Itinerary> = List(count) { Itinerary() }
+    private fun itineraries(count: Int): List<TripItinerary> = List(count) { TripItinerary() }
 
     @Test
     fun `initial state is Loading before itineraries are set`() = runTest {


### PR DESCRIPTION
## Summary

The trip-itinerary path (`TripPlanRepository`, `DirectionsGenerator`, the Compose trip-plan/results UI, the trip-plan monitor) read/wrote `org.opentripplanner.api.model.*` directly — POJOs from an unpublished 2017 snapshot jar (`edu.usf.cutr.opentripplanner.android:opentripplanner-pojos:1.0.0-SNAPSHOT`) that the project doesn't control, leaking as far as ViewModel/Compose signatures.

- Introduces `TripItinerary`/`TripLeg`/`TripPlace`/etc. (`directions/model/TripItinerary.kt`) as the app's own domain model, mapped once at the wire boundary (`api/adapters/TripPlanAdapters.kt`, following the existing `RegionAdapters.kt`/`ArrivalAdapters.kt` convention), and retargets every downstream consumer onto it.
- Server-provided timestamps are typed `ServerTime` (`org.onebusaway.android.time`), not raw `Instant` — matching this codebase's existing clock-domain-tagging pattern.
- `from`/`to`/`startTime`/`endTime` are non-null in the domain model: a well-formed OTP leg always has two endpoints and absolute times, so the adapter asserts that once (throwing on a genuinely malformed response) instead of every consumer repeating a `!!`.
- Fixes two real Android-serialization boundaries that relied on the OTP1 POJOs implementing `java.io.Serializable`: `TripRequestBuilder`'s `OptimizeType` Bundle write (now a plain `Boolean`), and the trip-monitor "trip changed" notification `Intent` (now JSON-encoded via kotlinx.serialization instead of `putExtra(String, Serializable)`).
- Removes several now-dead helpers that only existed to support the old POJOs: `ConversionUtils.fixTimezoneOffsets`/`getDuration`/`parseOtpDate`, `DirectionsGenerator.getTotalTimeTraveled` — all confirmed zero-caller before deletion.

Bikeshare (`BikeRentalStation`) migration and OTP 2.x GraphQL support are scoped out and tracked separately under the umbrella tracking issue.

Tracking: #1778
Follow-ups: #1779 (bikeshare), #1780 (OTP 2.x GraphQL)

## Test plan

- [x] `./gradlew :onebusaway-android:compileObaGoogleDebugKotlin -PwarningsAsErrors=true` — clean
- [x] `./gradlew :onebusaway-android:lintObaGoogleDebug -PwarningsAsErrors=true` — clean (no new baseline entries)
- [x] `./gradlew :onebusaway-android:testObaGoogleDebugUnitTest -PwarningsAsErrors=true` — all pass, including a new test covering the adapter's "missing required field" contract
- [x] On-device: built, installed, and manually verified the trip-planning flow (origin/destination entry → itineraries render → directions list → map route) on a physical device
- [ ] Live trip-plan monitoring (the notification `Intent` JSON round-trip) could not be manually exercised — that UI entry point is currently deprecated/removed from the app; covered by unit tests (`TripMonitorDeciderTest`) only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a unified trip itinerary model supporting transit, walking directions, stops, steps, geometry, timing, delays, and route modes.
  * Trip plans now decode into app-ready itinerary data for displaying results, directions, maps, and trip monitoring.
  * Added reliable itinerary serialization for restoring trip plans from notifications.

* **Bug Fixes**
  * Improved handling of missing required trip data and unknown direction or location values.
  * Preserved accurate trip timing, duration, delay, and geometry information across trip planning features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->