### PR TITLE
Extract a generic BoundedLruCache (fixes #1796)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/data/BoundedLruCache.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/data/BoundedLruCache.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.extrapolation.data
+
+/**
+ * A generic bounded, access-ordered LRU cache backed by a plain [LinkedHashMap]: once [maxSize]
+ * entries are held, each insert evicts the least-recently-used one. Every access (read or write)
+ * promotes its entry.
+ *
+ * Every method is `@Synchronized`: the access-order map mutates on read as well as write, and
+ * callers arrive on arbitrary threads, so all access must be serialized. Use [compute] rather
+ * than a separate [get] and [put] when a write depends on the prior value — that keeps the
+ * read-transform-write atomic instead of racing with a concurrent writer between the two calls.
+ */
+internal class BoundedLruCache<K : Any, V : Any>(private val maxSize: Int) {
+
+    private val entries =
+            object : LinkedHashMap<K, V>(16, 0.75f, /* accessOrder = */ true) {
+                override fun removeEldestEntry(eldest: MutableMap.MutableEntry<K, V>): Boolean =
+                        size > maxSize
+            }
+
+    /** The cached value for [key], or null if it was never cached (or has been evicted). */
+    @Synchronized
+    fun get(key: K): V? = entries[key]
+
+    /** Stores [value] under [key], promoting it in the retention order. */
+    @Synchronized
+    fun put(key: K, value: V) {
+        entries[key] = value
+    }
+
+    /**
+     * Atomically applies [transform] to the current value for [key] (or a fresh [default] if
+     * absent), stores the result, and returns it — the compute-and-put that [get]+[put] can't
+     * express without a race.
+     */
+    @Synchronized
+    fun compute(key: K, default: () -> V, transform: (V) -> V): V {
+        val newValue = transform(entries[key] ?: default())
+        entries[key] = newValue
+        return newValue
+    }
+
+    /** The keys currently cached (the eviction working set). */
+    @Synchronized
+    fun keys(): Set<K> = entries.keys.toSet()
+
+    /** Drops all cached entries. */
+    @Synchronized
+    fun clear() {
+        entries.clear()
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/data/NeighborTripCache.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/data/NeighborTripCache.kt
@@ -24,23 +24,18 @@ import org.onebusaway.android.models.TripRouteInfo
  * re-select the same vehicle. Sized like [ShapeCache] against the same [MAX_TRACKED_TRIPS] ceiling —
  * this is a much smaller, occasional cache (populated only on a vehicle selection, not every poll), so
  * eviction pressure here is negligible in practice.
+ *
+ * Backed by [BoundedLruCache], which covers the synchronization rationale.
  */
 internal class NeighborTripCache {
 
-    private val trips =
-            object : LinkedHashMap<String, TripRouteInfo>(16, 0.75f, /* accessOrder = */ true) {
-                override fun removeEldestEntry(
-                        eldest: MutableMap.MutableEntry<String, TripRouteInfo>
-                ): Boolean = size > MAX_TRACKED_TRIPS
-            }
+    private val trips = BoundedLruCache<String, TripRouteInfo>(MAX_TRACKED_TRIPS)
 
     /** The cached route info for [tripId], or null if never resolved (or evicted). */
-    @Synchronized
-    fun get(tripId: String): TripRouteInfo? = trips[tripId]
+    fun get(tripId: String): TripRouteInfo? = trips.get(tripId)
 
     /** Stores [info] under [tripId], promoting it in the retention order. */
-    @Synchronized
     fun put(tripId: String, info: TripRouteInfo) {
-        trips[tripId] = info
+        trips.put(tripId, info)
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/data/ShapeCache.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/data/ShapeCache.kt
@@ -37,26 +37,17 @@ internal const val MAX_CACHED_SHAPES = MAX_TRACKED_TRIPS
  * a single shared [Polyline] instance, deduplicating the (for rail, sizable) shapes across the up
  * to [MAX_TRACKED_TRIPS] trips the store tracks.
  *
- * Synchronized for the same reason [TripStateCache] is: lookups and writes both promote, so the
- * access-order map mutates on read, and callers arrive on arbitrary threads — all access must be
- * serialized.
+ * Backed by [BoundedLruCache], which covers the synchronization rationale.
  */
 internal class ShapeCache {
 
-    private val shapes =
-            object : LinkedHashMap<String, Polyline>(16, 0.75f, /* accessOrder = */ true) {
-                override fun removeEldestEntry(
-                        eldest: MutableMap.MutableEntry<String, Polyline>
-                ): Boolean = size > MAX_CACHED_SHAPES
-            }
+    private val shapes = BoundedLruCache<String, Polyline>(MAX_CACHED_SHAPES)
 
     /** The cached shape for [shapeId], or null if it was never cached (or has been evicted). */
-    @Synchronized
-    fun get(shapeId: String): Polyline? = shapes[shapeId]
+    fun get(shapeId: String): Polyline? = shapes.get(shapeId)
 
     /** Stores [polyline] under [shapeId], promoting it in the retention order. */
-    @Synchronized
     fun put(shapeId: String, polyline: Polyline) {
-        shapes[shapeId] = polyline
+        shapes.put(shapeId, polyline)
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/data/TripStateCache.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/data/TripStateCache.kt
@@ -30,34 +30,22 @@ internal const val MAX_TRACKED_TRIPS = 100
  * them; consumers only read, via [lookupTripState] — a cheap map get, fine for per-frame loops.
  * Lookups and writes both promote, so actively watched trips are never the eviction victims.
  *
- * Backed by a plain access-order [LinkedHashMap] (not `android.util.LruCache`) so the data layer
- * carries no Android dependency and is exercisable in JVM unit tests. Every method is
- * `@Synchronized`: writes are get-transform-put rather than atomic, and the access-order map
- * mutates on read, so all access is serialized.
+ * Backed by [BoundedLruCache] (not `android.util.LruCache`) so the data layer carries no Android
+ * dependency and is exercisable in JVM unit tests.
  */
 internal class TripStateCache {
 
-    private val trips =
-            object : LinkedHashMap<String, TripState>(16, 0.75f, /* accessOrder = */ true) {
-                override fun removeEldestEntry(
-                        eldest: MutableMap.MutableEntry<String, TripState>
-                ): Boolean = size > MAX_TRACKED_TRIPS
-            }
+    private val trips = BoundedLruCache<String, TripState>(MAX_TRACKED_TRIPS)
 
     /**
      * The current snapshot for [tripId], or null if the trip has never been recorded (or has
      * been evicted). Promotes the trip in the retention order.
      */
-    @Synchronized
-    fun lookupTripState(tripId: String?): TripState? = tripId?.let { trips[it] }
+    fun lookupTripState(tripId: String?): TripState? = tripId?.let { trips.get(it) }
 
-    /**
-     * Applies [transform] to the current snapshot for [tripId] (or a fresh empty one) and stores
-     * the result — the compute-and-put that the map doesn't provide.
-     */
-    @Synchronized
+    /** Applies [transform] to the current snapshot for [tripId] (or a fresh empty one). */
     private fun update(tripId: String, transform: (TripState) -> TripState) {
-        trips[tripId] = transform(trips[tripId] ?: TripState.empty(tripId))
+        trips.compute(tripId, { TripState.empty(tripId) }, transform)
     }
 
     // --- Writes ---
@@ -101,11 +89,9 @@ internal class TripStateCache {
     // --- Introspection and cleanup ---
 
     /** IDs of the trips currently tracked (the eviction working set). */
-    @Synchronized
-    fun getTrackedTripIds(): Set<String> = trips.keys.toSet()
+    fun getTrackedTripIds(): Set<String> = trips.keys()
 
     /** Drops all tracked trips. For tests only. */
-    @Synchronized
     @VisibleForTesting
     fun clearAllTrips() {
         trips.clear()

--- a/onebusaway-android/src/test/java/org/onebusaway/android/extrapolation/data/BoundedLruCacheTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/extrapolation/data/BoundedLruCacheTest.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.extrapolation.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Unit tests for the generic [BoundedLruCache] shell (no Android dependencies). */
+class BoundedLruCacheTest {
+
+    @Test
+    fun `returns the stored value for a hit and null for a miss`() {
+        val cache = BoundedLruCache<String, Int>(2)
+        cache.put("a", 1)
+
+        assertEquals(1, cache.get("a"))
+        assertNull(cache.get("b"))
+    }
+
+    @Test
+    fun `evicts the least-recently-used entry past the bound`() {
+        val cache = BoundedLruCache<String, Int>(2)
+        cache.put("a", 1)
+        cache.put("b", 2)
+        cache.get("a") // promote a to most-recently-used
+        cache.put("c", 3) // overflow -> evicts the eldest, now b
+
+        assertNull("the least-recently-used entry is evicted", cache.get("b"))
+        assertEquals("the promoted entry survives eviction", 1, cache.get("a"))
+        assertEquals(3, cache.get("c"))
+    }
+
+    @Test
+    fun `keys reflects the current working set`() {
+        val cache = BoundedLruCache<String, Int>(2)
+        cache.put("a", 1)
+        cache.put("b", 2)
+        cache.put("c", 3) // evicts a
+
+        val keys = cache.keys()
+        assertEquals(2, keys.size)
+        assertFalse("a" in keys)
+        assertTrue("b" in keys)
+        assertTrue("c" in keys)
+    }
+
+    @Test
+    fun `clear drops all entries`() {
+        val cache = BoundedLruCache<String, Int>(2)
+        cache.put("a", 1)
+
+        cache.clear()
+
+        assertNull(cache.get("a"))
+        assertTrue(cache.keys().isEmpty())
+    }
+
+    @Test
+    fun `compute seeds from default when absent and returns the new value`() {
+        val cache = BoundedLruCache<String, Int>(2)
+
+        val result = cache.compute("a", default = { 0 }) { it + 1 }
+
+        assertEquals(1, result)
+        assertEquals(1, cache.get("a"))
+    }
+
+    @Test
+    fun `compute transforms the existing value rather than the default`() {
+        val cache = BoundedLruCache<String, Int>(2)
+        cache.put("a", 5)
+
+        val result = cache.compute("a", default = { 0 }) { it + 1 }
+
+        assertEquals(6, result)
+        assertEquals(6, cache.get("a"))
+    }
+}


### PR DESCRIPTION
## Summary
- `ShapeCache`, `NeighborTripCache`, and `TripStateCache` each hand-rolled the same bounded, access-ordered `LinkedHashMap`/`removeEldestEntry`/`@Synchronized` shell. Extracted that shell into a generic `BoundedLruCache<K, V>` (`extrapolation/data/BoundedLruCache.kt`); the three now delegate to it.
- `TripStateCache`'s atomic get-transform-put (`update()`) now uses a `compute(key, default, transform)` method on `BoundedLruCache` itself, rather than reaching around the cache's public API to lock on its instance monitor directly.
- Mechanical extraction only — no change to any cache's sizing or eviction policy, and `BoundedLruCache` stays in `extrapolation/data/` (not promoted to `util/`), per the issue's stated scope.

## Test plan
- [x] `./gradlew :onebusaway-android:compileObaGoogleDebugKotlin -PwarningsAsErrors=true` — compiles clean
- [x] `./gradlew :onebusaway-android:testObaGoogleDebugUnitTest --tests "org.onebusaway.android.extrapolation.data.*"` — `BoundedLruCacheTest` (6/6) and `ShapeCacheTest` (2/2) pass
- [x] `./gradlew :onebusaway-android:connectedObaGoogleDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=org.onebusaway.android.extrapolation.test.TripStateCacheTest` — 18/18 pass on-device (Pixel 7 Pro)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved internal caching for trip, route, shape, and state data.
  * Caches now consistently limit stored entries and remove the least recently used items when full.
  * Improved cache safety when data is accessed or updated concurrently.

* **Tests**
  * Added coverage for cache retrieval, eviction, clearing, key tracking, and value updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->