### PR TITLE
Recents dropdown under the focused search box

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/database/oba/RouteDao.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/database/oba/RouteDao.kt
@@ -17,6 +17,7 @@ package org.onebusaway.android.database.oba
 
 import androidx.room.ColumnInfo
 import androidx.room.Dao
+import androidx.room.Embedded
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
@@ -31,8 +32,19 @@ data class RouteListRow(
     val url: String?,
 )
 
+/** A [RouteListRow] plus the raw [accessTime], for merging recent stops and routes into one time-ordered list. */
+data class RouteRecentRow(
+    @Embedded val row: RouteListRow,
+    @ColumnInfo(name = "access_time") val accessTime: Long?,
+)
+
 private const val ROUTE_REGION_SCOPE =
     "(:regionId IS NULL OR region_id = :regionId OR region_id IS NULL)"
+
+/** The recents predicate + ordering (newest first, capped), shared by the two recent-route queries. */
+private const val ROUTE_RECENT_FILTER =
+    "((access_time IS NOT NULL AND access_time > :cutoff) OR use_count > 0) AND $ROUTE_REGION_SCOPE"
+private const val ROUTE_RECENT_ORDER = "ORDER BY access_time DESC, use_count DESC LIMIT 20"
 
 /** Room access for routes + the My-tab recent/starred lists (the legacy `routes` table). */
 @Dao
