### PR TITLE
Arrivals: factor out an EtaStrip composable + scroll-affordance polish

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/RouteRowGroup.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/RouteRowGroup.kt
@@ -49,6 +49,11 @@ data class RouteRowGroup(val trips: List<ArrivalInfo>) {
     /** The soonest trip; source of the row's route badge, headsign, and route-level actions/color. */
     val representative: ArrivalInfo get() = trips.first()
 
+    /** Index of the soonest *upcoming* (first non-negative ETA) trip — the ETA the row is sorted by
+     *  (see [departureSortEta]) — or null when every trip is recent-past. Lets a row justify that pill
+     *  to the leading edge so the recent-past pills overflow before it. */
+    val firstUpcomingIndex: Int? get() = trips.indexOfFirst { it.eta >= 0 }.takeIf { it >= 0 }
+
     val routeId: String get() = representative.routeId
 
     /** The direction name shown on top of the row (may be blank). */

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
@@ -17,24 +17,17 @@ package org.onebusaway.android.ui.arrivals.components
 
 import androidx.compose.animation.core.FastOutLinearInEasing
 import androidx.compose.animation.core.RepeatMode
-import androidx.compose.animation.core.animate
 import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.combinedClickable
-import androidx.compose.foundation.horizontalScroll
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.IntrinsicSize
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -42,12 +35,9 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowForward
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
@@ -57,40 +47,19 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableFloatStateOf
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberUpdatedState
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.clipToBounds
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.Stroke
-import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.hapticfeedback.HapticFeedbackType
-import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
-import androidx.compose.ui.input.nestedscroll.NestedScrollSource
-import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.CustomAccessibilityAction
-import androidx.compose.ui.semantics.customActions
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontFamily
@@ -99,21 +68,10 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.IntOffset
-import androidx.compose.ui.unit.Velocity
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import kotlin.coroutines.cancellation.CancellationException
-import kotlin.math.roundToInt
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.currentCoroutineContext
-import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.launch
 import org.onebusaway.android.R
 import org.onebusaway.android.models.ArrivalData
 import org.onebusaway.android.models.FrequencyWindow
@@ -350,6 +308,9 @@ fun RouteArrivalRow(
                         dataVersion = dataVersion,
                         actionsFor = actionsFor,
                         callbacks = callbacks,
+                        // Justify the soonest upcoming pill to the leading edge (the ETA the row is
+                        // sorted by), so recent-past pills overflow left.
+                        start = group.firstUpcomingIndex,
                         firstPillModifier = etaAnchor,
                     )
                 }
@@ -403,326 +364,6 @@ private fun DirectionHeader(direction: String) {
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
         )
