### PR TITLE
Move "Recent stops/routes" into the drawer; retire the three-dot menu

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeNavHost.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeNavHost.kt
@@ -178,7 +178,7 @@ fun HomeNavHost(
                     onSettings = { menuNav(NavRoutes.SETTINGS, R.string.analytics_label_button_press_settings) },
                     onSearch = { query -> navController.navigateFromHome(NavRoutes.search(query)) },
                     onRecentStopsRoutes = {
-                        // The user found the overflow on their own — don't later spotlight it in onboarding.
+                        // The user found the drawer item on their own — don't later spotlight it in onboarding.
                         PreferencesEntryPoint.get(context).setBoolean(ArrivalTutorial.KEY_MORE_MENU, true)
                         navController.navigateFromHome(NavRoutes.myRecent())
                     },

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -359,6 +359,7 @@ fun HomeScreen(
             drawerState = drawerState,
             onStarredStops = onStarredStops,
             onStarredRoutes = onStarredRoutes,
+            onRecentStopsRoutes = onRecentStopsRoutes,
             onReminders = onReminders,
             onPlanTrip = onPlanTrip,
             onPayFare = onPayFare,
@@ -373,19 +374,14 @@ fun HomeScreen(
             // The TopAppBar applies its own top window inset (status bar), so the Column doesn't.
             Column(Modifier.fillMaxSize()) {
                 HomeTopBar(
-                    // HOME is always the map now; the list tabs are their own destinations with their
-                    // own top bars, so the home bar shows no list sort/clear.
+                    // HOME is always the map now; the list tabs are their own destinations with their own
+                    // top bars.
                     title = stringResource(R.string.navdrawer_item_nearby),
-                    showSort = false,
-                    showClear = false,
-                    clearLabel = R.string.my_option_clear_starred_stops,
                     onOpenDrawer = { scope.launch { drawerState.open() } },
                     onSearch = onSearch,
-                    onSort = {},
-                    onClear = {},
-                    onRecentStopsRoutes = onRecentStopsRoutes,
-                    // Wire the top bar's overflow anchor slot to the "recent stops/routes" spotlight target.
-                    overflowModifier = Modifier.tutorialAnchor(tutorialState, ArrivalTutorial.KEY_MORE_MENU),
+                    // Recent stops/routes now lives in the drawer, so the onboarding spotlight points at the
+                    // hamburger that opens it (was the retired overflow ⋮).
+                    menuModifier = Modifier.tutorialAnchor(tutorialState, ArrivalTutorial.KEY_MORE_MENU),
                 )
                 BottomSheetScaffold(
                     modifier = Modifier
@@ -510,6 +506,7 @@ private fun HomeDrawer(
     drawerState: DrawerState,
     onStarredStops: () -> Unit,
     onStarredRoutes: () -> Unit,
+    onRecentStopsRoutes: () -> Unit,
     onReminders: () -> Unit,
     onPlanTrip: () -> Unit,
     onPayFare: () -> Unit,
@@ -537,6 +534,7 @@ private fun HomeDrawer(
                 payFareAvailable = availability.payFareAvailable,
                 onStarredStops = { close(); onStarredStops() },
                 onStarredRoutes = { close(); onStarredRoutes() },
+                onRecentStopsRoutes = { close(); onRecentStopsRoutes() },
                 onReminders = { close(); onReminders() },
                 onPlanTrip = { close(); onPlanTrip() },
                 onPayFare = { close(); onPayFare() },

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/chrome/HomeTopBar.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/chrome/HomeTopBar.kt
@@ -13,14 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-// `overflowModifier` is a named anchor a host attaches to the overflow (⋮) button for the onboarding
+// `menuModifier` is a named anchor a host attaches to the hamburger (☰) button for the onboarding
 // spotlight — a sub-element modifier, not the bar's root `modifier` — so ModifierParameter's
 // "name it modifier" rule doesn't apply here.
 @file:Suppress("ModifierParameter")
 
 package org.onebusaway.android.ui.home.chrome
 
-import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.text.BasicTextField
@@ -30,10 +29,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.Menu
-import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Search
-import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -54,7 +50,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.SolidColor
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import org.onebusaway.android.R
@@ -62,29 +57,22 @@ import org.onebusaway.android.R
 /**
  * Home's Material3 top bar, replacing the hosted `MaterialToolbar` + options menu. It toggles between
  * two modes:
- *  - **idle** — the [title] (the selected nav item) with a hamburger that opens the drawer, plus a
- *    search action, a Sort action (when [showSort]), and an overflow with "Recent stops/routes" and a
- *    Clear item (when [showClear]).
+ *  - **idle** — the [title] (the selected nav item) with a hamburger that opens the drawer (where
+ *    "Recent stops/routes" now lives), plus a search action.
  *  - **search** — tapping search flips the whole bar into an autofocused text field; submitting calls
  *    [onSearch] (which fires the legacy `ACTION_SEARCH` → `SearchActivity`); the back arrow exits.
  *
- * Sort/Clear and the per-tab [clearLabel] are gated by the caller from `HomeUiState`, so the bar stays
- * a pure function of state. Container color matches [org.onebusaway.android.ui.compose.components.ObaTopAppBar].
+ * The bar stays a pure function of state. Container color matches
+ * [org.onebusaway.android.ui.compose.components.ObaTopAppBar].
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun HomeTopBar(
     title: String,
-    showSort: Boolean,
-    showClear: Boolean,
-    @StringRes clearLabel: Int,
     onOpenDrawer: () -> Unit,
     onSearch: (String) -> Unit,
-    onSort: () -> Unit,
-    onClear: () -> Unit,
-    onRecentStopsRoutes: () -> Unit,
-    // Opaque anchor a host may attach to the overflow (⋮) button (e.g. for an onboarding spotlight).
-    overflowModifier: Modifier = Modifier,
+    // Opaque anchor a host may attach to the hamburger (☰) button (e.g. for an onboarding spotlight).
+    menuModifier: Modifier = Modifier,
 ) {
     var searching by remember { mutableStateOf(false) }
     val colors = TopAppBarDefaults.topAppBarColors(
@@ -104,7 +92,7 @@ fun HomeTopBar(
             title = { Text(title) },
             colors = colors,
             navigationIcon = {
-                IconButton(onClick = onOpenDrawer) {
+                IconButton(onClick = onOpenDrawer, modifier = menuModifier) {
                     Icon(Icons.Default.Menu, stringResource(R.string.navigation_drawer_open))
                 }
             },
@@ -112,52 +100,8 @@ fun HomeTopBar(
                 IconButton(onClick = { searching = true }) {
                     Icon(Icons.Default.Search, stringResource(R.string.map_option_search))
                 }
-                if (showSort) {
-                    IconButton(onClick = onSort) {
-                        Icon(
-                            painterResource(R.drawable.ic_action_content_sort),
-                            stringResource(R.string.menu_option_sort_by)
-                        )
-                    }
-                }
-                HomeOverflow(showClear, clearLabel, onClear, onRecentStopsRoutes, overflowModifier)
             }
         )
-    }
-}
-
-/** The overflow (⋮): always "Recent stops/routes", plus the per-tab Clear item on the starred tabs. */
-@Composable
-private fun HomeOverflow(
-    showClear: Boolean,
-    @StringRes clearLabel: Int,
-    onClear: () -> Unit,
-    onRecentStopsRoutes: () -> Unit,
-    overflowModifier: Modifier,
-) {
-    var expanded by remember { mutableStateOf(false) }
-    Box {
-        IconButton(onClick = { expanded = true }, modifier = overflowModifier) {
-            Icon(Icons.Default.MoreVert, contentDescription = null)
-        }
-        DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
-            DropdownMenuItem(
-                text = { Text(stringResource(R.string.my_recent_menu_title)) },
-                onClick = {
-                    expanded = false
-                    onRecentStopsRoutes()
-                }
-            )
-            if (showClear) {
-                DropdownMenuItem(
-                    text = { Text(stringResource(clearLabel)) },
-                    onClick = {
-                        expanded = false
-                        onClear()
-                    }
-                )
-            }
-        }
     }
 }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/drawer/HomeNavDrawer.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/drawer/HomeNavDrawer.kt
@@ -53,6 +53,7 @@ fun HomeNavDrawerSheet(
     payFareAvailable: Boolean,
     onStarredStops: () -> Unit,
     onStarredRoutes: () -> Unit,
+    onRecentStopsRoutes: () -> Unit,
     onReminders: () -> Unit,
     onPlanTrip: () -> Unit,
     onPayFare: () -> Unit,
@@ -67,6 +68,7 @@ fun HomeNavDrawerSheet(
         Column(Modifier.verticalScroll(rememberScrollState())) {
             DrawerRow(R.string.navdrawer_item_starred_stops, R.drawable.stop_flag, onStarredStops)
             DrawerRow(R.string.navdrawer_item_starred_routes, R.drawable.ic_route, onStarredRoutes)
+            DrawerRow(R.string.my_recent_menu_title, R.drawable.history_24, onRecentStopsRoutes)
             if (showReminders) {
                 DrawerRow(R.string.navdrawer_item_my_reminders, R.drawable.ic_drawer_alarm, onReminders)
             }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tutorial/ArrivalTutorial.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tutorial/ArrivalTutorial.kt
@@ -21,8 +21,9 @@ import org.onebusaway.android.preferences.PreferencesRepository
 /**
  * The arrivals-panel onboarding sequence — the Compose successor to the legacy ShowcaseView
  * "arrival header" tutorial chain (which spotlighted XML views removed in the Compose migration).
- * Spotlights, in order, the ETA pill, the slide-up chevron, and the top-bar overflow (see the
- * [Modifier.tutorialAnchor] call sites in `ArrivalsPanel` / the sheet host). Shown once the first
+ * Spotlights, in order, the ETA pill, the slide-up chevron, and the hamburger menu — which now holds
+ * "Recent stops/routes" (see the [Modifier.tutorialAnchor] call sites in `ArrivalsPanel` / the sheet
+ * host). Shown once the first
  * time a stop's arrivals load, gated by [pendingSteps]; "show tutorials again" re-arms it by clearing
  * the [resetKeys] (see `TutorialPrefs.resetAllTutorials`).
  *
@@ -39,7 +40,11 @@ object ArrivalTutorial {
     /** Slide-up chevron — pull the panel up for the full arrivals list. */
     const val KEY_PANEL = ".tutorial_compose_arrival_panel"
 
-    /** Top-bar overflow (⋮) — find recently viewed stops and routes. */
+    /**
+     * Hamburger menu (☰) — "Recent stops/routes" moved out of the retired overflow into the drawer, so
+     * this now spotlights the nav icon that opens it. The persisted pref value stays the legacy
+     * `.tutorial_compose_more_menu` so users who already saw the step aren't re-shown it.
+     */
     const val KEY_MORE_MENU = ".tutorial_compose_more_menu"
 
     /** The sequence, in display order. */
@@ -59,7 +64,7 @@ object ArrivalTutorial {
             id = KEY_MORE_MENU,
             title = R.string.tutorial_recent_stops_routes_title,
             body = R.string.tutorial_recent_stops_routes_text,
-            bodyIcon = R.drawable.more_vert,
+            bodyIcon = R.drawable.history_24,
         ),
     )
 

--- a/onebusaway-android/src/main/res/drawable/history_24.xml
+++ b/onebusaway-android/src/main/res/drawable/history_24.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M13,3c-4.97,0 -9,4.03 -9,9L1,12l3.89,3.89 0.07,0.14L9,12L6,12c0,-3.87 3.13,-7 7,-7s7,3.13 7,7 -3.13,7 -7,7c-1.93,0 -3.68,-0.79 -4.94,-2.06l-1.42,1.42C8.27,19.99 10.51,21 13,21c4.97,0 9,-4.03 9,-9s-4.03,-9 -9,-9zM12,8v5l4.28,2.54 0.72,-1.21 -3.5,-2.08L13.5,8L12,8z"/>
+</vector>

--- a/onebusaway-android/src/main/res/values-es/strings.xml
+++ b/onebusaway-android/src/main/res/values-es/strings.xml
@@ -792,7 +792,7 @@
     </string>
     <string name="tutorial_recent_stops_routes_title">Paradas y rutas recientes</string>
     <string name="tutorial_recent_stops_routes_text">Encuentra las paradas y rutas que recientemente has mirado
-        accediendo por medio del botón \"Más\" en la parte superior derecha de la pantalla.
+        en el menú.
     </string>
 
     <!-- Permissions -->

--- a/onebusaway-android/src/main/res/values-fi/strings.xml
+++ b/onebusaway-android/src/main/res/values-fi/strings.xml
@@ -629,8 +629,8 @@
         nähdäksesi lisää tälle pysäkille saapuvia vuoroja.
     </string>
     <string name="tutorial_recent_stops_routes_title">Viimeisimmät pysäkit ja reitit</string>
-    <string name="tutorial_recent_stops_routes_text">Ruudun oikeasta laidasta löytyvän \"Lisää\" napin 
-        avulla löydät pysäkit ja reitit joita olet viimeksi katsellut.
+    <string name="tutorial_recent_stops_routes_text">Valikon avulla löydät pysäkit ja reitit
+        joita olet viimeksi katsellut.
     </string>
     <string name="tutorial_opt_out_dialog_title">Näytetäänkö opas?</string>
     <string name="tutorial_opt_out_dialog_text">Haluatko nähdä ponnahdusikkunoiden kuvaukset %1$sn käytöstä? Voit aina ottaa ponnahdusikkunat käyttöön tai poistaa ne käytöstä asetuksista, tai näyttää oppaan myöhemmin Ohje-valikon kautta.</string>

--- a/onebusaway-android/src/main/res/values-it/strings.xml
+++ b/onebusaway-android/src/main/res/values-it/strings.xml
@@ -639,7 +639,7 @@
     <string name="tutorial_arrival_header_sliding_panel_title">Scorri in su per mostrare più arrivi</string>
     <string name="tutorial_arrival_header_sliding_panel_text">Tocca la freccia o trascina il pannello in su per vedere altri arrivi a questa fermata.</string>
     <string name="tutorial_recent_stops_routes_title">Fermate e linee recenti</string>
-    <string name="tutorial_recent_stops_routes_text">Per ritrovare le fermate e le linee cercate di recente, tocca il pulsante \&quot;Altro\&quot; in alto a destra.</string>
+    <string name="tutorial_recent_stops_routes_text">Per ritrovare le fermate e le linee cercate di recente, apri il menu.</string>
 
     <!-- Permissions -->
     <string name="location_permissions_title">Autorizzazioni per la posizione</string>

--- a/onebusaway-android/src/main/res/values-pl/strings.xml
+++ b/onebusaway-android/src/main/res/values-pl/strings.xml
@@ -743,7 +743,7 @@
     </string>
     <string name="tutorial_recent_stops_routes_title">Ostatnie przystanki i trasy</string>
     <string name="tutorial_recent_stops_routes_text">Znajdź przystanki i trasy które ostatnio
-        przeglądając klikając przycisk \"Więcej\" u góry ekranu.
+        przeglądałeś w menu.
     </string>
     <string name="tutorial_opt_out_dialog_title">Pokazać samouczek?</string>
     <string name="tutorial_opt_out_dialog_text">Czy chcesz zobaczyć wyskakujące opisy jak korzystać z %1$s? Zawsze możesz włączyć lub wyłączyć wyskakujące okienka w Ustawieniach, lub wyświetlić samouczek później przez Pomoc.</string>

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -826,7 +826,7 @@
     </string>
     <string name="tutorial_recent_stops_routes_title">Recent stops and routes</string>
     <string name="tutorial_recent_stops_routes_text">Find the stops and routes that you\'ve recently
-        looked at via the \"More\" button at the top right of the screen.
+        looked at in the menu.
     </string>
     <!-- Onboarding spotlight card: the corner close button's accessibility label + the final-step action -->
     <string name="tutorial_button_close">End tutorial</string>


### PR DESCRIPTION
## What

The home top bar's overflow (⋮) menu held a single visible item — **Recent stops/routes**. This moves that item into the hamburger navigation drawer as a first-class row and retires the three-dot menu entirely.

On HOME the overflow's other code paths (Sort / Clear) were already dead — `showSort`/`showClear` were hardcoded `false` and the list Sort/Clear affordances live on the list destinations' own top bars (`HomeListsDestinations`), so "Recent stops/routes" was the only thing the overflow ever showed.

## Changes

- **`HomeNavDrawer`** — new **Recent stops/routes** `DrawerRow` (history icon), grouped with the starred-stops/routes rows, wired through `HomeScreen`'s `HomeDrawer`.
- **`HomeTopBar`** — deleted the overflow (`HomeOverflow` + the `showClear`/`clearLabel`/`onClear`/`onRecentStopsRoutes` params). Also dropped the now-solitary dead `showSort`/`onSort` (single caller hardcoded it off).
- **Onboarding tutorial** — the "recent stops/routes" spotlight step now anchors the **hamburger** instead of the overflow (renamed `menuModifier` slot) and uses the history icon. The persisted pref value stays `.tutorial_compose_more_menu`, so users who already saw the step aren't re-shown it.
- **Strings** — updated the tutorial body copy (+ es/fi/it/pl) to point at the menu. Since the spotlight already highlights the hamburger, the copy no longer names a screen position (RTL-safe).
- **New asset** — `res/drawable/history_24.xml` (Material "history" vector).

## Notes for reviewers

- The four **non-English translations** (es/fi/it/pl) were updated by hand to drop the stale "More button" wording. Spanish/Italian are solid; a native-speaker glance at Finnish/Polish would be welcome.
- Compiles clean under the strict CI gate (`-PwarningsAsErrors=true`). Not yet exercised on a device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added “Recent stops/routes” to the navigation drawer.
  * Updated the home screen to access navigation and search through the simplified top bar.

* **Documentation**
  * Updated onboarding guidance and translations to direct users to the menu for recent stops and routes.
  * Added a history icon for the recent stops/routes menu item.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->