### PR TITLE
Adjacency focus phase 2: draw route lines

### DIFF
--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
@@ -50,6 +50,7 @@ import org.onebusaway.android.map.render.ContinuationBadgeBitmaps
 import org.onebusaway.android.map.render.CorrectionSmoother
 import org.onebusaway.android.map.render.GeoPoint
 import org.onebusaway.android.map.render.MapPing
+import org.onebusaway.android.map.render.MapRenderSnapshot
 import org.onebusaway.android.map.render.MapRenderState
 import org.onebusaway.android.map.render.MarkerRendering
 import org.onebusaway.android.map.render.PingTarget
@@ -77,11 +78,12 @@ import java.util.concurrent.TimeUnit
  * host can route taps back to focus / info-window handlers. It replaces the declarative maps-compose
  * `ObaMapContent` + the `VehicleMarkerLayer`/`TripMarkerLayer` Compose overlays.
  *
- * Two redraw paths, the same two recomposition boundaries the Compose flavor had:
- *  - [renderStatic] clear-and-redraws the static annotations (route polylines / bikes / generics /
- *    trip-stop dots) and reconciles the stop markers in place ([reconcileStopMarkers], so unchanged
- *    stops don't blink), driven by snapshot/trip-stop changes (viewport loads, the vehicle poll,
- *    focus) — a bounded cost.
+ * Three redraw paths split by update cadence:
+ *  - [renderRoutePolylines] independently reconciles the infrequently-changing route layer, so
+ *    stop-only viewport updates retain every long native line.
+ *  - [renderStatic] clear-and-redraws the remaining static annotations (bikes / generics / trip-stop
+ *    dots) and reconciles stop markers in place ([reconcileStopMarkers], so unchanged stops neither
+ *    blink nor receive redundant native position/z-index writes).
  *  - [renderDynamic] (the live route vehicles + the selected vehicle's band/fast-estimate marker) is pulled at
  *    ~20Hz by the adapter's frame loop. It moves native markers **in place** to their freshly
  *    extrapolated positions (so the icons glide with the map, an open info window survives, and there's
@@ -126,10 +128,16 @@ class GoogleMapRenderer(
     private val _vehicleResponse = MutableStateFlow<RouteTrips?>(null)
     val vehicleResponse: StateFlow<RouteTrips?> = _vehicleResponse.asStateFlow()
 
-    // The static annotations added by the last [renderStatic], removed (not map.clear()) on the next so
-    // the per-frame dynamic layer below survives a static redraw.
+    // The non-route static annotations added by the last [renderStatic], removed (not map.clear()) on
+    // the next so the retained route and per-frame dynamic layers survive a static redraw.
     private val staticMarkers = mutableListOf<Marker>()
     private val staticPolylines = mutableListOf<Polyline>()
+
+    // Whole-route lines are reconciled independently from the combined static snapshot: stop list,
+    // focus, or bike changes retain these native polylines. Snapshot copies keep the same List instance,
+    // making the common stop-only update an O(1) identity check; equal republished values are retained too.
+    private val routePolylines = mutableListOf<Polyline>()
+    private var renderedRoutePolylines: List<RoutePolyline> = emptyList()
 
     // The dynamic layer, tracked by identity so [renderDynamic] can move markers in place: route vehicles
     // keyed by active trip id, and the band's (interaction-free) polylines re-added each frame. The
@@ -210,11 +218,10 @@ class GoogleMapRenderer(
     private val descriptorCache =
         BitmapDescriptorCache(DESCRIPTOR_CACHE_SIZE) { BitmapDescriptorFactory.fromBitmap(it) }
 
-    // Remove the redrawn static annotations — polylines, trip-stop dots, bikes, generic markers (not
-    // map.clear(), which would also wipe the per-frame dynamic layer) — and clear the bike tap map
-    // [bikeByMarker]. The reconciled stop markers are tracked apart in [stopMarkersByStopId] and
-    // deliberately survive (their tap map [stopByMarker] is left intact too). Shared by [renderStatic]
-    // (before it redraws) and [dispose].
+    // Remove the redrawn non-route static annotations — continuation polylines, trip-stop dots, bikes,
+    // generic markers (not map.clear(), which would also wipe the retained route and per-frame dynamic
+    // layers) — and clear their tap maps. Reconciled route/stop annotations deliberately survive.
+    // Shared by [renderStatic] (before it redraws) and [dispose].
     private fun clearStatic() {
         staticMarkers.forEach { it.remove() }
         staticMarkers.clear()
@@ -225,23 +232,8 @@ class GoogleMapRenderer(
     }
 
     /** Redraw the static layer (everything but the live vehicles + trip-focus overlay). */
-    fun renderStatic() {
+    fun renderStatic(snapshot: MapRenderSnapshot = renderState.snapshot.value) {
         clearStatic()
-
-        val snapshot = renderState.snapshot.value
-
-        for (polyline in snapshot.routePolylines) {
-            // Stamp travel-direction chevrons only when the line asked for them (a single trip/leg or a
-            // route narrowed to one direction); an undirected whole-route shape draws a plain stroke.
-            val stroke = StrokeStyle.colorBuilder(polyline.resolvedColor)
-                .apply { if (polyline.directional) stamp(arrowStamp) }
-                .build()
-            val options = PolylineOptions()
-                .width(widthPx(polyline))
-                .addSpan(StyleSpan(stroke))
-                .addPoints(polyline.points)
-            staticPolylines.add(map.addPolyline(options))
-        }
 
         reconcileStopMarkers(snapshot.stops, snapshot.focusedStopId, snapshot.stopBand)
 
@@ -275,6 +267,28 @@ class GoogleMapRenderer(
         }
 
         snapshot.routeContinuation?.let { continuation -> renderContinuation(continuation) }
+    }
+
+    /** Reconcile the independently collected route layer, retaining equal native polylines. */
+    fun renderRoutePolylines(next: List<RoutePolyline> = renderState.snapshot.value.routePolylines) {
+        if (renderedRoutePolylines === next || renderedRoutePolylines == next) return
+
+        routePolylines.forEach { it.remove() }
+        routePolylines.clear()
+        renderedRoutePolylines = next
+
+        for (polyline in next) {
+            // Stamp travel-direction chevrons only when the line asked for them (a single trip/leg or a
+            // route narrowed to one direction); an undirected whole-route shape draws a plain stroke.
+            val stroke = StrokeStyle.colorBuilder(polyline.resolvedColor)
+                .apply { if (polyline.directional) stamp(arrowStamp) }
+                .build()
+            val options = PolylineOptions()
+                .width(widthPx(polyline))
+                .addSpan(StyleSpan(stroke))
+                .addPoints(polyline.points)
+            routePolylines.add(map.addPolyline(options))
+        }
     }
 
     /**
@@ -378,16 +392,21 @@ class GoogleMapRenderer(
                 )
                 // Only the markers whose icon kind changed need a new icon (and matching anchor: the
                 // full icon is anchored on its circle per direction, the dot/star/circle at the marker
-                // center). Position and the backing StopMarker are refreshed unconditionally, since a
-                // projected route stop can keep the same kind (ROUTE_CIRCLE) while its on-route point
-                // moves — gating those on the kind change would strand the marker at a stale coordinate.
+                // center). Geometry and tap data are compared with the previously rendered model below:
+                // a projected route stop can move without a kind change, but the common retained nearby
+                // stop now avoids redundant native position/z-index writes.
                 if (previousKind != kind) {
                     existing.setIcon(stopIcon(stop, kind))
                     val (anchorX, anchorY) = stopAnchor(stop, kind)
                     existing.setAnchor(anchorX, anchorY)
                 }
-                existing.position = stop.point.toLatLng()
-                existing.zIndex = if (stop.favorite) FAVORITE_STOP_Z_INDEX else 0f
+                val previous = stopByMarker[existing]
+                if (previous?.point != stop.point) {
+                    existing.position = stop.point.toLatLng()
+                }
+                if (previous?.favorite != stop.favorite) {
+                    existing.zIndex = if (stop.favorite) FAVORITE_STOP_Z_INDEX else 0f
+                }
                 stopByMarker[existing] = stop
             }
         }
@@ -431,6 +450,9 @@ class GoogleMapRenderer(
         dotSmoother.retainOnly(emptySet())
 
         clearStatic()
+        routePolylines.forEach { it.remove() }
+        routePolylines.clear()
+        renderedRoutePolylines = emptyList()
 
         stopMarkersByStopId.values.forEach { it.remove() }
         stopMarkersByStopId.clear()

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
@@ -278,15 +278,21 @@ class GoogleMapRenderer(
         renderedRoutePolylines = next
 
         for (polyline in next) {
-            // Stamp travel-direction chevrons only when the line asked for them (a single trip/leg or a
-            // route narrowed to one direction); an undirected whole-route shape draws a plain stroke.
-            val stroke = StrokeStyle.colorBuilder(polyline.resolvedColor)
-                .apply { if (polyline.directional) stamp(arrowStamp) }
-                .build()
             val options = PolylineOptions()
                 .width(widthPx(polyline))
-                .addSpan(StyleSpan(stroke))
                 .addPoints(polyline.points)
+            if (polyline.directional) {
+                // Advanced spans are substantially more expensive for Maps to retessellate while
+                // zooming. Reserve that path for the lines that actually need repeated chevrons.
+                val stroke = StrokeStyle.colorBuilder(polyline.resolvedColor)
+                    .stamp(arrowStamp)
+                    .build()
+                options.addSpan(StyleSpan(stroke))
+            } else {
+                // Adjacency focus uses undirected whole-route shapes. The classic solid-color path is
+                // both the exact requested appearance and cheaper than an equivalent one-color span.
+                options.color(polyline.resolvedColor)
+            }
             routePolylines.add(map.addPolyline(options))
         }
     }

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleComposeAdapter.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleComposeAdapter.kt
@@ -64,6 +64,7 @@ import org.onebusaway.android.map.render.CameraSnapshot
 import org.onebusaway.android.map.render.GeoPoint
 import org.onebusaway.android.map.render.MapProjector
 import org.onebusaway.android.map.render.ScreenOffset
+import org.onebusaway.android.map.render.routePolylineRenderFlow
 import org.onebusaway.android.ui.compose.findActivity
 import org.onebusaway.android.util.PermissionUtils
 import org.onebusaway.android.util.ThemeUtils
@@ -175,7 +176,6 @@ class GoogleComposeAdapter : ObaComposeMapAdapter {
                 }
                 map.setOnCameraIdleListener { host.onCameraIdle(snapshot(map)) }
 
-                r.renderRoutePolylines()
                 r.renderStatic()
                 createdRenderer = r
                 renderer = r
@@ -198,11 +198,10 @@ class GoogleComposeAdapter : ObaComposeMapAdapter {
                     .collect { activeRenderer.renderStatic(it) }
             }
             // Route lines have their own change boundary: viewport stop updates retain the native
-            // Google polylines instead of removing/recreating every long adjacency shape.
+            // Google polylines instead of removing/recreating every long adjacency shape. Canonical
+            // route geometry stays in renderState for framing; only this renderer-bound copy is clipped.
             LaunchedEffect(activeRenderer) {
-                renderState.snapshot
-                    .map { it.routePolylines }
-                    .distinctUntilChanged()
+                routePolylineRenderFlow(renderState.snapshot, host.camera)
                     .collect { activeRenderer.renderRoutePolylines(it) }
             }
             // The vehicle set (which vehicles exist + their icons): reconcile the markers whenever it's

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleComposeAdapter.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleComposeAdapter.kt
@@ -48,7 +48,9 @@ import com.google.android.gms.maps.model.MapStyleOptions
 import com.google.android.gms.maps.model.Marker
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.map
 import org.onebusaway.android.R
 import org.onebusaway.android.map.MapHost
 import org.onebusaway.android.time.WallTime
@@ -78,10 +80,10 @@ private const val FRAME_INTERVAL_NANOS = 50_000_000L
  * Google flavor's [ObaComposeMapAdapter]: hosts the classic [MapView] inside an [AndroidView] (no more
  * android-maps-compose), bridging the MapView's imperative lifecycle to Compose via a
  * [LifecycleEventObserver], and drives the shared [MapHost]. It sets the style, builds the
- * [GoogleMapRenderer] and re-renders on every render-state change, wires map/marker/info-window clicks
- * to [callbacks], reports camera idles to [MapHost.onCameraIdle], applies the render state's camera
- * gestures + retained framing intent, and enables the location blue dot from the host's
- * permission-derived flag.
+ * [GoogleMapRenderer] and collects its static and route layers independently, wires
+ * map/marker/info-window clicks to [callbacks], reports camera idles to [MapHost.onCameraIdle], applies
+ * the render state's camera gestures + retained framing intent, and enables the location blue dot from
+ * the host's permission-derived flag.
  *
  * The live route vehicles + the trip-focus estimate markers are native [Marker]s moved in place at
  * ~20Hz (the [GoogleMapRenderer.renderDynamic] loop below), so they glide with the map — no Compose
@@ -173,6 +175,7 @@ class GoogleComposeAdapter : ObaComposeMapAdapter {
                 }
                 map.setOnCameraIdleListener { host.onCameraIdle(snapshot(map)) }
 
+                r.renderRoutePolylines()
                 r.renderStatic()
                 createdRenderer = r
                 renderer = r
@@ -185,10 +188,22 @@ class GoogleComposeAdapter : ObaComposeMapAdapter {
         val activeRenderer = renderer
         val activeInfoWindows = infoWindows
         if (activeRenderer != null && activeInfoWindows != null) {
-            // Static layer (stops / routes / bikes / generics): redraw only when the snapshot changes
-            // (viewport loads, the vehicle poll, focus) — a bounded cost.
+            // Non-route static layer (stops / bikes / generics): strip route lines before distinctness
+            // so a route-only change never churns these annotations, and stop-only emissions cannot
+            // touch the independently collected native route layer below.
             LaunchedEffect(activeRenderer) {
-                renderState.snapshot.collect { activeRenderer.renderStatic() }
+                renderState.snapshot
+                    .map { it.copy(routePolylines = emptyList()) }
+                    .distinctUntilChanged()
+                    .collect { activeRenderer.renderStatic(it) }
+            }
+            // Route lines have their own change boundary: viewport stop updates retain the native
+            // Google polylines instead of removing/recreating every long adjacency shape.
+            LaunchedEffect(activeRenderer) {
+                renderState.snapshot
+                    .map { it.routePolylines }
+                    .distinctUntilChanged()
+                    .collect { activeRenderer.renderRoutePolylines(it) }
             }
             // The vehicle set (which vehicles exist + their icons): reconcile the markers whenever it's
             // pushed — a poll, a direction switch, or leaving route mode (null). Discrete, so it's reactive

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/data/StopArrivalsDataSource.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/data/StopArrivalsDataSource.kt
@@ -33,6 +33,7 @@ import org.onebusaway.android.models.ObaRoute
 import org.onebusaway.android.models.ObaSituation
 import org.onebusaway.android.models.ObaStop
 import org.onebusaway.android.models.ObaTrip
+import org.onebusaway.android.models.TripPatternGeometry
 
 /**
  * A resolved snapshot of a stop's arrivals-and-departures: the [arrivals] plus the references the
@@ -76,6 +77,22 @@ class StopArrivals internal constructor(
 
     /** Resolves a trip from the references pool by id (for its block id), or null. */
     fun trip(id: String): ObaTrip? = refs.trip(id)?.let(::DtoTrip)
+
+    /**
+     * Resolves the exact, distinct GTFS shapes used by [tripIds]. This deliberately starts from the
+     * displayed arrivals' trip ids instead of expanding their route ids through `stops-for-route`,
+     * which would include unrelated branches and variants of the same route.
+     */
+    fun tripPatternGeometries(tripIds: Iterable<String>): Set<TripPatternGeometry> =
+        tripIds.mapNotNullTo(LinkedHashSet()) { tripId ->
+            val trip = trip(tripId) ?: return@mapNotNullTo null
+            val shapeId = trip.shapeId?.takeIf(String::isNotBlank) ?: return@mapNotNullTo null
+            TripPatternGeometry(
+                shapeId = shapeId,
+                routeId = trip.routeId,
+                routeColor = route(trip.routeId)?.color,
+            )
+        }
 
     /** Resolves a situation (service alert) from the references pool by id, or null. */
     fun situation(id: String): ObaSituation? = refs.situation(id)?.let(::DtoSituation)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/AdjacencyMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/AdjacencyMapController.kt
@@ -15,23 +15,30 @@
  */
 package org.onebusaway.android.map
 
+import kotlin.math.cos
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
+import org.onebusaway.android.map.render.GeoPoint
 import org.onebusaway.android.map.render.MapRenderState
 import org.onebusaway.android.map.render.ROUTE_LINE_WIDTH_DP
 import org.onebusaway.android.map.render.RoutePolyline
 import org.onebusaway.android.map.render.RoutePolylineTransform
+import org.onebusaway.android.models.TripPatternGeometry
 
 private val ADJACENCY_ROUTE_TRANSFORMS = setOf(
     RoutePolylineTransform.VIEWPORT_CLIP,
     RoutePolylineTransform.ZOOM_SIMPLIFY,
 )
 
+internal const val ADJACENCY_DOWNSTREAM_LINE_WIDTH_DP = ROUTE_LINE_WIDTH_DP
+internal const val ADJACENCY_UPSTREAM_LINE_WIDTH_DP = ROUTE_LINE_WIDTH_DP * 0.275f
+
 /**
- * Draws the whole-route lines for the routes with upcoming arrivals at one focused stop. This is an
- * overlay on nearby-stops mode, distinct from [RouteMapController]'s mutually exclusive single-route
- * mode. It owns [MapRenderState]'s route polylines only while [session] is non-null.
+ * Draws the exact trip-pattern lines with upcoming arrivals at one focused stop, narrowing the
+ * upstream stroke and emphasizing downstream travel. This is an overlay on nearby-stops mode,
+ * distinct from [RouteMapController]'s mutually exclusive single-route mode. It owns
+ * [MapRenderState]'s route polylines only while [session] is non-null.
  */
 internal class AdjacencyMapController(
     private val renderState: MapRenderState,
@@ -39,32 +46,41 @@ internal class AdjacencyMapController(
     private val scope: CoroutineScope,
 ) {
 
-    private data class Session(val stopId: String, val routeIds: Set<String>)
+    private data class Session(
+        val stopId: String,
+        val stopPoint: GeoPoint,
+        val tripPatterns: Set<TripPatternGeometry>,
+    )
 
     private var session: Session? = null
 
     private var loadJob: Job? = null
 
     /**
-     * Load and draw [routeIds] for [stopId]. Repeating the same session is a no-op so periodic arrivals
-     * refreshes do not repeatedly fetch unchanged shapes. A changed session replaces the old lines.
+     * Load and draw [tripPatterns] for [stopId]. Repeating the same session is a no-op so periodic
+     * arrivals refreshes do not repeatedly fetch unchanged shapes. A changed session replaces the
+     * old lines.
      */
-    fun start(stopId: String, routeIds: Set<String>) {
-        if (routeIds.isEmpty()) {
+    fun start(
+        stopId: String,
+        stopPoint: GeoPoint,
+        tripPatterns: Set<TripPatternGeometry>,
+    ) {
+        if (tripPatterns.isEmpty()) {
             stop()
             return
         }
-        val next = Session(stopId, LinkedHashSet(routeIds))
+        val next = Session(stopId, stopPoint, LinkedHashSet(tripPatterns))
         if (session == next) return
 
         stop()
         session = next
         loadJob = scope.launch {
-            val result = repository.getShapes(next.routeIds)
+            val result = repository.getShapes(next.tripPatterns)
             // A repository fetch can outlive a cancelled join through SingleFlight. Only the session
             // that is still current may publish into the shared route-polyline slot.
             if (session == next) {
-                renderState.setRoutePolylines(result.toRoutePolylines())
+                renderState.setRoutePolylines(result.toRoutePolylines(next.stopPoint))
             }
         }
     }
@@ -82,17 +98,97 @@ internal class AdjacencyMapController(
     }
 }
 
-/** Convert every successfully resolved whole-route shape into the existing shared render model. */
-internal fun AdjacencyShapes.toRoutePolylines(): List<RoutePolyline> =
-    shapes.values.flatMap { shape ->
-        shape.polylines
-            .filter { it.size >= 2 }
-            .map { points ->
+/**
+ * Convert every trip-pattern shape into a thin upstream segment and a wide downstream segment.
+ * GTFS shape points are travel-ordered; [stopPoint] is projected onto the nearest segment so both
+ * strokes meet exactly even when the stop falls between vertices.
+ */
+internal fun AdjacencyShapes.toRoutePolylines(stopPoint: GeoPoint): List<RoutePolyline> = buildList {
+    shapes.values.forEach { shape ->
+        val split = splitPolylineAtStop(shape.points, stopPoint) ?: return@forEach
+        split.upstream.takeIf { it.size >= 2 }?.let { points ->
+            add(
                 RoutePolyline(
-                    color = shape.route?.color,
+                    color = shape.routeColor,
                     points = points,
-                    widthDp = ROUTE_LINE_WIDTH_DP,
+                    widthDp = ADJACENCY_UPSTREAM_LINE_WIDTH_DP,
                     transforms = ADJACENCY_ROUTE_TRANSFORMS,
                 )
-            }
+            )
+        }
+        split.downstream.takeIf { it.size >= 2 }?.let { points ->
+            add(
+                RoutePolyline(
+                    color = shape.routeColor,
+                    points = points,
+                    widthDp = ADJACENCY_DOWNSTREAM_LINE_WIDTH_DP,
+                    transforms = ADJACENCY_ROUTE_TRANSFORMS,
+                )
+            )
+        }
     }
+}
+
+internal data class StopSplitPolyline(
+    val upstream: List<GeoPoint>,
+    val downstream: List<GeoPoint>,
+)
+
+/** Project [stopPoint] onto [points], then split the travel-ordered line at that projection. */
+internal fun splitPolylineAtStop(
+    points: List<GeoPoint>,
+    stopPoint: GeoPoint,
+): StopSplitPolyline? {
+    if (points.size < 2) return null
+    val cosLat = cos(Math.toRadians(stopPoint.latitude))
+    val px = stopPoint.longitude * cosLat
+    val py = stopPoint.latitude
+    var bestSegment = 0
+    var bestFraction = 0.0
+    var bestDistanceSquared = Double.MAX_VALUE
+
+    for (index in 0 until points.lastIndex) {
+        val start = points[index]
+        val end = points[index + 1]
+        val ax = start.longitude * cosLat
+        val ay = start.latitude
+        val dx = end.longitude * cosLat - ax
+        val dy = end.latitude - ay
+        val lengthSquared = dx * dx + dy * dy
+        val fraction = if (lengthSquared <= 0.0) {
+            0.0
+        } else {
+            (((px - ax) * dx + (py - ay) * dy) / lengthSquared).coerceIn(0.0, 1.0)
+        }
+        val projectedX = ax + fraction * dx
+        val projectedY = ay + fraction * dy
+        val distanceSquared =
+            (projectedX - px) * (projectedX - px) +
+                (projectedY - py) * (projectedY - py)
+        if (distanceSquared < bestDistanceSquared) {
+            bestDistanceSquared = distanceSquared
+            bestSegment = index
+            bestFraction = fraction
+        }
+    }
+
+    val start = points[bestSegment]
+    val end = points[bestSegment + 1]
+    val splitPoint = when (bestFraction) {
+        0.0 -> start
+        1.0 -> end
+        else -> GeoPoint(
+            latitude = start.latitude + bestFraction * (end.latitude - start.latitude),
+            longitude = start.longitude + bestFraction * (end.longitude - start.longitude),
+        )
+    }
+    val upstream = points.subList(0, bestSegment + 1).toMutableList()
+    if (upstream.last() != splitPoint) upstream += splitPoint
+    val downstream = mutableListOf(splitPoint)
+    if (splitPoint == end) {
+        downstream += points.subList(bestSegment + 2, points.size)
+    } else {
+        downstream += points.subList(bestSegment + 1, points.size)
+    }
+    return StopSplitPolyline(upstream, downstream)
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/AdjacencyMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/AdjacencyMapController.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.map
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import org.onebusaway.android.map.render.MapRenderState
+import org.onebusaway.android.map.render.ROUTE_LINE_WIDTH_DP
+import org.onebusaway.android.map.render.RoutePolyline
+
+/**
+ * Draws the whole-route lines for the routes with upcoming arrivals at one focused stop. This is an
+ * overlay on nearby-stops mode, distinct from [RouteMapController]'s mutually exclusive single-route
+ * mode. It owns [MapRenderState]'s route polylines only while [session] is non-null.
+ */
+internal class AdjacencyMapController(
+    private val renderState: MapRenderState,
+    private val repository: AdjacencyRouteShapeRepository,
+    private val scope: CoroutineScope,
+) {
+
+    private data class Session(val stopId: String, val routeIds: Set<String>)
+
+    private var session: Session? = null
+
+    private var loadJob: Job? = null
+
+    /**
+     * Load and draw [routeIds] for [stopId]. Repeating the same session is a no-op so periodic arrivals
+     * refreshes do not repeatedly fetch unchanged shapes. A changed session replaces the old lines.
+     */
+    fun start(stopId: String, routeIds: Set<String>) {
+        if (routeIds.isEmpty()) {
+            stop()
+            return
+        }
+        val next = Session(stopId, LinkedHashSet(routeIds))
+        if (session == next) return
+
+        stop()
+        session = next
+        loadJob = scope.launch {
+            val result = repository.getShapes(next.routeIds)
+            // A repository fetch can outlive a cancelled join through SingleFlight. Only the session
+            // that is still current may publish into the shared route-polyline slot.
+            if (session == next) {
+                renderState.setRoutePolylines(result.toRoutePolylines())
+            }
+        }
+    }
+
+    /**
+     * Cancel adjacency loading and clear its lines. If no adjacency session owns the shared slot, this
+     * is deliberately a no-op so a late clear cannot erase a single-route controller's line.
+     */
+    fun stop() {
+        if (session == null) return
+        session = null
+        loadJob?.cancel()
+        loadJob = null
+        renderState.clearRoutePolylines()
+    }
+}
+
+/** Convert every successfully resolved whole-route shape into the existing shared render model. */
+internal fun AdjacencyShapes.toRoutePolylines(): List<RoutePolyline> =
+    shapes.values.flatMap { shape ->
+        shape.polylines
+            .filter { it.size >= 2 }
+            .map { points ->
+                RoutePolyline(
+                    color = shape.route?.color,
+                    points = points,
+                    widthDp = ROUTE_LINE_WIDTH_DP,
+                )
+            }
+    }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/AdjacencyMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/AdjacencyMapController.kt
@@ -21,6 +21,12 @@ import kotlinx.coroutines.launch
 import org.onebusaway.android.map.render.MapRenderState
 import org.onebusaway.android.map.render.ROUTE_LINE_WIDTH_DP
 import org.onebusaway.android.map.render.RoutePolyline
+import org.onebusaway.android.map.render.RoutePolylineTransform
+
+private val ADJACENCY_ROUTE_TRANSFORMS = setOf(
+    RoutePolylineTransform.VIEWPORT_CLIP,
+    RoutePolylineTransform.ZOOM_SIMPLIFY,
+)
 
 /**
  * Draws the whole-route lines for the routes with upcoming arrivals at one focused stop. This is an
@@ -86,6 +92,7 @@ internal fun AdjacencyShapes.toRoutePolylines(): List<RoutePolyline> =
                     color = shape.route?.color,
                     points = points,
                     widthDp = ROUTE_LINE_WIDTH_DP,
+                    transforms = ADJACENCY_ROUTE_TRANSFORMS,
                 )
             }
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/AdjacencyRouteShapeRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/AdjacencyRouteShapeRepository.kt
@@ -33,6 +33,7 @@ import kotlin.time.Duration.Companion.minutes
 import org.onebusaway.android.api.data.MapDataSource
 import org.onebusaway.android.extrapolation.data.BoundedLruCache
 import org.onebusaway.android.map.render.GeoPoint
+import org.onebusaway.android.map.render.simplifyRoutePolyline
 import org.onebusaway.android.models.ObaRoute
 import org.onebusaway.android.models.RouteMapData
 import org.onebusaway.android.time.ElapsedTime
@@ -75,6 +76,7 @@ interface AdjacencyRouteShapeRepository {
 
 private const val MAX_CONCURRENT_ROUTE_FETCHES = 2
 private const val MAX_CACHED_ROUTE_SHAPES = 32
+private const val ADJACENCY_SHAPE_SIMPLIFICATION_METERS = 2.0
 private val ROUTE_SHAPE_CACHE_TTL = 10.minutes
 private const val TAG = "AdjacencyRouteShapes"
 
@@ -199,6 +201,15 @@ internal fun RouteMapData.toAdjacencyShape(routeId: String): AdjacencyRouteShape
     AdjacencyRouteShape(
         routeId = routeId,
         route = route,
-        polylines = polylines.map { line -> line.map(Location::toGeoPoint) },
+        // Simplify once in fetchAndCacheShape's Dispatchers.Default block. Google Maps otherwise has
+        // to retain and retessellate every GTFS shape vertex during a pinch zoom; caching the result
+        // keeps that work out of both the renderer and every later focus on the same route. A fixed
+        // world-space tolerance avoids swapping geometry as the camera crosses zoom levels.
+        polylines = polylines.map { line ->
+            simplifyRoutePolyline(
+                line.map(Location::toGeoPoint),
+                ADJACENCY_SHAPE_SIMPLIFICATION_METERS,
+            )
+        },
         stopIds = stops.mapTo(LinkedHashSet()) { it.stop.id },
     )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/AdjacencyRouteShapeRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/AdjacencyRouteShapeRepository.kt
@@ -30,102 +30,99 @@ import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withContext
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
-import org.onebusaway.android.api.data.MapDataSource
+import org.onebusaway.android.api.data.TripVehiclesDataSource
 import org.onebusaway.android.extrapolation.data.BoundedLruCache
 import org.onebusaway.android.map.render.GeoPoint
 import org.onebusaway.android.map.render.simplifyRoutePolyline
-import org.onebusaway.android.models.ObaRoute
-import org.onebusaway.android.models.RouteMapData
+import org.onebusaway.android.models.TripPatternGeometry
 import org.onebusaway.android.time.ElapsedTime
 import org.onebusaway.android.util.SingleFlight
 
 /**
- * One focused route's whole-route shape for adjacency focus (#1827): the merged (undirected)
- * [polylines] to draw, the [route] for the badge's color/name, and the ids of the [stopIds] it serves
- * (so non-adjacent stops can be minimized). Slimmer than [RouteMap] because several are held at once
- * and adjacency draws only the whole route (no per-direction shapes or direction picker).
+ * One exact trip-pattern shape for adjacency focus (#1827). [shapeId] comes from a trip serving the
+ * selected stop, so [points] cannot include unrelated branches belonging to the same [routeId].
  */
 data class AdjacencyRouteShape(
+    val shapeId: String,
     val routeId: String,
-    val route: ObaRoute?,
-    val polylines: List<List<GeoPoint>>,
-    val stopIds: Set<String>,
+    val routeColor: Int?,
+    val points: List<GeoPoint>,
 )
 
 /**
- * The result of a multi-route shape fetch: the [shapes] that resolved (keyed by route id, in the
- * requested set's iteration order) and the [failedRouteIds] that didn't (network error, non-OK code,
+ * The result of a multi-pattern shape fetch: the [shapes] that resolved (keyed by shape id, in the
+ * requested set's iteration order) and the [failedShapeIds] that didn't (network error, non-OK code,
  * or no API endpoint). The two partition the requested set — a caller draws what resolved and ignores
  * the rest.
  */
 data class AdjacencyShapes(
     val shapes: Map<String, AdjacencyRouteShape>,
-    val failedRouteIds: Set<String>,
+    val failedShapeIds: Set<String>,
 )
 
 /**
- * Fetches the whole-route shapes for a *set* of routes at once — the routes with an upcoming arrival at
- * a tapped stop, drawn together as adjacency focus (#1827). Tolerates partial failure: a route that
- * fails to load lands in [AdjacencyShapes.failedRouteIds] rather than failing the whole call.
+ * Fetches the exact shapes for the distinct trip patterns with an upcoming arrival at a tapped stop.
+ * Tolerates partial failure: a shape that fails lands in [AdjacencyShapes.failedShapeIds] rather than
+ * failing the whole call.
  */
 interface AdjacencyRouteShapeRepository {
 
-    /** Fetches [routeIds]'s shapes concurrently (bounded), cached, and de-duped; never throws per-route. */
-    suspend fun getShapes(routeIds: Set<String>): AdjacencyShapes
+    /** Fetches [tripPatterns] concurrently (bounded), cached, and de-duped; never throws per shape. */
+    suspend fun getShapes(tripPatterns: Set<TripPatternGeometry>): AdjacencyShapes
 }
 
-private const val MAX_CONCURRENT_ROUTE_FETCHES = 2
-private const val MAX_CACHED_ROUTE_SHAPES = 32
+private const val MAX_CONCURRENT_SHAPE_FETCHES = 2
+private const val MAX_CACHED_SHAPES = 32
 private const val ADJACENCY_SHAPE_SIMPLIFICATION_METERS = 2.0
-private val ROUTE_SHAPE_CACHE_TTL = 10.minutes
+private val SHAPE_CACHE_TTL = 10.minutes
 private const val TAG = "AdjacencyRouteShapes"
 
-/** One successfully mapped route shape and the monotonic time it entered the completed cache. */
-private data class CachedRouteShape(
-    val shape: AdjacencyRouteShape,
+/** One successfully mapped shape and the monotonic time it entered the completed cache. */
+private data class CachedShapeGeometry(
+    val points: List<GeoPoint>,
     val storedAt: ElapsedTime,
 )
 
-/** Thread-safe, success-only LRU with an age limit so route-map changes eventually refresh. */
-private class RouteShapeCache(
+/** Thread-safe, success-only LRU with an age limit so GTFS shape changes eventually refresh. */
+private class ShapeGeometryCache(
     maxSize: Int,
     private val ttl: Duration,
     private val now: () -> ElapsedTime,
 ) {
-    private val shapes = BoundedLruCache<String, CachedRouteShape>(maxSize)
+    private val shapes = BoundedLruCache<String, CachedShapeGeometry>(maxSize)
 
     @Synchronized
-    fun get(routeId: String): AdjacencyRouteShape? {
-        val cached = shapes.get(routeId) ?: return null
+    fun get(shapeId: String): List<GeoPoint>? {
+        val cached = shapes.get(shapeId) ?: return null
         return if (now() - cached.storedAt < ttl) {
-            cached.shape
+            cached.points
         } else {
-            shapes.remove(routeId)
+            shapes.remove(shapeId)
             null
         }
     }
 
     @Synchronized
-    fun put(routeId: String, shape: AdjacencyRouteShape) {
-        shapes.put(routeId, CachedRouteShape(shape, now()))
+    fun put(shapeId: String, points: List<GeoPoint>) {
+        shapes.put(shapeId, CachedShapeGeometry(points, now()))
     }
 }
 
 /**
- * Fans out over [MapDataSource.routeMap], one request per route, with three safeguards against a
- * fetch storm at a busy hub (a stop with many upcoming routes = many `stops-for-route` calls):
+ * Fans out over [TripVehiclesDataSource.shape], one request per distinct trip pattern, with three
+ * safeguards against a fetch storm at a busy hub:
  *
- * - **Bounded concurrency** via a [Semaphore] of [MAX_CONCURRENT_ROUTE_FETCHES] permits, so at most N
+ * - **Bounded concurrency** via a [Semaphore] of [MAX_CONCURRENT_SHAPE_FETCHES] permits, so at most N
  *   requests are in flight and the rest queue. This deliberately uses a semaphore rather than
  *   [Dispatchers.IO]`.limitedParallelism` (the [org.onebusaway.android.extrapolation.data.TripObservationFetcher]
  *   precedent): the data source's Retrofit calls are main-safe `suspend` calls that hold no dispatcher
  *   thread while awaiting the response, so a limited dispatcher wouldn't actually bound in-flight
  *   requests — a semaphore held across the `suspend` call does, and it's exercisable under virtual time.
- * - **In-flight de-dup** via [SingleFlight], so a route already being fetched (e.g. an immediate re-tap,
- *   or two routes sharing the set) is joined, not re-requested. The permit is acquired *inside* the
- *   coalesced block so joined callers consume none.
+ * - **In-flight de-dup** via [SingleFlight], so a shape already being fetched (e.g. an immediate
+ *   re-tap, or several arrivals sharing a pattern) is joined, not re-requested. The permit is acquired
+ *   *inside* the coalesced block so joined callers consume none.
  * - **Completed-result cache**: successful shapes live in a 32-entry access-ordered LRU for ten
- *   minutes. This suppresses sequential re-fetches while users focus nearby stops that share routes,
+ *   minutes. This suppresses sequential re-fetches while users focus nearby stops that share shapes,
  *   bounds the potentially large polyline working set, and eventually refreshes server changes.
  *   Failures are never cached, so a later focus can retry them.
  *
@@ -139,77 +136,80 @@ private class RouteShapeCache(
  */
 @Singleton
 class DefaultAdjacencyRouteShapeRepository internal constructor(
-    private val mapDataSource: MapDataSource,
+    private val tripVehiclesDataSource: TripVehiclesDataSource,
     fetchScope: CoroutineScope,
     private val log: (String) -> Unit,
-    cacheSize: Int = MAX_CACHED_ROUTE_SHAPES,
-    cacheTtl: Duration = ROUTE_SHAPE_CACHE_TTL,
+    cacheSize: Int = MAX_CACHED_SHAPES,
+    cacheTtl: Duration = SHAPE_CACHE_TTL,
     now: () -> ElapsedTime = ElapsedTime::now,
 ) : AdjacencyRouteShapeRepository {
 
     @Inject
-    constructor(mapDataSource: MapDataSource) : this(
-        mapDataSource = mapDataSource,
+    constructor(tripVehiclesDataSource: TripVehiclesDataSource) : this(
+        tripVehiclesDataSource = tripVehiclesDataSource,
         fetchScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate),
         log = { Log.w(TAG, it) },
     )
 
-    private val permits = Semaphore(MAX_CONCURRENT_ROUTE_FETCHES)
-    private val shapeFetches = SingleFlight<String, AdjacencyRouteShape>(fetchScope)
-    private val shapeCache = RouteShapeCache(cacheSize, cacheTtl, now)
+    private val permits = Semaphore(MAX_CONCURRENT_SHAPE_FETCHES)
+    private val shapeFetches = SingleFlight<String, List<GeoPoint>>(fetchScope)
+    private val shapeCache = ShapeGeometryCache(cacheSize, cacheTtl, now)
 
-    override suspend fun getShapes(routeIds: Set<String>): AdjacencyShapes = coroutineScope {
-        val results = routeIds
-            .map { id -> async { id to fetchShape(id) } }
+    override suspend fun getShapes(
+        tripPatterns: Set<TripPatternGeometry>
+    ): AdjacencyShapes = coroutineScope {
+        // Shape ids, not trips, are the render identity: several arrivals commonly share one pattern.
+        val patternsByShapeId = LinkedHashMap<String, TripPatternGeometry>()
+        tripPatterns.forEach { patternsByShapeId.putIfAbsent(it.shapeId, it) }
+        val results = patternsByShapeId.values
+            .map { pattern -> async { pattern to fetchShape(pattern.shapeId) } }
             .awaitAll()
         val shapes = LinkedHashMap<String, AdjacencyRouteShape>()
         val failed = LinkedHashSet<String>()
-        for ((id, shape) in results) {
-            if (shape != null) shapes[id] = shape else failed += id
+        for ((pattern, points) in results) {
+            if (points != null) {
+                shapes[pattern.shapeId] = AdjacencyRouteShape(
+                    shapeId = pattern.shapeId,
+                    routeId = pattern.routeId,
+                    routeColor = pattern.routeColor,
+                    points = points,
+                )
+            } else {
+                failed += pattern.shapeId
+            }
         }
         AdjacencyShapes(shapes, failed)
     }
 
     /** Returns a fresh cache hit, or joins/starts a single-flight fetch; null on failure (no throw). */
-    private suspend fun fetchShape(routeId: String): AdjacencyRouteShape? =
-        shapeCache.get(routeId) ?: shapeFetches.run(routeId) {
+    private suspend fun fetchShape(shapeId: String): List<GeoPoint>? =
+        shapeCache.get(shapeId) ?: shapeFetches.run(shapeId) {
             // Re-check inside SingleFlight: a racing request may have populated the cache after this
             // caller's first lookup but before its coalesced block started.
-            shapeCache.get(routeId) ?: fetchAndCacheShape(routeId)
+            shapeCache.get(shapeId) ?: fetchAndCacheShape(shapeId)
         }
 
-    /** Fetches and maps one route, caching only a successful completed shape. */
-    private suspend fun fetchAndCacheShape(routeId: String): AdjacencyRouteShape? {
-        // The permit bounds in-flight network requests only; hold it just for the fetch. routeMap
-        // returns Result; a failure/absent endpoint resolves to null (drawn as a failed id) and
+    /** Fetches and maps one exact GTFS shape, caching only a successful completed shape. */
+    private suspend fun fetchAndCacheShape(shapeId: String): List<GeoPoint>? {
+        // The permit bounds in-flight network requests only; hold it just for the fetch. shape
+        // returns Result; a failure/absent endpoint resolves to null (recorded as a failed id) and
         // never throws, so SingleFlight's own error path (its Log.e) never runs.
-        val data = permits.withPermit {
-            mapDataSource.routeMap(routeId)
-                .onFailure { log("route shape fetch failed for $routeId: $it") }
+        val polyline = permits.withPermit {
+            tripVehiclesDataSource.shape(shapeId)
+                .onFailure { log("trip shape fetch failed for $shapeId: $it") }
                 .getOrNull()
         }
-        // Walking the shape into GeoPoints is CPU-bound; keep it off the main thread (as
-        // MapDataSource already does for the decode) so a busy hub's focus doesn't jank.
-        return data
-            ?.let { withContext(Dispatchers.Default) { it.toAdjacencyShape(routeId) } }
-            ?.also { shapeCache.put(routeId, it) }
+        // Walking the shape into GeoPoints is CPU-bound; keep it off the main thread so a busy hub's
+        // focus doesn't jank.
+        return polyline
+            ?.let {
+                withContext(Dispatchers.Default) {
+                    simplifyRoutePolyline(
+                        it.points.map(Location::toGeoPoint),
+                        ADJACENCY_SHAPE_SIMPLIFICATION_METERS,
+                    )
+                }
+            }
+            ?.also { shapeCache.put(shapeId, it) }
     }
 }
-
-/** Maps a wire [RouteMapData] to the slim adjacency shape, converting shape points to [GeoPoint]. */
-internal fun RouteMapData.toAdjacencyShape(routeId: String): AdjacencyRouteShape =
-    AdjacencyRouteShape(
-        routeId = routeId,
-        route = route,
-        // Simplify once in fetchAndCacheShape's Dispatchers.Default block. Google Maps otherwise has
-        // to retain and retessellate every GTFS shape vertex during a pinch zoom; caching the result
-        // keeps that work out of both the renderer and every later focus on the same route. A fixed
-        // world-space tolerance avoids swapping geometry as the camera crosses zoom levels.
-        polylines = polylines.map { line ->
-            simplifyRoutePolyline(
-                line.map(Location::toGeoPoint),
-                ADJACENCY_SHAPE_SIMPLIFICATION_METERS,
-            )
-        },
-        stopIds = stops.mapTo(LinkedHashSet()) { it.stop.id },
-    )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
@@ -31,6 +31,7 @@ import org.onebusaway.android.R
 import org.onebusaway.android.models.ObaRoute
 import org.onebusaway.android.models.ObaStop
 import org.onebusaway.android.models.RouteMapDirection
+import org.onebusaway.android.models.TripPatternGeometry
 import org.onebusaway.android.api.data.MapDataSource
 import org.onebusaway.android.database.oba.StopCacheRepository
 import org.onebusaway.android.database.oba.StopDao
@@ -39,6 +40,7 @@ import org.onebusaway.android.models.ObaTripStatus
 import org.onebusaway.android.map.bike.BikeStationsRepository
 import org.onebusaway.android.map.render.CameraCommand
 import org.onebusaway.android.map.render.CameraSnapshot
+import org.onebusaway.android.map.render.GeoPoint
 import org.onebusaway.android.map.render.MapRenderState
 import org.onebusaway.android.location.LocationRepository
 import org.onebusaway.android.preferences.PreferencesRepository
@@ -361,11 +363,18 @@ class MapViewModel @Inject constructor(
      * has precedence, and the stop must still be the rendered focus so a stale arrivals result cannot
      * restore an overlay after focus has moved.
      */
-    fun showStopAdjacency(stopId: String, routeIds: Set<String>) {
+    fun showStopAdjacency(
+        stopId: String,
+        stopLat: Double,
+        stopLon: Double,
+        routeIds: Set<String>,
+        tripPatterns: Set<TripPatternGeometry>,
+    ) {
         if (routeController.isActive) return
         val focusedStopId = renderState.snapshot.value.focusedStopId
         if (focusedStopId == null || !focusedStopId.equals(stopId, ignoreCase = true)) return
-        adjacencyController.start(stopId, routeIds)
+        val displayedPatterns = tripPatterns.filterTo(LinkedHashSet()) { it.routeId in routeIds }
+        adjacencyController.start(stopId, GeoPoint(stopLat, stopLon), displayedPatterns)
     }
 
     /** Clear only an active adjacency overlay, leaving any single-route line untouched. */

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
@@ -69,9 +69,10 @@ data class RouteHeader(
 /**
  * The **home map** view model: the coordinator that composes the shared [MapHost] (the flavor-neutral
  * map surface — render state, camera, padding, my-location/region framing) with the use-case
- * controllers the home map needs — [StopsMapController] (nearby stops), [RouteMapController] (a route +
- * its vehicles), and [BikeLayerController] (the bikeshare overlay). [showNearbyStops] / [showRoute] start the
- * matching controller (the route controller is the single source of truth for whether a route is
+ * controllers the home map needs — [StopsMapController] (nearby stops), [AdjacencyMapController]
+ * (focused-stop route lines), [RouteMapController] (a route + its vehicles), and [BikeLayerController]
+ * (the bikeshare overlay). [showNearbyStops] / [showStopAdjacency] start the matching controller (the
+ * route controller is the single source of truth for whether a route is
  * shown — there is no separate "mode" state); the controllers react to the live camera
  * ([MapHost.onCameraIdle]) on [viewModelScope], so there is no imperative host — a flavor adapter only
  * binds to the host.
@@ -97,6 +98,7 @@ class MapViewModel @Inject constructor(
     private val savedStateHandle: SavedStateHandle,
     private val mapDataSource: MapDataSource,
     private val routeRepository: RouteMapRepository,
+    private val adjacencyRouteShapeRepository: AdjacencyRouteShapeRepository,
     private val bikeStationsRepository: BikeStationsRepository,
     private val regionRepo: RegionRepository,
     private val locationRepository: LocationRepository,
@@ -148,6 +150,15 @@ class MapViewModel @Inject constructor(
         // The home map reads through the persistent stop cache (#1754) so stops appear instantly on a
         // slow/cold-start load.
         stopCache = stopCache,
+    )
+
+    // The multi-route line overlay shown while a stop's arrivals drawer is focused. It shares the
+    // route-polyline render slot with route mode, so all view transitions stop it before another
+    // producer starts and its own stop() clears only while it holds an active session.
+    private val adjacencyController = AdjacencyMapController(
+        renderState = mapHost.renderState,
+        repository = adjacencyRouteShapeRepository,
+        scope = viewModelScope,
     )
 
     // ----- Map-host surface (delegated) -----
@@ -291,6 +302,7 @@ class MapViewModel @Inject constructor(
      * above.
      */
     private fun leaveCurrentView() {
+        adjacencyController.stop()
         stopsController.stop()
         routeController.stop()
         bikeController.stop()
@@ -310,6 +322,7 @@ class MapViewModel @Inject constructor(
 
     /** A tap away from any marker clears the stop focus + deselects any vehicle (the old onMapClick). */
     fun onMapTapped() {
+        adjacencyController.stop()
         stopsController.clearStopFocus()
         renderState.setSelectedVehicle(null)
     }
@@ -337,8 +350,26 @@ class MapViewModel @Inject constructor(
     fun focusStop(stop: ObaStop, routes: List<ObaRoute>?, overlayExpanded: Boolean) =
         stopsController.focusStop(stop, routes, overlayExpanded)
 
-    /** Clear the map's render focus (back-press from a peeking arrivals sheet; a Home map directive). */
-    fun clearFocus() = stopsController.clearFocus()
+    /** Clear the map's render focus and adjacency lines (back-press from the arrivals sheet). */
+    fun clearFocus() {
+        adjacencyController.stop()
+        stopsController.clearFocus()
+    }
+
+    /**
+     * Draw the routes with upcoming arrivals at [stopId] without moving the camera. Single-route mode
+     * has precedence, and the stop must still be the rendered focus so a stale arrivals result cannot
+     * restore an overlay after focus has moved.
+     */
+    fun showStopAdjacency(stopId: String, routeIds: Set<String>) {
+        if (routeController.isActive) return
+        val focusedStopId = renderState.snapshot.value.focusedStopId
+        if (focusedStopId == null || !focusedStopId.equals(stopId, ignoreCase = true)) return
+        adjacencyController.start(stopId, routeIds)
+    }
+
+    /** Clear only an active adjacency overlay, leaving any single-route line untouched. */
+    fun clearAdjacency() = adjacencyController.stop()
 
     /** The map's initial camera, read live from the host each time the adapter (re)composes. */
     val cameraSeed: MapCameraSeed get() = mapHost.cameraSeed

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
@@ -62,6 +62,12 @@ const val DEFAULT_ROUTE_LINE_COLOR: Int = 0xFF0000FF.toInt()
  */
 const val ROUTE_LINE_WIDTH_DP: Float = 10f
 
+/** Optional renderer-bound geometry transforms. Lines opt in explicitly; the default is pass-through. */
+enum class RoutePolylineTransform {
+    VIEWPORT_CLIP,
+    ZOOM_SIMPLIFY,
+}
+
 /**
  * One route/itinerary polyline: an ordered list of points and an optional [color]. A null [color]
  * means "use the [DEFAULT_ROUTE_LINE_COLOR]" — choosing the fallback is a display decision, so producers
@@ -78,6 +84,10 @@ const val ROUTE_LINE_WIDTH_DP: Float = 10f
  * [dashed] asks the renderer to draw a dashed stroke instead of solid — set it for a preview/hint line
  * that should read as distinct from the primary route shown (the route-continuation line, #1691), so it
  * doesn't blend into a busy basemap the way a plain solid stroke can.
+ *
+ * [transforms] opts this line into renderer-bound geometry processing. Canonical [points] stay intact in
+ * [MapRenderState] for framing and other consumers; both native adapters apply the requested transforms
+ * only to the list they render. An empty set is a strict pass-through.
  */
 data class RoutePolyline(
     val color: Int?,
@@ -85,6 +95,7 @@ data class RoutePolyline(
     val widthDp: Float? = null,
     val directional: Boolean = false,
     val dashed: Boolean = false,
+    val transforms: Set<RoutePolylineTransform> = emptySet(),
 ) {
     /** The [color] to draw, applying the [DEFAULT_ROUTE_LINE_COLOR] fallback in one place for every renderer. */
     val resolvedColor: Int get() = color ?: DEFAULT_ROUTE_LINE_COLOR

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/RoutePolylineRenderPipeline.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/RoutePolylineRenderPipeline.kt
@@ -1,0 +1,344 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.map.render
+
+import java.util.ArrayDeque
+import kotlin.math.PI
+import kotlin.math.atan
+import kotlin.math.cos
+import kotlin.math.exp
+import kotlin.math.ln
+import kotlin.math.pow
+import kotlin.math.tan
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapLatest
+import kotlinx.coroutines.withContext
+import org.onebusaway.android.util.EARTH_RADIUS_METERS
+
+private const val MAX_MERCATOR_LATITUDE = 85.05112878
+private const val VIEWPORT_MARGIN_MULTIPLIER = 1.0
+private const val SIMPLIFICATION_ERROR_PIXELS = 0.75
+private const val MIN_SIMPLIFICATION_METERS = 2.0
+private const val METERS_PER_PIXEL_AT_EQUATOR_ZOOM_ZERO = 156543.03392804097
+private const val COORDINATE_EPSILON = 1e-12
+
+internal data class RoutePolylineRenderContext(val camera: CameraSnapshot?)
+
+internal fun interface RoutePolylineRenderPass {
+    fun apply(polylines: List<RoutePolyline>, context: RoutePolylineRenderContext): List<RoutePolyline>
+}
+
+/** Ordered, flavor-neutral processing of canonical route geometry before a native renderer sees it. */
+internal class RoutePolylineRenderPipeline(
+    private val passes: List<RoutePolylineRenderPass>,
+) {
+    fun apply(polylines: List<RoutePolyline>, camera: CameraSnapshot?): List<RoutePolyline> =
+        passes.fold(polylines) { current, pass ->
+            pass.apply(current, RoutePolylineRenderContext(camera))
+        }
+}
+
+private val DEFAULT_ROUTE_POLYLINE_PIPELINE = RoutePolylineRenderPipeline(
+    listOf(ViewportClipRoutePolylinePass(), ZoomSimplifyRoutePolylinePass())
+)
+
+/**
+ * Combines canonical geometry with the last settled camera and performs opt-in transforms away from
+ * the UI thread. Collection resumes in the adapter's main-thread scope for native map mutations.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+internal fun routePolylineRenderFlow(
+    snapshot: StateFlow<MapRenderSnapshot>,
+    camera: StateFlow<CameraSnapshot?>,
+    dispatcher: CoroutineDispatcher = Dispatchers.Default,
+    pipeline: RoutePolylineRenderPipeline = DEFAULT_ROUTE_POLYLINE_PIPELINE,
+): Flow<List<RoutePolyline>> =
+    combine(
+        snapshot.map { it.routePolylines }.distinctUntilChanged(),
+        camera,
+    ) { polylines, viewport -> polylines to viewport }
+        .mapLatest { (polylines, viewport) ->
+            withContext(dispatcher) { pipeline.apply(polylines, viewport) }
+        }
+        .distinctUntilChanged()
+
+internal class ViewportClipRoutePolylinePass : RoutePolylineRenderPass {
+    override fun apply(
+        polylines: List<RoutePolyline>,
+        context: RoutePolylineRenderContext,
+    ): List<RoutePolyline> {
+        if (polylines.none { RoutePolylineTransform.VIEWPORT_CLIP in it.transforms }) return polylines
+        val camera = context.camera
+            ?: return polylines.filterNot { RoutePolylineTransform.VIEWPORT_CLIP in it.transforms }
+        val clipBounds = camera.toPaddedMercatorBounds()
+        return buildList {
+            for (polyline in polylines) {
+                if (RoutePolylineTransform.VIEWPORT_CLIP !in polyline.transforms) {
+                    add(polyline)
+                } else {
+                    clipPolyline(polyline, camera.center.longitude, clipBounds).forEach(::add)
+                }
+            }
+        }
+    }
+}
+
+internal class ZoomSimplifyRoutePolylinePass : RoutePolylineRenderPass {
+    override fun apply(
+        polylines: List<RoutePolyline>,
+        context: RoutePolylineRenderContext,
+    ): List<RoutePolyline> {
+        if (polylines.none { RoutePolylineTransform.ZOOM_SIMPLIFY in it.transforms }) return polylines
+        val camera = context.camera ?: return polylines
+        val latitude = camera.center.latitude.coerceIn(-MAX_MERCATOR_LATITUDE, MAX_MERCATOR_LATITUDE)
+        val metresPerPixel = METERS_PER_PIXEL_AT_EQUATOR_ZOOM_ZERO *
+            cos(Math.toRadians(latitude)) / 2.0.pow(camera.zoom.coerceIn(0.0, 30.0))
+        val tolerance = maxOf(MIN_SIMPLIFICATION_METERS, metresPerPixel * SIMPLIFICATION_ERROR_PIXELS)
+        var changed = false
+        val simplified = polylines.map { polyline ->
+            if (RoutePolylineTransform.ZOOM_SIMPLIFY !in polyline.transforms) return@map polyline
+            val points = simplifyRoutePolyline(polyline.points, tolerance)
+            if (points === polyline.points) {
+                polyline
+            } else {
+                changed = true
+                polyline.copy(points = points)
+            }
+        }
+        return if (changed) simplified else polylines
+    }
+}
+
+internal data class MercatorPoint(
+    val x: Double,
+    val y: Double,
+    val source: GeoPoint? = null,
+)
+
+internal data class MercatorBounds(
+    val left: Double,
+    val right: Double,
+    val bottom: Double,
+    val top: Double,
+) {
+    fun contains(point: MercatorPoint): Boolean =
+        point.x in left..right && point.y in bottom..top
+}
+
+private data class ClippedSegment(val start: MercatorPoint, val end: MercatorPoint)
+
+internal fun CameraSnapshot.toPaddedMercatorBounds(): MercatorBounds {
+    val west = projectedLongitude(southWest.longitude, center.longitude)
+    var east = projectedLongitude(northEast.longitude, center.longitude)
+    if (east < west) east += 2.0 * PI
+    val south = projectedLatitude(southWest.latitude)
+    val north = projectedLatitude(northEast.latitude)
+    val horizontalMargin = (east - west) * VIEWPORT_MARGIN_MULTIPLIER
+    val verticalMargin = (north - south) * VIEWPORT_MARGIN_MULTIPLIER
+    return MercatorBounds(
+        left = west - horizontalMargin,
+        right = east + horizontalMargin,
+        bottom = south - verticalMargin,
+        top = north + verticalMargin,
+    )
+}
+
+internal fun clipPolyline(
+    polyline: RoutePolyline,
+    centerLongitude: Double,
+    bounds: MercatorBounds,
+): List<RoutePolyline> {
+    if (polyline.points.size < 2) return emptyList()
+    val projected = polyline.points.map { it.toMercator(centerLongitude) }
+    if (projected.all(bounds::contains)) return listOf(polyline)
+
+    val fragments = mutableListOf<MutableList<MercatorPoint>>()
+    var current: MutableList<MercatorPoint>? = null
+    fun finishCurrent() {
+        current?.takeIf { it.size >= 2 }?.let(fragments::add)
+        current = null
+    }
+
+    for (index in 0 until projected.lastIndex) {
+        val clipped = clipSegment(projected[index], projected[index + 1], bounds)
+        if (clipped == null) {
+            finishCurrent()
+            continue
+        }
+        val fragment = current
+        if (fragment == null || !fragment.last().samePosition(clipped.start)) {
+            finishCurrent()
+            current = mutableListOf(clipped.start, clipped.end)
+        } else if (!fragment.last().samePosition(clipped.end)) {
+            fragment.add(clipped.end)
+        }
+    }
+    finishCurrent()
+
+    return fragments.map { fragment ->
+        polyline.copy(points = fragment.map(MercatorPoint::toGeoPoint))
+    }
+}
+
+private fun clipSegment(
+    start: MercatorPoint,
+    end: MercatorPoint,
+    bounds: MercatorBounds,
+): ClippedSegment? {
+    val dx = end.x - start.x
+    val dy = end.y - start.y
+    var entry = 0.0
+    var exit = 1.0
+
+    fun retain(p: Double, q: Double): Boolean {
+        if (p == 0.0) return q >= 0.0
+        val ratio = q / p
+        if (p < 0.0) {
+            if (ratio > exit) return false
+            if (ratio > entry) entry = ratio
+        } else {
+            if (ratio < entry) return false
+            if (ratio < exit) exit = ratio
+        }
+        return true
+    }
+
+    if (!retain(-dx, start.x - bounds.left) ||
+        !retain(dx, bounds.right - start.x) ||
+        !retain(-dy, start.y - bounds.bottom) ||
+        !retain(dy, bounds.top - start.y)
+    ) {
+        return null
+    }
+    return ClippedSegment(
+        start = interpolate(start, end, entry),
+        end = interpolate(start, end, exit),
+    )
+}
+
+private fun interpolate(start: MercatorPoint, end: MercatorPoint, fraction: Double): MercatorPoint =
+    when {
+        fraction <= COORDINATE_EPSILON -> start
+        fraction >= 1.0 - COORDINATE_EPSILON -> end
+        else -> MercatorPoint(
+            x = start.x + (end.x - start.x) * fraction,
+            y = start.y + (end.y - start.y) * fraction,
+        )
+    }
+
+private fun GeoPoint.toMercator(centerLongitude: Double): MercatorPoint = MercatorPoint(
+    x = projectedLongitude(longitude, centerLongitude),
+    y = projectedLatitude(latitude),
+    source = this,
+)
+
+private fun MercatorPoint.toGeoPoint(): GeoPoint = source ?: GeoPoint(
+    latitude = Math.toDegrees(2.0 * atan(exp(y)) - PI / 2.0),
+    longitude = normalizeLongitude(Math.toDegrees(x)),
+)
+
+private fun MercatorPoint.samePosition(other: MercatorPoint): Boolean =
+    kotlin.math.abs(x - other.x) <= COORDINATE_EPSILON &&
+        kotlin.math.abs(y - other.y) <= COORDINATE_EPSILON
+
+private fun projectedLongitude(longitude: Double, centerLongitude: Double): Double {
+    var delta = longitude - centerLongitude
+    while (delta > 180.0) delta -= 360.0
+    while (delta < -180.0) delta += 360.0
+    return Math.toRadians(centerLongitude + delta)
+}
+
+private fun projectedLatitude(latitude: Double): Double {
+    val radians = Math.toRadians(latitude.coerceIn(-MAX_MERCATOR_LATITUDE, MAX_MERCATOR_LATITUDE))
+    return ln(tan(PI / 4.0 + radians / 2.0))
+}
+
+private fun normalizeLongitude(longitude: Double): Double {
+    var normalized = longitude
+    while (normalized > 180.0) normalized -= 360.0
+    while (normalized < -180.0) normalized += 360.0
+    return normalized
+}
+
+/** Douglas-Peucker simplification in a local metre projection. Endpoints are always retained. */
+internal fun simplifyRoutePolyline(points: List<GeoPoint>, toleranceMeters: Double): List<GeoPoint> {
+    if (points.size <= 2 || toleranceMeters <= 0.0) return points
+
+    val meanLatitudeRadians = Math.toRadians(points.sumOf(GeoPoint::latitude) / points.size)
+    val longitudeScale = EARTH_RADIUS_METERS * cos(meanLatitudeRadians)
+    val latitudeScale = EARTH_RADIUS_METERS
+    val originLatitudeRadians = Math.toRadians(points.first().latitude)
+    val originLongitudeRadians = Math.toRadians(points.first().longitude)
+    val x = DoubleArray(points.size)
+    val y = DoubleArray(points.size)
+    for (index in points.indices) {
+        var longitudeDelta = Math.toRadians(points[index].longitude) - originLongitudeRadians
+        if (longitudeDelta > PI) longitudeDelta -= 2.0 * PI
+        if (longitudeDelta < -PI) longitudeDelta += 2.0 * PI
+        x[index] = longitudeDelta * longitudeScale
+        y[index] = (Math.toRadians(points[index].latitude) - originLatitudeRadians) * latitudeScale
+    }
+
+    val keep = BooleanArray(points.size)
+    keep[0] = true
+    keep[points.lastIndex] = true
+    val ranges = ArrayDeque<IntRange>()
+    ranges.addLast(0..points.lastIndex)
+    val toleranceSquared = toleranceMeters * toleranceMeters
+
+    while (ranges.isNotEmpty()) {
+        val range = ranges.removeLast()
+        val start = range.first
+        val end = range.last
+        val segmentX = x[end] - x[start]
+        val segmentY = y[end] - y[start]
+        val segmentLengthSquared = segmentX * segmentX + segmentY * segmentY
+        var farthestIndex = -1
+        var farthestDistanceSquared = toleranceSquared
+
+        for (index in start + 1 until end) {
+            val fraction = if (segmentLengthSquared == 0.0) {
+                0.0
+            } else {
+                (((x[index] - x[start]) * segmentX + (y[index] - y[start]) * segmentY) /
+                    segmentLengthSquared).coerceIn(0.0, 1.0)
+            }
+            val offsetX = x[index] - (x[start] + fraction * segmentX)
+            val offsetY = y[index] - (y[start] + fraction * segmentY)
+            val distanceSquared = offsetX * offsetX + offsetY * offsetY
+            if (distanceSquared > farthestDistanceSquared) {
+                farthestDistanceSquared = distanceSquared
+                farthestIndex = index
+            }
+        }
+
+        if (farthestIndex >= 0) {
+            keep[farthestIndex] = true
+            ranges.addLast(start..farthestIndex)
+            ranges.addLast(farthestIndex..end)
+        }
+    }
+
+    if (keep.all { it }) return points
+    return points.filterIndexed { index, _ -> keep[index] }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/models/MapData.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/models/MapData.kt
@@ -26,6 +26,17 @@ data class NearbyStops(
 )
 
 /**
+ * One distinct trip pattern to draw for a focused stop. [shapeId] identifies the exact GTFS shape
+ * used by an upcoming trip, rather than the union of every branch belonging to [routeId]. Multiple
+ * arrivals that share a shape collapse to one instance before the map fetches or renders it.
+ */
+data class TripPatternGeometry(
+    val shapeId: String,
+    val routeId: String,
+    val routeColor: Int?,
+)
+
+/**
  * A route's stops, the serving routes (for stop-marker icons), the route + agency name, and its
  * decoded shape. Polylines are [Location] points (the neutral geo type); the map layer turns them
  * into its render `GeoPoint`s. Each [RouteMapStop] carries the direction(s) it serves, so the overlay

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.kt
@@ -296,7 +296,7 @@ class HomeActivity : AppCompatActivity() {
      */
     private fun onArrivalsLoaded(loaded: ArrivalsLoaded) {
         val stop = loaded.stop ?: return
-        viewModel.onArrivalsLoaded(stop, loaded.routes, loaded.routeIds)
+        viewModel.onArrivalsLoaded(stop, loaded.routes, loaded.routeIds, loaded.tripPatterns)
     }
 
     private fun goToSendFeedBack() {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsRepository.kt
@@ -39,6 +39,7 @@ import org.onebusaway.android.database.oba.markStopUsed
 import org.onebusaway.android.models.ObaRoute
 import org.onebusaway.android.models.ObaSituation
 import org.onebusaway.android.models.ObaStop
+import org.onebusaway.android.models.TripPatternGeometry
 import org.onebusaway.android.time.ElapsedTime
 import org.onebusaway.android.time.ServerTime
 import org.onebusaway.android.models.contentKey
@@ -206,6 +207,9 @@ data class ArrivalsLoaded(
      *  from the computed [ArrivalsData.routeGroups] (which reflects the past-arrivals filter), not the
      *  raw response, so it matches what the drawer shows. */
     val routeIds: Set<String>,
+    /** The exact distinct GTFS shapes used by the displayed arrivals' trips. Unlike [routeIds], this
+     *  does not expand a route into unrelated branches or variants. */
+    val tripPatterns: Set<TripPatternGeometry>,
 )
 
 /** The fields the service-alert dialog shows, decoupled from `ObaSituation`. */
@@ -476,14 +480,15 @@ class DefaultArrivalsRepository @Inject constructor(
 
     override fun lastLoaded(): ArrivalsLoaded? = lastGood.get()?.loaded
 
-    /** Pairs the response's stop/routes/hasArrivals with the drawer-1:1 route set derived from the
-     *  *computed* [data] (see [ArrivalsLoaded.routeIds]). */
+    /** Pairs the response's stop/routes/hasArrivals with the drawer-1:1 route set and exact trip
+     *  shapes derived from the *computed* [data] (see [ArrivalsLoaded.routeIds]). */
     private fun loadedSnapshot(snapshot: StopArrivals, data: ArrivalsData): ArrivalsLoaded =
         ArrivalsLoaded(
             stop = snapshot.stop,
             routes = snapshot.routes,
             hasArrivals = snapshot.hasArrivals,
             routeIds = focusedRouteIds(data.routeGroups),
+            tripPatterns = snapshot.tripPatternGeometries(data.arrivals.map { it.tripId }),
         )
 
     companion object {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
@@ -78,7 +78,7 @@ class HomeViewModel @Inject constructor(
     private val _mapBottomPadding = MutableStateFlow(0)
     val mapBottomPadding: StateFlow<Int> = _mapBottomPadding.asStateFlow()
 
-    // One-shot outbound map interactions (recenter / show route / focus / clear focus) that can't be
+    // One-shot outbound map interactions (recenter / show route / adjacency / focus) that can't be
     // modeled as state. MapFeature collects these and calls the map view model — so this VM needs no
     // reference to the map's VM (the seam the old MapInteractionBus filled). Buffered so a directive
     // issued just before the collector is active isn't dropped.
@@ -118,7 +118,7 @@ class HomeViewModel @Inject constructor(
     private var pendingMapFocus: Boolean = false
 
     // The routes with an upcoming arrival at the focused stop (the drawer's rows, 1:1) — the input to
-    // adjacency focus (#1827). Pure coordination state consumed imperatively by the map (phase 2), not
+    // adjacency focus (#1827). Pure coordination state carried to the map in ShowStopAdjacency, not
     // composed off, so it's a plain property like [settledSheet]; not saved-state (arrivals reload and
     // repopulate it after a restore).
     var focusedRouteIds: Set<String> = emptySet()
@@ -126,9 +126,16 @@ class HomeViewModel @Inject constructor(
 
     /** A map stop gained focus (non-null) or focus was cleared (null). Persists across process death. */
     fun onStopFocused(stop: FocusedStop?) {
-        // Reset the adjacency route set on any focus change (switch or clear) so the previous stop's
-        // routes don't leak; a fresh arrivals load repopulates it (#1827).
-        focusedRouteIds = emptySet()
+        val previousId = _uiState.value.focusedStop?.id
+        val sameStop = previousId?.equals(stop?.id, ignoreCase = true) ?: (stop == null)
+        // Clear the prior stop's adjacency session immediately; a fresh arrivals load starts the new
+        // one. A same-stop re-selection is a no-op so it cannot discard a completed overlay.
+        if (!sameStop || stop == null) {
+            focusedRouteIds = emptySet()
+        }
+        if (!sameStop) {
+            emitMapDirective(MapDirective.ClearAdjacency)
+        }
         savedState[KEY_STOP_ID] = stop?.id
         savedState[KEY_STOP_NAME] = stop?.name
         savedState[KEY_STOP_CODE] = stop?.code
@@ -234,19 +241,21 @@ class HomeViewModel @Inject constructor(
     /**
      * Arrivals loaded for the focused [stop]. Records the drawer's [routeIds] for adjacency focus
      * (#1827) on every load. Then, if a restore/deep-link focus is pending, consume the latch and tell
-     * the map to focus it (recenter + add the marker) via [mapDirectives] — so the map reacts to a
-     * directive rather than the activity relaying one VM's decision into another's method. A fresh map
-     * tap already centered the stop and set no pending focus, so beyond recording the routes it's a no-op.
+     * the map to focus it (recenter + add the marker) via [mapDirectives]. Then activates adjacency for
+     * the loaded route set; a fresh map tap already established the render focus, while a restore emits
+     * [MapDirective.FocusStop] first so the map can validate the adjacency request against that focus.
      */
     fun onArrivalsLoaded(stop: ObaStop, routes: List<ObaRoute>?, routeIds: Set<String>) {
         // Record the drawer's routes on every load (not just a pending restore focus) — adjacency focus
         // reads this whenever the map wants it (#1827).
         focusedRouteIds = routeIds
-        if (!pendingMapFocus) {
-            return
+        if (pendingMapFocus) {
+            pendingMapFocus = false
+            emitMapDirective(MapDirective.FocusStop(stop, routes, settledSheet == ArrivalsSheetState.Expanded))
         }
-        pendingMapFocus = false
-        emitMapDirective(MapDirective.FocusStop(stop, routes, settledSheet == ArrivalsSheetState.Expanded))
+        // FocusStop must be dispatched first on restore so the map can validate this stop as the
+        // current rendered focus before starting its adjacency session.
+        emitMapDirective(MapDirective.ShowStopAdjacency(stop.id, focusedRouteIds))
     }
 
     /** Animate the map's camera back onto the focused stop, if one is focused (else a no-op). */
@@ -393,6 +402,12 @@ sealed interface MapDirective {
 
     /** Enter route mode for [request]'s route (the "show vehicles on map" action). */
     data class ShowRoute(val request: ShowRouteRequest) : MapDirective
+
+    /** Draw all upcoming routes for the currently focused stop, without reframing the camera. */
+    data class ShowStopAdjacency(val stopId: String, val routeIds: Set<String>) : MapDirective
+
+    /** Clear an active adjacency overlay when the focused stop changes or is removed. */
+    object ClearAdjacency : MapDirective
 
     /** Clear the map's render focus (back-press from a peeking arrivals sheet). */
     object ClearFocus : MapDirective

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
@@ -25,6 +25,7 @@ import org.onebusaway.android.map.ShowRouteRequest
 import org.onebusaway.android.region.Region
 import org.onebusaway.android.models.ObaRoute
 import org.onebusaway.android.models.ObaStop
+import org.onebusaway.android.models.TripPatternGeometry
 import org.onebusaway.android.location.LocationRepository
 import org.onebusaway.android.region.RegionRepository
 import org.onebusaway.android.region.RegionStatus
@@ -124,6 +125,10 @@ class HomeViewModel @Inject constructor(
     var focusedRouteIds: Set<String> = emptySet()
         private set
 
+    /** Exact trip-pattern shapes for the focused stop; route ids remain separate for stop adjacency. */
+    var focusedTripPatterns: Set<TripPatternGeometry> = emptySet()
+        private set
+
     /** A map stop gained focus (non-null) or focus was cleared (null). Persists across process death. */
     fun onStopFocused(stop: FocusedStop?) {
         val previousId = _uiState.value.focusedStop?.id
@@ -132,6 +137,7 @@ class HomeViewModel @Inject constructor(
         // one. A same-stop re-selection is a no-op so it cannot discard a completed overlay.
         if (!sameStop || stop == null) {
             focusedRouteIds = emptySet()
+            focusedTripPatterns = emptySet()
         }
         if (!sameStop) {
             emitMapDirective(MapDirective.ClearAdjacency)
@@ -245,17 +251,31 @@ class HomeViewModel @Inject constructor(
      * the loaded route set; a fresh map tap already established the render focus, while a restore emits
      * [MapDirective.FocusStop] first so the map can validate the adjacency request against that focus.
      */
-    fun onArrivalsLoaded(stop: ObaStop, routes: List<ObaRoute>?, routeIds: Set<String>) {
+    fun onArrivalsLoaded(
+        stop: ObaStop,
+        routes: List<ObaRoute>?,
+        routeIds: Set<String>,
+        tripPatterns: Set<TripPatternGeometry> = emptySet(),
+    ) {
         // Record the drawer's routes on every load (not just a pending restore focus) — adjacency focus
         // reads this whenever the map wants it (#1827).
         focusedRouteIds = routeIds
+        focusedTripPatterns = tripPatterns
         if (pendingMapFocus) {
             pendingMapFocus = false
             emitMapDirective(MapDirective.FocusStop(stop, routes, settledSheet == ArrivalsSheetState.Expanded))
         }
         // FocusStop must be dispatched first on restore so the map can validate this stop as the
         // current rendered focus before starting its adjacency session.
-        emitMapDirective(MapDirective.ShowStopAdjacency(stop.id, focusedRouteIds))
+        emitMapDirective(
+            MapDirective.ShowStopAdjacency(
+                stopId = stop.id,
+                stopLat = stop.latitude,
+                stopLon = stop.longitude,
+                routeIds = focusedRouteIds,
+                tripPatterns = focusedTripPatterns,
+            )
+        )
     }
 
     /** Animate the map's camera back onto the focused stop, if one is focused (else a no-op). */
@@ -404,7 +424,13 @@ sealed interface MapDirective {
     data class ShowRoute(val request: ShowRouteRequest) : MapDirective
 
     /** Draw all upcoming routes for the currently focused stop, without reframing the camera. */
-    data class ShowStopAdjacency(val stopId: String, val routeIds: Set<String>) : MapDirective
+    data class ShowStopAdjacency(
+        val stopId: String,
+        val stopLat: Double,
+        val stopLon: Double,
+        val routeIds: Set<String>,
+        val tripPatterns: Set<TripPatternGeometry> = emptySet(),
+    ) : MapDirective
 
     /** Clear an active adjacency overlay when the focused stop changes or is removed. */
     object ClearAdjacency : MapDirective

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
@@ -202,7 +202,13 @@ fun MapFeature(
                     mapViewModel.recenterOnFocusedStop(directive.lat, directive.lon)
                 is MapDirective.ShowRoute -> mapViewModel.toRoute(directive.request)
                 is MapDirective.ShowStopAdjacency ->
-                    mapViewModel.showStopAdjacency(directive.stopId, directive.routeIds)
+                    mapViewModel.showStopAdjacency(
+                        directive.stopId,
+                        directive.stopLat,
+                        directive.stopLon,
+                        directive.routeIds,
+                        directive.tripPatterns,
+                    )
                 MapDirective.ClearAdjacency -> mapViewModel.clearAdjacency()
                 MapDirective.ClearFocus -> mapViewModel.clearFocus()
                 is MapDirective.FocusStop ->

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
@@ -201,6 +201,9 @@ fun MapFeature(
                 is MapDirective.RecenterOnFocusedStop ->
                     mapViewModel.recenterOnFocusedStop(directive.lat, directive.lon)
                 is MapDirective.ShowRoute -> mapViewModel.toRoute(directive.request)
+                is MapDirective.ShowStopAdjacency ->
+                    mapViewModel.showStopAdjacency(directive.stopId, directive.routeIds)
+                MapDirective.ClearAdjacency -> mapViewModel.clearAdjacency()
                 MapDirective.ClearFocus -> mapViewModel.clearFocus()
                 is MapDirective.FocusStop ->
                     mapViewModel.focusStop(directive.stop, directive.routes, directive.overlayExpanded)

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
@@ -44,9 +44,11 @@ import org.onebusaway.android.map.render.BikeMarker
 import org.onebusaway.android.map.render.CorrectionSmoother
 import org.onebusaway.android.map.render.GeoPoint
 import org.onebusaway.android.map.render.MapPing
+import org.onebusaway.android.map.render.MapRenderSnapshot
 import org.onebusaway.android.map.render.MapRenderState
 import org.onebusaway.android.map.render.PingTarget
 import org.onebusaway.android.map.render.MapVehicles
+import org.onebusaway.android.map.render.RoutePolyline
 import org.onebusaway.android.map.render.StopBand
 import org.onebusaway.android.map.render.StopIconKind
 import org.onebusaway.android.map.render.StopMarker
@@ -67,11 +69,12 @@ import org.onebusaway.android.util.getRouteDisplayName
  * `StopOverlay` used), keeping marker→data maps so the host can route taps back to focus/info-window
  * handlers.
  *
- * Two redraw paths, mirroring the Google flavor's two recomposition boundaries:
- *  - [renderStatic] clear-and-redraws the static annotations (route polylines / bikes / generics /
- *    trip-stop dots) and reconciles the stop markers in place ([reconcileStopMarkers], so unchanged
- *    stops don't blink), driven by snapshot/trip-stop changes (viewport loads, the vehicle poll,
- *    focus) — a bounded cost.
+ * Three redraw paths split by update cadence:
+ *  - [renderRoutePolylines] independently reconciles the infrequently-changing route layer, so
+ *    stop-only viewport updates retain every long native line.
+ *  - [renderStatic] clear-and-redraws the remaining static annotations (bikes / generics / trip-stop
+ *    dots) and reconciles stop markers in place ([reconcileStopMarkers], so unchanged stops neither
+ *    blink nor receive redundant native position writes).
  *  - [renderDynamic] (the live vehicle markers + the selected vehicle's band/fast-estimate marker) is pulled each
  *    display frame by the adapter's vsync loop. It updates marker positions **in place** (so an open
  *    info window survives and there's no per-frame flicker) and only adds/removes annotations as the
@@ -114,9 +117,15 @@ class MapLibreRenderer(
 
     private val vehicleByMarker = HashMap<Marker, VehicleMarker>()
 
-    // The static annotations added by the last [renderStatic], removed (not map.clear()) on the next so
-    // the per-frame dynamic layer below survives a static redraw.
+    // The non-route static annotations added by the last [renderStatic], removed (not map.clear()) on
+    // the next so the retained route and per-frame dynamic layers survive a static redraw.
     private val staticAnnotations = mutableListOf<Annotation>()
+
+    // Whole-route lines are reconciled independently from the combined static snapshot: stop list,
+    // focus, or bike changes retain these native polylines. Snapshot copies keep the same List instance,
+    // making the common stop-only update an O(1) identity check; equal republished values are retained too.
+    private val routePolylines = mutableListOf<Polyline>()
+    private var renderedRoutePolylines: List<RoutePolyline> = emptyList()
 
     // The dynamic layer, tracked by identity so [renderDynamic] can move markers in place: route
     // vehicles keyed by active trip id, the trip-focus estimate markers keyed by role, and the band's
@@ -161,10 +170,9 @@ class MapLibreRenderer(
     private val pingPaint by lazy { Paint(Paint.ANTI_ALIAS_FLAG).apply { style = Paint.Style.STROKE } }
 
     /** Redraw the static layer (everything but the live vehicles + trip-focus overlay). */
-    fun renderStatic() {
-        val snapshot = renderState.snapshot.value
-        // Remove only our own static annotations (not map.clear(), which would also wipe the per-frame
-        // dynamic layer), then redraw them from the snapshot. Classic annotations have no diffing.
+    fun renderStatic(snapshot: MapRenderSnapshot = renderState.snapshot.value) {
+        // Remove only our own non-route static annotations (not map.clear(), which would also wipe the
+        // retained route and per-frame dynamic layers), then redraw them from the snapshot.
         if (staticAnnotations.isNotEmpty()) {
             map.removeAnnotations(staticAnnotations)
             staticAnnotations.clear()
@@ -172,14 +180,6 @@ class MapLibreRenderer(
         // Stop markers are reconciled in place (not in staticAnnotations), so they survive this; only
         // the bike tap map is cleared here.
         bikeByMarker.clear()
-
-        for (polyline in snapshot.routePolylines) {
-            val options = PolylineOptions().color(polyline.resolvedColor).width(polyline.widthDp ?: ROUTE_WIDTH_DP)
-            for (point in polyline.points) {
-                options.add(point.toLatLng())
-            }
-            staticAnnotations.add(map.addPolyline(options))
-        }
 
         reconcileStopMarkers(snapshot.stops, snapshot.focusedStopId, snapshot.stopBand)
 
@@ -215,6 +215,23 @@ class MapLibreRenderer(
                     MarkerOptions().position(generic.point.toLatLng())
                 )
             )
+        }
+    }
+
+    /** Reconcile the independently collected route layer, retaining equal native polylines. */
+    fun renderRoutePolylines(next: List<RoutePolyline> = renderState.snapshot.value.routePolylines) {
+        if (renderedRoutePolylines === next || renderedRoutePolylines == next) return
+
+        if (routePolylines.isNotEmpty()) map.removeAnnotations(routePolylines)
+        routePolylines.clear()
+        renderedRoutePolylines = next
+
+        for (polyline in next) {
+            val options = PolylineOptions().color(polyline.resolvedColor).width(polyline.widthDp ?: ROUTE_WIDTH_DP)
+            for (point in polyline.points) {
+                options.add(point.toLatLng())
+            }
+            routePolylines.add(map.addPolyline(options))
         }
     }
 
@@ -254,13 +271,15 @@ class MapLibreRenderer(
                 )
                 // Only the markers whose icon kind changed need a new icon (maplibre centers the icon
                 // on the position, so the dot/star/circle lands on the stop with no anchor change).
-                // Position and the backing StopMarker are refreshed unconditionally, since a projected
-                // route stop can keep the same kind (ROUTE_CIRCLE) while its on-route point moves —
-                // gating those on the kind change would strand the marker at a stale coordinate.
+                // Geometry and tap data are compared with the previously rendered model below: a
+                // projected route stop can move without a kind change, but the common retained nearby
+                // stop now avoids a redundant native position write.
                 if (previousKind != kind) {
                     existing.icon = stopIcon(stop, kind)
                 }
-                existing.position = stop.point.toLatLng()
+                if (stopByMarker[existing]?.point != stop.point) {
+                    existing.position = stop.point.toLatLng()
+                }
                 stopByMarker[existing] = stop
             }
         }

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreComposeAdapter.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreComposeAdapter.kt
@@ -61,7 +61,9 @@ import org.onebusaway.android.util.PermissionUtils
 import org.onebusaway.android.util.ThemeUtils
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.map
 import kotlin.math.abs
 
 private const val STYLE_URL_LIGHT = "https://tiles.openfreemap.org/styles/liberty"
@@ -74,10 +76,10 @@ private const val FRAME_INTERVAL_NANOS = 8_333_333L
  * maplibre flavor's [ObaComposeMapAdapter]: hosts the classic maplibre [MapView] inside an
  * [AndroidView] (there is no maplibre-compose), bridging the MapView's imperative lifecycle to Compose
  * via a [LifecycleEventObserver], and drives the [MapHost]: it sets the style, builds the
- * [MapLibreRenderer] and re-renders on every render-state change, wires map/marker/info-window clicks
- * to [callbacks], reports camera idles to [MapHost.onCameraIdle], applies the render state's camera
- * gestures + retained framing intent, and enables the location blue dot from the host's
- * permission-derived flag. There is no imperative host.
+ * [MapLibreRenderer] and collects its static and route layers independently, wires
+ * map/marker/info-window clicks to [callbacks], reports camera idles to [MapHost.onCameraIdle], applies
+ * the render state's camera gestures + retained framing intent, and enables the location blue dot from
+ * the host's permission-derived flag. There is no imperative host.
  *
  * Lifecycle note: `addObserver` on an already-STARTED/RESUMED lifecycle synchronously dispatches the
  * upward events, so the MapView still receives `onStart`/`onResume` when it enters composition late.
@@ -167,6 +169,7 @@ class MapLibreComposeAdapter : ObaComposeMapAdapter {
                         val target = map.cameraPosition.target
                         if (target != null) host.onCameraIdle(snapshot(map, target)) else host.onCameraSettled()
                     }
+                    r.renderRoutePolylines()
                     r.renderStatic()
                 }
             }
@@ -176,10 +179,22 @@ class MapLibreComposeAdapter : ObaComposeMapAdapter {
         // Re-render the maplibre annotations, and enable the blue dot from the view model's permission flag.
         val activeRenderer = renderer
         if (activeRenderer != null) {
-            // Static layer (stops / routes / bikes / generics): redraw only when the snapshot changes
-            // (viewport loads, the vehicle poll, focus) — a bounded cost.
+            // Non-route static layer (stops / bikes / generics): strip route lines before distinctness
+            // so a route-only change never churns these annotations, and stop-only emissions cannot
+            // touch the independently collected native route layer below.
             LaunchedEffect(activeRenderer) {
-                renderState.snapshot.collect { activeRenderer.renderStatic() }
+                renderState.snapshot
+                    .map { it.copy(routePolylines = emptyList()) }
+                    .distinctUntilChanged()
+                    .collect { activeRenderer.renderStatic(it) }
+            }
+            // Route lines have their own change boundary: viewport stop updates retain the native
+            // maplibre polylines instead of removing/recreating every long adjacency shape.
+            LaunchedEffect(activeRenderer) {
+                renderState.snapshot
+                    .map { it.routePolylines }
+                    .distinctUntilChanged()
+                    .collect { activeRenderer.renderRoutePolylines(it) }
             }
             // The vehicle set (which vehicles exist + their icons): reconcile the markers whenever it's
             // pushed — a poll, a direction switch, or leaving route mode (null). Discrete, so it's reactive

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreComposeAdapter.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreComposeAdapter.kt
@@ -57,6 +57,7 @@ import org.onebusaway.android.map.maplibre.MapLibreRenderer
 import org.onebusaway.android.map.compose.drivePings
 import org.onebusaway.android.map.render.CameraSnapshot
 import org.onebusaway.android.map.render.GeoPoint
+import org.onebusaway.android.map.render.routePolylineRenderFlow
 import org.onebusaway.android.util.PermissionUtils
 import org.onebusaway.android.util.ThemeUtils
 import kotlinx.coroutines.flow.collectLatest
@@ -169,7 +170,6 @@ class MapLibreComposeAdapter : ObaComposeMapAdapter {
                         val target = map.cameraPosition.target
                         if (target != null) host.onCameraIdle(snapshot(map, target)) else host.onCameraSettled()
                     }
-                    r.renderRoutePolylines()
                     r.renderStatic()
                 }
             }
@@ -189,11 +189,10 @@ class MapLibreComposeAdapter : ObaComposeMapAdapter {
                     .collect { activeRenderer.renderStatic(it) }
             }
             // Route lines have their own change boundary: viewport stop updates retain the native
-            // maplibre polylines instead of removing/recreating every long adjacency shape.
+            // maplibre polylines instead of removing/recreating every long adjacency shape. Canonical
+            // route geometry stays in renderState for framing; only this renderer-bound copy is clipped.
             LaunchedEffect(activeRenderer) {
-                renderState.snapshot
-                    .map { it.routePolylines }
-                    .distinctUntilChanged()
+                routePolylineRenderFlow(renderState.snapshot, host.camera)
                     .collect { activeRenderer.renderRoutePolylines(it) }
             }
             // The vehicle set (which vehicles exist + their icons): reconcile the markers whenever it's

--- a/onebusaway-android/src/test/java/org/onebusaway/android/api/data/StopArrivalsTripPatternTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/api/data/StopArrivalsTripPatternTest.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.api.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.onebusaway.android.api.contract.ArrivalsForStop
+import org.onebusaway.android.api.contract.EntryWithReferences
+import org.onebusaway.android.api.contract.References
+import org.onebusaway.android.api.contract.RouteReference
+import org.onebusaway.android.api.contract.TripReference
+import org.onebusaway.android.models.TripPatternGeometry
+
+class StopArrivalsTripPatternTest {
+
+    @Test
+    fun `trip patterns include only shapes belonging to the supplied stop trips`() {
+        val snapshot = StopArrivals(
+            data = EntryWithReferences(
+                entry = ArrivalsForStop(stopId = "stop"),
+                references = References(
+                    routes = listOf(RouteReference(id = "route")),
+                    trips = listOf(
+                        TripReference(id = "served-1", routeId = "route", shapeId = "served-shape"),
+                        TripReference(id = "served-2", routeId = "route", shapeId = "served-shape"),
+                        TripReference(id = "other-branch", routeId = "route", shapeId = "other-shape"),
+                        TripReference(id = "missing-shape", routeId = "route"),
+                    ),
+                ),
+            ),
+            currentTime = 0L,
+            minutesAfter = 65,
+        )
+
+        val patterns = snapshot.tripPatternGeometries(
+            listOf("served-1", "served-2", "missing-shape", "unknown-trip")
+        )
+
+        assertEquals(
+            setOf(TripPatternGeometry("served-shape", "route", null)),
+            patterns,
+        )
+    }
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/AdjacencyMapControllerTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/AdjacencyMapControllerTest.kt
@@ -1,0 +1,157 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.map
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.onebusaway.android.map.render.GeoPoint
+import org.onebusaway.android.map.render.MapRenderState
+import org.onebusaway.android.map.render.ROUTE_LINE_WIDTH_DP
+import org.onebusaway.android.map.render.RoutePolyline
+import org.onebusaway.android.models.ObaRoute
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AdjacencyMapControllerTest {
+
+    private data class Request(
+        val routeIds: Set<String>,
+        val result: CompletableDeferred<AdjacencyShapes> = CompletableDeferred(),
+    )
+
+    private class FakeRepository : AdjacencyRouteShapeRepository {
+        val requests = mutableListOf<Request>()
+
+        override suspend fun getShapes(routeIds: Set<String>): AdjacencyShapes {
+            val request = Request(LinkedHashSet(routeIds))
+            requests += request
+            return request.result.await()
+        }
+    }
+
+    @Test
+    fun `resolved shapes publish colored whole-route lines and ignore invalid paths`() = runTest {
+        val state = MapRenderState()
+        val repository = FakeRepository()
+        val controller = AdjacencyMapController(state, repository, backgroundScope)
+        val first = listOf(GeoPoint(47.60, -122.30), GeoPoint(47.61, -122.31))
+        val second = listOf(GeoPoint(47.62, -122.32), GeoPoint(47.63, -122.33))
+
+        controller.start("stop", linkedSetOf("red", "fallback", "failed"))
+        runCurrent()
+        repository.requests.single().result.complete(
+            AdjacencyShapes(
+                shapes = linkedMapOf(
+                    "red" to shape("red", 0xFFCC0000.toInt(), listOf(first, listOf(first.first()))),
+                    "fallback" to shape("fallback", null, listOf(second)),
+                ),
+                failedRouteIds = setOf("failed"),
+            )
+        )
+        runCurrent()
+
+        val lines = state.snapshot.value.routePolylines
+        assertEquals(listOf(first, second), lines.map { it.points })
+        assertEquals(listOf(0xFFCC0000.toInt(), null), lines.map { it.color })
+        assertTrue(lines.all { it.widthDp == ROUTE_LINE_WIDTH_DP && !it.directional && !it.dashed })
+    }
+
+    @Test
+    fun `same stop and route set does not refetch while a changed set replaces the lines`() = runTest {
+        val state = MapRenderState()
+        val repository = FakeRepository()
+        val controller = AdjacencyMapController(state, repository, backgroundScope)
+        val oldLine = line(GeoPoint(1.0, 1.0), GeoPoint(2.0, 2.0))
+
+        controller.start("stop", setOf("a"))
+        runCurrent()
+        repository.requests.single().result.complete(shapes("a", oldLine.points))
+        runCurrent()
+        controller.start("stop", setOf("a"))
+        runCurrent()
+        assertEquals(1, repository.requests.size)
+
+        controller.start("stop", setOf("a", "b"))
+        runCurrent()
+        assertTrue(state.snapshot.value.routePolylines.isEmpty())
+        assertEquals(setOf("a", "b"), repository.requests.last().routeIds)
+    }
+
+    @Test
+    fun `a replaced session cannot publish after the new focus`() = runTest {
+        val state = MapRenderState()
+        val repository = FakeRepository()
+        val controller = AdjacencyMapController(state, repository, backgroundScope)
+        val oldPoints = listOf(GeoPoint(1.0, 1.0), GeoPoint(2.0, 2.0))
+        val newPoints = listOf(GeoPoint(3.0, 3.0), GeoPoint(4.0, 4.0))
+
+        controller.start("old", setOf("old-route"))
+        runCurrent()
+        val oldRequest = repository.requests.single()
+        controller.start("new", setOf("new-route"))
+        runCurrent()
+        val newRequest = repository.requests.last()
+
+        oldRequest.result.complete(shapes("old-route", oldPoints))
+        newRequest.result.complete(shapes("new-route", newPoints))
+        runCurrent()
+
+        assertEquals(listOf(newPoints), state.snapshot.value.routePolylines.map { it.points })
+    }
+
+    @Test
+    fun `empty set clears an active session but inactive stop preserves foreign route lines`() = runTest {
+        val state = MapRenderState()
+        val repository = FakeRepository()
+        val controller = AdjacencyMapController(state, repository, backgroundScope)
+        val foreignLine = line(GeoPoint(1.0, 1.0), GeoPoint(2.0, 2.0))
+        state.setRoutePolylines(listOf(foreignLine))
+
+        controller.stop()
+        assertEquals(listOf(foreignLine), state.snapshot.value.routePolylines)
+
+        controller.start("stop", setOf("a"))
+        runCurrent()
+        controller.start("stop", emptySet())
+
+        assertTrue(state.snapshot.value.routePolylines.isEmpty())
+        assertEquals(1, repository.requests.size)
+    }
+
+    private fun shapes(routeId: String, points: List<GeoPoint>) = AdjacencyShapes(
+        shapes = mapOf(routeId to shape(routeId, null, listOf(points))),
+        failedRouteIds = emptySet(),
+    )
+
+    private fun shape(routeId: String, color: Int?, polylines: List<List<GeoPoint>>) =
+        AdjacencyRouteShape(routeId, TestRoute(routeId, color), polylines, emptySet())
+
+    private fun line(vararg points: GeoPoint) = RoutePolyline(null, points.toList())
+
+    private data class TestRoute(override val id: String, override val color: Int?) : ObaRoute {
+        override val shortName: String = id
+        override val longName: String? = null
+        override val description: String? = null
+        override val type: Int = ObaRoute.TYPE_BUS
+        override val url: String? = null
+        override val textColor: Int? = null
+        override val agencyId: String = "agency"
+    }
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/AdjacencyMapControllerTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/AdjacencyMapControllerTest.kt
@@ -26,6 +26,7 @@ import org.onebusaway.android.map.render.GeoPoint
 import org.onebusaway.android.map.render.MapRenderState
 import org.onebusaway.android.map.render.ROUTE_LINE_WIDTH_DP
 import org.onebusaway.android.map.render.RoutePolyline
+import org.onebusaway.android.map.render.RoutePolylineTransform
 import org.onebusaway.android.models.ObaRoute
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -71,6 +72,14 @@ class AdjacencyMapControllerTest {
         assertEquals(listOf(first, second), lines.map { it.points })
         assertEquals(listOf(0xFFCC0000.toInt(), null), lines.map { it.color })
         assertTrue(lines.all { it.widthDp == ROUTE_LINE_WIDTH_DP && !it.directional && !it.dashed })
+        assertTrue(
+            lines.all {
+                it.transforms == setOf(
+                    RoutePolylineTransform.VIEWPORT_CLIP,
+                    RoutePolylineTransform.ZOOM_SIMPLIFY,
+                )
+            }
+        )
     }
 
     @Test

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/AdjacencyMapControllerTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/AdjacencyMapControllerTest.kt
@@ -24,46 +24,52 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.onebusaway.android.map.render.GeoPoint
 import org.onebusaway.android.map.render.MapRenderState
-import org.onebusaway.android.map.render.ROUTE_LINE_WIDTH_DP
 import org.onebusaway.android.map.render.RoutePolyline
 import org.onebusaway.android.map.render.RoutePolylineTransform
-import org.onebusaway.android.models.ObaRoute
+import org.onebusaway.android.models.TripPatternGeometry
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class AdjacencyMapControllerTest {
 
     private data class Request(
-        val routeIds: Set<String>,
+        val tripPatterns: Set<TripPatternGeometry>,
         val result: CompletableDeferred<AdjacencyShapes> = CompletableDeferred(),
     )
 
     private class FakeRepository : AdjacencyRouteShapeRepository {
         val requests = mutableListOf<Request>()
 
-        override suspend fun getShapes(routeIds: Set<String>): AdjacencyShapes {
-            val request = Request(LinkedHashSet(routeIds))
+        override suspend fun getShapes(
+            tripPatterns: Set<TripPatternGeometry>
+        ): AdjacencyShapes {
+            val request = Request(LinkedHashSet(tripPatterns))
             requests += request
             return request.result.await()
         }
     }
 
     @Test
-    fun `resolved shapes publish colored whole-route lines and ignore invalid paths`() = runTest {
+    fun `resolved shapes publish colored downstream lines and ignore invalid paths`() = runTest {
         val state = MapRenderState()
         val repository = FakeRepository()
         val controller = AdjacencyMapController(state, repository, backgroundScope)
         val first = listOf(GeoPoint(47.60, -122.30), GeoPoint(47.61, -122.31))
         val second = listOf(GeoPoint(47.62, -122.32), GeoPoint(47.63, -122.33))
 
-        controller.start("stop", linkedSetOf("red", "fallback", "failed"))
+        controller.start(
+            "stop",
+            first.first(),
+            patterns("red", "invalid", "fallback", "failed"),
+        )
         runCurrent()
         repository.requests.single().result.complete(
             AdjacencyShapes(
                 shapes = linkedMapOf(
-                    "red" to shape("red", 0xFFCC0000.toInt(), listOf(first, listOf(first.first()))),
-                    "fallback" to shape("fallback", null, listOf(second)),
+                    "red" to shape("red", 0xFFCC0000.toInt(), first),
+                    "invalid" to shape("invalid", null, listOf(first.first())),
+                    "fallback" to shape("fallback", null, second),
                 ),
-                failedRouteIds = setOf("failed"),
+                failedShapeIds = setOf("failed"),
             )
         )
         runCurrent()
@@ -71,7 +77,11 @@ class AdjacencyMapControllerTest {
         val lines = state.snapshot.value.routePolylines
         assertEquals(listOf(first, second), lines.map { it.points })
         assertEquals(listOf(0xFFCC0000.toInt(), null), lines.map { it.color })
-        assertTrue(lines.all { it.widthDp == ROUTE_LINE_WIDTH_DP && !it.directional && !it.dashed })
+        assertTrue(
+            lines.all {
+                it.widthDp == ADJACENCY_DOWNSTREAM_LINE_WIDTH_DP && !it.directional && !it.dashed
+            }
+        )
         assertTrue(
             lines.all {
                 it.transforms == setOf(
@@ -89,18 +99,18 @@ class AdjacencyMapControllerTest {
         val controller = AdjacencyMapController(state, repository, backgroundScope)
         val oldLine = line(GeoPoint(1.0, 1.0), GeoPoint(2.0, 2.0))
 
-        controller.start("stop", setOf("a"))
+        controller.start("stop", oldLine.points.first(), patterns("a"))
         runCurrent()
         repository.requests.single().result.complete(shapes("a", oldLine.points))
         runCurrent()
-        controller.start("stop", setOf("a"))
+        controller.start("stop", oldLine.points.first(), patterns("a"))
         runCurrent()
         assertEquals(1, repository.requests.size)
 
-        controller.start("stop", setOf("a", "b"))
+        controller.start("stop", oldLine.points.first(), patterns("a", "b"))
         runCurrent()
         assertTrue(state.snapshot.value.routePolylines.isEmpty())
-        assertEquals(setOf("a", "b"), repository.requests.last().routeIds)
+        assertEquals(setOf("a", "b"), repository.requests.last().tripPatterns.map { it.shapeId }.toSet())
     }
 
     @Test
@@ -111,15 +121,15 @@ class AdjacencyMapControllerTest {
         val oldPoints = listOf(GeoPoint(1.0, 1.0), GeoPoint(2.0, 2.0))
         val newPoints = listOf(GeoPoint(3.0, 3.0), GeoPoint(4.0, 4.0))
 
-        controller.start("old", setOf("old-route"))
+        controller.start("old", oldPoints.first(), patterns("old-shape"))
         runCurrent()
         val oldRequest = repository.requests.single()
-        controller.start("new", setOf("new-route"))
+        controller.start("new", newPoints.first(), patterns("new-shape"))
         runCurrent()
         val newRequest = repository.requests.last()
 
-        oldRequest.result.complete(shapes("old-route", oldPoints))
-        newRequest.result.complete(shapes("new-route", newPoints))
+        oldRequest.result.complete(shapes("old-shape", oldPoints))
+        newRequest.result.complete(shapes("new-shape", newPoints))
         runCurrent()
 
         assertEquals(listOf(newPoints), state.snapshot.value.routePolylines.map { it.points })
@@ -136,31 +146,49 @@ class AdjacencyMapControllerTest {
         controller.stop()
         assertEquals(listOf(foreignLine), state.snapshot.value.routePolylines)
 
-        controller.start("stop", setOf("a"))
+        controller.start("stop", foreignLine.points.first(), patterns("a"))
         runCurrent()
-        controller.start("stop", emptySet())
+        controller.start("stop", foreignLine.points.first(), emptySet())
 
         assertTrue(state.snapshot.value.routePolylines.isEmpty())
         assertEquals(1, repository.requests.size)
     }
 
-    private fun shapes(routeId: String, points: List<GeoPoint>) = AdjacencyShapes(
-        shapes = mapOf(routeId to shape(routeId, null, listOf(points))),
-        failedRouteIds = emptySet(),
+    @Test
+    fun `shape is split at projected stop with thin upstream and wide downstream`() {
+        val start = GeoPoint(0.0, 0.0)
+        val middle = GeoPoint(0.0, 10.0)
+        val end = GeoPoint(0.0, 20.0)
+        val projectedStop = GeoPoint(0.0, 4.0)
+        val result = shapes("shape", listOf(start, middle, end))
+
+        val lines = result.toRoutePolylines(GeoPoint(1.0, 4.0))
+
+        assertEquals(
+            listOf(
+                listOf(start, projectedStop),
+                listOf(projectedStop, middle, end),
+            ),
+            lines.map { it.points },
+        )
+        assertEquals(
+            listOf(ADJACENCY_UPSTREAM_LINE_WIDTH_DP, ADJACENCY_DOWNSTREAM_LINE_WIDTH_DP),
+            lines.map { it.widthDp },
+        )
+        assertTrue(ADJACENCY_DOWNSTREAM_LINE_WIDTH_DP > ADJACENCY_UPSTREAM_LINE_WIDTH_DP)
+    }
+
+    private fun shapes(shapeId: String, points: List<GeoPoint>) = AdjacencyShapes(
+        shapes = mapOf(shapeId to shape(shapeId, null, points)),
+        failedShapeIds = emptySet(),
     )
 
-    private fun shape(routeId: String, color: Int?, polylines: List<List<GeoPoint>>) =
-        AdjacencyRouteShape(routeId, TestRoute(routeId, color), polylines, emptySet())
+    private fun shape(shapeId: String, color: Int?, points: List<GeoPoint>) =
+        AdjacencyRouteShape(shapeId, "route-$shapeId", color, points)
+
+    private fun patterns(vararg shapeIds: String): Set<TripPatternGeometry> =
+        shapeIds.mapTo(LinkedHashSet()) { TripPatternGeometry(it, "route-$it", null) }
 
     private fun line(vararg points: GeoPoint) = RoutePolyline(null, points.toList())
 
-    private data class TestRoute(override val id: String, override val color: Int?) : ObaRoute {
-        override val shortName: String = id
-        override val longName: String? = null
-        override val description: String? = null
-        override val type: Int = ObaRoute.TYPE_BUS
-        override val url: String? = null
-        override val textColor: Int? = null
-        override val agencyId: String = "agency"
-    }
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/AdjacencyPolylineSimplifierTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/AdjacencyPolylineSimplifierTest.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.map
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Test
+import org.onebusaway.android.map.render.GeoPoint
+import org.onebusaway.android.map.render.simplifyRoutePolyline
+import org.onebusaway.android.util.EARTH_RADIUS_METERS
+
+class AdjacencyPolylineSimplifierTest {
+
+    @Test
+    fun `dense collinear points collapse to endpoints`() {
+        val points = (0..100).map { index -> point(eastMeters = index.toDouble()) }
+
+        val simplified = simplifyRoutePolyline(points, toleranceMeters = 2.0)
+
+        assertEquals(listOf(points.first(), points.last()), simplified)
+    }
+
+    @Test
+    fun `sub-tolerance deviation is removed`() {
+        val points = listOf(
+            point(eastMeters = 0.0),
+            point(eastMeters = 10.0, northMeters = 1.0),
+            point(eastMeters = 20.0),
+        )
+
+        val simplified = simplifyRoutePolyline(points, toleranceMeters = 2.0)
+
+        assertEquals(listOf(points.first(), points.last()), simplified)
+    }
+
+    @Test
+    fun `meaningful bend and endpoints are retained`() {
+        val points = listOf(
+            point(eastMeters = 0.0),
+            point(eastMeters = 10.0, northMeters = 3.0),
+            point(eastMeters = 20.0),
+        )
+
+        assertEquals(points, simplifyRoutePolyline(points, toleranceMeters = 2.0))
+    }
+
+    @Test
+    fun `closed route loop retains meaningful corners`() {
+        val start = point(eastMeters = 0.0)
+        val points = listOf(
+            start,
+            point(eastMeters = 10.0),
+            point(eastMeters = 10.0, northMeters = 10.0),
+            point(eastMeters = 0.0, northMeters = 10.0),
+            start,
+        )
+
+        assertEquals(points, simplifyRoutePolyline(points, toleranceMeters = 2.0))
+    }
+
+    @Test
+    fun `disabled simplification returns the original list`() {
+        val points = listOf(point(eastMeters = 0.0), point(eastMeters = 1.0), point(eastMeters = 2.0))
+
+        assertSame(points, simplifyRoutePolyline(points, toleranceMeters = 0.0))
+    }
+
+    private fun point(eastMeters: Double, northMeters: Double = 0.0): GeoPoint =
+        GeoPoint(
+            latitude = Math.toDegrees(northMeters / EARTH_RADIUS_METERS),
+            longitude = Math.toDegrees(eastMeters / EARTH_RADIUS_METERS),
+        )
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/AdjacencyRouteShapeRepositoryTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/AdjacencyRouteShapeRepositoryTest.kt
@@ -25,34 +25,34 @@ import kotlinx.coroutines.test.runTest
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
-import org.onebusaway.android.api.adapters.ObaStopElement
-import org.onebusaway.android.api.data.MapDataSource
-import org.onebusaway.android.models.NearbyStops
-import org.onebusaway.android.models.RouteMapData
-import org.onebusaway.android.models.RouteMapStop
+import org.onebusaway.android.api.data.TripVehiclesDataSource
+import org.onebusaway.android.models.ObaTripSchedule
+import org.onebusaway.android.models.RouteTrips
+import org.onebusaway.android.models.TripPatternGeometry
+import org.onebusaway.android.models.TripRouteInfo
 import org.onebusaway.android.time.ElapsedTime
+import org.onebusaway.android.util.Polyline
 
 /**
  * The multi-route shape fetch's bounded concurrency, single-flight de-dup, completed-result cache,
- * and partial-failure tolerance, driven against a fake [MapDataSource] under virtual time. Fixtures
- * use empty polyline lists so no unmockable [android.location.Location] is constructed (JVM tests
- * can't touch Android statics); point conversion is a trivial `GeoPoint(lat, lon)` map covered
- * implicitly.
+ * and partial-failure tolerance, driven against a fake [TripVehiclesDataSource] under virtual time.
+ * Fixtures use empty polylines so no unmockable [android.location.Location] is constructed.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class AdjacencyRouteShapeRepositoryTest {
 
     /**
-     * A [MapDataSource] whose `routeMap` counts per-id calls, tracks peak concurrency, and (when a
+     * A fake shape source that counts per-id calls, tracks peak concurrency, and (when a
      * gate is registered for the id) parks until that gate completes — so a test can hold N fetches
      * in flight and observe the bound. [scriptFor] decides each id's [Result].
      */
-    private class FakeMapDataSource(
-        private val scriptFor: (String) -> Result<RouteMapData?> = { Result.success(routeMapData(it)) },
-    ) : MapDataSource {
+    private class FakeTripVehiclesDataSource(
+        private val scriptFor: (String) -> Result<Polyline?> = {
+            Result.success(Polyline(emptyList()))
+        },
+    ) : TripVehiclesDataSource {
 
         val callCounts = mutableMapOf<String, Int>()
         val gates = mutableMapOf<String, CompletableDeferred<Unit>>()
@@ -60,25 +60,29 @@ class AdjacencyRouteShapeRepositoryTest {
         var maxActive = 0
             private set
 
-        override suspend fun nearbyStops(
-            lat: Double, lon: Double, latSpan: Double, lonSpan: Double, maxCount: Int?,
-        ): Result<NearbyStops?> = throw UnsupportedOperationException("not used")
-
-        override suspend fun routeMap(routeId: String): Result<RouteMapData?> {
-            callCounts[routeId] = (callCounts[routeId] ?: 0) + 1
+        override suspend fun shape(shapeId: String): Result<Polyline?> {
+            callCounts[shapeId] = (callCounts[shapeId] ?: 0) + 1
             active++
             maxActive = maxOf(maxActive, active)
             try {
-                gates[routeId]?.await()
-                return scriptFor(routeId)
+                gates[shapeId]?.await()
+                return scriptFor(shapeId)
             } finally {
                 active--
             }
         }
+
+        override suspend fun tripsForRoute(routeId: String): Result<RouteTrips> = unused()
+        override suspend fun tripDetails(tripId: String): Result<RouteTrips> = unused()
+        override suspend fun tripSchedule(tripId: String): Result<ObaTripSchedule?> = unused()
+        override suspend fun trip(tripId: String): Result<TripRouteInfo?> = unused()
+
+        private fun <T> unused(): Result<T> =
+            throw UnsupportedOperationException("not used")
     }
 
     private fun repo(
-        source: MapDataSource,
+        source: TripVehiclesDataSource,
         scope: kotlinx.coroutines.CoroutineScope,
         cacheSize: Int = 32,
         cacheTtl: Duration = 10.seconds,
@@ -92,16 +96,22 @@ class AdjacencyRouteShapeRepositoryTest {
         now = now,
     )
 
+    private fun patterns(ids: Iterable<String>): Set<TripPatternGeometry> =
+        ids.mapTo(LinkedHashSet()) { TripPatternGeometry(it, "route-$it", null) }
+
+    private fun pattern(shapeId: String, routeId: String = "route-$shapeId", color: Int? = null) =
+        TripPatternGeometry(shapeId, routeId, color)
+
     // Bounded concurrency ------------------------------------------------------------------------
 
     @Test
     fun boundsConcurrentFetchesToTwoAndDrainsInWaves() = runTest {
         val ids = (0 until 5).map { it.toString() }.toSet()
-        val fake = FakeMapDataSource()
+        val fake = FakeTripVehiclesDataSource()
         ids.forEach { fake.gates[it] = CompletableDeferred() }
         val repo = repo(fake, backgroundScope)
 
-        val fetch = async { repo.getShapes(ids) }
+        val fetch = async { repo.getShapes(patterns(ids)) }
 
         runCurrent()
         // 5 requested, 2 permits -> at most 2 in flight at once.
@@ -116,20 +126,20 @@ class AdjacencyRouteShapeRepositoryTest {
         ids.forEach { fake.gates[it]!!.complete(Unit) }
         val result = fetch.await()
         assertEquals(5, result.shapes.size)
-        assertTrue(result.failedRouteIds.isEmpty())
+        assertTrue(result.failedShapeIds.isEmpty())
         assertTrue(fake.callCounts.values.all { it == 1 })
     }
 
     // Single-flight de-dup + completed cache -----------------------------------------------------
 
     @Test
-    fun concurrentGetShapesForSameRouteShareOneFetch() = runTest {
-        val fake = FakeMapDataSource()
+    fun concurrentGetShapesForSameShapeShareOneFetch() = runTest {
+        val fake = FakeTripVehiclesDataSource()
         fake.gates["A"] = CompletableDeferred()
         val repo = repo(fake, backgroundScope)
 
-        backgroundScope.launch { repo.getShapes(setOf("A")) }
-        backgroundScope.launch { repo.getShapes(setOf("A")) }
+        backgroundScope.launch { repo.getShapes(setOf(pattern("A"))) }
+        backgroundScope.launch { repo.getShapes(setOf(pattern("A"))) }
         runCurrent()
 
         fake.gates["A"]!!.complete(Unit)
@@ -138,12 +148,12 @@ class AdjacencyRouteShapeRepositoryTest {
     }
 
     @Test
-    fun sequentialGetShapesForSameRouteReuseCompletedSuccess() = runTest {
-        val fake = FakeMapDataSource()
+    fun sequentialGetShapesForSameShapeReuseCompletedSuccess() = runTest {
+        val fake = FakeTripVehiclesDataSource()
         val repo = repo(fake, backgroundScope)
 
-        repo.getShapes(setOf("A"))
-        val second = repo.getShapes(setOf("A"))
+        repo.getShapes(setOf(pattern("A")))
+        val second = repo.getShapes(setOf(pattern("A")))
 
         assertEquals(setOf("A"), second.shapes.keys)
         assertEquals(1, fake.callCounts["A"])
@@ -151,14 +161,14 @@ class AdjacencyRouteShapeRepositoryTest {
 
     @Test
     fun completedCacheEvictsLeastRecentlyUsedShapePastBound() = runTest {
-        val fake = FakeMapDataSource()
+        val fake = FakeTripVehiclesDataSource()
         val repo = repo(fake, backgroundScope, cacheSize = 2)
 
-        repo.getShapes(setOf("A"))
-        repo.getShapes(setOf("B"))
-        repo.getShapes(setOf("A")) // promote A, making B the eviction victim
-        repo.getShapes(setOf("C"))
-        repo.getShapes(setOf("B"))
+        repo.getShapes(setOf(pattern("A")))
+        repo.getShapes(setOf(pattern("B")))
+        repo.getShapes(setOf(pattern("A"))) // promote A, making B the eviction victim
+        repo.getShapes(setOf(pattern("C")))
+        repo.getShapes(setOf(pattern("B")))
 
         assertEquals(1, fake.callCounts["A"])
         assertEquals(2, fake.callCounts["B"])
@@ -168,7 +178,7 @@ class AdjacencyRouteShapeRepositoryTest {
     @Test
     fun completedCacheRefetchesAtExpiry() = runTest {
         var nowMs = 0L
-        val fake = FakeMapDataSource()
+        val fake = FakeTripVehiclesDataSource()
         val repo = repo(
             fake,
             backgroundScope,
@@ -176,28 +186,28 @@ class AdjacencyRouteShapeRepositoryTest {
             now = { ElapsedTime(nowMs) },
         )
 
-        repo.getShapes(setOf("A"))
+        repo.getShapes(setOf(pattern("A")))
         nowMs = 9_999L
-        repo.getShapes(setOf("A"))
+        repo.getShapes(setOf(pattern("A")))
         assertEquals(1, fake.callCounts["A"])
 
         nowMs = 10_000L
-        repo.getShapes(setOf("A"))
+        repo.getShapes(setOf(pattern("A")))
         assertEquals(2, fake.callCounts["A"])
     }
 
     @Test
     fun failedResultIsNotCachedAndLaterSuccessIsCached() = runTest {
         var attempts = 0
-        val fake = FakeMapDataSource { id ->
+        val fake = FakeTripVehiclesDataSource {
             if (attempts++ == 0) Result.failure(RuntimeException("network"))
-            else Result.success(routeMapData(id))
+            else Result.success(Polyline(emptyList()))
         }
         val repo = repo(fake, backgroundScope)
 
-        assertEquals(setOf("A"), repo.getShapes(setOf("A")).failedRouteIds)
-        assertEquals(setOf("A"), repo.getShapes(setOf("A")).shapes.keys)
-        assertEquals(setOf("A"), repo.getShapes(setOf("A")).shapes.keys)
+        assertEquals(setOf("A"), repo.getShapes(setOf(pattern("A"))).failedShapeIds)
+        assertEquals(setOf("A"), repo.getShapes(setOf(pattern("A"))).shapes.keys)
+        assertEquals(setOf("A"), repo.getShapes(setOf(pattern("A"))).shapes.keys)
         assertEquals(2, fake.callCounts["A"])
     }
 
@@ -205,30 +215,30 @@ class AdjacencyRouteShapeRepositoryTest {
 
     @Test
     fun partialFailure_returnsSuccessesAndListsFailures() = runTest {
-        val fake = FakeMapDataSource { id ->
+        val fake = FakeTripVehiclesDataSource { id ->
             when (id) {
-                "ok" -> Result.success(routeMapData("ok"))
+                "ok" -> Result.success(Polyline(emptyList()))
                 "boom" -> Result.failure(RuntimeException("network"))
                 else -> Result.success(null) // no API endpoint
             }
         }
         val repo = repo(fake, backgroundScope)
 
-        val result = repo.getShapes(setOf("ok", "boom", "none"))
+        val result = repo.getShapes(patterns(setOf("ok", "boom", "none")))
 
         assertEquals(setOf("ok"), result.shapes.keys)
-        assertEquals(setOf("boom", "none"), result.failedRouteIds)
+        assertEquals(setOf("boom", "none"), result.failedShapeIds)
     }
 
     @Test
     fun emptyInput_makesNoCalls() = runTest {
-        val fake = FakeMapDataSource()
+        val fake = FakeTripVehiclesDataSource()
         val repo = repo(fake, backgroundScope)
 
         val result = repo.getShapes(emptySet())
 
         assertTrue(result.shapes.isEmpty())
-        assertTrue(result.failedRouteIds.isEmpty())
+        assertTrue(result.failedShapeIds.isEmpty())
         assertTrue(fake.callCounts.isEmpty())
     }
 
@@ -236,12 +246,12 @@ class AdjacencyRouteShapeRepositoryTest {
 
     @Test
     fun cancellingOneJoinerNeitherKillsTheSharedFetchNorLeaksThePermit() = runTest {
-        val fake = FakeMapDataSource()
+        val fake = FakeTripVehiclesDataSource()
         fake.gates["A"] = CompletableDeferred()
         val repo = repo(fake, backgroundScope)
 
-        val doomed = backgroundScope.launch { repo.getShapes(setOf("A")) }
-        val survivor = async { repo.getShapes(setOf("A")) }
+        val doomed = backgroundScope.launch { repo.getShapes(setOf(pattern("A"))) }
+        val survivor = async { repo.getShapes(setOf(pattern("A"))) }
         runCurrent()
 
         doomed.cancel() // one joiner gives up; the shared fetch runs on the repo's own scope
@@ -252,39 +262,24 @@ class AdjacencyRouteShapeRepositoryTest {
         assertEquals(1, fake.callCounts["A"])
 
         // A different later fetch still acquires a permit (none leaked).
-        repo.getShapes(setOf("B"))
+        repo.getShapes(setOf(pattern("B")))
         assertEquals(1, fake.callCounts["B"])
     }
 
     // Mapping ------------------------------------------------------------------------------------
 
     @Test
-    fun toAdjacencyShape_mapsRouteIdAndStopIds() {
-        val data = routeMapData("R", stopIds = listOf("s1", "s2"))
-        val shape = data.toAdjacencyShape("R")
+    fun returnedShapeKeepsRequestedShapeRouteAndColor() = runTest {
+        val fake = FakeTripVehiclesDataSource()
+        val repo = repo(fake, backgroundScope)
 
-        assertEquals("R", shape.routeId)
-        assertNull(shape.route)
-        assertEquals(setOf("s1", "s2"), shape.stopIds)
-        assertTrue(shape.polylines.isEmpty())
-    }
+        val result = repo.getShapes(setOf(pattern("served-shape", "shared-route", 0xFF336699.toInt())))
+        val shape = result.shapes.getValue("served-shape")
 
-    companion object {
-        /** A minimal [RouteMapData] with empty shapes (no [android.location.Location] built). */
-        // routeId is a call-site label documenting which route this fake data stands in for;
-        // RouteMapData carries no route-id field (the id is applied later by toAdjacencyShape), so
-        // the body has no use for it. Test-only helper; no tracking issue.
-        private fun routeMapData(
-            @Suppress("UNUSED_PARAMETER") routeId: String,
-            stopIds: List<String> = emptyList(),
-        ) = RouteMapData(
-            route = null,
-            agencyName = null,
-            stops = stopIds.map { RouteMapStop(ObaStopElement(id = it), emptySet()) },
-            routes = emptyList(),
-            directions = emptyList(),
-            polylines = emptyList(),
-            polylinesByDirection = emptyMap(),
-        )
+        assertEquals("served-shape", shape.shapeId)
+        assertEquals("shared-route", shape.routeId)
+        assertEquals(0xFF336699.toInt(), shape.routeColor)
+        assertTrue(shape.points.isEmpty())
+        assertEquals(setOf("served-shape"), fake.callCounts.keys)
     }
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/render/RoutePolylineRenderPipelineTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/render/RoutePolylineRenderPipelineTest.kt
@@ -1,0 +1,196 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.map.render
+
+import kotlin.math.cos
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.onebusaway.android.util.EARTH_RADIUS_METERS
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class RoutePolylineRenderPipelineTest {
+
+    private val pipeline = RoutePolylineRenderPipeline(
+        listOf(ViewportClipRoutePolylinePass(), ZoomSimplifyRoutePolylinePass())
+    )
+
+    @Test
+    fun `unmarked lines pass through with their list identity`() {
+        val line = RoutePolyline(0xFF123456.toInt(), listOf(point(0.0, 0.0), point(0.0, 1.0)))
+        val lines = listOf(line)
+
+        assertSame(lines, pipeline.apply(lines, camera()))
+        assertSame(lines, pipeline.apply(lines, null))
+    }
+
+    @Test
+    fun `viewport lines wait for a camera while ordinary lines remain`() {
+        val ordinary = RoutePolyline(null, listOf(point(0.0, 0.0), point(0.0, 1.0)))
+        val clipped = viewportLine(point(0.0, 0.0), point(0.0, 1.0))
+
+        assertEquals(listOf(ordinary), pipeline.apply(listOf(ordinary, clipped), null))
+    }
+
+    @Test
+    fun `render flow processes a copy while canonical geometry stays complete`() = runTest {
+        val raw = viewportLine(point(0.0, -4.0), point(0.0, 4.0))
+        val snapshot = MutableStateFlow(MapRenderSnapshot(routePolylines = listOf(raw)))
+        val viewport = MutableStateFlow<CameraSnapshot?>(null)
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+
+        assertTrue(routePolylineRenderFlow(snapshot, viewport, dispatcher).first().isEmpty())
+        viewport.value = camera()
+        val rendered = routePolylineRenderFlow(snapshot, viewport, dispatcher).first().single()
+
+        assertEquals(-3.0, rendered.points.first().longitude, 1e-8)
+        assertEquals(3.0, rendered.points.last().longitude, 1e-8)
+        assertSame(raw, snapshot.value.routePolylines.single())
+        assertEquals(listOf(-4.0, 4.0), raw.points.map(GeoPoint::longitude), 0.0)
+    }
+
+    @Test
+    fun `one-screen margin retains an inside line unchanged`() {
+        val line = viewportLine(point(0.0, -2.9), point(0.0, 2.9))
+
+        val result = pipeline.apply(listOf(line), camera())
+
+        assertEquals(listOf(line), result)
+        assertSame(line, result.single())
+    }
+
+    @Test
+    fun `crossing line is clipped to the padded viewport`() {
+        val line = viewportLine(point(0.0, -4.0), point(0.0, 4.0))
+
+        val result = pipeline.apply(listOf(line), camera()).single()
+
+        assertEquals(-3.0, result.points.first().longitude, 1e-8)
+        assertEquals(3.0, result.points.last().longitude, 1e-8)
+        assertEquals(line.color, result.color)
+        assertEquals(line.widthDp, result.widthDp)
+        assertEquals(line.transforms, result.transforms)
+    }
+
+    @Test
+    fun `outside excursion produces separate fragments without a connector`() {
+        val line = viewportLine(
+            point(0.0, 0.0),
+            point(0.0, 4.0),
+            point(0.0, 5.0),
+            point(0.0, 4.0),
+            point(0.0, 0.0),
+        )
+
+        val result = pipeline.apply(listOf(line), camera())
+
+        assertEquals(2, result.size)
+        assertEquals(listOf(0.0, 3.0), result[0].points.map(GeoPoint::longitude), 1e-8)
+        assertEquals(listOf(3.0, 0.0), result[1].points.map(GeoPoint::longitude), 1e-8)
+    }
+
+    @Test
+    fun `fully outside line is omitted`() {
+        val line = viewportLine(point(0.0, 10.0), point(0.0, 11.0))
+
+        assertTrue(pipeline.apply(listOf(line), camera()).isEmpty())
+    }
+
+    @Test
+    fun `segments crossing the antimeridian clip in the camera's unwrapped world`() {
+        val line = viewportLine(point(0.0, 175.0), point(0.0, -177.0))
+        val camera = camera(
+            center = point(0.0, 179.0),
+            southWest = point(-1.0, 178.0),
+            northEast = point(1.0, -180.0),
+        )
+
+        val result = pipeline.apply(listOf(line), camera).single()
+
+        assertEquals(176.0, result.points.first().longitude, 1e-8)
+        assertEquals(-178.0, result.points.last().longitude, 1e-8)
+    }
+
+    @Test
+    fun `zoom simplification keeps a visible bend and removes a sub-pixel bend`() {
+        val latitude = 47.6
+        val points = listOf(
+            localPoint(latitude, eastMeters = 0.0),
+            localPoint(latitude, eastMeters = 50.0, northMeters = 10.0),
+            localPoint(latitude, eastMeters = 100.0),
+        )
+        val line = RoutePolyline(
+            color = null,
+            points = points,
+            transforms = setOf(RoutePolylineTransform.ZOOM_SIMPLIFY),
+        )
+
+        val overview = pipeline.apply(listOf(line), camera(center = point(latitude, 0.0), zoom = 10.0))
+        val close = pipeline.apply(listOf(line), camera(center = point(latitude, 0.0), zoom = 20.0))
+
+        assertEquals(listOf(points.first(), points.last()), overview.single().points)
+        assertEquals(points, close.single().points)
+    }
+
+    private fun viewportLine(vararg points: GeoPoint) = RoutePolyline(
+        color = 0xFF123456.toInt(),
+        points = points.toList(),
+        widthDp = 10f,
+        transforms = setOf(
+            RoutePolylineTransform.VIEWPORT_CLIP,
+            RoutePolylineTransform.ZOOM_SIMPLIFY,
+        ),
+    )
+
+    private fun camera(
+        center: GeoPoint = point(0.0, 0.0),
+        zoom: Double = 20.0,
+        southWest: GeoPoint = point(-1.0, -1.0),
+        northEast: GeoPoint = point(1.0, 1.0),
+    ) = CameraSnapshot(
+        center = center,
+        zoom = zoom,
+        latSpan = northEast.latitude - southWest.latitude,
+        lonSpan = 2.0,
+        southWest = southWest,
+        northEast = northEast,
+    )
+
+    private fun point(latitude: Double, longitude: Double) = GeoPoint(latitude, longitude)
+
+    private fun localPoint(
+        latitude: Double,
+        eastMeters: Double,
+        northMeters: Double = 0.0,
+    ): GeoPoint {
+        val latitudeRadians = Math.toRadians(latitude)
+        return GeoPoint(
+            latitude = latitude + Math.toDegrees(northMeters / EARTH_RADIUS_METERS),
+            longitude = Math.toDegrees(eastMeters / (EARTH_RADIUS_METERS * cos(latitudeRadians))),
+        )
+    }
+
+    private fun assertEquals(expected: List<Double>, actual: List<Double>, delta: Double) {
+        assertEquals(expected.size, actual.size)
+        expected.zip(actual).forEach { (left, right) -> assertEquals(left, right, delta) }
+    }
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
@@ -52,6 +52,8 @@ private class MapDirectiveRecorder(private val vm: HomeViewModel) {
 
     val recenters get() = sent.filterIsInstance<MapDirective.RecenterOnFocusedStop>().map { it.lat to it.lon }
     val routesShown get() = sent.filterIsInstance<MapDirective.ShowRoute>().map { it.request.routeId }
+    val adjacencies get() = sent.filterIsInstance<MapDirective.ShowStopAdjacency>()
+    val clearAdjacencyCount get() = sent.count { it is MapDirective.ClearAdjacency }
     val clearFocusCount get() = sent.count { it is MapDirective.ClearFocus }
     val focusStops get() = sent.filterIsInstance<MapDirective.FocusStop>()
     val lastBottomPadding get() = vm.mapBottomPadding.value
@@ -286,12 +288,13 @@ class HomeViewModelTest {
         val job = launch { map.collect() }
         advanceUntilIdle()
 
-        // No pending focus: the load still records the routes but emits no map directive.
+        // No pending restored focus: the load still starts adjacency for the already-tapped stop.
         vm.onArrivalsLoaded(obaStop, null, setOf("40", "44"))
         advanceUntilIdle()
 
         assertEquals(setOf("40", "44"), vm.focusedRouteIds)
         assertEquals(0, map.focusStops.size)
+        assertEquals(listOf(setOf("40", "44")), map.adjacencies.map { it.routeIds })
         job.cancel()
     }
 
@@ -308,17 +311,25 @@ class HomeViewModelTest {
 
         assertEquals(setOf("7"), vm.focusedRouteIds)
         assertEquals(1, map.focusStops.size) // pending focus still dispatched
+        assertTrue(map.sent.indexOfFirst { it is MapDirective.FocusStop } <
+            map.sent.indexOfFirst { it is MapDirective.ShowStopAdjacency })
         job.cancel()
     }
 
     @Test
     fun `focusing a different stop resets the route set`() = runTest {
         val vm = viewModel()
+        val map = MapDirectiveRecorder(vm)
+        val job = launch { map.collect() }
+        advanceUntilIdle()
         vm.onArrivalsLoaded(obaStop, null, setOf("40"))
         assertEquals(setOf("40"), vm.focusedRouteIds)
 
         vm.onStopFocused(FocusedStop("2", "2nd Ave", "200", 47.6, -122.3))
+        advanceUntilIdle()
         assertEquals(emptySet<String>(), vm.focusedRouteIds)
+        assertEquals(1, map.clearAdjacencyCount)
+        job.cancel()
     }
 
     @Test
@@ -526,4 +537,3 @@ class HomeViewModelTest {
         assertEquals(0, region.refreshCount)
     }
 }
-

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
@@ -29,6 +29,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.onebusaway.android.location.FakeLocationRepository
 import org.onebusaway.android.map.ShowRouteRequest
+import org.onebusaway.android.models.TripPatternGeometry
 import org.onebusaway.android.region.FakeRegionRepository
 import org.onebusaway.android.region.RegionStatus
 import org.onebusaway.android.region.region
@@ -289,12 +290,18 @@ class HomeViewModelTest {
         advanceUntilIdle()
 
         // No pending restored focus: the load still starts adjacency for the already-tapped stop.
-        vm.onArrivalsLoaded(obaStop, null, setOf("40", "44"))
+        val tripPatterns = setOf(
+            TripPatternGeometry("shape-40-express", "40", 0xFF112233.toInt()),
+            TripPatternGeometry("shape-44-local", "44", null),
+        )
+        vm.onArrivalsLoaded(obaStop, null, setOf("40", "44"), tripPatterns)
         advanceUntilIdle()
 
         assertEquals(setOf("40", "44"), vm.focusedRouteIds)
+        assertEquals(tripPatterns, vm.focusedTripPatterns)
         assertEquals(0, map.focusStops.size)
         assertEquals(listOf(setOf("40", "44")), map.adjacencies.map { it.routeIds })
+        assertEquals(listOf(tripPatterns), map.adjacencies.map { it.tripPatterns })
         job.cancel()
     }
 


### PR DESCRIPTION
Phase 2 ("Lines") of the adjacency-focus PR stack for #1827. Stacked on #1832.

## What changed

- Added an `AdjacencyMapController` that loads the focused stop's upcoming route shapes through the phase-1 repository and publishes the resolved whole-route polylines into the existing shared render model.
- Added Home-to-map directives for starting and clearing adjacency focus, including restored-focus ordering and stale-focus validation.
- Defined lifecycle ownership against single-route mode: route mode wins, entering it tears adjacency down, and a late adjacency clear cannot erase route-mode lines.
- Kept the camera fixed and reused the existing Google and MapLibre `routePolylines` rendering paths.
- Split route-polylines into their own distinct snapshot flow in both flavors, retaining equal native lines across stop-only updates instead of removing and recreating long adjacency shapes.
- Retained stop markers now compare against their previously rendered model and skip unchanged native position writes (plus unchanged Google z-index writes).

Partial route-shape failures draw the routes that resolved. Repeated arrivals refreshes with the same stop and route set do not refetch shapes, and stop-only snapshot updates no longer rebuild the resolved native route lines.

## Scope

This PR intentionally contains lines only. Stop minimization, de-focused multi-route vehicles, and route badges remain later phases of #1827.

## Validation

- `./gradlew :onebusaway-android:testObaGoogleDebugUnitTest :onebusaway-android:testObaMaplibreDebugUnitTest -PwarningsAsErrors=true`
- `./gradlew :onebusaway-android:lintObaGoogleDebug -PwarningsAsErrors=true`

Both passed.

On-device interaction validation on a Pixel 7 Pro (repeated stop focus plus pan/zoom over 60 seconds) exercised 1,489 frames: 40 missed the frame deadline (2.69%), with one 45-frame `Choreographer` stall. App CPU averaged 85.5% (p90 175%), and the already-warm device moved from thermal status 2 to 3. This confirms the amended paths were tested under interaction rather than only at idle, while also documenting remaining thermal pressure outside the eliminated annotation churn.

