### PR TITLE
Map load failures: log the underlying cause before collapsing to a toast code (#1462)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapEffect.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapEffect.kt
@@ -15,6 +15,8 @@
  */
 package org.onebusaway.android.map
 
+import android.util.Log
+
 import org.onebusaway.android.api.ObaApi
 import org.onebusaway.android.api.ObaApiException
 
@@ -59,9 +61,28 @@ sealed interface MapEffect {
      */
     data class ShowError(val code: Int) : MapEffect {
         companion object {
-            /** The status code a failed load reports: an [ObaApiException]'s code, else a generic I/O error. */
-            fun from(cause: Throwable): ShowError =
-                ShowError((cause as? ObaApiException)?.code ?: ObaApi.OBA_IO_EXCEPTION)
+            private const val TAG = "MapEffect"
+
+            /**
+             * The status code a failed load reports: an [ObaApiException]'s code, else a generic I/O error.
+             *
+             * This collapse is lossy — the user-facing toast is just a status code, so the underlying
+             * [cause] (which HTTP/app code, or the exact parse failure and offending field) is otherwise
+             * discarded here. Log it first, so a single-region load failure that reduces to the generic
+             * "Unable to get stops." toast (e.g. #1462) is diagnosable from logcat / crash reports rather
+             * than vanishing. An [ObaApiException] carries its own status, so the code is enough; any other
+             * throwable (a transport failure, or a kotlinx `SerializationException` naming a bad field) is
+             * logged with its full stack.
+             */
+            fun from(cause: Throwable): ShowError {
+                val code = (cause as? ObaApiException)?.code ?: ObaApi.OBA_IO_EXCEPTION
+                if (cause is ObaApiException) {
+                    Log.w(TAG, "Map load failed with OBA status code $code")
+                } else {
+                    Log.w(TAG, "Map load failed (reporting code $code); underlying cause:", cause)
+                }
+                return ShowError(code)
+            }
         }
     }
 }


### PR DESCRIPTION
## What

`MapEffect.ShowError.from(cause)` reduces any failed map/route load to a single status code for the user-facing toast, discarding the real throwable. Both failure sites funnel through it — the stops path (`StopsMapController.onStopsLoaded`, `StopsMapController.kt:310`) and the route path (`RouteMapController.onRouteLoaded`, `RouteMapController.kt:466`) — so a parse failure or an unexpected app-level code both vanish into the same opaque **"Unable to get stops."** with nothing logged.

This PR logs the cause at that collapse point (one place, covering both call sites, no `Context` needed):
- An `ObaApiException` is self-describing → log just its status code.
- Any other throwable (a transport failure, or a kotlinx `SerializationException` naming the offending field) → logged with its full stack.

No user-facing or mapping behavior change; purely diagnostic.

## Why (investigation of #1462)

#1462 reports the Washington D.C. region failing with "Unable to get stop". I couldn't reproduce it, and neither could an earlier commenter. Probing D.C.'s live server (`https://buseta.wmata.com/onebusaway-api-webapp/`, OBA v2.4.3.11) with the app's own API key:

- Every endpoint the map/stop flow uses returns **HTTP 200 with valid, complete JSON** — `agencies-with-coverage`, `stops-for-location` (point + map-style bbox, `limitExceeded`), `stop`, `arrivals-and-departures-for-stop`.
- All stop `routeIds` resolve against `references.routes`; all field types are correct; the region record is normal.
- The map's parse path (kotlinx.serialization, `ignoreUnknownKeys` + `coerceInputValues`, fully-defaulted wire models) has **no region-specific branch** — the same parser runs for every region.

So the server isn't the cause today, and the only client-side route to that toast is a wire **type-mismatch** parse error or a non-standard envelope `code` — exactly the detail `ShowError.from` was throwing away. The original report was almost certainly a transient WMATA server/data window that has since recovered. Rather than chase an unreproducible symptom, this makes the **next** such report actionable.

## Testing

- Compiles clean under the CI gate: `./gradlew :onebusaway-android:compileObaGoogleDebugKotlin -PwarningsAsErrors=true`.
- No unit test added: the code→toast mapping is unchanged (only logging is new), and JVM unit tests here have no `android.util.Log` stub (`returnDefaultValues` is off; no Robolectric), so a test would fight the stub for no behavioral coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when map-related requests fail.
  * Added diagnostic logging for unexpected errors while avoiding unnecessary details for known API errors.
  * Preserved appropriate error codes for API and network failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->