### PR TITLE
CI: stop running Android Lint on the PR/push path

### DIFF
--- a/.github/workflows/android-nightly.yml
+++ b/.github/workflows/android-nightly.yml
@@ -113,8 +113,8 @@ jobs:
           target: google_apis
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
-          # Select only the @SmokeTest-annotated classes; -x lint keeps the ~10-min lint off this leg
-          # (android.yml already gates lint on the PR path).
+          # Select only the @SmokeTest-annotated classes; -x lint keeps the ~10-min lint off this leg.
+          # (Lint no longer runs on the PR path either — it's slated for its own nightly heavyweight run.)
           script: >-
             ./gradlew connectedObaGoogleDebugAndroidTest
             -Pandroid.testInstrumentationRunnerArguments.annotation=org.onebusaway.android.SmokeTest

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -35,15 +35,10 @@ jobs:
       - name: Gradle cache
         uses: gradle/actions/setup-gradle@v3
 
-      # Android Lint gate: catches minSdk (NewApi) regressions and other lint errors that
-      # compile + API-33 tests can't see (#1692). Runs on the host before the emulator so it
-      # fails fast; `check` below keeps skipping lint (-x lint) to avoid running it twice.
-      - name: Android Lint
-        # --build-cache: store the obaGoogleDebug compile outputs this step produces in the Gradle
-        # build cache so the "run tests" step below reuses them (and setup-gradle persists the cache
-        # across CI runs). Build cache is enabled per-invocation here, NOT in gradle.properties, to
-        # avoid arming a stale-R.jar footgun for local multi-worktree dev (which shares ~/.gradle).
-        run: ./gradlew :onebusaway-android:lintObaGoogleDebug --build-cache -PwarningsAsErrors=true --stacktrace
+      # NOTE: Android Lint intentionally does NOT run on the PR/push path. lintObaGoogleDebug is
+      # heavyweight (~7-15 min) and dominates this job's wall-clock; it's being moved to a dedicated
+      # nightly heavyweight run instead. The "run tests" step below keeps `-x lint` so `check` doesn't
+      # pull lint back in. (Kotlin `-PwarningsAsErrors` compile gating still runs here via `check`.)
 
       - name: AVD cache
         uses: actions/cache@v4


### PR DESCRIPTION
Per request: drop the heavyweight Android Lint step from the per-PR/push CI. `lintObaGoogleDebug` takes ~7–15 min and dominates the `test` job's wall-clock; it's slated to move to a dedicated **nightly heavyweight** run.

## Changes
- **`android.yml`**: remove the `Android Lint` step. The `run tests` step already passes `-x lint`, so `check` won't pull lint back in — lint now runs nowhere on the PR path. Kotlin `-PwarningsAsErrors` compile gating still runs (via `check` / `connectedAndroidTest`).
- **`android-nightly.yml`**: correct a now-stale comment that claimed `android.yml` gates lint on the PR path.

## Notes
- No app/source change — PR CI just gets faster and loses the lint gate temporarily.
- **Trade-off:** until the nightly lint leg lands, `NewApi`/minSdk lint regressions won't be caught in CI. Re-adding lint as a nightly job is the intended follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **CI Improvements**
  * Streamlined Android pull request and push checks by excluding Android Lint from the standard workflow.
  * Android Lint is planned to run separately in a dedicated nightly workflow.
  * Existing Android tests and warning enforcement continue to run as before.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->