### PR TITLE
Map route header: tap the banner to reframe the map to the route's extent (#1825)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
@@ -384,6 +384,17 @@ class MapViewModel @Inject constructor(
     fun exitRouteMode() = showNearbyStops()
 
     /**
+     * Reframe the map to the shown route's full extent — the route header's tap-the-banner affordance.
+     * Re-issues the retained route framing (via [MapHost.frameRoute]), which re-fires even though it's
+     * already the current framing, snapping the camera back after the user has panned/zoomed away or
+     * switched direction. Guarded on an active route so a stray tap can't set a stale route fit outside
+     * route mode (the header only shows in route mode, so this is belt-and-suspenders).
+     */
+    fun frameRoute() {
+        if (routeController.isActive) mapHost.frameRoute()
+    }
+
+    /**
      * Switch the shown route to another of its directions (one of the header's [RouteHeader.directions]
      * ids) via the header's swap affordance. Re-filters the stops + vehicles in place (no reload /
      * reframe). On a real switch, persists the choice and retires the launch anchor

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -461,6 +461,9 @@ fun HomeScreen(
                             // The switch-direction affordance calls straight into the map VM (which
                             // re-filters stops/vehicles + persists the choice), like the height report below.
                             onSelectRouteDirection = mapViewModel::selectRouteDirection,
+                            // Tapping the header body reframes the map to the route's full extent (VM
+                            // re-issues the retained route framing).
+                            onFrameRoute = mapViewModel::frameRoute,
                             onLearnMore = onLearnMore,
                             onOpenSurvey = onOpenSurvey,
                             // The route header reports its height straight to the map VM (which owns the
@@ -561,6 +564,7 @@ private fun BoxScope.HomeMapOverlays(
     routeHeader: RouteHeader?,
     onCancelRouteMode: () -> Unit,
     onSelectRouteDirection: (Int) -> Unit,
+    onFrameRoute: () -> Unit,
     onLearnMore: () -> Unit,
     onOpenSurvey: (url: String) -> Unit,
     onRouteHeaderHeight: (Int) -> Unit,
@@ -589,6 +593,7 @@ private fun BoxScope.HomeMapOverlays(
             header = routeHeader,
             onCancel = onCancelRouteMode,
             onSelectDirection = onSelectRouteDirection,
+            onFrameRoute = onFrameRoute,
             onHeight = onRouteHeaderHeight,
             modifier = Modifier.align(Alignment.TopCenter).fillMaxWidth(),
         )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/RouteHeaderOverlay.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/RouteHeaderOverlay.kt
@@ -16,6 +16,7 @@
 package org.onebusaway.android.ui.home.map
 
 import androidx.annotation.DrawableRes
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -42,6 +43,7 @@ import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -71,13 +73,16 @@ private val HEADER_ICON_BUTTON_SIZE = 40.dp
  * route's favorite star no longer lives here — it's the arrival row's own corner toggle.
  *
  * [onSelectDirection] switches which direction of the route is shown (the id is one of
- * [RouteHeader.directions]).
+ * [RouteHeader.directions]). [onFrameRoute] reframes the map to the route's full extent — invoked by a tap
+ * on the banner body (the badge + name column), scoped to leave the switch-direction / cancel icons as
+ * their own separate tap targets.
  */
 @Composable
 fun RouteHeaderOverlay(
     header: RouteHeader,
     onCancel: () -> Unit,
     onSelectDirection: (Int) -> Unit,
+    onFrameRoute: () -> Unit,
     onHeight: (Int) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -109,36 +114,51 @@ fun RouteHeaderOverlay(
                     .padding(4.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                // A square route roundel: the short name shrinks to fit inside the tile, on the same
-                // HCT-normalized GTFS-color chip as the arrival rows.
-                val (badgeContainer, badgeContent) = rememberRouteBadgeColors(header.routeColor)
-                LineBadge(
-                    text = header.shortName,
-                    maxFontSize = 45.sp,
-                    width = 64.dp,
-                    square = true,
-                    color = badgeContent,
-                    containerColor = badgeContainer,
-                    modifier = Modifier.padding(horizontal = 10.dp),
-                )
-                Column(Modifier.weight(1f)) {
-                    if (header.longName.isNotEmpty()) {
-                        Text(
-                            text = header.longName,
-                            fontSize = 16.sp,
-                            fontWeight = FontWeight.Bold,
-                            maxLines = 2,
-                            overflow = TextOverflow.Ellipsis,
-                        )
-                    }
-                    if (directionLabel != null) {
-                        // The same arrow-glyph + tightened-monospace treatment as an arrivals row, so
-                        // the headsign reads identically on both surfaces (#1823).
-                        DirectionHeadsign(directionLabel)
-                    }
-                    if (header.agency.isNotEmpty()) {
-                        // One type-scale step below the direction line so it recedes as secondary info.
-                        Text(text = header.agency, style = MaterialTheme.typography.bodySmall)
+                // The badge + name column is one tap target that reframes the map to the route's extent.
+                // Scoped to this inner Row (given the outer Row's remaining width via weight) so it doesn't
+                // overlap the switch-direction / cancel icons, which consume their own taps as separate
+                // nodes; the click semantics announce the action for accessibility.
+                Row(
+                    Modifier
+                        .weight(1f)
+                        .clickable(
+                            onClickLabel = stringResource(R.string.route_header_frame_route),
+                            role = Role.Button,
+                            onClick = onFrameRoute,
+                        ),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    // A square route roundel: the short name shrinks to fit inside the tile, on the same
+                    // HCT-normalized GTFS-color chip as the arrival rows.
+                    val (badgeContainer, badgeContent) = rememberRouteBadgeColors(header.routeColor)
+                    LineBadge(
+                        text = header.shortName,
+                        maxFontSize = 45.sp,
+                        width = 64.dp,
+                        square = true,
+                        color = badgeContent,
+                        containerColor = badgeContainer,
+                        modifier = Modifier.padding(horizontal = 10.dp),
+                    )
+                    Column(Modifier.weight(1f)) {
+                        if (header.longName.isNotEmpty()) {
+                            Text(
+                                text = header.longName,
+                                fontSize = 16.sp,
+                                fontWeight = FontWeight.Bold,
+                                maxLines = 2,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                        }
+                        if (directionLabel != null) {
+                            // The same arrow-glyph + tightened-monospace treatment as an arrivals row, so
+                            // the headsign reads identically on both surfaces (#1823).
+                            DirectionHeadsign(directionLabel)
+                        }
+                        if (header.agency.isNotEmpty()) {
+                            // One type-scale step below the direction line so it recedes as secondary info.
+                            Text(text = header.agency, style = MaterialTheme.typography.bodySmall)
+                        }
                     }
                 }
                 // A route with a single direction has nothing to switch to — the affordance is hidden.
@@ -250,6 +270,7 @@ private fun RouteHeaderOverlayPreview() {
                 ),
                 onCancel = {},
                 onSelectDirection = {},
+                onFrameRoute = {},
                 onHeight = {},
             )
             Spacer(Modifier.size(12.dp))
@@ -268,6 +289,7 @@ private fun RouteHeaderOverlayPreview() {
                 ),
                 onCancel = {},
                 onSelectDirection = {},
+                onFrameRoute = {},
                 onHeight = {},
             )
             Spacer(Modifier.size(12.dp))
@@ -287,6 +309,7 @@ private fun RouteHeaderOverlayPreview() {
                 ),
                 onCancel = {},
                 onSelectDirection = {},
+                onFrameRoute = {},
                 onHeight = {},
             )
             Spacer(Modifier.size(12.dp))
@@ -300,6 +323,7 @@ private fun RouteHeaderOverlayPreview() {
                 ),
                 onCancel = {},
                 onSelectDirection = {},
+                onFrameRoute = {},
                 onHeight = {},
             )
             Spacer(Modifier.size(12.dp))
@@ -308,6 +332,7 @@ private fun RouteHeaderOverlayPreview() {
                 header = RouteHeader(loading = true, shortName = "", longName = "", agency = ""),
                 onCancel = {},
                 onSelectDirection = {},
+                onFrameRoute = {},
                 onHeight = {},
             )
         }

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -335,6 +335,8 @@
     </string>
     <!-- Route map header: switch which direction of the route is shown -->
     <string name="route_header_switch_direction">Switch direction</string>
+    <!-- Route map header: tap the banner body to reframe the map to the route's full extent -->
+    <string name="route_header_frame_route">Frame route on map</string>
     <!-- Fallback label for a route direction whose headsign is missing -->
     <string name="route_direction_unnamed">Other direction</string>
 


### PR DESCRIPTION
Closes #1825. **Stacked on #1826** (`feature/1823-shared-direction-headsign`) — review/merge that first; this PR's base will retarget to `main` once it lands.

## What

The route-mode header banner was inert except for its switch-direction and cancel icons. After the user pans/zooms away — or switches direction — there was no quick way back to the route overview. This makes the banner body tappable to reframe the map to the route's full extent, mirroring how the arrivals sheet's title recenters on the stop.

## How

- **`RouteHeaderOverlay`** — the badge + name/agency column is now wrapped in an inner `Row` (given the outer row's remaining width via `weight(1f)`) with a `clickable` that carries `Role.Button` + an `onClickLabel` ("Frame route on map") for accessibility. Scoped to that inner row so it doesn't overlap the switch-direction / cancel `IconButton`s, which keep consuming their own taps as separate nodes.
- **`MapViewModel.frameRoute()`** — re-issues the retained route framing via `MapHost.frameRoute()` (`FramingIntent.Route`), which re-fires even when it's already the current framing (the framing flow is a `SharedFlow`, so the identical value isn't swallowed — the same mechanism the recent-routes re-tap / `reframe` path already relies on). Guarded on an active route so a stray call can't set a stale route fit outside route mode.
- **`HomeScreen`** — threads `onFrameRoute = mapViewModel::frameRoute` through `HomeMapOverlays` alongside the existing `onCancelRouteMode` / `onSelectRouteDirection` callbacks.
- New string `route_header_frame_route`; all five `RouteHeaderOverlayPreview` instances pass a no-op.

Frames the **whole route's** bounding box (`FramingIntent.Route`), matching "full extent of the route" in the issue rather than the selected-direction extent.

## Acceptance criteria

- [x] Tapping the header banner reframes the map to the route's full extent via the existing `frameRoute()` / `FramingIntent.Route` path.
- [x] Switch-direction and cancel affordances still work and are not triggered by a header-body tap (separate tap nodes).
- [x] The tappable region is announced with a content description / role (`Role.Button` + `onClickLabel`).
- [x] Works after panning/zooming away and after a direction switch (the retained framing re-fires).

## Verification

- Compiles clean under the CI gate: `./gradlew :onebusaway-android:compileObaGoogleDebugKotlin -PwarningsAsErrors=true`.
- Installed `obaGoogleDebug` on a physical device and launched `HomeActivity` (boots cleanly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Tap the active route banner to re-center the map and show the full route.
  - Added accessibility support and labeling for the new map-framing action.
  - Existing direction-switching and route-cancel controls remain available separately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->