### PR TITLE
Arrivals: extract shared etaAnnotatedString builder for the two ETA renderers

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
@@ -51,6 +51,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
@@ -477,22 +478,15 @@ private fun EtaContent(
             )
             EtaRealtimeIndicator(predicted, color)
         } else {
-            // One consistent "Xhr Ymin" shape: ["23", "min"] under an hour (the "0hr" is omitted), or
-            // ["1", "hr", " 30", "min"] past it. All parts render as a single AnnotatedString (not
-            // separate Text composables) so the text shaper kerns across the number/unit boundary
-            // instead of gluing together independently-measured boxes — splitting them produced
-            // inconsistent gaps (e.g. "1hr" vs "4hr") since cross-Text kerning isn't a thing.
+            // Numbers emphasized, unit letters not (see formatEtaParts for the part shape;
+            // etaAnnotatedString for why they render as a single AnnotatedString).
             val etaParts = DisplayFormat.formatEtaParts(LocalContext.current, eta)
-            val emphasizedSpan = SpanStyle(fontSize = 36.sp, fontWeight = FontWeight.Bold, color = color)
-            val unemphasizedSpan = MaterialTheme.typography.bodyMedium.toSpanStyle().copy(color = color)
             Text(
-                text = buildAnnotatedString {
-                    etaParts.forEach { part ->
-                        withStyle(if (part.emphasized) emphasizedSpan else unemphasizedSpan) {
-                            append(part.text)
-                        }
-                    }
-                },
+                text = etaAnnotatedString(
+                    etaParts,
+                    emphasizedSpan = SpanStyle(fontSize = 36.sp, fontWeight = FontWeight.Bold, color = color),
+                    unemphasizedSpan = MaterialTheme.typography.bodyMedium.toSpanStyle().copy(color = color),
+                ),
                 textDecoration = decoration
             )
             EtaRealtimeIndicator(predicted, color)
@@ -529,6 +523,28 @@ internal fun RealtimeIndicator(color: Color, modifier: Modifier = Modifier) {
 
 private fun strikeThroughIf(canceled: Boolean): TextDecoration =
     if (canceled) TextDecoration.LineThrough else TextDecoration.None
+
+/**
+ * Renders [DisplayFormat.formatEtaParts] output as a single [AnnotatedString] — not separate Text
+ * composables — so the text shaper kerns across the number/unit boundary instead of gluing together
+ * independently-measured boxes; splitting them produced inconsistent gaps (e.g. "1hr" vs "4hr") since
+ * cross-Text kerning isn't a thing (#1777).
+ *
+ * Numbers render with [emphasizedSpan], the trailing unit letters with [unemphasizedSpan]. Callers
+ * pass both spans because the two ETA surfaces style them differently — the drawer's [EtaPill] (white,
+ * its own sizes) vs. the arrival row's ETA (route color, Material type).
+ */
+internal fun etaAnnotatedString(
+    etaParts: List<DisplayFormat.EtaPart>,
+    emphasizedSpan: SpanStyle,
+    unemphasizedSpan: SpanStyle,
+): AnnotatedString = buildAnnotatedString {
+    etaParts.forEach { part ->
+        withStyle(if (part.emphasized) emphasizedSpan else unemphasizedSpan) {
+            append(part.text)
+        }
+    }
+}
 
 // ---------------------------------------------------------------------------------------------
 // Previews.

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStrip.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStrip.kt
@@ -60,11 +60,9 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.PlatformTextStyle
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.LineHeightStyle
 import androidx.compose.ui.text.style.TextDecoration
-import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
@@ -403,9 +401,8 @@ internal fun EtaPill(
     } else {
         Modifier
     }
-    // One consistent "Xhr Ymin" shape: ["23", "min"] under an hour (the "0hr" is omitted), or
-    // ["1", "hr", " 30", "min"] past it — every number stays bold-sized, only the unit letters
-    // shrink, so the leftover minutes stay as legible as the hour count (#1777).
+    // Numbers stay bold-sized, only the unit letters shrink (see formatEtaParts for the part shape;
+    // etaAnnotatedString for why they render as a single AnnotatedString).
     val etaParts = if (eta != 0L) DisplayFormat.formatEtaParts(LocalContext.current, eta) else null
     // See tightLineStyle's doc: keyed to each Text's own (dominant) size, so the padding/gap values
     // below are the actual on-screen spacing rather than a guess fighting Android's hidden font padding.
@@ -438,23 +435,20 @@ internal fun EtaPill(
                         style = remember(baseTextStyle, nowSize) { tightLineStyle(baseTextStyle, nowSize) }
                     )
                 } else {
-                    // A single AnnotatedString (not separate Text composables) so the text shaper kerns
-                    // across the number/unit boundary instead of gluing together independently-measured
-                    // boxes — splitting them produced inconsistent gaps (e.g. "1hr" vs "4hr").
                     Text(
-                        text = buildAnnotatedString {
-                            etaParts.forEach { part ->
-                                withStyle(
-                                    SpanStyle(
-                                        fontSize = if (part.emphasized) numberSize else labelSize,
-                                        fontWeight = if (part.emphasized) FontWeight.Bold else FontWeight.Normal,
-                                        color = Color.White
-                                    )
-                                ) {
-                                    append(part.text)
-                                }
-                            }
-                        },
+                        text = etaAnnotatedString(
+                            etaParts,
+                            emphasizedSpan = SpanStyle(
+                                fontSize = numberSize,
+                                fontWeight = FontWeight.Bold,
+                                color = Color.White
+                            ),
+                            unemphasizedSpan = SpanStyle(
+                                fontSize = labelSize,
+                                fontWeight = FontWeight.Normal,
+                                color = Color.White
+                            ),
+                        ),
                         textDecoration = decoration,
                         // Keyed to numberSize (the line's dominant glyph) — the smaller labelSize span
                         // rides the same trimmed line box rather than getting one of its own.


### PR DESCRIPTION
## What

`EtaPill` (in `EtaStrip.kt`) and `EtaContent` (in `ArrivalRows.kt`) each built the *same* `buildAnnotatedString` loop over `DisplayFormat.formatEtaParts`, carrying a near-verbatim copy of the "render the parts as one `AnnotatedString` so the shaper kerns across the number/unit boundary" comment — which had already started drifting between the two copies.

This extracts that loop into one helper:

```kotlin
internal fun etaAnnotatedString(
    etaParts: List<DisplayFormat.EtaPart>,
    emphasizedSpan: SpanStyle,
    unemphasizedSpan: SpanStyle,
): AnnotatedString
```

- Lives beside the other shared `internal` helpers in `ArrivalRows.kt` (e.g. `RealtimeIndicator`), matching the package's existing convention rather than adding a new file.
- Each surface keeps owning its own appearance by passing the two spans it needs — the drawer pill (white, its own sizes) vs. the arrival row (route color, Material type) — since they share no visual values.

Also drops the `"Xhr Ymin"` shape enumeration (`["23","min"]` / `["1","hr"," 30","min"]`) from both callers' comments: it's already documented authoritatively on `DisplayFormat.formatEtaParts`' KDoc, so it was triplicated and drifting. The callers now defer to `formatEtaParts` (part shape) and `etaAnnotatedString` (why one `AnnotatedString`).

## Why

Removes copy-paste duplication on the app's most active surface and gives the kerning invariant a single home — the return type makes it impossible for a caller to re-split the parts across multiple `Text`s (the bug the single-`AnnotatedString` approach guards against, #1777).

## Testing

Pure refactor, no behavior change — same span logic, just extracted.

- Compiles clean under the strict CI gate: `./gradlew :onebusaway-android:compileObaGoogleDebugKotlin -PwarningsAsErrors=true` ✅
- `ArrivalInfoTest` + `DisplayFormatTest` pass ✅ (the `formatEtaParts` logic feeding both renderers is unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Standardized ETA text rendering across arrival rows and ETA pills.
  - Preserved existing emphasis for numeric and supporting ETA text.
  - Maintained current typography, line spacing, and text decoration in ETA displays.
  - No changes to the displayed arrival information or overall user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->