### PR TITLE
Animate EtaStrip's leading pill as trips depart live between polls

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStrip.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStrip.kt
@@ -179,6 +179,11 @@ internal fun EtaStrip(
     val justifyIndex = start?.takeIf { it in 1..trips.lastIndex }
     var pinnedIndex by remember { mutableIntStateOf(justifyIndex ?: 0) }
 
+    // A later poll can SHRINK `trips` (recent-past trips aging out of the feed), which the
+    // forward-only ratchet above can't fix on its own — clamp back onto the new list's bounds so the
+    // pin always names a real pill instead of freezing `pinnedOffsetPx` on one that no longer exists.
+    pinnedIndex = pinnedIndex.coerceAtMost(trips.lastIndex.coerceAtLeast(0))
+
     // Bridges values that change across recompositions into the long-lived effect below, which
     // otherwise would close over a stale snapshot the moment it first suspends — the same idiom as
     // `versionState` a few lines down.

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStrip.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStrip.kt
@@ -96,11 +96,9 @@ import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import kotlin.coroutines.cancellation.CancellationException
 import kotlin.math.roundToInt
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.currentCoroutineContext
-import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
@@ -136,6 +134,11 @@ private val PULL_TO_LOAD_MAX = 72.dp
  * that reveals a trailing load-more affordance; releasing past [PULL_TO_LOAD_THRESHOLD] widens the
  * arrivals window via [ArrivalRowCallbacks.onLoadMore] — this replaced the drawer's footer button
  * (issue #1707 follow-up). A TalkBack custom action exposes the same load-more for non-drag users.
+ *
+ * The strip also keeps its soonest *upcoming* pill pinned to the leading edge over time: it snaps
+ * there instantly on first display (using [start]), then as the shared live clock ticks a trip's ETA
+ * past zero between polls, glides the strip left so the just-departed pill visibly slides into the
+ * left overflow instead of sitting there stale until the next poll.
  */
 @Composable
 internal fun EtaStrip(
@@ -164,13 +167,46 @@ internal fun EtaStrip(
     // the (pill-less) empty-trips case; nothing reads it since the pill loop below never runs.
     val liveNow = rememberLiveServerTime(trips.firstOrNull()?.serverNow ?: ServerTime(0L))
 
-    // Justify the `start` pill to the leading edge: capture its content-x (positionInParent is
-    // scroll-independent, so it's the offset from the content's start) once, then scroll there. One-shot
-    // — a later ETA update or a user scroll isn't yanked back.
+    // The pinned pill's own content-x (positionInParent is scroll-independent, so it's the offset from
+    // the content's start), -1 until measured. Only the currently-pinned pill is ever measured — see
+    // the pill loop below — so this holds one live value rather than a map of every pill's offset.
+    var pinnedOffsetPx by remember { mutableIntStateOf(-1) }
+
+    // The pill currently pinned to the strip's leading edge — earlier (recent-past) pills overflow off
+    // the left, reachable via the left chevron. Starts at the poll-time first-upcoming index (or 0,
+    // already the strip's start, when every trip is upcoming); only ever advances forward, from the
+    // BOOKKEEPER effect below — never yanked backward by an ordinary poll data reshuffle.
     val justifyIndex = start?.takeIf { it in 1..trips.lastIndex }
-    var justifyOffsetPx by remember { mutableIntStateOf(-1) }
-    LaunchedEffect(justifyOffsetPx) {
-        if (justifyOffsetPx > 0) scrollState.scrollTo(justifyOffsetPx)
+    var pinnedIndex by remember { mutableIntStateOf(justifyIndex ?: 0) }
+
+    // Bridges values that change across recompositions into the long-lived effect below, which
+    // otherwise would close over a stale snapshot the moment it first suspends — the same idiom as
+    // `versionState` a few lines down.
+    val tripsState = rememberUpdatedState(trips)
+    val liveNowState = rememberUpdatedState(liveNow)
+
+    // BOOKKEEPER: advances `pinnedIndex` as `liveNow` ticks a trip's countdown past zero between
+    // polls — a single long-lived collector (not re-launched per tick), so a departure is observed
+    // exactly once as a level change, not by polling a recomposition-derived key. Never backward, so
+    // an ordinary poll data reshuffle can't yank the pin; only a live departure moves it.
+    LaunchedEffect(Unit) {
+        snapshotFlow { tripsState.value.indexOfFirst { it.liveEta(liveNowState.value) >= 0 } }
+            .collect { current -> if (current > pinnedIndex) pinnedIndex = current }
+    }
+
+    // CHASER: keeps the strip's leading edge on whatever pill is currently pinned. Instant for the
+    // cold-start snap onto `justifyIndex` (so the strip never visibly slides on first display), then
+    // [glideTo] takes over for every later departure — the same self-correcting chase the load-more
+    // reveal transaction's FOLLOWER below uses, so a target that moves mid-glide (another departure
+    // landing before the previous glide finishes, or the pinned pill's own width shifting as its digit
+    // count changes) is simply chased again next iteration instead of overshooting/undershooting a
+    // stale pixel value.
+    LaunchedEffect(Unit) {
+        if (justifyIndex != null) {
+            val offsetPx = snapshotFlow { pinnedOffsetPx.takeIf { it >= 0 } }.filterNotNull().first()
+            scrollState.scrollTo(offsetPx)
+        }
+        scrollState.glideTo { pinnedOffsetPx.takeIf { it >= 0 } }
     }
     val density = LocalDensity.current
     val triggerPx = remember(density) { with(density) { PULL_TO_LOAD_THRESHOLD.toPx() } }
@@ -210,23 +246,13 @@ internal fun EtaStrip(
         if (token == NO_LOAD_REQUEST) return@LaunchedEffect
         try {
             coroutineScope {
-                // FOLLOWER: glides to the current end whenever there is one to reach. Each glide runs
-                // TO COMPLETION and the loop then re-evaluates against current state (never
-                // collectLatest: a change mid-glide is caught by the fresh level-triggered re-await,
-                // so there is no lost-update window).
+                // FOLLOWER: glides to the current end whenever there is one to reach — [glideTo] runs
+                // each glide to completion and then re-evaluates against current state (never
+                // collectLatest: a change mid-glide is caught by the fresh level-triggered re-await, so
+                // there is no lost-update window). A drag that actually travels ends the whole
+                // transaction via the nested-scroll hook, not this loop.
                 val follower = launch {
-                    while (true) {
-                        snapshotFlow { scrollState.maxValue > scrollState.value }.first { it }
-                        try {
-                            scrollState.animateScrollTo(scrollState.maxValue)
-                        } catch (cause: CancellationException) {
-                            currentCoroutineContext().ensureActive() // real teardown propagates
-                            // Lost the scrollable mutex to a touch. Never contest user input: resume
-                            // the chase only once the strip is fully at rest. (A drag that actually
-                            // travels ends the whole transaction via the nested-scroll hook.)
-                            snapshotFlow { scrollState.isScrollInProgress }.first { !it }
-                        }
-                    }
+                    scrollState.glideTo { scrollState.maxValue.takeIf { it > scrollState.value } }
                 }
                 // AWAIT RESULT: level-triggered on the VM's StateFlow — a Finished that landed before
                 // we started collecting is still observed (StateFlow replays its value).
@@ -343,19 +369,22 @@ internal fun EtaStrip(
                 verticalAlignment = Alignment.Bottom
             ) {
                 trips.forEachIndexed { index, trip ->
-                    val pillModifier = when {
-                        index == 0 -> firstPillModifier
-                        // Measure the justify pill's content offset once — attached only until captured,
-                        // so the callback self-detaches (writing justifyOffsetPx recomposes the strip).
-                        index == justifyIndex && justifyOffsetPx < 0 -> Modifier.onGloballyPositioned { coords ->
+                    // Only the currently-pinned pill measures its content-space offset — it's the one
+                    // pill CHASER (above) ever reads, and re-measuring continuously (not just once)
+                    // catches its own width shifting as its digit count changes. As `pinnedIndex`
+                    // advances, this modifier simply moves to the new pill on the next recomposition.
+                    val measureOffset = if (index == pinnedIndex) {
+                        Modifier.onGloballyPositioned { coords ->
                             // Offset within the scroll content Row (its direct parent), which is
                             // content-space and so scroll-independent.
                             coords.parentLayoutCoordinates?.let { parent ->
-                                justifyOffsetPx = parent.localPositionOf(coords, Offset.Zero).x.roundToInt()
+                                pinnedOffsetPx = parent.localPositionOf(coords, Offset.Zero).x.roundToInt()
                             }
                         }
-                        else -> Modifier
+                    } else {
+                        Modifier
                     }
+                    val pillModifier = if (index == 0) firstPillModifier.then(measureOffset) else measureOffset
                     EtaPillWithMenu(
                         trip = trip,
                         liveNow = liveNow,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStripLoadMore.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStripLoadMore.kt
@@ -96,11 +96,16 @@ internal fun Modifier.acknowledgeVersion(version: State<Long>, into: MutableLong
  * of snapshot state, not a suspend function. Never contests a real user drag: losing the scrollable
  * mutex to one just waits for the strip to go idle before re-deriving the target on the next iteration
  * (the caller's own nested-scroll hook is what ends the chase for good, by cancelling this coroutine).
+ *
+ * Clamped to `[0, maxValue]` before comparing OR animating — `animateScrollTo` clamps internally, but
+ * comparing against the raw (unclamped) target would keep re-firing forever once `value` settles at
+ * `maxValue` for a target that's past the reachable end (e.g. the pinned pill sitting near the end of
+ * a short strip).
  */
 internal suspend fun ScrollState.glideTo(target: () -> Int?) {
     while (true) {
-        snapshotFlow { target() }.filterNotNull().first { it != value }
-        val next = target() ?: continue
+        snapshotFlow { target()?.coerceIn(0, maxValue) }.filterNotNull().first { it != value }
+        val next = target()?.coerceIn(0, maxValue) ?: continue
         try {
             animateScrollTo(next)
         } catch (cause: CancellationException) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStripLoadMore.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStripLoadMore.kt
@@ -15,10 +15,17 @@
  */
 package org.onebusaway.android.ui.arrivals.components
 
+import androidx.compose.foundation.ScrollState
 import androidx.compose.runtime.MutableLongState
 import androidx.compose.runtime.State
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.layout
+import kotlin.coroutines.cancellation.CancellationException
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
 import org.onebusaway.android.ui.arrivals.LoadMoreState
 
 /**
@@ -80,3 +87,25 @@ internal fun Modifier.acknowledgeVersion(version: State<Long>, into: MutableLong
         into.longValue = version.value
         layout(placeable.width, placeable.height) { placeable.place(0, 0) }
     }
+
+/**
+ * Repeatedly glides toward whatever [target] currently evaluates to (null means "nothing to chase
+ * right now"), re-deriving it fresh each iteration rather than animating once toward a value captured
+ * before the glide started — so a moving target (a growing max, a newly-pinned pill) is chased rather
+ * than over/undershot. [target] is read inside `snapshotFlow`, so it must be a plain synchronous read
+ * of snapshot state, not a suspend function. Never contests a real user drag: losing the scrollable
+ * mutex to one just waits for the strip to go idle before re-deriving the target on the next iteration
+ * (the caller's own nested-scroll hook is what ends the chase for good, by cancelling this coroutine).
+ */
+internal suspend fun ScrollState.glideTo(target: () -> Int?) {
+    while (true) {
+        snapshotFlow { target() }.filterNotNull().first { it != value }
+        val next = target() ?: continue
+        try {
+            animateScrollTo(next)
+        } catch (cause: CancellationException) {
+            currentCoroutineContext().ensureActive() // real teardown propagates
+            snapshotFlow { isScrollInProgress }.first { !it }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- The ETA strip's leading pill previously justified itself only once, on mount, using the poll-time ETA. As a trip's live countdown ticks past zero between polls, the strip now advances the pinned pill and animates the scroll left, so the just-departed pill visibly slides into the left overflow instead of sitting there stale until the next poll.
- The animation is built as a self-correcting "chase" (re-derives its target every iteration rather than animating once toward a value captured up front), matching the shape of the existing load-more reveal transaction's `FOLLOWER`. That shared shape is now factored out into a `ScrollState.glideTo()` helper in `EtaStripLoadMore.kt`, used by both the new justify logic and the existing load-more follower.
- Only the currently-pinned pill is measured (via `onGloballyPositioned`), rather than tracking every pill's offset in a map.

## Test plan
- [x] `./gradlew :onebusaway-android:compileObaGoogleDebugKotlin -PwarningsAsErrors=true` — clean, zero warnings
- [x] Installed on a physical device and manually watched an ETA pill count down through zero; strip animates left into the overflow
- [ ] CI: `connectedObaGoogleDebugAndroidTest` (note: `EtaStripJustifyTest`, which covers the cold-start snap, was independently confirmed flaky on this reviewer's specific physical device/OS combo even on `main` before this change — unrelated pre-existing environment issue, not introduced here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved arrival-time strip scrolling with more consistent pill pinning and alignment as upcoming departures change.
  * Updated load-more behavior so the strip reliably glides to newly revealed content.
  * Enhanced handling of interrupted scrolling to ensure the strip continues smoothly after cancellations, including when pill sizes or digits change dynamically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->