@@ -172,10 +184,16 @@ interface RouteDao {
 
     @Query(
         "SELECT _id AS id, short_name, long_name, url FROM routes " +
-            "WHERE ((access_time IS NOT NULL AND access_time > :cutoff) OR use_count > 0) " +
-            "AND $ROUTE_REGION_SCOPE ORDER BY access_time DESC, use_count DESC LIMIT 20"
+            "WHERE $ROUTE_RECENT_FILTER $ROUTE_RECENT_ORDER"
     )
     fun recents(cutoff: Long, regionId: Long?): Flow<List<RouteListRow>>
+
+    /** Same rows as [recents], but carrying access_time so callers can merge stops and routes by recency. */
+    @Query(
+        "SELECT _id AS id, short_name, long_name, url, access_time FROM routes " +
+            "WHERE $ROUTE_RECENT_FILTER $ROUTE_RECENT_ORDER"
+    )
+    fun recentsForSearch(cutoff: Long, regionId: Long?): Flow<List<RouteRecentRow>>
 
     @Query(
         "SELECT _id AS id, short_name, long_name, url FROM routes " +

--- a/onebusaway-android/src/main/java/org/onebusaway/android/database/oba/StopDao.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/database/oba/StopDao.kt
@@ -17,6 +17,7 @@ package org.onebusaway.android.database.oba
 
 import androidx.room.ColumnInfo
 import androidx.room.Dao
+import androidx.room.Embedded
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
@@ -35,11 +36,22 @@ data class StopListRow(
     val favorite: Int?,
 )
 
+/** A [StopListRow] plus the raw [accessTime], for merging recent stops and routes into one time-ordered list. */
+data class StopRecentRow(
+    @Embedded val row: StopListRow,
+    @ColumnInfo(name = "access_time") val accessTime: Long?,
+)
+
 /** The legacy projected UI_NAME expression, reused across the stop list queries. */
 private const val UI_NAME = "(CASE WHEN user_name IS NOT NULL THEN user_name ELSE name END)"
 
 /** The legacy region scope: rows for the active region, or with no region, or (when none active) all. */
 private const val REGION_SCOPE = "(:regionId IS NULL OR region_id = :regionId OR region_id IS NULL)"
+
+/** The recents predicate + ordering (newest first, capped), shared by the two recent-stop queries. */
+private const val RECENT_FILTER =
+    "((access_time IS NOT NULL AND access_time > :cutoff) OR use_count > 0) AND $REGION_SCOPE"
+private const val RECENT_ORDER = "ORDER BY access_time DESC, use_count DESC LIMIT 20"
 
 /** Room access for stop user-state + the My-tab recent/starred lists (the legacy `stops` table). */
 @Dao
@@ -117,10 +129,16 @@ interface StopDao {
 
     @Query(
         "SELECT _id AS id, $UI_NAME AS ui_name, direction, latitude, longitude, favorite FROM stops " +
-            "WHERE ((access_time IS NOT NULL AND access_time > :cutoff) OR use_count > 0) " +
-            "AND $REGION_SCOPE ORDER BY access_time DESC, use_count DESC LIMIT 20"
+            "WHERE $RECENT_FILTER $RECENT_ORDER"
     )
     fun recents(cutoff: Long, regionId: Long?): Flow<List<StopListRow>>
+
+    /** Same rows as [recents], but carrying access_time so callers can merge stops and routes by recency. */
+    @Query(
+        "SELECT _id AS id, $UI_NAME AS ui_name, direction, latitude, longitude, favorite, access_time " +
+            "FROM stops WHERE $RECENT_FILTER $RECENT_ORDER"
+    )
+    fun recentsForSearch(cutoff: Long, regionId: Long?): Flow<List<StopRecentRow>>
 
     @Query(
         "SELECT _id AS id, $UI_NAME AS ui_name, direction, latitude, longitude, favorite FROM stops " +

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeNavHost.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeNavHost.kt
@@ -75,6 +75,7 @@ import org.onebusaway.android.ui.nav.consumeRouteReveal
 import org.onebusaway.android.ui.nav.RESULT_MAP_STOP_ID
 import org.onebusaway.android.ui.nav.consumeStopReveal
 import org.onebusaway.android.ui.nav.navigateFromHome
+import org.onebusaway.android.ui.nav.revealRouteOnMap
 import org.onebusaway.android.ui.settings.settingsGraph
 import org.onebusaway.android.ui.survey.SurveyViewModel
 import org.onebusaway.android.ui.tripdetails.TripDetailsLauncher
@@ -182,6 +183,10 @@ fun HomeNavHost(
                         PreferencesEntryPoint.get(context).setBoolean(ArrivalTutorial.KEY_MORE_MENU, true)
                         navController.navigateFromHome(NavRoutes.myRecent())
                     },
+                    // Recents dropdown taps mirror the My Recent screen: a stop opens its arrivals, a route
+                    // reveals on the map.
+                    onRecentStop = { id, name -> navController.navigateFromHome(NavRoutes.arrivals(id, name)) },
+                    onRecentRoute = { routeId -> navController.revealRouteOnMap(routeId) },
                     onHelpAction = { action ->
                         if (action == HelpAction.AGENCIES) navController.navigateFromHome(NavRoutes.AGENCIES)
                         else a.onHelpActionExternal(action)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -55,6 +55,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalWindowInfo
@@ -69,6 +70,8 @@ import org.onebusaway.android.map.RouteHeader
 import org.onebusaway.android.map.MapViewModel
 import org.onebusaway.android.map.ShowRouteRequest
 import org.onebusaway.android.ui.arrivals.ArrivalsViewModel
+import org.onebusaway.android.ui.compose.ListUiState
+import org.onebusaway.android.ui.compose.findActivity
 import org.onebusaway.android.ui.compose.navigationBarBottomPadding
 import org.onebusaway.android.ui.compose.theme.ObaTheme
 import org.onebusaway.android.ui.home.arrivals.ArrivalsSheetHost
@@ -84,6 +87,9 @@ import org.onebusaway.android.ui.home.help.HelpFeature
 import org.onebusaway.android.ui.home.help.HelpViewModel
 import org.onebusaway.android.ui.home.map.MapChrome
 import org.onebusaway.android.ui.home.map.MapFeature
+import org.onebusaway.android.ui.mylists.RecentItem
+import org.onebusaway.android.ui.mylists.SearchRecentsRepository
+import org.onebusaway.android.ui.mylists.rememberListVm
 import org.onebusaway.android.ui.home.map.RouteHeaderOverlay
 import org.onebusaway.android.ui.survey.SurveyFeature
 import org.onebusaway.android.ui.tutorial.ArrivalTutorial
@@ -120,6 +126,9 @@ class HomeCallbacks(
     val onSettings: () -> Unit,
     val onSearch: (String) -> Unit,
     val onRecentStopsRoutes: () -> Unit,
+    // Search-box recents dropdown: tapping a stop opens its arrivals; tapping a route reveals it on the map.
+    val onRecentStop: (id: String, name: String?) -> Unit,
+    val onRecentRoute: (routeId: String) -> Unit,
     // Wraps [HomeActivityActions.onHelpActionExternal] with the one branch that's a navigation (AGENCIES).
     val onHelpAction: (HelpAction) -> Unit,
     val onShowTrip: (tripId: String, stopId: String) -> Unit,
@@ -193,6 +202,14 @@ fun HomeScreen(
         val density = LocalDensity.current
         val resources = LocalResources.current
         val snackbarHostState = remember { SnackbarHostState() }
+        // The unified recent stops+routes list for the search field's dropdown. Hosted here (like the
+        // My-tab lists, via rememberListVm) so MapTopChrome stays a pure, VM-free chrome composable;
+        // empty until it resolves.
+        val app = LocalContext.current.findActivity().applicationContext
+        val searchRecents = rememberListVm("home.searchRecents") { SearchRecentsRepository(app) }
+        val recents: List<RecentItem> =
+            (searchRecents.state.collectAsStateWithLifecycle().value as? ListUiState.Success)?.items
+                .orEmpty()
         // Drives the arrivals-panel onboarding spotlight; provided to the sheet content (so the panel's
         // anchors can register) and read by [TutorialOverlay] below, which draws over the whole screen.
         val tutorialState = rememberTutorialState()
@@ -479,6 +496,9 @@ fun HomeScreen(
                             MapTopChrome(
                                 onOpenDrawer = openDrawer,
                                 onSearch = onSearch,
+                                recents = recents,
+                                onRecentStop = onRecentStop,
+                                onRecentRoute = onRecentRoute,
                                 // Recent stops/routes lives in the drawer, so the onboarding spotlight points at
                                 // the menu FAB that opens it (was the retired overflow ⋮).
                                 menuModifier = Modifier.tutorialAnchor(tutorialState, ArrivalTutorial.KEY_MORE_MENU),

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/chrome/MapTopChrome.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/chrome/MapTopChrome.kt
@@ -153,6 +153,7 @@ fun MapTopChrome(
                     focusManager.clearFocus()
                     onRecentRoute(routeId)
                 },
+                onDismiss = { focusManager.clearFocus() },
                 modifier = Modifier.weight(1f),
             )
         }
@@ -179,6 +180,7 @@ private fun SearchField(
     onSubmit: (String) -> Unit,
     onRecentStop: (id: String, name: String?) -> Unit,
     onRecentRoute: (routeId: String) -> Unit,
+    onDismiss: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     var query by remember { mutableStateOf("") }
@@ -250,8 +252,11 @@ private fun SearchField(
                         }
                     }
                 )
-                if (query.isNotEmpty()) {
-                    IconButton(onClick = { query = "" }) {
+                // The X shows whenever the field is active — there's text, or the field is focused with the
+                // recents list showing. It clears the query when there's text; on an already-blank field
+                // (recents showing) the same X dismisses the search (clears focus, collapsing the dropdown).
+                if (query.isNotEmpty() || expanded) {
+                    IconButton(onClick = { if (query.isNotEmpty()) query = "" else onDismiss() }) {
                         Icon(Icons.Default.Clear, stringResource(R.string.stop_info_clear))
                     }
                 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/chrome/MapTopChrome.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/chrome/MapTopChrome.kt
@@ -20,11 +20,12 @@
 
 package org.onebusaway.android.ui.home.chrome
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -53,8 +54,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
@@ -63,23 +66,32 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import org.onebusaway.android.R
+import org.onebusaway.android.ui.mylists.RecentItem
+import org.onebusaway.android.ui.mylists.filterRecents
 
 /**
  * Home's floating map chrome that replaces the old solid `TopAppBar`: the map now runs edge-to-edge and
  * these controls float over its top edge (mirroring the bottom [org.onebusaway.android.ui.home.map.MapChrome]
- * FABs). A menu (☰) FAB in the top-start corner opens the drawer (where "Recent stops/routes" lives), and
- * an always-editable search field fills the rest of the row — it reads as a text field, not a button, so
- * there is no button-to-field flip: tapping it focuses the field directly. Submitting calls [onSearch]
- * (which fires the legacy `ACTION_SEARCH` → `SearchActivity`).
+ * FABs). A menu (☰) FAB in the top-start corner opens the drawer, and an always-editable search field fills
+ * the rest of the row — it reads as a text field, not a button, so there is no button-to-field flip: tapping
+ * it focuses the field directly. When focused, the field expands into a connected surface hosting a
+ * [SearchRecentsDropdown] of the user's [recents] (filtered live by the query); tapping a row fires
+ * [onRecentStop] / [onRecentRoute], while submitting still calls [onSearch] (the full `ACTION_SEARCH` →
+ * `SearchActivity`), so recents are a shortcut distinct from a full search.
  *
- * The caller supplies the status-bar inset (this composable adds only its own FAB margins), so it stays a
- * pure function of state. The menu FAB carries the my-location FAB's accent branding (white on
- * [R.color.theme_accent] green); the search field stays a neutral light surface so the query reads clearly.
+ * The caller supplies the status-bar inset (this composable adds only its own FAB margins) and the
+ * [recents] + tap lambdas, so it stays a pure, VM-free function of state. The menu FAB carries the
+ * my-location FAB's accent branding (white on [R.color.theme_accent] green); the search field stays a
+ * neutral light surface so the query reads clearly.
  */
 @Composable
 fun MapTopChrome(
     onOpenDrawer: () -> Unit,
     onSearch: (String) -> Unit,
+    // The unified recent stops+routes list for the search dropdown, and the row-tap handlers.
+    recents: List<RecentItem>,
+    onRecentStop: (id: String, name: String?) -> Unit,
+    onRecentRoute: (routeId: String) -> Unit,
     // Opaque anchor a host may attach to the menu (☰) FAB (e.g. for an onboarding spotlight).
     menuModifier: Modifier = Modifier,
     modifier: Modifier = Modifier,
@@ -91,7 +103,9 @@ fun MapTopChrome(
             .padding(horizontal = margin)
             .padding(top = TOP_CHROME_TOP_MARGIN),
         horizontalArrangement = Arrangement.spacedBy(margin),
-        verticalAlignment = Alignment.CenterVertically,
+        // Top-aligned so the menu FAB stays put at the top of the row as the search field expands its
+        // dropdown downward (rather than re-centering against the taller field).
+        verticalAlignment = Alignment.Top,
     ) {
         FloatingActionButton(
             onClick = onOpenDrawer,
@@ -102,7 +116,10 @@ fun MapTopChrome(
             Icon(Icons.Default.Menu, stringResource(R.string.navigation_drawer_open))
         }
         SearchField(
+            recents = recents,
             onSubmit = onSearch,
+            onRecentStop = onRecentStop,
+            onRecentRoute = onRecentRoute,
             modifier = Modifier.weight(1f),
         )
     }
@@ -113,65 +130,119 @@ fun MapTopChrome(
  * field (never autofocused, so the keyboard only appears once the user taps it), and a clear button that
  * shows once there is text. Submitting via the IME "search" action forwards a non-blank, trimmed query to
  * [onSubmit].
+ *
+ * When focused with matching [recents], the pill morphs into a connected rounded surface that hosts the
+ * [SearchRecentsDropdown] beneath the query row (one surface, one shadow — so the field + dropdown read as
+ * a single expanded control). Tapping a recent row fires [onRecentStop] / [onRecentRoute] and collapses;
+ * system back or losing focus collapses too. Submitting still runs a full search, distinct from the recents.
  */
 @Composable
 private fun SearchField(
+    recents: List<RecentItem>,
     onSubmit: (String) -> Unit,
+    onRecentStop: (id: String, name: String?) -> Unit,
+    onRecentRoute: (routeId: String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     var query by remember { mutableStateOf("") }
+    var focused by remember { mutableStateOf(false) }
+    val focusManager = LocalFocusManager.current
     // Shown as the visual placeholder AND set as the field's accessibility label — decorationBox text
     // alone isn't exposed to screen readers, so BasicTextField needs the label in semantics too.
     val hint = stringResource(R.string.search_hint)
+
+    // The recents to show while focused: the full list when blank, live-filtered by the query otherwise.
+    // Expand only when there's something to show — a query with no recent match just relies on submit.
+    val shown = remember(recents, query) { filterRecents(recents, query) }
+    val expanded = focused && shown.isNotEmpty()
+
+    // Morph the pill (fully rounded) into a rounded-top / less-rounded-bottom surface when it expands, so
+    // the field + dropdown read as one connected container rather than two stacked pills.
+    val shape = if (expanded) {
+        RoundedCornerShape(
+            topStart = TOP_CHROME_HEIGHT / 2, topEnd = TOP_CHROME_HEIGHT / 2,
+            bottomStart = 20.dp, bottomEnd = 20.dp,
+        )
+    } else {
+        RoundedCornerShape(percent = 50)
+    }
+
+    // System back collapses the field (dismisses the keyboard + dropdown) instead of leaving the screen.
+    BackHandler(enabled = focused) { focusManager.clearFocus() }
+
     Surface(
-        modifier = modifier.height(TOP_CHROME_HEIGHT),
-        shape = RoundedCornerShape(percent = 50),
+        modifier = modifier,
+        shape = shape,
         color = MaterialTheme.colorScheme.surfaceContainerHighest,
         contentColor = MaterialTheme.colorScheme.onSurface,
         shadowElevation = 6.dp,
     ) {
-        Row(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(start = 16.dp, end = 4.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Icon(
-                Icons.Default.Search,
-                contentDescription = stringResource(R.string.map_option_search),
-                tint = LocalContentColor.current.copy(alpha = 0.7f),
-            )
-            Spacer(Modifier.width(12.dp))
-            BasicTextField(
-                value = query,
-                onValueChange = { query = it },
-                singleLine = true,
-                textStyle = MaterialTheme.typography.bodyLarge.copy(color = LocalContentColor.current),
-                cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
-                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
-                keyboardActions = KeyboardActions(
-                    onSearch = { if (query.isNotBlank()) onSubmit(query.trim()) }
-                ),
+        Column {
+            Row(
                 modifier = Modifier
-                    .weight(1f)
-                    .semantics { contentDescription = hint },
-                decorationBox = { innerTextField ->
-                    Box(contentAlignment = Alignment.CenterStart) {
-                        if (query.isEmpty()) {
-                            Text(
-                                hint,
-                                style = MaterialTheme.typography.bodyLarge,
-                                color = LocalContentColor.current.copy(alpha = 0.6f)
-                            )
+                    .fillMaxWidth()
+                    .height(TOP_CHROME_HEIGHT)
+                    .padding(start = 16.dp, end = 4.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    Icons.Default.Search,
+                    contentDescription = stringResource(R.string.map_option_search),
+                    tint = LocalContentColor.current.copy(alpha = 0.7f),
+                )
+                Spacer(Modifier.width(12.dp))
+                BasicTextField(
+                    value = query,
+                    onValueChange = { query = it },
+                    singleLine = true,
+                    textStyle = MaterialTheme.typography.bodyLarge.copy(color = LocalContentColor.current),
+                    cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
+                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+                    keyboardActions = KeyboardActions(
+                        onSearch = {
+                            if (query.isNotBlank()) {
+                                focusManager.clearFocus()
+                                onSubmit(query.trim())
+                            }
                         }
-                        innerTextField()
+                    ),
+                    modifier = Modifier
+                        .weight(1f)
+                        .onFocusChanged { focused = it.isFocused }
+                        .semantics { contentDescription = hint },
+                    decorationBox = { innerTextField ->
+                        Box(contentAlignment = Alignment.CenterStart) {
+                            if (query.isEmpty()) {
+                                Text(
+                                    hint,
+                                    style = MaterialTheme.typography.bodyLarge,
+                                    color = LocalContentColor.current.copy(alpha = 0.6f)
+                                )
+                            }
+                            innerTextField()
+                        }
+                    }
+                )
+                if (query.isNotEmpty()) {
+                    IconButton(onClick = { query = "" }) {
+                        Icon(Icons.Default.Clear, stringResource(R.string.stop_info_clear))
                     }
                 }
-            )
-            if (query.isNotEmpty()) {
-                IconButton(onClick = { query = "" }) {
-                    Icon(Icons.Default.Clear, stringResource(R.string.stop_info_clear))
-                }
+            }
+            if (expanded) {
+                SearchRecentsDropdown(
+                    recents = shown,
+                    // A tap leaves search: collapse (clear focus) before dispatching, so returning to HOME
+                    // doesn't strand the field expanded.
+                    onRecentStop = { id, name ->
+                        focusManager.clearFocus()
+                        onRecentStop(id, name)
+                    },
+                    onRecentRoute = { routeId ->
+                        focusManager.clearFocus()
+                        onRecentRoute(routeId)
+                    },
+                )
             }
         }
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/chrome/MapTopChrome.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/chrome/MapTopChrome.kt
@@ -138,7 +138,7 @@ fun MapTopChrome(
             SearchField(
                 recents = recents,
                 focused = searchFocused,
-                onFocusChanged = { searchFocused = it },
+                onFocusChange = { searchFocused = it },
                 // Leaving search (submit / recents tap) clears focus first, so the field collapses and
                 // returning to HOME doesn't strand it expanded.
                 onSubmit = { query ->
@@ -162,21 +162,21 @@ fun MapTopChrome(
 
 /**
  * The always-visible search field: a floating rounded pill with a leading search glyph, an inline query
- * field (never autofocused, so the keyboard only appears once the user taps it), and a clear button that
- * shows once there is text. Submitting via the IME "search" action forwards a non-blank, trimmed query to
- * [onSubmit].
+ * field (never autofocused, so the keyboard only appears once the user taps it), and a trailing X that
+ * clears the query when there's text and otherwise (on a focused, blank field) dismisses the search.
+ * Submitting via the IME "search" action forwards a non-blank, trimmed query to [onSubmit].
  *
  * When [focused] with matching [recents], the pill morphs into a connected rounded surface that hosts the
  * [SearchRecentsDropdown] beneath the query row (one surface, one shadow — so the field + dropdown read as
  * a single expanded control). Tapping a recent row fires [onRecentStop] / [onRecentRoute]; submitting runs
  * a full search (distinct from the recents). Focus is owned by the caller ([MapTopChrome]), which reports
- * changes via [onFocusChanged] and drives collapse (clearing focus) on submit / recents tap / tap-outside.
+ * changes via [onFocusChange] and drives collapse (clearing focus) on submit / recents tap / tap-outside.
  */
 @Composable
 private fun SearchField(
     recents: List<RecentItem>,
     focused: Boolean,
-    onFocusChanged: (Boolean) -> Unit,
+    onFocusChange: (Boolean) -> Unit,
     onSubmit: (String) -> Unit,
     onRecentStop: (id: String, name: String?) -> Unit,
     onRecentRoute: (routeId: String) -> Unit,
@@ -193,16 +193,14 @@ private fun SearchField(
     val shown = remember(recents, query) { filterRecents(recents, query) }
     val expanded = focused && shown.isNotEmpty()
 
-    // Morph the pill (fully rounded) into a rounded-top / less-rounded-bottom surface when it expands, so
-    // the field + dropdown read as one connected container rather than two stacked pills.
-    val shape = if (expanded) {
-        RoundedCornerShape(
-            topStart = TOP_CHROME_HEIGHT / 2, topEnd = TOP_CHROME_HEIGHT / 2,
-            bottomStart = 20.dp, bottomEnd = 20.dp,
-        )
-    } else {
-        RoundedCornerShape(percent = 50)
-    }
+    // Only the bottom corners morph: a full pill when collapsed, with its bottom squared slightly when it
+    // expands so it reads as one connected surface with the dropdown beneath it.
+    val pillRadius = TOP_CHROME_HEIGHT / 2
+    val bottomRadius = if (expanded) EXPANDED_BOTTOM_RADIUS else pillRadius
+    val shape = RoundedCornerShape(
+        topStart = pillRadius, topEnd = pillRadius,
+        bottomStart = bottomRadius, bottomEnd = bottomRadius,
+    )
 
     Surface(
         modifier = modifier,
@@ -237,7 +235,7 @@ private fun SearchField(
                     ),
                     modifier = Modifier
                         .weight(1f)
-                        .onFocusChanged { onFocusChanged(it.isFocused) }
+                        .onFocusChanged { onFocusChange(it.isFocused) }
                         .semantics { contentDescription = hint },
                     decorationBox = { innerTextField ->
                         Box(contentAlignment = Alignment.CenterStart) {
@@ -255,9 +253,16 @@ private fun SearchField(
                 // The X shows whenever the field is active — there's text, or the field is focused with the
                 // recents list showing. It clears the query when there's text; on an already-blank field
                 // (recents showing) the same X dismisses the search (clears focus, collapsing the dropdown).
+                // The glyph is the same either way (per design); the a11y label tracks the actual action.
                 if (query.isNotEmpty() || expanded) {
-                    IconButton(onClick = { if (query.isNotEmpty()) query = "" else onDismiss() }) {
-                        Icon(Icons.Default.Clear, stringResource(R.string.stop_info_clear))
+                    val hasText = query.isNotEmpty()
+                    IconButton(onClick = { if (hasText) query = "" else onDismiss() }) {
+                        Icon(
+                            Icons.Default.Clear,
+                            contentDescription = stringResource(
+                                if (hasText) R.string.stop_info_clear else R.string.search_close
+                            ),
+                        )
                     }
                 }
             }
@@ -279,6 +284,10 @@ private val TOP_CHROME_TOP_MARGIN = 8.dp
 // Both the menu FAB and the search field are sized to this height — ~90% of the default 56dp FAB, so the
 // top chrome sits a touch more compactly over the map.
 private val TOP_CHROME_HEIGHT = 50.dp
+
+// The search field's bottom-corner radius while expanded: squared off from the full pill so it connects
+// to the recents dropdown beneath it.
+private val EXPANDED_BOTTOM_RADIUS = 20.dp
 
 /**
  * Vertical footprint of the floating top chrome below the status-bar inset: its top margin + the row

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/chrome/MapTopChrome.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/chrome/MapTopChrome.kt
@@ -21,11 +21,13 @@
 package org.onebusaway.android.ui.home.chrome
 
 import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -57,6 +59,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
@@ -97,31 +100,62 @@ fun MapTopChrome(
     modifier: Modifier = Modifier,
 ) {
     val margin = dimensionResource(R.dimen.fab_margin_horizontal)
-    Row(
-        modifier = modifier
-            .fillMaxWidth()
-            .padding(horizontal = margin)
-            .padding(top = TOP_CHROME_TOP_MARGIN),
-        horizontalArrangement = Arrangement.spacedBy(margin),
-        // Top-aligned so the menu FAB stays put at the top of the row as the search field expands its
-        // dropdown downward (rather than re-centering against the taller field).
-        verticalAlignment = Alignment.Top,
-    ) {
-        FloatingActionButton(
-            onClick = onOpenDrawer,
-            containerColor = colorResource(R.color.theme_accent),
-            contentColor = Color.White,
-            modifier = menuModifier.size(TOP_CHROME_HEIGHT),
-        ) {
-            Icon(Icons.Default.Menu, stringResource(R.string.navigation_drawer_open))
+    val focusManager = LocalFocusManager.current
+    // The search field's focus is owned here so a full-screen tap-catcher can sit behind the chrome and
+    // dismiss the field/dropdown on any tap outside it.
+    var searchFocused by remember { mutableStateOf(false) }
+    // System back collapses the field (dismisses the keyboard + dropdown) instead of leaving the screen.
+    BackHandler(enabled = searchFocused) { focusManager.clearFocus() }
+
+    Box(modifier.fillMaxSize()) {
+        // While focused, an invisible full-screen catcher behind the chrome clears focus on any tap
+        // outside the field/dropdown (which are drawn above it) — defocusing collapses the dropdown.
+        if (searchFocused) {
+            Box(
+                Modifier
+                    .fillMaxSize()
+                    .pointerInput(Unit) { detectTapGestures { focusManager.clearFocus() } }
+            )
         }
-        SearchField(
-            recents = recents,
-            onSubmit = onSearch,
-            onRecentStop = onRecentStop,
-            onRecentRoute = onRecentRoute,
-            modifier = Modifier.weight(1f),
-        )
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = margin)
+                .padding(top = TOP_CHROME_TOP_MARGIN),
+            horizontalArrangement = Arrangement.spacedBy(margin),
+            // Top-aligned so the menu FAB stays put at the top of the row as the search field expands its
+            // dropdown downward (rather than re-centering against the taller field).
+            verticalAlignment = Alignment.Top,
+        ) {
+            FloatingActionButton(
+                onClick = onOpenDrawer,
+                containerColor = colorResource(R.color.theme_accent),
+                contentColor = Color.White,
+                modifier = menuModifier.size(TOP_CHROME_HEIGHT),
+            ) {
+                Icon(Icons.Default.Menu, stringResource(R.string.navigation_drawer_open))
+            }
+            SearchField(
+                recents = recents,
+                focused = searchFocused,
+                onFocusChanged = { searchFocused = it },
+                // Leaving search (submit / recents tap) clears focus first, so the field collapses and
+                // returning to HOME doesn't strand it expanded.
+                onSubmit = { query ->
+                    focusManager.clearFocus()
+                    onSearch(query)
+                },
+                onRecentStop = { id, name ->
+                    focusManager.clearFocus()
+                    onRecentStop(id, name)
+                },
+                onRecentRoute = { routeId ->
+                    focusManager.clearFocus()
+                    onRecentRoute(routeId)
+                },
+                modifier = Modifier.weight(1f),
+            )
+        }
     }
 }
 
@@ -131,22 +165,23 @@ fun MapTopChrome(
  * shows once there is text. Submitting via the IME "search" action forwards a non-blank, trimmed query to
  * [onSubmit].
  *
- * When focused with matching [recents], the pill morphs into a connected rounded surface that hosts the
+ * When [focused] with matching [recents], the pill morphs into a connected rounded surface that hosts the
  * [SearchRecentsDropdown] beneath the query row (one surface, one shadow — so the field + dropdown read as
- * a single expanded control). Tapping a recent row fires [onRecentStop] / [onRecentRoute] and collapses;
- * system back or losing focus collapses too. Submitting still runs a full search, distinct from the recents.
+ * a single expanded control). Tapping a recent row fires [onRecentStop] / [onRecentRoute]; submitting runs
+ * a full search (distinct from the recents). Focus is owned by the caller ([MapTopChrome]), which reports
+ * changes via [onFocusChanged] and drives collapse (clearing focus) on submit / recents tap / tap-outside.
  */
 @Composable
 private fun SearchField(
     recents: List<RecentItem>,
+    focused: Boolean,
+    onFocusChanged: (Boolean) -> Unit,
     onSubmit: (String) -> Unit,
     onRecentStop: (id: String, name: String?) -> Unit,
     onRecentRoute: (routeId: String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     var query by remember { mutableStateOf("") }
-    var focused by remember { mutableStateOf(false) }
-    val focusManager = LocalFocusManager.current
     // Shown as the visual placeholder AND set as the field's accessibility label — decorationBox text
     // alone isn't exposed to screen readers, so BasicTextField needs the label in semantics too.
     val hint = stringResource(R.string.search_hint)
@@ -166,9 +201,6 @@ private fun SearchField(
     } else {
         RoundedCornerShape(percent = 50)
     }
-
-    // System back collapses the field (dismisses the keyboard + dropdown) instead of leaving the screen.
-    BackHandler(enabled = focused) { focusManager.clearFocus() }
 
     Surface(
         modifier = modifier,
@@ -199,16 +231,11 @@ private fun SearchField(
                     cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
                     keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
                     keyboardActions = KeyboardActions(
-                        onSearch = {
-                            if (query.isNotBlank()) {
-                                focusManager.clearFocus()
-                                onSubmit(query.trim())
-                            }
-                        }
+                        onSearch = { if (query.isNotBlank()) onSubmit(query.trim()) }
                     ),
                     modifier = Modifier
                         .weight(1f)
-                        .onFocusChanged { focused = it.isFocused }
+                        .onFocusChanged { onFocusChanged(it.isFocused) }
                         .semantics { contentDescription = hint },
                     decorationBox = { innerTextField ->
                         Box(contentAlignment = Alignment.CenterStart) {
@@ -232,16 +259,8 @@ private fun SearchField(
             if (expanded) {
                 SearchRecentsDropdown(
                     recents = shown,
-                    // A tap leaves search: collapse (clear focus) before dispatching, so returning to HOME
-                    // doesn't strand the field expanded.
-                    onRecentStop = { id, name ->
-                        focusManager.clearFocus()
-                        onRecentStop(id, name)
-                    },
-                    onRecentRoute = { routeId ->
-                        focusManager.clearFocus()
-                        onRecentRoute(routeId)
-                    },
+                    onRecentStop = onRecentStop,
+                    onRecentRoute = onRecentRoute,
                 )
             }
         }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/chrome/SearchRecentsDropdown.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/chrome/SearchRecentsDropdown.kt
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.home.chrome
+
+import androidx.annotation.DrawableRes
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import org.onebusaway.android.R
+import org.onebusaway.android.ui.compose.components.RouteRowContent
+import org.onebusaway.android.ui.compose.components.StopRowContent
+import org.onebusaway.android.ui.mylists.RecentItem
+
+// ~4 rows (each ~48-56dp) stay visible; the rest scroll. A fixed cap, not content-driven, so the
+// dropdown never grows to crowd the keyboard.
+private val DROPDOWN_MAX_HEIGHT = 224.dp
+
+/**
+ * The recents dropdown that hangs inside the expanded search field: a "Recents" section header (so it's
+ * clear these are recent shortcuts and submitting the field runs a full, separate search) over a
+ * scrollable, height-capped list of the unified recent stops+routes. Each row carries a leading type icon
+ * (stop_flag / ic_route — the glyphs the Recent tabs use) so the mixed list scans at a glance, then reuses
+ * [StopRowContent] / [RouteRowContent] for the body. Tapping fires [onRecentStop] (→ arrivals) or
+ * [onRecentRoute] (→ reveal on map).
+ *
+ * Renders no surface of its own — the caller ([MapTopChrome]'s search field) provides the connected
+ * container so the field + dropdown read as one expanded surface.
+ */
+@Composable
+fun SearchRecentsDropdown(
+    recents: List<RecentItem>,
+    onRecentStop: (id: String, name: String?) -> Unit,
+    onRecentRoute: (routeId: String) -> Unit,
+) {
+    Column(Modifier.fillMaxWidth()) {
+        // A divider + muted section header separate the recents from the query field above and label
+        // them, so the user reads them as recents (a shortcut), distinct from submitting a full search.
+        HorizontalDivider()
+        Text(
+            text = stringResource(R.string.search_recents_header),
+            style = MaterialTheme.typography.labelMedium,
+            color = LocalContentColor.current.copy(alpha = 0.6f),
+            modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 12.dp, bottom = 4.dp),
+        )
+        LazyColumn(Modifier.heightIn(max = DROPDOWN_MAX_HEIGHT)) {
+            itemsIndexed(recents, key = { _, item -> item.key }) { index, item ->
+                if (index > 0) HorizontalDivider()
+                when (item) {
+                    is RecentItem.Stop -> RecentRow(
+                        icon = R.drawable.stop_flag,
+                        onClick = { onRecentStop(item.stop.id, item.stop.name) },
+                    ) {
+                        StopRowContent(
+                            name = item.stop.name,
+                            direction = item.stop.rawDirection.orEmpty(),
+                            isFavorite = item.stop.isFavorite,
+                            modifier = Modifier.weight(1f),
+                        )
+                    }
+
+                    is RecentItem.Route -> RecentRow(
+                        icon = R.drawable.ic_route,
+                        onClick = { onRecentRoute(item.route.id) },
+                    ) {
+                        RouteRowContent(
+                            shortName = item.route.shortName,
+                            longName = item.route.longName,
+                            modifier = Modifier.weight(1f),
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+/** One dropdown row: a leading type [icon] (muted tint) then the caller's row [content], clickable. */
+@Composable
+private fun RecentRow(
+    @DrawableRes icon: Int,
+    onClick: () -> Unit,
+    content: @Composable RowScope.() -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            painter = painterResource(icon),
+            contentDescription = null,
+            tint = colorResource(R.color.navdrawer_icon_tint),
+            modifier = Modifier.size(24.dp),
+        )
+        Spacer(Modifier.width(16.dp))
+        content()
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/mylists/MyListModels.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/mylists/MyListModels.kt
@@ -60,6 +60,25 @@ data class RouteListItem(
 )
 
 /**
+ * One entry in the unified "recent stops AND routes" list (the search-box dropdown). Wraps either a
+ * [StopListItem] or a [RouteListItem] and carries the raw [accessTime] used to merge the two kinds into
+ * one newest-first order. [key] is a stable, type-tagged id for `LazyColumn` keying (a stop and a route
+ * could share the same underlying id).
+ */
+sealed interface RecentItem {
+    val accessTime: Long?
+    val key: String
+
+    data class Stop(val stop: StopListItem, override val accessTime: Long?) : RecentItem {
+        override val key: String get() = "stop:${stop.id}"
+    }
+
+    data class Route(val route: RouteListItem, override val accessTime: Long?) : RecentItem {
+        override val key: String get() = "route:${route.id}"
+    }
+}
+
+/**
  * A saved trip-reminder row (My Reminders). [tripId] + [stopId] identify the reminder; the display
  * strings ([name] with a "(no name)" fallback, formatted [headsign], "Route X" [routeText], and the
  * "Departs at …" [departureText]) are resolved in the repository.

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/mylists/MyListRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/mylists/MyListRepository.kt
@@ -41,7 +41,9 @@ import org.onebusaway.android.app.di.NetworkEntryPoint
 import org.onebusaway.android.app.di.RegionEntryPoint
 import org.onebusaway.android.database.oba.ReminderRow
 import org.onebusaway.android.database.oba.RouteListRow
+import org.onebusaway.android.database.oba.RouteRecentRow
 import org.onebusaway.android.database.oba.StopListRow
+import org.onebusaway.android.database.oba.StopRecentRow
 import org.onebusaway.android.database.oba.TripDepartureTime
 import org.onebusaway.android.ui.arrivals.ArrivalInfo
 import org.onebusaway.android.time.ServerTime
@@ -105,6 +107,69 @@ private fun RouteListRow.toRouteItem() = RouteListItem(
     longName = longName?.takeIf { it.isNotEmpty() },
     url = url?.takeIf { it.isNotEmpty() },
 )
+
+// The recent-row variants embed the list row + access_time, so reuse the exact list-row mappers on the
+// embedded [row] and keep the display formatting in one place.
+private fun StopRecentRow.toRecentItem(context: Context) =
+    RecentItem.Stop(row.toStopItem(context), accessTime)
+
+private fun RouteRecentRow.toRecentItem() =
+    RecentItem.Route(row.toRouteItem(), accessTime)
+
+/** How many recents the search dropdown holds; ~4 are visible, the rest scroll (matches the list caps). */
+private const val RECENTS_LIMIT = 20
+
+/** Merge recent stops and routes into one newest-first list, capped at [limit]. Pure; unit-tested. */
+internal fun mergeRecents(
+    stops: List<RecentItem>,
+    routes: List<RecentItem>,
+    limit: Int,
+): List<RecentItem> =
+    (stops + routes)
+        .sortedByDescending { it.accessTime ?: Long.MIN_VALUE }
+        .take(limit)
+
+/**
+ * Filter [items] to those whose stop name / route short-or-long name contains [query] (case-insensitive).
+ * A blank query passes the list through unchanged. Pure; unit-tested.
+ */
+internal fun filterRecents(items: List<RecentItem>, query: String): List<RecentItem> {
+    val q = query.trim()
+    if (q.isEmpty()) return items
+    return items.filter { item ->
+        when (item) {
+            is RecentItem.Stop -> item.stop.name.contains(q, ignoreCase = true)
+            is RecentItem.Route ->
+                item.route.shortName.contains(q, ignoreCase = true) ||
+                    item.route.longName?.contains(q, ignoreCase = true) == true
+        }
+    }
+}
+
+/** The unified recent stops+routes list behind the search-box dropdown; read-only (no remove/clear). */
+class SearchRecentsRepository(private val context: Context) : MyListRepository<RecentItem> {
+
+    private val entryPoint = DatabaseEntryPoint.get(context)
+    private val stopDao = entryPoint.stopDao()
+    private val routeDao = entryPoint.routeDao()
+    private val region = RegionEntryPoint.get(context).region
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    override fun observe(): Flow<List<RecentItem>> =
+        region.flatMapLatest { r ->
+            val cutoff = recentCutoff()
+            combine(
+                stopDao.recentsForSearch(cutoff, r?.id),
+                routeDao.recentsForSearch(cutoff, r?.id),
+            ) { stops, routes ->
+                mergeRecents(
+                    stops.map { it.toRecentItem(context) },
+                    routes.map { it.toRecentItem() },
+                    RECENTS_LIMIT,
+                )
+            }
+        }.flowOn(Dispatchers.IO)
+}
 
 /** Recently viewed stops, marked unused on removal/clear. */
 class RecentStopsRepository(private val context: Context) : MyListRepository<StopListItem> {

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -342,6 +342,8 @@
 
     <!-- My stops/routes -->
     <string name="my_recent_title">Recent</string>
+    <!-- Section header on the search field's recents dropdown -->
+    <string name="search_recents_header">Recents</string>
     <string name="my_recent_menu_title">Recent stops/routes</string>
     <string name="my_recent_stops">Stops</string>
     <string name="my_recent_routes">Routes</string>

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -344,6 +344,8 @@
     <string name="my_recent_title">Recent</string>
     <!-- Section header on the search field's recents dropdown -->
     <string name="search_recents_header">Recents</string>
+    <!-- Accessibility label for the search field's X when it dismisses the (empty) search rather than clearing text -->
+    <string name="search_close">Close search</string>
     <string name="my_recent_menu_title">Recent stops/routes</string>
     <string name="my_recent_stops">Stops</string>
     <string name="my_recent_routes">Routes</string>

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/mylists/SearchRecentsTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/mylists/SearchRecentsTest.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.mylists
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/** Unit tests for the pure merge/filter helpers behind the search-box recents dropdown. */
+class SearchRecentsTest {
+
+    private fun stop(id: String, name: String, accessTime: Long?) = RecentItem.Stop(
+        StopListItem(id = id, name = name, rawDirection = "N", directionText = "Northbound",
+            lat = 0.0, lon = 0.0, isFavorite = false),
+        accessTime,
+    )
+
+    private fun route(id: String, shortName: String, longName: String?, accessTime: Long?) =
+        RecentItem.Route(RouteListItem(id = id, shortName = shortName, longName = longName, url = null), accessTime)
+
+    // --- mergeRecents ---
+
+    @Test
+    fun `merge interleaves stops and routes strictly by accessTime descending`() {
+        val stops = listOf(stop("s1", "Alpha", 100), stop("s2", "Beta", 300))
+        val routes = listOf(route("r1", "8", "Rainier", 200), route("r2", "40", "Ballard", 400))
+
+        val merged = mergeRecents(stops, routes, limit = 10)
+
+        // Sorted purely by accessTime desc: r2@400, s2@300, r1@200, s1@100.
+        assertEquals(listOf("route:r2", "stop:s2", "route:r1", "stop:s1"), merged.map { it.key })
+    }
+
+    @Test
+    fun `merge sorts null accessTime last`() {
+        val stops = listOf(stop("s1", "Alpha", null))
+        val routes = listOf(route("r1", "8", "Rainier", 50))
+
+        val merged = mergeRecents(stops, routes, limit = 10)
+
+        assertEquals(listOf("route:r1", "stop:s1"), merged.map { it.key })
+    }
+
+    @Test
+    fun `merge respects the limit, keeping the newest`() {
+        val stops = listOf(stop("s1", "Alpha", 100), stop("s2", "Beta", 500))
+        val routes = listOf(route("r1", "8", "Rainier", 300))
+
+        val merged = mergeRecents(stops, routes, limit = 2)
+
+        assertEquals(listOf("stop:s2", "route:r1"), merged.map { it.key })
+    }
+
+    @Test
+    fun `merge is stable for equal timestamps - stops keep their order before routes`() {
+        val stops = listOf(stop("s1", "Alpha", 100), stop("s2", "Beta", 100))
+        val routes = listOf(route("r1", "8", "Rainier", 100))
+
+        val merged = mergeRecents(stops, routes, limit = 10)
+
+        // sortedByDescending is stable, and stops are concatenated first.
+        assertEquals(listOf("stop:s1", "stop:s2", "route:r1"), merged.map { it.key })
+    }
+
+    // --- filterRecents ---
+
+    private val sample = listOf(
+        stop("s1", "Broadway & E Denny Way", 400),
+        route("r1", "8", "Rainier Beach", 300),
+        stop("s2", "3rd Ave & Pine St", 200),
+        route("r2", "40", "Downtown Ballard", 100),
+    )
+
+    @Test
+    fun `filter with a blank query passes the list through unchanged`() {
+        assertEquals(sample, filterRecents(sample, "   "))
+    }
+
+    @Test
+    fun `filter matches stop names case-insensitively`() {
+        assertEquals(listOf("stop:s1"), filterRecents(sample, "broadway").map { it.key })
+    }
+
+    @Test
+    fun `filter matches route short name and long name`() {
+        assertEquals(listOf("route:r1"), filterRecents(sample, "8").map { it.key })
+        assertEquals(listOf("route:r2"), filterRecents(sample, "ballard").map { it.key })
+    }
+
+    @Test
+    fun `filter returns empty when nothing matches`() {
+        assertEquals(emptyList<String>(), filterRecents(sample, "zzz").map { it.key })
+    }
+}


### PR DESCRIPTION
## What

When the home search field is focused, a dropdown of the user's **unified most-recent stops and routes** hangs beneath it — newest first, ~4 visible and scrollable — **filtered live** as they type, under a **"Recents"** section header. Tapping a stop opens its arrivals; a route reveals on the map. Submitting the field still runs the full search as before, so recents are a shortcut clearly distinct from a full search.

This surfaces recents at the moment of search intent (a follow-on to #1845, which moved "Recent stops/routes" into the drawer).

> **Rebased onto the map top-chrome FAB-ification (#1847, now merged).** #1846 was originally built on the retired `HomeTopBar` flip-to-search bar; it's been re-expressed on the new floating `MapTopChrome` **persistent search field**. The data layer, tests, and `SearchRecentsDropdown` are unchanged in spirit; the UI integration is new.

## How

**Data** — a new `SearchRecentsRepository` combines the existing recent-stops and recent-routes Room flows and merge-sorts them by `access_time` (a column both `stops`/`routes` tables already share). New `StopRecentRow`/`RouteRecentRow` projections (Room `@Embedded` over the existing list rows + `access_time`) expose the timestamp. Two pure, unit-tested helpers back the feature: `mergeRecents` (ordering) and `filterRecents` (the type-ahead).

**UI (adapted for the FAB chrome)** — the `MapTopChrome` search field now tracks focus. When focused with matching recents, the pill **morphs into a connected rounded surface** that hosts the dropdown beneath the query row (one surface, one shadow), so the field + dropdown read as a single expanded control that fits the FAB search box. The row is top-aligned so the menu FAB stays put as the field expands. `SearchRecentsDropdown` renders no surface of its own (the field provides the container), shows a muted **"Recents"** header, filters live by the query, and hides when empty. Tapping a recent, submitting, or system back all clear focus and collapse. `HomeScreen` hosts the unified recents (`rememberListVm`, like the My-tab lists) so `MapTopChrome` stays a pure, VM-free chrome composable.

## Notes for reviewers

- **The dropdown filters recents only, not a live server search.** A query with no recent match hides the dropdown and relies on submit for the real search. Intentional — it's a recents shortcut — and the "Recents" header makes that boundary explicit.
- `access_time` is device-clock epoch ms (same clock for both tables), so cross-type interleave is a purely local ordering concern — no server-clock (#1612) interaction.
- Dismissal on focus-loss / system back is handled; **tap-outside-to-dismiss (a map-tap scrim) is a possible follow-up** if desired.

## Test status

- ✅ Compiles clean under the strict CI gate (`-PwarningsAsErrors=true`), including KSP/Room query verification, on top of merged `main`.
- ✅ 8/8 `SearchRecentsTest` unit tests pass (merge ordering, null handling, limit, stability; filter passthrough/match/no-match).
- ✅ Installs and boots clean on a physical device. Interactive focus→dropdown check pending (device was locked at verification time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added focus-driven floating search in the map header with live filtering, clear action, and a capped “Recents” dropdown.
  * Unified recents now combine recently viewed stops and routes (newest-first, capped), and selection reveals the appropriate destination (stops → arrivals, routes → reveal on map).
  * Search recents filter matches stop names and route short/long names.
* **Bug Fixes**
  * Improved recents ordering by access time, with null timestamps shown last and stable ordering for equal times.
* **Tests**
  * Added unit tests covering recents merge/interleaving, limiting, and filtering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->