### PR TITLE
Unify toRoute()'s reframe branch through RouteMapController (fixes #1797)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
@@ -402,15 +402,10 @@ class MapViewModel @Inject constructor(
         if (routeController.routeId == request.routeId &&
             routeController.directionStopId == request.directionStopId
         ) {
-            // Honor a requested direction override here too (not just in the re-entry branch below) so
-            // this branch is correct for any initialDirectionId-bearing request, not just the ones that
-            // happen not to hit it today (a no-op when null or already the shown direction).
-            request.initialDirectionId?.let { routeController.selectDirection(it) }
-            if (request.focusTripId == null) {
-                mapHost.frameRoute()
-            } else {
-                routeController.requestFocus(request.focusTripId)
-            }
+            // Delegate the whole request to the controller (#1797) rather than hand-picking fields here,
+            // so a field added later to ShowRouteRequest is visible at reframe()'s one call site instead
+            // of silently unhandled by an independently-written branch.
+            routeController.reframe(request)
         } else {
             enterRoute(
                 request.routeId,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
@@ -228,6 +228,22 @@ class RouteMapController(
         tryFocusVehicle(currentVehicleLayer())
     }
 
+    /**
+     * Re-apply [request] to the route this controller already has open (MapViewModel.toRoute's reframe
+     * branch — see its doc for the reframe-vs-reenter split). An instant, local-only reaction: must NOT
+     * call [start] (no network reload, no vehicle-poll reset). [selectDirection]'s no-op guard is fine
+     * here since reframing the already-shown direction is exactly the "not a real switch" case it exists
+     * to skip. [requestFocus] falls through into the same FIT/DROP resolution ([tryFocusVehicle]) the
+     * initial-load tail ([onRouteLoaded]) uses; absent a focus, reframes now via [MapHost.frameRoute] —
+     * the same call that tail makes when it isn't deferring to a focus. Takes the whole [request] rather
+     * than picking fields, so a new [ShowRouteRequest] field is at least reachable here — though [start]'s
+     * own parameter list still needs a matching update (#1797).
+     */
+    fun reframe(request: ShowRouteRequest) {
+        request.initialDirectionId?.let { selectDirection(it) }
+        request.focusTripId?.let { requestFocus(it) } ?: host.frameRoute()
+    }
+
     // Resolve a pending focus against [layer] (the just-built vehicle set, threaded in so the poll path
     // doesn't re-run the extrapolation), once we actually have vehicles to check. With a marker for the
     // trip present, fit the vehicle together with the originating stop; absent, the pending focus is


### PR DESCRIPTION
## Summary
- `MapViewModel.toRoute()` had two independently-written branches (reframe vs. re-entry) that could silently diverge on which `ShowRouteRequest` fields they honor — this already bit once when `initialDirectionId` was added in #1795 and the reframe branch initially missed it.
- The reframe branch now delegates the whole request to a new `RouteMapController.reframe(request)`, which falls through into the same `selectDirection` / `requestFocus` / `host.frameRoute()` primitives the re-entry path's post-load tail (`onRouteLoaded`) already uses, instead of hand-picking fields directly in `MapViewModel`.
- No intended behavior change — this is a structural refactor (the "structural merge" option from #1797), not a new feature. `RouteMapController.start`'s re-entry semantics are untouched.

## Test plan

Compiles clean under the strict CI gate (`compileObaGoogleDebugKotlin -PwarningsAsErrors=true`, zero warnings). No existing unit/instrumented test exercises `MapViewModel.toRoute`/`RouteMapController` (only the pure `resolveVehicleFocus` decision table is covered, via `FocusResolutionTest`), so this needs a manual pass on a device:

- [x] Enter a route via search/starred/recent (re-entry branch, unchanged) — route loads normally with a spinner and frames to its full extent.
- [x] Re-tap the same route from the same list while already viewing it (reframe branch, no focus) — camera snaps back to the route's extent **instantly**, with **no loading spinner flash** and no vehicle marker flicker/reset.
- [x] Tap an ETA pill for a currently-running trip on that route (reframe branch, with focus) — map fits the vehicle + originating stop, with a brief ping ripple on the vehicle marker.
- [x] Tap an ETA pill for a trip with **no** live vehicle right now — get the "vehicle isn't on the map" toast, and the camera does **not** move.
- [x] Switch direction via the header's direction-switch affordance (or a route-continuation badge) while already on the route (reframe branch, direction override) — stops/line switch to the new direction instantly, no reload spinner, any selected vehicle deselects.
- [x] Exit to nearby-stops mode and enter a **different** route — confirms the (untouched) re-entry branch still behaves normally: spinner, fresh load, full-route frame.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved route map updates when changing direction or focusing on a specific trip.
  * Route details now refresh smoothly without unnecessarily reloading the route.
  * Ensured route framing and trip focus are applied consistently when revisiting an open route.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->