### PR TITLE
Change ETA pill to a localized "Xhr Ymin" format past an hour

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
@@ -82,6 +82,7 @@ import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.colorResource
@@ -90,10 +91,13 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.CustomAccessibilityAction
 import androidx.compose.ui.semantics.customActions
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.Velocity
@@ -123,6 +127,7 @@ import org.onebusaway.android.ui.compose.components.LineBadge
 import org.onebusaway.android.ui.compose.components.rememberRouteBadgeColors
 import org.onebusaway.android.ui.arrivals.RouteRowGroup
 import org.onebusaway.android.ui.compose.theme.ObaTheme
+import org.onebusaway.android.util.DisplayFormat
 
 /**
  * The per-arrival menu actions (legacy `showListItemMenu`). Implemented by the host activity,
@@ -857,25 +862,25 @@ private fun EtaContent(
             )
             EtaRealtimeIndicator(predicted, color)
         } else {
+            // One consistent "Xhr Ymin" shape: ["23", "min"] under an hour (the "0hr" is omitted), or
+            // ["1", "hr", " 30", "min"] past it. All parts render as a single AnnotatedString (not
+            // separate Text composables) so the text shaper kerns across the number/unit boundary
+            // instead of gluing together independently-measured boxes — splitting them produced
+            // inconsistent gaps (e.g. "1hr" vs "4hr") since cross-Text kerning isn't a thing.
+            val etaParts = DisplayFormat.formatEtaParts(LocalContext.current, eta)
+            val emphasizedSpan = SpanStyle(fontSize = 36.sp, fontWeight = FontWeight.Bold, color = color)
+            val unemphasizedSpan = MaterialTheme.typography.bodyMedium.toSpanStyle().copy(color = color)
             Text(
-                text = eta.toString(),
-                fontSize = 36.sp,
-                fontWeight = FontWeight.Bold,
-                color = color,
-                textDecoration = decoration,
-                modifier = Modifier.alignByBaseline()
+                text = buildAnnotatedString {
+                    etaParts.forEach { part ->
+                        withStyle(if (part.emphasized) emphasizedSpan else unemphasizedSpan) {
+                            append(part.text)
+                        }
+                    }
+                },
+                textDecoration = decoration
             )
-            // "min" shares the number's baseline; the indicator rides at its upper-right.
-            Row(modifier = Modifier.alignByBaseline(), verticalAlignment = Alignment.Top) {
-                Text(
-                    text = " " + stringResource(R.string.minutes_abbreviation),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = color,
-                    textDecoration = decoration,
-                    modifier = Modifier.alignByBaseline()
-                )
-                EtaRealtimeIndicator(predicted, color)
-            }
+            EtaRealtimeIndicator(predicted, color)
         }
     }
 }
@@ -955,44 +960,56 @@ internal fun EtaPill(
     } else {
         Modifier
     }
+    // One consistent "Xhr Ymin" shape: ["23", "min"] under an hour (the "0hr" is omitted), or
+    // ["1", "hr", " 30", "min"] past it — every number stays bold-sized, only the unit letters
+    // shrink, so the leftover minutes stay as legible as the hour count (#1777).
+    val etaParts = if (eta != 0L) DisplayFormat.formatEtaParts(LocalContext.current, eta) else null
     Surface(modifier = modifier.then(interaction), shape = shape, color = color) {
-        // Content bottom-aligned so that, with the strip bottom-aligning pills of different sizes, every
-        // pill's digits land on the same baseline (digits have no descender, so bottom ≈ baseline).
+        // Bottom-centers the whole (baseline-aligned) content block, so pills of different sizes in
+        // the strip still share a common bottom edge.
         Box(
             modifier = Modifier
                 .height(pillHeight)
                 .padding(horizontal = 6.dp),
             contentAlignment = Alignment.BottomCenter
         ) {
-            Row(verticalAlignment = Alignment.Bottom) {
-                if (eta != 0L) {
+            Row {
+                if (etaParts == null) {
                     Text(
-                        text = eta.toString(),
-                        fontSize = numberSize,
+                        text = stringResource(R.string.stop_info_eta_now),
+                        fontSize = nowSize,
                         fontWeight = FontWeight.Bold,
                         color = Color.White,
                         textDecoration = decoration
                     )
-                }
-                // The trailing label ("min" / "Now") with the radiating real-time indicator at its
-                // upper-right: top-aligning this inner row floats the small indicator to the label's
-                // top. The Box is always present so the pill width is stable whether or not it's live.
-                Row(verticalAlignment = Alignment.Top) {
+                } else {
+                    // A single AnnotatedString (not separate Text composables) so the text shaper
+                    // kerns across the number/unit boundary instead of gluing together
+                    // independently-measured boxes — splitting them produced inconsistent gaps
+                    // (e.g. "1hr" vs "4hr") since cross-Text kerning isn't a thing.
                     Text(
-                        text = if (eta == 0L) {
-                            stringResource(R.string.stop_info_eta_now)
-                        } else {
-                            " " + stringResource(R.string.minutes_abbreviation)
+                        text = buildAnnotatedString {
+                            etaParts.forEach { part ->
+                                withStyle(
+                                    SpanStyle(
+                                        fontSize = if (part.emphasized) numberSize else labelSize,
+                                        fontWeight = if (part.emphasized) FontWeight.Bold else FontWeight.Normal,
+                                        color = Color.White
+                                    )
+                                ) {
+                                    append(part.text)
+                                }
+                            }
                         },
-                        fontSize = if (eta == 0L) nowSize else labelSize,
-                        fontWeight = if (eta == 0L) FontWeight.Bold else FontWeight.Normal,
-                        color = Color.White,
                         textDecoration = decoration
                     )
-                    Box(Modifier.padding(start = 2.dp).size(indicatorSize)) {
-                        if (predicted) {
-                            RealtimeIndicator(color = Color.White, modifier = Modifier.fillMaxSize())
-                        }
+                }
+                // The radiating real-time indicator floats above the trailing unit ("min" / "Now"); it
+                // isn't baseline-aligned, so it takes the Row's default top alignment instead. The Box
+                // is always present so the pill width is stable whether or not it's live.
+                Box(Modifier.padding(start = 2.dp).size(indicatorSize)) {
+                    if (predicted) {
+                        RealtimeIndicator(color = Color.White, modifier = Modifier.fillMaxSize())
                     }
                 }
             }
@@ -1170,6 +1187,9 @@ private fun EtaPillStripPreview() {
                 EtaPill(12, colorResource(R.color.stop_info_early), predicted = true)
                 EtaPill(22, colorResource(R.color.stop_info_scheduled_time), predicted = false)
                 EtaPill(8, colorResource(R.color.stop_info_scheduled_time), predicted = false, canceled = true)
+                // Past an hour: the number switches to hours, the leftover minutes fold into the label (#1777).
+                EtaPill(83, colorResource(R.color.stop_info_scheduled_time), predicted = true)
+                EtaPill(125, colorResource(R.color.stop_info_early), predicted = false)
             }
         }
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/DisplayFormat.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/DisplayFormat.kt
@@ -19,6 +19,8 @@ package org.onebusaway.android.util
 import android.content.Context
 import android.text.format.DateUtils
 import androidx.annotation.StringRes
+import androidx.annotation.VisibleForTesting
+import kotlin.math.abs
 import org.onebusaway.android.R
 
 /**
@@ -127,6 +129,48 @@ object DisplayFormat {
                         )
                 }
             }
+        }
+    }
+
+    /** One piece of an ETA pill's display — a bold number or a small unit abbreviation, rendered in
+     *  sequence — see [formatEtaParts]. */
+    data class EtaPart(val text: String, val emphasized: Boolean)
+
+    /**
+     * Splits a non-zero ETA in minutes into one consistent "Xhr Ymin" shape of alternating
+     * bold-number/small-unit parts, rather than switching formats by magnitude (#1777): under an
+     * hour it's just `["23", "min"]` (the "0hr" is omitted), and past an hour it's
+     * `["1", "hr", " 30", "min"]`. Every number stays bold-sized so the leftover minutes stay as
+     * legible as the hour count. [minutes] may be negative for a recent-past arrival; the sign
+     * stays on the leading number.
+     */
+    @JvmStatic
+    fun formatEtaParts(context: Context, minutes: Long): List<EtaPart> = formatEtaParts(
+        minutes = minutes,
+        minutesAbbrev = context.getString(R.string.minutes_abbreviation),
+        hoursAbbrev = context.getString(R.string.eta_hours_abbreviation)
+    )
+
+    /** Pure core of [formatEtaParts] — takes the localized abbreviations directly so the split/roundoff
+     *  logic is unit-testable without an Android [Context]. */
+    @VisibleForTesting
+    fun formatEtaParts(minutes: Long, minutesAbbrev: String, hoursAbbrev: String): List<EtaPart> {
+        val magnitude = abs(minutes)
+        val sign = if (minutes < 0) "-" else ""
+        val hours = magnitude / MINUTES_IN_HOUR
+        val remainderMinutes = magnitude % MINUTES_IN_HOUR
+        return if (hours == 0L) {
+            listOf(
+                EtaPart("$sign$remainderMinutes", emphasized = true),
+                EtaPart(minutesAbbrev, emphasized = false)
+            )
+        } else {
+            listOf(
+                EtaPart("$sign$hours", emphasized = true),
+                EtaPart(hoursAbbrev, emphasized = false),
+                EtaPart(" $remainderMinutes", emphasized = true),
+                EtaPart(minutesAbbrev, emphasized = false)
+            )
         }
     }
 

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -687,6 +687,9 @@
     <string name="kilometers_abbreviation">km</string>
     <string name="minutes_abbreviation">min</string>
     <string name="minutes_full">minutes</string>
