### PR TITLE
Map: drop the Google compass below the menu FAB

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapHost.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapHost.kt
@@ -187,10 +187,13 @@ class MapHost(
 
     // ----- Padding + camera commands -----
 
-    // Map content padding: the route-mode header sets the top, the arrivals sheet sets the bottom.
-    // Declarative state the renderer applies (Google: GoogleMap contentPadding), replacing the old
-    // imperative mapView.setPadding(...) relay through HomeActivity.
-    fun setTopPadding(px: Int) = renderState.setTopPadding(px)
+    // Map content padding: the floating top chrome (status bar + FAB-row clearance) and the route-mode
+    // header both set the top; the arrivals sheet sets the bottom. Declarative state the renderer applies
+    // (Google: GoogleMap contentPadding), replacing the old imperative mapView.setPadding(...) relay
+    // through HomeActivity.
+    fun setTopChromeInset(px: Int) = renderState.setTopChromeInset(px)
+
+    fun setRouteHeaderPadding(px: Int) = renderState.setRouteHeaderPadding(px)
 
     fun setBottomPadding(px: Int) = renderState.setBottomPadding(px)
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
@@ -216,9 +216,13 @@ class MapViewModel @Inject constructor(
             .map { it?.toRouteHeader() }
             .stateIn(viewModelScope, SharingStarted.Eagerly, null)
 
-    /** The route header reported its measured height; derive the map's top padding (0 clears it). */
+    /**
+     * The route header reported its measured height; report its contribution to the map's top padding
+     * (0 clears it). Stacks on the always-present floating-chrome inset set from
+     * [org.onebusaway.android.ui.home.map.MapFeature].
+     */
     fun setRouteHeaderHeight(heightPx: Int) {
-        mapHost.setTopPadding(if (heightPx > 0) heightPx + routeHeaderMarkerPaddingPx else 0)
+        mapHost.setRouteHeaderPadding(if (heightPx > 0) heightPx + routeHeaderMarkerPaddingPx else 0)
     }
 
     // Map the controller's raw load into the display header: blank-but-loading until the route resolves,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
@@ -44,8 +44,10 @@ fun interface MapProjector {
 }
 
 /**
- * The map's content padding, in pixels. [topPx] keeps content (vehicle markers) below the route-mode
- * header; [bottomPx] keeps the focused stop above the arrivals sheet. Held as declarative state and
+ * The map's content padding, in pixels. [topPx] keeps content (the Google compass, vehicle markers)
+ * below the floating top chrome — the status-bar inset + menu/search FAB-row clearance, plus the
+ * route-mode header when a route is shown; [bottomPx] keeps the focused stop above the arrivals sheet.
+ * Held as declarative state and
  * applied by the renderer (the Google adapter's `GoogleMap(contentPadding=…)`) instead of an
  * imperative `mapView.setPadding(...)` poke. Kept in its own flow (not [MapRenderSnapshot]) so a
  * padding change doesn't recompose the overlay content.
@@ -255,7 +257,26 @@ class MapRenderState {
 
     val padding: StateFlow<MapPadding> = _padding.asStateFlow()
 
-    fun setTopPadding(px: Int) = _padding.update { it.copy(topPx = px) }
+    // Top padding is the sum of two producer-owned contributions — the always-present floating-chrome
+    // inset (status bar + FAB-row clearance) and the route-mode header height (0 when no route) — held
+    // separately so each producer updates only its own without clobbering the other.
+    private var topChromeInsetPx = 0
+    private var routeHeaderPaddingPx = 0
+
+    private fun applyTopPadding() =
+        _padding.update { it.copy(topPx = topChromeInsetPx + routeHeaderPaddingPx) }
+
+    /** The floating top-chrome inset (status bar + FAB-row clearance); keeps the compass below the FABs. */
+    fun setTopChromeInset(px: Int) {
+        topChromeInsetPx = px
+        applyTopPadding()
+    }
+
+    /** The route-mode header's contribution to the top padding (0 clears it when no route is shown). */
+    fun setRouteHeaderPadding(px: Int) {
+        routeHeaderPaddingPx = px
+        applyTopPadding()
+    }
 
     fun setBottomPadding(px: Int) = _padding.update { it.copy(bottomPx = px) }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/chrome/MapTopChrome.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/chrome/MapTopChrome.kt
@@ -67,6 +67,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
 import org.onebusaway.android.R
 import org.onebusaway.android.ui.mylists.RecentItem
@@ -303,3 +304,14 @@ internal val MAP_TOP_CHROME_CLEARANCE = TOP_CHROME_TOP_MARGIN + TOP_CHROME_HEIGH
  */
 fun Modifier.mapTopChromeOverlayInset(): Modifier =
     this.statusBarsPadding().padding(top = MAP_TOP_CHROME_CLEARANCE)
+
+/**
+ * The floating top chrome's total vertical footprint in **pixels**: the caller-measured [statusBarTopPx]
+ * plus [MAP_TOP_CHROME_CLEARANCE]. Fed into the map's top content padding so the Google compass and any
+ * centered content clear the menu/search FAB row. Shares [MAP_TOP_CHROME_CLEARANCE] with
+ * [mapTopChromeOverlayInset], so the map padding can't drift from the overlays that line up against the
+ * same row. Deliberately not `@Composable`: the caller reads the snapshot-backed status-bar inset inside
+ * a `snapshotFlow` so inset changes don't recompose the map.
+ */
+fun mapTopChromeInsetPx(statusBarTopPx: Int, density: Density): Int =
+    statusBarTopPx + with(density) { MAP_TOP_CHROME_CLEARANCE.roundToPx() }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
@@ -32,10 +32,12 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Checkbox
@@ -50,12 +52,14 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -66,6 +70,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlinx.coroutines.flow.distinctUntilChanged
 import org.onebusaway.android.R
 import org.onebusaway.android.app.di.AnalyticsEntryPoint
 import org.onebusaway.android.analytics.PlausibleAnalytics
@@ -83,6 +88,7 @@ import org.onebusaway.android.map.render.GeoPoint
 import org.onebusaway.android.ui.home.FocusedStop
 import org.onebusaway.android.ui.home.HomeViewModel
 import org.onebusaway.android.ui.home.MapDirective
+import org.onebusaway.android.ui.home.chrome.mapTopChromeInsetPx
 import org.onebusaway.android.ui.home.chrome.mapTopChromeOverlayInset
 import org.onebusaway.android.ui.tutorial.MapStopSpotlight
 import org.onebusaway.android.util.LayerUtils
@@ -194,6 +200,17 @@ fun MapFeature(
     // Compose state) so a padding change doesn't recompose this — the map — composable.
     LaunchedEffect(mapViewModel, homeViewModel) {
         homeViewModel.mapBottomPadding.collect { mapViewModel.host.setBottomPadding(it) }
+    }
+    // Publish the floating top chrome's footprint (status-bar inset + FAB-row clearance) as the map's
+    // baseline top inset, so the Google compass and centered content clear the FABs instead of drawing at
+    // topPx=0 behind them. The status-bar inset read is confined to a snapshotFlow (not composition), so
+    // inset churn feeds the VM without recomposing the map — same discipline as the bottom-padding wiring.
+    val statusBars = WindowInsets.statusBars
+    val density = LocalDensity.current
+    LaunchedEffect(mapViewModel, statusBars, density) {
+        snapshotFlow { mapTopChromeInsetPx(statusBars.getTop(density), density) }
+            .distinctUntilChanged()
+            .collect { mapViewModel.host.setTopChromeInset(it) }
     }
     LaunchedEffect(mapViewModel, homeViewModel) {
         homeViewModel.mapDirectives.collect { directive ->


### PR DESCRIPTION
## Problem

The FAB-ification of the map's top chrome (#1847) made the map edge-to-edge with a floating menu (☰) FAB + search row over the top. But the Google Maps compass's on-screen Y-position is governed **solely** by the map's top content padding, which was `0` outside route mode — so the compass drew at the map's top-left, stranded behind the status bar and colliding with the menu FAB.

MapLibre disables its own compass, so this is Google-flavor-only in effect.

## Fix

Feed the floating top chrome's footprint (status-bar inset + menu/search FAB-row clearance) into the map's top content padding, so the compass — and any centered content — drops below the FAB row. Google's SDK offers no compass-only position API; `setPadding` is the standard lever, and this is exactly analogous to the existing bottom padding that lifts content above the arrivals sheet.

- **`MapRenderState`** composes `topPx` from two producer-owned contributions — an always-present floating-chrome inset + the route-mode header height (0 when no route) — summed in the shared sink so neither producer clobbers the other.
- **`MapHost`** relays the two setters (`setTopChromeInset` / `setRouteHeaderPadding`); **`MapViewModel.setRouteHeaderHeight`** now writes the route-header contribution, stacking on the baseline. This also fixes a latent gap: the route header floats *below* the FAB row but its padding previously ignored the status-bar + clearance above it.
- **`MapTopChrome`** exposes `mapTopChromeInsetPx(statusBarTopPx, density)`, reusing the `MAP_TOP_CHROME_CLEARANCE` constant so the map padding can't drift from the overlays that line up against the same row.
- **`MapFeature`** publishes the inset via a `snapshotFlow` inside a `LaunchedEffect`, so status-bar inset changes feed the VM without recomposing the map — the same discipline the bottom-padding wiring already follows.

## Note on cross-flavor behavior

`topPx` is the shared "keep content below top overlays" concept both flavors honor for framing (the route header always did). Folding in the chrome inset generalizes that correctly: framed vehicle/stop content shouldn't land under the FAB row on MapLibre either. This is an intended, defensible consequence, not a Google-only special case pushed into shared code.

## Testing

- `./gradlew :onebusaway-android:compileObaGoogleDebugKotlin :onebusaway-android:compileObaMaplibreDebugKotlin -PwarningsAsErrors=true` — clean (CI warning gate).
- Installed `obaGoogleDebug` on a physical Pixel 7 Pro and verified: rotating the map now shows the compass sitting below the menu FAB rather than behind it / the status bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved map layout spacing around the status bar, floating controls, and route header.
  * Prevented the compass and vehicle markers from being obscured by top-of-screen content.
  * Map padding now adapts automatically to system insets and screen density.
  * Improved transitions between home and route views by keeping top navigation elements and map content properly separated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->