### PR TITLE
Adjacency focus phase 1 (data): focused route-id set + multi-route shape fetch

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/app/di/RepositoryModule.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/app/di/RepositoryModule.kt
@@ -41,6 +41,8 @@ import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import javax.inject.Singleton
+import org.onebusaway.android.map.AdjacencyRouteShapeRepository
+import org.onebusaway.android.map.DefaultAdjacencyRouteShapeRepository
 import org.onebusaway.android.map.DefaultRouteMapRepository
 import org.onebusaway.android.map.RouteMapRepository
 import org.onebusaway.android.map.bike.BikeStationsRepository
@@ -236,4 +238,12 @@ abstract class RepositoryModule {
     abstract fun bindTripObservationFetcher(
         impl: DefaultTripObservationFetcher
     ): TripObservationFetcher
+
+    // Adjacency focus (#1827): @Singleton because it owns the SingleFlight de-dup state that coalesces
+    // concurrent/re-tap route-shape fetches (the trip-observation fetcher precedent above).
+    @Binds
+    @Singleton
+    abstract fun bindAdjacencyRouteShapeRepository(
+        impl: DefaultAdjacencyRouteShapeRepository
+    ): AdjacencyRouteShapeRepository
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/data/BoundedLruCache.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/data/BoundedLruCache.kt
@@ -43,6 +43,10 @@ internal class BoundedLruCache<K : Any, V : Any>(private val maxSize: Int) {
         entries[key] = value
     }
 
+    /** Removes [key], returning its previous value when present. */
+    @Synchronized
+    fun remove(key: K): V? = entries.remove(key)
+
     /**
      * Atomically applies [transform] to the current value for [key] (or a fresh [default] if
      * absent), stores the result, and returns it — the compute-and-put that [get]+[put] can't

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/AdjacencyRouteShapeRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/AdjacencyRouteShapeRepository.kt
@@ -1,0 +1,150 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.map
+
+import android.location.Location
+import android.util.Log
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
+import kotlinx.coroutines.withContext
+import org.onebusaway.android.api.data.MapDataSource
+import org.onebusaway.android.map.render.GeoPoint
+import org.onebusaway.android.models.ObaRoute
+import org.onebusaway.android.models.RouteMapData
+import org.onebusaway.android.util.SingleFlight
+
+/**
+ * One focused route's whole-route shape for adjacency focus (#1827): the merged (undirected)
+ * [polylines] to draw, the [route] for the badge's color/name, and the ids of the [stopIds] it serves
+ * (so non-adjacent stops can be minimized). Slimmer than [RouteMap] because several are held at once
+ * and adjacency draws only the whole route (no per-direction shapes or direction picker).
+ */
+data class AdjacencyRouteShape(
+    val routeId: String,
+    val route: ObaRoute?,
+    val polylines: List<List<GeoPoint>>,
+    val stopIds: Set<String>,
+)
+
+/**
+ * The result of a multi-route shape fetch: the [shapes] that resolved (keyed by route id, in the
+ * requested set's iteration order) and the [failedRouteIds] that didn't (network error, non-OK code,
+ * or no API endpoint). The two partition the requested set — a caller draws what resolved and ignores
+ * the rest.
+ */
+data class AdjacencyShapes(
+    val shapes: Map<String, AdjacencyRouteShape>,
+    val failedRouteIds: Set<String>,
+)
+
+/**
+ * Fetches the whole-route shapes for a *set* of routes at once — the routes with an upcoming arrival at
+ * a tapped stop, drawn together as adjacency focus (#1827). Tolerates partial failure: a route that
+ * fails to load lands in [AdjacencyShapes.failedRouteIds] rather than failing the whole call.
+ */
+interface AdjacencyRouteShapeRepository {
+
+    /** Fetches [routeIds]'s shapes concurrently (bounded) and de-duped; never throws for a failed route. */
+    suspend fun getShapes(routeIds: Set<String>): AdjacencyShapes
+}
+
+private const val MAX_CONCURRENT_ROUTE_FETCHES = 2
+private const val TAG = "AdjacencyRouteShapes"
+
+/**
+ * Fans out over [MapDataSource.routeMap], one request per route, with two safeguards against a
+ * fetch storm at a busy hub (a stop with many upcoming routes = many `stops-for-route` calls):
+ *
+ * - **Bounded concurrency** via a [Semaphore] of [MAX_CONCURRENT_ROUTE_FETCHES] permits, so at most N
+ *   requests are in flight and the rest queue. This deliberately uses a semaphore rather than
+ *   [Dispatchers.IO]`.limitedParallelism` (the [org.onebusaway.android.extrapolation.data.TripObservationFetcher]
+ *   precedent): the data source's Retrofit calls are main-safe `suspend` calls that hold no dispatcher
+ *   thread while awaiting the response, so a limited dispatcher wouldn't actually bound in-flight
+ *   requests — a semaphore held across the `suspend` call does, and it's exercisable under virtual time.
+ * - **In-flight de-dup** via [SingleFlight], so a route already being fetched (e.g. an immediate re-tap,
+ *   or two routes sharing the set) is joined, not re-requested. The permit is acquired *inside* the
+ *   coalesced block so joined callers consume none.
+ *
+ * The coalesced fetch runs on the process-lifetime [fetchScope], so a caller that cancels mid-fetch
+ * (tapping away) abandons its join immediately while the in-flight work completes for the next caller
+ * to re-join — the desired de-dup across re-taps. No persistent shape cache yet (#1827 follow-up), so
+ * a later tap re-fetches once the prior fetch has completed and cleared.
+ *
+ * `@Singleton` because it owns the [SingleFlight] de-dup state (the [org.onebusaway.android.extrapolation.data.DefaultTripObservationFetcher]
+ * precedent).
+ */
+@Singleton
+class DefaultAdjacencyRouteShapeRepository internal constructor(
+    private val mapDataSource: MapDataSource,
+    fetchScope: CoroutineScope,
+    private val log: (String) -> Unit,
+) : AdjacencyRouteShapeRepository {
+
+    @Inject
+    constructor(mapDataSource: MapDataSource) : this(
+        mapDataSource = mapDataSource,
+        fetchScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate),
+        log = { Log.w(TAG, it) },
+    )
+
+    private val permits = Semaphore(MAX_CONCURRENT_ROUTE_FETCHES)
+    private val shapeFetches = SingleFlight<String, AdjacencyRouteShape>(fetchScope)
+
+    override suspend fun getShapes(routeIds: Set<String>): AdjacencyShapes = coroutineScope {
+        val results = routeIds
+            .map { id -> async { id to fetchShape(id) } }
+            .awaitAll()
+        val shapes = LinkedHashMap<String, AdjacencyRouteShape>()
+        val failed = LinkedHashSet<String>()
+        for ((id, shape) in results) {
+            if (shape != null) shapes[id] = shape else failed += id
+        }
+        AdjacencyShapes(shapes, failed)
+    }
+
+    /** Joins or starts the single-flight fetch for [routeId]; null on any failure (no throw). */
+    private suspend fun fetchShape(routeId: String): AdjacencyRouteShape? =
+        shapeFetches.run(routeId) {
+            // The permit bounds in-flight network requests only; hold it just for the fetch. routeMap
+            // returns Result; a failure/absent endpoint resolves to null (drawn as a failed id) and
+            // never throws, so SingleFlight's own error path (its Log.e) never runs.
+            val data = permits.withPermit {
+                mapDataSource.routeMap(routeId)
+                    .onFailure { log("route shape fetch failed for $routeId: $it") }
+                    .getOrNull()
+            }
+            // Walking the shape into GeoPoints is CPU-bound; keep it off the main thread (as
+            // MapDataSource already does for the decode) so a busy hub's focus doesn't jank.
+            data?.let { withContext(Dispatchers.Default) { it.toAdjacencyShape(routeId) } }
+        }
+}
+
+/** Maps a wire [RouteMapData] to the slim adjacency shape, converting shape points to [GeoPoint]. */
+internal fun RouteMapData.toAdjacencyShape(routeId: String): AdjacencyRouteShape =
+    AdjacencyRouteShape(
+        routeId = routeId,
+        route = route,
+        polylines = polylines.map { line -> line.map(Location::toGeoPoint) },
+        stopIds = stops.mapTo(LinkedHashSet()) { it.stop.id },
+    )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/AdjacencyRouteShapeRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/AdjacencyRouteShapeRepository.kt
@@ -28,10 +28,14 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withContext
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
 import org.onebusaway.android.api.data.MapDataSource
