### PR TITLE
Docs: relax the PR squash policy (single or multi-commit both fine)

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -62,8 +62,8 @@ If you can, please submit a pull request with the fix or improvements including 
 3. Write tests and code
 4. Run the unit tests with `gradlew connectedObaGoogleDebugAndroidTest` to make sure you didn't break anything
 5. Apply the `AndroidStyle.xml` style template to your code in Android Studio.
-6. If you have multiple commits please combine them into one commit by squashing them.  See [this article](http://eli.thegreenplace.net/2014/02/19/squashing-github-pull-requests-into-a-single-commit) and [this Git documentation](http://git-scm.com/book/en/Git-Tools-Rewriting-History#Squashing-Commits) for instructions.
-7. Push the commit to your fork
+6. Your PR branch may be a single squashed commit or a string of commits — whichever you prefer. The PR is squashed when it's merged to `main`, so you don't need to squash it yourself.
+7. Push your commits to your fork
 8. Submit a pull request with a motive for your change and the method you used to achieve it
 9. [Search for issues](https://github.com/OneBusAway/onebusaway-android/search?q=&ref=cmdform&type=Issues) related to your pull request and mention them in the pull request description or comments
 
@@ -78,7 +78,6 @@ We will accept pull requests if:
 * It keeps the OneBusAway for Android code base clean and well structured
 * We think other users will benefit from the same functionality
 * If it makes changes to the UI the pull request should include screenshots
-* It is a single commit (please use `git rebase -i` to squash commits)
 
 ## License
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,4 +4,4 @@ Please make sure these boxes are checked before submitting your pull request - t
 
 - [ ] Run the unit tests with `gradlew connectedObaGoogleDebugAndroidTest` to make sure you didn't break anything
 
-- [ ] If you have multiple commits please combine them into one commit by squashing them for the initial submission of the pull request.  When addressing comments on a pull request, please push a new commit per comment when possible (reviewers will squash and merge using GitHub merge tool)
+- [ ] Your PR may be a single squashed commit or a string of commits — either is fine. The PR is squashed when it's merged to `main`, so no need to squash it yourself.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,5 +3,3 @@ Please make sure these boxes are checked before submitting your pull request - t
 - [ ] Apply the `AndroidStyle.xml` style template to your code in Android Studio.
 
 - [ ] Run the unit tests with `gradlew connectedObaGoogleDebugAndroidTest` to make sure you didn't break anything
-
-- [ ] Your PR may be a single squashed commit or a string of commits — either is fine. The PR is squashed when it's merged to `main`, so no need to squash it yourself.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -296,6 +296,8 @@ This allows white-label brands to only override `app_name` instead of duplicatin
 
 ## Contributing
 
-- PRs should be single squashed commits
+- A PR branch may be a single squashed commit or a string of commits — either is fine. On merge to
+  `main` the PR is squashed, and the branch may be kept (archived) for an arbitrary period for future
+  git archeology.
 - ICLA signature required via CLA Assistant
 - Run tests before submitting: `./gradlew connectedObaGoogleDebugAndroidTest`


### PR DESCRIPTION
## Summary

Updates contributor and agent-facing docs to reflect the current PR policy: a PR branch may be **a single squashed commit or a string of commits** — either is fine. The PR is squashed when it's merged to `main` (and the branch may be archived for a while for future git archeology), so contributors no longer need to squash before submitting.

This cancels the prior "PRs should be single squashed commits" rule.

## Changes

- **`CLAUDE.md`** — replaced the single-squashed-commit rule with the new policy.
- **`.github/CONTRIBUTING.md`** — reworded the "combine into one commit by squashing" step; removed the "It is a single commit" acceptance-criteria bullet.
- **`.github/PULL_REQUEST_TEMPLATE.md`** — dropped the squash checklist item entirely (it's now always satisfied, so it was just noise).

Left as-is: `docs/superpowers/plans/2026-06-22-umami-analytics.md` mentions the old rule, but it's a dated historical plan doc, not live policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)