### PR TITLE
Remove dead RouteDao/RouteFavoritesRepository.isFavorite (fixes #1807)

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/database/oba/RouteDaoTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/database/oba/RouteDaoTest.kt
@@ -22,7 +22,6 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -80,18 +79,18 @@ class RouteDaoTest {
     }
 
     @Test
-    fun isFavorite_reflectsTheFavoriteBit() = runBlocking {
-        // No row yet -> not a favorite (the route-map header's default before a star lands).
-        assertFalse(dao.isFavorite("r4").first())
+    fun favoriteRouteIds_reflectsTheFavoriteBit() = runBlocking {
+        // No row yet -> not in the favorites set.
+        assertTrue(dao.favoriteRouteIds().first().isEmpty())
 
         dao.storeRouteDetails("r4", "40", "Route 40", "http://u", regionId = 4L, now = 100)
-        assertFalse(dao.isFavorite("r4").first())   // row exists, favorite still unset
+        assertTrue(dao.favoriteRouteIds().first().isEmpty())   // row exists, favorite still unset
 
         dao.setFavorite("r4", 1)
-        assertTrue(dao.isFavorite("r4").first())
+        assertEquals(listOf("r4"), dao.favoriteRouteIds().first())
 
         dao.setFavorite("r4", 0)
-        assertFalse(dao.isFavorite("r4").first())
+        assertTrue(dao.favoriteRouteIds().first().isEmpty())
     }
 
     @Test

--- a/onebusaway-android/src/main/java/org/onebusaway/android/database/oba/RouteDao.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/database/oba/RouteDao.kt
@@ -52,15 +52,11 @@ interface RouteDao {
 
     /**
      * The ids of every starred (favorite) route, live — the arrivals list overlays this to star rows +
-     * promote favorited routes to the drawer header (#1751), reacting to a star toggle from any surface
-     * (an arrival row, the route-map header) without a re-fetch.
+     * promote favorited routes to the drawer header (#1751), reacting to a star toggle from an arrival
+     * row without a re-fetch.
      */
     @Query("SELECT _id FROM routes WHERE favorite = 1")
     fun favoriteRouteIds(): Flow<List<String>>
-
-    /** Whether [routeId] is starred, live — drives the route-map header star toggle (#1727). */
-    @Query("SELECT EXISTS(SELECT 1 FROM routes WHERE _id = :routeId AND favorite = 1)")
-    fun isFavorite(routeId: String): Flow<Boolean>
 
     // --- Usage/metadata writes (the legacy partial upsert; see RoutesStore) ---
 
@@ -133,8 +129,8 @@ interface RouteDao {
      * row starts at `use_count = 0`. Favoriting/unfavoriting a route is not a "view", so it must not
      * bump the recents (`access_time`) or the frequency sort (`use_count`) (#1727 review). Null **or
      * empty** name/URL arguments preserve any existing value rather than clobbering it — a star from a
-     * surface that only has a bare short name (e.g. the route-map header, whose loaded route may carry
-     * an empty long name) must not wipe a good long name; the network backfill fills it in afterward.
+     * surface that only has a bare short name (whose loaded route may carry an empty long name) must not
+     * wipe a good long name; the network backfill fills it in afterward.
      */
     @Transaction
     suspend fun ensureRouteDetails(

--- a/onebusaway-android/src/main/java/org/onebusaway/android/database/oba/RouteFavoritesRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/database/oba/RouteFavoritesRepository.kt
@@ -34,11 +34,11 @@ import org.onebusaway.android.region.RegionRepository
 import org.onebusaway.android.util.routeDisplayNames
 
 /**
- * The single owner of route-favorite membership — a wholesale `routes.favorite` bit (#1751). Every
- * surface that stars a route (the per-arrival star, the route-map header) writes through [setFavorite]
- * so the import gating, the row-existence guarantee, and the bookmark analytics live in one place
- * instead of being re-implemented (and drifting) per surface; every surface that shows the star reads
- * one of the reactive flows below, so a toggle from any surface re-flags the others with no re-fetch.
+ * The single owner of route-favorite membership — a wholesale `routes.favorite` bit (#1751). The
+ * arrival-row star writes through [setFavorite] so the import gating, the row-existence guarantee, and
+ * the bookmark analytics live in one place instead of being re-implemented (and drifting) per surface;
+ * every surface that shows the star reads [favoriteRouteIds] below, so a toggle re-flags every row with
+ * no re-fetch.
  */
 @Singleton
 class RouteFavoritesRepository @Inject constructor(
@@ -59,17 +59,13 @@ class RouteFavoritesRepository @Inject constructor(
             .map { it.toSet() }
             .distinctUntilChanged()
 
-    /** Whether [routeId] is starred, live — deduped against unrelated `routes` writes. */
-    fun isFavorite(routeId: String): Flow<Boolean> =
-        routeDao.isFavorite(routeId).distinctUntilChanged()
-
     /**
      * Stars (or unstars) [routeId] wholesale. Ensures the `routes` row exists (so the Starred Routes
      * folder can JOIN it for its display name/URL) before flipping the flag, gated on the one-time
      * import, and reports the bookmark event. Pass whatever [shortName]/[longName]/[url] the caller has
      * in hand (null/empty values leave any existing value untouched); on a **star** the full details are
      * then backfilled from the network so the folder always shows a proper long name — regardless of
-     * which surface starred it (the route-map header's loaded route often carries an empty long name).
+     * which surface starred it (a starring surface's loaded route often carries an empty long name).
      */
     suspend fun setFavorite(
         routeId: String,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
@@ -22,21 +22,16 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
-import kotlinx.coroutines.launch
 import org.onebusaway.android.R
 import org.onebusaway.android.models.ObaRoute
 import org.onebusaway.android.models.ObaStop
 import org.onebusaway.android.models.RouteMapDirection
 import org.onebusaway.android.api.data.MapDataSource
-import org.onebusaway.android.database.oba.RouteFavoritesRepository
 import org.onebusaway.android.database.oba.StopCacheRepository
 import org.onebusaway.android.database.oba.StopDao
 import org.onebusaway.android.extrapolation.data.TripObservationRepository
@@ -109,7 +104,6 @@ class MapViewModel @Inject constructor(
     private val tripObservationRepository: TripObservationRepository,
     private val stopDao: StopDao,
     private val stopCache: StopCacheRepository,
-    private val routeFavorites: RouteFavoritesRepository,
     @param:ApplicationContext private val context: Context,
 ) : ViewModel() {
 
@@ -221,37 +215,6 @@ class MapViewModel @Inject constructor(
             // save — and it emits only a few times per route session, so the idle collector is free.
             .map { it?.toRouteHeader() }
             .stateIn(viewModelScope, SharingStarted.Eagerly, null)
-
-    /**
-     * Whether the shown route is starred, live — drives the route-mode header's star toggle (#1727).
-     * Flat-maps the loaded route's id into the reactive `routes.favorite` query, so starring/unstarring
-     * (here or from an arrival row) re-flags the header immediately. False while no route is loaded.
-     */
-    // WhileSubscribed, not Eagerly (unlike the routeHeader sibling above): this flat-maps into a live
-    // Room query, so keeping it collected while nothing observes it (route mode not shown) would hold a
-    // DB invalidation observer for no reason. The 5s window rides out config changes / brief detaches.
-    @OptIn(ExperimentalCoroutinesApi::class)
-    val isRouteFavorite: StateFlow<Boolean> =
-        routeController.loadedRoute
-            .flatMapLatest { loaded ->
-                val id = (loaded as? LoadedRoute.Loaded)?.route?.id
-                if (id == null) flowOf(false) else routeFavorites.isFavorite(id)
-            }
-            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
-
-    /**
-     * Toggle the shown route's star (the route-mode header star, #1727) — a wholesale single
-     * `routes.favorite` bit (#1751), through the shared [RouteFavoritesRepository] so it gets the same
-     * import gating + analytics as the arrival-row star. No-op until the route has loaded; passes the
-     * loaded route's URL so no network backfill is needed.
-     */
-    fun toggleRouteFavorite() {
-        val route = (routeController.loadedRoute.value as? LoadedRoute.Loaded)?.route ?: return
-        val favorite = !isRouteFavorite.value
-        viewModelScope.launch {
-            routeFavorites.setFavorite(route.id, route.shortName, route.longName, route.url, favorite)
-        }
-    }
 
     /** The route header reported its measured height; derive the map's top padding (0 clears it). */
     fun setRouteHeaderHeight(heightPx: Int) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
@@ -73,6 +73,7 @@ import org.onebusaway.android.time.ServerTime
 import org.onebusaway.android.ui.arrivals.ArrivalActions
 import org.onebusaway.android.ui.arrivals.ArrivalInfo
 import org.onebusaway.android.ui.arrivals.LoadMoreState
+import org.onebusaway.android.ui.compose.components.FavoriteStarButton
 import org.onebusaway.android.ui.compose.components.LineBadge
 import org.onebusaway.android.ui.compose.components.rememberRouteBadgeColors
 import org.onebusaway.android.ui.arrivals.RouteRowGroup
@@ -239,7 +240,8 @@ internal fun ArrivalRowContent(
  * - Tapping the row body frames the whole route/direction on the map ([ArrivalRowCallbacks.onShowVehiclesOnMap]).
  * - Tapping a pill focuses that specific trip's vehicle + stop ([ArrivalRowCallbacks.onEtaClick]).
  * - Long-pressing a pill opens that trip's menu (details / reminder / report).
- * - The top-right overflow ⋮ opens the route-level menu (star / show-only / schedule).
+ * - The top-left corner star toggles the route favorite ([ArrivalRowCallbacks.onRouteFavorite]).
+ * - The top-right overflow ⋮ opens the route-level menu (show-only / schedule).
  *
  * [actionsFor] resolves each trip's [ArrivalActions] (keyed by trip id upstream); the representative
  * trip's actions drive the badge color and the route menu. [etaAnchor] is attached to the first pill
@@ -312,6 +314,22 @@ fun RouteArrivalRow(
                 // Reserve room on the right so the last pill never slides under the overflow icon.
                 Spacer(Modifier.width(20.dp))
             }
+            if (routeActions != null) {
+                // Own layer, overlaid on top of the row rather than laid out inline, so the star can
+                // sit in the corner without shifting the badge/pills (mirrors the overflow icon below).
+                Box(Modifier.align(Alignment.TopStart)) {
+                    FavoriteStarButton(
+                        isFavorite = isFavorite,
+                        onClick = { callbacks.onRouteFavorite(routeActions) },
+                        tint = colorResource(R.color.navdrawer_icon_tint),
+                        iconSize = 20.dp,
+                        // Tighten the button's touch box to the icon + a small margin, like the corner
+                        // overflow icon below, instead of Material's 48dp default — keeps the star flush
+                        // in the corner with no compensating offset.
+                        modifier = Modifier.size(28.dp),
+                    )
+                }
+            }
             Box(Modifier.align(Alignment.TopEnd)) {
                 CornerIcon(
                     iconRes = R.drawable.more_vert,
@@ -324,7 +342,6 @@ fun RouteArrivalRow(
                     onDismiss = { menuExpanded = false },
                     routeId = group.routeId,
                     actions = routeActions,
-                    isFavorite = isFavorite,
                     filterActive = filterActive,
                     callbacks = callbacks,
                 )
@@ -383,27 +400,19 @@ private fun CornerIcon(
     )
 }
 
-/** The route-level overflow menu (the row's ⋮): star the route, narrow the stop to this route, and
- *  open its schedule. Per-trip actions live on each pill's long-press menu ([TripActionsMenu]). */
+/** The route-level overflow menu (the row's ⋮): narrow the stop to this route and open its schedule.
+ *  The route's star now lives only as the row's own corner toggle ([FavoriteStarButton]) — no longer
+ *  duplicated here. Per-trip actions live on each pill's long-press menu ([TripActionsMenu]). */
 @Composable
 internal fun RouteActionsMenu(
     expanded: Boolean,
     onDismiss: () -> Unit,
     routeId: String,
     actions: ArrivalActions?,
-    isFavorite: Boolean,
     filterActive: Boolean,
     callbacks: ArrivalRowCallbacks
 ) {
     DropdownMenu(expanded = expanded, onDismissRequest = onDismiss) {
-        if (actions != null) {
-            val favLabel = if (isFavorite) {
-                R.string.bus_options_menu_remove_star
-            } else {
-                R.string.bus_options_menu_add_star
-            }
-            MenuRow(favLabel) { onDismiss(); callbacks.onRouteFavorite(actions) }
-        }
         val filterLabel = if (filterActive) {
             R.string.bus_options_menu_show_all_routes
         } else {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -643,7 +643,7 @@ private fun ArrivalsDragHandle(onToggle: () -> Unit, modifier: Modifier = Modifi
         contentAlignment = Alignment.Center,
     ) {
         Surface(
-            // Same muted grey as the header's star/icon tint, so the handle matches the panel chrome.
+            // Same muted grey as the header's icon tint, so the handle matches the panel chrome.
             color = colorResource(R.color.navdrawer_icon_tint),
             shape = RoundedCornerShape(percent = 50),
         ) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -452,7 +452,6 @@ fun HomeScreen(
                             fabBottomInset = fabInsetTarget,
                             modifier = Modifier.fillMaxSize(),
                         )
-                        val isRouteFavorite by mapViewModel.isRouteFavorite.collectAsStateWithLifecycle()
                         HomeMapOverlays(
                             weatherViewModel = weatherViewModel,
                             donationViewModel = donationViewModel,
@@ -462,10 +461,6 @@ fun HomeScreen(
                             // The switch-direction affordance calls straight into the map VM (which
                             // re-filters stops/vehicles + persists the choice), like the height report below.
                             onSelectRouteDirection = mapViewModel::selectRouteDirection,
-                            // The star reads/writes the route's single favorite bit straight on the map VM,
-                            // like the direction switch — starring here or from an arrival row stays in sync.
-                            isRouteFavorite = isRouteFavorite,
-                            onToggleRouteFavorite = mapViewModel::toggleRouteFavorite,
                             onLearnMore = onLearnMore,
                             onOpenSurvey = onOpenSurvey,
                             // The route header reports its height straight to the map VM (which owns the
@@ -566,8 +561,6 @@ private fun BoxScope.HomeMapOverlays(
     routeHeader: RouteHeader?,
     onCancelRouteMode: () -> Unit,
     onSelectRouteDirection: (Int) -> Unit,
-    isRouteFavorite: Boolean,
-    onToggleRouteFavorite: () -> Unit,
     onLearnMore: () -> Unit,
     onOpenSurvey: (url: String) -> Unit,
     onRouteHeaderHeight: (Int) -> Unit,
@@ -596,8 +589,6 @@ private fun BoxScope.HomeMapOverlays(
             header = routeHeader,
             onCancel = onCancelRouteMode,
             onSelectDirection = onSelectRouteDirection,
-            isFavorite = isRouteFavorite,
-            onToggleFavorite = onToggleRouteFavorite,
             onHeight = onRouteHeaderHeight,
             modifier = Modifier.align(Alignment.TopCenter).fillMaxWidth(),
         )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/RouteHeaderOverlay.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/RouteHeaderOverlay.kt
@@ -50,14 +50,13 @@ import androidx.compose.ui.unit.sp
 import org.onebusaway.android.R
 import org.onebusaway.android.map.RouteHeader
 import org.onebusaway.android.models.RouteMapDirection
-import org.onebusaway.android.ui.compose.components.FavoriteStarButton
 import org.onebusaway.android.ui.compose.components.LineBadge
 import org.onebusaway.android.ui.compose.components.RadioOptionList
 import org.onebusaway.android.ui.compose.components.rememberRouteBadgeColors
 import org.onebusaway.android.ui.compose.theme.ObaTheme
 
-// The route-header action icons (favorite / switch-direction / cancel) share one size + tint so they
-// read as one control group: a larger-than-default 36dp icon in a deliberately tightened 40dp touch box
+// The route-header action icons (switch-direction / cancel) share one size + tint so they read as
+// one control group: a larger-than-default 36dp icon in a deliberately tightened 40dp touch box
 // (below Material's 48dp default — a conscious trade-off for a compact header banner).
 private val HEADER_ICON_SIZE = 36.dp
 private val HEADER_ICON_BUTTON_SIZE = 40.dp
@@ -65,24 +64,19 @@ private val HEADER_ICON_BUTTON_SIZE = 40.dp
 /**
  * The route-mode header overlay (the Compose replacement for the legacy `route_info_head.xml` /
  * `RouteMapController.RoutePopup`). Renders the route short/long name + agency (or a spinner while the
- * route loads), the current direction's headsign, a favorite (star) toggle, a switch-direction
- * affordance (when the route has more than one direction), and a cancel button that exits route mode. It
- * reports its measured height via [onHeight] so the host can set the map's top padding (keeping vehicle
- * markers visible under it).
+ * route loads), the current direction's headsign, a switch-direction affordance (when the route has more
+ * than one direction), and a cancel button that exits route mode. It reports its measured height via
+ * [onHeight] so the host can set the map's top padding (keeping vehicle markers visible under it). The
+ * route's favorite star no longer lives here — it's the arrival row's own corner toggle.
  *
  * [onSelectDirection] switches which direction of the route is shown (the id is one of
  * [RouteHeader.directions]).
- *
- * [isFavorite] drives the star's filled/outline state and [onToggleFavorite] toggles the route's star
- * (a wholesale `routes.favorite` bit, #1751/#1727), kept in sync with the arrival-row star.
  */
 @Composable
 fun RouteHeaderOverlay(
     header: RouteHeader,
     onCancel: () -> Unit,
     onSelectDirection: (Int) -> Unit,
-    isFavorite: Boolean,
-    onToggleFavorite: () -> Unit,
     onHeight: (Int) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -114,15 +108,6 @@ fun RouteHeaderOverlay(
                     .padding(4.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                // The favorite star, inline and to the left of the badge — the first of the shared-style
-                // header action icons (larger icon, tightened touch box).
-                FavoriteStarButton(
-                    isFavorite = isFavorite,
-                    onClick = onToggleFavorite,
-                    tint = colorResource(R.color.navdrawer_icon_tint),
-                    iconSize = HEADER_ICON_SIZE,
-                    modifier = Modifier.size(HEADER_ICON_BUTTON_SIZE),
-                )
                 // A square route roundel: the short name shrinks to fit inside the tile, on the same
                 // HCT-normalized GTFS-color chip as the arrival rows.
                 val (badgeContainer, badgeContent) = rememberRouteBadgeColors(header.routeColor)
@@ -178,7 +163,7 @@ fun RouteHeaderOverlay(
 /**
  * A route-header action icon button in the shared header style: the [HEADER_ICON_SIZE] icon tinted with
  * the nav-drawer icon color, in the tightened [HEADER_ICON_BUTTON_SIZE] box. Used by the switch-direction
- * and cancel actions; the favorite star ([FavoriteStarButton]) matches these but stays its own toggle.
+ * and cancel actions.
  */
 @Composable
 private fun HeaderIconButton(
@@ -266,8 +251,6 @@ private fun RouteHeaderOverlayPreview() {
                 ),
                 onCancel = {},
                 onSelectDirection = {},
-                isFavorite = true,
-                onToggleFavorite = {},
                 onHeight = {},
             )
             Spacer(Modifier.size(12.dp))
@@ -286,8 +269,6 @@ private fun RouteHeaderOverlayPreview() {
                 ),
                 onCancel = {},
                 onSelectDirection = {},
-                isFavorite = false,
-                onToggleFavorite = {},
                 onHeight = {},
             )
             Spacer(Modifier.size(12.dp))
@@ -307,8 +288,6 @@ private fun RouteHeaderOverlayPreview() {
                 ),
                 onCancel = {},
                 onSelectDirection = {},
-                isFavorite = false,
-                onToggleFavorite = {},
                 onHeight = {},
             )
             Spacer(Modifier.size(12.dp))
@@ -322,8 +301,6 @@ private fun RouteHeaderOverlayPreview() {
                 ),
                 onCancel = {},
                 onSelectDirection = {},
-                isFavorite = false,
-                onToggleFavorite = {},
                 onHeight = {},
             )
             Spacer(Modifier.size(12.dp))
@@ -332,8 +309,6 @@ private fun RouteHeaderOverlayPreview() {
                 header = RouteHeader(loading = true, shortName = "", longName = "", agency = ""),
                 onCancel = {},
                 onSelectDirection = {},
-                isFavorite = false,
-                onToggleFavorite = {},
                 onHeight = {},
             )
         }


### PR DESCRIPTION
Follow-up to #1808, stacked on it. Removes the dead single-id favorite query the route-header star left behind, and the doc/comment staleness from the same removal.

## What changed
- **Delete `RouteFavoritesRepository.isFavorite(routeId): Flow<Boolean>`** and the **`RouteDao.isFavorite(routeId)`** query it wraps — after #1808 dropped `MapViewModel.isRouteFavorite`/`toggleRouteFavorite`, the only remaining caller was `RouteDaoTest`.
- **Keep the favorite-column round-trip coverage** by refolding `RouteDaoTest`'s `isFavorite_reflectsTheFavoriteBit` onto the surviving `favoriteRouteIds()` query (renamed `favoriteRouteIds_reflectsTheFavoriteBit`), so `setFavorite`'s write is still exercised end-to-end through the flow production actually reads.
- **Fix stale docs** the header star left behind:
  - `RouteFavoritesRepository` class doc — now describes one starring surface (the arrival-row star) and the one surviving flow (`favoriteRouteIds`).
  - `RouteDao.favoriteRouteIds` / `ensureRouteDetails` doc examples that named "the route-map header" as a starring surface.
  - `HomeScreen`'s drag-handle comment ("the header's star/icon tint" → "icon tint" — `RouteHeaderOverlay` no longer has a star).

## Notes
- The route-mode header overlay itself (`RouteHeaderOverlay`, route name/agency) still exists — only its *star* is gone, so comments about the header existing are untouched.
- Flagged by a `/simplify` altitude-review pass on #1808; scoped out of that PR since it reaches into files #1808 didn't otherwise touch.

## Verification
- `./gradlew :onebusaway-android:compileObaGoogleDebugKotlin -PwarningsAsErrors=true` — clean (Room KSP regen included).
- `./gradlew :onebusaway-android:compileObaGoogleDebugAndroidTestKotlin -PwarningsAsErrors=true` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)