### PR TITLE
Arrivals: widen the ETA strip, make its overflow chevrons scroll

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
@@ -292,7 +292,11 @@ fun RouteArrivalRow(
                 Spacer(Modifier.width(10.dp))
                 Column(Modifier.weight(1f)) {
                     if (direction.isNotBlank()) {
-                        DirectionHeader(direction)
+                        // Only the header needs its own clearance from the overlaid overflow icon
+                        // (it sits right under it); the ETA strip below reaches the row's true end —
+                        // its own trailing chevron gutter already reserves that room, and the pills
+                        // sit low enough in the row to clear the icon vertically.
+                        DirectionHeader(direction, modifier = Modifier.padding(end = OVERFLOW_ICON_CLEARANCE))
                         Spacer(Modifier.height(6.dp))
                     }
                     EtaStrip(
@@ -309,8 +313,6 @@ fun RouteArrivalRow(
                 if (onAlertClick != null) {
                     ArrivalAlertIndicator(onClick = onAlertClick)
                 }
-                // Reserve room on the right so the last pill never slides under the overflow icon.
-                Spacer(Modifier.width(20.dp))
             }
             Box(Modifier.align(Alignment.TopEnd)) {
                 CornerIcon(
@@ -339,8 +341,8 @@ fun RouteArrivalRow(
  * the destination in a slightly-tightened monospace so it reads like the sign on the bus.
  */
 @Composable
-private fun DirectionHeader(direction: String) {
-    Row(verticalAlignment = Alignment.CenterVertically) {
+private fun DirectionHeader(direction: String, modifier: Modifier = Modifier) {
+    Row(modifier = modifier, verticalAlignment = Alignment.CenterVertically) {
         Icon(
             imageVector = Icons.AutoMirrored.Filled.ArrowForward,
             contentDescription = null,
@@ -362,6 +364,11 @@ private fun DirectionHeader(direction: String) {
 /** The alert-indicator tap for a row: opens the arrival's active alert, or null when it has none. */
 internal fun alertClick(actions: ArrivalActions?, callbacks: ArrivalRowCallbacks): (() -> Unit)? =
     actions?.alertSituationId?.let { id -> { callbacks.onShowAlert(id) } }
+
+/** Horizontal clearance [RouteArrivalRow] gives the direction header so it doesn't run under the
+ *  overlaid corner icon below ([CornerIcon]'s own footprint is 18dp + 4dp padding on each side —
+ *  this is a bit tighter, tuned by eye against a device screenshot rather than derived from it). */
+private val OVERFLOW_ICON_CLEARANCE = 20.dp
 
 /** A small tap target tucked into a card corner — the legacy overlaid star / overflow icons. */
 @Composable

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStrip.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStrip.kt
@@ -17,11 +17,10 @@ package org.onebusaway.android.ui.arrivals.components
 
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.ScrollState
-import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
@@ -59,7 +58,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.onGloballyPositioned
@@ -108,8 +106,10 @@ import org.onebusaway.android.util.DisplayFormat
 
 /**
  * The horizontally-scrollable strip of per-trip ETA pills below the direction name. When the pills
- * overflow the row, a right-edge fade + chevron appears to signal there's more to scroll to; it's a
- * pure visual hint (no pointer handling) so it never blocks the strip's own drag-to-scroll.
+ * overflow the row, a chevron appears at that edge to signal there's more to scroll to; tapping it
+ * moves the strip one strip-width further that direction (or to the end, whichever is closer). The
+ * chevron's own tap target is a narrow side gutter separate from the pills, so it never blocks the
+ * strip's own drag-to-scroll.
  *
  * Dragging the strip past its last pill (once there's nothing more to scroll) builds a resistive pull
  * ([SlideBox]'s gesture) that reveals a trailing load-more affordance; releasing once it's armed
@@ -159,6 +159,13 @@ internal fun EtaStrip(
     // BOOKKEEPER effect below — never yanked backward by an ordinary poll data reshuffle.
     var pinnedIndex by remember { mutableIntStateOf(start?.takeIf { it in 1..trips.lastIndex } ?: 0) }
 
+    // A one-shot scroll target (absolute, same units as pinnedOffsetPx) set by tapping an overflow
+    // chevron; takes priority over the pinned-pill anchor below. Left in place once reached — like an
+    // ordinary drag, an arrow tap should stick rather than snap back — and cleared only when the pin
+    // itself next advances (see the BOOKKEEPER effect), so live departure-tracking still wins over a
+    // stale manual position exactly as it already does against a plain drag.
+    var arrowOverridePx by remember { mutableStateOf<Int?>(null) }
+
     // A later poll can SHRINK `trips` (recent-past trips aging out of the feed), which the
     // forward-only ratchet above can't fix on its own — clamp back onto the new list's bounds so the
     // pin always names a real pill instead of freezing `pinnedOffsetPx` on one that no longer exists.
@@ -176,10 +183,23 @@ internal fun EtaStrip(
     // an ordinary poll data reshuffle can't yank the pin; only a live departure moves it.
     LaunchedEffect(Unit) {
         snapshotFlow { tripsState.value.indexOfFirst { it.liveEta(liveNowState.value) >= 0 } }
-            .collect { current -> if (current > pinnedIndex) pinnedIndex = current }
+            .collect { current ->
+                if (current > pinnedIndex) {
+                    pinnedIndex = current
+                    arrowOverridePx = null
+                }
+            }
     }
 
     val loadMoreLabel = stringResource(R.string.stop_info_load_more_arrivals)
+
+    // Jumps the strip one viewport toward the given direction (or to the end, whichever is
+    // closer) by setting the one-shot arrow override above; SlideBox's own glide clamps the
+    // result to [0, maxValue], so no clamping is needed here.
+    fun jumpArrow(forward: Boolean) {
+        val delta = if (forward) scrollState.viewportSize else -scrollState.viewportSize
+        arrowOverridePx = scrollState.value + delta
+    }
 
     // The strip's active load-more request: the token returned at fire time, NO_LOAD_REQUEST at rest.
     // Saveable so a list eviction / recreation mid-load resumes (or cleanly ends) the transaction.
@@ -246,7 +266,12 @@ internal fun EtaStrip(
     ) {
         // Left gutter: a chevron back toward earlier arrivals, shown once the strip is scrolled off its
         // start. Reserved (like the right gutter) so toggling it never reflows the pills.
-        ScrollChevronGutter(visible = canScrollBackward && !loadingMore, pointsRight = false)
+        ScrollChevronGutter(
+            visible = canScrollBackward && !loadingMore,
+            pointsRight = false,
+            contentDescriptionRes = R.string.stop_info_eta_strip_scroll_earlier,
+            onClick = { jumpArrow(forward = false) },
+        )
 
         // The scrollable pill content, inside the gesture-owning SlideBox: the strip DECLARES what it
         // rests on — the pinned pill, or the trailing end while a load-more reveal is live — and the
@@ -254,7 +279,7 @@ internal fun EtaStrip(
         // gesture lives in the box too (the gutters don't scroll).
         SlideBox(
             state = slideBox,
-            anchorPx = { pinnedOffsetPx.takeIf { it >= 0 } },
+            anchorPx = { arrowOverridePx ?: pinnedOffsetPx.takeIf { it >= 0 } },
             followEnd = request.intValue != NO_LOAD_REQUEST,
             onPullFired = {
                 // The VM sets Loading(token) synchronously inside onLoadMore, so the spinner is
@@ -276,9 +301,6 @@ internal fun EtaStrip(
             // Bottom-align so a smaller recent-past pill sits on the same baseline as the full-size ones.
             verticalAlignment = Alignment.Bottom,
             overlay = {
-                // Fade the content out at whichever edge has more content sliding under it.
-                if (canScrollBackward && !loadingMore) EdgeFade(atStart = true)
-                if (canScrollForward && !loadingMore) EdgeFade(atStart = false)
                 // The pull-revealed load-more chip (invisible at rest, armed as the pull crosses the
                 // threshold). Hidden while loading — the inline spinner takes over then.
                 if (!loadingMore) {
@@ -336,23 +358,41 @@ internal fun EtaStrip(
 
         // Right gutter: a chevron forward toward later arrivals (the pull-past-the-end load affordance
         // takes over inside the content box once you reach the end).
-        ScrollChevronGutter(visible = canScrollForward && !loadingMore, pointsRight = true)
+        ScrollChevronGutter(
+            visible = canScrollForward && !loadingMore,
+            pointsRight = true,
+            contentDescriptionRes = R.string.stop_info_eta_strip_scroll_later,
+            onClick = { jumpArrow(forward = true) },
+        )
     }
 }
 
 /**
  * A fixed-width trailing/leading gutter holding the "more to scroll" chevron, [visible] when that
  * direction has more content. [pointsRight] picks the direction; the left reuses the right chevron
- * drawable rotated 180°. The slot is reserved even when hidden so toggling it never reflows the pills.
+ * drawable rotated 180°. The slot is reserved even when hidden so toggling it never reflows the
+ * pills. Tapping it fires [onClick] (a one-page scroll toward that edge); only wired up while
+ * [visible], so a hidden gutter is never an invisible tap target.
  */
 @Composable
-private fun ScrollChevronGutter(visible: Boolean, pointsRight: Boolean) {
-    Box(Modifier.fillMaxHeight().width(20.dp), contentAlignment = Alignment.Center) {
+private fun ScrollChevronGutter(
+    visible: Boolean,
+    pointsRight: Boolean,
+    contentDescriptionRes: Int,
+    onClick: () -> Unit,
+) {
+    Box(
+        Modifier
+            .fillMaxHeight()
+            .width(20.dp)
+            .clickable(enabled = visible, onClick = onClick),
+        contentAlignment = Alignment.Center
+    ) {
         if (visible) {
             Icon(
                 painter = painterResource(R.drawable.ic_navigation_chevron_right),
-                // Decorative: a pure "there's more to scroll" hint, not an actionable control.
-                contentDescription = null,
+                // Resolved only while shown, since this composable recomposes on every liveNow tick.
+                contentDescription = stringResource(contentDescriptionRes),
                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier
                     .size(20.dp)
@@ -360,27 +400,6 @@ private fun ScrollChevronGutter(visible: Boolean, pointsRight: Boolean) {
             )
         }
     }
-}
-
-/**
- * A gradient over the strip's [atStart]/end edge that fades the content out as it slides under the
- * matching chevron gutter — solid (the card color) at that edge, transparent inward.
- */
-@Composable
-private fun BoxScope.EdgeFade(atStart: Boolean) {
-    val surface = MaterialTheme.colorScheme.surfaceContainer
-    val brush = remember(surface, atStart) {
-        Brush.horizontalGradient(
-            if (atStart) listOf(surface, Color.Transparent) else listOf(Color.Transparent, surface)
-        )
-    }
-    Box(
-        Modifier
-            .align(if (atStart) Alignment.CenterStart else Alignment.CenterEnd)
-            .fillMaxHeight()
-            .width(24.dp)
-            .background(brush)
-    )
 }
 
 /**
@@ -655,7 +674,7 @@ private fun EtaStripPreviewFrame(
 @Preview(showBackground = true, widthDp = 240, name = "EtaStrip · overflowing (chevron)")
 @Composable
 private fun EtaStripOverflowPreview() {
-    // Enough pills to exceed the 240dp width, so the right-edge fade + chevron hint appears.
+    // Enough pills to exceed the 240dp width, so the right-edge chevron hint appears.
     EtaStripPreviewFrame(trips = northgatePills(6))
 }
 
@@ -663,7 +682,7 @@ private fun EtaStripOverflowPreview() {
 @Composable
 private fun EtaStripScrolledPreview() {
     // Started part-way scrolled (content hanging off BOTH ends), so both the left- and right-edge
-    // chevrons/fades show. The initial offset clamps to the range after layout.
+    // chevrons show. The initial offset clamps to the range after layout.
     EtaStripPreviewFrame(trips = northgatePills(7), scrollState = rememberScrollState(initial = 300))
 }
 

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -271,6 +271,8 @@
         </item>
     </plurals>
     <string name="stop_info_load_more_arrivals">Load more arrivals</string>
+    <string name="stop_info_eta_strip_scroll_earlier">Show earlier arrivals</string>
+    <string name="stop_info_eta_strip_scroll_later">Show later arrivals</string>
     <string name="stop_info_item_options_title">Bus options</string>
     <string name="stop_info_filter_title">Show only these routes</string>
     <!-- Not a plural candidate: "%2$d routes" is a ratio's denominator ("N of M"), not a count that


### PR DESCRIPTION
## Summary
- The ETA strip stopped short of the arrival row's true right edge: `RouteArrivalRow` reserved a trailing `Spacer(20.dp)` for the overlaid overflow (⋮) icon, duplicating clearance that `EtaStrip`'s own right chevron gutter already reserves unconditionally. Moved that clearance onto just the direction header (which actually sits under the icon) and let the strip use the full row width.
- The left/right overflow chevrons were purely decorative. Tapping one now scrolls the strip one strip-width toward that edge (or to the end, whichever is closer) — routed through `SlideBox`'s existing single-owner anchor mechanism (`anchorPx`) rather than driving the `ScrollState` directly, preserving the single-scroll-owner invariant from #1801. The jump sticks like an ordinary drag (no snap-back) and is only cleared when a live trip departure next advances the pinned pill.
- Removed the edge-fade gradient overlay now that the chevrons communicate overflow on their own (plus the now-unused `background`/`Brush`/`BoxScope` imports it pulled in).

## Test plan
- [x] `./gradlew :onebusaway-android:compileObaGoogleDebugKotlin -PwarningsAsErrors=true` — clean
- [x] `./gradlew :onebusaway-android:testObaGoogleDebugUnitTest --tests "org.onebusaway.android.ui.arrivals.*"` — passing
- [x] Installed on a physical device via `installObaGoogleDebug`
- [ ] Manual on-device check of the widened strip and chevron-tap scrolling (not yet driven interactively this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clickable chevrons to ETA strips for navigating to earlier or later arrivals.
  * Added accessibility labels for the new arrival navigation controls.

* **Bug Fixes**
  * Improved arrival row spacing so direction headers no longer overlap the overflow icon.
  * Updated scroll behavior so the selected arrival remains consistent as live departures advance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->