### PR TITLE
Arrivals: replace the animated real-time indicator with a static glyph

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
@@ -15,13 +15,6 @@
  */
 package org.onebusaway.android.ui.arrivals.components
 
-import androidx.compose.animation.core.FastOutLinearInEasing
-import androidx.compose.animation.core.RepeatMode
-import androidx.compose.animation.core.animateFloat
-import androidx.compose.animation.core.infiniteRepeatable
-import androidx.compose.animation.core.rememberInfiniteTransition
-import androidx.compose.animation.core.tween
-import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -55,7 +48,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
@@ -501,7 +493,7 @@ private fun EtaContent(
     }
 }
 
-/** The real-time indicator's reserved column (so ETAs right-justify alike); animates when live. */
+/** The real-time indicator's reserved column (so ETAs right-justify alike); shown when live. */
 @Composable
 private fun EtaRealtimeIndicator(predicted: Boolean, color: Color) {
     Box(Modifier.padding(start = 2.dp).size(8.dp)) {
@@ -510,32 +502,22 @@ private fun EtaRealtimeIndicator(predicted: Boolean, color: Color) {
 }
 
 /**
- * The pulsing real-time "connectedness" indicator: concentric stroked circles expanding and
- * contracting at staggered durations (transparent fill, stroked outline, FastOutLinearIn, REVERSE
- * repeat). Shared by the standalone/list ETA and the map drawer's ETA pill.
+ * The real-time ("connectedness") indicator: a static Material `rss_feed` glyph marking an
+ * AVL-tracked arrival. Shared by the standalone/list ETA and the map drawer's ETA pill.
+ *
+ * Deliberately static: the previous concentric-rings version ran an infinite animation per
+ * indicator, and a stop with many live pills kept the whole arrivals screen re-rendering every
+ * vsync at 120Hz (main thread pegged ~30%, ~35% of frames missing the 8.3ms deadline). A glyph
+ * conveys the same "live" cue at zero steady-state cost.
  */
 @Composable
 internal fun RealtimeIndicator(color: Color, modifier: Modifier = Modifier) {
-    val transition = rememberInfiniteTransition(label = "realtime")
-    // Staggered durations make the rings radiate out of phase, matching the legacy 1500/1800/2000.
-    val rings = listOf(1500, 1800, 2000).map { duration ->
-        transition.animateFloat(
-            initialValue = 0f,
-            targetValue = 1f,
-            animationSpec = infiniteRepeatable(
-                animation = tween(durationMillis = duration, easing = FastOutLinearInEasing),
-                repeatMode = RepeatMode.Reverse
-            ),
-            label = "realtime-$duration"
-        )
-    }
-    Canvas(modifier) {
-        val maxRadius = size.minDimension / 2f
-        val stroke = Stroke(width = 1.2.dp.toPx())
-        rings.forEach { ring ->
-            drawCircle(color = color, radius = maxRadius * ring.value, style = stroke)
-        }
-    }
+    Icon(
+        painter = painterResource(R.drawable.ic_rss_feed),
+        contentDescription = null,
+        modifier = modifier,
+        tint = color,
+    )
 }
 
 private fun strikeThroughIf(canceled: Boolean): TextDecoration =

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStrip.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStrip.kt
@@ -619,7 +619,7 @@ internal fun EtaPill(
     val numberSize = 28.sp
     val labelSize = 14.sp
     val nowSize = 22.sp
-    val indicatorSize = 8.dp
+    val indicatorSize = 12.dp // 1.5× the base accent; overlaid, so the extra size overlaps, not widens
     val clockTimeSize = 10.sp
     val topPadding = 3.dp
     val bottomPadding = 3.5.dp
@@ -642,19 +642,22 @@ internal fun EtaPill(
     // below are the actual on-screen spacing rather than a guess fighting Android's hidden font padding.
     val baseTextStyle = LocalTextStyle.current
     Surface(modifier = modifier.then(interaction), shape = shape, color = color) {
-        // Sized to its own content (no fixed height) so the optional clock-time line simply adds to
-        // the pill's height rather than being clipped by — or leaving a gap below it in — a height
-        // guessed independently of the actual text metrics. Pills of different heights (with vs.
-        // without a clock line) still share a bottom edge via the strip's own
-        // `verticalAlignment = Alignment.Bottom` (EtaStrip's Row).
-        Column(
-            modifier = Modifier.padding(
-                start = 6.dp, end = 6.dp, top = topPadding, bottom = bottomPadding
-            ),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(clockTimeGap)
-        ) {
-            Row {
+        // A Box so the live indicator can overlay the pill (below) instead of reserving layout width:
+        // live and scheduled pills stay identical widths, and the glyph is free to overlap the ETA
+        // text at the top-trailing corner rather than widening the pill.
+        Box {
+            // Sized to its own content (no fixed height) so the optional clock-time line simply adds to
+            // the pill's height rather than being clipped by — or leaving a gap below it in — a height
+            // guessed independently of the actual text metrics. Pills of different heights (with vs.
+            // without a clock line) still share a bottom edge via the strip's own
+            // `verticalAlignment = Alignment.Bottom` (EtaStrip's Row).
+            Column(
+                modifier = Modifier.padding(
+                    start = 6.dp, end = 6.dp, top = topPadding, bottom = bottomPadding
+                ),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(clockTimeGap)
+            ) {
                 if (etaParts == null) {
                     Text(
                         text = stringResource(R.string.stop_info_eta_now),
@@ -688,22 +691,25 @@ internal fun EtaPill(
                         style = remember(baseTextStyle, numberSize) { tightLineStyle(baseTextStyle, numberSize) }
                     )
                 }
-                // The radiating real-time indicator floats above the trailing unit ("min" / "Now"); it
-                // isn't baseline-aligned, so it takes the Row's default top alignment. The Box is always
-                // present so the pill width is stable whether or not it's live.
-                Box(Modifier.padding(start = 2.dp).size(indicatorSize)) {
-                    if (predicted) {
-                        RealtimeIndicator(color = Color.White, modifier = Modifier.fillMaxSize())
-                    }
+                if (clockTime != null) {
+                    Text(
+                        text = clockTime,
+                        fontSize = clockTimeSize,
+                        color = Color.White.copy(alpha = 0.8f),
+                        textDecoration = decoration,
+                        style = remember(baseTextStyle, clockTimeSize) { tightLineStyle(baseTextStyle, clockTimeSize) }
+                    )
                 }
             }
-            if (clockTime != null) {
-                Text(
-                    text = clockTime,
-                    fontSize = clockTimeSize,
-                    color = Color.White.copy(alpha = 0.8f),
-                    textDecoration = decoration,
-                    style = remember(baseTextStyle, clockTimeSize) { tightLineStyle(baseTextStyle, clockTimeSize) }
+            // The live indicator, overlaid on the top-trailing corner so its 1.5× size overlaps the
+            // ETA text a little instead of widening the pill (drawn last = on top).
+            if (predicted) {
+                RealtimeIndicator(
+                    color = Color.White,
+                    modifier = Modifier
+                        .align(Alignment.TopEnd)
+                        .padding(top = 1.dp, end = 1.dp)
+                        .size(indicatorSize),
                 )
             }
         }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripdetails/TripDetailsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripdetails/TripDetailsScreen.kt
@@ -260,7 +260,7 @@ private fun TripHeaderSection(header: TripHeader) {
 
 /**
  * The lateness-colored status pill (white text on the deviation color). When the trip is real-time,
- * the radiating indicator sits inside the pill, right of the text, in the same white as the lettering.
+ * the real-time indicator sits inside the pill, right of the text, in the same white as the lettering.
  */
 @Composable
 private fun StatusPill(text: String, color: Color, isRealtime: Boolean) {

--- a/onebusaway-android/src/main/res/drawable/ic_rss_feed.xml
+++ b/onebusaway-android/src/main/res/drawable/ic_rss_feed.xml
@@ -1,0 +1,11 @@
+<!-- Material Symbols "rss_feed" (24dp). The real-time / AVL-tracked arrival indicator; tinted at
+     the call site via Icon(tint = ...). Static by design — see RealtimeIndicator's KDoc. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M4,17.82a2.18,2.18 0 1,0 4.36,0a2.18,2.18 0 1,0 -4.36,0zM4,4.44v2.83c7.03,0 12.73,5.7 12.73,12.73h2.83c0,-8.59 -6.97,-15.56 -15.56,-15.56zM4,10.1v2.83c3.9,0 7.07,3.17 7.07,7.07h2.83c0,-5.47 -4.43,-9.9 -9.9,-9.9z" />
+</vector>


### PR DESCRIPTION
## Summary

The per-arrival real-time "connectedness" indicator (the small pulsing rings next to a live ETA) ran an **infinite Compose animation per predicted pill** — a `rememberInfiniteTransition` with 3 `animateFloat`s drawn on a `Canvas`, in `RealtimeIndicator`. On a stop with many live arrivals, every one of those runs continuously, keeping the whole arrivals screen re-rendering every vsync.

Measured on a **Pixel 7 Pro (120Hz)** with a busy stop sitting **idle** (nothing touched):

| Metric (idle) | Before |
|---|---|
| Main (UI) thread CPU | **~31%** |
| RenderThread CPU | ~12% |
| Frames drawn | **~120 fps** (should be ~0 when idle) |
| Median UI-side frame | **11 ms** (over the 8.3 ms 120Hz budget) |
| Legacy jank (missed vsync deadline) | **~35%** |
| GPU time (median) | 5 ms — *not* GPU-bound |

So it was pure main-thread animation + draw-invalidation cost, scaling with the number of live pills.

## Change

- Replace the animated rings with a **static Material `rss_feed` glyph**, added as a vector drawable (`res/drawable/ic_rss_feed.xml`, loaded via `painterResource` — the pattern the rest of the app's ~90 icons use) — the same "live" cue at **zero steady-state cost**. `RealtimeIndicator` keeps its signature, so the list rows, ETA pills, and trip-details status/vehicle indicators all switch over.
- In the **ETA pill**, the indicator is now a top-trailing-corner **overlay (1.5× size)** instead of a layout sibling, so it no longer reserves width — live and scheduled pills stay identical widths and the larger glyph overlaps the ETA text.
- Removed the now-dead animation imports and the single-child `Row` the refactor left in `EtaPill`; fixed stale "radiating" comments.

## Test plan

- [x] `:onebusaway-android:compileObaGoogleDebugKotlin -PwarningsAsErrors=true` — clean under the strict CI gate
- [x] **Before** state profiled on-device (Pixel 7 Pro, busy Puget Sound stop) — the table above
- [x] Static build installs cleanly; the `ic_rss_feed` drawable inflates with no VectorDrawable/PathParser errors in logcat
- [x] `/simplify` pass (reuse/simplification/efficiency/altitude): switched from an inline `ImageVector` to the repo-standard drawable XML + `painterResource`, and dropped the leftover single-child `Row`
- [ ] **Post-fix on-device re-measurement pending** — removing the infinite animations eliminates the only continuous animation on that idle screen, so the ~120 fps idle redraw and the ~31% idle main-thread CPU go away by construction, but I have not yet re-captured the numbers to confirm
- [ ] Visual confirmation of the final overlaid 1.5× glyph on a live stop pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Replaced the animated real-time indicator with a static RSS feed icon.
  * Increased the indicator size and refined its placement within ETA pills.
  * Preserved ETA text and optional clock-time layout while improving overlay positioning.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->