### PR TITLE
CI: declare org.apache.http.legacy to stop the flaky instrumented-test crash

### DIFF
--- a/onebusaway-android/src/main/AndroidManifest.xml
+++ b/onebusaway-android/src/main/AndroidManifest.xml
@@ -60,6 +60,15 @@
         android:networkSecurityConfig="@xml/network_security_config"
         tools:targetApi="24">
 
+        <!-- Apache HTTP legacy: removed from the default classpath at targetSdk 28+. Google Play
+             Services' Maps dynamite module (loaded in-process on the API-33 emulator) references
+             org.apache.http.* and crashes the instrumentation process with a NoClassDefFoundError
+             for org.apache.http.ProtocolVersion when it isn't present, flaking the connected tests
+             (e.g. ArrivalsPanelHeaderTest, EtaStripJustifyTest). required="false" so it's a no-op on
+             devices/images that lack it. See #1819 CI flakiness. -->
+        <uses-library
+            android:name="org.apache.http.legacy"
+            android:required="false" />
 
         <meta-data
             android:name="android.app.default_searchable"


### PR DESCRIPTION
## Problem
The API-33 connected-test job (`test (33)` → "run tests") flakes repeatedly — seen on **#1838, #1835, #1831**, and every PR in the #1819 stack — with:

```
java.lang.NoClassDefFoundError: Failed resolution of: Lorg/apache/http/ProtocolVersion;
  ... Didn't find class "org.apache.http.ProtocolVersion" on path:
      DexPathList[[zip file ".../com.google.android.gms/.../MapsDynamite.apk"], ...]
Test run failed to complete. Instrumentation run failed due to Process crashed.
```

Google Play Services' **Maps dynamite** module (loaded in-process on the emulator) references `org.apache.http.*`, which was removed from the default classpath at `targetSdk 28+`. When it's absent the whole **instrumentation process crashes**, taking down whatever tests happen to be running (observed: `ArrivalsPanelHeaderTest.alertToggleMeetsMinimumTouchTarget`, `EtaStripJustifyTest.justifiesEvenWhenPillsFit`) — a process crash, **not** a real assertion failure. That's why the failing test set varies run to run.

## Fix
Declare the legacy library in the app manifest so it's on the app-process classpath:

```xml
<uses-library android:name="org.apache.http.legacy" android:required="false" />
```

`required="false"` makes it a no-op on images/devices that don't provide it → **no behaviour change on real devices**; it only restores the classes the emulator's Play Services needs. This is the documented fix for this exact `MapsDynamite` / `ProtocolVersion` crash.

## Verification
- [x] Merges into the app's main manifest (`processObaGoogleDebugMainManifest`).
- [ ] CI: the connected-test job should stop crashing on this. (CI green builds confidence; because the underlying job is flaky, a couple of clean runs are the real signal.)

Not part of #1819 — a standalone CI-stability fix that unblocks the whole stack **and** main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with certain emulator and test environments.
  * Reduced instrumentation and CI failures related to missing legacy networking classes.
  * The compatibility library remains optional and does not affect devices where it is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->