### PR TITLE
Search results: type glyph, route-colored badge, operating agency (#1824)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/data/LocationSearchDataSource.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/data/LocationSearchDataSource.kt
@@ -28,6 +28,16 @@ import org.onebusaway.android.models.ObaRoute
 import org.onebusaway.android.models.ObaStop
 
 /**
+ * Routes near a location together with the operating-agency display names resolved from the same
+ * response's references pool (agency id → name). The combined-search screen shows the agency under
+ * each route's long name; [agencyNames] is empty when the response carried no agency references.
+ */
+data class RoutesNearResult(
+    val routes: List<ObaRoute>,
+    val agencyNames: Map<String, String>,
+)
+
+/**
  * Fetches routes/stops near a location from the modernized OBA REST client, adapting the wire
  * references to the [ObaRoute]/[ObaStop] model interfaces so callers never see the DTOs.
  *
@@ -38,7 +48,7 @@ import org.onebusaway.android.models.ObaStop
  */
 interface LocationSearchDataSource {
 
-    suspend fun routesNear(lat: Double, lon: Double, query: String?, radius: Int?): Result<List<ObaRoute>>
+    suspend fun routesNear(lat: Double, lon: Double, query: String?, radius: Int?): Result<RoutesNearResult>
 
     suspend fun stopsNear(lat: Double, lon: Double, query: String?, radius: Int?): Result<List<ObaStop>>
 
@@ -54,8 +64,14 @@ class DefaultLocationSearchDataSource @Inject constructor(
 
     override suspend fun routesNear(
         lat: Double, lon: Double, query: String?, radius: Int?,
-    ): Result<List<ObaRoute>> = api.call {
-        it.routesForLocation(lat, lon, query, radius).requireData().list.map(::DtoRoute)
+    ): Result<RoutesNearResult> = api.call {
+        val data = it.routesForLocation(lat, lon, query, radius).requireData()
+        RoutesNearResult(
+            routes = data.list.map(::DtoRoute),
+            // Index the response's referenced agencies by id so the combined-search row can show the
+            // operating agency under each route's long name (mirrors the arrivals path's refs.agency).
+            agencyNames = data.references.agencies.associate { agency -> agency.id to agency.name },
+        )
     }.onFailure { Log.e(TAG, "routesNear failed", it) }
 
     override suspend fun stopsNear(

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/ResultRows.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/ResultRows.kt
@@ -89,21 +89,40 @@ fun StopRowContent(
 
 /**
  * The visual content of a route result row: the prominent short-name [LineBadge] on the left and
- * an optional description to its right, matching the legacy list. The caller supplies its own
- * click handling and padding via [modifier].
+ * an optional description (plus operating agency) to its right, matching the legacy list. The caller
+ * supplies its own click handling and padding via [modifier].
+ *
+ * The badge renders as the route-colored chip derived from [routeColor] (via [rememberRouteBadgeColors]),
+ * matching the arrivals row and map header; a null [routeColor] falls back to the neutral chip. The
+ * operating [agency] is shown one type step below the long name and omitted when null/blank.
  */
 @Composable
-fun RouteRowContent(shortName: String, longName: String?, modifier: Modifier = Modifier) {
+fun RouteRowContent(
+    shortName: String,
+    longName: String?,
+    modifier: Modifier = Modifier,
+    routeColor: Int? = null,
+    agency: String? = null
+) {
     Row(modifier, verticalAlignment = Alignment.CenterVertically) {
-        LineBadge(shortName)
+        val (containerColor, contentColor) = rememberRouteBadgeColors(routeColor)
+        LineBadge(shortName, containerColor = containerColor, color = contentColor)
         Spacer(Modifier.width(12.dp))
-        if (longName != null) {
-            Text(
-                text = longName,
-                style = MaterialTheme.typography.bodyLarge,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.weight(1f)
-            )
+        Column(Modifier.weight(1f)) {
+            if (longName != null) {
+                Text(
+                    text = longName,
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            if (!agency.isNullOrBlank()) {
+                Text(
+                    text = agency,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
         }
     }
 }
@@ -116,13 +135,20 @@ private fun RouteRowContentPreview() {
         .padding(horizontal = 16.dp, vertical = 12.dp)
     ObaTheme {
         Column {
-            RouteRowContent("8", "Seattle Center - Capitol Hill - Rainier Beach", rowModifier)
+            RouteRowContent(
+                "8", "Seattle Center - Capitol Hill - Rainier Beach", rowModifier,
+                routeColor = 0x00A651, agency = "King County Metro"
+            )
             HorizontalDivider()
-            RouteRowContent("12", "Interlaken Park - Capitol Hill - Downtown Seattle", rowModifier)
+            RouteRowContent(
+                "12", "Interlaken Park - Capitol Hill - Downtown Seattle", rowModifier,
+                routeColor = 0x0075BF, agency = "King County Metro"
+            )
             HorizontalDivider()
+            // No color → neutral chip; no agency → agency line omitted.
             RouteRowContent("225", "Sheridan Park", rowModifier)
             HorizontalDivider()
-            RouteRowContent("40", null, rowModifier)
+            RouteRowContent("40", null, rowModifier, routeColor = 0xE31837, agency = "Sound Transit")
         }
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/search/RouteSearchContent.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/search/RouteSearchContent.kt
@@ -79,6 +79,7 @@ private fun RouteSearchRow(
         RouteRowContent(
             shortName = route.shortName,
             longName = route.longName,
+            routeColor = route.routeColor,
             modifier = Modifier
                 .fillMaxWidth()
                 .combinedClickable(

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/search/RouteSearchRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/search/RouteSearchRepository.kt
@@ -34,7 +34,8 @@ data class RouteSearchResult(
     val id: String,
     val shortName: String,
     val longName: String?,
-    val url: String?
+    val url: String?,
+    val routeColor: Int? = null
 )
 
 /** Searches routes by name/number near the user. */
@@ -80,7 +81,8 @@ class DefaultRouteSearchRepository(
             id = route.id,
             shortName = names.shortName,
             longName = names.longName,
-            url = route.url?.takeIf { it.isNotEmpty() }
+            url = route.url?.takeIf { it.isNotEmpty() },
+            routeColor = route.color
         )
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/searchresults/SearchResultsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/searchresults/SearchResultsRepository.kt
@@ -16,6 +16,7 @@
 package org.onebusaway.android.ui.searchresults
 
 import org.onebusaway.android.api.data.LocationSearchDataSource
+import org.onebusaway.android.api.data.RoutesNearResult
 
 import javax.inject.Inject
 import android.location.Location
@@ -74,18 +75,20 @@ class DefaultSearchResultsRepository @Inject constructor(
         importGate.awaitReady()
         val userInfo = runCatching { stopDao.userInfoMap().toStopUserInfoMap() }.getOrDefault(emptyMap())
         val items = buildList {
-            routeResult.getOrNull()?.forEach { add(toRoute(it)) }
+            routeResult.getOrNull()?.let { result ->
+                result.routes.forEach { add(toRoute(it, result.agencyNames)) }
+            }
             stopResult.getOrNull()?.forEach { add(toStop(it, userInfo[it.id])) }
         }
         Result.success(items)
     }
 
     /** Searches around the user, widening to the region's default center when nothing matches. */
-    private suspend fun searchRoutes(query: String, center: Location): List<ObaRoute> {
+    private suspend fun searchRoutes(query: String, center: Location): RoutesNearResult {
         val near = search
             .routesNear(center.latitude, center.longitude, query, SearchCenter.DEFAULT_SEARCH_RADIUS_METERS)
             .getOrThrow()
-        if (near.isNotEmpty()) return near
+        if (near.routes.isNotEmpty()) return near
         val default = searchCenter.regionCenter() ?: return near
         return search
             .routesNear(default.latitude, default.longitude, query, SearchCenter.DEFAULT_SEARCH_RADIUS_METERS)
@@ -97,13 +100,16 @@ class DefaultSearchResultsRepository @Inject constructor(
             .stopsNear(center.latitude, center.longitude, query, SearchCenter.DEFAULT_SEARCH_RADIUS_METERS)
             .getOrThrow()
 
-    private fun toRoute(route: ObaRoute): SearchResultItem.Route {
+    private fun toRoute(route: ObaRoute, agencyNames: Map<String, String>): SearchResultItem.Route {
         val names = routeDisplayNames(route)
         return SearchResultItem.Route(
             id = route.id,
             shortName = names.shortName,
             longName = names.longName,
-            url = route.url?.takeIf { it.isNotEmpty() }
+            url = route.url?.takeIf { it.isNotEmpty() },
+            routeColor = route.color,
+            // A blank agency name renders as no line (RouteRowContent guards isNullOrBlank).
+            agency = agencyNames[route.agencyId]
         )
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/searchresults/SearchResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/searchresults/SearchResultsScreen.kt
@@ -115,7 +115,7 @@ private fun RouteResultRow(
 ) {
     ResultRow(
         painter = painterResource(R.drawable.ic_route),
-        contentDescription = stringResource(R.string.search_result_type_route),
+        contentDescription = stringResource(R.string.route_shortcut),
         onClick = { onShowOnMap(route) }
     ) {
         RouteRowContent(
@@ -135,7 +135,7 @@ private fun StopResultRow(
 ) {
     ResultRow(
         painter = painterResource(R.drawable.stop_flag),
-        contentDescription = stringResource(R.string.search_result_type_stop),
+        contentDescription = stringResource(R.string.stop_shortcut),
         onClick = { onShowOnMap(stop) }
     ) {
         StopRowContent(

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/searchresults/SearchResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/searchresults/SearchResultsScreen.kt
@@ -17,15 +17,23 @@ package org.onebusaway.android.ui.searchresults
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -105,16 +113,18 @@ private fun RouteResultRow(
     route: SearchResultItem.Route,
     onShowOnMap: (SearchResultItem.Route) -> Unit
 ) {
-    Column {
+    ResultRow(
+        painter = painterResource(R.drawable.ic_route),
+        contentDescription = stringResource(R.string.search_result_type_route),
+        onClick = { onShowOnMap(route) }
+    ) {
         RouteRowContent(
             shortName = route.shortName,
             longName = route.longName,
-            modifier = Modifier
-                .fillMaxWidth()
-                .clickable { onShowOnMap(route) }
-                .padding(horizontal = 16.dp, vertical = 12.dp)
+            modifier = Modifier.weight(1f),
+            routeColor = route.routeColor,
+            agency = route.agency
         )
-        HorizontalDivider()
     }
 }
 
@@ -123,16 +133,49 @@ private fun StopResultRow(
     stop: SearchResultItem.Stop,
     onShowOnMap: (SearchResultItem.Stop) -> Unit
 ) {
-    Column {
+    ResultRow(
+        painter = painterResource(R.drawable.stop_flag),
+        contentDescription = stringResource(R.string.search_result_type_stop),
+        onClick = { onShowOnMap(stop) }
+    ) {
         StopRowContent(
             name = stop.name,
             direction = stop.direction,
             isFavorite = stop.isFavorite,
+            modifier = Modifier.weight(1f)
+        )
+    }
+}
+
+/**
+ * A combined-search list row: a leading result-type glyph (a route or stop marker in a consistent
+ * tinted column, so the two are distinguishable at a glance), the type-specific [content], and a
+ * trailing divider. The whole row is clickable via [onClick].
+ */
+@Composable
+private fun ResultRow(
+    painter: Painter,
+    contentDescription: String,
+    onClick: () -> Unit,
+    content: @Composable RowScope.() -> Unit
+) {
+    Column {
+        Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .clickable { onShowOnMap(stop) }
-                .padding(horizontal = 16.dp, vertical = 12.dp)
-        )
+                .clickable(onClick = onClick)
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                painter = painter,
+                contentDescription = contentDescription,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(24.dp)
+            )
+            Spacer(Modifier.width(12.dp))
+            content()
+        }
         HorizontalDivider()
     }
 }
@@ -145,7 +188,11 @@ private fun SearchResultsScreenSuccessPreview() {
             title = "8",
             state = ListUiState.Success(
                 listOf(
-                    SearchResultItem.Route("1_8", "8", "Seattle Center - Rainier Beach", null),
+                    SearchResultItem.Route(
+                        "1_8", "8", "Seattle Center - Rainier Beach", null,
+                        routeColor = 0x00A651, agency = "King County Metro"
+                    ),
+                    SearchResultItem.Route("1_40", "40", "Downtown - Northgate", null),
                     SearchResultItem.Stop("1_100", "Broadway & E Denny Way", "S", true, 47.6, -122.3),
                     SearchResultItem.Stop("1_101", "Stop with no direction", "", false, 47.6, -122.3)
                 )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/searchresults/SearchResultsUiState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/searchresults/SearchResultsUiState.kt
@@ -24,12 +24,17 @@ sealed interface SearchResultItem {
     /**
      * @param longName secondary name (long name or description), or null when there is none
      * @param url the route's schedule page, used when registering the route in recents
+     * @param routeColor the route's GTFS color as an Android ARGB int, or null when unset; drives the
+     *   route-colored [LineBadge] chip (a null falls back to the neutral chip)
+     * @param agency the operating agency's display name, or null/blank when unknown (the row omits it)
      */
     data class Route(
         val id: String,
         val shortName: String,
         val longName: String?,
-        val url: String?
+        val url: String?,
+        val routeColor: Int? = null,
+        val agency: String? = null
     ) : SearchResultItem
 
     /** @param direction raw compass direction code ("N", "SW", ...); empty when unknown. */

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -410,10 +410,6 @@
     <string name="find_hint_noresults">There are no results that match your search.</string>
     <string name="search_stop_hint">Enter a stop number</string>
     <string name="search_route_hint">Enter a route name/number</string>
-    <!-- Content descriptions for the leading result-type glyph in the combined search results list. -->
-    <string name="search_result_type_route">Route</string>
-    <string name="search_result_type_stop">Stop</string>
-
     <string name="route_shortcut">Route</string>
     <string name="stop_shortcut">Stop</string>
     <string name="recent_stops_shortcut">Recent Stops</string>

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -410,6 +410,9 @@
     <string name="find_hint_noresults">There are no results that match your search.</string>
     <string name="search_stop_hint">Enter a stop number</string>
     <string name="search_route_hint">Enter a route name/number</string>
+    <!-- Content descriptions for the leading result-type glyph in the combined search results list. -->
+    <string name="search_result_type_route">Route</string>
+    <string name="search_result_type_stop">Stop</string>
 
     <string name="route_shortcut">Route</string>
     <string name="stop_shortcut">Stop</string>


### PR DESCRIPTION
Closes #1824.

Three improvements to the combined search results rows so a mixed route/stop list is quicker to scan and shows the operating agency.

## Changes

### 1. Leading result-type glyph
Every row is prefixed with an icon of its result type — `ic_route` for routes, `stop_flag` for stops (the same stop glyph used by the starred-stops drawer item and the My-Lists recent-stops header). Consistent 24dp size + `onSurfaceVariant` tint so they read as one column of type markers. Scoped to the combined-search screen (not the shared `RouteRowContent`/`StopRowContent`) so single-type lists don't gain a redundant marker.

### 2. Route-colored `LineBadge` chip
`RouteRowContent` now renders the badge as the route-colored rounded chip via `rememberRouteBadgeColors(routeColor)`, matching the arrivals row (`ArrivalRows.kt`) and map header (`RouteHeaderOverlay.kt`). A null color falls back to the neutral chip. The My-Lists route search screen (`RouteSearchContent`) gets the colored chip too — `routeColor` is plumbed onto `RouteSearchResult`.

### 3. Operating agency under the long name
The route's operating agency renders one type-scale step below the long name (`bodySmall`, muted `onSurfaceVariant`), mirroring how the stop row stacks its direction. Resolved from the routes-for-location response's referenced agencies (`references.agency(id)?.name`, same pattern as the arrivals path), and omitted when unknown/blank.

## Data plumbing
- `LocationSearchDataSource.routesNear` now returns `RoutesNearResult(routes, agencyNames)` — the routes plus an agency-id→name map derived from the response references — so the combined search can label the agency without leaking wire DTOs past the data-source boundary. `routesNearOrEmpty` (used by My-Lists) is unchanged.
- `SearchResultItem.Route` gains `routeColor: Int?` and `agency: String?` (both default null / inert for other callers).

## Testing
- Compiles clean under `-PwarningsAsErrors=true` (CI gate).
- `SearchResultsViewModelTest` suite passes.
- Installed `obaGoogleDebug` on a device and confirmed the glyph, colored chip, and agency line render in the combined results (and the colored chip in My-Lists route search).
- `@Preview`s updated: route with color+agency, route without, stops.

Ran `/simplify` (4-agent cleanup pass) over the diff: extracted the duplicated row scaffold into a shared `ResultRow`, and dropped a redundant blank-check now owned by the UI guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Combined search results now display route colors and operating-agency names.
  - Route and stop results include clear icons and accessibility labels.
  - Entire result rows are clickable for easier map navigation.
  - Search can show available route or stop results when the other search fails.
- **UI Improvements**
  - Route badges use service colors when available, with a neutral fallback.
  - Agency names appear beneath route names where provided.
  - Improved spacing and layout for route results, including missing long names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->