### PR TITLE
Add a nightly API 23 floor smoke leg (#1818)

### DIFF
--- a/.github/workflows/android-nightly.yml
+++ b/.github/workflows/android-nightly.yml
@@ -1,11 +1,20 @@
-name: Android Nightly (all brands)
+name: Android Nightly
 
-# The PR/push workflow (android.yml) only exercises the shipping `oba` brand's tests to keep the
-# grid small (see the beforeVariants filter in onebusaway-android/build.gradle). This nightly job
-# restores the full brand × platform grid via -PbuildAllBrands=true so that a change breaking the
-# sample white-label brands (agencyX/agencyY) or the third-party `kiedybus` brand is still caught —
-# just off the PR critical path. Unit tests + `check` are JVM-only, so no emulator is needed here;
-# instrumented tests remain oba-only in android.yml.
+# Two nightly legs that both live off the PR critical path:
+#
+# 1. all-brands — the PR/push workflow (android.yml) only exercises the shipping `oba` brand's tests
+#    to keep the grid small (see the beforeVariants filter in onebusaway-android/build.gradle). This
+#    leg restores the full brand × platform grid via -PbuildAllBrands=true so a change breaking the
+#    sample white-label brands (agencyX/agencyY) or the third-party `kiedybus` brand is still caught.
+#    Unit tests + `check` are JVM-only, so it needs no emulator.
+#
+# 2. smoke-api23 — `minSdk` is 23 but no other job *launches* the app below API 33, so runtime-only
+#    floor risks (core-library desugaring, pre-26 platform shims, Compose on a 2015-era runtime,
+#    startup itself) go unbooted; a crash-on-boot at the floor would ship. This leg boots an API 23
+#    emulator, installs obaGoogleDebug, and runs the @SmokeTest-annotated subset of the instrumented
+#    suite (org.onebusaway.android.SmokeTest — see that annotation + issue #1818). Small and stable
+#    on purpose: it answers "does the app boot and do the core flows run on the floor?", not "re-run
+#    everything". Both instrumented suites otherwise remain oba-only in android.yml.
 
 on:
   schedule:
@@ -17,7 +26,7 @@ on:
 # One nightly run at a time: if a run is still going when the next cron fires (or a manual
 # dispatch overlaps), cancel the stale one so they don't race on the shared Gradle cache.
 concurrency:
-  group: nightly-all-brands
+  group: nightly
   cancel-in-progress: true
 
 jobs:
@@ -41,3 +50,69 @@ jobs:
 
       - name: Full-grid tests + check (all brands)
         run: ./gradlew test check -PbuildAllBrands=true --build-cache -x lint -PwarningsAsErrors=true --stacktrace
+
+  smoke-api23:
+    # Boot the minSdk floor: install obaGoogleDebug on an API 23 emulator and run the @SmokeTest
+    # subset. Independent of all-brands, so it runs in parallel. See the header for why this exists.
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+        with:
+          # This job only runs tests; it never pushes, so don't leave the token in git config.
+          persist-credentials: false
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: 21
+          distribution: 'temurin'
+
+      - name: Gradle cache
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: AVD cache
+        uses: actions/cache@v4
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-23
+
+      # API 23 (google_apis) ships only an x86 system image — no x86_64 at this level. If the 23 image
+      # proves too flaky on hosted runners, bump to 24/25 (still pre-26, so still exercises desugaring
+      # + the notification-channel shim floor) before giving up. See issue #1818.
+      - name: create AVD and generate snapshot for caching
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 23
+          force-avd-creation: false
+          arch: x86
+          target: google_apis
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: false
+          script: echo "Generated AVD snapshot for caching."
+
+      - name: run smoke subset
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 23
+          force-avd-creation: false
+          arch: x86
+          target: google_apis
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
+          # Select only the @SmokeTest-annotated classes; -x lint keeps the ~10-min lint off this leg
+          # (android.yml already gates lint on the PR path).
+          script: >-
+            ./gradlew connectedObaGoogleDebugAndroidTest
+            -Pandroid.testInstrumentationRunnerArguments.annotation=org.onebusaway.android.SmokeTest
+            --build-cache -x lint -PwarningsAsErrors=true --stacktrace

--- a/.github/workflows/android-nightly.yml
+++ b/.github/workflows/android-nightly.yml
@@ -55,6 +55,9 @@ jobs:
     # Boot the minSdk floor: install obaGoogleDebug on an API 23 emulator and run the @SmokeTest
     # subset. Independent of all-brands, so it runs in parallel. See the header for why this exists.
     runs-on: ubuntu-latest
+    # Cap the run so a wedged emulator boot / KVM stall can't hang the nightly and burn CI minutes.
+    # The whole leg (AVD boot + install + smoke subset) is well under this in the normal case.
+    timeout-minutes: 45
     steps:
       - name: checkout
         uses: actions/checkout@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,8 +162,14 @@ Tests are in `onebusaway-android/src/androidTest/java/`. Key test classes:
 - Region functionality tests (RegionsTest)
 - Utility tests (LocationUtilsTest, RegionUtilTest)
 
-CI runs on API level 33 emulator via GitHub Actions, and is **strict** — Kotlin warnings and Android
-Lint errors both fail the build (see "CI is strict" under Build Commands).
+The PR/push instrumented suite runs on an **API 33** emulator via GitHub Actions, and CI is **strict** —
+Kotlin warnings and Android Lint errors both fail the build (see "CI is strict" under Build Commands).
+
+Separately, a nightly **API 23 floor leg** (`smoke-api23` in `android-nightly.yml`, #1818) boots the
+`minSdk` floor — which the API-33 path never exercises at runtime — and runs the `@SmokeTest`-annotated
+subset (`org.onebusaway.android.SmokeTest`) to catch a crash-on-boot / desugaring / Compose-on-old-runtime
+regression the static checks can't see. Keep that subset **small and stable**; tag a new test with
+`@SmokeTest` only when it guards a core floor behaviour, and never tag a device-flaky one.
 
 ## Time domains: server clock vs device clock (#1612)
 

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/SmokeTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/SmokeTest.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android
+
+/**
+ * Marks an instrumented test as part of the **API-23 floor smoke subset** — a small, stable set of
+ * tests the nightly `smoke-api23` CI leg runs on a minSdk-floor emulator to answer "does the app boot
+ * and do the core flows run on the oldest platform we support?" (issue #1818).
+ *
+ * `minSdk` is 23 but the PR/nightly grid otherwise only *executes* the app at API 33+, so runtime-only
+ * floor risks — core-library desugaring correctness, pre-26 platform behavioural shims (notification
+ * channels, JobScheduler/WorkManager), Compose on a 2015-era runtime, and startup itself — go unbooted.
+ * The `smoke-api23` job in `.github/workflows/android-nightly.yml` selects exactly the tests carrying
+ * this annotation via the runner's `annotation` argument:
+ *
+ * ```
+ * -Pandroid.testInstrumentationRunnerArguments.annotation=org.onebusaway.android.SmokeTest
+ * ```
+ *
+ * Keep the tagged set **small and stable** — this leg exists to catch a floor regression within a day,
+ * not to re-run the whole suite. Device-flaky tests must stay out of it, and prefer tagging at the
+ * class level so the whole class's methods are included.
+ */
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+annotation class SmokeTest

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/SmokeTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/SmokeTest.kt
@@ -31,8 +31,10 @@ package org.onebusaway.android
  * ```
  *
  * Keep the tagged set **small and stable** — this leg exists to catch a floor regression within a day,
- * not to re-run the whole suite. Device-flaky tests must stay out of it, and prefer tagging at the
- * class level so the whole class's methods are included.
+ * not to re-run the whole suite. Device-flaky tests must stay out of it. Tag at the **class** level when
+ * the class is small and cohesive (every method guards the same floor behaviour); for a large or
+ * mixed-concern class, tag only the focused method(s) that exercise the floor risk so the subset stays
+ * small — the runner's `annotation` filter selects method-level tags too.
  */
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/database/AppDatabaseMigrationTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/database/AppDatabaseMigrationTest.kt
@@ -23,6 +23,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.onebusaway.android.SmokeTest
 
 /**
  * Validates that [MIGRATION_2_3] produces a schema matching the exported `3.json` and that the dead
@@ -33,6 +34,7 @@ import org.junit.runner.RunWith
  * [MIGRATION_5_6] adds `regions.otp_base_graphql_url` defaulting existing rows to OTP1 (#1780); and
  * that [MIGRATION_6_7] drops the retired `stop_routes_filter` table.
  */
+@SmokeTest // API-23 floor smoke subset (#1818): exercises Room migrations + java.time desugaring
 @RunWith(AndroidJUnit4::class)
 class AppDatabaseMigrationTest {
 

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/database/oba/RouteDaoTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/database/oba/RouteDaoTest.kt
@@ -27,12 +27,14 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.onebusaway.android.SmokeTest
 import org.onebusaway.android.database.AppDatabase
 
 /**
  * Verifies [RouteDao]'s `@Transaction` merge-on-write helpers against a real (in-memory) Room DB — the
  * classic silent-data-loss shape where re-recording a route must not clobber columns another path set.
  */
+@SmokeTest // API-23 floor smoke subset (#1818): exercises Room runtime CRUD/@Transaction on the floor
 @RunWith(AndroidJUnit4::class)
 class RouteDaoTest {
 

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/extrapolation/test/TripStateCacheTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/extrapolation/test/TripStateCacheTest.kt
@@ -45,7 +45,6 @@ import org.onebusaway.android.models.Status
 import org.onebusaway.android.util.Polyline
 
 /** Instrumented tests for the trip-state cache: recording, retention/eviction, and hydration. */
-@SmokeTest // API-23 floor smoke subset (#1818): exercises java.time/kotlin.time desugaring + core math
 @RunWith(AndroidJUnit4::class)
 class TripStateCacheTest {
 
@@ -264,6 +263,10 @@ class TripStateCacheTest {
 
     // --- GammaExtrapolator tests ---
 
+    // API-23 floor smoke subset (#1818): one deterministic method stands in for this large, mixed
+    // class — it exercises the kotlin.time Duration math and the extrapolation core on the floor
+    // runtime. The cache-eviction, polyline, and end-to-end tests stay out to keep the subset small.
+    @SmokeTest
     @Test
     fun testGammaExtrapolator_returnsDistanceDistribution() {
         val serviceDate = 1L

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/extrapolation/test/TripStateCacheTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/extrapolation/test/TripStateCacheTest.kt
@@ -34,6 +34,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.onebusaway.android.SmokeTest
 import org.onebusaway.android.extrapolation.ExtrapolationResult
 import org.onebusaway.android.extrapolation.data.TripObservation
 import org.onebusaway.android.extrapolation.data.TripStateCache
@@ -44,6 +45,7 @@ import org.onebusaway.android.models.Status
 import org.onebusaway.android.util.Polyline
 
 /** Instrumented tests for the trip-state cache: recording, retention/eviction, and hydration. */
+@SmokeTest // API-23 floor smoke subset (#1818): exercises java.time/kotlin.time desugaring + core math
 @RunWith(AndroidJUnit4::class)
 class TripStateCacheTest {
 

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/HomeActivitySmokeTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/HomeActivitySmokeTest.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui
+
+import androidx.lifecycle.Lifecycle
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.onebusaway.android.SmokeTest
+
+/**
+ * The core "**does the app boot?**" check for the API-23 floor smoke leg (#1818). `minSdk` is 23 but no
+ * CI job otherwise *launches* the app below API 33, so a crash-on-boot at the floor — a desugaring gap,
+ * an unguarded API-26+ platform call (e.g. a `NotificationChannel`), a Compose-on-old-runtime failure —
+ * would ship unseen. Booting the real [HomeActivity] with its production Hilt graph exercises exactly
+ * that surface; this test is where the nightly leg's canary (a deliberate API-26 break) is caught.
+ *
+ * [ActivityScenarioRule] drives the activity through its lifecycle in `@Before` and tears it down after;
+ * a crash anywhere in `onCreate`/`onResume` (or the initial composition of the setContent tree) fails
+ * the launch before the body ever runs, which is the signal we want. The body then confirms the process
+ * actually settled at [Lifecycle.State.RESUMED] rather than immediately finishing or bouncing.
+ *
+ * Deliberately assertion-light: this is a smoke test of startup, not a functional test of the home
+ * screen. It doesn't touch the network, location, or the region picker — reaching RESUMED is the bar.
+ */
+@SmokeTest
+@RunWith(AndroidJUnit4::class)
+class HomeActivitySmokeTest {
+
+    @get:Rule
+    val scenarioRule = ActivityScenarioRule(HomeActivity::class.java)
+
+    @Test
+    fun homeActivity_launchesAndReachesResumed() {
+        assertEquals(Lifecycle.State.RESUMED, scenarioRule.scenario.state)
+        scenarioRule.scenario.onActivity { activity ->
+            assertFalse("HomeActivity finished during launch", activity.isFinishing)
+        }
+    }
+}

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/compose/components/SlideBoxTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/compose/components/SlideBoxTest.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.unit.dp
 import org.junit.Rule
 import org.junit.Test
+import org.onebusaway.android.SmokeTest
 
 /**
  * On-device tests for the SlideBox's single-owner anchor-chasing glide. This is the regression test
@@ -33,6 +34,7 @@ import org.junit.Test
  * ScrollState), a moving anchor could livelock in mutual animateScrollTo cancellation and the scroll
  * never converged, so the settle assertions below would time out.
  */
+@SmokeTest // API-23 floor smoke subset (#1818): exercises Compose rendering on a 2015-era runtime
 class SlideBoxTest {
 
     // See EtaStripJustifyTest for why the deprecated rule (Unconfined composition) is kept — under

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/util/test/PolylineDecoderTest.java
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/util/test/PolylineDecoderTest.java
@@ -17,6 +17,7 @@ package org.onebusaway.android.util.test;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.onebusaway.android.SmokeTest;
 import org.onebusaway.android.util.PolylineDecoder;
 
 import android.location.Location;
@@ -31,6 +32,8 @@ import static junit.framework.Assert.assertNotNull;
 /**
  * Tests decoding the Google "encoded polyline" points and levels via {@link PolylineDecoder}.
  */
+// API-23 floor smoke subset (#1818): exercises a basic util/resource path on the floor.
+@SmokeTest
 @RunWith(AndroidJUnit4.class)
 public class PolylineDecoderTest {
 


### PR DESCRIPTION
## What

`minSdk` is 23, but no CI job ever *launches* the app below API 33, so runtime-only floor risks — core-library desugaring, pre-26 platform shims (notification channels, JobScheduler/WorkManager), Compose on a 2015-era runtime, and startup itself — go unbooted. Today a crash-on-boot at API 23 would ship. Fixes #1818.

## Changes

- **`@SmokeTest` annotation** (`androidTest/.../SmokeTest.kt`) — RUNTIME-retained marker; the emulator leg selects tagged tests via the runner's `annotation` argument, keeping the PR critical path unchanged.
- **`HomeActivitySmokeTest`** — boots the real `HomeActivity` (production Hilt graph) via `ActivityScenarioRule` and asserts it reaches `RESUMED`. This is the "does the app boot on the floor?" check and the surface an API-26 canary (e.g. an unguarded `NotificationChannel`) would crash.
- **Tagged a small, stable subset** spanning the floor risks: `AppDatabaseMigrationTest` (Room + java.time desugaring), `RouteDaoTest` (Room runtime CRUD), `SlideBoxTest` (Compose on old runtime), `TripStateCacheTest` (time desugaring/math), `PolylineDecoderTest` (util path). Deliberately skips the `#1792`-broken `EtaStripJustifyTest`.
- **`smoke-api23` job in `android-nightly.yml`** — boots an API 23 `google_apis` emulator (x86; no x86_64 at 23), installs `obaGoogleDebug`, runs the `@SmokeTest`-filtered subset. Reuses `android.yml`'s KVM + AVD-cache pattern. Renamed the workflow/concurrency group to `nightly` and documented both legs.
- **CLAUDE.md** — documents the floor leg and the rule for tagging `@SmokeTest`.

## Testing / verification

- Compiles clean under `-PwarningsAsErrors=true` (`compileObaGoogleDebugAndroidTest{Kotlin,Java}`).
- The `smoke-api23` leg runs on `schedule`/`workflow_dispatch` only (not `pull_request`), so it's being exercised via a manual dispatch on this branch — see the run linked in a comment below.
- **Canary (acceptance criteria):** a deliberate API-26-only runtime break (e.g. an unguarded `NotificationChannel` on boot) should fail this leg. This can be demonstrated by dispatching the workflow on a branch carrying that injected break.

## Notes

- If the API 23 hosted image proves flaky, the job comment documents the fallback: bump to 24/25 (still pre-26, still exercises the desugaring + notification-shim floor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated nightly smoke-test run on an Android API 23 emulator (to exercise boot and core flows at the minimum supported level).
  * Introduced a smoke-test marker to select which instrumentation tests are included in this API 23 subset.
  * Added/updated smoke coverage for app startup, database migrations, route/DAO behavior, trip state/extrapolation, UI components, and polyline decoding.
* **Documentation**
  * Expanded testing guidance to cover the standard CI path and the new nightly API 23 floor smoke suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->