### PR TITLE
Build: centralize SDK levels + JDK target in the version catalog (#1819 follow-up)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,9 +27,12 @@ adb shell am start -n com.joulespersecond.seattlebusbot/org.onebusaway.android.u
 
 ### Dependency + plugin versions live in `gradle/libs.versions.toml` (#1819)
 
-All dependency and plugin coordinates resolve from the Gradle **version catalog** at
-`gradle/libs.versions.toml` (auto-imported; exposes `libs.*` accessors). Bump a version there, in one
-place — not in a build script. Plugins are applied via the `plugins {}` DSL (`alias(libs.plugins.…)`),
+All dependency and plugin coordinates — plus the Android SDK levels (`compileSdk`/`minSdk`/`targetSdk`)
+and the JDK/Kotlin target (`jdk`) — resolve from the Gradle **version catalog** at
+`gradle/libs.versions.toml` (auto-imported; exposes `libs.*` accessors; the SDK/JDK entries are read as
+`libs.versions.<name>.get()`). Bump a version there, in one place — not in a build script. Only
+`versionCode`/`versionName` stay in `build.gradle.kts` (release-cadence app identity; gradle-play-publisher
+auto-increments `versionCode`). Plugins are applied via the `plugins {}` DSL (`alias(libs.plugins.…)`),
 with resolution repositories in `settings.gradle.kts`'s `pluginManagement`; the root `build.gradle.kts`
 declares them `apply false`. All the build scripts are **Kotlin DSL** (`.kts`) — root, `settings`, the
 app module (`onebusaway-android/build.gradle.kts`), and `:lint-rules`. The brand flavor files under

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,5 @@
-# Gradle version catalog — the single source of truth for dependency + plugin coordinates.
+# Gradle version catalog — the single source of truth for dependency + plugin coordinates, plus the
+# Android SDK levels and JDK/Kotlin target (see the first [versions] block).
 #
 # Auto-imported by Gradle from this path (gradle/libs.versions.toml); exposes typed `libs.*`
 # accessors in the build scripts. Introduced in #1819 (build modernization). Bumps happen here,
@@ -7,6 +8,16 @@
 # NOTE: migrating to this catalog kept every version bit-identical — no upgrades rode along.
 
 [versions]
+# --- Android SDK levels + JDK/Kotlin target (project config, not dependency coordinates) ---
+# Centralized here so the app and :lint-rules share one source for the JVM target. Referenced from
+# the build scripts as libs.versions.<name>.get() (they resolve to plain strings). versionCode /
+# versionName intentionally stay in build.gradle.kts — they're release-cadence app identity, and
+# gradle-play-publisher auto-increments versionCode.
+compileSdk = "37"
+minSdk = "23"
+targetSdk = "36"
+jdk = "17"
+
 # --- Build tooling / plugins ---
 agp = "9.2.0"
 # Kotlin Gradle plugin + its compiler plugins (serialization, compose) all track the Kotlin

--- a/lint-rules/build.gradle.kts
+++ b/lint-rules/build.gradle.kts
@@ -13,12 +13,12 @@ plugins {
 // gradle/libs.versions.toml.
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.toVersion(libs.versions.jdk.get())
+    targetCompatibility = JavaVersion.toVersion(libs.versions.jdk.get())
 }
 
 kotlin {
-    jvmToolchain(17)
+    jvmToolchain(libs.versions.jdk.get().toInt())
 }
 
 dependencies {

--- a/onebusaway-android/build.gradle.kts
+++ b/onebusaway-android/build.gradle.kts
@@ -48,11 +48,11 @@ repositories {
 }
 
 android {
-    compileSdk = 37
+    compileSdk = libs.versions.compileSdk.get().toInt()
 
     defaultConfig {
-        minSdk = 23
-        targetSdk = 36
+        minSdk = libs.versions.minSdk.get().toInt()
+        targetSdk = libs.versions.targetSdk.get().toInt()
         versionCode = 153
         versionName = "26.1.0"
 
@@ -143,8 +143,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.toVersion(libs.versions.jdk.get())
+        targetCompatibility = JavaVersion.toVersion(libs.versions.jdk.get())
         // Backport java.time.* (API 26) to minSdk 23. See issue #1693.
         isCoreLibraryDesugaringEnabled = true
     }
@@ -213,7 +213,7 @@ android {
 // there is no generated `kotlin { }` accessor to rely on. Configure the extension by type instead.
 configure<KotlinAndroidProjectExtension> {
     compilerOptions {
-        jvmTarget.set(JvmTarget.JVM_17)
+        jvmTarget.set(JvmTarget.fromTarget(libs.versions.jdk.get()))
         // Promote Kotlin warnings to errors, but only when -PwarningsAsErrors=true is passed (CI
         // does; see .github/workflows/android.yml). Local builds default to off, so a Kotlin/AGP
         // bump that introduces new warnings can't block day-to-day work — it surfaces in CI


### PR DESCRIPTION
**Stacked on #1840** (base = `modernize-gradle-kts-app-1819`). A small follow-up to the #1819 stack: move the project-level version numbers still hardcoded in the build scripts into the version catalog, so `gradle/libs.versions.toml` is the single source for them too.

> ⚠️ Merge order: #1838 → #1839 → #1840 → this. Targets the #1840 branch.

## What changed
- `[versions]` gains `compileSdk = "37"`, `minSdk = "23"`, `targetSdk = "36"`, `jdk = "17"`.
- `onebusaway-android/build.gradle.kts` reads them via `libs.versions.<name>.get()` — SDK levels as `.toInt()`, the JDK target via `JavaVersion.toVersion(...)` and `JvmTarget.fromTarget(...)`.
- `lint-rules/build.gradle.kts` reads `jdk` for its `sourceCompatibility`/`targetCompatibility` and `jvmToolchain`. The **Java-17 target was duplicated across both modules** and is now shared from one place — the main motivation.

`versionCode`/`versionName` deliberately **stay** in `build.gradle.kts`: they're release-cadence app identity, gradle-play-publisher auto-increments `versionCode`, and BUILD.md points release managers at the build script to bump `versionName`.

## Why (and why now)
This wasn't one of #1819's four steps — the epic scoped the catalog to dependency + plugin coordinates. But with the whole build now Kotlin DSL, centralizing the remaining SDK/toolchain versions is a natural tidy-up, and it removes the duplicated Java-17 declaration between the two modules.

## Verification (values bit-identical)
- [x] Merged debug manifest: `minSdkVersion="23"`, `targetSdkVersion="36"`.
- [x] Compiled bytecode major version 61 (Java 17) for **both** `:onebusaway-android` and `:lint-rules`.
- [x] `obaGoogleDebug` + `obaMaplibreDebug` + `:lint-rules:jar` compile clean under `-PwarningsAsErrors=true`.
- [x] `lintObaGoogleDebug -PwarningsAsErrors=true` → "no new issues" (plain SDK ints in the catalog don't trigger the dependency-currency checks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Centralized Android SDK and JDK compatibility settings for more consistent project builds.
  * Standardized Java and Kotlin toolchain targets across modules.

* **Documentation**
  * Clarified project guidance for managing SDK, JDK, dependency, and plugin versions through the version catalog.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->