### PR TITLE
Add Dependabot config for Gradle deps and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,41 @@
+# Dependabot configuration
+# Docs: https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#
+# Gradle dependency/plugin versions and the SDK/JDK levels resolve from the
+# version catalog at gradle/libs.versions.toml (see CLAUDE.md). Dependabot reads
+# the catalog and the Kotlin-DSL build scripts directly.
+version: 2
+updates:
+  # Gradle: app + plugin dependencies (via gradle/libs.versions.toml)
+  - package-ecosystem: gradle
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    # Group low-risk updates into a single PR to cut review noise; keep major
+    # bumps as individual PRs since CI is strict (warnings-as-errors + lint) and
+    # they need careful, one-at-a-time review.
+    groups:
+      gradle-minor-and-patch:
+        update-types:
+          - minor
+          - patch
+    labels:
+      - dependencies
+
+  # GitHub Actions used by the CI workflows under .github/workflows/
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    groups:
+      github-actions:
+        update-types:
+          - minor
+          - patch
+    labels:
+      - dependencies
+      - github-actions


### PR DESCRIPTION
## Summary
Adds `.github/dependabot.yml` to enable Dependabot version updates for two ecosystems:

- **`gradle`** — watches the version catalog (`gradle/libs.versions.toml`) and the Kotlin-DSL build scripts. Minor/patch updates are **grouped into a single weekly PR** to cut review noise; major bumps stay as **individual PRs** so they can be reviewed one at a time against the strict CI (warnings-as-errors + lint).
- **`github-actions`** — keeps the CI workflow actions current (e.g. `setup-java@v3`, `gradle/actions/setup-gradle@v3` are behind).

Both run weekly on Mondays, capped at 10 open PRs, labeled `dependencies`.

## Notes
- Takes effect only once merged to the default branch (`main`); Dependabot ignores the config on feature branches.
- The `dependencies` label exists on GitHub repos by default; the `github-actions` label may need to be created (or Dependabot will just skip applying it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)