### PR TITLE
Arrivals drawer: show service alerts immediately on toggle

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsScreen.kt
@@ -17,8 +17,6 @@ package org.onebusaway.android.ui.arrivals
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.MutableTransitionState
-import androidx.compose.animation.expandVertically
-import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.clickable
@@ -355,27 +353,23 @@ internal fun ArrivalsList(
     etaAnchor: Modifier = Modifier
 ) {
     LazyColumn(state = listState, modifier = modifier.fillMaxSize(), contentPadding = contentPadding) {
-        if (content.hasAlerts) {
-            // One item for the whole alert section so it stays in the list and animates as a unit:
-            // toggling [showAlerts] slides it open/closed and the rows below glide up. Hosts that keep
-            // alerts visible pass showAlerts = true, so it's shown from the start without animating.
+        if (content.hasAlerts && showAlerts) {
+            // The whole alert section is one item, present only while [showAlerts] is set. Toggling the
+            // header's alert icon adds/removes this item; Modifier.animateItem() fades it in/out and lets
+            // the route rows below glide into place. (An always-present item gated by AnimatedVisibility
+            // stranded the section at zero height in the collapsed peek — the lazy layout didn't remeasure
+            // it on toggle, so the alerts only appeared after a drag forced a relayout.)
             item(key = "alerts") {
-                AnimatedVisibility(
-                    visible = showAlerts,
-                    enter = expandVertically() + fadeIn(),
-                    exit = shrinkVertically() + fadeOut()
-                ) {
-                    Column {
-                        if (content.alerts.isNotEmpty()) {
-                            AlertList(
-                                alerts = content.alerts,
-                                onShowAlert = handler::onShowAlert,
-                                onHideAlert = handler::onHideAlert
-                            )
-                        }
-                        if (content.hiddenAlertCount > 0) {
-                            HiddenAlertsRow(content.hiddenAlertCount, onShowHiddenAlerts)
-                        }
+                Column(Modifier.animateItem()) {
+                    if (content.alerts.isNotEmpty()) {
+                        AlertList(
+                            alerts = content.alerts,
+                            onShowAlert = handler::onShowAlert,
+                            onHideAlert = handler::onHideAlert
+                        )
+                    }
+                    if (content.hiddenAlertCount > 0) {
+                        HiddenAlertsRow(content.hiddenAlertCount, onShowHiddenAlerts)
                     }
                 }
             }
@@ -395,7 +389,9 @@ internal fun ArrivalsList(
                     isFavorite = group.routeId in content.favoriteRouteIds,
                     callbacks = rowCallbacks,
                     // The onboarding ETA spotlight anchors on the first route row's pill only.
-                    etaAnchor = if (index == 0) etaAnchor else Modifier
+                    etaAnchor = if (index == 0) etaAnchor else Modifier,
+                    // Glide up/down as the alert section above is toggled in/out.
+                    modifier = Modifier.animateItem()
                 )
             }
         }


### PR DESCRIPTION
## Problem

Regression from #1812. Tapping the arrivals-drawer header's alert icon set the toggle state, but the service alerts did not appear until the drawer was dragged up and dropped back to its collapsed peek. To see alerts you had to: tap the icon (nothing visible), drag the drawer to full, then drop it back to minimum — only then did they render.

## Root cause

The alert section was an **always-present** `LazyColumn` item whose visibility was gated by a nested `AnimatedVisibility`:

```kotlin
item(key = "alerts") {
    AnimatedVisibility(visible = showAlerts, ...) { /* alerts */ }
}
```

When collapsed the item sat in the list at **zero height**, and toggling `showAlerts` false→true did not cause the lazy layout to remeasure it. Only a later drag — a full sheet/list relayout — brought it on screen. This is the known fragility of nesting a size-animating `AnimatedVisibility` inside a lazy item.

## Fix

- Include the alerts item **conditionally** (`if (content.hasAlerts && showAlerts)`) instead of always-present-and-hidden — `LazyColumn` handles item add/remove deterministically.
- Keep the motion with the idiomatic tool: `Modifier.animateItem()` fades the section in/out and lets the route rows below glide into place (restoring #1812's intended animation without the fragile pattern).
- Drop the now-unused `expandVertically` / `fadeIn` imports.

## Verification

- Compiles clean under the CI gate (`-PwarningsAsErrors=true`).
- Device-verified on a Pixel 7 Pro: tapping the header alert icon at the collapsed peek now expands the alerts immediately (no drag-cycle), and toggling again collapses them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved animations in the arrivals list when service alerts appear or disappear.
  * Route rows now move more smoothly as the alert section changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->