### PR TITLE
Build: root + settings + lint-rules to Kotlin DSL (#1819 step 3a)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@
 
 // Plugins are declared here (apply false) so their versions — sourced from gradle/libs.versions.toml —
 // are pinned build-wide and applied per-module. Replaces the old `buildscript { classpath ... }` block
-// (#1819); plugin resolution repositories now live in settings.gradle's pluginManagement.
+// (#1819); plugin resolution repositories now live in settings.gradle.kts's pluginManagement.
 plugins {
     alias(libs.plugins.android.application) apply false
     // kotlin-android is applied transitively (the compose/serialization compiler plugins pull in KGP),

--- a/lint-rules/build.gradle.kts
+++ b/lint-rules/build.gradle.kts
@@ -5,7 +5,7 @@
  * consumed by the app module via `lintChecks project(':lint-rules')`. Nothing here runs on device.
  */
 plugins {
-    id 'java-library'
+    `java-library`
     alias(libs.plugins.kotlin.jvm)
 }
 
@@ -23,18 +23,18 @@ kotlin {
 
 dependencies {
     // lint-api/lint-checks are provided by the lint runtime that loads this jar, so compileOnly.
-    compileOnly libs.lint.api
-    compileOnly libs.lint.checks
+    compileOnly(libs.lint.api)
+    compileOnly(libs.lint.checks)
 
-    testImplementation libs.lint.api
-    testImplementation libs.lint.checks
-    testImplementation libs.lint.tests
-    testImplementation libs.junit
+    testImplementation(libs.lint.api)
+    testImplementation(libs.lint.checks)
+    testImplementation(libs.lint.tests)
+    testImplementation(libs.junit)
 }
 
 // Lint discovers the registry through this manifest attribute when the jar is loaded via lintChecks.
-jar {
+tasks.jar {
     manifest {
-        attributes('Lint-Registry-v2': 'org.onebusaway.lint.TimeDomainIssueRegistry')
+        attributes(mapOf("Lint-Registry-v2" to "org.onebusaway.lint.TimeDomainIssueRegistry"))
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,8 +12,8 @@ pluginManagement {
 plugins {
     // Settings-scope plugin: it runs before the version catalog is available, so its version stays a
     // literal here rather than a `libs.` reference.
-    id 'org.gradle.toolchains.foojay-resolver-convention' version '1.0.0'
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 
-include ':onebusaway-android'
-include ':lint-rules'
+include(":onebusaway-android")
+include(":lint-rules")


### PR DESCRIPTION
**Stacked on #1838** (base = `modernize-gradle-catalog-1819`). Second phase of #1819: begin the Kotlin DSL conversion (step 3), starting with the three straightforward scripts per the issue's "root and settings first, then the app module" sequencing.

> ⚠️ Review/merge #1838 first — this PR targets that branch, not `main`.

## What changed
- `settings.gradle` → **`settings.gradle.kts`**
- `build.gradle` (root) → **`build.gradle.kts`**
- `lint-rules/build.gradle` → **`lint-rules/build.gradle.kts`**

Pure syntax conversion, **no behavior change**. Preserved verbatim: the `plugins {}` catalog aliases (`apply false` at root), `pluginManagement` + `allprojects` repositories, the java/kotlin toolchain config, and the `Lint-Registry-v2` jar manifest attribute. The `libs.*` accessors work identically from Kotlin DSL.

## Deliberately NOT in this PR
The app module (`onebusaway-android/build.gradle`) **stays Groovy** here. Its conversion is the big one — Groovy flavor-file coupling via `getPeliasKey`, the `XmlSlurper`-based `validateStringPlaceholders` task, and the AGP `androidComponents`/`onVariants` callbacks — and lands as its own stacked PR (**#1819 step 3b**). A Kotlin-DSL root with a Groovy app module is a fully supported mix.

## Verification
- [x] `./gradlew :onebusaway-android:compileObaGoogleDebugKotlin -PwarningsAsErrors=true` green.
- [x] `:lint-rules:jar` builds; manifest still carries `Lint-Registry-v2: org.onebusaway.lint.TimeDomainIssueRegistry`.
- [x] `-PbuildAllBrands=true` grid configures; `publishObaGoogleReleaseBundle` (and siblings) present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated Gradle build scripts to use consistent Kotlin DSL syntax across settings and module build files.
  * Migrated lint-rules configuration to Kotlin DSL style (plugin, dependencies, and manifest attributes).
* **Documentation**
  * Corrected build script documentation to reference the Kotlin settings file and aligned related formatting.
* **Chores**
  * Kept the existing build behavior and configuration intact while adjusting syntax and formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->