+    <!-- The ETA pill's hour unit — deliberately "hr" (not the single-letter hours_abbreviation used
+         elsewhere) to read friendlier alongside "min" in the "Xhr Ymin" format (#1777). -->
+    <string name="eta_hours_abbreviation">hr</string>
 
     <string name="preferences_preferred_vibration_title">Vibrate</string>
     <!-- Note: %1$s is replaced with app_name for white-label support -->

--- a/onebusaway-android/src/test/java/org/onebusaway/android/util/DisplayFormatTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/util/DisplayFormatTest.kt
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.onebusaway.android.util.DisplayFormat.EtaPart
+
+/**
+ * JVM unit tests for [DisplayFormat.formatEtaParts]'s minutes/hours split (issue #1777): one
+ * consistent "Xhr Ymin" shape of alternating bold-number/small-unit parts for every non-zero ETA,
+ * with the "Xhr" segment simply omitted under an hour, rather than switching between a bare-minute
+ * format and an hours+minutes format depending on magnitude.
+ */
+class DisplayFormatTest {
+
+    private fun format(minutes: Long): List<EtaPart> =
+        DisplayFormat.formatEtaParts(minutes, minutesAbbrev = "min", hoursAbbrev = "hr")
+
+    @Test
+    fun `zero minutes omits the hour segment`() {
+        assertEquals(
+            listOf(EtaPart("0", emphasized = true), EtaPart("min", emphasized = false)),
+            format(0)
+        )
+    }
+
+    @Test
+    fun `under an hour omits the hour segment`() {
+        assertEquals(
+            listOf(EtaPart("23", emphasized = true), EtaPart("min", emphasized = false)),
+            format(23)
+        )
+    }
+
+    @Test
+    fun `fifty nine minutes still omits the hour segment`() {
+        assertEquals(
+            listOf(EtaPart("59", emphasized = true), EtaPart("min", emphasized = false)),
+            format(59)
+        )
+    }
+
+    @Test
+    fun `exactly one hour includes a zero leftover-minutes segment`() {
+        assertEquals(
+            listOf(
+                EtaPart("1", emphasized = true),
+                EtaPart("hr", emphasized = false),
+                EtaPart(" 0", emphasized = true),
+                EtaPart("min", emphasized = false)
+            ),
+            format(60)
+        )
+    }
+
+    @Test
+    fun `an hour and change splits into bold hour and bold leftover minutes, with a gap between the halves`() {
+        assertEquals(
+            listOf(
+                EtaPart("1", emphasized = true),
+                EtaPart("hr", emphasized = false),
+                EtaPart(" 23", emphasized = true),
+                EtaPart("min", emphasized = false)
+            ),
+            format(83)
+        )
+    }
+
+    @Test
+    fun `multiple hours split correctly`() {
+        assertEquals(
+            listOf(
+                EtaPart("2", emphasized = true),
+                EtaPart("hr", emphasized = false),
+                EtaPart(" 5", emphasized = true),
+                EtaPart("min", emphasized = false)
+            ),
+            format(125)
+        )
+    }
+
+    @Test
+    fun `a recent-past eta under an hour keeps its sign on the number`() {
+        assertEquals(
+            listOf(EtaPart("-5", emphasized = true), EtaPart("min", emphasized = false)),
+            format(-5)
+        )
+    }
+
+    @Test
+    fun `a recent-past eta over an hour keeps its sign on the leading hour number`() {
+        assertEquals(
+            listOf(
+                EtaPart("-1", emphasized = true),
+                EtaPart("hr", emphasized = false),
+                EtaPart(" 23", emphasized = true),
+                EtaPart("min", emphasized = false)
+            ),
+            format(-83)
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- The ETA pill previously always showed a raw minute count ("125 min"), which is hard to parse past an hour and isn't how elapsed time is conventionally expressed.
- It now renders a consistent "Xhr Ymin" shape for every non-zero ETA — the "Xhr" segment is simply omitted under an hour (e.g. "23min"), and past an hour it's e.g. "2hr 5min". The leftover minutes stay bold/legible, matching the hour count.
- Number and unit segments render as a single `AnnotatedString` (rather than separate `Text` composables) so the text shaper kerns correctly across the number/unit boundary.
- Investigated the iOS app and Android's own `DateComponentsFormatter`-style options; iOS doesn't solve this either (always raw minutes), so this introduces the hour+minute split fresh, following the existing hour/minute string-resource convention already used elsewhere in this codebase (`DisplayFormat.getNoArrivalsMessage`).

Fixes #1777.

## Test plan
- [x] `./gradlew :onebusaway-android:compileObaGoogleDebugKotlin -PwarningsAsErrors=true` — clean, matches CI's strict warnings gate
- [x] `./gradlew :onebusaway-android:testObaGoogleDebugUnitTest -PwarningsAsErrors=true` — all unit tests pass, including new `DisplayFormatTest` coverage of the minute/hour split (boundary at 60, sign handling, multi-hour)
- [x] Installed on a physical device and confirmed the pill renders correctly against live transit data (both under- and over-an-hour arrivals)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * ETA displays now use consistent formatting for minutes and hour-plus-minute arrivals.
  * Arrival times over an hour are shown in a clearer “X hr Y min” format.
  * Past arrival times retain their negative indicator, while canceled trips and realtime indicators continue to display as before.
  * ETA pills now align units and realtime indicators more consistently.
* **Bug Fixes**
  * Improved handling of zero-minute, under-an-hour, and multi-hour ETA values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->