+import org.onebusaway.android.extrapolation.data.BoundedLruCache
 import org.onebusaway.android.map.render.GeoPoint
 import org.onebusaway.android.models.ObaRoute
 import org.onebusaway.android.models.RouteMapData
+import org.onebusaway.android.time.ElapsedTime
 import org.onebusaway.android.util.SingleFlight
 
 /**
@@ -65,15 +69,48 @@ data class AdjacencyShapes(
  */
 interface AdjacencyRouteShapeRepository {
 
-    /** Fetches [routeIds]'s shapes concurrently (bounded) and de-duped; never throws for a failed route. */
+    /** Fetches [routeIds]'s shapes concurrently (bounded), cached, and de-duped; never throws per-route. */
     suspend fun getShapes(routeIds: Set<String>): AdjacencyShapes
 }
 
 private const val MAX_CONCURRENT_ROUTE_FETCHES = 2
+private const val MAX_CACHED_ROUTE_SHAPES = 32
+private val ROUTE_SHAPE_CACHE_TTL = 10.minutes
 private const val TAG = "AdjacencyRouteShapes"
 
+/** One successfully mapped route shape and the monotonic time it entered the completed cache. */
+private data class CachedRouteShape(
+    val shape: AdjacencyRouteShape,
+    val storedAt: ElapsedTime,
+)
+
+/** Thread-safe, success-only LRU with an age limit so route-map changes eventually refresh. */
+private class RouteShapeCache(
+    maxSize: Int,
+    private val ttl: Duration,
+    private val now: () -> ElapsedTime,
+) {
+    private val shapes = BoundedLruCache<String, CachedRouteShape>(maxSize)
+
+    @Synchronized
+    fun get(routeId: String): AdjacencyRouteShape? {
+        val cached = shapes.get(routeId) ?: return null
+        return if (now() - cached.storedAt < ttl) {
+            cached.shape
+        } else {
+            shapes.remove(routeId)
+            null
+        }
+    }
+
+    @Synchronized
+    fun put(routeId: String, shape: AdjacencyRouteShape) {
+        shapes.put(routeId, CachedRouteShape(shape, now()))
+    }
+}
+
 /**
- * Fans out over [MapDataSource.routeMap], one request per route, with two safeguards against a
+ * Fans out over [MapDataSource.routeMap], one request per route, with three safeguards against a
  * fetch storm at a busy hub (a stop with many upcoming routes = many `stops-for-route` calls):
  *
  * - **Bounded concurrency** via a [Semaphore] of [MAX_CONCURRENT_ROUTE_FETCHES] permits, so at most N
@@ -85,20 +122,27 @@ private const val TAG = "AdjacencyRouteShapes"
  * - **In-flight de-dup** via [SingleFlight], so a route already being fetched (e.g. an immediate re-tap,
  *   or two routes sharing the set) is joined, not re-requested. The permit is acquired *inside* the
  *   coalesced block so joined callers consume none.
+ * - **Completed-result cache**: successful shapes live in a 32-entry access-ordered LRU for ten
+ *   minutes. This suppresses sequential re-fetches while users focus nearby stops that share routes,
+ *   bounds the potentially large polyline working set, and eventually refreshes server changes.
+ *   Failures are never cached, so a later focus can retry them.
  *
  * The coalesced fetch runs on the process-lifetime [fetchScope], so a caller that cancels mid-fetch
  * (tapping away) abandons its join immediately while the in-flight work completes for the next caller
- * to re-join — the desired de-dup across re-taps. No persistent shape cache yet (#1827 follow-up), so
- * a later tap re-fetches once the prior fetch has completed and cleared.
+ * to re-join — the desired de-dup across re-taps. A successful completion is then available to later
+ * callers through the repository-owned cache.
  *
- * `@Singleton` because it owns the [SingleFlight] de-dup state (the [org.onebusaway.android.extrapolation.data.DefaultTripObservationFetcher]
- * precedent).
+ * `@Singleton` because it owns both the [SingleFlight] de-dup state and the completed-result cache (the
+ * [org.onebusaway.android.extrapolation.data.DefaultTripObservationFetcher] precedent).
  */
 @Singleton
 class DefaultAdjacencyRouteShapeRepository internal constructor(
     private val mapDataSource: MapDataSource,
     fetchScope: CoroutineScope,
     private val log: (String) -> Unit,
+    cacheSize: Int = MAX_CACHED_ROUTE_SHAPES,
+    cacheTtl: Duration = ROUTE_SHAPE_CACHE_TTL,
+    now: () -> ElapsedTime = ElapsedTime::now,
 ) : AdjacencyRouteShapeRepository {
 
     @Inject
@@ -110,6 +154,7 @@ class DefaultAdjacencyRouteShapeRepository internal constructor(
 
     private val permits = Semaphore(MAX_CONCURRENT_ROUTE_FETCHES)
     private val shapeFetches = SingleFlight<String, AdjacencyRouteShape>(fetchScope)
+    private val shapeCache = RouteShapeCache(cacheSize, cacheTtl, now)
 
     override suspend fun getShapes(routeIds: Set<String>): AdjacencyShapes = coroutineScope {
         val results = routeIds
@@ -123,21 +168,30 @@ class DefaultAdjacencyRouteShapeRepository internal constructor(
         AdjacencyShapes(shapes, failed)
     }
 
-    /** Joins or starts the single-flight fetch for [routeId]; null on any failure (no throw). */
+    /** Returns a fresh cache hit, or joins/starts a single-flight fetch; null on failure (no throw). */
     private suspend fun fetchShape(routeId: String): AdjacencyRouteShape? =
-        shapeFetches.run(routeId) {
-            // The permit bounds in-flight network requests only; hold it just for the fetch. routeMap
-            // returns Result; a failure/absent endpoint resolves to null (drawn as a failed id) and
-            // never throws, so SingleFlight's own error path (its Log.e) never runs.
-            val data = permits.withPermit {
-                mapDataSource.routeMap(routeId)
-                    .onFailure { log("route shape fetch failed for $routeId: $it") }
-                    .getOrNull()
-            }
-            // Walking the shape into GeoPoints is CPU-bound; keep it off the main thread (as
-            // MapDataSource already does for the decode) so a busy hub's focus doesn't jank.
-            data?.let { withContext(Dispatchers.Default) { it.toAdjacencyShape(routeId) } }
+        shapeCache.get(routeId) ?: shapeFetches.run(routeId) {
+            // Re-check inside SingleFlight: a racing request may have populated the cache after this
+            // caller's first lookup but before its coalesced block started.
+            shapeCache.get(routeId) ?: fetchAndCacheShape(routeId)
         }
+
+    /** Fetches and maps one route, caching only a successful completed shape. */
+    private suspend fun fetchAndCacheShape(routeId: String): AdjacencyRouteShape? {
+        // The permit bounds in-flight network requests only; hold it just for the fetch. routeMap
+        // returns Result; a failure/absent endpoint resolves to null (drawn as a failed id) and
+        // never throws, so SingleFlight's own error path (its Log.e) never runs.
+        val data = permits.withPermit {
+            mapDataSource.routeMap(routeId)
+                .onFailure { log("route shape fetch failed for $routeId: $it") }
+                .getOrNull()
+        }
+        // Walking the shape into GeoPoints is CPU-bound; keep it off the main thread (as
+        // MapDataSource already does for the decode) so a busy hub's focus doesn't jank.
+        return data
+            ?.let { withContext(Dispatchers.Default) { it.toAdjacencyShape(routeId) } }
+            ?.also { shapeCache.put(routeId, it) }
+    }
 }
 
 /** Maps a wire [RouteMapData] to the slim adjacency shape, converting shape points to [GeoPoint]. */

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.kt
@@ -296,7 +296,7 @@ class HomeActivity : AppCompatActivity() {
      */
     private fun onArrivalsLoaded(loaded: ArrivalsLoaded) {
         val stop = loaded.stop ?: return
-        viewModel.onArrivalsLoaded(stop, loaded.routes)
+        viewModel.onArrivalsLoaded(stop, loaded.routes, loaded.routeIds)
     }
 
     private fun goToSendFeedBack() {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsRepository.kt
@@ -22,6 +22,7 @@ import android.content.Context
 import android.os.SystemClock
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.io.IOException
+import java.util.concurrent.atomic.AtomicReference
 import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
@@ -246,9 +247,12 @@ class DefaultArrivalsRepository @Inject constructor(
      * - [loaded] — the map-relevant snapshot prebuilt from the *computed* [ArrivalsData] so its
      *   [ArrivalsLoaded.routeIds] matches the drawer's rows (see [ArrivalsLoaded]).
      *
-     * Published through the single `@Volatile` [lastGood] with one write per load, so a concurrent
-     * getArrivals (e.g. a user refresh overlapping the poll loop) can't publish a new snapshot while
-     * [lastLoaded] still reflects the old one, or mix a new snapshot with an old receipt time.
+     * Published through the single [AtomicReference] [lastGood] with one write per load, so a
+     * concurrent getArrivals (e.g. a user refresh overlapping the poll loop) can't publish a new
+     * snapshot while [lastLoaded] still reflects the old one, or mix a new snapshot with an old
+     * receipt time. A fresh load publishes unconditionally (new data always wins); the stale-fallback
+     * path publishes with `compareAndSet` against the holder it read, so it can never roll a
+     * concurrently-published fresh snapshot back to the old one.
      */
     private data class LastGood(
         val snapshot: StopArrivals,
@@ -256,8 +260,7 @@ class DefaultArrivalsRepository @Inject constructor(
         val loaded: ArrivalsLoaded,
     )
 
-    @Volatile
-    private var lastGood: LastGood? = null
+    private val lastGood = AtomicReference<LastGood?>(null)
 
     // Whether the viewed stop has been recorded in the Stops table this session. Recording (a) creates
     // the row so the favorite toggle's UPDATE actually persists, and (b) marks it used so it appears in
@@ -289,12 +292,12 @@ class DefaultArrivalsRepository @Inject constructor(
                     snapshot.stop?.let { recordStop(it, System.currentTimeMillis()); stopRecorded = true }
                 }
                 val data = toData(snapshot, isStale = false, now = snapshot.currentTime)
-                lastGood = LastGood(snapshot, receivedMs, loadedSnapshot(snapshot, data))
+                lastGood.set(LastGood(snapshot, receivedMs, loadedSnapshot(snapshot, data)))
                 Result.success(data)
             },
             // Refresh failed but we have prior data — keep showing it (legacy stale fallback).
             onFailure = { error ->
-                lastGood?.let { stale ->
+                lastGood.get()?.let { stale ->
                     // No fresh server time; project the last good server clock forward by the elapsed
                     // device time so stale ETAs/countdowns keep advancing (legacy behavior) without
                     // reintroducing device clock skew (#1612).
@@ -303,8 +306,9 @@ class DefaultArrivalsRepository @Inject constructor(
                         (SystemClock.elapsedRealtime() - stale.elapsedMs)
                     val data = toData(stale.snapshot, isStale = true, now = now)
                     // Keep the same snapshot/receipt time; refresh only the derived map snapshot so its
-                    // stale ETAs advance. Still one volatile write, so readers stay consistent.
-                    lastGood = stale.copy(loaded = loadedSnapshot(stale.snapshot, data))
+                    // stale ETAs advance. CAS so this can't roll back a fresh snapshot a concurrent
+                    // successful load published while toData ran — if it did, its holder simply stands.
+                    lastGood.compareAndSet(stale, stale.copy(loaded = loadedSnapshot(stale.snapshot, data)))
                     Result.success(data)
                 }
                     ?: Result.failure(
@@ -464,11 +468,11 @@ class DefaultArrivalsRepository @Inject constructor(
     }
 
     override fun alertDetails(id: String): AlertDetails? =
-        lastGood?.snapshot?.situation(id)?.let {
+        lastGood.get()?.snapshot?.situation(id)?.let {
             AlertDetails(it.id, it.summary, it.description, it.url)
         }
 
-    override fun lastLoaded(): ArrivalsLoaded? = lastGood?.loaded
+    override fun lastLoaded(): ArrivalsLoaded? = lastGood.get()?.loaded
 
     /** Pairs the response's stop/routes/hasArrivals with the drawer-1:1 route set derived from the
      *  *computed* [data] (see [ArrivalsLoaded.routeIds]). */

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsRepository.kt
@@ -201,6 +201,10 @@ data class ArrivalsLoaded(
     val stop: ObaStop?,
     val routes: List<ObaRoute>?,
     val hasArrivals: Boolean,
+    /** The routes with an upcoming arrival — the drawer's rows, 1:1 (adjacency focus, #1827). Derived
+     *  from the computed [ArrivalsData.routeGroups] (which reflects the past-arrivals filter), not the
+     *  raw response, so it matches what the drawer shows. */
+    val routeIds: Set<String>,
 )
 
 /** The fields the service-alert dialog shows, decoupled from `ObaSituation`. */
@@ -243,6 +247,13 @@ class DefaultArrivalsRepository @Inject constructor(
     @Volatile
     private var lastGood: LastGood? = null
 
+    /** The map-relevant snapshot of the last good load, prebuilt from the *computed* [ArrivalsData] so
+     *  its [ArrivalsLoaded.routeIds] matches the drawer's rows (see [ArrivalsLoaded]). Held in one
+     *  `@Volatile` reference so [lastLoaded] reads stop/routes/routeIds as a consistent set — same
+     *  discipline as [lastGood]. */
+    @Volatile
+    private var lastLoadedSnapshot: ArrivalsLoaded? = null
+
     // Whether the viewed stop has been recorded in the Stops table this session. Recording (a) creates
     // the row so the favorite toggle's UPDATE actually persists, and (b) marks it used so it appears in
     // Recent stops. markAsUsed bumps USE_COUNT, so this is done once — not on every 60s poll/refresh.
@@ -270,7 +281,9 @@ class DefaultArrivalsRepository @Inject constructor(
                 if (!stopRecorded) {
                     snapshot.stop?.let { recordStop(it, System.currentTimeMillis()); stopRecorded = true }
                 }
-                Result.success(toData(snapshot, isStale = false, now = snapshot.currentTime))
+                val data = toData(snapshot, isStale = false, now = snapshot.currentTime)
+                lastLoadedSnapshot = loadedSnapshot(snapshot, data)
+                Result.success(data)
             },
             // Refresh failed but we have prior data — keep showing it (legacy stale fallback).
             onFailure = { error ->
@@ -281,7 +294,9 @@ class DefaultArrivalsRepository @Inject constructor(
                     @Suppress("RawClockArithmetic") // both operands are ElapsedTime (monotonic); sanctioned skew-free crossing
                     val now = stale.snapshot.currentTime +
                         (SystemClock.elapsedRealtime() - stale.elapsedMs)
-                    Result.success(toData(stale.snapshot, isStale = true, now = now))
+                    val data = toData(stale.snapshot, isStale = true, now = now)
+                    lastLoadedSnapshot = loadedSnapshot(stale.snapshot, data)
+                    Result.success(data)
                 }
                     ?: Result.failure(
                         IOException(
@@ -444,10 +459,17 @@ class DefaultArrivalsRepository @Inject constructor(
             AlertDetails(it.id, it.summary, it.description, it.url)
         }
 
-    override fun lastLoaded(): ArrivalsLoaded? {
-        val snapshot = lastGood?.snapshot ?: return null
-        return ArrivalsLoaded(snapshot.stop, snapshot.routes, snapshot.hasArrivals)
-    }
+    override fun lastLoaded(): ArrivalsLoaded? = lastLoadedSnapshot
+
+    /** Pairs the response's stop/routes/hasArrivals with the drawer-1:1 route set derived from the
+     *  *computed* [data] (see [ArrivalsLoaded.routeIds]). */
+    private fun loadedSnapshot(snapshot: StopArrivals, data: ArrivalsData): ArrivalsLoaded =
+        ArrivalsLoaded(
+            stop = snapshot.stop,
+            routes = snapshot.routes,
+            hasArrivals = snapshot.hasArrivals,
+            routeIds = focusedRouteIds(data.routeGroups),
+        )
 
     companion object {
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsRepository.kt
@@ -237,22 +237,27 @@ class DefaultArrivalsRepository @Inject constructor(
     private val preferences: PreferencesRepository,
 ) : ArrivalsRepository {
 
-    /** The last good snapshot paired with the monotonic device time it was received, so the
-     *  stale-fallback path can project that server clock forward by elapsed device time (#1612). The
-     *  two must be read as a consistent pair; held in one `@Volatile` reference so a concurrent
-     *  getArrivals (e.g. a user refresh overlapping the poll loop) can't mix a new snapshot with an
-     *  old receipt time. */
-    private data class LastGood(val snapshot: StopArrivals, val elapsedMs: Long)
+    /**
+     * Everything derived from the last good load, held as one unit so all three readers
+     * ([alertDetails], [lastLoaded], and the stale-fallback path) see a mutually consistent set:
+     * - [snapshot] — the raw response, for situation lookups and stale re-projection.
+     * - [elapsedMs] — the monotonic device time the snapshot was received, so the stale-fallback path
+     *   can project that server clock forward by elapsed device time (#1612).
+     * - [loaded] — the map-relevant snapshot prebuilt from the *computed* [ArrivalsData] so its
+     *   [ArrivalsLoaded.routeIds] matches the drawer's rows (see [ArrivalsLoaded]).
+     *
+     * Published through the single `@Volatile` [lastGood] with one write per load, so a concurrent
+     * getArrivals (e.g. a user refresh overlapping the poll loop) can't publish a new snapshot while
+     * [lastLoaded] still reflects the old one, or mix a new snapshot with an old receipt time.
+     */
+    private data class LastGood(
+        val snapshot: StopArrivals,
+        val elapsedMs: Long,
+        val loaded: ArrivalsLoaded,
+    )
 
     @Volatile
     private var lastGood: LastGood? = null
-
-    /** The map-relevant snapshot of the last good load, prebuilt from the *computed* [ArrivalsData] so
-     *  its [ArrivalsLoaded.routeIds] matches the drawer's rows (see [ArrivalsLoaded]). Held in one
-     *  `@Volatile` reference so [lastLoaded] reads stop/routes/routeIds as a consistent set — same
-     *  discipline as [lastGood]. */
-    @Volatile
-    private var lastLoadedSnapshot: ArrivalsLoaded? = null
 
     // Whether the viewed stop has been recorded in the Stops table this session. Recording (a) creates
     // the row so the favorite toggle's UPDATE actually persists, and (b) marks it used so it appears in
@@ -275,14 +280,16 @@ class DefaultArrivalsRepository @Inject constructor(
 
         result.fold(
             onSuccess = { snapshot ->
-                lastGood = LastGood(snapshot, SystemClock.elapsedRealtime())
+                // Stamp the receipt time as close to the response as possible (before the DB reads in
+                // toData), then publish the whole consistent set with one write once [data] is built.
+                val receivedMs = SystemClock.elapsedRealtime()
                 // Record the stop once per session so favoriting persists (setFavorite is an
                 // UPDATE — it needs the row to exist) and the stop shows in Recent stops.
                 if (!stopRecorded) {
                     snapshot.stop?.let { recordStop(it, System.currentTimeMillis()); stopRecorded = true }
                 }
                 val data = toData(snapshot, isStale = false, now = snapshot.currentTime)
-                lastLoadedSnapshot = loadedSnapshot(snapshot, data)
+                lastGood = LastGood(snapshot, receivedMs, loadedSnapshot(snapshot, data))
                 Result.success(data)
             },
             // Refresh failed but we have prior data — keep showing it (legacy stale fallback).
@@ -295,7 +302,9 @@ class DefaultArrivalsRepository @Inject constructor(
                     val now = stale.snapshot.currentTime +
                         (SystemClock.elapsedRealtime() - stale.elapsedMs)
                     val data = toData(stale.snapshot, isStale = true, now = now)
-                    lastLoadedSnapshot = loadedSnapshot(stale.snapshot, data)
+                    // Keep the same snapshot/receipt time; refresh only the derived map snapshot so its
+                    // stale ETAs advance. Still one volatile write, so readers stay consistent.
+                    lastGood = stale.copy(loaded = loadedSnapshot(stale.snapshot, data))
                     Result.success(data)
                 }
                     ?: Result.failure(
@@ -459,7 +468,7 @@ class DefaultArrivalsRepository @Inject constructor(
             AlertDetails(it.id, it.summary, it.description, it.url)
         }
 
-    override fun lastLoaded(): ArrivalsLoaded? = lastLoadedSnapshot
+    override fun lastLoaded(): ArrivalsLoaded? = lastGood?.loaded
 
     /** Pairs the response's stop/routes/hasArrivals with the drawer-1:1 route set derived from the
      *  *computed* [data] (see [ArrivalsLoaded.routeIds]). */

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsRepository.kt
@@ -19,7 +19,6 @@ import org.onebusaway.android.api.data.StopArrivalsDataSource
 import org.onebusaway.android.api.data.StopArrivals
 
 import android.content.Context
-import android.os.SystemClock
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.io.IOException
 import java.util.concurrent.atomic.AtomicReference
@@ -40,6 +39,7 @@ import org.onebusaway.android.database.oba.markStopUsed
 import org.onebusaway.android.models.ObaRoute
 import org.onebusaway.android.models.ObaSituation
 import org.onebusaway.android.models.ObaStop
+import org.onebusaway.android.time.ElapsedTime
 import org.onebusaway.android.time.ServerTime
 import org.onebusaway.android.models.contentKey
 import org.onebusaway.android.preferences.PreferencesRepository
@@ -242,7 +242,7 @@ class DefaultArrivalsRepository @Inject constructor(
      * Everything derived from the last good load, held as one unit so all three readers
      * ([alertDetails], [lastLoaded], and the stale-fallback path) see a mutually consistent set:
      * - [snapshot] — the raw response, for situation lookups and stale re-projection.
-     * - [elapsedMs] — the monotonic device time the snapshot was received, so the stale-fallback path
+     * - [receivedAt] — the monotonic device time the snapshot was received, so the stale-fallback path
      *   can project that server clock forward by elapsed device time (#1612).
      * - [loaded] — the map-relevant snapshot prebuilt from the *computed* [ArrivalsData] so its
      *   [ArrivalsLoaded.routeIds] matches the drawer's rows (see [ArrivalsLoaded]).
@@ -256,7 +256,7 @@ class DefaultArrivalsRepository @Inject constructor(
      */
     private data class LastGood(
         val snapshot: StopArrivals,
-        val elapsedMs: Long,
+        val receivedAt: ElapsedTime,
         val loaded: ArrivalsLoaded,
     )
 
@@ -285,14 +285,14 @@ class DefaultArrivalsRepository @Inject constructor(
             onSuccess = { snapshot ->
                 // Stamp the receipt time as close to the response as possible (before the DB reads in
                 // toData), then publish the whole consistent set with one write once [data] is built.
-                val receivedMs = SystemClock.elapsedRealtime()
+                val receivedAt = ElapsedTime.now()
                 // Record the stop once per session so favoriting persists (setFavorite is an
                 // UPDATE — it needs the row to exist) and the stop shows in Recent stops.
                 if (!stopRecorded) {
                     snapshot.stop?.let { recordStop(it, System.currentTimeMillis()); stopRecorded = true }
                 }
-                val data = toData(snapshot, isStale = false, now = snapshot.currentTime)
-                lastGood.set(LastGood(snapshot, receivedMs, loadedSnapshot(snapshot, data)))
+                val data = toData(snapshot, isStale = false, now = ServerTime(snapshot.currentTime))
+                lastGood.set(LastGood(snapshot, receivedAt, loadedSnapshot(snapshot, data)))
                 Result.success(data)
             },
             // Refresh failed but we have prior data — keep showing it (legacy stale fallback).
@@ -300,10 +300,10 @@ class DefaultArrivalsRepository @Inject constructor(
                 lastGood.get()?.let { stale ->
                     // No fresh server time; project the last good server clock forward by the elapsed
                     // device time so stale ETAs/countdowns keep advancing (legacy behavior) without
-                    // reintroducing device clock skew (#1612).
-                    @Suppress("RawClockArithmetic") // both operands are ElapsedTime (monotonic); sanctioned skew-free crossing
-                    val now = stale.snapshot.currentTime +
-                        (SystemClock.elapsedRealtime() - stale.elapsedMs)
+                    // reintroducing device clock skew (#1612) — a same-domain ElapsedTime subtraction,
+                    // so the typed API allows it directly.
+                    val now = ServerTime(stale.snapshot.currentTime) +
+                        (ElapsedTime.now() - stale.receivedAt)
                     val data = toData(stale.snapshot, isStale = true, now = now)
                     // Keep the same snapshot/receipt time; refresh only the derived map snapshot so its
                     // stale ETAs advance. CAS so this can't roll back a fresh snapshot a concurrent
@@ -328,7 +328,7 @@ class DefaultArrivalsRepository @Inject constructor(
         // Server clock as "now" so ETAs/countdowns and alert active-window checks cancel any device
         // clock skew — the fresh response's currentTime, or (on the stale path) the last good server
         // clock projected forward by elapsed device time (#1612).
-        now: Long
+        now: ServerTime
     ): ArrivalsData {
         // The unified route row shows lateness via the ETA pill's color, not a verbose status label,
         // so we don't fold the arrival/departure word in. Every production caller now passes false
@@ -338,7 +338,7 @@ class DefaultArrivalsRepository @Inject constructor(
         // Favorite state is a live overlay applied in the ViewModel (from the reactive starred-route
         // set), not baked here — so a star toggle re-flags the list without this re-fetch.
         val arrivals = convertArrivals(
-            context, snapshot.arrivals, ServerTime(now), includeArrivalDepartureLabel
+            context, snapshot.arrivals, now, includeArrivalDepartureLabel
         )
         val stop = snapshot.stop
         val userInfo = stopDao.userInfo(snapshot.stopId)
@@ -352,7 +352,9 @@ class DefaultArrivalsRepository @Inject constructor(
         // Pure grouping; no store write. Hidden state is derived in the ViewModel from [alertHideState]
         // plus [ArrivalsData.hideAlertsByDefault], so nothing on the load path can race the snapshot.
         val situations = snapshot.situations()
-        val isActive = { s: ObaSituation -> SituationUtils.isActiveWindowForSituation(s, now) }
+        // .epochMs unwrap: isActiveWindowForSituation is a legacy Long-taking helper (its "now" is
+        // documented as the server clock); the domain is re-asserted right here at the hand-off.
+        val isActive = { s: ObaSituation -> SituationUtils.isActiveWindowForSituation(s, now.epochMs) }
         val activeAlerts = planActiveAlerts(situations, isActive)
         // The situation ids that are active right now, so a per-arrival alert indicator lights up
         // only for currently-active alerts — matching the banner's active set (issue #1687 Bug 2).

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/RouteRowGroup.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/RouteRowGroup.kt
@@ -152,3 +152,16 @@ fun orderRouteGroupsByFavorite(
     groups: List<RouteRowGroup>,
     favoriteRouteIds: Set<String>
 ): List<RouteRowGroup> = orderGroupsByFavorite(groups, favoriteRouteIds) { it.routeId }
+
+/**
+ * The distinct route ids of [groups], in first-seen order. Generic (over any `T` + a route-id
+ * selector) so it's unit-testable with lightweight fakes, mirroring [orderGroupsByFavorite].
+ */
+fun <T> routeIdSet(groups: List<T>, routeIdOf: (T) -> String): Set<String> =
+    groups.mapTo(LinkedHashSet()) { routeIdOf(it) }
+
+/**
+ * The set of routes with an upcoming arrival at the stop — every route the drawer shows a row for
+ * (adjacency focus draws these 1:1, scheduled or tracked; issue #1827). First-seen (departure) order.
+ */
+fun focusedRouteIds(groups: List<RouteRowGroup>): Set<String> = routeIdSet(groups) { it.routeId }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
@@ -117,8 +117,18 @@ class HomeViewModel @Inject constructor(
     // host on each create from the restored focusedStop, so it needn't be persisted).
     private var pendingMapFocus: Boolean = false
 
+    // The routes with an upcoming arrival at the focused stop (the drawer's rows, 1:1) — the input to
+    // adjacency focus (#1827). Pure coordination state consumed imperatively by the map (phase 2), not
+    // composed off, so it's a plain property like [settledSheet]; not saved-state (arrivals reload and
+    // repopulate it after a restore).
+    var focusedRouteIds: Set<String> = emptySet()
+        private set
+
     /** A map stop gained focus (non-null) or focus was cleared (null). Persists across process death. */
     fun onStopFocused(stop: FocusedStop?) {
+        // Reset the adjacency route set on any focus change (switch or clear) so the previous stop's
+        // routes don't leak; a fresh arrivals load repopulates it (#1827).
+        focusedRouteIds = emptySet()
         savedState[KEY_STOP_ID] = stop?.id
         savedState[KEY_STOP_NAME] = stop?.name
         savedState[KEY_STOP_CODE] = stop?.code
@@ -222,12 +232,16 @@ class HomeViewModel @Inject constructor(
     }
 
     /**
-     * Arrivals loaded for the focused [stop]. If a restore/deep-link focus is pending, consume the latch
-     * and tell the map to focus it (recenter + add the marker) via [mapDirectives] — so the map reacts
-     * to a directive rather than the activity relaying one VM's decision into another's method. A fresh
-     * map tap already centered the stop and set no pending focus, so this is then a no-op.
+     * Arrivals loaded for the focused [stop]. Records the drawer's [routeIds] for adjacency focus
+     * (#1827) on every load. Then, if a restore/deep-link focus is pending, consume the latch and tell
+     * the map to focus it (recenter + add the marker) via [mapDirectives] — so the map reacts to a
+     * directive rather than the activity relaying one VM's decision into another's method. A fresh map
+     * tap already centered the stop and set no pending focus, so beyond recording the routes it's a no-op.
      */
-    fun onArrivalsLoaded(stop: ObaStop, routes: List<ObaRoute>?) {
+    fun onArrivalsLoaded(stop: ObaStop, routes: List<ObaRoute>?, routeIds: Set<String>) {
+        // Record the drawer's routes on every load (not just a pending restore focus) — adjacency focus
+        // reads this whenever the map wants it (#1827).
+        focusedRouteIds = routeIds
         if (!pendingMapFocus) {
             return
         }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/extrapolation/data/BoundedLruCacheTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/extrapolation/data/BoundedLruCacheTest.kt
@@ -72,6 +72,16 @@ class BoundedLruCacheTest {
     }
 
     @Test
+    fun `remove drops and returns the requested entry`() {
+        val cache = BoundedLruCache<String, Int>(2)
+        cache.put("a", 1)
+
+        assertEquals(1, cache.remove("a"))
+        assertNull(cache.get("a"))
+        assertNull(cache.remove("missing"))
+    }
+
+    @Test
     fun `compute seeds from default when absent and returns the new value`() {
         val cache = BoundedLruCache<String, Int>(2)
 

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/AdjacencyRouteShapeRepositoryTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/AdjacencyRouteShapeRepositoryTest.kt
@@ -1,0 +1,217 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.map
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.onebusaway.android.api.adapters.ObaStopElement
+import org.onebusaway.android.api.data.MapDataSource
+import org.onebusaway.android.models.NearbyStops
+import org.onebusaway.android.models.RouteMapData
+import org.onebusaway.android.models.RouteMapStop
+
+/**
+ * The multi-route shape fetch's bounded concurrency, single-flight de-dup, and partial-failure
+ * tolerance, driven against a fake [MapDataSource] under virtual time. Fixtures use empty polyline
+ * lists so no unmockable [android.location.Location] is constructed (JVM tests can't touch Android
+ * statics); point conversion is a trivial `GeoPoint(lat, lon)` map covered implicitly.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class AdjacencyRouteShapeRepositoryTest {
+
+    /**
+     * A [MapDataSource] whose `routeMap` counts per-id calls, tracks peak concurrency, and (when a
+     * gate is registered for the id) parks until that gate completes — so a test can hold N fetches
+     * in flight and observe the bound. [scriptFor] decides each id's [Result].
+     */
+    private class FakeMapDataSource(
+        private val scriptFor: (String) -> Result<RouteMapData?> = { Result.success(routeMapData(it)) },
+    ) : MapDataSource {
+
+        val callCounts = mutableMapOf<String, Int>()
+        val gates = mutableMapOf<String, CompletableDeferred<Unit>>()
+        private var active = 0
+        var maxActive = 0
+            private set
+
+        override suspend fun nearbyStops(
+            lat: Double, lon: Double, latSpan: Double, lonSpan: Double, maxCount: Int?,
+        ): Result<NearbyStops?> = throw UnsupportedOperationException("not used")
+
+        override suspend fun routeMap(routeId: String): Result<RouteMapData?> {
+            callCounts[routeId] = (callCounts[routeId] ?: 0) + 1
+            active++
+            maxActive = maxOf(maxActive, active)
+            try {
+                gates[routeId]?.await()
+                return scriptFor(routeId)
+            } finally {
+                active--
+            }
+        }
+    }
+
+    private fun repo(source: MapDataSource, scope: kotlinx.coroutines.CoroutineScope) =
+        DefaultAdjacencyRouteShapeRepository(source, scope, log = {})
+
+    // Bounded concurrency ------------------------------------------------------------------------
+
+    @Test
+    fun boundsConcurrentFetchesToTwoAndDrainsInWaves() = runTest {
+        val ids = (0 until 5).map { it.toString() }.toSet()
+        val fake = FakeMapDataSource()
+        ids.forEach { fake.gates[it] = CompletableDeferred() }
+        val repo = repo(fake, backgroundScope)
+
+        val fetch = async { repo.getShapes(ids) }
+
+        runCurrent()
+        // 5 requested, 2 permits -> at most 2 in flight at once.
+        assertEquals(2, fake.maxActive)
+
+        // Releasing two lets the next wave in; the bound holds throughout.
+        fake.gates["0"]!!.complete(Unit)
+        fake.gates["1"]!!.complete(Unit)
+        runCurrent()
+        assertEquals(2, fake.maxActive)
+
+        ids.forEach { fake.gates[it]!!.complete(Unit) }
+        val result = fetch.await()
+        assertEquals(5, result.shapes.size)
+        assertTrue(result.failedRouteIds.isEmpty())
+        assertTrue(fake.callCounts.values.all { it == 1 })
+    }
+
+    // Single-flight de-dup -----------------------------------------------------------------------
+
+    @Test
+    fun concurrentGetShapesForSameRouteShareOneFetch() = runTest {
+        val fake = FakeMapDataSource()
+        fake.gates["A"] = CompletableDeferred()
+        val repo = repo(fake, backgroundScope)
+
+        backgroundScope.launch { repo.getShapes(setOf("A")) }
+        backgroundScope.launch { repo.getShapes(setOf("A")) }
+        runCurrent()
+
+        fake.gates["A"]!!.complete(Unit)
+        advanceUntilIdle()
+        assertEquals(1, fake.callCounts["A"])
+    }
+
+    @Test
+    fun sequentialGetShapesRefetch_noCache() = runTest {
+        val fake = FakeMapDataSource()
+        val repo = repo(fake, backgroundScope)
+
+        repo.getShapes(setOf("A"))
+        repo.getShapes(setOf("A"))
+        assertEquals(2, fake.callCounts["A"])
+    }
+
+    // Partial failure ----------------------------------------------------------------------------
+
+    @Test
+    fun partialFailure_returnsSuccessesAndListsFailures() = runTest {
+        val fake = FakeMapDataSource { id ->
+            when (id) {
+                "ok" -> Result.success(routeMapData("ok"))
+                "boom" -> Result.failure(RuntimeException("network"))
+                else -> Result.success(null) // no API endpoint
+            }
+        }
+        val repo = repo(fake, backgroundScope)
+
+        val result = repo.getShapes(setOf("ok", "boom", "none"))
+
+        assertEquals(setOf("ok"), result.shapes.keys)
+        assertEquals(setOf("boom", "none"), result.failedRouteIds)
+    }
+
+    @Test
+    fun emptyInput_makesNoCalls() = runTest {
+        val fake = FakeMapDataSource()
+        val repo = repo(fake, backgroundScope)
+
+        val result = repo.getShapes(emptySet())
+
+        assertTrue(result.shapes.isEmpty())
+        assertTrue(result.failedRouteIds.isEmpty())
+        assertTrue(fake.callCounts.isEmpty())
+    }
+
+    // Cancellation -------------------------------------------------------------------------------
+
+    @Test
+    fun cancellingOneJoinerNeitherKillsTheSharedFetchNorLeaksThePermit() = runTest {
+        val fake = FakeMapDataSource()
+        fake.gates["A"] = CompletableDeferred()
+        val repo = repo(fake, backgroundScope)
+
+        val doomed = backgroundScope.launch { repo.getShapes(setOf("A")) }
+        val survivor = async { repo.getShapes(setOf("A")) }
+        runCurrent()
+
+        doomed.cancel() // one joiner gives up; the shared fetch runs on the repo's own scope
+        fake.gates["A"]!!.complete(Unit)
+
+        // The surviving joiner still gets the shape from the single shared fetch.
+        assertEquals(setOf("A"), survivor.await().shapes.keys)
+        assertEquals(1, fake.callCounts["A"])
+
+        // A later fetch still acquires a permit (none leaked) and re-runs (no cache).
+        repo.getShapes(setOf("A"))
+        assertEquals(2, fake.callCounts["A"])
+    }
+
+    // Mapping ------------------------------------------------------------------------------------
+
+    @Test
+    fun toAdjacencyShape_mapsRouteIdAndStopIds() {
+        val data = routeMapData("R", stopIds = listOf("s1", "s2"))
+        val shape = data.toAdjacencyShape("R")
+
+        assertEquals("R", shape.routeId)
+        assertNull(shape.route)
+        assertEquals(setOf("s1", "s2"), shape.stopIds)
+        assertTrue(shape.polylines.isEmpty())
+    }
+
+    companion object {
+        /** A minimal [RouteMapData] with empty shapes (no [android.location.Location] built). */
+        private fun routeMapData(
+            @Suppress("UNUSED_PARAMETER") routeId: String,
+            stopIds: List<String> = emptyList(),
+        ) = RouteMapData(
+            route = null,
+            agencyName = null,
+            stops = stopIds.map { RouteMapStop(ObaStopElement(id = it), emptySet()) },
+            routes = emptyList(),
+            directions = emptyList(),
+            polylines = emptyList(),
+            polylinesByDirection = emptyMap(),
+        )
+    }
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/AdjacencyRouteShapeRepositoryTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/AdjacencyRouteShapeRepositoryTest.kt
@@ -22,6 +22,8 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -31,12 +33,14 @@ import org.onebusaway.android.api.data.MapDataSource
 import org.onebusaway.android.models.NearbyStops
 import org.onebusaway.android.models.RouteMapData
 import org.onebusaway.android.models.RouteMapStop
+import org.onebusaway.android.time.ElapsedTime
 
 /**
- * The multi-route shape fetch's bounded concurrency, single-flight de-dup, and partial-failure
- * tolerance, driven against a fake [MapDataSource] under virtual time. Fixtures use empty polyline
- * lists so no unmockable [android.location.Location] is constructed (JVM tests can't touch Android
- * statics); point conversion is a trivial `GeoPoint(lat, lon)` map covered implicitly.
+ * The multi-route shape fetch's bounded concurrency, single-flight de-dup, completed-result cache,
+ * and partial-failure tolerance, driven against a fake [MapDataSource] under virtual time. Fixtures
+ * use empty polyline lists so no unmockable [android.location.Location] is constructed (JVM tests
+ * can't touch Android statics); point conversion is a trivial `GeoPoint(lat, lon)` map covered
+ * implicitly.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class AdjacencyRouteShapeRepositoryTest {
@@ -73,8 +77,20 @@ class AdjacencyRouteShapeRepositoryTest {
         }
     }
 
-    private fun repo(source: MapDataSource, scope: kotlinx.coroutines.CoroutineScope) =
-        DefaultAdjacencyRouteShapeRepository(source, scope, log = {})
+    private fun repo(
+        source: MapDataSource,
+        scope: kotlinx.coroutines.CoroutineScope,
+        cacheSize: Int = 32,
+        cacheTtl: Duration = 10.seconds,
+        now: () -> ElapsedTime = { ElapsedTime(0L) },
+    ) = DefaultAdjacencyRouteShapeRepository(
+        source,
+        scope,
+        log = {},
+        cacheSize = cacheSize,
+        cacheTtl = cacheTtl,
+        now = now,
+    )
 
     // Bounded concurrency ------------------------------------------------------------------------
 
@@ -104,7 +120,7 @@ class AdjacencyRouteShapeRepositoryTest {
         assertTrue(fake.callCounts.values.all { it == 1 })
     }
 
-    // Single-flight de-dup -----------------------------------------------------------------------
+    // Single-flight de-dup + completed cache -----------------------------------------------------
 
     @Test
     fun concurrentGetShapesForSameRouteShareOneFetch() = runTest {
@@ -122,12 +138,66 @@ class AdjacencyRouteShapeRepositoryTest {
     }
 
     @Test
-    fun sequentialGetShapesRefetch_noCache() = runTest {
+    fun sequentialGetShapesForSameRouteReuseCompletedSuccess() = runTest {
         val fake = FakeMapDataSource()
         val repo = repo(fake, backgroundScope)
 
         repo.getShapes(setOf("A"))
+        val second = repo.getShapes(setOf("A"))
+
+        assertEquals(setOf("A"), second.shapes.keys)
+        assertEquals(1, fake.callCounts["A"])
+    }
+
+    @Test
+    fun completedCacheEvictsLeastRecentlyUsedShapePastBound() = runTest {
+        val fake = FakeMapDataSource()
+        val repo = repo(fake, backgroundScope, cacheSize = 2)
+
         repo.getShapes(setOf("A"))
+        repo.getShapes(setOf("B"))
+        repo.getShapes(setOf("A")) // promote A, making B the eviction victim
+        repo.getShapes(setOf("C"))
+        repo.getShapes(setOf("B"))
+
+        assertEquals(1, fake.callCounts["A"])
+        assertEquals(2, fake.callCounts["B"])
+        assertEquals(1, fake.callCounts["C"])
+    }
+
+    @Test
+    fun completedCacheRefetchesAtExpiry() = runTest {
+        var nowMs = 0L
+        val fake = FakeMapDataSource()
+        val repo = repo(
+            fake,
+            backgroundScope,
+            cacheTtl = 10.seconds,
+            now = { ElapsedTime(nowMs) },
+        )
+
+        repo.getShapes(setOf("A"))
+        nowMs = 9_999L
+        repo.getShapes(setOf("A"))
+        assertEquals(1, fake.callCounts["A"])
+
+        nowMs = 10_000L
+        repo.getShapes(setOf("A"))
+        assertEquals(2, fake.callCounts["A"])
+    }
+
+    @Test
+    fun failedResultIsNotCachedAndLaterSuccessIsCached() = runTest {
+        var attempts = 0
+        val fake = FakeMapDataSource { id ->
+            if (attempts++ == 0) Result.failure(RuntimeException("network"))
+            else Result.success(routeMapData(id))
+        }
+        val repo = repo(fake, backgroundScope)
+
+        assertEquals(setOf("A"), repo.getShapes(setOf("A")).failedRouteIds)
+        assertEquals(setOf("A"), repo.getShapes(setOf("A")).shapes.keys)
+        assertEquals(setOf("A"), repo.getShapes(setOf("A")).shapes.keys)
         assertEquals(2, fake.callCounts["A"])
     }
 
@@ -181,9 +251,9 @@ class AdjacencyRouteShapeRepositoryTest {
         assertEquals(setOf("A"), survivor.await().shapes.keys)
         assertEquals(1, fake.callCounts["A"])
 
-        // A later fetch still acquires a permit (none leaked) and re-runs (no cache).
-        repo.getShapes(setOf("A"))
-        assertEquals(2, fake.callCounts["A"])
+        // A different later fetch still acquires a permit (none leaked).
+        repo.getShapes(setOf("B"))
+        assertEquals(1, fake.callCounts["B"])
     }
 
     // Mapping ------------------------------------------------------------------------------------

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/AdjacencyRouteShapeRepositoryTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/AdjacencyRouteShapeRepositoryTest.kt
@@ -201,6 +201,9 @@ class AdjacencyRouteShapeRepositoryTest {
 
     companion object {
         /** A minimal [RouteMapData] with empty shapes (no [android.location.Location] built). */
+        // routeId is a call-site label documenting which route this fake data stands in for;
+        // RouteMapData carries no route-id field (the id is applied later by toAdjacencyShape), so
+        // the body has no use for it. Test-only helper; no tracking issue.
         private fun routeMapData(
             @Suppress("UNUSED_PARAMETER") routeId: String,
             stopIds: List<String> = emptyList(),

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/RouteRowGroupingTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/RouteRowGroupingTest.kt
@@ -263,6 +263,24 @@ class RouteRowGroupingTest {
         assertEquals(listOf("A", "B"), order(items, setOf("A", "B")))
     }
 
+    // Route-id set (adjacency focus, #1827) -------------------------------------------------------
+
+    @Test
+    fun routeIdSet_dedupesRoutesAndKeepsFirstSeenOrder() {
+        // Two directions of route A, interleaved with B — one distinct id per route, first-seen order.
+        val items = listOf(
+            FakeItem("A", "North", 2),
+            FakeItem("B", "East", 5),
+            FakeItem("A", "South", 8),
+        )
+        assertEquals(listOf("A", "B"), routeIdSet(items) { it.routeId }.toList())
+    }
+
+    @Test
+    fun routeIdSet_empty_returnsEmpty() {
+        assertEquals(emptySet<String>(), routeIdSet(emptyList<FakeItem>()) { it.routeId })
+    }
+
     // Group-level active-alert resolution ---------------------------------------------------------
 
     /** A minimal [ArrivalActions] carrying just the alert id under test — the row derivation reads

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
@@ -159,7 +159,7 @@ class HomeViewModelTest {
         val stop = FocusedStop("1", "Main St", "100", 47.6, -122.3)
         vm.applyInitialFocus(stop)
         assertEquals(stop, vm.uiState.value.focusedStop)
-        vm.onArrivalsLoaded(obaStop, null)
+        vm.onArrivalsLoaded(obaStop, null, emptySet())
         advanceUntilIdle()
         assertEquals(1, map.focusStops.size) // pending was marked -> focus dispatched to the map
         job.cancel()
@@ -176,7 +176,7 @@ class HomeViewModelTest {
         advanceUntilIdle()
         vm.applyInitialFocus(null) // intent carries no stop
         assertEquals(restored, vm.uiState.value.focusedStop) // unchanged
-        vm.onArrivalsLoaded(obaStop, null)
+        vm.onArrivalsLoaded(obaStop, null, emptySet())
         advanceUntilIdle()
         assertEquals(1, map.focusStops.size) // pending was marked
         job.cancel()
@@ -190,7 +190,7 @@ class HomeViewModelTest {
         advanceUntilIdle()
         vm.applyInitialFocus(null)
         assertNull(vm.uiState.value.focusedStop)
-        vm.onArrivalsLoaded(obaStop, null)
+        vm.onArrivalsLoaded(obaStop, null, emptySet())
         advanceUntilIdle()
         assertEquals(0, map.focusStops.size) // not pending -> nothing dispatched
         job.cancel()
@@ -206,11 +206,11 @@ class HomeViewModelTest {
         advanceUntilIdle()
         vm.markPendingMapFocus()
         // Pending -> dispatch FocusStop (sheet not expanded -> overlayExpanded false); latch then clears.
-        vm.onArrivalsLoaded(obaStop, null)
+        vm.onArrivalsLoaded(obaStop, null, emptySet())
         advanceUntilIdle()
         assertEquals(1, map.focusStops.size)
         assertEquals(false, map.focusStops.single().overlayExpanded)
-        vm.onArrivalsLoaded(obaStop, null)         // latch cleared -> no further dispatch
+        vm.onArrivalsLoaded(obaStop, null, emptySet())         // latch cleared -> no further dispatch
         advanceUntilIdle()
         assertEquals(1, map.focusStops.size)
         job.cancel()
@@ -222,7 +222,7 @@ class HomeViewModelTest {
         val map = MapDirectiveRecorder(vm)
         val job = launch { map.collect() }
         advanceUntilIdle()
-        vm.onArrivalsLoaded(obaStop, null)
+        vm.onArrivalsLoaded(obaStop, null, emptySet())
         advanceUntilIdle()
         assertEquals(0, map.focusStops.size)
         job.cancel()
@@ -239,7 +239,7 @@ class HomeViewModelTest {
         vm.onSheetSettled(ArrivalsSheetState.Expanded, 120)
 
         vm.markPendingMapFocus()
-        vm.onArrivalsLoaded(obaStop, null)
+        vm.onArrivalsLoaded(obaStop, null, emptySet())
         advanceUntilIdle()
         assertEquals(true, map.focusStops.single().overlayExpanded)
         job.cancel()
@@ -275,6 +275,60 @@ class HomeViewModelTest {
         assertNull(vm.uiState.value.focusedStop)
         assertEquals(1, map.clearFocusCount)
         job.cancel()
+    }
+
+    // --- adjacency focus route set (#1827) ---
+
+    @Test
+    fun `arrivals load records the drawer route set even without a pending focus`() = runTest {
+        val vm = viewModel()
+        val map = MapDirectiveRecorder(vm)
+        val job = launch { map.collect() }
+        advanceUntilIdle()
+
+        // No pending focus: the load still records the routes but emits no map directive.
+        vm.onArrivalsLoaded(obaStop, null, setOf("40", "44"))
+        advanceUntilIdle()
+
+        assertEquals(setOf("40", "44"), vm.focusedRouteIds)
+        assertEquals(0, map.focusStops.size)
+        job.cancel()
+    }
+
+    @Test
+    fun `arrivals load records the route set before the pending-focus dispatch`() = runTest {
+        val vm = viewModel()
+        val map = MapDirectiveRecorder(vm)
+        val job = launch { map.collect() }
+        advanceUntilIdle()
+        vm.markPendingMapFocus()
+
+        vm.onArrivalsLoaded(obaStop, null, setOf("7"))
+        advanceUntilIdle()
+
+        assertEquals(setOf("7"), vm.focusedRouteIds)
+        assertEquals(1, map.focusStops.size) // pending focus still dispatched
+        job.cancel()
+    }
+
+    @Test
+    fun `focusing a different stop resets the route set`() = runTest {
+        val vm = viewModel()
+        vm.onArrivalsLoaded(obaStop, null, setOf("40"))
+        assertEquals(setOf("40"), vm.focusedRouteIds)
+
+        vm.onStopFocused(FocusedStop("2", "2nd Ave", "200", 47.6, -122.3))
+        assertEquals(emptySet<String>(), vm.focusedRouteIds)
+    }
+
+    @Test
+    fun `clearing map focus resets the route set`() = runTest {
+        val vm = viewModel()
+        vm.onArrivalsLoaded(obaStop, null, setOf("40"))
+        assertEquals(setOf("40"), vm.focusedRouteIds)
+
+        vm.requestClearMapFocus()
+        assertEquals(emptySet<String>(), vm.focusedRouteIds)
     }
 
     // --- focus + SavedStateHandle ---


### PR DESCRIPTION
Phase 1 ("Data") of the adjacency-focus PR stack (#1827). **Pure data-layer groundwork — no UI, no user-visible behavior change.** The new repository is unconsumed and `focusedRouteIds` is unread until phase 2, so there is no runtime surface to drive here.

## What's in it

**1. Focused route-id set: arrivals → `HomeViewModel`**
- A pure `focusedRouteIds(routeGroups)` helper (on the generic `routeIdSet`, mirroring the existing `orderGroupsByFavorite`/`orderRouteGroupsByFavorite` pair) derives the drawer's routes **1:1** — every route with an upcoming arrival, scheduled or tracked (the issue's decided definition, not the `predicted` subset).
- It's derived from the **computed** `ArrivalsData.routeGroups` (which reflects the past-arrivals filter), so `ArrivalsLoaded` now carries a prebuilt `@Volatile lastLoadedSnapshot` set in both `getArrivals` fold branches, rather than being re-derived from the raw `StopArrivals` on read.
- `HomeActivity` relays it into `HomeViewModel.onArrivalsLoaded`, which stores it on a plain `focusedRouteIds` property (coordination state like `settledSheet`), updated on every load and reset on focus change/clear.

**2. `AdjacencyRouteShapeRepository` — multi-route shape fetch**
- Fetches whole-route shapes for a **set** of routes at once: bounded concurrency via a `Semaphore` (deliberately not `limitedParallelism` — the Retrofit calls are main-safe suspend calls that hold no dispatcher thread while awaiting, so a limited dispatcher wouldn't actually bound in-flight requests; documented at the call site), `SingleFlight` in-flight de-dup, and a success-only 32-entry LRU with a 10-minute TTL for sequential stop focuses. Partial failures still land in `failedRouteIds` and are never cached, so later focuses retry them.
- The `Location → GeoPoint` conversion runs off the main thread. `@Singleton` because it owns the in-flight de-dup and completed-result cache state.

## Testing
Pure logic (route-id derivation, and the fetch's bounded concurrency / in-flight de-dup / completed-cache hits / LRU eviction / TTL expiry / failure retry / partial-failure / cancellation behavior) is JVM-unit-tested. Focused repository/cache tests pass; compiles clean under `-PwarningsAsErrors=true`.

## Follow-ups (rest of the stack, per #1827)
Lines producer + `MapDirective`, stop minimization, de-focused vehicles, Google badges, then MapLibre badges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved adjacency map rendering by loading whole-route shapes for multiple routes with bounded concurrent fetches and in-flight de-duplication.
  * Enhanced map focus coordination by tracking the focused stop’s route ID set through arrivals updates.
* **Bug Fixes**
  * Arrivals “last good” behavior now keeps derived focused-route data consistent across normal and fallback loads.
  * Route-shape loading tolerates partial failures by returning successful routes while reporting which routes failed.
* **Tests**
  * Added a new adjacency route-shape repository test suite (concurrency, de-duplication, caching, partial failures) and updated home/route grouping tests for the new route-set behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
