### PR TITLE
Route map: show interlining as a continuation line + badge

### DIFF
--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
@@ -26,6 +26,8 @@ import com.google.android.gms.maps.model.BitmapDescriptor
 import com.google.android.gms.maps.model.BitmapDescriptorFactory
 import com.google.android.gms.maps.model.Circle
 import com.google.android.gms.maps.model.CircleOptions
+import com.google.android.gms.maps.model.Dash
+import com.google.android.gms.maps.model.Gap
 import com.google.android.gms.maps.model.LatLng
 import com.google.android.gms.maps.model.Marker
 import com.google.android.gms.maps.model.MarkerOptions
@@ -43,6 +45,8 @@ import org.onebusaway.android.map.compose.formatDataAge
 import org.onebusaway.android.map.googlemapsv2.compose.BikeIcons
 import org.onebusaway.android.map.render.BikeBand
 import org.onebusaway.android.map.render.BikeMarker
+import org.onebusaway.android.map.render.ContinuationBadge
+import org.onebusaway.android.map.render.ContinuationBadgeBitmaps
 import org.onebusaway.android.map.render.CorrectionSmoother
 import org.onebusaway.android.map.render.GeoPoint
 import org.onebusaway.android.map.render.MapPing
@@ -50,6 +54,8 @@ import org.onebusaway.android.map.render.MapRenderState
 import org.onebusaway.android.map.render.MarkerRendering
 import org.onebusaway.android.map.render.PingTarget
 import org.onebusaway.android.map.render.MapVehicles
+import org.onebusaway.android.map.render.RouteContinuation
+import org.onebusaway.android.map.render.RoutePolyline
 import org.onebusaway.android.map.render.StopBand
 import org.onebusaway.android.map.render.StopIconKind
 import org.onebusaway.android.map.render.StopMarker
