### PR TITLE
Show loaded-window end time on arrivals "load more" footer

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsRepository.kt
@@ -23,6 +23,7 @@ import android.os.SystemClock
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.io.IOException
 import javax.inject.Inject
+import kotlin.time.Duration.Companion.minutes
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -111,6 +112,9 @@ data class ArrivalsData(
     val header: StopHeader,
     /** The effective time window after the loader's empty-result expansion. */
     val minutesAfter: Int,
+    /** The server-clock instant the shown arrivals window ends at (the response's `currentTime` plus
+     *  [minutesAfter]) — the "Showing arrivals until HH:MM" footnote formats this. */
+    val windowEnd: ServerTime,
     val isStale: Boolean,
     val actions: Map<String, ArrivalActions>,
     /** Every active, de-duplicated alert for the stop — *including* hidden ones. The ViewModel
@@ -336,6 +340,9 @@ class DefaultArrivalsRepository @Inject constructor(
             routeGroups = groupArrivalsByRouteDirection(arrivals) { agencyNameFor(snapshot, it.routeId) },
             header = header,
             minutesAfter = snapshot.minutesAfter,
+            // The window ends [minutesAfter] past the response's own server clock — not the projected
+            // `now` — so the footnote names the true boundary of the data actually shown.
+            windowEnd = ServerTime(snapshot.currentTime) + snapshot.minutesAfter.minutes,
             isStale = isStale,
             actions = buildActions(snapshot, arrivals, activeSituationIds),
             activeAlerts = activeAlerts,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsScreen.kt
@@ -415,7 +415,7 @@ internal fun ArrivalsList(
 private fun LoadMoreFooter(windowEnd: ServerTime, loading: Boolean, onClick: () -> Unit) {
     val context = LocalContext.current
     // Formatting hits DateUtils; key it to windowEnd so the spinner toggling on each tap doesn't reformat.
-    val untilTime = remember(windowEnd) { DisplayFormat.formatTime(context, windowEnd.epochMs) }
+    val untilTime = remember(windowEnd, context) { DisplayFormat.formatTime(context, windowEnd.epochMs) }
     Row(
         modifier = Modifier
             .fillMaxWidth()

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.animation.core.MutableTransitionState
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -86,6 +87,7 @@ import org.onebusaway.android.ui.arrivals.components.RouteArrivalRow
 import org.onebusaway.android.ui.arrivals.dialogs.StopDetailsHost
 import org.onebusaway.android.util.DisplayFormat
 import org.onebusaway.android.ui.compose.components.LoadingContent
+import org.onebusaway.android.time.ServerTime
 import org.onebusaway.android.time.WallTime
 
 /** Refresh interval matching the legacy ArrivalsListFragment (fixed 60s, not the server value). */
@@ -397,31 +399,48 @@ internal fun ArrivalsList(
         }
         item(key = "load_more") {
             val loading by loadingMore.collectAsStateWithLifecycle()
-            LoadMoreButton(loading = loading, onClick = onLoadMore)
+            LoadMoreFooter(windowEnd = content.windowEnd, loading = loading, onClick = onLoadMore)
         }
     }
 }
 
 /**
- * The list's "load more trips" footer button: widens the stop's arrivals time window and reloads —
- * replaces the old per-strip pull-to-reload gesture, which was scoped to the whole stop (not just the
- * route the gesture was fired from) and so surprised riders when it pulled in other routes' trips
- * too. Shown below the arrivals (or the empty-list message) so it's always reachable.
+ * The list's "load more trips" footer: a muted "Showing arrivals until HH:MM" note giving the rider
+ * the window's current far edge, followed by the clickable "load more" affordance that widens the
+ * stop's arrivals time window and reloads. Shown below the arrivals (or the empty-list message) so
+ * it's always reachable. (Replaces the old per-strip pull-to-reload gesture, which surprised riders by
+ * pulling in other routes' trips too.)
  */
 @Composable
