### PR TITLE
Trip planning: migrate OTP1 request-building off the vendored POJOs

### DIFF
--- a/onebusaway-android/build.gradle
+++ b/onebusaway-android/build.gradle
@@ -311,9 +311,12 @@ dependencies {
     implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3'
     // For sorting alphanumeric route names
     implementation 'org.onebusaway.util:comparators:1.0.0'
-    // OpenTripPlanner response POJOs. The directions/ + trip-planner UI read these types directly;
-    // the OTP `/plan` JSON is now decoded by api/contract/OtpPlanModels.kt (kotlinx.serialization)
-    // and mapped onto them, replacing the old Jackson data-binding.
+    // OpenTripPlanner POJOs — an unpublished, unpatchable 2017-era SNAPSHOT (#1778). The trip-itinerary
+    // path no longer reads these directly: the OTP `/plan` request is built and the response decoded
+    // via our own types (TripRequestBuilder / api/contract/OtpPlanModels.kt), mapped onto the app-owned
+    // domain model in directions/model/TripItinerary.kt. The only remaining consumer is the bikeshare
+    // `BikeRentalStation` path (BikeModels.kt, BikeLayerController.kt, map/bike/, map/compose/Bike*);
+    // once that's migrated too (#1779), this dependency can be removed entirely.
     implementation 'edu.usf.cutr.opentripplanner.android:opentripplanner-pojos:1.0.0-SNAPSHOT'
     // Pelias for point-of-interest search and geocoding for trip planning origin and destination
     implementation 'com.github.OneBusAway:pelias-client-library:v1.1.0'

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/contract/OtpPlanModels.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/contract/OtpPlanModels.kt
@@ -60,6 +60,43 @@ data class OtpErrorDto(
     val missing: List<String> = emptyList(),
 )
 
+/**
+ * Mirrors OTP1's `org.opentripplanner.api.ws.Message` wire error-id vocabulary exactly — the legal
+ * values of [OtpErrorDto.id] — ids verified against the vendored jar's enum constructor arguments
+ * (`Message(String, int)`), not guessed. Only the codes
+ * [org.onebusaway.android.ui.tripplan.DefaultTripPlanRepository]'s `errorMessage` maps to a
+ * user-facing string are included; the vendored enum also has a `PLAN_OK` (200) success code this app
+ * never needs to name.
+ */
+internal enum class OtpErrorId(val id: Int) {
+    SYSTEM_ERROR(500),
+    OUTSIDE_BOUNDS(400),
+    PATH_NOT_FOUND(404),
+    NO_TRANSIT_TIMES(406),
+    REQUEST_TIMEOUT(408),
+    BOGUS_PARAMETER(413),
+    GEOCODE_FROM_NOT_FOUND(440),
+    GEOCODE_TO_NOT_FOUND(450),
+    GEOCODE_FROM_TO_NOT_FOUND(460),
+    TOO_CLOSE(409),
+    LOCATION_NOT_ACCESSIBLE(470),
+    GEOCODE_FROM_AMBIGUOUS(340),
+    GEOCODE_TO_AMBIGUOUS(350),
+    GEOCODE_FROM_TO_AMBIGUOUS(360),
+    UNDERSPECIFIED_TRIANGLE(370),
+    TRIANGLE_NOT_AFFINE(371),
+    TRIANGLE_OPTIMIZE_TYPE_NOT_SET(372),
+    TRIANGLE_VALUES_NOT_SET(373),
+}
+
+/**
+ * The app-owned replacement for the vendored `org.opentripplanner.api.ws.Request` — an OTP `/plan`
+ * query-parameter map. [parameters]' keys match the wire names the vendored `Request` pushed via its
+ * own setters exactly (verified against the vendored jar's `paramPush` calls): `fromPlace`/`toPlace`/
+ * `optimize`/`wheelchair`/`arriveBy`/`date`/`time`/`mode`/`maxWalkDistance`/`showIntermediateStops`.
+ */
+data class TripPlanRequest(val parameters: Map<String, String>)
+
 @Serializable
 data class OtpItineraryDto(
     val duration: Double? = null,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/TripRequestBuilder.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/TripRequestBuilder.kt
@@ -21,14 +21,13 @@ import androidx.core.os.BundleCompat
 import android.text.TextUtils
 import android.util.Log
 import org.onebusaway.android.R
+import org.onebusaway.android.api.contract.TripPlanRequest
 import org.onebusaway.android.app.di.PreferencesEntryPoint
 import org.onebusaway.android.app.di.RegionEntryPoint
+import org.onebusaway.android.directions.model.TripMode
 import org.onebusaway.android.ui.tripplan.TripModes
 import org.onebusaway.android.util.BikeshareAvailability
 import org.onebusaway.android.util.RegionUtils
-import org.opentripplanner.api.ws.Request
-import org.opentripplanner.routing.core.OptimizeType
-import org.opentripplanner.routing.core.TraverseMode
 import java.io.UnsupportedEncodingException
 import java.net.MalformedURLException
 import java.net.URL
@@ -84,10 +83,12 @@ class TripRequestBuilder(context: Context, private val mBundle: Bundle) {
 
     fun getOptimizeTransfers(): Boolean = mBundle.getBoolean(OPTIMIZE_TRANSFERS)
 
-    /** The OTP1 wire enum, derived from [getOptimizeTransfers] only where [buildRequest] needs it —
-     * never itself persisted, so it never has to cross a Bundle/Intent serialization boundary. */
-    private fun getOptimizeType(): OptimizeType =
-        if (getOptimizeTransfers()) OptimizeType.TRANSFERS else OptimizeType.QUICK
+    /** The OTP `optimize` wire value, derived from [getOptimizeTransfers] only where [buildRequest]
+     * needs it — never itself persisted, so it never has to cross a Bundle/Intent serialization
+     * boundary. Mirrors OTP1's `OptimizeType.TRANSFERS`/`QUICK` wire names exactly (verified against
+     * the vendored jar); the other five `OptimizeType` values are never requested by this app. */
+    private fun getOptimizeType(): String =
+        if (getOptimizeTransfers()) "TRANSFERS" else "QUICK"
 
     fun setWheelchairAccessible(wheelchair: Boolean): TripRequestBuilder {
         mBundle.putBoolean(WHEELCHAIR_ACCESSIBLE, wheelchair)
@@ -117,27 +118,27 @@ class TripRequestBuilder(context: Context, private val mBundle: Bundle) {
         val modes: List<String> = when (id) {
             // Transit only
             TripModes.TRANSIT_ONLY ->
-                listOf(TraverseMode.TRANSIT.toString(), TraverseMode.WALK.toString())
+                listOf(TripMode.TRANSIT.name, TripMode.WALK.name)
             // Transit & bikeshare
             TripModes.TRANSIT_AND_BIKE ->
                 if (BikeshareAvailability.isEnabled(mContext)) {
                     listOf(
-                        TraverseMode.TRANSIT.toString(),
-                        TraverseMode.WALK.toString(),
+                        TripMode.TRANSIT.name,
+                        TripMode.WALK.name,
                         mContext.getString(R.string.traverse_mode_bicycle_rent)
                     )
                 } else {
-                    listOf(TraverseMode.TRANSIT.toString(), TraverseMode.WALK.toString())
+                    listOf(TripMode.TRANSIT.name, TripMode.WALK.name)
                 }
 
             TripModes.BUS_ONLY ->
-                listOf(TraverseMode.BUS.toString(), TraverseMode.WALK.toString())
+                listOf(TripMode.BUS.name, TripMode.WALK.name)
 
             TripModes.RAIL_ONLY ->
                 listOf(
-                    TraverseMode.RAIL.toString(),
-                    TraverseMode.TRAM.toString(),
-                    TraverseMode.WALK.toString()
+                    TripMode.RAIL.name,
+                    TripMode.TRAM.name,
+                    TripMode.WALK.name
                 )
 
             TripModes.BIKESHARE ->
@@ -146,7 +147,7 @@ class TripRequestBuilder(context: Context, private val mBundle: Bundle) {
             else -> {
                 Log.e(TAG, "Invalid mode set ID")
                 mModeId = -1
-                listOf(TraverseMode.TRANSIT.toString(), TraverseMode.WALK.toString())
+                listOf(TripMode.TRANSIT.name, TripMode.WALK.name)
             }
         }
 
@@ -167,45 +168,41 @@ class TripRequestBuilder(context: Context, private val mBundle: Bundle) {
     private fun getModeString(): String? = mBundle.getString(MODE_SET)
 
     /**
-     * Builds the OTP [Request] from the current bundle state. Consumed by the coroutine
+     * Builds the OTP [TripPlanRequest] from the current bundle state. Consumed by the coroutine
      * trip-plan repository (both the UI plan path and the trip-plan monitor background plan).
      *
      * @throws IllegalArgumentException if the origin or destination is missing
      */
-    fun buildRequest(): Request {
+    fun buildRequest(): TripPlanRequest {
         val fromParam = getAddressString(from)
         val toParam = getAddressString(to)
 
-        if (TextUtils.isEmpty(fromParam) || TextUtils.isEmpty(toParam)) {
+        if (fromParam.isNullOrEmpty() || toParam.isNullOrEmpty()) {
             throw IllegalArgumentException("Must supply start and end to route between.")
         }
-
-        val request = Request()
-        request.setArriveBy(arriveBy)
-        request.setFrom(fromParam)
-        request.setTo(toParam)
-        request.setOptimize(getOptimizeType())
-        request.setWheelchair(getWheelchairAccessible())
-
-        getMaxWalkDistance()?.let { request.setMaxWalkDistance(it) }
 
         val d = dateTime
             ?: throw IllegalArgumentException("Must supply a date/time to route at.")
 
         // OTP expects date/time in this format
         val zoned = d.atZone(ZoneId.systemDefault())
-        request.setDateTime(DATE_FORMATTER.format(zoned), TIME_FORMATTER.format(zoned))
 
+        val parameters = mutableMapOf(
+            "fromPlace" to fromParam,
+            "toPlace" to toParam,
+            "optimize" to getOptimizeType(),
+            "wheelchair" to getWheelchairAccessible().toString(),
+            "arriveBy" to arriveBy.toString(),
+            "date" to DATE_FORMATTER.format(zoned),
+            "time" to TIME_FORMATTER.format(zoned),
+            // Our default. This could be configurable.
+            "showIntermediateStops" to true.toString(),
+        )
+        getMaxWalkDistance()?.let { parameters["maxWalkDistance"] = it.toString() }
         // Request mode set does not work properly
-        val modeString = mBundle.getString(MODE_SET)
-        if (modeString != null) {
-            request.parameters["mode"] = modeString
-        }
+        mBundle.getString(MODE_SET)?.let { parameters["mode"] = it }
 
-        // Our default. This could be configurable.
-        request.setShowIntermediateStops(true)
-
-        return request
+        return TripPlanRequest(parameters)
     }
 
     /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanRepository.kt
@@ -26,15 +26,15 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.onebusaway.android.R
 import org.onebusaway.android.api.adapters.toTripItinerary
+import org.onebusaway.android.api.contract.OtpErrorId
 import org.onebusaway.android.api.contract.OtpPlanParser
 import org.onebusaway.android.api.contract.OtpResponseDto
 import org.onebusaway.android.api.contract.OtpWebService
+import org.onebusaway.android.api.contract.TripPlanRequest
 import org.onebusaway.android.directions.model.TripItinerary
+import org.onebusaway.android.directions.model.TripMode
 import org.onebusaway.android.directions.util.CustomAddress
 import org.onebusaway.android.directions.util.TripRequestBuilder
-import org.opentripplanner.api.ws.Message
-import org.opentripplanner.api.ws.Request
-import org.opentripplanner.routing.core.TraverseMode
 import org.onebusaway.android.preferences.PreferencesRepository
 
 /** Plans a trip against the region's OpenTripPlanner server. */
@@ -116,7 +116,7 @@ class DefaultTripPlanRepository @Inject constructor(
      * the bike layer and reset on region change) so later plans skip the probe.
      */
     private fun requestPlan(
-        request: Request,
+        request: TripPlanRequest,
         baseUrl: String,
         oldServer: Boolean
     ): OtpResponseDto {
@@ -132,10 +132,15 @@ class DefaultTripPlanRepository @Inject constructor(
                 first = false
             }
         }.let { params ->
-            if (request.bikeRental) {
+            // Read from the built mode string, not TripRequestBuilder.mModeId: mModeId is unset after
+            // initFromBundleSimple (the trip-plan-monitor restore path never repopulates it), and even
+            // on the direct path TRANSIT_AND_BIKE only actually requests bike rental when bikeshare is
+            // enabled — the mode string is the one place both facts are already resolved.
+            val bikeRentalToken = context.getString(R.string.traverse_mode_bicycle_rent)
+            if (modeStringRequestsBikeRental(request.parameters["mode"], bikeRentalToken)) {
                 // Pre-1.0 servers spell bike rental as "BICYCLE, WALK"; modern ones as "BICYCLE_RENT".
-                val bicycle = TraverseMode.BICYCLE.toString()
-                val rental = if (ancientServer) "$bicycle, ${TraverseMode.WALK}"
+                val bicycle = TripMode.BICYCLE.name
+                val rental = if (ancientServer) "$bicycle, ${TripMode.WALK.name}"
                              else bicycle + OTP_RENTAL_QUALIFIER
                 params.replace(bicycle, rental)
             } else {
@@ -150,7 +155,7 @@ class DefaultTripPlanRepository @Inject constructor(
         } catch (e: IOException) {
             // Transport failure / timeout (SocketTimeoutException is an IOException) — mirror the legacy
             // catch-all mapping to the request-timeout message.
-            throw IOException(errorMessage(Message.REQUEST_TIMEOUT.id), e)
+            throw IOException(errorMessage(OtpErrorId.REQUEST_TIMEOUT.id), e)
         }
 
         // A server-root base we assumed was modern but that failed at the HTTP layer is a pre-1.0
@@ -169,7 +174,7 @@ class DefaultTripPlanRepository @Inject constructor(
             }
             body.use { OtpPlanParser.parse(it.byteStream()) }
         } catch (e: IOException) {
-            throw IOException(errorMessage(Message.REQUEST_TIMEOUT.id), e)
+            throw IOException(errorMessage(OtpErrorId.REQUEST_TIMEOUT.id), e)
         }
 
         // Record a discovered pre-1.0 server so later plans (and the bike layer) skip the probe.
@@ -180,29 +185,29 @@ class DefaultTripPlanRepository @Inject constructor(
     }
 
     private fun errorMessage(errorCode: Int): String = when (errorCode) {
-        Message.SYSTEM_ERROR.id -> context.getString(R.string.tripplanner_error_system)
-        Message.OUTSIDE_BOUNDS.id -> context.getString(R.string.tripplanner_error_outside_bounds)
-        Message.PATH_NOT_FOUND.id -> context.getString(R.string.tripplanner_error_path_not_found)
-        Message.NO_TRANSIT_TIMES.id -> context.getString(R.string.tripplanner_error_no_transit_times)
-        Message.REQUEST_TIMEOUT.id -> context.getString(R.string.tripplanner_error_request_timeout)
-        Message.BOGUS_PARAMETER.id -> context.getString(R.string.tripplanner_error_bogus_parameter)
-        Message.GEOCODE_FROM_NOT_FOUND.id ->
+        OtpErrorId.SYSTEM_ERROR.id -> context.getString(R.string.tripplanner_error_system)
+        OtpErrorId.OUTSIDE_BOUNDS.id -> context.getString(R.string.tripplanner_error_outside_bounds)
+        OtpErrorId.PATH_NOT_FOUND.id -> context.getString(R.string.tripplanner_error_path_not_found)
+        OtpErrorId.NO_TRANSIT_TIMES.id -> context.getString(R.string.tripplanner_error_no_transit_times)
+        OtpErrorId.REQUEST_TIMEOUT.id -> context.getString(R.string.tripplanner_error_request_timeout)
+        OtpErrorId.BOGUS_PARAMETER.id -> context.getString(R.string.tripplanner_error_bogus_parameter)
+        OtpErrorId.GEOCODE_FROM_NOT_FOUND.id ->
             context.getString(R.string.tripplanner_error_geocode_from_not_found)
-        Message.GEOCODE_TO_NOT_FOUND.id ->
+        OtpErrorId.GEOCODE_TO_NOT_FOUND.id ->
             context.getString(R.string.tripplanner_error_geocode_to_not_found)
-        Message.GEOCODE_FROM_TO_NOT_FOUND.id ->
+        OtpErrorId.GEOCODE_FROM_TO_NOT_FOUND.id ->
             context.getString(R.string.tripplanner_error_geocode_from_to_not_found)
-        Message.TOO_CLOSE.id -> context.getString(R.string.tripplanner_error_too_close)
-        Message.LOCATION_NOT_ACCESSIBLE.id ->
+        OtpErrorId.TOO_CLOSE.id -> context.getString(R.string.tripplanner_error_too_close)
+        OtpErrorId.LOCATION_NOT_ACCESSIBLE.id ->
             context.getString(R.string.tripplanner_error_location_not_accessible)
-        Message.GEOCODE_FROM_AMBIGUOUS.id ->
+        OtpErrorId.GEOCODE_FROM_AMBIGUOUS.id ->
             context.getString(R.string.tripplanner_error_geocode_from_ambiguous)
-        Message.GEOCODE_TO_AMBIGUOUS.id ->
+        OtpErrorId.GEOCODE_TO_AMBIGUOUS.id ->
             context.getString(R.string.tripplanner_error_geocode_to_ambiguous)
-        Message.GEOCODE_FROM_TO_AMBIGUOUS.id ->
+        OtpErrorId.GEOCODE_FROM_TO_AMBIGUOUS.id ->
             context.getString(R.string.tripplanner_error_geocode_from_to_ambiguous)
-        Message.UNDERSPECIFIED_TRIANGLE.id, Message.TRIANGLE_NOT_AFFINE.id,
-        Message.TRIANGLE_OPTIMIZE_TYPE_NOT_SET.id, Message.TRIANGLE_VALUES_NOT_SET.id ->
+        OtpErrorId.UNDERSPECIFIED_TRIANGLE.id, OtpErrorId.TRIANGLE_NOT_AFFINE.id,
+        OtpErrorId.TRIANGLE_OPTIMIZE_TYPE_NOT_SET.id, OtpErrorId.TRIANGLE_VALUES_NOT_SET.id ->
             context.getString(R.string.tripplanner_error_triangle)
         else -> context.getString(R.string.tripplanner_error_not_defined)
     }
@@ -229,6 +234,15 @@ internal fun otpPlanUrl(baseUrl: String, query: String, oldServer: Boolean): Str
     } else {
         "$baseUrl$OTP_ROUTERS_SEGMENT$OTP_PLAN_LOCATION$query"
     }
+
+/**
+ * True when [modeString] (the OTP `mode` query value built by
+ * [org.onebusaway.android.directions.util.TripRequestBuilder.setModeSetById]) includes the bike-rental
+ * wire token — pulled out as a standalone, `Context`-free function so this (previously never-true —
+ * see #1778) derivation is unit-testable.
+ */
+internal fun modeStringRequestsBikeRental(modeString: String?, bikeRentalToken: String): Boolean =
+    modeString?.contains(bikeRentalToken) == true
 
 /**
  * Assembles a [TripRequestBuilder] from these [TripPlanParams]. Shared by the UI plan path

--- a/onebusaway-android/src/test/java/org/onebusaway/android/api/contract/OtpErrorIdTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/api/contract/OtpErrorIdTest.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.api.contract
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pins [OtpErrorId]'s wire ids against the vendored `org.opentripplanner.api.ws.Message` jar they were
+ * transcribed from (`Message(String, int)` constructor arguments, read via `javap`/CFR — see #1778) —
+ * a transcription slip here would silently swap which user-facing error string a given OTP `/plan`
+ * error response maps to.
+ */
+class OtpErrorIdTest {
+
+    @Test
+    fun idsMatchVendoredMessageEnum() {
+        assertEquals(500, OtpErrorId.SYSTEM_ERROR.id)
+        assertEquals(400, OtpErrorId.OUTSIDE_BOUNDS.id)
+        assertEquals(404, OtpErrorId.PATH_NOT_FOUND.id)
+        assertEquals(406, OtpErrorId.NO_TRANSIT_TIMES.id)
+        assertEquals(408, OtpErrorId.REQUEST_TIMEOUT.id)
+        assertEquals(413, OtpErrorId.BOGUS_PARAMETER.id)
+        assertEquals(440, OtpErrorId.GEOCODE_FROM_NOT_FOUND.id)
+        assertEquals(450, OtpErrorId.GEOCODE_TO_NOT_FOUND.id)
+        assertEquals(460, OtpErrorId.GEOCODE_FROM_TO_NOT_FOUND.id)
+        assertEquals(409, OtpErrorId.TOO_CLOSE.id)
+        assertEquals(470, OtpErrorId.LOCATION_NOT_ACCESSIBLE.id)
+        assertEquals(340, OtpErrorId.GEOCODE_FROM_AMBIGUOUS.id)
+        assertEquals(350, OtpErrorId.GEOCODE_TO_AMBIGUOUS.id)
+        assertEquals(360, OtpErrorId.GEOCODE_FROM_TO_AMBIGUOUS.id)
+        assertEquals(370, OtpErrorId.UNDERSPECIFIED_TRIANGLE.id)
+        assertEquals(371, OtpErrorId.TRIANGLE_NOT_AFFINE.id)
+        assertEquals(372, OtpErrorId.TRIANGLE_OPTIMIZE_TYPE_NOT_SET.id)
+        assertEquals(373, OtpErrorId.TRIANGLE_VALUES_NOT_SET.id)
+    }
+
+    @Test
+    fun idsAreUnique() {
+        val ids = OtpErrorId.entries.map { it.id }
+        assertEquals(ids.size, ids.toSet().size)
+    }
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/ModeStringRequestsBikeRentalTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/ModeStringRequestsBikeRentalTest.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.tripplan
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Covers [modeStringRequestsBikeRental], which [DefaultTripPlanRepository]'s pre-1.0-server URL
+ * rewrite uses to detect a bike-rental request. Before #1778 this came from the vendored
+ * `Request.bikeRental` field, which nothing in this app ever set (bikeshare mode has always been
+ * requested via the `BICYCLE_RENT` mode-string token instead), so the rewrite had been dead since the
+ * bikeshare feature shipped in 2017. This pins the fix: the token's presence in the built mode string
+ * is now the source of truth.
+ */
+class ModeStringRequestsBikeRentalTest {
+
+    @Test
+    fun bikeRentalModeIsDetected() {
+        assertTrue(modeStringRequestsBikeRental("TRANSIT,WALK,BICYCLE_RENT", "BICYCLE_RENT"))
+        assertTrue(modeStringRequestsBikeRental("BICYCLE_RENT", "BICYCLE_RENT"))
+    }
+
+    @Test
+    fun nonBikeRentalModesAreNotDetected() {
+        assertFalse(modeStringRequestsBikeRental("TRANSIT,WALK", "BICYCLE_RENT"))
+        assertFalse(modeStringRequestsBikeRental("BUS,WALK", "BICYCLE_RENT"))
+        assertFalse(modeStringRequestsBikeRental(null, "BICYCLE_RENT"))
+    }
+}


### PR DESCRIPTION
## Summary

`TripRequestBuilder`/`TripPlanRepository` still built the outgoing OTP `/plan` request with the vendored, unpublished `edu.usf.cutr.opentripplanner.android:opentripplanner-pojos:1.0.0-SNAPSHOT` jar (`org.opentripplanner.api.ws.Request`/`Message`, `org.opentripplanner.routing.core.OptimizeType`/`TraverseMode`) even after #1782 migrated the response side onto the app-owned `TripItinerary` domain model.

- Retargets request-building onto app-owned types — `TripPlanRequest` (an OTP `/plan` query-parameter map) and `OtpErrorId` (the OTP wire error-id vocabulary) — placed in `api/contract/OtpPlanModels.kt` alongside the existing `OtpResponseDto`/`OtpErrorDto` family, matching this codebase's existing layering.
- Reuses the existing `TripMode` enum (already used for the response side) instead of `TraverseMode` for building the OTP `mode` query parameter.
- `OptimizeType` is gone entirely — replaced by the two literal wire values (`"QUICK"`/`"TRANSFERS"`) it ever produced.

**Bug fix found along the way:** the pre-1.0-OTP-server bike-rental URL rewrite in `TripPlanRepository.requestPlan()` has been dead code since the bikeshare feature shipped in 2017 — nothing ever called the vendored `Request.setBikeRental(true)`, since bikeshare mode has always been requested via the `BICYCLE_RENT` mode-string token instead (a completely separate mechanism). A user selecting bikeshare mode against a region running a pre-1.0 OTP server would send a mode string that server can't parse. Now derives the flag by checking for that token's presence in the built `mode` query string — the one source of truth valid on both the direct UI-build path and the trip-plan-monitor's bundle-restore path (`initFromBundleSimple` never repopulates `mModeId`).

The `opentripplanner-pojos` dependency itself stays in `build.gradle`: bikeshare (`BikeRentalStation`) is still a live consumer, tracked separately in #1779. Once that lands, the dependency can be removed entirely.

Tracking: #1778

## Test plan

- [x] `./gradlew :onebusaway-android:compileObaGoogleDebugKotlin -PwarningsAsErrors=true` — clean
- [x] `./gradlew :onebusaway-android:testObaGoogleDebugUnitTest -PwarningsAsErrors=true` — all pass, including new `OtpErrorIdTest` (pins the 18 transcribed wire error-ids against the vendored jar) and `ModeStringRequestsBikeRentalTest` (pins the bike-rental-detection fix)
- [ ] Lint (`lintObaGoogleDebug`) not run locally per this repo's convention — left to CI
- [ ] On-device manual trip-planning verification not performed in this environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated trip planning requests to use the app’s internal request format.
  * Added support for clearer handling of trip-planning error responses.
  * Preserved bike-rental trip planning while using the updated request format.

* **Bug Fixes**
  * Improved detection of bike-rental modes in trip-planning requests.

* **Tests**
  * Added coverage for error-code mappings and bike-rental mode detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->