-    }
-}
-
-// Pull-past-end-to-load tuning. The strip captures a drag that continues past its last pill and, once
-// it crosses [PULL_TO_LOAD_THRESHOLD], loads more arrivals on release (the old footer button's job).
-/** Finger travel maps to pull distance at this ratio, so the pull lags the finger for a rubber-band feel. */
-private const val PULL_RESISTANCE = 0.5f
-/** Pull distance (post-resistance) that arms the load-more trigger. */
-private val PULL_TO_LOAD_THRESHOLD = 48.dp
-/** Pull distance is clamped here so the strip can't be dragged arbitrarily far off its end. */
-private val PULL_TO_LOAD_MAX = 72.dp
-/**
- * The horizontally-scrollable strip of per-trip ETA pills below the direction name. When the pills
- * overflow the row, a right-edge fade + chevron appears to signal there's more to scroll to; it's a
- * pure visual hint (no pointer handling) so it never blocks the strip's own drag-to-scroll.
- *
- * Dragging the strip past its last pill (once there's nothing more to scroll) builds a resistive pull
- * that reveals a trailing load-more affordance; releasing past [PULL_TO_LOAD_THRESHOLD] widens the
- * arrivals window via [ArrivalRowCallbacks.onLoadMore] — this replaced the drawer's footer button
- * (issue #1707 follow-up). A TalkBack custom action exposes the same load-more for non-drag users.
- */
-@Composable
-private fun EtaStrip(
-    trips: List<ArrivalInfo>,
-    // The Content.dataVersion this strip's trips came from. MUST come from the same Content object as
-    // the trips themselves, so the strip can never see a version ahead of its rendered pills.
-    dataVersion: Long,
-    actionsFor: (ArrivalInfo) -> ArrivalActions?,
-    callbacks: ArrivalRowCallbacks,
-    modifier: Modifier = Modifier,
-    firstPillModifier: Modifier = Modifier,
-) {
-    val scrollState = rememberScrollState()
-    val canScrollForward by remember { derivedStateOf { scrollState.canScrollForward } }
-    val density = LocalDensity.current
-    val triggerPx = remember(density) { with(density) { PULL_TO_LOAD_THRESHOLD.toPx() } }
-    val maxPullPx = remember(density) { with(density) { PULL_TO_LOAD_MAX.toPx() } }
-    // Current pull distance in px (post-resistance). Written from the nested-scroll callbacks and read
-    // in the layout/graphics phase, so growing it during a drag doesn't recompose the whole strip.
-    val pull = remember { mutableFloatStateOf(0f) }
-    // Whether the pull has crossed the arm threshold. A derivedState kept out of this composable's own
-    // read set so only its reader (the chip) recomposes when it flips — never the whole strip per frame.
-    val armed = remember(triggerPx) { derivedStateOf { pull.floatValue >= triggerPx } }
-    val loadMoreLabel = stringResource(R.string.stop_info_load_more_arrivals)
-    val haptic = LocalHapticFeedback.current
-
-    // The strip's active load-more request: the token returned at fire time, NO_LOAD_REQUEST at rest.
-    // Saveable so a list eviction / recreation mid-load resumes (or cleanly ends) the transaction.
-    val request = rememberSaveable { mutableIntStateOf(NO_LOAD_REQUEST) }
-    val loadMore by callbacks.loadMoreState.collectAsStateWithLifecycle()
-    // The spinner shows from fire until the composition that carries the completing data's version, so
-    // the spinner and the new pills swap in the SAME composition — never a frame where both/neither
-    // show. At rest, request is NO_LOAD_REQUEST, which reads as Superseded → no spinner.
-    val loadingMore = spinnerVisible(loadMoreOutcome(loadMore, request.intValue), dataVersion)
-
-    // Layout acknowledgement: the highest dataVersion whose strip content has been MEASURED. Written in
-    // the measure pass that wraps horizontalScroll — the same pass (and snapshot batch) in which
-    // scrollState.maxValue is brought up to date — so `measuredVersion >= V` GUARANTEES maxValue is
-    // consistent with data version V. Read only from snapshotFlow (never composition), so writing it
-    // per layout pass can't cause recomposition loops.
-    val measuredVersion = remember { mutableLongStateOf(0L) }
-    val versionState = rememberUpdatedState(dataVersion)
-
-    // The reveal transaction for this strip's request: keep the strip pinned to its (moving) right end
-    // — first the spinner slot, then the reloaded pills — and settle once the layout provably reflects
-    // the data that completed the request. Every wait is a level-triggered predicate over monotonic
-    // snapshot/StateFlow state, so a signal that fires before we start listening is still observed.
-    LaunchedEffect(request.intValue) {
-        val token = request.intValue
-        if (token == NO_LOAD_REQUEST) return@LaunchedEffect
-        try {
-            coroutineScope {
-                // FOLLOWER: glides to the current end whenever there is one to reach. Each glide runs
-                // TO COMPLETION and the loop then re-evaluates against current state (never
-                // collectLatest: a change mid-glide is caught by the fresh level-triggered re-await,
-                // so there is no lost-update window).
-                val follower = launch {
-                    while (true) {
-                        snapshotFlow { scrollState.maxValue > scrollState.value }.first { it }
-                        try {
-                            scrollState.animateScrollTo(scrollState.maxValue)
-                        } catch (cause: CancellationException) {
-                            currentCoroutineContext().ensureActive() // real teardown propagates
-                            // Lost the scrollable mutex to a touch. Never contest user input: resume
-                            // the chase only once the strip is fully at rest. (A drag that actually
-                            // travels ends the whole transaction via the nested-scroll hook.)
-                            snapshotFlow { scrollState.isScrollInProgress }.first { !it }
-                        }
-                    }
-                }
-                // AWAIT RESULT: level-triggered on the VM's StateFlow — a Finished that landed before
-                // we started collecting is still observed (StateFlow replays its value).
-                val landed = callbacks.loadMoreState
-                    .map { loadMoreOutcome(it, token) }
-                    .first { it !is LoadMoreOutcome.Pending }
-                if (landed is LoadMoreOutcome.Landed) {
-                    // SETTLE: wait until (a) layout reflects the completing data's version — which,
-                    // via the layout-ack modifier, also means maxValue is current for that data and
-                    // the spinner slot is gone (spinner and new pills swap in the same composition,
-                    // both keyed on dataVersion) — and (b) we are at rest at the true end. Success
-                    // with new pills, success with none for this row, and failure all take this one
-                    // path: the end is wherever layout says it is.
-                    snapshotFlow {
-                        measuredVersion.longValue >= landed.dataVersion &&
-                            scrollState.value == scrollState.maxValue &&
-                            !scrollState.isScrollInProgress
-                    }.first { it }
-                }
-                follower.cancel()
-            }
-        } finally {
-            // Idempotent teardown; guarded so a user-takeover or a re-fire (which already moved
-            // `request`) isn't clobbered.
-            if (request.intValue == token) request.intValue = NO_LOAD_REQUEST
-        }
-    }
-
-    val pullConnection = remember(scrollState, callbacks, triggerPx, maxPullPx, haptic) {
-        object : NestedScrollConnection {
-            // Dragging back toward the pills unwinds an active pull before the strip itself scrolls.
-            override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
-                // Programmatic glides dispatch as SideEffect; only real user input drives the pull and
-                // the take-over below.
-                if (source != NestedScrollSource.UserInput) return Offset.Zero
-                // A real user scroll on this strip while a reveal transaction is active ends it: the
-                // user wins, the transaction effect is cancelled (killing any in-flight glide via the
-                // scrollable mutex), and the spinner is dropped. The load itself continues in the
-                // ViewModel; its pills land unanimated.
-                if (request.intValue != NO_LOAD_REQUEST) request.intValue = NO_LOAD_REQUEST
-                // Dragging back toward the pills unwinds an active pull before the strip itself scrolls.
-                if (available.x > 0f && pull.floatValue > 0f) {
-                    val consumedFinger = (pull.floatValue / PULL_RESISTANCE).coerceAtMost(available.x)
-                    pull.floatValue -= consumedFinger * PULL_RESISTANCE
-                    return Offset(consumedFinger, 0f)
-                }
-                return Offset.Zero
-            }
-
-            // Past the strip's end, a further left-drag (negative x) builds the resistive pull; a light
-            // tick fires the instant it crosses the arm threshold (rising edge only).
-            override fun onPostScroll(consumed: Offset, available: Offset, source: NestedScrollSource): Offset {
-                if (source == NestedScrollSource.UserInput && available.x < 0f && !scrollState.canScrollForward) {
-                    val before = pull.floatValue
-                    pull.floatValue = (before - available.x * PULL_RESISTANCE).coerceAtMost(maxPullPx)
-                    if (before < triggerPx && pull.floatValue >= triggerPx) {
-                        haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                    }
-                    return Offset(available.x, 0f)
-                }
-                return Offset.Zero
-            }
-
-            // Drag released: fire load-more if armed (the reveal transaction, keyed on the request
-            // token, then pins the strip to its end), then spring the pull back.
-            override suspend fun onPreFling(available: Velocity): Velocity {
-                if (pull.floatValue <= 0f) return Velocity.Zero
-                if (pull.floatValue >= triggerPx) {
-                    // The VM sets Loading(token) synchronously inside onLoadMore, so the spinner is
-                    // already visible in the composition this write lands in — no gap.
-                    request.intValue = callbacks.onLoadMore()
-                }
-                animate(pull.floatValue, 0f) { value, _ -> pull.floatValue = value }
-                // Swallow the fling — there's nothing left to scroll to at the strip's end.
-                return available
-            }
-        }
-    }
-
-    Box(
-        modifier
-            .clipToBounds()
-            .nestedScroll(pullConnection)
-            .semantics {
-                customActions = listOf(
-                    // The full transaction, so TalkBack users get the same spinner + reveal.
-                    CustomAccessibilityAction(loadMoreLabel) {
-                        request.intValue = callbacks.onLoadMore(); true
-                    }
-                )
-            }
-    ) {
-        Row(
-            modifier = Modifier
-                // Follow the pull so the pills slide aside, opening the gap the load-more chip fills.
-                .offset { IntOffset(-pull.floatValue.roundToInt(), 0) }
-                // The composition↔layout bridge: measure the scroll content, then record the data
-                // version this layout reflects (see acknowledgeVersion).
-                .acknowledgeVersion(versionState, measuredVersion)
-                .horizontalScroll(scrollState),
-            horizontalArrangement = Arrangement.spacedBy(6.dp),
-            // Bottom-align so a smaller recent-past pill sits on the same baseline as the full-size ones.
-            verticalAlignment = Alignment.Bottom
-        ) {
-            trips.forEachIndexed { index, trip ->
-                EtaPillWithMenu(
-                    trip = trip,
-                    actions = actionsFor(trip),
-                    callbacks = callbacks,
-                    modifier = if (index == 0) firstPillModifier else Modifier,
-                )
-            }
-            // While the reload is in flight, the spinner rides as a real tail item so it reserves its
-            // own slot to the right of the last pill (rather than overlaying it); when the completing
-            // data's composition lands it's dropped in the same frame the new pills appear, and the
-            // strip glides left to the new end.
-            if (loadingMore) {
-                Box(
-                    modifier = Modifier.size(width = 28.dp, height = 32.dp),
-                    contentAlignment = Alignment.Center
-                ) {
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(20.dp),
-                        strokeWidth = 2.dp,
-                        color = MaterialTheme.colorScheme.primary
-                    )
-                }
-            }
-        }
-        // The pull-revealed load-more chip (invisible at rest, armed as the pull crosses the threshold).
-        // Hidden while loading — the inline spinner above takes over then.
-        if (!loadingMore) {
-            LoadMorePullChip(
-                progress = { (pull.floatValue / triggerPx).coerceIn(0f, 1f) },
-                armed = { armed.value },
-                contentDescription = loadMoreLabel,
-                modifier = Modifier.align(Alignment.CenterEnd),
-            )
-        }
-        if (canScrollForward && !loadingMore) {
-            Row(
-                modifier = Modifier
-                    .align(Alignment.CenterEnd)
-                    .fillMaxHeight(),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Box(
-                    Modifier
-                        .width(24.dp)
-                        .fillMaxHeight()
-                        .background(
-                            Brush.horizontalGradient(
-                                listOf(Color.Transparent, MaterialTheme.colorScheme.surfaceContainer)
-                            )
-                        )
-                )
-                Icon(
-                    painter = painterResource(R.drawable.ic_navigation_chevron_right),
-                    // Decorative: a pure "there's more to scroll" hint over the scrollable pill strip,
-                    // not an actionable control — so TalkBack skips it.
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier
-                        .background(MaterialTheme.colorScheme.surfaceContainer)
-                        .size(20.dp)
-                )
-            }
-        }
-    }
-}
-
-/**
- * The circular load-more affordance uncovered as the ETA strip is pulled past its end. [progress]
- * (0..1, read in the graphics phase to avoid recomposing on every drag frame) fades and slides it in;
- * [armed] (progress has reached 1) flips it to the primary color so "release to load" reads at a glance.
- */
-@Composable
-private fun LoadMorePullChip(
-    progress: () -> Float,
-    armed: () -> Boolean,
-    contentDescription: String,
-    modifier: Modifier = Modifier,
-) {
-    val slidePx = with(LocalDensity.current) { 20.dp.toPx() }
-    // Reading the arm lambda here scopes threshold-crossing recomposition to just this small chip.
-    val isArmed = armed()
-    val container = if (isArmed) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surfaceVariant
-    val content = if (isArmed) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurfaceVariant
-    Box(
-        modifier = modifier
-            .graphicsLayer {
-                val p = progress()
-                alpha = p
-                // Slide in from the right edge as the pull grows (fully seated at p == 1).
-                translationX = (1f - p) * slidePx
-            }
-            .size(30.dp)
-            .clip(CircleShape)
-            .background(container),
-        contentAlignment = Alignment.Center
-    ) {
-        Icon(
-            imageVector = Icons.AutoMirrored.Filled.ArrowForward,
-            contentDescription = contentDescription,
-            tint = content,
-            modifier = Modifier.size(18.dp)
-        )
-    }
-}
-
-/** A single ETA pill with its long-press per-trip menu. Tap focuses the vehicle; long-press opens
- *  the menu (trip details / reminder / report). */
-@Composable
-private fun EtaPillWithMenu(
-    trip: ArrivalInfo,
-    actions: ArrivalActions?,
-    callbacks: ArrivalRowCallbacks,
-    modifier: Modifier = Modifier,
-) {
-    var expanded by remember { mutableStateOf(false) }
-    Box {
-        EtaPill(
-            eta = trip.eta,
-            color = colorResource(trip.color),
-            predicted = trip.predicted,
-            modifier = modifier,
-            canceled = trip.status == Status.CANCELED,
-            onClick = { callbacks.onEtaClick(trip) },
-            onLongClick = { expanded = true },
-        )
-        TripActionsMenu(expanded, { expanded = false }, trip, actions, callbacks)
     }
 }
 
