### PR TITLE
Remove the duplicated corner favorite-star overlay in RouteArrivalRow

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
@@ -366,22 +366,6 @@ fun RouteArrivalRow(
                     )
                 }
             }
-            if (routeActions != null) {
-                // Own layer, overlaid on top of the row rather than laid out inline, so the star can
-                // sit in the corner without shifting the badge/pills (mirrors the overflow icon below).
-                Box(Modifier.align(Alignment.TopStart)) {
-                    FavoriteStarButton(
-                        isFavorite = isFavorite,
-                        onClick = { callbacks.onRouteFavorite(routeActions) },
-                        tint = colorResource(R.color.navdrawer_icon_tint),
-                        iconSize = 20.dp,
-                        // Tighten the button's touch box to the icon + a small margin, like the corner
-                        // overflow icon below, instead of Material's 48dp default — keeps the star flush
-                        // in the corner with no compensating offset.
-                        modifier = Modifier.size(28.dp),
-                    )
-                }
-            }
             Box(Modifier.align(Alignment.TopEnd)) {
                 CornerIcon(
                     iconRes = R.drawable.more_vert,


### PR DESCRIPTION
## What

`RouteArrivalRow` rendered its corner favorite-star **twice** — two byte-identical `if (routeActions != null) { Box(Modifier.align(Alignment.TopStart)) { FavoriteStarButton(...) } }` blocks stacked at the exact same position. A copy-paste slip from the route-star work (#1808 / #1809).

## Why it matters

Beyond drawing the star's semantics node twice, it turned **CI red on `main` and every branch cut from it**: the shared `ArrivalAlertIndicatorTest` asserts exactly one node carries the "add star to route" content description, so it matched 2 nodes and failed with `Failed to retrieve bounds of the node` (`fetchOneOrThrow` → "Expected exactly '1' node but found '2'").

## How

Delete the duplicate block — one corner star remains.

## Testing

- Compiles clean under the strict gate (`./gradlew :onebusaway-android:compileObaGoogleDebugKotlin -PwarningsAsErrors=true`).
- Ran `ArrivalAlertIndicatorTest` on a physical device via `connectedObaGoogleDebugAndroidTest` — now passes (single star node), where it previously failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Changes**
  * Removed the favorite star toggle from route arrival rows.
  * Route actions remain available through the corner overflow menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->