### PR TITLE
Lint: clear two nightly-lint errors orphaned by #1846

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/mylists/MyListRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/mylists/MyListRepository.kt
@@ -84,7 +84,7 @@ private val RECENT_WINDOW_MS = 7 * DateUtils.DAY_IN_MILLIS
 
 // Device-clock recent-window cutoff, compared against locally-stamped access times (same clock).
 @Suppress("RawClockArithmetic")
-private fun recentCutoff(): Long = System.currentTimeMillis() - RECENT_WINDOW_MS
+internal fun recentCutoff(): Long = System.currentTimeMillis() - RECENT_WINDOW_MS
 
 private fun StopListRow.toStopItem(context: Context): StopListItem {
     val directionText = direction?.takeIf { it.isNotEmpty() }
@@ -110,10 +110,10 @@ private fun RouteListRow.toRouteItem() = RouteListItem(
 
 // The recent-row variants embed the list row + access_time, so reuse the exact list-row mappers on the
 // embedded [row] and keep the display formatting in one place.
-private fun StopRecentRow.toRecentItem(context: Context) =
+internal fun StopRecentRow.toRecentItem(context: Context) =
     RecentItem.Stop(row.toStopItem(context), accessTime)
 
-private fun RouteRecentRow.toRecentItem() =
+internal fun RouteRecentRow.toRecentItem() =
     RecentItem.Route(row.toRouteItem(), accessTime)
 
 /** How many recents the search dropdown holds; ~4 are visible, the rest scroll (matches the list caps). */

--- a/onebusaway-android/src/main/res/values-es/strings.xml
+++ b/onebusaway-android/src/main/res/values-es/strings.xml
@@ -22,7 +22,6 @@
     <string name="app_name">OneBusAway</string>
 
     <!-- Navigation Drawer -->
-    <string name="navdrawer_item_nearby">Cerca</string>
     <string name="navdrawer_item_starred_stops">Paradas favoritas</string>
     <string name="navdrawer_item_starred_routes">Rutas favoritas</string>
     <string name="navdrawer_item_my_reminders">Mis recordatorios</string>

--- a/onebusaway-android/src/main/res/values-fi/strings.xml
+++ b/onebusaway-android/src/main/res/values-fi/strings.xml
@@ -20,7 +20,6 @@
     <string name="app_name">OneBusAway</string>
 
     <!-- Navigation Drawer -->
-    <string name="navdrawer_item_nearby">Lähistöllä</string>
     <string name="navdrawer_item_starred_stops">Suosikkipysäkit</string>
     <string name="navdrawer_item_my_reminders">Muistutukseni</string>
     <string name="navdrawer_item_settings">Asetukset</string>

--- a/onebusaway-android/src/main/res/values-it/strings.xml
+++ b/onebusaway-android/src/main/res/values-it/strings.xml
@@ -20,7 +20,6 @@
     <string name="app_name">OneBusAway</string>
 
     <!-- Navigation Drawer -->
-    <string name="navdrawer_item_nearby">Nei dintorni</string>
     <string name="navdrawer_item_starred_stops">Fermate preferite</string>
     <string name="navdrawer_item_starred_routes">Linee preferite</string>
     <string name="navdrawer_item_my_reminders">I miei promemoria</string>

--- a/onebusaway-android/src/main/res/values-pl/strings.xml
+++ b/onebusaway-android/src/main/res/values-pl/strings.xml
@@ -3,7 +3,6 @@
     <string name="app_name">OneBusAway</string>
 
     <!-- Navigation Drawer -->
-    <string name="navdrawer_item_nearby">W pobliżu</string>
     <string name="navdrawer_item_starred_stops">Ulubione przystanki</string>
     <string name="navdrawer_item_my_reminders">Moje przypomnienia</string>
     <string name="navdrawer_item_settings">Ustawienia</string>

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -21,7 +21,6 @@
     <string name="app_name">OneBusAway</string>
 
     <!-- Navigation Drawer -->
-    <string name="navdrawer_item_nearby">Nearby</string>
     <string name="navdrawer_item_starred_stops">Starred stops</string>
     <string name="navdrawer_item_starred_routes">Starred routes</string>
     <string name="navdrawer_item_my_reminders">My reminders</string>


### PR DESCRIPTION
## What

The nightly Android Lint leg (`lintObaGoogleDebug`, intentionally **not** run on the PR/push path — `android.yml` passes `-x lint`) flags two pre-existing errors that landed with the recents dropdown (#1846). Neither is in `lint-baseline.xml`, so the nightly run fails on them. This clears both.

## How

- **`SyntheticAccessor` (×3) in `MyListRepository.kt`** — three file-private top-level helpers (`recentCutoff`, and the `StopRecentRow` / `RouteRecentRow` `toRecentItem` extensions) are called from the repository classes in the same file, which forces the compiler to emit synthetic accessors. Made them `internal` (still module-scoped, not public API) so the accessor goes away.
- **`UnusedResources`** — `navdrawer_item_nearby` is no longer referenced anywhere in code or layouts (orphaned by the single-activity Compose migration). Removed the base declaration and its four translations (es/it/pl/fi).

## Testing

- `./gradlew :onebusaway-android:lintObaGoogleDebug -PwarningsAsErrors=true` → **"Lint found no new issues"**, build succeeds.
- `./gradlew :onebusaway-android:compileObaGoogleDebugKotlin -PwarningsAsErrors=true` clean.

## Note

The lint run still reports ~90 stale baseline entries (`listed in the baseline file but not found`). That's separate baseline drift, not a build failure — left for a dedicated regenerate-and-review pass per CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Navigation**
  * Removed the “Nearby” navigation drawer label from the default, Spanish, Finnish, Italian, and Polish translations.
  * Other navigation drawer items remain unchanged.

* **Refactor**
  * Improved internal reuse of recent-item processing within the app module without changing its behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->