@@ -781,31 +422,6 @@ internal fun RouteActionsMenu(
         if (!url.isNullOrBlank()) {
             MenuRow(R.string.bus_options_menu_show_route_schedule) {
                 onDismiss(); callbacks.onShowRouteSchedule(url)
-            }
-        }
-    }
-}
-
-/** The per-trip menu opened by long-pressing a pill: trip details, a reminder, or a problem report
- *  for that specific trip. Route-wide actions live on the row's ⋮ menu ([RouteActionsMenu]). */
-@Composable
-internal fun TripActionsMenu(
-    expanded: Boolean,
-    onDismiss: () -> Unit,
-    arrival: ArrivalInfo,
-    actions: ArrivalActions?,
-    callbacks: ArrivalRowCallbacks
-) {
-    DropdownMenu(expanded = expanded, onDismissRequest = onDismiss) {
-        MenuRow(R.string.bus_options_menu_show_trip_details) {
-            onDismiss(); callbacks.onShowTripStatus(arrival)
-        }
-        MenuRow(R.string.bus_options_menu_set_reminder) {
-            onDismiss(); callbacks.onSetReminder(arrival)
-        }
-        if (actions != null) {
-            MenuRow(R.string.bus_options_menu_report_trip_problem) {
-                onDismiss(); callbacks.onReportArrivalProblem(actions)
             }
         }
     }
@@ -925,98 +541,6 @@ internal fun RealtimeIndicator(color: Color, modifier: Modifier = Modifier) {
 private fun strikeThroughIf(canceled: Boolean): TextDecoration =
     if (canceled) TextDecoration.LineThrough else TextDecoration.None
 
-/**
- * The prominent white-on-lateness ETA pill — one per trip in a route row's strip (and the Home legend
- * dialog, which passes no clicks). [onClick] taps focus that trip's vehicle + stop; [onLongClick]
- * opens the trip menu; [canceled] strikes the text through.
- *
- * A recent-past (negative-ETA) trip renders **compact** — 75% of the size — to de-emphasize it against
- * the upcoming arrivals, while the strip bottom-aligns so its digits still sit on the shared baseline.
- */
-@OptIn(ExperimentalFoundationApi::class)
-@Composable
-internal fun EtaPill(
-    eta: Long,
-    color: Color,
-    predicted: Boolean,
-    modifier: Modifier = Modifier,
-    canceled: Boolean = false,
-    onClick: (() -> Unit)? = null,
-    onLongClick: (() -> Unit)? = null,
-) {
-    val decoration = if (canceled) TextDecoration.LineThrough else null
-    val shape = RoundedCornerShape(8.dp)
-    // Recent-past arrivals (negative ETA) shrink to 75% so the upcoming "big numbers" dominate the strip.
-    val compact = eta < 0
-    val pillHeight = if (compact) 24.dp else 32.dp
-    val numberSize = if (compact) 21.sp else 28.sp
-    val labelSize = if (compact) 11.sp else 14.sp
-    val nowSize = if (compact) 17.sp else 22.sp
-    val indicatorSize = if (compact) 6.dp else 8.dp
-    // A single combinedClickable serves both tap (focus vehicle) and long-press (trip menu). Placed on
-    // the modifier the Surface clips, so the ripple stays inside the pill.
-    val interaction = if (onClick != null || onLongClick != null) {
-        Modifier.combinedClickable(onClick = { onClick?.invoke() }, onLongClick = onLongClick)
-    } else {
-        Modifier
-    }
-    // One consistent "Xhr Ymin" shape: ["23", "min"] under an hour (the "0hr" is omitted), or
-    // ["1", "hr", " 30", "min"] past it — every number stays bold-sized, only the unit letters
-    // shrink, so the leftover minutes stay as legible as the hour count (#1777).
-    val etaParts = if (eta != 0L) DisplayFormat.formatEtaParts(LocalContext.current, eta) else null
-    Surface(modifier = modifier.then(interaction), shape = shape, color = color) {
-        // Bottom-centers the whole (baseline-aligned) content block, so pills of different sizes in
-        // the strip still share a common bottom edge.
-        Box(
-            modifier = Modifier
-                .height(pillHeight)
-                .padding(horizontal = 6.dp),
-            contentAlignment = Alignment.BottomCenter
-        ) {
-            Row {
-                if (etaParts == null) {
-                    Text(
-                        text = stringResource(R.string.stop_info_eta_now),
-                        fontSize = nowSize,
-                        fontWeight = FontWeight.Bold,
-                        color = Color.White,
-                        textDecoration = decoration
-                    )
-                } else {
-                    // A single AnnotatedString (not separate Text composables) so the text shaper
-                    // kerns across the number/unit boundary instead of gluing together
-                    // independently-measured boxes — splitting them produced inconsistent gaps
-                    // (e.g. "1hr" vs "4hr") since cross-Text kerning isn't a thing.
-                    Text(
-                        text = buildAnnotatedString {
-                            etaParts.forEach { part ->
-                                withStyle(
-                                    SpanStyle(
-                                        fontSize = if (part.emphasized) numberSize else labelSize,
-                                        fontWeight = if (part.emphasized) FontWeight.Bold else FontWeight.Normal,
-                                        color = Color.White
-                                    )
-                                ) {
-                                    append(part.text)
-                                }
-                            }
-                        },
-                        textDecoration = decoration
-                    )
-                }
-                // The radiating real-time indicator floats above the trailing unit ("min" / "Now"); it
-                // isn't baseline-aligned, so it takes the Row's default top alignment instead. The Box
-                // is always present so the pill width is stable whether or not it's live.
-                Box(Modifier.padding(start = 2.dp).size(indicatorSize)) {
-                    if (predicted) {
-                        RealtimeIndicator(color = Color.White, modifier = Modifier.fillMaxSize())
-                    }
-                }
-            }
-        }
-    }
-}
-
 // ---------------------------------------------------------------------------------------------
 // Previews.
 
@@ -1061,7 +585,7 @@ private const val PREVIEW_MIN_MS = 60_000L
  * color. A null context is passed deliberately — the row shows only the badge, headsign, and pills, so
  * the (context-dependent) status/time labels stay empty and no resources/app singletons are touched.
  */
-private fun previewArrival(
+internal fun previewArrival(
     shortName: String,
     headsign: String,
     etaMinutes: Long,
@@ -1088,7 +612,7 @@ private fun previewArrival(
 }
 
 /** No-op [ArrivalRowCallbacks] for previews (nothing is interactive in a static preview). */
-private fun previewRowCallbacks() = ArrivalRowCallbacks(
+internal fun previewRowCallbacks() = ArrivalRowCallbacks(
     onRouteFavorite = {},
     onShowVehiclesOnMap = {},
     onEtaClick = {},
@@ -1164,32 +688,6 @@ private fun RouteArrivalRowPreview() {
                     filterActive = false,
                     callbacks = callbacks,
                 )
-            }
-        }
-    }
-}
-
-@Preview(showBackground = true)
-@Composable
-private fun EtaPillStripPreview() {
-    ObaTheme {
-        Surface(color = MaterialTheme.colorScheme.surfaceContainer) {
-            // Bottom-aligned like the real strip, so the compact past pill shares the baseline.
-            Row(
-                Modifier.padding(8.dp),
-                horizontalArrangement = Arrangement.spacedBy(6.dp),
-                verticalAlignment = Alignment.Bottom
-            ) {
-                // A recent-past arrival: renders at 75% size.
-                EtaPill(-3, colorResource(R.color.stop_info_delayed), predicted = true)
-                EtaPill(0, colorResource(R.color.stop_info_ontime), predicted = true)
-                EtaPill(5, colorResource(R.color.stop_info_delayed), predicted = true)
-                EtaPill(12, colorResource(R.color.stop_info_early), predicted = true)
-                EtaPill(22, colorResource(R.color.stop_info_scheduled_time), predicted = false)
-                EtaPill(8, colorResource(R.color.stop_info_scheduled_time), predicted = false, canceled = true)
-                // Past an hour: the number switches to hours, the leftover minutes fold into the label (#1777).
-                EtaPill(83, colorResource(R.color.stop_info_scheduled_time), predicted = true)
-                EtaPill(125, colorResource(R.color.stop_info_early), predicted = false)
             }
         }
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStrip.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStrip.kt
@@ -1,0 +1,697 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.arrivals.components
+
+import androidx.compose.animation.core.animate
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowForward
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.CustomAccessibilityAction
+import androidx.compose.ui.semantics.customActions
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.Velocity
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlin.coroutines.cancellation.CancellationException
+import kotlin.math.roundToInt
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+import org.onebusaway.android.R
+import org.onebusaway.android.models.Status
+import org.onebusaway.android.ui.arrivals.ArrivalActions
+import org.onebusaway.android.ui.arrivals.ArrivalInfo
+import org.onebusaway.android.ui.compose.theme.ObaTheme
+import org.onebusaway.android.util.DisplayFormat
+
+// The ETA strip: a route/direction's per-trip ETA pills in a horizontally-scrollable, overflow-aware
+// row (the scroll + "there's more" chevron), each pill carrying its long-press menu, plus the
+// pull-past-the-end gesture that widens the arrivals window. Split out of ArrivalRows.kt so the strip
+// is a self-contained unit; RouteArrivalRow supplies the badge/divider/heading scaffold around it.
+
+// Pull-past-end-to-load tuning. The strip captures a drag that continues past its last pill and, once
+// it crosses [PULL_TO_LOAD_THRESHOLD], loads more arrivals on release (the old footer button's job).
+/** Finger travel maps to pull distance at this ratio, so the pull lags the finger for a rubber-band feel. */
+private const val PULL_RESISTANCE = 0.5f
+/** Pull distance (post-resistance) that arms the load-more trigger. */
+private val PULL_TO_LOAD_THRESHOLD = 48.dp
+/** Pull distance is clamped here so the strip can't be dragged arbitrarily far off its end. */
+private val PULL_TO_LOAD_MAX = 72.dp
+
+/**
+ * The horizontally-scrollable strip of per-trip ETA pills below the direction name. When the pills
+ * overflow the row, a right-edge fade + chevron appears to signal there's more to scroll to; it's a
+ * pure visual hint (no pointer handling) so it never blocks the strip's own drag-to-scroll.
+ *
+ * Dragging the strip past its last pill (once there's nothing more to scroll) builds a resistive pull
+ * that reveals a trailing load-more affordance; releasing past [PULL_TO_LOAD_THRESHOLD] widens the
+ * arrivals window via [ArrivalRowCallbacks.onLoadMore] — this replaced the drawer's footer button
+ * (issue #1707 follow-up). A TalkBack custom action exposes the same load-more for non-drag users.
+ */
+@Composable
+internal fun EtaStrip(
+    trips: List<ArrivalInfo>,
+    // The Content.dataVersion this strip's trips came from. MUST come from the same Content object as
+    // the trips themselves, so the strip can never see a version ahead of its rendered pills.
+    dataVersion: Long,
+    actionsFor: (ArrivalInfo) -> ArrivalActions?,
+    callbacks: ArrivalRowCallbacks,
+    modifier: Modifier = Modifier,
+    // The trip index to justify to the strip's leading (left) edge on first display; earlier trips
+    // (e.g. the recent-past, negative-ETA pills) then overflow off the left, reachable via the left
+    // chevron. Null (or index 0) leaves the strip at its start.
+    start: Int? = null,
+    firstPillModifier: Modifier = Modifier,
+    // Hoisted so callers (and previews) can control/observe the scroll — e.g. a preview starts it
+    // mid-scroll to show both edge chevrons.
+    scrollState: ScrollState = rememberScrollState(),
+) {
+    val canScrollForward by remember { derivedStateOf { scrollState.canScrollForward } }
+    val canScrollBackward by remember { derivedStateOf { scrollState.canScrollBackward } }
+
+    // Justify the `start` pill to the leading edge: capture its content-x (positionInParent is
+    // scroll-independent, so it's the offset from the content's start) once, then scroll there. One-shot
+    // — a later ETA update or a user scroll isn't yanked back.
+    val justifyIndex = start?.takeIf { it in 1..trips.lastIndex }
+    var justifyOffsetPx by remember { mutableIntStateOf(-1) }
+    LaunchedEffect(justifyOffsetPx) {
+        if (justifyOffsetPx > 0) scrollState.scrollTo(justifyOffsetPx)
+    }
+    val density = LocalDensity.current
+    val triggerPx = remember(density) { with(density) { PULL_TO_LOAD_THRESHOLD.toPx() } }
+    val maxPullPx = remember(density) { with(density) { PULL_TO_LOAD_MAX.toPx() } }
+    // Current pull distance in px (post-resistance). Written from the nested-scroll callbacks and read
+    // in the layout/graphics phase, so growing it during a drag doesn't recompose the whole strip.
+    val pull = remember { mutableFloatStateOf(0f) }
+    // Whether the pull has crossed the arm threshold. A derivedState kept out of this composable's own
+    // read set so only its reader (the chip) recomposes when it flips — never the whole strip per frame.
+    val armed = remember(triggerPx) { derivedStateOf { pull.floatValue >= triggerPx } }
+    val loadMoreLabel = stringResource(R.string.stop_info_load_more_arrivals)
+    val haptic = LocalHapticFeedback.current
+
+    // The strip's active load-more request: the token returned at fire time, NO_LOAD_REQUEST at rest.
+    // Saveable so a list eviction / recreation mid-load resumes (or cleanly ends) the transaction.
+    val request = rememberSaveable { mutableIntStateOf(NO_LOAD_REQUEST) }
+    val loadMore by callbacks.loadMoreState.collectAsStateWithLifecycle()
+    // The spinner shows from fire until the composition that carries the completing data's version, so
+    // the spinner and the new pills swap in the SAME composition — never a frame where both/neither
+    // show. At rest, request is NO_LOAD_REQUEST, which reads as Superseded → no spinner.
+    val loadingMore = spinnerVisible(loadMoreOutcome(loadMore, request.intValue), dataVersion)
+
+    // Layout acknowledgement: the highest dataVersion whose strip content has been MEASURED. Written in
+    // the measure pass that wraps horizontalScroll — the same pass (and snapshot batch) in which
+    // scrollState.maxValue is brought up to date — so `measuredVersion >= V` GUARANTEES maxValue is
+    // consistent with data version V. Read only from snapshotFlow (never composition), so writing it
+    // per layout pass can't cause recomposition loops.
+    val measuredVersion = remember { mutableLongStateOf(0L) }
+    val versionState = rememberUpdatedState(dataVersion)
+
+    // The reveal transaction for this strip's request: keep the strip pinned to its (moving) right end
+    // — first the spinner slot, then the reloaded pills — and settle once the layout provably reflects
+    // the data that completed the request. Every wait is a level-triggered predicate over monotonic
+    // snapshot/StateFlow state, so a signal that fires before we start listening is still observed.
+    LaunchedEffect(request.intValue) {
+        val token = request.intValue
+        if (token == NO_LOAD_REQUEST) return@LaunchedEffect
+        try {
+            coroutineScope {
+                // FOLLOWER: glides to the current end whenever there is one to reach. Each glide runs
+                // TO COMPLETION and the loop then re-evaluates against current state (never
+                // collectLatest: a change mid-glide is caught by the fresh level-triggered re-await,
+                // so there is no lost-update window).
+                val follower = launch {
+                    while (true) {
+                        snapshotFlow { scrollState.maxValue > scrollState.value }.first { it }
+                        try {
+                            scrollState.animateScrollTo(scrollState.maxValue)
+                        } catch (cause: CancellationException) {
+                            currentCoroutineContext().ensureActive() // real teardown propagates
+                            // Lost the scrollable mutex to a touch. Never contest user input: resume
+                            // the chase only once the strip is fully at rest. (A drag that actually
+                            // travels ends the whole transaction via the nested-scroll hook.)
+                            snapshotFlow { scrollState.isScrollInProgress }.first { !it }
+                        }
+                    }
+                }
+                // AWAIT RESULT: level-triggered on the VM's StateFlow — a Finished that landed before
+                // we started collecting is still observed (StateFlow replays its value).
+                val landed = callbacks.loadMoreState
+                    .map { loadMoreOutcome(it, token) }
+                    .first { it !is LoadMoreOutcome.Pending }
+                if (landed is LoadMoreOutcome.Landed) {
+                    // SETTLE: wait until (a) layout reflects the completing data's version — which,
+                    // via the layout-ack modifier, also means maxValue is current for that data and
+                    // the spinner slot is gone (spinner and new pills swap in the same composition,
+                    // both keyed on dataVersion) — and (b) we are at rest at the true end. Success
+                    // with new pills, success with none for this row, and failure all take this one
+                    // path: the end is wherever layout says it is.
+                    snapshotFlow {
+                        measuredVersion.longValue >= landed.dataVersion &&
+                            scrollState.value == scrollState.maxValue &&
+                            !scrollState.isScrollInProgress
+                    }.first { it }
+                }
+                follower.cancel()
+            }
+        } finally {
+            // Idempotent teardown; guarded so a user-takeover or a re-fire (which already moved
+            // `request`) isn't clobbered.
+            if (request.intValue == token) request.intValue = NO_LOAD_REQUEST
+        }
+    }
+
+    val pullConnection = remember(scrollState, callbacks, triggerPx, maxPullPx, haptic) {
+        object : NestedScrollConnection {
+            // Dragging back toward the pills unwinds an active pull before the strip itself scrolls.
+            override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
+                // Programmatic glides dispatch as SideEffect; only real user input drives the pull and
+                // the take-over below.
+                if (source != NestedScrollSource.UserInput) return Offset.Zero
+                // A real user scroll on this strip while a reveal transaction is active ends it: the
+                // user wins, the transaction effect is cancelled (killing any in-flight glide via the
+                // scrollable mutex), and the spinner is dropped. The load itself continues in the
+                // ViewModel; its pills land unanimated.
+                if (request.intValue != NO_LOAD_REQUEST) request.intValue = NO_LOAD_REQUEST
+                // Dragging back toward the pills unwinds an active pull before the strip itself scrolls.
+                if (available.x > 0f && pull.floatValue > 0f) {
+                    val consumedFinger = (pull.floatValue / PULL_RESISTANCE).coerceAtMost(available.x)
+                    pull.floatValue -= consumedFinger * PULL_RESISTANCE
+                    return Offset(consumedFinger, 0f)
+                }
+                return Offset.Zero
+            }
+
+            // Past the strip's end, a further left-drag (negative x) builds the resistive pull; a light
+            // tick fires the instant it crosses the arm threshold (rising edge only).
+            override fun onPostScroll(consumed: Offset, available: Offset, source: NestedScrollSource): Offset {
+                if (source == NestedScrollSource.UserInput && available.x < 0f && !scrollState.canScrollForward) {
+                    val before = pull.floatValue
+                    pull.floatValue = (before - available.x * PULL_RESISTANCE).coerceAtMost(maxPullPx)
+                    if (before < triggerPx && pull.floatValue >= triggerPx) {
+                        haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                    }
+                    return Offset(available.x, 0f)
+                }
+                return Offset.Zero
+            }
+
+            // Drag released: fire load-more if armed (the reveal transaction, keyed on the request
+            // token, then pins the strip to its end), then spring the pull back.
+            override suspend fun onPreFling(available: Velocity): Velocity {
+                if (pull.floatValue <= 0f) return Velocity.Zero
+                if (pull.floatValue >= triggerPx) {
+                    // The VM sets Loading(token) synchronously inside onLoadMore, so the spinner is
+                    // already visible in the composition this write lands in — no gap.
+                    request.intValue = callbacks.onLoadMore()
+                }
+                animate(pull.floatValue, 0f) { value, _ -> pull.floatValue = value }
+                // Swallow the fling — there's nothing left to scroll to at the strip's end.
+                return available
+            }
+        }
+    }
+
+    Row(
+        modifier.semantics {
+            customActions = listOf(
+                // The full transaction, so TalkBack users get the same spinner + reveal.
+                CustomAccessibilityAction(loadMoreLabel) {
+                    request.intValue = callbacks.onLoadMore(); true
+                }
+            )
+        },
+        verticalAlignment = Alignment.Bottom
+    ) {
+        // Left gutter: a chevron back toward earlier arrivals, shown once the strip is scrolled off its
+        // start. Reserved (like the right gutter) so toggling it never reflows the pills.
+        ScrollChevronGutter(visible = canScrollBackward && !loadingMore, pointsRight = false)
+
+        // The scrollable pill content. An edge fade marks whichever end has more to scroll to, and the
+        // pull-to-load chip overlays the trailing edge; the pull gesture lives here (the gutters don't
+        // scroll).
+        Box(
+            Modifier
+                .weight(1f)
+                .clipToBounds()
+                .nestedScroll(pullConnection)
+        ) {
+            Row(
+                modifier = Modifier
+                    // Follow the pull so the pills slide aside, opening the gap the load-more chip fills.
+                    .offset { IntOffset(-pull.floatValue.roundToInt(), 0) }
+                    // The composition↔layout bridge: measure the scroll content, then record the data
+                    // version this layout reflects (see acknowledgeVersion).
+                    .acknowledgeVersion(versionState, measuredVersion)
+                    .horizontalScroll(scrollState),
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                // Bottom-align so a smaller recent-past pill sits on the same baseline as the full-size ones.
+                verticalAlignment = Alignment.Bottom
+            ) {
+                trips.forEachIndexed { index, trip ->
+                    val pillModifier = when {
+                        index == 0 -> firstPillModifier
+                        // Measure the justify pill's content offset once — attached only until captured,
+                        // so the callback self-detaches (writing justifyOffsetPx recomposes the strip).
+                        index == justifyIndex && justifyOffsetPx < 0 -> Modifier.onGloballyPositioned { coords ->
+                            // Offset within the scroll content Row (its direct parent), which is
+                            // content-space and so scroll-independent.
+                            coords.parentLayoutCoordinates?.let { parent ->
+                                justifyOffsetPx = parent.localPositionOf(coords, Offset.Zero).x.roundToInt()
+                            }
+                        }
+                        else -> Modifier
+                    }
+                    EtaPillWithMenu(
+                        trip = trip,
+                        actions = actionsFor(trip),
+                        callbacks = callbacks,
+                        modifier = pillModifier,
+                    )
+                }
+                // While the reload is in flight, the spinner rides as a real tail item so it reserves its
+                // own slot to the right of the last pill (rather than overlaying it); when the completing
+                // data's composition lands it's dropped in the same frame the new pills appear, and the
+                // strip glides left to the new end.
+                if (loadingMore) {
+                    Box(
+                        modifier = Modifier.size(width = 28.dp, height = 32.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(20.dp),
+                            strokeWidth = 2.dp,
+                            color = MaterialTheme.colorScheme.primary
+                        )
+                    }
+                }
+            }
+            // Fade the content out at whichever edge has more content sliding under it.
+            if (canScrollBackward && !loadingMore) EdgeFade(atStart = true)
+            if (canScrollForward && !loadingMore) EdgeFade(atStart = false)
+            // The pull-revealed load-more chip (invisible at rest, armed as the pull crosses the
+            // threshold). Hidden while loading — the inline spinner above takes over then.
+            if (!loadingMore) {
+                LoadMorePullChip(
+                    progress = { (pull.floatValue / triggerPx).coerceIn(0f, 1f) },
+                    armed = { armed.value },
+                    contentDescription = loadMoreLabel,
+                    modifier = Modifier.align(Alignment.CenterEnd),
+                )
+            }
+        }
+
+        // Right gutter: a chevron forward toward later arrivals (the pull-past-the-end load affordance
+        // takes over inside the content box once you reach the end).
+        ScrollChevronGutter(visible = canScrollForward && !loadingMore, pointsRight = true)
+    }
+}
+
+/**
+ * A fixed-width trailing/leading gutter holding the "more to scroll" chevron, [visible] when that
+ * direction has more content. [pointsRight] picks the direction; the left reuses the right chevron
+ * drawable rotated 180°. The slot is reserved even when hidden so toggling it never reflows the pills.
+ */
+@Composable
+private fun ScrollChevronGutter(visible: Boolean, pointsRight: Boolean) {
+    Box(Modifier.fillMaxHeight().width(20.dp), contentAlignment = Alignment.Center) {
+        if (visible) {
+            Icon(
+                painter = painterResource(R.drawable.ic_navigation_chevron_right),
+                // Decorative: a pure "there's more to scroll" hint, not an actionable control.
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier
+                    .size(20.dp)
+                    .rotate(if (pointsRight) 0f else 180f)
+            )
+        }
+    }
+}
+
+/**
+ * A gradient over the strip's [atStart]/end edge that fades the content out as it slides under the
+ * matching chevron gutter — solid (the card color) at that edge, transparent inward.
+ */
+@Composable
+private fun BoxScope.EdgeFade(atStart: Boolean) {
+    val surface = MaterialTheme.colorScheme.surfaceContainer
+    val brush = remember(surface, atStart) {
+        Brush.horizontalGradient(
+            if (atStart) listOf(surface, Color.Transparent) else listOf(Color.Transparent, surface)
+        )
+    }
+    Box(
+        Modifier
+            .align(if (atStart) Alignment.CenterStart else Alignment.CenterEnd)
+            .fillMaxHeight()
+            .width(24.dp)
+            .background(brush)
+    )
+}
+
+/**
+ * The circular load-more affordance uncovered as the ETA strip is pulled past its end. [progress]
+ * (0..1, read in the graphics phase to avoid recomposing on every drag frame) fades and slides it in;
+ * [armed] (progress has reached 1) flips it to the primary color so "release to load" reads at a glance.
+ */
+@Composable
+private fun LoadMorePullChip(
+    progress: () -> Float,
+    armed: () -> Boolean,
+    contentDescription: String,
+    modifier: Modifier = Modifier,
+) {
+    val slidePx = with(LocalDensity.current) { 20.dp.toPx() }
+    // Reading the arm lambda here scopes threshold-crossing recomposition to just this small chip.
+    val isArmed = armed()
+    val container = if (isArmed) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surfaceVariant
+    val content = if (isArmed) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurfaceVariant
+    Surface(
+        modifier = modifier.graphicsLayer {
+            val p = progress()
+            alpha = p
+            // Slide in from the right edge as the pull grows (fully seated at p == 1).
+            translationX = (1f - p) * slidePx
+        },
+        shape = CircleShape,
+        color = container,
+        // Sets LocalContentColor, so the Icon below inherits it instead of an explicit tint.
+        contentColor = content,
+    ) {
+        Box(Modifier.size(30.dp), contentAlignment = Alignment.Center) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.ArrowForward,
+                contentDescription = contentDescription,
+                modifier = Modifier.size(18.dp)
+            )
+        }
+    }
+}
+
+/** A single ETA pill with its long-press per-trip menu. Tap focuses the vehicle; long-press opens
+ *  the menu (trip details / reminder / report). */
+@Composable
+private fun EtaPillWithMenu(
+    trip: ArrivalInfo,
+    actions: ArrivalActions?,
+    callbacks: ArrivalRowCallbacks,
+    modifier: Modifier = Modifier,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    Box {
+        EtaPill(
+            eta = trip.eta,
+            color = colorResource(trip.color),
+            predicted = trip.predicted,
+            modifier = modifier,
+            canceled = trip.status == Status.CANCELED,
+            onClick = { callbacks.onEtaClick(trip) },
+            onLongClick = { expanded = true },
+        )
+        TripActionsMenu(expanded, { expanded = false }, trip, actions, callbacks)
+    }
+}
+
+/** The per-trip menu opened by long-pressing a pill: trip details, a reminder, or a problem report
+ *  for that specific trip. Route-wide actions live on the row's ⋮ menu ([RouteActionsMenu]). */
+@Composable
+internal fun TripActionsMenu(
+    expanded: Boolean,
+    onDismiss: () -> Unit,
+    arrival: ArrivalInfo,
+    actions: ArrivalActions?,
+    callbacks: ArrivalRowCallbacks
+) {
+    DropdownMenu(expanded = expanded, onDismissRequest = onDismiss) {
+        MenuRow(R.string.bus_options_menu_show_trip_details) {
+            onDismiss(); callbacks.onShowTripStatus(arrival)
+        }
+        MenuRow(R.string.bus_options_menu_set_reminder) {
+            onDismiss(); callbacks.onSetReminder(arrival)
+        }
+        if (actions != null) {
+            MenuRow(R.string.bus_options_menu_report_trip_problem) {
+                onDismiss(); callbacks.onReportArrivalProblem(actions)
+            }
+        }
+    }
+}
+
+/**
+ * The prominent white-on-lateness ETA pill — one per trip in a route row's strip (and the Home legend
+ * dialog, which passes no clicks). [onClick] taps focus that trip's vehicle + stop; [onLongClick]
+ * opens the trip menu; [canceled] strikes the text through.
+ *
+ * A recent-past (negative-ETA) trip renders **compact** — 75% of the size — to de-emphasize it against
+ * the upcoming arrivals, while the strip bottom-aligns so its digits still sit on the shared baseline.
+ */
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+internal fun EtaPill(
+    eta: Long,
+    color: Color,
+    predicted: Boolean,
+    modifier: Modifier = Modifier,
+    canceled: Boolean = false,
+    onClick: (() -> Unit)? = null,
+    onLongClick: (() -> Unit)? = null,
+) {
+    val decoration = if (canceled) TextDecoration.LineThrough else null
+    val shape = RoundedCornerShape(8.dp)
+    // Recent-past arrivals (negative ETA) shrink to 75% so the upcoming "big numbers" dominate the strip.
+    val compact = eta < 0
+    val pillHeight = if (compact) 24.dp else 32.dp
+    val numberSize = if (compact) 21.sp else 28.sp
+    val labelSize = if (compact) 11.sp else 14.sp
+    val nowSize = if (compact) 17.sp else 22.sp
+    val indicatorSize = if (compact) 6.dp else 8.dp
+    // A single combinedClickable serves both tap (focus vehicle) and long-press (trip menu). Placed on
+    // the modifier the Surface clips, so the ripple stays inside the pill.
+    val interaction = if (onClick != null || onLongClick != null) {
+        Modifier.combinedClickable(onClick = { onClick?.invoke() }, onLongClick = onLongClick)
+    } else {
+        Modifier
+    }
+    // One consistent "Xhr Ymin" shape: ["23", "min"] under an hour (the "0hr" is omitted), or
+    // ["1", "hr", " 30", "min"] past it — every number stays bold-sized, only the unit letters
+    // shrink, so the leftover minutes stay as legible as the hour count (#1777).
+    val etaParts = if (eta != 0L) DisplayFormat.formatEtaParts(LocalContext.current, eta) else null
+    Surface(modifier = modifier.then(interaction), shape = shape, color = color) {
+        // Bottom-centers the whole (baseline-aligned) content block, so pills of different sizes in
+        // the strip still share a common bottom edge.
+        Box(
+            modifier = Modifier
+                .height(pillHeight)
+                .padding(horizontal = 6.dp),
+            contentAlignment = Alignment.BottomCenter
+        ) {
+            Row {
+                if (etaParts == null) {
+                    Text(
+                        text = stringResource(R.string.stop_info_eta_now),
+                        fontSize = nowSize,
+                        fontWeight = FontWeight.Bold,
+                        color = Color.White,
+                        textDecoration = decoration
+                    )
+                } else {
+                    // A single AnnotatedString (not separate Text composables) so the text shaper kerns
+                    // across the number/unit boundary instead of gluing together independently-measured
+                    // boxes — splitting them produced inconsistent gaps (e.g. "1hr" vs "4hr").
+                    Text(
+                        text = buildAnnotatedString {
+                            etaParts.forEach { part ->
+                                withStyle(
+                                    SpanStyle(
+                                        fontSize = if (part.emphasized) numberSize else labelSize,
+                                        fontWeight = if (part.emphasized) FontWeight.Bold else FontWeight.Normal,
+                                        color = Color.White
+                                    )
+                                ) {
+                                    append(part.text)
+                                }
+                            }
+                        },
+                        textDecoration = decoration
+                    )
+                }
+                // The radiating real-time indicator floats above the trailing unit ("min" / "Now"); it
+                // isn't baseline-aligned, so it takes the Row's default top alignment. The Box is always
+                // present so the pill width is stable whether or not it's live.
+                Box(Modifier.padding(start = 2.dp).size(indicatorSize)) {
+                    if (predicted) {
+                        RealtimeIndicator(color = Color.White, modifier = Modifier.fillMaxSize())
+                    }
+                }
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------------------------
+// Previews.
+
+/** [count] "40 Northgate" pills with increasing upcoming ETAs, for the strip previews. */
+private fun northgatePills(count: Int) =
+    List(count) { previewArrival("40", "Northgate", etaMinutes = 3L + it * 8) }
+
+/**
+ * Shared strip-preview scaffold. height(IntrinsicSize.Min) bounds the row to the pill height — as
+ * RouteArrivalRow's IntrinsicSize.Min row does in production — so the chevrons' fillMaxHeight resolves
+ * to the pills instead of filling the whole preview surface.
+ */
+@Composable
+private fun EtaStripPreviewFrame(
+    trips: List<ArrivalInfo>,
+    scrollState: ScrollState = rememberScrollState(),
+) {
+    ObaTheme {
+        Surface(color = MaterialTheme.colorScheme.surfaceContainer) {
+            Box(Modifier.height(IntrinsicSize.Min).padding(8.dp)) {
+                EtaStrip(
+                    trips = trips,
+                    dataVersion = 1L,
+                    actionsFor = { null },
+                    callbacks = previewRowCallbacks(),
+                    scrollState = scrollState,
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true, widthDp = 240, name = "EtaStrip · overflowing (chevron)")
+@Composable
+private fun EtaStripOverflowPreview() {
+    // Enough pills to exceed the 240dp width, so the right-edge fade + chevron hint appears.
+    EtaStripPreviewFrame(trips = northgatePills(6))
+}
+
+@Preview(showBackground = true, widthDp = 240, name = "EtaStrip · scrolled (both chevrons)")
+@Composable
+private fun EtaStripScrolledPreview() {
+    // Started part-way scrolled (content hanging off BOTH ends), so both the left- and right-edge
+    // chevrons/fades show. The initial offset clamps to the range after layout.
+    EtaStripPreviewFrame(trips = northgatePills(7), scrollState = rememberScrollState(initial = 300))
+}
+
+@Preview(showBackground = true, widthDp = 240, name = "EtaStrip · fits (no chevron)")
+@Composable
+private fun EtaStripFitsPreview() {
+    // Two pills fit inside 240dp, so no scroll and no chevron.
+    EtaStripPreviewFrame(
+        trips = listOf(
+            previewArrival("8", "Rainier Beach", etaMinutes = 4),
+            previewArrival("8", "Rainier Beach", etaMinutes = 12),
+        )
+    )
+}
+
+/** A gallery of individual [EtaPill] states (not the strip): compact recent-past, "Now", the
+ *  lateness colors, a canceled pill, and the past-an-hour "Xhr Ymin" form. */
+@Preview(showBackground = true)
+@Composable
+private fun EtaPillVariantsPreview() {
+    ObaTheme {
+        Surface(color = MaterialTheme.colorScheme.surfaceContainer) {
+            // Bottom-aligned like the real strip, so the compact past pill shares the baseline.
+            Row(
+                Modifier.padding(8.dp),
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                verticalAlignment = Alignment.Bottom
+            ) {
+                // A recent-past arrival: renders at 75% size.
+                EtaPill(-3, colorResource(R.color.stop_info_delayed), predicted = true)
+                EtaPill(0, colorResource(R.color.stop_info_ontime), predicted = true)
+                EtaPill(5, colorResource(R.color.stop_info_delayed), predicted = true)
+                EtaPill(12, colorResource(R.color.stop_info_early), predicted = true)
+                EtaPill(22, colorResource(R.color.stop_info_scheduled_time), predicted = false)
+                EtaPill(8, colorResource(R.color.stop_info_scheduled_time), predicted = false, canceled = true)
+                // Past an hour: the number switches to hours, the leftover minutes fold into the label (#1777).
+                EtaPill(83, colorResource(R.color.stop_info_scheduled_time), predicted = true)
+                EtaPill(125, colorResource(R.color.stop_info_early), predicted = false)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Follow-up polish on the arrivals ETA strip (after #1773 / #1774), all in one place.

## Refactor
Splits the ETA strip out of the 1176-line `ArrivalRows.kt` into a self-contained **`EtaStrip.kt`** — the strip (horizontal scroll, overflow chevrons, the pull-past-the-end load-more gesture + reveal), the pills, and the per-trip menu. `RouteArrivalRow` and the legacy flat-row bits stay behind and reach the shared helpers cross-file (same `components` package, so external importers are unaffected).

## UX
- **Overflow chevrons moved outside the content box.** They now sit in reserved leading/trailing gutters with the edge fade at the content's matching edge, instead of a single right chevron perched over the last pill. Reserving the gutter means toggling a chevron never reflows the pills.
- **Symmetric left chevron + left fade**, shown once the strip is scrolled off its start (reuses the right chevron drawable rotated 180°).
- **Opens on the soonest upcoming ETA.** `EtaStrip` takes a `start` index and justifies that pill to the leading edge on first display, so recent-past (just-departed) pills overflow off the *left* — reachable via the new left chevron. `RouteArrivalRow` passes `RouteRowGroup.firstUpcomingIndex` (the first non-negative ETA — the row's sort key), so the past/upcoming boundary stays owned by the grouping model.
- Load-more pull chip drawn with `Surface(shape = CircleShape)`.

## Notes
- The "justify" is a one-shot, scroll-independent measure-then-`scrollTo` (the strip is a `Row` + `horizontalScroll`, so it's pixel- not index-addressed). The measurer self-detaches after the single capture.
- Previews: `EtaStrip` fits / overflowing / scrolled (both chevrons) via a shared frame, all height-bounded so the chevrons' `fillMaxHeight` resolves to the pill height. Note the justify is a post-layout scroll effect, so it shows in interactive/on-device runs, not the static preview.
- On-device verified on a Pixel 7 Pro.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a refreshed arrival-time strip with horizontally scrollable ETA pills.
  * Added edge indicators and pull-to-load-more support for additional arrivals.
  * Added accessibility support for loading more arrivals.
  * Added long-press actions for individual trips.
* **Improvements**
  * Improved alignment of recent-past and upcoming arrival labels.
  * Updated arrival previews to support the refreshed layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->