-private fun LoadMoreButton(loading: Boolean, onClick: () -> Unit) {
-    TextButton(
-        onClick = onClick,
-        enabled = !loading,
+private fun LoadMoreFooter(windowEnd: ServerTime, loading: Boolean, onClick: () -> Unit) {
+    val context = LocalContext.current
+    // Formatting hits DateUtils; key it to windowEnd so the spinner toggling on each tap doesn't reformat.
+    val untilTime = remember(windowEnd) { DisplayFormat.formatTime(context, windowEnd.epochMs) }
+    Row(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 12.dp, vertical = 4.dp)
+            .padding(horizontal = 16.dp, vertical = 4.dp),
+        // Center the pair as a unit, with a gap just wider than a space between them.
+        horizontalArrangement = Arrangement.spacedBy(2.dp, Alignment.CenterHorizontally),
+        verticalAlignment = Alignment.CenterVertically
     ) {
+        Text(
+            text = stringResource(R.string.stop_info_showing_trips_until, untilTime),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
         if (loading) {
             CircularProgressIndicator(modifier = Modifier.size(18.dp), strokeWidth = 2.dp)
-            Spacer(Modifier.width(8.dp))
         }
-        Text(stringResource(R.string.stop_info_load_more_arrivals))
+        // The clickable "load more" retains the old button's TextButton styling (primary-colored text);
+        // trimmed content padding keeps the gap to the note tight rather than the default 12dp inset.
+        TextButton(
+            onClick = onClick,
+            enabled = !loading,
+            contentPadding = PaddingValues(horizontal = 4.dp, vertical = 4.dp)
+        ) {
+            Text(stringResource(R.string.stop_info_load_more))
+        }
     }
 }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsUiState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsUiState.kt
@@ -15,6 +15,8 @@
  */
 package org.onebusaway.android.ui.arrivals
 
+import org.onebusaway.android.time.ServerTime
+
 
 /** The stop being viewed, for the arrivals screen header. */
 data class StopHeader(
@@ -87,6 +89,9 @@ sealed interface ArrivalsUiState {
         val arrivals: List<ArrivalInfo>,
         val routeGroups: List<RouteRowGroup>,
         val minutesAfter: Int,
+        /** Server-clock instant the shown arrivals window ends at — formatted for the "Showing
+         *  arrivals until HH:MM" footnote beside the load-more button. */
+        val windowEnd: ServerTime,
         val isStale: Boolean,
         val actions: Map<String, ArrivalActions> = emptyMap(),
         /** The starred route ids, live — a row's star + the drawer-header promotion read from this, so a

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsViewModel.kt
@@ -250,6 +250,7 @@ class ArrivalsViewModel @AssistedInject constructor(
             // the live favorite set, so a star toggle re-orders the list with no re-fetch (#1707/#1751).
             routeGroups = orderRouteGroupsByFavorite(routeGroups, favoriteRouteIds),
             minutesAfter = minutesAfter,
+            windowEnd = windowEnd,
             isStale = isStale,
             actions = actions,
             favoriteRouteIds = favoriteRouteIds,

--- a/onebusaway-android/src/main/res/values-es/strings.xml
+++ b/onebusaway-android/src/main/res/values-es/strings.xml
@@ -310,7 +310,8 @@
         <item quantity="many"><xliff:g id="count">%2$d</xliff:g>h %1$d+ min
         </item>
     </plurals>
-    <string name="stop_info_load_more_arrivals">Cargar más llegadas</string>
+    <string name="stop_info_showing_trips_until">Mostrando viajes hasta %1$s</string>
+    <string name="stop_info_load_more">Cargar más</string>
     <string name="stop_info_item_options_title">Opciones de bus</string>
     <string name="stop_info_clear">Limpiar</string>
     <string name="stop_info_favorite">Parada Favorita</string>

--- a/onebusaway-android/src/main/res/values-fi/strings.xml
+++ b/onebusaway-android/src/main/res/values-fi/strings.xml
@@ -261,7 +261,8 @@
         <item quantity="other"><xliff:g id="count">%2$d</xliff:g> t %1$d+ min
         </item>
     </plurals>
-    <string name="stop_info_load_more_arrivals">Näytä lisää saapuvia</string>
+    <string name="stop_info_showing_trips_until">Näytetään vuorot %1$s asti</string>
+    <string name="stop_info_load_more">Näytä lisää</string>
     <string name="stop_info_item_options_title">Toiminnot</string>
     <string name="stop_info_clear">Tyhjennä</string>
     <string name="stop_info_favorite">Suosikkipysäkki</string>

--- a/onebusaway-android/src/main/res/values-it/strings.xml
+++ b/onebusaway-android/src/main/res/values-it/strings.xml
@@ -215,7 +215,8 @@
         <item quantity="many"><xliff:g id="count">%2$d</xliff:g>h %1$d+ min
         </item>
     </plurals>
-    <string name="stop_info_load_more_arrivals">Carica più arrivi</string>
+    <string name="stop_info_showing_trips_until">Corse mostrate fino alle %1$s</string>
+    <string name="stop_info_load_more">Carica altri</string>
     <string name="stop_info_item_options_title">Opzioni</string>
     <string name="stop_info_clear">Cancella</string>
     <string name="stop_info_favorite">La mia fermata</string>

--- a/onebusaway-android/src/main/res/values-pl/strings.xml
+++ b/onebusaway-android/src/main/res/values-pl/strings.xml
@@ -236,7 +236,8 @@
         <item quantity="other"><xliff:g id="count">%2$d</xliff:g>godz. %1$d+ min
         </item>
     </plurals>
-    <string name="stop_info_load_more_arrivals">Wczytaj więcej przyjazdów</string>
+    <string name="stop_info_showing_trips_until">Pokazywanie kursów do %1$s</string>
+    <string name="stop_info_load_more">Wczytaj więcej</string>
     <string name="stop_info_item_options_title">Opcje</string>
     <string name="stop_info_clear">Wyczyść</string>
     <string name="stop_info_favorite">Ulubiony przystanek</string>

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -269,7 +269,11 @@
         <item quantity="other"><xliff:g id="count">%2$d</xliff:g>h %1$d+ min
         </item>
     </plurals>
-    <string name="stop_info_load_more_arrivals">Load more arrivals</string>
+    <!-- Footnote below the arrivals list; %1$s is the clock time the shown window ends at, e.g. "3:45 PM".
+         "trips" is the umbrella term (each listed item is a trip, shown by its arrival or departure time). -->
+    <string name="stop_info_showing_trips_until">Showing trips until %1$s</string>
+    <!-- Clickable affordance beside the above footnote that widens the arrivals time window -->
+    <string name="stop_info_load_more">Load more</string>
     <string name="stop_info_eta_strip_scroll_earlier">Show earlier arrivals</string>
     <string name="stop_info_eta_strip_scroll_later">Show later arrivals</string>
     <string name="stop_info_item_options_title">Bus options</string>

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/ArrivalsViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/ArrivalsViewModelTest.kt
@@ -30,6 +30,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.onebusaway.android.testing.MainDispatcherRule
+import org.onebusaway.android.time.ServerTime
 
 /** The arguments of a single [ArrivalsRepository.favoriteRoute] call, for assertions. */
 private data class FavoriteRouteCall(
@@ -136,6 +137,7 @@ class ArrivalsViewModelTest {
             routeGroups = emptyList(),
             header = header(favorite),
             minutesAfter = minutesAfter,
+            windowEnd = ServerTime(minutesAfter * 60_000L),
             isStale = isStale,
             actions = emptyMap(),
             activeAlerts = emptyList(),

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/ArrivalsViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/ArrivalsViewModelTest.kt
@@ -165,6 +165,8 @@ class ArrivalsViewModelTest {
         val state = viewModel.state.value
         assertTrue(state is ArrivalsUiState.Content)
         assertEquals("Pine St & 3rd Ave", (state as ArrivalsUiState.Content).header.name)
+        // The window-end instant rides through unchanged from ArrivalsData into the Content state.
+        assertEquals(ServerTime(65 * 60_000L), state.windowEnd)
     }
 
     @Test


### PR DESCRIPTION
## What

The arrivals list footer previously showed only a **Load more arrivals** button, giving no sense of how far ahead the currently-loaded results reach. This adds a muted **Showing trips until HH:MM** note beside a trimmed **Load more** affordance, centered as a pair with a tight gap.

Before → After:
- `[      Load more arrivals      ]`
- `Showing trips until 3:45 PM   Load more`

## How

- **Window-end time is a typed `ServerTime`, minted in the domain layer.** `DefaultArrivalsRepository.toData` computes `windowEnd = ServerTime(snapshot.currentTime) + snapshot.minutesAfter.minutes` at the wire→domain boundary — based on the response's own server clock, **not** the stale-path projected `now`, so the note names the true far edge of the data actually shown. It rides the existing `ArrivalsData → ArrivalsUiState.Content` pipeline as a typed field and is unwrapped (`.epochMs`) only at the composable to feed `DisplayFormat.formatTime` (which honors the device 12/24-hour setting). Consistent with CLAUDE.md's "Time domains" rules.
- The format call is `remember()`-keyed on `windowEnd`, so the load-more spinner toggling doesn't reformat each recomposition.
- Footer shows in both the standalone arrivals screen and the map bottom-sheet panel (both render the shared `ArrivalsList`).

## Wording

"trips" is the umbrella noun — each row is a GTFS trip, shown by its arrival **or** departure time ("arrivals" alone was wrong for departure-only entries). Strings are updated in all supported languages, each using its own transit-domain word for a scheduled run: es *viajes*, fi *vuorot*, it *corse*, pl *kursy*. The old `stop_info_load_more_arrivals` string is replaced by `stop_info_showing_trips_until` + `stop_info_load_more`.

## Testing

- `compileObaGoogleDebugKotlin -PwarningsAsErrors=true` clean (CI gate).
- `ArrivalsViewModelTest` passes (fixture updated for the new field).
- Installed and verified on a physical device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated arrivals footer to show a “Showing trips until HH:MM” time-window note.
  * Reworked the “Load more” control to use separate loading feedback and disable the button while loading.
  * Ensured the displayed time-window boundary matches the arrivals data shown.

* **Localization**
  * Replaced the old “Load more arrivals” wording with new “Showing trips until …” and “Load more” strings across supported languages.

* **Tests**
  * Extended view-model tests to verify the arrivals UI state includes the expected window end time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->