@@ -109,6 +115,10 @@ class GoogleMapRenderer(
     private val bikeByMarker = HashMap<Marker, BikeMarker>()
 
     private val vehicleByMarker = HashMap<Marker, VehicleMarker>()
+
+    // The route-continuation badge marker's tap target (#1691) — at most one at a time (the trigger is
+    // the single selected vehicle), but kept as a map like the other *ByMarker lookups for symmetry.
+    private val continuationBadgeByMarker = HashMap<Marker, ContinuationBadge>()
 
     // The latest trips-for-route poll, published as it changes (after the markers are reconciled). The
     // change-detector for the vehicle reconcile, the source a vehicle info window reads its content from,
@@ -211,6 +221,7 @@ class GoogleMapRenderer(
         staticPolylines.forEach { it.remove() }
         staticPolylines.clear()
         bikeByMarker.clear()
+        continuationBadgeByMarker.clear()
     }
 
     /** Redraw the static layer (everything but the live vehicles + trip-focus overlay). */
@@ -220,16 +231,15 @@ class GoogleMapRenderer(
         val snapshot = renderState.snapshot.value
 
         for (polyline in snapshot.routePolylines) {
-            val width = polyline.widthDp?.let { it * density } ?: DEFAULT_ROUTE_WIDTH_PX
             // Stamp travel-direction chevrons only when the line asked for them (a single trip/leg or a
             // route narrowed to one direction); an undirected whole-route shape draws a plain stroke.
             val stroke = StrokeStyle.colorBuilder(polyline.resolvedColor)
                 .apply { if (polyline.directional) stamp(arrowStamp) }
                 .build()
             val options = PolylineOptions()
-                .width(width)
+                .width(widthPx(polyline))
                 .addSpan(StyleSpan(stroke))
-            for (point in polyline.points) options.add(point.toLatLng())
+                .addPoints(polyline.points)
             staticPolylines.add(map.addPolyline(options))
         }
 
@@ -263,6 +273,66 @@ class GoogleMapRenderer(
             generic.hue?.let { options.icon(BitmapDescriptorFactory.defaultMarker(it)) }
             staticMarkers.add(map.addMarker(options)!!)
         }
+
+        snapshot.routeContinuation?.let { continuation -> renderContinuation(continuation) }
+    }
+
+    /**
+     * Draws the selected vehicle's route continuation (#1691): a dashed line in the neighbor route's
+     * own color (so it reads clearly against a busy basemap instead of blending into a gray street), an
+     * arrowhead marker at its end oriented along the shape's travel direction, and a tappable pill badge
+     * halfway along the line.
+     */
+    private fun renderContinuation(continuation: RouteContinuation) {
+        val polyline = continuation.polyline
+        val options = PolylineOptions().color(polyline.resolvedColor).width(widthPx(polyline))
+        if (polyline.dashed) options.pattern(listOf(Dash(CONTINUATION_DASH_LENGTH_PX), Gap(CONTINUATION_GAP_LENGTH_PX)))
+        options.addPoints(polyline.points)
+        staticPolylines.add(map.addPolyline(options))
+
+        val arrow = continuation.arrow
+        staticMarkers.add(
+            map.addMarker(
+                MarkerOptions()
+                    .position(arrow.point.toLatLng())
+                    .icon(continuationArrowIcon(polyline.resolvedColor))
+                    .anchor(0.5f, 1f)
+                    .rotation(arrow.bearing)
+                    .flat(true)
+                    .zIndex(CONTINUATION_BADGE_Z_INDEX)
+            )!!
+        )
+
+        val badge = continuation.badge
+        val marker = map.addMarker(
+            MarkerOptions()
+                .position(badge.point.toLatLng())
+                .icon(continuationBadgeIcon(badge.routeShortName, polyline.resolvedColor))
+                .anchor(0.5f, 0.5f)
+                .zIndex(CONTINUATION_BADGE_Z_INDEX)
+        )!!
+        staticMarkers.add(marker)
+        continuationBadgeByMarker[marker] = badge
+    }
+
+    private fun continuationBadgeIcon(routeShortName: String, color: Int): BitmapDescriptor =
+        descriptorCache.get("continuation-badge:$routeShortName:$color") {
+            ContinuationBadgeBitmaps.badge(routeShortName, color)
+        }
+
+    private fun continuationArrowIcon(color: Int): BitmapDescriptor =
+        descriptorCache.get("continuation-arrow:$color") {
+            ContinuationBadgeBitmaps.arrow(color)
+        }
+
+    /** [RoutePolyline.widthDp] scaled to screen pixels, or the shared default when it carries none. */
+    private fun widthPx(polyline: RoutePolyline): Float =
+        polyline.widthDp?.let { it * density } ?: DEFAULT_ROUTE_WIDTH_PX
+
+    /** Appends [points] to the receiver, shared by every static polyline draw. */
+    private fun PolylineOptions.addPoints(points: List<GeoPoint>): PolylineOptions {
+        for (point in points) add(point.toLatLng())
+        return this
     }
 
     /**
@@ -706,6 +776,9 @@ class GoogleMapRenderer(
 
     fun vehicleForMarker(marker: Marker): VehicleMarker? = vehicleByMarker[marker]
 
+    /** The route-continuation badge (#1691) tapped, or null if [marker] isn't that badge. */
+    fun continuationBadgeForMarker(marker: Marker): ContinuationBadge? = continuationBadgeByMarker[marker]
+
     /** The live route-vehicle marker for [tripId], or null if that vehicle isn't currently drawn. */
     fun vehicleMarkerForTripId(tripId: String): Marker? = vehicleMarkersByTripId[tripId]
 
@@ -729,6 +802,14 @@ class GoogleMapRenderer(
         // The ping ripple draws above the route line/band (gms always draws Circles beneath markers, so it
         // never covers the vehicle icon regardless of this value).
         private const val PING_Z_INDEX = 3f
+
+        // The route-continuation badge (#1691) draws above vehicles so it's always reliably tappable.
+        private const val CONTINUATION_BADGE_Z_INDEX = 1.5f
+
+        // The route-continuation line's dash pattern (#1691), in screen pixels like every other gms
+        // polyline dimension here.
+        private const val CONTINUATION_DASH_LENGTH_PX = 24f
+        private const val CONTINUATION_GAP_LENGTH_PX = 16f
 
         // The (arbitrary, constant) ease key for a TripEstimateMarker's single-marker easer.
         private const val ESTIMATE_EASE_KEY = "estimate"

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleComposeAdapter.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleComposeAdapter.kt
@@ -350,6 +350,11 @@ private fun routeMarkerTap(
         }
         return true
     }
+    val continuationBadge = renderer.continuationBadgeForMarker(marker)
+    if (continuationBadge != null) {
+        cb.onRouteContinuationClick(continuationBadge.routeId, continuationBadge.directionId)
+        return true
+    }
     // Trip-focus estimate markers + the most-recent-data dot (titled markers): the SDK's default
     // title/snippet info window, which dismisses any open custom bubble.
     infoWindows.clear()

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/data/TripVehiclesDataSource.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/data/TripVehiclesDataSource.kt
@@ -16,6 +16,7 @@
 package org.onebusaway.android.api.data
 
 import org.onebusaway.android.api.adapters.toObaTripSchedule
+import org.onebusaway.android.api.adapters.colorArgb
 import org.onebusaway.android.api.adapters.DtoTripDetails
 import org.onebusaway.android.api.adapters.DtoRoute
 import org.onebusaway.android.api.adapters.DtoTrip
@@ -35,6 +36,7 @@ import org.onebusaway.android.models.ObaTrip
 import org.onebusaway.android.models.ObaTripDetails
 import org.onebusaway.android.models.ObaTripSchedule
 import org.onebusaway.android.models.RouteTrips
+import org.onebusaway.android.models.TripRouteInfo
 import org.onebusaway.android.util.Polyline
 import org.onebusaway.android.util.PolylineDecoder
 
@@ -119,6 +121,14 @@ interface TripVehiclesDataSource {
 
     /** The decoded shape polyline, or null when the response carries no usable points. */
     suspend fun shape(shapeId: String): Result<Polyline?>
+
+    /**
+     * The static route identity for an arbitrary [tripId], independent of trips-for-route — for a trip
+     * the current route's poll never fetched (the interlining continuation's neighbor trip, #1691, is
+     * on a different route than anything trips-for-route/tripDetails above have seen). Resolves the
+     * route's shortName/color from the same response's references, so one call is enough.
+     */
+    suspend fun trip(tripId: String): Result<TripRouteInfo?>
 }
 
 class DefaultTripVehiclesDataSource @Inject constructor(
@@ -143,6 +153,20 @@ class DefaultTripVehiclesDataSource @Inject constructor(
             .takeIf { it.isNotEmpty() }
             ?.let { Polyline(it) }
     }.onFailure { Log.e(TAG, "shape($shapeId) failed", it) }
+
+    override suspend fun trip(tripId: String): Result<TripRouteInfo?> = api.call {
+        val data = it.trip(tripId).requireData()
+        val entry = data.entry
+        val route = data.references.route(entry.routeId)
+        TripRouteInfo(
+            tripId = entry.id,
+            routeId = entry.routeId,
+            shapeId = entry.shapeId?.takeIf { s -> s.isNotEmpty() },
+            routeShortName = route?.shortName,
+            routeColor = route?.colorArgb(),
+            directionId = entry.directionId?.toIntOrNull(),
+        )
+    }.onFailure { Log.e(TAG, "trip($tripId) failed", it) }
 
     private companion object {
         const val TAG = "TripVehiclesDataSource"

--- a/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/data/NeighborTripCache.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/data/NeighborTripCache.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.extrapolation.data
+
+import org.onebusaway.android.models.TripRouteInfo
+
+/**
+ * A bounded, access-ordered LRU of [TripRouteInfo] keyed by trip id, owned by
+ * [DefaultTripObservationRepository]. Backs [TripObservationRepository.resolveNeighborTrip]'s
+ * tap-driven memoization (#1691): a trip's route/shape never changes, so once resolved it's cheap to
+ * re-select the same vehicle. Sized like [ShapeCache] against the same [MAX_TRACKED_TRIPS] ceiling —
+ * this is a much smaller, occasional cache (populated only on a vehicle selection, not every poll), so
+ * eviction pressure here is negligible in practice.
+ */
+internal class NeighborTripCache {
+
+    private val trips =
+            object : LinkedHashMap<String, TripRouteInfo>(16, 0.75f, /* accessOrder = */ true) {
+                override fun removeEldestEntry(
+                        eldest: MutableMap.MutableEntry<String, TripRouteInfo>
+                ): Boolean = size > MAX_TRACKED_TRIPS
+            }
+
+    /** The cached route info for [tripId], or null if never resolved (or evicted). */
+    @Synchronized
+    fun get(tripId: String): TripRouteInfo? = trips[tripId]
+
+    /** Stores [info] under [tripId], promoting it in the retention order. */
+    @Synchronized
+    fun put(tripId: String, info: TripRouteInfo) {
+        trips[tripId] = info
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/data/TripObservationFetcher.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/data/TripObservationFetcher.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.withContext
 import org.onebusaway.android.models.ObaTripSchedule
 import org.onebusaway.android.models.RouteTrips
+import org.onebusaway.android.models.TripRouteInfo
 import org.onebusaway.android.time.ServiceDate
 import org.onebusaway.android.util.Polyline
 import org.onebusaway.android.util.SingleFlight
@@ -55,6 +56,13 @@ interface TripObservationFetcher {
     suspend fun tripSchedule(tripId: String): ObaTripSchedule?
 
     suspend fun shape(shapeId: String): Polyline?
+
+    /**
+     * A trip's route identity + shapeId, independent of the trip-details/trips-for-route polls above —
+     * for a trip that may be on a different route entirely (the interlining continuation's neighbor
+     * trip, #1691). Immutable like [tripSchedule]/[shape], so it's [SingleFlight]-coalesced too.
+     */
+    suspend fun tripRouteInfo(tripId: String): TripRouteInfo?
 }
 
 /**
@@ -94,6 +102,7 @@ class DefaultTripObservationFetcher @Inject constructor(
 
     private val scheduleFetches = SingleFlight<String, ObaTripSchedule>(fetchScope)
     private val shapeFetches = SingleFlight<String, Polyline>(fetchScope)
+    private val tripRouteInfoFetches = SingleFlight<String, TripRouteInfo>(fetchScope)
 
     override suspend fun tripDetails(tripId: String): TripDetails? =
             guarded("trip details for $tripId") {
@@ -150,6 +159,13 @@ class DefaultTripObservationFetcher @Inject constructor(
                     guarded("shape for $shapeId") { dataSource.shape(shapeId).getOrThrow() }
                 }.also {
                     if (it == null) Log.w(TAG, "Shape fetch for $shapeId yielded no polyline")
+                }
+            }
+
+    override suspend fun tripRouteInfo(tripId: String): TripRouteInfo? =
+            tripRouteInfoFetches.run(tripId) {
+                guarded("route info for trip $tripId") {
+                    dataSource.trip(tripId).getOrThrow()
                 }
             }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/data/TripObservationRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/data/TripObservationRepository.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
 import org.onebusaway.android.models.RouteTrips
+import org.onebusaway.android.models.TripRouteInfo
 import org.onebusaway.android.time.WallTime
 import org.onebusaway.android.util.Polyline
 
@@ -85,6 +86,15 @@ interface TripObservationRepository {
      * rather than its own copy.
      */
     suspend fun ensureShape(tripId: String, shapeId: String): Polyline?
+
+    /**
+     * Resolves [tripId]'s route identity + shapeId from the standalone `trip` endpoint — for a trip
+     * the current route's poll never fetched (the interlining continuation's neighbor trip, #1691).
+     * Tap-driven (called once per vehicle selection by [org.onebusaway.android.map.RouteMapController],
+     * not polled): a successful resolution is cached by trip id (a trip's route never changes), so
+     * re-selecting the same vehicle later is free; a failure isn't cached, so the next selection retries.
+     */
+    suspend fun resolveNeighborTrip(tripId: String): TripRouteInfo?
 }
 
 @Singleton
@@ -94,6 +104,7 @@ class DefaultTripObservationRepository @Inject constructor(
 
     private val cache = TripStateCache()
     private val shapeCache = ShapeCache()
+    private val neighborTripCache = NeighborTripCache()
 
     override fun lookupTripState(tripId: String?): TripState? = cache.lookupTripState(tripId)
 
@@ -141,6 +152,10 @@ class DefaultTripObservationRepository @Inject constructor(
                 ?: fetcher.shape(shapeId)?.also { shapeCache.put(shapeId, it) }
         return polyline?.also { cache.putPolyline(tripId, it) }
     }
+
+    override suspend fun resolveNeighborTrip(tripId: String): TripRouteInfo? =
+            neighborTripCache.get(tripId)
+                    ?: fetcher.tripRouteInfo(tripId)?.also { neighborTripCache.put(tripId, it) }
 
     /** Records everything a trip details poll carries: shapeId/active-trip, schedule, service date, observations. */
     private fun recordTripDetails(tripId: String, details: TripDetails) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
@@ -402,6 +402,10 @@ class MapViewModel @Inject constructor(
         if (routeController.routeId == request.routeId &&
             routeController.directionStopId == request.directionStopId
         ) {
+            // Honor a requested direction override here too (not just in the re-entry branch below) so
+            // this branch is correct for any initialDirectionId-bearing request, not just the ones that
+            // happen not to hit it today (a no-op when null or already the shown direction).
+            request.initialDirectionId?.let { routeController.selectDirection(it) }
             if (request.focusTripId == null) {
                 mapHost.frameRoute()
             } else {
@@ -412,6 +416,7 @@ class MapViewModel @Inject constructor(
                 request.routeId,
                 zoomToRoute = true,
                 directionStopId = request.directionStopId,
+                initialDirectionId = request.initialDirectionId,
                 focusTripId = request.focusTripId,
             )
         }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
@@ -22,12 +22,14 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import org.onebusaway.android.extrapolation.ExtrapolatedVehicle
 import org.onebusaway.android.extrapolation.extrapolatedVehicles
 import org.onebusaway.android.extrapolation.extrapolationFromState
 import org.onebusaway.android.models.RouteTrips
+import org.onebusaway.android.models.TripRouteInfo
 import org.onebusaway.android.extrapolation.data.TripObservationRepository
 import org.onebusaway.android.time.WallTime
 import java.net.HttpURLConnection
@@ -36,12 +38,15 @@ import org.onebusaway.android.models.ObaStop
 import org.onebusaway.android.models.RouteMapDirection
 import org.onebusaway.android.models.RouteMapStop
 import org.onebusaway.android.util.Polyline
+import org.onebusaway.android.map.render.ContinuationArrow
+import org.onebusaway.android.map.render.ContinuationBadge
 import org.onebusaway.android.map.render.DEFAULT_ROUTE_LINE_COLOR
 import org.onebusaway.android.map.render.FramingIntent
 import org.onebusaway.android.map.render.GeoPoint
 import org.onebusaway.android.map.render.MapRenderState
 import org.onebusaway.android.map.render.MapVehicles
 import org.onebusaway.android.map.render.ROUTE_LINE_WIDTH_DP
+import org.onebusaway.android.map.render.RouteContinuation
 import org.onebusaway.android.map.render.RoutePolyline
 import org.onebusaway.android.map.render.VehicleMarker
 
@@ -137,9 +142,12 @@ class RouteMapController(
 
     private var vehicleJob: Job? = null
 
-    // Drives the selected vehicle's trip overlay (the uncertainty band + fast-estimate marker). A tap
-    // selects a vehicle (renderState.selectedVehicleTripId); this collector installs a per-frame overlay
-    // sampler for that trip and clears it on deselect. Cancelled with the route session in [stop].
+    // Drives everything a tap-selected vehicle shows: the trip overlay (the uncertainty band +
+    // fast-estimate marker, [showSelectionOverlay]) and the route continuation (#1691, [showContinuation]).
+    // A tap selects a vehicle (renderState.selectedVehicleTripId); collectLatest so a fast reselect
+    // cancels an in-flight continuation resolution (a suspending network fetch) for the previous
+    // selection instead of racing it — [showSelectionOverlay] has no suspension point, so it's unaffected
+    // by collectLatest either way. Cancelled with the route session in [stop].
     private var selectionJob: Job? = null
 
     // A pending arrivals ETA-pill focus: fit trip [tripId]'s live vehicle together with the originating
@@ -191,12 +199,15 @@ class RouteMapController(
         // directionState is read live since it's resolved only once the route loads.
         renderState.setVehiclesSampler { nowMs -> sampleVehicles(WallTime(nowMs)) }
         // A tapped vehicle enters a focused state that shows its extrapolation band + fast-estimate
-        // marker; react to the selection state here (a tap sets it, a map/background tap clears it).
-        // Cancel any collector from a prior start() so a re-entered session doesn't leak one that
-        // stop() can no longer reach.
+        // marker, and resolves its route continuation (#1691); react to the selection state here (a tap
+        // sets it, a map/background tap clears it). Cancel any collector from a prior start() so a
+        // re-entered session doesn't leak one that stop() can no longer reach.
         selectionJob?.cancel()
         selectionJob = scope.launch {
-            renderState.selectedVehicleTripId.collect { tripId -> showSelectionOverlay(tripId) }
+            renderState.selectedVehicleTripId.collectLatest { tripId ->
+                showSelectionOverlay(tripId)
+                showContinuation(tripId)
+            }
         }
         // Defer the on-load framing while a focus is pending: the focus decision (below, once the first
         // set arrives) either fits the vehicle+stop box or, failing that, frames the route itself.
@@ -301,6 +312,68 @@ class RouteMapController(
     private fun currentRouteColor(): Int =
         (_loadedRoute.value as? LoadedRoute.Loaded)?.route?.color ?: DEFAULT_ROUTE_LINE_COLOR
 
+    /**
+     * Resolve (or clear) the selected vehicle's route continuation (#1691); driven by [selectionJob]'s
+     * collectLatest, so a slow fetch for a superseded selection is cancelled, not raced.
+     */
+    private suspend fun showContinuation(tripId: String?) {
+        renderState.setRouteContinuation(resolveContinuation(tripId))
+    }
+
+    /**
+     * Whether the selected vehicle's block continues onto a different route on its next scheduled trip,
+     * and if so, the dashed line + arrow + badge to draw for it. Returns null at any step that isn't
+     * (yet) available: no selection, no schedule, no neighbor trip, the neighbor is on the *same* route
+     * (an ordinary same-route direction reversal — see [isRouteContinuation]), or the neighbor's shape
+     * isn't resolvable.
+     */
+    private suspend fun resolveContinuation(tripId: String?): RouteContinuation? {
+        val currentRouteId = routeId ?: return null
+        val id = tripId ?: return null
+        val state = tripObservationRepository.lookupTripState(id) ?: return null
+        val anchor = state.polyline?.points?.lastOrNull()?.toGeoPoint() ?: return null
+        val nextTripId = state.schedule?.nextTripId ?: return null
+        val neighbor = tripObservationRepository.resolveNeighborTrip(nextTripId) ?: return null
+        if (!isRouteContinuation(currentRouteId, neighbor.routeId)) return null
+        val shapeId = neighbor.shapeId ?: return null
+        val neighborShape = tripObservationRepository.ensureShape(nextTripId, shapeId) ?: return null
+        return buildRouteContinuation(anchor, neighborShape, neighbor)
+    }
+
+    /**
+     * [anchor] is the selected trip's own shape's last point (its last stop — not the vehicle's live
+     * position, which hasn't started the next route yet). Draws a dashed line, in the neighbor route's
+     * own color, from [anchor] through the neighbor shape's first [CONTINUATION_LINE_LENGTH_METERS],
+     * terminated with an arrowhead oriented along the shape's travel direction there; the badge sits
+     * halfway between [anchor] and the arrowhead.
+     */
+    private fun buildRouteContinuation(
+        anchor: GeoPoint,
+        neighborShape: Polyline,
+        neighbor: TripRouteInfo,
+    ): RouteContinuation? {
+        val tail = neighborShape.subPolyline(0.0, CONTINUATION_LINE_LENGTH_METERS) ?: return null
+        val badgePoint = neighborShape.interpolate(CONTINUATION_LINE_LENGTH_METERS / 2) ?: return null
+        val endSeg = neighborShape.segmentIndex(CONTINUATION_LINE_LENGTH_METERS)
+        val arrowPoint = neighborShape.interpolate(CONTINUATION_LINE_LENGTH_METERS, endSeg) ?: return null
+        val lineColor = neighbor.routeColor ?: CONTINUATION_FALLBACK_LINE_COLOR
+        return RouteContinuation(
+            polyline = RoutePolyline(
+                color = lineColor,
+                points = listOf(anchor) + tail.map { it.toGeoPoint() },
+                widthDp = CONTINUATION_LINE_WIDTH_DP,
+                dashed = true,
+            ),
+            arrow = ContinuationArrow(arrowPoint.toGeoPoint(), neighborShape.bearingAt(endSeg)),
+            badge = ContinuationBadge(
+                badgePoint.toGeoPoint(),
+                neighbor.routeId,
+                neighbor.routeShortName.orEmpty(),
+                neighbor.directionId,
+            ),
+        )
+    }
+
     /** Recompute + push the vehicle set (the renderer reconciles markers from it), then resolve any pending focus. */
     private fun publishVehicleSet() {
         val layer = currentVehicleLayer()
@@ -334,8 +407,9 @@ class RouteMapController(
         renderState.setVehicleSet(null)
         renderState.setVehiclesSampler(null)
         renderState.setSelectedVehicle(null)
-        // The selection collector is cancelled above, so clear its overlay sampler explicitly.
+        // The selection collector is cancelled above, so clear its overlays explicitly.
         renderState.setTripOverlaySampler(null)
+        renderState.setRouteContinuation(null)
         _loadedRoute.value = null
     }
 
@@ -547,6 +621,34 @@ internal fun resolveVehicleFocus(
     markerPresent -> FocusResolution.FIT
     else -> FocusResolution.DROP
 }
+
+/**
+ * True when [neighborRouteId] genuinely differs from [currentRouteId] — the interlining continuation
+ * test (#1691). Deliberately just a routeId compare, not "does the block continue" (true at nearly
+ * every trip boundary — almost every trip has *a* next trip) and not a headsign/directionId change
+ * (also true at an ordinary same-route direction reversal): verified live against KCM block
+ * `1_8094451` that trip `1_664701340`'s `nextTripId` stays on route 45 with only a directionId flip
+ * 0→1 (not interlining), while its `previousTripId`'s routeId genuinely differs (75 vs 45) and is.
+ * [neighborRouteId] must come from the neighbor trip's own resolved record ([TripRouteInfo.routeId]),
+ * never guessed from headsign/direction.
+ */
+internal fun isRouteContinuation(currentRouteId: String, neighborRouteId: String): Boolean =
+    neighborRouteId.isNotEmpty() && neighborRouteId != currentRouteId
+
+// How far (meters) the route-continuation line (#1691) is drawn into the next route's shape before it
+// terminates in an arrowhead — a visual design choice (how much of the next route to preview), tunable
+// to taste. Not a data heuristic: it doesn't affect the interlining decision itself (that's the exact
+// routeId compare in [isRouteContinuation]) — only how much of an already-confirmed continuation is
+// drawn, no different from the existing ROUTE_LINE_WIDTH_DP constant.
+private const val CONTINUATION_LINE_LENGTH_METERS = 900.0
+
+// Drawn narrower than the shown route's own line ([ROUTE_LINE_WIDTH_DP]) so a continuation reads as a
+// preview/hint rather than as equally-weighted with the route the rider is actually looking at.
+private const val CONTINUATION_LINE_WIDTH_DP = ROUTE_LINE_WIDTH_DP * 0.7f
+
+// Used only when the neighbor route carries no GTFS color to draw the continuation line in its own
+// color with.
+private const val CONTINUATION_FALLBACK_LINE_COLOR = 0xFF9E9E9E.toInt() // opaque gray
 
 /** The latest trips-for-route [response] and the device clock ([loadNanos]) when it landed. */
 private data class VehiclePoll(val response: RouteTrips, val loadNanos: Long)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/ShowRouteRequest.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/ShowRouteRequest.kt
@@ -31,9 +31,13 @@ package org.onebusaway.android.map
  *   vehicle↔stop relationship. When no live vehicle is running that trip, the map shows the route and
  *   raises the "vehicle isn't on the map" toast. A plain arrival-row tap leaves this null (frame the whole
  *   route); only the ETA pill sets it.
+ * @property initialDirectionId when non-null (the route-continuation badge tap, #1691), the GTFS
+ *   direction to show instead of the route's default — validated against the loaded route's directions
+ *   by [RouteMapController], falling back to the default when it doesn't match.
  */
 data class ShowRouteRequest(
     val routeId: String,
     val directionStopId: String? = null,
     val focusTripId: String? = null,
+    val initialDirectionId: Int? = null,
 )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/compose/ObaMapCallbacks.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/compose/ObaMapCallbacks.kt
@@ -39,6 +39,9 @@ interface ObaMapCallbacks {
     /** A vehicle marker tap — the host selects it (e.g. to show its most-recent-data marker). */
     fun onVehicleClick(status: ObaTripStatus) {}
 
+    /** The route-continuation badge tap (#1691) — the host navigates the map to [routeId]'s [directionId]. */
+    fun onRouteContinuationClick(routeId: String, directionId: Int?) {}
+
     /** The vehicle info-window "more info" tap — the host navigates (e.g. to TripDetails). */
     fun onVehicleInfoWindowClick(status: ObaTripStatus)
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/ContinuationBadgeBitmaps.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/ContinuationBadgeBitmaps.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.map.render
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.Path
+import android.graphics.RectF
+import androidx.core.graphics.createBitmap
+
+/**
+ * Bitmaps for the route-continuation overlay (#1691): the tappable pill badge showing a route short
+ * name, and the arrowhead terminating the continuation line. Resource-free and flavor-neutral (like
+ * [TripStopBitmaps]/[BikeBitmaps]), so a flavor renderer just wraps the [Bitmap] as a marker icon.
+ *
+ * A prototype-quality first pass: legible + tappable, not a final visual design.
+ */
+object ContinuationBadgeBitmaps {
+
+    private const val TEXT_SIZE_PX = 38f
+    private const val HORIZONTAL_PADDING_PX = 26f
+    private const val VERTICAL_PADDING_PX = 16f
+    private const val CORNER_RADIUS_PX = 22f
+    private const val BACKGROUND_ALPHA = 230
+
+    private const val ARROW_WIDTH_PX = 56f
+    private const val ARROW_HEIGHT_PX = 60f
+    private const val ARROW_STROKE_PX = 4f
+
+    /**
+     * The badge bitmap for [routeShortName] — sized to fit the text, a rounded-rect pill filled with
+     * [color] (the continuation line's own color). Text is black or white, whichever contrasts better
+     * with [color], so the badge stays legible across the full range of GTFS route colors.
+     */
+    fun badge(routeShortName: String, color: Int): Bitmap {
+        val textPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            this.color = legibleTextColor(color)
+            textSize = TEXT_SIZE_PX
+            isFakeBoldText = true
+            textAlign = Paint.Align.CENTER
+        }
+        val metrics = textPaint.fontMetrics
+        val textWidth = textPaint.measureText(routeShortName)
+        val width = (textWidth + HORIZONTAL_PADDING_PX * 2).coerceAtLeast(CORNER_RADIUS_PX * 2)
+        val height = (metrics.descent - metrics.ascent) + VERTICAL_PADDING_PX * 2
+
+        val bitmap = createBitmap(width.toInt(), height.toInt())
+        val canvas = Canvas(bitmap)
+        canvas.drawRoundRect(
+            RectF(0f, 0f, width, height),
+            CORNER_RADIUS_PX,
+            CORNER_RADIUS_PX,
+            Paint(Paint.ANTI_ALIAS_FLAG).apply {
+                this.color = Color.argb(BACKGROUND_ALPHA, Color.red(color), Color.green(color), Color.blue(color))
+                style = Paint.Style.FILL
+            },
+        )
+        val baseline = height / 2f - (metrics.ascent + metrics.descent) / 2f
+        canvas.drawText(routeShortName, width / 2f, baseline, textPaint)
+        return bitmap
+    }
+
+    /** Black or white, whichever contrasts better against [background] by relative luminance. */
+    private fun legibleTextColor(background: Int): Int {
+        val luminance = (0.299 * Color.red(background) + 0.587 * Color.green(background) + 0.114 * Color.blue(background)) / 255
+        return if (luminance > 0.6) Color.BLACK else Color.WHITE
+    }
+
+    /**
+     * The arrowhead bitmap terminating a continuation line, filled with [color] (the line's own color)
+     * and outlined in white for contrast against any basemap. Drawn tip-up (bearing 0°); the renderer
+     * anchors it bottom-center at the line's end point and rotates it to the line's travel bearing, so
+     * the tip points onward from that point.
+     */
+    fun arrow(color: Int): Bitmap {
+        val bitmap = createBitmap(ARROW_WIDTH_PX.toInt(), ARROW_HEIGHT_PX.toInt())
+        val canvas = Canvas(bitmap)
+        val path = Path().apply {
+            moveTo(ARROW_WIDTH_PX / 2f, 0f)
+            lineTo(ARROW_WIDTH_PX, ARROW_HEIGHT_PX)
+            lineTo(0f, ARROW_HEIGHT_PX)
+            close()
+        }
+        canvas.drawPath(path, Paint(Paint.ANTI_ALIAS_FLAG).apply { this.color = color; style = Paint.Style.FILL })
+        canvas.drawPath(
+            path,
+            Paint(Paint.ANTI_ALIAS_FLAG).apply {
+                this.color = Color.WHITE
+                style = Paint.Style.STROKE
+                strokeWidth = ARROW_STROKE_PX
+                strokeJoin = Paint.Join.ROUND
+            },
+        )
+        return bitmap
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
@@ -74,12 +74,17 @@ const val ROUTE_LINE_WIDTH_DP: Float = 10f
  * whose points aren't a single travel order, leaves it false so the line reads as undirected. Whether a
  * renderer can honor it is flavor-specific (Google stamps a chevron texture; the maplibre classic
  * annotation has no arrow support yet).
+ *
+ * [dashed] asks the renderer to draw a dashed stroke instead of solid — set it for a preview/hint line
+ * that should read as distinct from the primary route shown (the route-continuation line, #1691), so it
+ * doesn't blend into a busy basemap the way a plain solid stroke can.
  */
 data class RoutePolyline(
     val color: Int?,
     val points: List<GeoPoint>,
     val widthDp: Float? = null,
     val directional: Boolean = false,
+    val dashed: Boolean = false,
 ) {
     /** The [color] to draw, applying the [DEFAULT_ROUTE_LINE_COLOR] fallback in one place for every renderer. */
     val resolvedColor: Int get() = color ?: DEFAULT_ROUTE_LINE_COLOR
@@ -149,6 +154,36 @@ data class StopMarker(
     val routeStop: Boolean = false,
 )
 
+/**
+ * A tappable badge marking where the selected vehicle's block continues onto a different route
+ * (#1691): a small pill halfway along the continuation line showing [routeShortName]. Tapping it
+ * navigates the map to [routeId], preferring [directionId] (the neighbor trip's own direction) over the
+ * target route's default when the wire response resolved one (via
+ * [org.onebusaway.android.map.MapViewModel.toRoute]).
+ */
+data class ContinuationBadge(
+    val point: GeoPoint,
+    val routeId: String,
+    val routeShortName: String,
+    val directionId: Int?,
+)
+
+/**
+ * The arrowhead terminating a route-continuation line (#1691), at [point] oriented along [bearing]
+ * (compass degrees, 0°=N — the shape's travel direction at that point) so it visually points onward
+ * into the next route.
+ */
+data class ContinuationArrow(val point: GeoPoint, val bearing: Float)
+
+/**
+ * The selected vehicle's route continuation (#1691): a single optional overlay, not a list — the
+ * trigger is the one selected vehicle, so at most one is ever shown. [polyline] runs from the
+ * transition point to [arrow]'s point, with [badge] halfway between them. Absent (null on
+ * [MapRenderSnapshot.routeContinuation]) when nothing is selected, the block doesn't continue onto a
+ * different route, or the continuation data hasn't resolved yet.
+ */
+data class RouteContinuation(val polyline: RoutePolyline, val arrow: ContinuationArrow, val badge: ContinuationBadge)
+
 /** Immutable snapshot of everything the map should render. Grows one overlay per phase. */
 data class MapRenderSnapshot(
     val routePolylines: List<RoutePolyline> = emptyList(),
@@ -163,6 +198,10 @@ data class MapRenderSnapshot(
     // by StopsMapController and carried here so a pure zoom re-fires the renderer like any other
     // snapshot change — keeping the renderer a pure function of the snapshot (no live camera reads).
     val stopBand: StopBand = StopBand.FULL,
+    // The selected vehicle's route continuation (#1691), or null. A discrete, infrequently-changing
+    // annotation like the fields above, so it rides the same renderStatic() redraw path rather than
+    // the 20Hz vehicle-motion sampler.
+    val routeContinuation: RouteContinuation? = null,
 )
 
 /**
@@ -373,6 +412,11 @@ class MapRenderState {
     /** Selects (or deselects with null) a vehicle by trip id; the renderer shows its data marker. */
     fun setSelectedVehicle(tripId: String?) {
         _selectedVehicleTripId.value = tripId
+    }
+
+    /** Sets (or clears) the selected vehicle's route continuation (#1691); redrawn with the next snapshot. */
+    fun setRouteContinuation(continuation: RouteContinuation?) {
+        _snapshot.update { it.copy(routeContinuation = continuation) }
     }
 
     // --- Trip-focus overlay (the speed-estimation trip map): the renderer pulls the extrapolated ---

--- a/onebusaway-android/src/main/java/org/onebusaway/android/models/TripRouteInfo.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/models/TripRouteInfo.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.models
+
+/**
+ * A trip's route identity + shape, resolved from the standalone `trip/{id}.json` endpoint — used for
+ * a trip the current route's trips-for-route poll never fetched, e.g. the interlining continuation's
+ * neighbor trip (#1691), which is on a *different* route than anything trips-for-route returns.
+ */
+data class TripRouteInfo(
+    val tripId: String,
+    val routeId: String,
+    val shapeId: String?,
+    val routeShortName: String?,
+    val routeColor: Int?,
+    // The trip's GTFS direction, so a continuation can navigate straight to the right direction instead
+    // of the route's default one. Null (rather than defaulting to 0, unlike ObaTrip.directionId's
+    // missing-value convention) when the wire response carries no direction_id — direction_id is
+    // optional per GTFS, and 0 is itself a valid direction, so collapsing "unknown" into it would send a
+    // rider to a specific, wrong-but-plausible direction instead of the route's default.
+    val directionId: Int? = null,
+)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
@@ -65,6 +65,7 @@ import org.onebusaway.android.models.ObaTripStatus
 import org.onebusaway.android.map.MapEffect
 import org.onebusaway.android.map.MapNavigation
 import org.onebusaway.android.map.MapViewModel
+import org.onebusaway.android.map.ShowRouteRequest
 import org.onebusaway.android.map.StopsBanner
 import org.onebusaway.android.map.compose.ObaMap
 import org.onebusaway.android.map.compose.ObaMapCallbacks
@@ -159,6 +160,10 @@ fun MapFeature(
 
             override fun onVehicleClick(status: ObaTripStatus) {
                 mapViewModel.onVehicleTapped(status)
+            }
+
+            override fun onRouteContinuationClick(routeId: String, directionId: Int?) {
+                mapViewModel.toRoute(ShowRouteRequest(routeId, initialDirectionId = directionId))
             }
 
             override fun onVehicleInfoWindowClick(status: ObaTripStatus) {

--- a/onebusaway-android/src/test/java/org/onebusaway/android/extrapolation/data/TripObservationRepositoryTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/extrapolation/data/TripObservationRepositoryTest.kt
@@ -25,6 +25,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertSame
 import org.onebusaway.android.models.ObaTripSchedule
 import org.onebusaway.android.models.RouteTrips
+import org.onebusaway.android.models.TripRouteInfo
 import org.onebusaway.android.util.Polyline
 import org.junit.Test
 
@@ -41,11 +42,15 @@ class TripObservationRepositoryTest {
     private class FakeFetcher(
             private val details: () -> TripDetails? = { null },
             /** Resolves a shapeId to its polyline; null (the default) means "no shape". */
-            private val shapeFor: (String) -> Polyline? = { null }
+            private val shapeFor: (String) -> Polyline? = { null },
+            /** Resolves a tripId to its route info; null (the default) means "not found". */
+            private val tripRouteInfoFor: (String) -> TripRouteInfo? = { null }
     ) : TripObservationFetcher {
         var tripDetailsCalls = 0
             private set
         var shapeCalls = 0
+            private set
+        var tripRouteInfoCalls = 0
             private set
 
         override suspend fun tripDetails(tripId: String): TripDetails? {
@@ -60,6 +65,11 @@ class TripObservationRepositoryTest {
         override suspend fun shape(shapeId: String): Polyline? {
             shapeCalls++
             return shapeFor(shapeId)
+        }
+
+        override suspend fun tripRouteInfo(tripId: String): TripRouteInfo? {
+            tripRouteInfoCalls++
+            return tripRouteInfoFor(tripId)
         }
     }
 
@@ -165,6 +175,36 @@ class TripObservationRepositoryTest {
         val second = repo.ensureShape("tripA", "shape1")
         assertEquals("the null result poisoned nothing, so the second call refetches", 2, fetcher.shapeCalls)
         assertSame("the second call resolves to the real polyline", shape, second)
+    }
+
+    @Test
+    fun `resolveNeighborTrip caches a successful resolution and skips the second fetch`() = runTest {
+        val info = TripRouteInfo("tripB", "route75", "shapeB", "75", null)
+        val fetcher = FakeFetcher(tripRouteInfoFor = { info })
+        val repo = DefaultTripObservationRepository(fetcher)
+
+        val first = repo.resolveNeighborTrip("tripB")
+        val second = repo.resolveNeighborTrip("tripB")
+
+        assertEquals("only the first call fetches", 1, fetcher.tripRouteInfoCalls)
+        assertSame("both calls resolve to the same cached instance", first, second)
+    }
+
+    @Test
+    fun `resolveNeighborTrip caches nothing on a null fetch and refetches later`() = runTest {
+        val info = TripRouteInfo("tripB", "route75", "shapeB", "75", null)
+        var next: TripRouteInfo? = null // first fetch yields null, then a real result
+        val fetcher = FakeFetcher(tripRouteInfoFor = { next })
+        val repo = DefaultTripObservationRepository(fetcher)
+
+        val first = repo.resolveNeighborTrip("tripB")
+        assertEquals("first call attempts the fetch", 1, fetcher.tripRouteInfoCalls)
+        assertEquals("a null fetch resolves to null", null, first)
+
+        next = info
+        val second = repo.resolveNeighborTrip("tripB")
+        assertEquals("the null result poisoned nothing, so the second call refetches", 2, fetcher.tripRouteInfoCalls)
+        assertSame("the second call resolves to the real result", info, second)
     }
 
     @Test

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteContinuationTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteContinuationTest.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.map
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * [isRouteContinuation] — the interlining continuation test (#1691): a plain routeId compare, not
+ * "does the block continue" (true at nearly every trip boundary) and not a headsign/directionId
+ * change (also true at an ordinary same-route direction reversal). Route ids are King County Metro's
+ * real ones for routes 45/75, captured live against the production API while investigating #1691;
+ * `route45Id`'s trip `1_664701340`'s `nextTripId` (still route 45, direction 0→1) is the
+ * false-positive case this test exists to rule out, and its `previousTripId` (route 75) is the
+ * genuine positive.
+ */
+class RouteContinuationTest {
+
+    private val route45Id = "1_100225"
+    private val route75Id = "1_100269"
+
+    @Test
+    fun same_route_direction_reversal_is_not_interlining() {
+        assertFalse(isRouteContinuation(route45Id, route45Id))
+    }
+
+    @Test
+    fun a_genuine_cross_route_block_continuation_is_interlining() {
+        assertTrue(isRouteContinuation(route45Id, route75Id))
+    }
+
+    @Test
+    fun an_unresolved_neighbor_route_id_is_never_a_continuation() {
+        assertFalse(isRouteContinuation(route45Id, ""))
+    }
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/dataview/TripTrajectoryViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/dataview/TripTrajectoryViewModelTest.kt
@@ -31,6 +31,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.onebusaway.android.models.RouteTrips
+import org.onebusaway.android.models.TripRouteInfo
 import org.onebusaway.android.extrapolation.data.TripObservationRepository
 import org.onebusaway.android.extrapolation.data.TripState
 import org.onebusaway.android.testing.MainDispatcherRule
@@ -61,6 +62,8 @@ class TripTrajectoryViewModelTest {
             emptyFlow()
 
         override suspend fun ensureShape(tripId: String, shapeId: String): Polyline? = null
+
+        override suspend fun resolveNeighborTrip(tripId: String): TripRouteInfo? = null
     }
 
     /**
@@ -90,6 +93,8 @@ class TripTrajectoryViewModelTest {
             emptyFlow()
 
         override suspend fun ensureShape(tripId: String, shapeId: String): Polyline? = null
+
+        override suspend fun resolveNeighborTrip(tripId: String): TripRouteInfo? = null
     }
 
     private fun viewModel(repo: TripObservationRepository) = TripTrajectoryViewModel(


### PR DESCRIPTION
## Summary

Closes #1691. When a route interlines with another (a vehicle finishes its current trip and continues as a different route on the same GTFS block), the route map today gives no hint of it. This adds a prototype overlay:

- When the rider selects a vehicle on the route map, if its current trip's `schedule.nextTripId` resolves to a **different** `routeId`, draw a dashed line in that route's own color from the end of the current trip's shape, terminated with an arrowhead oriented along the travel direction.
- A tappable pill badge sits halfway along the line, showing the connecting route's short name.
- Tapping the badge navigates the map to that route, in the neighbor trip's actual direction (not the route's default), so riders land on the correct branch.

**The interlining test** (`isRouteContinuation`) is a plain `routeId` compare — deliberately *not* "does the block continue" (true at nearly every trip boundary) and *not* a headsign/direction change (also true at an ordinary same-route direction reversal). Verified live against the King County Metro 45/75 example from the issue: a trip whose `nextTripId` stays on route 45 with only a direction flip is correctly *not* flagged, while a trip whose neighbor is genuinely on route 75 is.

**Scope**: Google Maps flavor only — maplibre's classic annotation API has no gradient/dash polyline support, so that's a follow-up. Triggered only by the selected vehicle (not every interlining vehicle on screen), since interlining is a per-block fact, not a per-direction one.

## Test plan

- [x] Unit tests for the interlining decision (`RouteContinuationTest`) using real KCM route 45/75 ids captured live against the production API
- [x] Unit tests for `resolveNeighborTrip`'s cache-on-success-only policy (`TripObservationRepositoryTest`)
- [x] `./gradlew :onebusaway-android:compileObaGoogleDebugKotlin -PwarningsAsErrors=true` — clean
- [x] `./gradlew :onebusaway-android:testObaGoogleDebugUnitTest` — full suite passes
- [x] Manually verified on a physical device: selected a live interlining vehicle on route 45, confirmed the dashed line + arrow + badge render correctly and tapping the badge lands on the correct direction of the connecting route; no crashes in logcat

🤖 Generated with [Claude Code](https://claude.com/claude-code)