### PR TITLE
Arrivals drawer: sort route rows by provider + line name, not departure time

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalInfo.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalInfo.kt
@@ -91,6 +91,11 @@ class ArrivalInfo(
     override val headsign: String? get() = data.headsign
     val shortName: String? get() = data.shortName
     val routeLongName: String? get() = data.routeLongName
+
+    /** The route-row sort/display name (#1822): short name falling back to the long name (the same
+     *  [getRouteDisplayName] fallback used elsewhere for this route), then the route id — never
+     *  blank, so it's always a valid [RouteRowGroup] sort key. */
+    override val lineName: String get() = getRouteDisplayName(shortName, routeLongName).ifEmpty { routeId }
     val stopSequence: Int get() = data.stopSequence
     val serviceDate: Long get() = data.serviceDate
     val vehicleId: String? get() = data.vehicleId

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsRepository.kt
@@ -331,7 +331,9 @@ class DefaultArrivalsRepository @Inject constructor(
         val activeSituationIds = situations.filter(isActive).mapTo(HashSet()) { it.id }
         return ArrivalsData(
             arrivals = arrivals,
-            routeGroups = groupArrivalsByRouteDirection(arrivals),
+            // Stable (agency, line, headsign) row order (#1822), not ETA — a row's position shouldn't
+            // drift as arrivals tick down or a poll refreshes.
+            routeGroups = groupArrivalsByRouteDirection(arrivals) { agencyNameFor(snapshot, it.routeId) },
             header = header,
             minutesAfter = snapshot.minutesAfter,
             isStale = isStale,
@@ -355,6 +357,12 @@ class DefaultArrivalsRepository @Inject constructor(
         stopDao.markStopUsed(stop, regionRepository.region.value?.id, now)
     }
 
+    /** The operating agency's display name for a route, or null when either the route or its agency
+     *  reference is missing from the snapshot. Shared by the route-row sort key and [buildActions] so
+     *  the two don't independently reimplement the same route→agency lookup. */
+    private fun agencyNameFor(snapshot: StopArrivals, routeId: String): String? =
+        snapshot.route(routeId)?.agencyId?.let(snapshot::agencyName)
+
     /** Precomputes the navigation/dialog data for each arrival (legacy reads these on menu tap). */
     private fun buildActions(
         snapshot: StopArrivals,
@@ -369,7 +377,7 @@ class DefaultArrivalsRepository @Inject constructor(
             routeLongName = arrival.routeLongName,
             routeColor = route?.color,
             scheduleUrl = route?.url,
-            agencyName = route?.agencyId?.let { snapshot.agencyName(it) },
+            agencyName = agencyNameFor(snapshot, arrival.routeId),
             blockId = snapshot.trip(arrival.tripId)?.blockId,
             alertSituationId = activeAlertFor(arrival.situationIds, activeSituationIds)
         )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/RouteRowGroup.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/RouteRowGroup.kt
@@ -15,23 +15,47 @@
  */
 package org.onebusaway.android.ui.arrivals
 
+import org.onebusaway.util.comparators.AlphanumComparator
+
 /**
  * The minimal shape the route-row grouping and ordering need from an arrival: its route, its
- * direction (headsign), and its ETA in minutes. [ArrivalInfo] implements this, but the pure
- * grouping/ordering functions below key off the interface so they stay unit-testable without a
- * `Context` (which building an [ArrivalInfo] requires).
+ * direction (headsign), its ETA in minutes, and its natural-sort line name (#1822). [ArrivalInfo]
+ * implements this, but the pure grouping/ordering functions below key off the interface so they stay
+ * unit-testable without a `Context` (which building an [ArrivalInfo] requires).
  */
 interface RouteDirectionItem {
     val routeId: String
     val headsign: String?
     val eta: Long
+
+    /** The stable line-name sort/display key (#1822) — e.g. "8", "40", "A Line" — resolved by the
+     *  implementer to a never-blank value (see [ArrivalInfo.lineName]'s fallback chain), so a blank
+     *  short name can't collapse every unnamed route into one comparator bucket. Unlike [headsign] or
+     *  agency (the latter needs an external accessor — see [groupByRouteDirection]), the line name is
+     *  intrinsic to the item and needs no outside lookup. */
+    val lineName: String
 }
 
-/** A group's departure sort key: the soonest *upcoming* (non-negative) ETA, or [Long.MAX_VALUE] when
- *  every trip is already in the past. Negative (recent-past) ETAs deliberately don't count toward
- *  ordering (#1707) — a row sorts by its next real arrival, not a just-departed one. */
-private fun List<RouteDirectionItem>.departureSortEta(): Long =
-    firstOrNull { it.eta >= 0 }?.eta ?: Long.MAX_VALUE
+/** Numeric-aware ("natural") comparator for [RouteDirectionItem.lineName] — "8" sorts before "40"
+ *  before "550" — the same comparator [org.onebusaway.android.util.RouteDisplay] already uses for
+ *  route short names, reused here rather than re-implementing natural sort. */
+private val LINE_NAME_COMPARATOR = AlphanumComparator()
+
+/** Case-insensitive, blank/null-last comparator shared by the agency and headsign sort fields below —
+ *  unnamed/unknown data shouldn't get to dominate the top of the list. */
+private val BLANK_LAST_COMPARATOR: Comparator<String?> = nullsLast(String.CASE_INSENSITIVE_ORDER)
+
+/** Orders groups by (agency, line, headsign) (#1822): agency (from [agencyNameOf]) and headsign
+ *  compare via [BLANK_LAST_COMPARATOR]; line name uses [LINE_NAME_COMPARATOR]. The headsign tiebreak
+ *  makes a route serving two directions at the stop deterministic regardless of incoming order. Reads
+ *  each group's representative (first) item once per comparison. */
+private fun <T : RouteDirectionItem> routeSortComparator(
+    agencyNameOf: (T) -> String?
+): Comparator<List<T>> =
+    compareBy<List<T>, String?>(BLANK_LAST_COMPARATOR) {
+        agencyNameOf(it.first())?.takeIf(String::isNotBlank)
+    }.thenBy(LINE_NAME_COMPARATOR) { it.first().lineName }
+        .thenBy(BLANK_LAST_COMPARATOR) { it.first().headsign?.takeIf(String::isNotBlank) }
 
 /**
  * One arrivals row: all upcoming trips for a single (route, direction) at the stop, ETA-sorted
@@ -49,9 +73,9 @@ data class RouteRowGroup(val trips: List<ArrivalInfo>) {
     /** The soonest trip; source of the row's route badge, headsign, and route-level actions/color. */
     val representative: ArrivalInfo get() = trips.first()
 
-    /** Index of the soonest *upcoming* (first non-negative ETA) trip — the ETA the row is sorted by
-     *  (see [departureSortEta]) — or null when every trip is recent-past. Lets a row justify that pill
-     *  to the leading edge so the recent-past pills overflow before it. */
+    /** Index of the soonest *upcoming* (first non-negative ETA) trip within [trips], or null when every
+     *  trip is recent-past. Lets a row justify that pill to the leading edge so the recent-past pills
+     *  overflow before it. */
     val firstUpcomingIndex: Int? get() = trips.indexOfFirst { it.eta >= 0 }.takeIf { it >= 0 }
 
     val routeId: String get() = representative.routeId
@@ -75,23 +99,36 @@ data class RouteRowGroup(val trips: List<ArrivalInfo>) {
 private fun RouteDirectionItem.groupKey(): String = "$routeId\u0000${headsign.orEmpty()}"
 
 /**
- * Groups [items] into (route, direction) rows, then orders the rows by **departure** — each row's
- * soonest *upcoming* (non-negative) ETA, so a route whose next real arrival is far off sorts below a
- * sooner one even if it also has a just-departed trip (#1707). Items within a row keep their incoming
- * ETA order (recent-past first, then upcoming). Stable, so rows with equal departure keys keep
+ * Groups [items] into (route, direction) rows, then orders the rows by the **stable** (agency, line,
+ * headsign) key (#1822) — not by ETA, so a row's position doesn't drift as arrivals tick down or a
+ * poll refreshes; only the *within-row* trip order stays ETA-driven (unchanged, see
+ * [RouteRowGroup.trips]). [agencyNameOf] resolves a group's agency name from its representative
+ * (first) item — the one part of the key not intrinsic to [RouteDirectionItem] (see
+ * [groupArrivalsByRouteDirection]'s caller for why). Stable, so groups with an equal key keep
  * first-seen order. Generic over [RouteDirectionItem] so it's testable with lightweight fakes.
  */
-fun <T : RouteDirectionItem> groupByRouteDirection(items: List<T>): List<List<T>> {
+fun <T : RouteDirectionItem> groupByRouteDirection(
+    items: List<T>,
+    agencyNameOf: (T) -> String?
+): List<List<T>> {
     val groups = LinkedHashMap<String, MutableList<T>>()
     for (item in items) {
         groups.getOrPut(item.groupKey()) { mutableListOf() }.add(item)
     }
-    return groups.values.sortedBy { it.departureSortEta() }
+    return groups.values.sortedWith(routeSortComparator(agencyNameOf))
 }
 
-/** Builds the departure-ordered route rows for the arrivals list (see [groupByRouteDirection]). */
-fun groupArrivalsByRouteDirection(arrivals: List<ArrivalInfo>): List<RouteRowGroup> =
-    groupByRouteDirection(arrivals).map { RouteRowGroup(it) }
+/**
+ * Builds the (agency, line, headsign)-ordered route rows for the arrivals list (#1822; see
+ * [groupByRouteDirection]). [agencyNameOf] resolves an arrival's agency display name — not carried on
+ * [ArrivalInfo] itself, only resolvable from the loaded snapshot's route/agency refs (see
+ * `ArrivalsRepository.toData`, the sole production caller) — null/blank sorts the row last.
+ */
+fun groupArrivalsByRouteDirection(
+    arrivals: List<ArrivalInfo>,
+    agencyNameOf: (ArrivalInfo) -> String?
+): List<RouteRowGroup> =
+    groupByRouteDirection(arrivals, agencyNameOf).map { RouteRowGroup(it) }
 
 /**
  * Stable favorite-first ordering: items whose [routeIdOf] is in [favoriteRouteIds] move to the top,
@@ -105,10 +142,11 @@ fun <T> orderGroupsByFavorite(
 ): List<T> = groups.sortedByDescending { routeIdOf(it) in favoriteRouteIds }
 
 /**
- * The final display order (#1707): **starred routes first, then the rest, each in departure order.**
- * [groups] is already departure-ordered (see [groupArrivalsByRouteDirection]) and the sort is stable,
- * so this only lifts the starred rows to the top without disturbing the within-partition order. A star
- * is the wholesale `routes.favorite` bit (#1751), so it keys off the group's route id.
+ * The final display order (#1707, #1822): **starred routes first, then the rest, each in
+ * (agency, line, headsign) order.** [groups] is already sorted that way (see
+ * [groupArrivalsByRouteDirection]) and the sort is stable, so this only lifts the starred rows to the
+ * top without disturbing the within-partition order. A star is the wholesale `routes.favorite` bit
+ * (#1751), so it keys off the group's route id.
  */
 fun orderRouteGroupsByFavorite(
     groups: List<RouteRowGroup>,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
@@ -610,19 +610,22 @@ internal fun previewArrival(
     predicted: Boolean = true,
     scheduleDeviationMinutes: Long = 0L,
     status: Status = Status.DEFAULT,
+    routeId: String = "route_$shortName",
+    routeLongName: String? = null,
 ): ArrivalInfo {
     val predictedMs = etaMinutes * PREVIEW_MIN_MS
     val scheduledMs = (etaMinutes - scheduleDeviationMinutes) * PREVIEW_MIN_MS
     return ArrivalInfo(
         context = null,
         data = PreviewArrivalData(
-            routeId = "route_$shortName",
+            routeId = routeId,
             shortName = shortName,
             headsign = headsign,
             scheduledArrivalTime = ServerTime(scheduledMs),
             predictedArrivalTime = if (predicted) ServerTime(predictedMs) else null,
             predicted = predicted,
             status = status,
+            routeLongName = routeLongName,
         ),
         now = ServerTime(0L),
         includeArrivalDepartureInStatusLabel = false,

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/RouteRowGroupingTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/RouteRowGroupingTest.kt
@@ -20,67 +20,28 @@ import org.junit.Test
 import org.onebusaway.android.ui.arrivals.components.previewArrival
 
 /**
- * JVM unit tests for the pure route-row grouping/ordering functions. They key off the
- * [RouteDirectionItem] interface, so a lightweight fake stands in for [ArrivalInfo] (which needs a
- * `Context`). Inputs mirror the real pipeline: already ETA-sorted (ascending, recent-past first).
+ * JVM unit tests for the pure route-row grouping/ordering functions. Grouping and the between-row
+ * (agency, line, headsign) sort (#1822) key off the [RouteDirectionItem] interface (which carries
+ * [RouteDirectionItem.lineName] intrinsically) plus an external agency-name accessor, so a
+ * lightweight fake stands in for [ArrivalInfo] (which needs a `Context`); [ArrivalInfo.lineName]'s
+ * own fallback chain is covered separately using [previewArrival]. Within-row trip order is
+ * untouched by any of this and stays whatever order the caller fed in (upstream: ETA-sorted,
+ * recent-past first).
  */
 class RouteRowGroupingTest {
 
     private data class FakeItem(
         override val routeId: String,
         override val headsign: String?,
-        override val eta: Long
+        override val eta: Long,
+        override val lineName: String = routeId,
+        val agencyName: String? = null,
     ) : RouteDirectionItem
 
-    // Grouping + departure ordering ---------------------------------------------------------------
+    /** [groupByRouteDirection] with the agency name read off [FakeItem] itself. */
+    private fun group(items: List<FakeItem>) = groupByRouteDirection(items) { it.agencyName }
 
-    @Test
-    fun grouping_ordersGroupsByDeparture_andKeepsTripsSorted() {
-        // ETA-sorted input interleaving two routes.
-        val items = listOf(
-            FakeItem("A", "North", 2),
-            FakeItem("B", "East", 5),
-            FakeItem("A", "North", 12),
-            FakeItem("B", "East", 20),
-            FakeItem("A", "North", 30),
-        )
-        val groups = groupByRouteDirection(items)
-
-        // Group order follows each group's soonest upcoming ETA: A (2) before B (5).
-        assertEquals(listOf("A", "B"), groups.map { it.first().routeId })
-        // Trips within a group stay ETA-sorted.
-        assertEquals(listOf(2L, 12L, 30L), groups[0].map { it.eta })
-        assertEquals(listOf(5L, 20L), groups[1].map { it.eta })
-    }
-
-    @Test
-    fun grouping_negativeEtaDoesNotCountTowardOrder() {
-        // Route A just departed (-2) but its next real arrival is far off (20); Route B is sooner (5).
-        // A must sort BELOW B — the departed trip doesn't pull A to the top.
-        val items = listOf(
-            FakeItem("A", "North", -2),
-            FakeItem("B", "East", 5),
-            FakeItem("A", "North", 20),
-        )
-        val groups = groupByRouteDirection(items)
-
-        assertEquals(listOf("B", "A"), groups.map { it.first().routeId })
-        // A still keeps its recent-past trip, shown first within the row.
-        assertEquals(listOf(-2L, 20L), groups.first { it.first().routeId == "A" }.map { it.eta })
-    }
-
-    @Test
-    fun grouping_allNegativeGroupSortsLast() {
-        // Route A has only departed trips; Route B has an upcoming one — B ranks first.
-        val items = listOf(
-            FakeItem("A", "North", -5),
-            FakeItem("A", "North", -2),
-            FakeItem("B", "East", 4),
-        )
-        val groups = groupByRouteDirection(items)
-
-        assertEquals(listOf("B", "A"), groups.map { it.first().routeId })
-    }
+    // Grouping (route, direction) into rows ---------------------------------------------------------
 
     @Test
     fun grouping_sameRouteTwoHeadsigns_producesTwoGroups() {
@@ -89,11 +50,11 @@ class RouteRowGroupingTest {
             FakeItem("A", "South", 6),
             FakeItem("A", "North", 15),
         )
-        val groups = groupByRouteDirection(items)
+        val groups = group(items)
 
         assertEquals(2, groups.size)
-        assertEquals(listOf("North", "North"), groups[0].map { it.headsign })
-        assertEquals(listOf("South"), groups[1].map { it.headsign })
+        assertEquals(listOf("North", "North"), groups.first { it.first().headsign == "North" }.map { it.headsign })
+        assertEquals(listOf("South"), groups.first { it.first().headsign == "South" }.map { it.headsign })
     }
 
     @Test
@@ -103,7 +64,7 @@ class RouteRowGroupingTest {
             FakeItem("A", "North", 4),
             FakeItem("A", "North", 4),
         )
-        val groups = groupByRouteDirection(items)
+        val groups = group(items)
 
         assertEquals(1, groups.size)
         assertEquals(2, groups[0].size)
@@ -115,12 +76,143 @@ class RouteRowGroupingTest {
             FakeItem("A", null, 1),
             FakeItem("A", "", 9),
         )
-        assertEquals(1, groupByRouteDirection(items).size)
+        assertEquals(1, group(items).size)
     }
 
     @Test
     fun grouping_empty_returnsEmpty() {
-        assertEquals(emptyList<List<FakeItem>>(), groupByRouteDirection(emptyList<FakeItem>()))
+        assertEquals(emptyList<List<FakeItem>>(), group(emptyList()))
+    }
+
+    @Test
+    fun grouping_keepsTripsInIncomingOrder() {
+        // Within-row trip order is untouched by the between-row sort (#1822) — it stays whatever order
+        // the caller fed in (upstream: ETA-sorted by ArrivalInfoUtils.InfoComparator).
+        val items = listOf(
+            FakeItem("A", "North", -2),
+            FakeItem("A", "North", 20),
+        )
+        assertEquals(listOf(-2L, 20L), group(items).single().map { it.eta })
+    }
+
+    // Between-row ordering: (agency, line, headsign) — stable, not ETA (#1822) -----------------------
+
+    @Test
+    fun ordering_sortsByLineNameNaturally_withinSameAgency() {
+        // Numeric-aware: "8" before "40" before "550", not lexicographic ("40" < "550" < "8").
+        val items = listOf(
+            FakeItem("r550", "X", eta = 1, agencyName = "Metro", lineName = "550"),
+            FakeItem("r8", "X", eta = 1, agencyName = "Metro", lineName = "8"),
+            FakeItem("r40", "X", eta = 1, agencyName = "Metro", lineName = "40"),
+        )
+        assertEquals(listOf("r8", "r40", "r550"), group(items).map { it.first().routeId })
+    }
+
+    @Test
+    fun ordering_sortsAlphanumericLineNames_viaAlphanumComparator() {
+        // Mixed numeric/alphanumeric short names ("8", "A Line", "RapidRide E") sort via
+        // AlphanumComparator (the same comparator RouteDisplay already uses for route short names):
+        // digit-led names sort before letter-led names, which then compare alphabetically.
+        val items = listOf(
+            FakeItem("rapidride", "X", eta = 1, agencyName = "Metro", lineName = "RapidRide E"),
+            FakeItem("aline", "X", eta = 1, agencyName = "Metro", lineName = "A Line"),
+            FakeItem("r8", "X", eta = 1, agencyName = "Metro", lineName = "8"),
+        )
+        assertEquals(listOf("r8", "aline", "rapidride"), group(items).map { it.first().routeId })
+    }
+
+    @Test
+    fun ordering_sortsByAgencyBeforeLineName() {
+        // Agency is the primary key: a numerically-later line in an earlier agency still sorts first.
+        val items = listOf(
+            FakeItem("r-zoo-8", "X", eta = 1, agencyName = "Zoo Transit", lineName = "8"),
+            FakeItem("r-metro-40", "X", eta = 1, agencyName = "Metro", lineName = "40"),
+        )
+        assertEquals(listOf("r-metro-40", "r-zoo-8"), group(items).map { it.first().routeId })
+    }
+
+    @Test
+    fun ordering_nullAgencySortsLast() {
+        val items = listOf(
+            FakeItem("named", "X", eta = 1, agencyName = "Metro", lineName = "1"),
+            FakeItem("unnamed", "X", eta = 1, agencyName = null, lineName = "1"),
+        )
+        assertEquals(listOf("named", "unnamed"), group(items).map { it.first().routeId })
+    }
+
+    @Test
+    fun ordering_blankAgencySortsLast_sameAsNull() {
+        val items = listOf(
+            FakeItem("blank", "X", eta = 1, agencyName = "", lineName = "1"),
+            FakeItem("named", "X", eta = 1, agencyName = "Metro", lineName = "1"),
+        )
+        assertEquals(listOf("named", "blank"), group(items).map { it.first().routeId })
+    }
+
+    @Test
+    fun ordering_tiesBrokenByHeadsign_deterministically() {
+        // Same (agency, line) serving two directions at the stop — order must not depend on input order.
+        val items = listOf(
+            FakeItem("r8", "West", eta = 1, agencyName = "Metro", lineName = "8"),
+            FakeItem("r8", "East", eta = 1, agencyName = "Metro", lineName = "8"),
+        )
+        assertEquals(listOf("East", "West"), group(items).map { it.first().headsign })
+    }
+
+    @Test
+    fun ordering_doesNotDependOnEta() {
+        // The whole point of #1822: a group with a far-off ETA can still sort above one with a near ETA,
+        // as long as its (agency, line) key sorts first.
+        val items = listOf(
+            FakeItem("r40", "X", eta = 1, agencyName = "Metro", lineName = "40"),
+            FakeItem("r8", "X", eta = 999, agencyName = "Metro", lineName = "8"),
+        )
+        assertEquals(listOf("r8", "r40"), group(items).map { it.first().routeId })
+    }
+
+    @Test
+    fun ordering_isStableAmongEqualKeys() {
+        // Equal (agency, line, headsign) keys keep first-seen order (frequency-style duplicate groups
+        // aside, this covers hypothetical equal-but-distinct groups).
+        val items = listOf(
+            FakeItem("first", "X", eta = 1, agencyName = "Metro", lineName = "8"),
+            FakeItem("second", "Y", eta = 1, agencyName = "Metro", lineName = "40"),
+        )
+        assertEquals(listOf("first", "second"), group(items).map { it.first().routeId })
+    }
+
+    // groupArrivalsByRouteDirection: line-name fallback chain on real ArrivalInfo (#1822) -------------
+
+    @Test
+    fun arrivalsGrouping_lineNameFallsBackToLongName_whenShortNameBlank() {
+        val arrivals = listOf(
+            previewArrival(shortName = "", headsign = "X", etaMinutes = 1, routeId = "blank-short", routeLongName = "Zephyr Line"),
+            previewArrival(shortName = "8", headsign = "X", etaMinutes = 1, routeId = "has-short"),
+        )
+        val groups = groupArrivalsByRouteDirection(arrivals) { null }
+        // "8" (numeric) sorts before "Zephyr Line" (non-numeric fallback) under natural ordering.
+        assertEquals(listOf("has-short", "blank-short"), groups.map { it.routeId })
+    }
+
+    @Test
+    fun arrivalsGrouping_lineNameFallsBackToRouteId_whenShortAndLongNameBlank() {
+        val arrivals = listOf(
+            previewArrival(shortName = "", headsign = "X", etaMinutes = 1, routeId = "aaa-fallback", routeLongName = null),
+        )
+        val groups = groupArrivalsByRouteDirection(arrivals) { null }
+        assertEquals("aaa-fallback", groups.single().representative.routeId)
+    }
+
+    @Test
+    fun arrivalsGrouping_usesSuppliedAgencyNameAccessor() {
+        val arrivals = listOf(
+            previewArrival(shortName = "8", headsign = "X", etaMinutes = 1, routeId = "zoo-route"),
+            previewArrival(shortName = "8", headsign = "X", etaMinutes = 1, routeId = "metro-route"),
+        )
+        val groups = groupArrivalsByRouteDirection(arrivals) { arrival ->
+            if (arrival.routeId == "metro-route") "Metro" else "Zoo Transit"
+        }
+        assertEquals(listOf("metro-route", "zoo-route"), groups.map { it.routeId })
     }
 
     // Favorite-first ordering ---------------------------------------------------------------------

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/RouteRowGroupingTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/RouteRowGroupingTest.kt
@@ -176,7 +176,7 @@ class RouteRowGroupingTest {
         // aside, this covers hypothetical equal-but-distinct groups).
         val items = listOf(
             FakeItem("first", "X", eta = 1, agencyName = "Metro", lineName = "8"),
-            FakeItem("second", "Y", eta = 1, agencyName = "Metro", lineName = "40"),
+            FakeItem("second", "X", eta = 1, agencyName = "Metro", lineName = "8"),
         )
         assertEquals(listOf("first", "second"), group(items).map { it.first().routeId })
     }


### PR DESCRIPTION
## Summary

Fixes #1822. The arrivals drawer's route rows were ordered by departure time (soonest upcoming ETA), but ETAs update continuously between polls while the row order doesn't re-sort live — so the "sorted by departure" order goes stale between refreshes.

Rows now sort by a **stable** key that doesn't drift as ETAs tick:

1. **Agency** (provider) — case-insensitive alphabetical, blank/null last.
2. **Line name** (route short name, falling back to long name, then route id) — natural/numeric-aware ordering via the existing `AlphanumComparator` (the same one `RouteDisplay.kt` already uses for route short names), so "8" sorts before "40" before "550".
3. **Headsign** — a deterministic tiebreak for a route serving two directions at the stop.

Starred routes still pin to the top and are ordered among themselves by the same scheme (this falls out for free — `orderRouteGroupsByFavorite` is a stable partition sort, so it just inherits whatever order `groupByRouteDirection` produces).

`RouteDirectionItem` gained a `lineName: String` member (intrinsic to the item, needs no outside lookup) alongside the existing `routeId`/`headsign`/`eta`; agency name still comes from an external accessor since it's only resolvable from the loaded snapshot's route/agency refs, not from `ArrivalInfo` itself.

## Test plan

- [x] `RouteRowGroupingTest` — 22 unit tests covering: grouping structure (unchanged), natural line-name ordering, agency-before-line precedence, null/blank-agency-last, headsign tiebreak, ETA-independence, sort stability, alphanumeric line names, and the `ArrivalInfo` line-name fallback chain (short → long → route id).
- [x] `./gradlew :onebusaway-android:compileObaGoogleDebugKotlin -PwarningsAsErrors=true` — clean.
- [x] Installed on a physical device; app launches and runs without crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Arrival rows now use a consistent display name for routes, with the route ID shown when no name is available.
  - Routes are now ordered predictably by agency, line name, and destination rather than changing based on departure times.
  - Line names sort naturally, including numeric and mixed alphanumeric names.
  - Routes with missing agency or destination information are placed consistently at the end.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->