### PR TITLE
Render the ETA strip's "NOW" pill at the same size as others

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStrip.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStrip.kt
@@ -522,7 +522,6 @@ internal fun EtaPill(
     val shape = RoundedCornerShape(8.dp)
     val numberSize = 28.sp
     val labelSize = 14.sp
-    val nowSize = 22.sp
     val indicatorSize = 12.dp // 1.5× the base accent; overlaid, so the extra size overlaps, not widens
     val clockTimeSize = 10.sp
     val topPadding = 3.dp
@@ -565,11 +564,11 @@ internal fun EtaPill(
                 if (etaParts == null) {
                     Text(
                         text = stringResource(R.string.stop_info_eta_now),
-                        fontSize = nowSize,
+                        fontSize = numberSize,
                         fontWeight = FontWeight.Bold,
                         color = Color.White,
                         textDecoration = decoration,
-                        style = remember(baseTextStyle, nowSize) { tightLineStyle(baseTextStyle, nowSize) }
+                        style = remember(baseTextStyle, numberSize) { tightLineStyle(baseTextStyle, numberSize) }
                     )
                 } else {
                     // A single AnnotatedString (not separate Text composables) so the text shaper kerns


### PR DESCRIPTION
## Summary
- The ETA strip's "NOW" label rendered at 22sp while every other ETA pill's number used 28sp, giving the "NOW" pill a special-cased, noticeably smaller look.
- Removed the `nowSize` constant and reuse `numberSize` for the "NOW" text so all pills render at a consistent size, with no compact-rendering branch left.

## Test plan
- [x] `./gradlew :onebusaway-android:compileObaGoogleDebugKotlin -PwarningsAsErrors=true` passes clean
- [ ] Visually confirm on device that "NOW" pills match the size of other ETA pills in the strip

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the “Now” arrival indicator to use consistent typography with other ETA values.
  * Improved visual consistency in arrival-time pills by removing the separate “Now” text sizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->