### PR TITLE
Build: enable R8 optimization on release builds

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,10 +21,4 @@ android.buildFeatures.buildConfig=true
 android.nonTransitiveRClass=false
 org.gradle.configuration-cache=true
 
-# Deprecated in AGP 10 (removal drops the override itself, forcing proguard-android-optimize.txt).
-# Kept for now: proguard-android.txt is a deliberate, tracked choice for byte-identical release
-# builds — see the ProguardAndroidTxtUsage lint-disable rationale in
-# onebusaway-android/build.gradle.kts. Revisit both together on the AGP 10 upgrade.
-android.r8.proguardAndroidTxt.disallowed=false
-
 

--- a/onebusaway-android/build.gradle.kts
+++ b/onebusaway-android/build.gradle.kts
@@ -138,7 +138,7 @@ android {
             signingConfig = signingConfigs.getByName("release")
             isMinifyEnabled = true
             isShrinkResources = true
-            proguardFiles(getDefaultProguardFile("proguard-android.txt"), "proguard-project.txt")
+            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-project.txt")
         }
     }
 
@@ -169,12 +169,12 @@ android {
         //    comments); currency is Dependabot/Renovate's job, not a build-failing check.
         //  - OldTargetApi: targetSdk (36) trails compileSdk (37). Bumping targetSdk is a deliberate,
         //    separately-tested change — an explicit #1819 non-goal (no version bumps ride along).
-        //  - ProguardAndroidTxtUsage: prefers proguard-android-optimize.txt. Switching changes release
-        //    R8 behavior, which #1819 requires stay byte-identical (assembleObaGoogleRelease unchanged).
+        // (ProguardAndroidTxtUsage was disabled here for #1819; the release build now uses
+        // proguard-android-optimize.txt, so that check passes on its own and is no longer suppressed.)
         disable += setOf(
             "MissingTranslation", "ExtraTranslation", "LogNotTimber",
             "GradleDependency", "NewerVersionAvailable", "AndroidGradlePluginVersion",
-            "OldTargetApi", "ProguardAndroidTxtUsage"
+            "OldTargetApi"
         )
         // Run the FULL lint catalog — including checks that are off by default and library-provided
         // ones (Compose, UseKtx, …) — so the checked set is comprehensive and current for the installed


### PR DESCRIPTION
## Summary

Switches the release build's default ProGuard/R8 config from `proguard-android.txt` to `proguard-android-optimize.txt`, which turns **R8's optimization passes on** for release builds, and retires the two deprecation stopgaps that only existed to keep the old file working.

The concrete difference between the two AGP-bundled files (extracted from AGP 9.3.0) is just:

```diff
-# ...Note that if you want to enable optimization... point to
-# "proguard-android-optimize.txt"... instead of this one...
--dontoptimize
+# Optimizations: If you don't want to optimize, use the proguard-android.txt configuration file
+# instead of this one, which turns off the optimization flags.
+-allowaccessmodification
```

`-dontoptimize` is a pre-R8 historical default (from the old ProGuard tool, where shrink and optimize were separate) that keeps R8 to shrink + obfuscate only. Dropping it lets R8 inline, merge classes/members, and do more aggressive dead-code elimination; `-allowaccessmodification` lets it widen access modifiers to enable those transforms. This is Google's recommended modern default (AGP 9 disallows the plain file by default for this reason).

### Changes
- `onebusaway-android/build.gradle.kts`: `getDefaultProguardFile("proguard-android.txt")` → `"proguard-android-optimize.txt"`.
- `gradle.properties`: remove `android.r8.proguardAndroidTxt.disallowed=false` — that override only existed to re-allow the now-abandoned deprecated file (and is itself scheduled for removal in AGP 10). Not needed on the optimize file.
- `onebusaway-android/build.gradle.kts` lint block: stop suppressing `ProguardAndroidTxtUsage`; it passes on its own now.

### Why this is a separate PR
Both stopgaps were deliberately deferred out of the #1819 build modernization: that work required the **release artifact stay byte-identical across the Groovy→Kotlin-DSL refactor** (a pure-refactor safety invariant — "we reorganized the build files, we didn't change what's built"). Enabling optimization changes release output *by design*, so it couldn't ride along. This PR is that deferred follow-up. Obfuscation stays **off** (`-dontobfuscate` in `proguard-project.txt`), so stack-trace / mapping semantics are unchanged in that dimension; only the optimization dimension changes.

## Verification

- **R8 optimization runs clean on the full `obaGoogle` class set.** The release R8 step (`minifyObaGoogleReleaseWithR8`) can't complete in a credential-less local env — the `gradle-play-publisher` version-code task fails first — so I exercised the identical R8 config (same `proguard-android-optimize.txt` + `proguard-project.txt`) by temporarily enabling `isMinifyEnabled` on a signable **debug** build. `minifyObaGoogleDebugWithR8` + `assembleObaGoogleDebug` succeeded. That temporary harness is **not** part of this diff.
- Config phase evaluates with **no AGP deprecation warning** (this PR + the base branch together clear both).

### ⚠️ Reviewer note — please confirm before merging
I could **not runtime-test an optimized release APK** in this environment (release signing unavailable). R8 optimization can surface missing keep rules for reflection-based code that `-dontoptimize` previously masked. The app's known reflection surfaces (Jackson POJOs, `ObaComposeMapAdapter` instantiation, Pelias/GeoJSON models) all have existing `-keep` rules in `proguard-project.txt`, and the build is clean, but I'd recommend a **beta-track smoke test of the optimized release build before promoting to production**.

## Stacking

Stacked on `fix/agp-deprecation-warnings` (#1867) — both PRs rework the same `gradle.properties` block, and together they resolve both AGP 10 deprecation warnings. Merge #1867 first (or squash-merge both); rebase-on-main is trivial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)