### PR TITLE
Docs: drop the stale, derivable Architecture section from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,35 +116,6 @@ The project uses two flavor dimensions:
 
 Default variant: `obaGoogleDebug`
 
-## Architecture
-
-### Source Structure
-Main module: `onebusaway-android/src/main/java/org/onebusaway/android/`
-
-Key packages:
-- `app/` - Application class and lifecycle management
-- `ui/` - Activities and Fragments (HomeActivity is the main entry point)
-- `io/` - REST API integration using Jackson for JSON binding
-  - `elements/` - Response data models
-  - `request/` - API request classes (e.g., ObaArrivalInfoRequest)
-- `provider/` - Content provider (ObaProvider, ObaContract)
-- `map/` - Google Maps integration (Google flavor only)
-- `region/` - Multi-region support for different OBA server instances
-- `directions/` - OpenTripPlanner integration for trip planning
-- `tripservice/` - WorkManager-based arrival reminders
-- `util/` - Utility classes (LocationUtils, PreferenceUtils, RegionUtils)
-
-### API Layer Pattern
-- Requests extend base classes and return typed responses
-- Jackson handles JSON serialization/deserialization
-- ObaApi provides static singleton access to API constants
-- Multi-region architecture auto-discovers OBA servers based on device location
-
-### Data Persistence
-- Content Provider with ObaContract for data access
-- Room database for structured storage (schemas in `schemas/` directory)
-- SharedPreferences for user settings via PreferenceUtils
-
 ## Configuration
 
 ### Required for Trip Planning (Pelias Geocoding)


### PR DESCRIPTION
Removes the `## Architecture` block (Source Structure / API Layer Pattern / Data Persistence, ~29 lines) from the root `CLAUDE.md`.

## Why
Two reasons:
1. **Derivable.** It's a README-style repo tour — the package list is what `ls`/`find` already show, so it's dead weight loaded into every session's context.
2. **Stale / misleading.** It describes things that no longer exist:
   - `io/ - REST API integration using Jackson for JSON binding` — the `io/` package was removed when the hand-rolled client was replaced.
   - `Jackson handles JSON serialization/deserialization` — Jackson is gone; the app parses everything through Retrofit + kotlinx.serialization (see the `#1819` note already in `CLAUDE.md` and the comment in `build.gradle.kts`).

## What stays
All the non-derivable, high-value guidance is untouched: the time-domain rules, typed instants, the "no unsanctioned heuristics" policy, CI-strictness, the variant grid, and the version-catalog notes.

Surfaced by a `/doctor` pass over the Claude Code setup. Docs-only, no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed outdated architecture guidance from the project documentation.
  * Simplified the documentation flow between build variants and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->