### PR TITLE
Migrate BikeRentalStation off the vendored OTP1 POJO library

### DIFF
--- a/onebusaway-android/build.gradle
+++ b/onebusaway-android/build.gradle
@@ -29,10 +29,6 @@ repositories {
         // OBA Releases - for comparator to sort alphanumeric routes
         url "https://repo.camsys-apps.com/releases"
     }
-    maven {
-        // CUTR Releases
-        url "https://github.com/CUTR-at-USF/cutr-mvn-repo/raw/master/snapshots"
-    }
     mavenCentral()
     maven { url 'https://jitpack.io' }
 }
@@ -311,13 +307,6 @@ dependencies {
     implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3'
     // For sorting alphanumeric route names
     implementation 'org.onebusaway.util:comparators:1.0.0'
-    // OpenTripPlanner POJOs — an unpublished, unpatchable 2017-era SNAPSHOT (#1778). The trip-itinerary
-    // path no longer reads these directly: the OTP `/plan` request is built and the response decoded
-    // via our own types (TripRequestBuilder / api/contract/OtpPlanModels.kt), mapped onto the app-owned
-    // domain model in directions/model/TripItinerary.kt. The only remaining consumer is the bikeshare
-    // `BikeRentalStation` path (BikeModels.kt, BikeLayerController.kt, map/bike/, map/compose/Bike*);
-    // once that's migrated too (#1779), this dependency can be removed entirely.
-    implementation 'edu.usf.cutr.opentripplanner.android:opentripplanner-pojos:1.0.0-SNAPSHOT'
     // Pelias for point-of-interest search and geocoding for trip planning origin and destination
     implementation 'com.github.OneBusAway:pelias-client-library:v1.1.0'
     implementation 'androidx.appcompat:appcompat:1.7.0'

--- a/onebusaway-android/proguard-project.txt
+++ b/onebusaway-android/proguard-project.txt
@@ -35,9 +35,6 @@
 # Keep all OneBusAway Android classes
 -keep class org.onebusaway.android.** { *; }
 
-# Keep all OpenTripPlanner POJO classes
--keep class org.opentripplanner.** { *; }
-
 # Keep all Pelias POJO classes for geocoding
 -keep class edu.usf.cutr.pelias.** { *; }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/adapters/BikeStationAdapters.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/adapters/BikeStationAdapters.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.api.adapters
+
+import org.onebusaway.android.api.contract.BikeRentalStationsDto
+import org.onebusaway.android.api.contract.BikeStationDto
+import org.onebusaway.android.map.bike.BikeStation
+
+/**
+ * Maps the OTP bike-rental wire DTOs (`api/contract/BikeModels.kt`) onto the app-owned
+ * [BikeStation] domain model (`map/bike/BikeStation.kt`), replacing the old `toBikeRentalStations()`
+ * mapper that built `org.opentripplanner.routing.bike_rental.BikeRentalStation` POJOs directly (#1779).
+ * Follows the same DTO-to-domain convention as [toTripItinerary].
+ */
+fun BikeRentalStationsDto.toBikeStations(): List<BikeStation> = stations.map { it.toBikeStation() }
+
+fun BikeStationDto.toBikeStation(): BikeStation = BikeStation(
+    id = id,
+    name = name,
+    latitude = y,
+    longitude = x,
+    bikesAvailable = bikesAvailable,
+    spacesAvailable = spacesAvailable,
+    allowDropoff = allowDropoff,
+    isFloatingBike = isFloatingBike,
+    realTimeData = realTimeData,
+)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/contract/BikeModels.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/contract/BikeModels.kt
@@ -16,16 +16,15 @@
 package org.onebusaway.android.api.contract
 
 import kotlinx.serialization.Serializable
-import org.opentripplanner.routing.bike_rental.BikeRentalStation
 
 /**
  * Bike-rental response models for [BikeWebService]. These come from an OpenTripPlanner server
  * (`routers/default/bike_rental`), not the OBA `where` API, and are plain JSON.
  *
- * The map/overlay consumers (BikeLayerController, MapRenderState, BikeInfoWindow, …) all read the
- * OTP library's [BikeRentalStation] POJO, so rather than ripple a new type through them, the DTO
- * decodes the wire and [toBikeRentalStations] maps onto that POJO (its fields are public and it has
- * a no-arg constructor). Property names mirror the OTP field names so no `@SerialName` is needed.
+ * [org.onebusaway.android.api.adapters.toBikeStations] (in `api/adapters/BikeStationAdapters.kt`) maps
+ * these onto the app-owned [org.onebusaway.android.map.bike.BikeStation] domain model the map/overlay
+ * consumers (BikeLayerController, MapRenderState, BikeInfoWindow, …) actually read. Property names
+ * mirror the OTP field names so no `@SerialName` is needed.
  */
 @Serializable
 data class BikeRentalStationsDto(
@@ -44,19 +43,3 @@ data class BikeStationDto(
     val isFloatingBike: Boolean = false,
     val realTimeData: Boolean = false,
 )
-
-/** Maps the decoded stations onto the OTP [BikeRentalStation] POJO the map consumers expect. */
-fun BikeRentalStationsDto.toBikeRentalStations(): List<BikeRentalStation> =
-    stations.map { it.toBikeRentalStation() }
-
-private fun BikeStationDto.toBikeRentalStation(): BikeRentalStation = BikeRentalStation().also {
-    it.id = id
-    it.name = name
-    it.x = x
-    it.y = y
-    it.bikesAvailable = bikesAvailable
-    it.spacesAvailable = spacesAvailable
-    it.allowDropoff = allowDropoff
-    it.isFloatingBike = isFloatingBike
-    it.realTimeData = realTimeData
-}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/BikeLayerController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/BikeLayerController.kt
@@ -30,13 +30,13 @@ import org.onebusaway.android.R
 import org.onebusaway.android.region.RegionRepository
 import org.onebusaway.android.util.BikeshareAvailability
 import org.onebusaway.android.map.bike.BikeAction
+import org.onebusaway.android.map.bike.BikeStation
 import org.onebusaway.android.map.bike.BikeStationsRepository
 import org.onebusaway.android.map.bike.bikeAction
 import org.onebusaway.android.map.bike.filterStations
 import org.onebusaway.android.map.render.BikeMarker
 import org.onebusaway.android.map.render.GeoPoint
 import org.onebusaway.android.preferences.PreferencesRepository
-import org.opentripplanner.routing.bike_rental.BikeRentalStation
 
 /**
  * The bikeshare overlay (the legacy `BikeshareMapController`). It **overlays every view** rather than
@@ -114,9 +114,9 @@ class BikeLayerController(
         loadJob = null
     }
 
-    private fun showBikeStations(stations: List<BikeRentalStation>, bikeshareVisible: Boolean) {
+    private fun showBikeStations(stations: List<BikeStation>, bikeshareVisible: Boolean) {
         val markers = stations.map {
-            BikeMarker(it.id, GeoPoint(it.y, it.x), it.isFloatingBike, it)
+            BikeMarker(it.id, GeoPoint(it.latitude, it.longitude), it.isFloatingBike, it)
         }
         host.renderState.setBikeStations(markers, bikeshareVisible)
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapNavigation.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapNavigation.kt
@@ -20,11 +20,11 @@ import org.onebusaway.android.R
 import org.onebusaway.android.app.di.RegionEntryPoint
 import org.onebusaway.android.app.di.AnalyticsEntryPoint
 import org.onebusaway.android.analytics.PlausibleAnalytics
+import org.onebusaway.android.map.bike.BikeStation
 import org.onebusaway.android.models.ObaTripStatus
 import org.onebusaway.android.ui.tripdetails.TripDetailsLauncher
 import org.onebusaway.android.util.ExternalIntents
 import org.onebusaway.android.util.RegionUtils
-import org.opentripplanner.routing.bike_rental.BikeRentalStation
 
 /**
  * Navigation launched from a map info-window tap. Flavor-neutral (no map-SDK types), so both the
@@ -49,7 +49,7 @@ object MapNavigation {
      * region's Hopr app (preserved verbatim from the legacy BikeStationOverlay.onInfoWindowClick).
      */
     @JvmStatic
-    fun openBikeDeepLink(context: Context, station: BikeRentalStation) {
+    fun openBikeDeepLink(context: Context, station: BikeStation) {
         val region = RegionEntryPoint.get(context).currentRegion() ?: return
         if (region.id != RegionUtils.TAMPA_REGION_ID.toLong()) {
             return

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/bike/BikeStation.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/bike/BikeStation.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.map.bike
+
+/**
+ * The app-owned replacement for the vendored, unpublished-snapshot
+ * `org.opentripplanner.routing.bike_rental.BikeRentalStation` POJO (#1779) — bikeshare station data
+ * read directly by shared, cross-flavor map UI: [org.onebusaway.android.map.compose.ObaMapCallbacks]
+ * (`onBikeClick`/`onBikeInfoWindowClick`), [org.onebusaway.android.map.compose.BikeInfoWindow], the
+ * [org.onebusaway.android.map.render.BikeMarker] render-state snapshot, and
+ * [BikeStationsRepository].
+ *
+ * Minted exactly once, in `api/adapters/BikeStationAdapters.kt`, from the OTP bike-rental wire DTO
+ * (`api/contract/BikeModels.kt`) — consumers never touch the wire shape. [latitude]/[longitude] replace
+ * the vendored POJO's `y`/`x` naming (OTP's GeoJSON-style axis order), the one field rename from the
+ * wire DTO; every other field mirrors [org.onebusaway.android.api.contract.BikeStationDto] exactly.
+ *
+ * All fields default so tests can build a fixture tersely (e.g. `BikeStation(id = "a")`); production
+ * code always goes through the adapter, which reads every field off the decoded wire response.
+ */
+data class BikeStation(
+    val id: String = "",
+    val name: String = "",
+    val latitude: Double = 0.0,
+    val longitude: Double = 0.0,
+    val bikesAvailable: Int = 0,
+    val spacesAvailable: Int = 0,
+    val allowDropoff: Boolean = false,
+    val isFloatingBike: Boolean = false,
+    val realTimeData: Boolean = false,
+)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/bike/BikeStationsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/bike/BikeStationsRepository.kt
@@ -18,22 +18,21 @@ package org.onebusaway.android.map.bike
 import javax.inject.Inject
 import android.location.Location
 import org.onebusaway.android.R
+import org.onebusaway.android.api.adapters.toBikeStations
 import org.onebusaway.android.api.contract.BikeWebService
-import org.onebusaway.android.api.contract.toBikeRentalStations
 import org.onebusaway.android.preferences.PreferencesRepository
 import org.onebusaway.android.region.RegionRepository
 import org.onebusaway.android.util.RegionUtils
-import org.opentripplanner.routing.bike_rental.BikeRentalStation
 
 /**
  * Loads bike rental stations from OpenTripPlanner for a map bounding box. Replaces the
- * `BikeStationLoader` `AsyncTaskLoader` + `BikeLoaderCallbacks`; couriers the raw OTP
- * [BikeRentalStation] list for the bike overlay. The corners are passed in Google-Maps terms
- * (southWest / northEast); the request maps them to OTP's lowerLeft / upperRight.
+ * `BikeStationLoader` `AsyncTaskLoader` + `BikeLoaderCallbacks`; couriers the app-owned [BikeStation]
+ * list for the bike overlay. The corners are passed in Google-Maps terms (southWest / northEast); the
+ * request maps them to OTP's lowerLeft / upperRight.
  */
 interface BikeStationsRepository {
     suspend fun getStations(southWest: Location, northEast: Location):
-            Result<List<BikeRentalStation>>
+            Result<List<BikeStation>>
 }
 
 class DefaultBikeStationsRepository @Inject constructor(
@@ -43,7 +42,7 @@ class DefaultBikeStationsRepository @Inject constructor(
 ) : BikeStationsRepository {
 
     override suspend fun getStations(southWest: Location, northEast: Location):
-            Result<List<BikeRentalStation>> = runCatching {
+            Result<List<BikeStation>> = runCatching {
         val base = otpBaseUrl() ?: error("No OTP base URL for the current region")
 
         // OTP servers differ in how their base URL is rooted (see TripPlanRepository): the "new"
@@ -67,10 +66,10 @@ class DefaultBikeStationsRepository @Inject constructor(
         useOldUrlStructure: Boolean,
         southWest: Location,
         northEast: Location,
-    ): List<BikeRentalStation> = bikeService.getBikeStations(
+    ): List<BikeStation> = bikeService.getBikeStations(
         bikeRentalUrl(base, useOldUrlStructure, southWest.latitude, southWest.longitude,
             northEast.latitude, northEast.longitude)
-    ).toBikeRentalStations()
+    ).toBikeStations()
 
     /** The custom OTP url (advanced setting) or the region's `otpBaseUrl`, trailing slash stripped. */
     private fun otpBaseUrl(): String? {
@@ -109,9 +108,9 @@ internal fun bikeRentalUrl(
  *  - non-empty filter → only the stations whose id is in the filter
  */
 internal fun filterStations(
-    all: List<BikeRentalStation>,
+    all: List<BikeStation>,
     selectedIds: List<String>?,
-): List<BikeRentalStation>? = when {
+): List<BikeStation>? = when {
     selectedIds == null -> all
     selectedIds.isEmpty() -> null
     else -> all.filter { selectedIds.contains(it.id) }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/compose/BikeInfoWindow.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/compose/BikeInfoWindow.kt
@@ -32,7 +32,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.onebusaway.android.R
-import org.opentripplanner.routing.bike_rental.BikeRentalStation
+import org.onebusaway.android.map.bike.BikeStation
 
 // Info-window contents sit on a white bubble, so text uses fixed dark colors.
 private val BikePrimary = Color(0xDE000000)
@@ -45,7 +45,7 @@ private val BikeSecondary = Color(0x99000000)
  * a `ComposeView` wrapped in its own bubble.
  */
 @Composable
-fun BikeInfoWindow(station: BikeRentalStation) {
+fun BikeInfoWindow(station: BikeStation) {
     Column(modifier = Modifier.padding(8.dp)) {
         Text(
             text = station.name,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/compose/NoOpObaMapCallbacks.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/compose/NoOpObaMapCallbacks.kt
@@ -17,8 +17,8 @@ package org.onebusaway.android.map.compose
 
 import org.onebusaway.android.models.ObaStop
 import org.onebusaway.android.models.ObaTripStatus
+import org.onebusaway.android.map.bike.BikeStation
 import org.onebusaway.android.map.render.GeoPoint
-import org.opentripplanner.routing.bike_rental.BikeRentalStation
 
 /**
  * A do-nothing [ObaMapCallbacks] for map screens that don't react to taps (the trip-plan location
@@ -30,9 +30,9 @@ object NoOpObaMapCallbacks : ObaMapCallbacks {
 
     override fun onMapClick(point: GeoPoint?) {}
 
-    override fun onBikeClick(station: BikeRentalStation) {}
+    override fun onBikeClick(station: BikeStation) {}
 
     override fun onVehicleInfoWindowClick(status: ObaTripStatus) {}
 
-    override fun onBikeInfoWindowClick(station: BikeRentalStation) {}
+    override fun onBikeInfoWindowClick(station: BikeStation) {}
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/compose/ObaMapCallbacks.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/compose/ObaMapCallbacks.kt
@@ -17,8 +17,8 @@ package org.onebusaway.android.map.compose
 
 import org.onebusaway.android.models.ObaStop
 import org.onebusaway.android.models.ObaTripStatus
+import org.onebusaway.android.map.bike.BikeStation
 import org.onebusaway.android.map.render.GeoPoint
-import org.opentripplanner.routing.bike_rental.BikeRentalStation
 
 /**
  * Map interaction a flavor's [ObaComposeMapAdapter] reports back to its host. Flavor-neutral (no
@@ -34,7 +34,7 @@ interface ObaMapCallbacks {
 
     fun onMapClick(point: GeoPoint?)
 
-    fun onBikeClick(station: BikeRentalStation)
+    fun onBikeClick(station: BikeStation)
 
     /** A vehicle marker tap — the host selects it (e.g. to show its most-recent-data marker). */
     fun onVehicleClick(status: ObaTripStatus) {}
@@ -43,5 +43,5 @@ interface ObaMapCallbacks {
     fun onVehicleInfoWindowClick(status: ObaTripStatus)
 
     /** The bike info-window "more info" tap — the host navigates (e.g. the bikeshare deep link). */
-    fun onBikeInfoWindowClick(station: BikeRentalStation)
+    fun onBikeInfoWindowClick(station: BikeStation)
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
@@ -23,10 +23,10 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import org.onebusaway.android.map.bike.BikeStation
 import org.onebusaway.android.models.RouteTrips
 import org.onebusaway.android.models.ObaStop
 import org.onebusaway.android.models.ObaTripStatus
-import org.opentripplanner.routing.bike_rental.BikeRentalStation
 
 /** A geographic point, flavor-neutral (carries no Google/maplibre `LatLng` dependency). */
 data class GeoPoint(val latitude: Double, val longitude: Double)
@@ -116,15 +116,16 @@ data class VehicleMarker(
 )
 
 /**
- * One bike-rental marker. [station] is the raw OTP pojo (the renderer reads its name/availability for
- * the info window and its floating-vs-station flag for the icon). [bikeshareVisible] on the snapshot
- * is the layer/directions-mode gate; the per-zoom icon band is chosen live by the renderer.
+ * One bike-rental marker. [station] is the app-owned domain type (the renderer reads its
+ * name/availability for the info window and its floating-vs-station flag for the icon).
+ * [bikeshareVisible] on the snapshot is the layer/directions-mode gate; the per-zoom icon band is
+ * chosen live by the renderer.
  */
 data class BikeMarker(
     val id: String,
     val point: GeoPoint,
     val isFloatingBike: Boolean,
-    val station: BikeRentalStation,
+    val station: BikeStation,
 )
 
 /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/InfrastructureIssueScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/InfrastructureIssueScreen.kt
@@ -177,11 +177,11 @@ fun InfrastructureIssueDestination(
                 point?.let { viewModel.onMapFocusChanged(null, it.latitude, it.longitude) }
             }
 
-            override fun onBikeClick(station: org.opentripplanner.routing.bike_rental.BikeRentalStation) {}
+            override fun onBikeClick(station: org.onebusaway.android.map.bike.BikeStation) {}
 
             override fun onVehicleInfoWindowClick(status: org.onebusaway.android.models.ObaTripStatus) {}
 
-            override fun onBikeInfoWindowClick(station: org.opentripplanner.routing.bike_rental.BikeRentalStation) {}
+            override fun onBikeInfoWindowClick(station: org.onebusaway.android.map.bike.BikeStation) {}
         }
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
@@ -66,6 +66,7 @@ import org.onebusaway.android.map.MapEffect
 import org.onebusaway.android.map.MapNavigation
 import org.onebusaway.android.map.MapViewModel
 import org.onebusaway.android.map.StopsBanner
+import org.onebusaway.android.map.bike.BikeStation
 import org.onebusaway.android.map.compose.ObaMap
 import org.onebusaway.android.map.compose.ObaMapCallbacks
 import org.onebusaway.android.map.render.GeoPoint
@@ -77,7 +78,6 @@ import org.onebusaway.android.util.LayerUtils
 import org.onebusaway.android.util.ObaRequestErrors
 import org.onebusaway.android.util.PermissionUtils
 import org.onebusaway.android.util.PreferenceUtils
-import org.opentripplanner.routing.bike_rental.BikeRentalStation
 
 /**
  * The self-wiring map feature module: renders [ObaMap] and owns everything that used to be map glue
@@ -139,7 +139,7 @@ fun MapFeature(
                 homeViewModel.onBikeStationFocused(null)
             }
 
-            override fun onBikeClick(station: BikeRentalStation) {
+            override fun onBikeClick(station: BikeStation) {
                 val bikeId = homeViewModel.uiState.value.focusedBikeStationId
                 if (bikeId == null || !bikeId.equals(station.id, ignoreCase = true)) {
                     homeViewModel.onBikeStationFocused(station.id)
@@ -167,7 +167,7 @@ fun MapFeature(
                 )
             }
 
-            override fun onBikeInfoWindowClick(station: BikeRentalStation) {
+            override fun onBikeInfoWindowClick(station: BikeStation) {
                 MapNavigation.openBikeDeepLink(context, station)
             }
         }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/api/BikeStationsDecodeTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/api/BikeStationsDecodeTest.kt
@@ -15,8 +15,8 @@
  */
 package org.onebusaway.android.api
 
+import org.onebusaway.android.api.adapters.toBikeStations
 import org.onebusaway.android.api.contract.BikeRentalStationsDto
-import org.onebusaway.android.api.contract.toBikeRentalStations
 
 import kotlinx.serialization.json.Json
 import org.junit.Assert.assertEquals
@@ -26,9 +26,10 @@ import org.junit.Test
 import java.io.File
 
 /**
- * Covers the OTP bike-rental decode + the mapping onto the OTP [BikeRentalStation] POJO the map
- * overlay consumes. The wire is plain JSON whose keys match the POJO field names; extra keys (e.g.
- * `networks`) must be ignored, not rejected.
+ * Covers the OTP bike-rental decode + the mapping onto the app-owned
+ * [org.onebusaway.android.map.bike.BikeStation] domain model the map overlay consumes. The wire is
+ * plain JSON whose keys match the DTO field names; extra keys (e.g. `networks`) must be ignored, not
+ * rejected.
  */
 class BikeStationsDecodeTest {
 
@@ -60,14 +61,14 @@ class BikeStationsDecodeTest {
         val dto = json.decodeFromString<BikeRentalStationsDto>(body)
         assertEquals(2, dto.stations.size)
 
-        val stations = dto.toBikeRentalStations()
+        val stations = dto.toBikeStations()
         assertEquals(2, stations.size)
 
         val first = stations[0]
         assertEquals("bike_1", first.id)
         assertEquals("Pine & 5th", first.name)
-        assertEquals(-122.334, first.x, 1e-6)
-        assertEquals(47.611, first.y, 1e-6)
+        assertEquals(-122.334, first.longitude, 1e-6)
+        assertEquals(47.611, first.latitude, 1e-6)
         assertEquals(4, first.bikesAvailable)
         assertEquals(6, first.spacesAvailable)
         assertTrue(first.allowDropoff)
@@ -78,14 +79,14 @@ class BikeStationsDecodeTest {
     }
 
     /**
-     * Decodes the real OTP Tampa bike-rental fixture and maps it onto [BikeRentalStation], porting
-     * the assertions from the retired live-network `BikeStationRequestTest`. Note the OTP server
-     * returns ids wrapped in literal quote characters (`"bike_3566"`), preserved verbatim.
+     * Decodes the real OTP Tampa bike-rental fixture and maps it onto [org.onebusaway.android.map.bike.BikeStation],
+     * porting the assertions from the retired live-network `BikeStationRequestTest`. Note the OTP
+     * server returns ids wrapped in literal quote characters (`"bike_3566"`), preserved verbatim.
      */
     @Test
     fun decodesTampaFixture() {
         val body = File("src/androidTest/res/raw/bike_rental_tampa_all.json").readText()
-        val stations = json.decodeFromString<BikeRentalStationsDto>(body).toBikeRentalStations()
+        val stations = json.decodeFromString<BikeRentalStationsDto>(body).toBikeStations()
 
         assertEquals(133, stations.size)
         stations.forEach { assertNotNull(it.name) }
@@ -94,8 +95,8 @@ class BikeStationsDecodeTest {
         val precision = 0.000001
         assertEquals("\"bike_3566\"", first.id)
         assertEquals("B-1165", first.name)
-        assertEquals(-82.40730666666667, first.x, precision)
-        assertEquals(28.066505, first.y, precision)
+        assertEquals(-82.40730666666667, first.longitude, precision)
+        assertEquals(28.066505, first.latitude, precision)
         assertEquals(1, first.bikesAvailable)
         assertEquals(0, first.spacesAvailable)
         assertEquals(false, first.allowDropoff)

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/bike/BikeStationFilterTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/bike/BikeStationFilterTest.kt
@@ -18,7 +18,6 @@ package org.onebusaway.android.map.bike
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
-import org.opentripplanner.routing.bike_rental.BikeRentalStation
 
 /**
  * Unit tests for [filterStations] — the directions-mode station filter ported from
@@ -27,8 +26,7 @@ import org.opentripplanner.routing.bike_rental.BikeRentalStation
  */
 class BikeStationFilterTest {
 
-    private fun station(id: String): BikeRentalStation =
-        BikeRentalStation().apply { this.id = id }
+    private fun station(id: String): BikeStation = BikeStation(id = id)
 
     private val all = listOf(station("a"), station("b"), station("c"))
 
@@ -51,7 +49,7 @@ class BikeStationFilterTest {
 
     @Test
     fun `filter ids not present yield an empty list`() {
-        assertEquals(emptyList<BikeRentalStation>(), filterStations(all, selectedIds = listOf("z")))
+        assertEquals(emptyList<BikeStation>(), filterStations(all, selectedIds = listOf("z")))
     }
 
     // --- bikeAction: the pure layer/mode gate from BikeshareMapController.updateData + showBikes ---


### PR DESCRIPTION
## Summary

`BikeRentalStation` (`org.opentripplanner.routing.bike_rental`) was the last consumer of the vendored, unpublished `edu.usf.cutr.opentripplanner.android:opentripplanner-pojos` jar once #1782 migrated trip-itinerary planning. Unlike `Itinerary`/`Leg`, it was baked directly into shared, cross-flavor UI: `ObaMapCallbacks`/`NoOpObaMapCallbacks`, `BikeInfoWindow`, `MapRenderState`'s `BikeMarker`, `BikeStationsRepository`, `MapNavigation`, and `BikeLayerController`.

- Introduces an app-owned `BikeStation` domain model (`map/bike/BikeStation.kt`) and a DTO→domain adapter (`api/adapters/BikeStationAdapters.kt`) from the existing `BikeStationDto` wire model, following the same shape as the itinerary migration's `TripItinerary.kt`/`TripPlanAdapters.kt`. Retargets every consumer onto it.
- `latitude`/`longitude` replace the vendored POJO's `x`/`y` naming; every other field mirrors the wire DTO exactly.
- With the last consumer gone, removes the `opentripplanner-pojos` dependency, its CUTR-at-USF raw-file "maven repo" entry, and the now-unused `-keep class org.opentripplanner.**` proguard rule — the actual root problem #1778 called out (an unpublished, unpatchable 2017-era SNAPSHOT fetched from a personal GitHub raw-file repo) is now fully gone from the project.

**Side effect worth flagging:** `BikeStation`'s plain data-class equality (full structural comparison) replaces the vendored POJO's id-only `equals()`/`hashCode()`. `MapRenderState`'s snapshot `StateFlow` dedups emissions by equality, so the old id-only equals could silently suppress a redraw when only live bike/space counts changed for an already-known station id. This fixes that staleness, at the cost of a fuller redraw when counts actually change — the correct trade, not a regression.

Tracking: #1778
Closes: #1779

## Test plan

- [x] `./gradlew :onebusaway-android:compileObaGoogleDebugKotlin -PwarningsAsErrors=true` — clean
- [x] `./gradlew :onebusaway-android:compileObaMaplibreDebugKotlin -PwarningsAsErrors=true` — clean (bike UI is cross-flavor)
- [x] `./gradlew :onebusaway-android:testObaGoogleDebugUnitTest -PwarningsAsErrors=true` — all pass, including updated `BikeStationFilterTest`/`BikeStationsDecodeTest`
- [ ] Lint (`lintObaGoogleDebug`) not run locally per this repo's convention — left to CI
- [ ] On-device manual bikeshare-layer verification not performed in this environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added improved support for bikeshare station data, including station details, availability, location, and real-time status.
  * Updated map markers, station information, filtering, and bikeshare interactions to use the new station data.
  * Continued support for bikeshare deep links and station selection.

* **Bug Fixes**
  * Improved bikeshare data decoding and coordinate handling for map display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->