### PR TITLE
Lint: regenerate baseline to drop 90 stale entries

### DIFF
--- a/onebusaway-android/lint-baseline.xml
+++ b/onebusaway-android/lint-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.2.0" type="baseline" client="gradle" dependencies="false" name="AGP (9.2.0)" variant="all" version="9.2.0">
+<issues format="6" by="lint 9.3.0" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.0)" variant="all" version="9.3.0">
 
     <issue
         id="InvalidPackage"
@@ -22,19 +22,8 @@
         errorLine2="                                           ~~~~~~~~">
         <location
             file="src/main/java/org/onebusaway/android/map/RouteMapController.kt"
-            line="220"
+            line="434"
             column="44"/>
-    </issue>
-
-    <issue
-        id="ComposableLambdaParameterNaming"
-        message="Composable lambda parameter should be named `content`"
-        errorLine1="    menu: @Composable () -> Unit = {}"
-        errorLine2="    ~~~~">
-        <location
-            file="src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalsPanel.kt"
-            line="314"
-            column="5"/>
     </issue>
 
     <issue
@@ -117,22 +106,22 @@
     <issue
         id="LogConditional"
         message="The log call Log.d(...) should be conditional: surround with `if (Log.isLoggable(...))` or `if (BuildConfig.DEBUG) { ... }`"
-        errorLine1="                    Log.d(TAG, &quot;No icon for mode set: $mode&quot;)"
-        errorLine2="                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        errorLine1="                    Log.d(TAG, &quot;No icon for mode: $mode&quot;)"
+        errorLine2="                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/onebusaway/android/directions/util/DirectionsGenerator.kt"
-            line="540"
+            line="507"
             column="21"/>
     </issue>
 
     <issue
         id="LogConditional"
         message="The log call Log.d(...) should be conditional: surround with `if (Log.isLoggable(...))` or `if (BuildConfig.DEBUG) { ... }`"
-        errorLine1="                    Log.d(TAG, &quot;No icon for mode set: $mode&quot;)"
-        errorLine2="                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        errorLine1="                    Log.d(TAG, &quot;No icon for mode: $mode&quot;)"
+        errorLine2="                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/onebusaway/android/directions/util/DirectionsGenerator.kt"
-            line="540"
+            line="507"
             column="21"/>
     </issue>
 
@@ -143,7 +132,7 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/onebusaway/android/ui/feedback/Feedback.kt"
-            line="170"
+            line="171"
             column="9"/>
     </issue>
 
@@ -253,7 +242,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/onebusaway/android/nav/NavigationService.kt"
-            line="305"
+            line="313"
             column="13"/>
     </issue>
 
@@ -286,7 +275,7 @@
         errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/onebusaway/android/nav/NavigationUploadWorker.java"
-            line="108"
+            line="106"
             column="25"/>
     </issue>
 
@@ -297,7 +286,7 @@
         errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/onebusaway/android/nav/NavigationUploadWorker.java"
-            line="112"
+            line="110"
             column="25"/>
     </issue>
 
@@ -308,7 +297,7 @@
         errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/onebusaway/android/nav/NavigationUploadWorker.java"
-            line="113"
+            line="111"
             column="25"/>
     </issue>
 
@@ -319,7 +308,7 @@
         errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/onebusaway/android/nav/NavigationUploadWorker.java"
-            line="114"
+            line="112"
             column="25"/>
     </issue>
 
@@ -330,7 +319,7 @@
         errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/onebusaway/android/nav/NavigationUploadWorker.java"
-            line="117"
+            line="115"
             column="25"/>
     </issue>
 
@@ -341,7 +330,7 @@
         errorLine2="        ^">
         <location
             file="src/main/java/org/onebusaway/android/nav/NavigationUploadWorker.java"
-            line="133"
+            line="131"
             column="9"/>
     </issue>
 
@@ -378,8 +367,6 @@
             column="30"/>
     </issue>
 
-
-
     <issue
         id="SyntheticAccessor"
         message="Access to `private` method `getOrdinal` of class `Companion` requires synthetic accessor"
@@ -387,7 +374,7 @@
         errorLine2="                                          ~~~~~~~~~~">
         <location
             file="src/main/java/org/onebusaway/android/directions/util/DirectionsGenerator.kt"
-            line="180"
+            line="167"
             column="43"/>
     </issue>
 
@@ -409,7 +396,7 @@
         errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/onebusaway/android/extrapolation/GammaExtrapolator.kt"
-            line="72"
+            line="73"
             column="17"/>
     </issue>
 
@@ -442,7 +429,7 @@
         errorLine2="                                                                ~~~~~~~~">
         <location
             file="src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleComposeAdapter.kt"
-            line="166"
+            line="174"
             column="65"/>
     </issue>
 
@@ -453,7 +440,7 @@
         errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleComposeAdapter.kt"
-            line="210"
+            line="215"
             column="29"/>
     </issue>
 
@@ -464,7 +451,7 @@
         errorLine2="                ~~~~~~~~~~~~~~~">
         <location
             file="src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleComposeAdapter.kt"
-            line="243"
+            line="255"
             column="17"/>
     </issue>
 
@@ -614,11 +601,44 @@
     <issue
         id="SyntheticAccessor"
         message="Access to `private` method `read` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="        val favoriteRouteIds = db.read(&quot;route_headsign_favorites&quot;) {"
+        errorLine2="                               ~~~~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="153"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `int` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            if ((int(&quot;exclude&quot;) ?: 0) == 0) str(&quot;route_id&quot;) else null"
+        errorLine2="                 ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="154"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            if ((int(&quot;exclude&quot;) ?: 0) == 0) str(&quot;route_id&quot;) else null"
+        errorLine2="                                            ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="154"
+            column="45"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `read` of class `LegacyDataImporterKt` requires synthetic accessor"
         errorLine1="        stops = db.read(&quot;stops&quot;) {"
         errorLine2="                ~~~~~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="149"
+            line="157"
             column="17"/>
     </issue>
 
@@ -629,7 +649,7 @@
         errorLine2="                 ~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="151"
+            line="159"
             column="18"/>
     </issue>
 
@@ -640,7 +660,7 @@
         errorLine2="                   ~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="152"
+            line="160"
             column="20"/>
     </issue>
 
@@ -651,7 +671,7 @@
         errorLine2="                   ~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="153"
+            line="161"
             column="20"/>
     </issue>
 
@@ -662,7 +682,7 @@
         errorLine2="                        ~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="154"
+            line="162"
             column="25"/>
     </issue>
 
@@ -673,7 +693,7 @@
         errorLine2="                       ~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="155"
+            line="163"
             column="24"/>
     </issue>
 
@@ -684,7 +704,7 @@
         errorLine2="                       ~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="156"
+            line="164"
             column="24"/>
     </issue>
 
@@ -695,7 +715,7 @@
         errorLine2="                        ~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="157"
+            line="165"
             column="25"/>
     </issue>
 
@@ -706,7 +726,7 @@
         errorLine2="                       ~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="158"
+            line="166"
             column="24"/>
     </issue>
 
@@ -717,7 +737,7 @@
         errorLine2="                         ~~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="159"
+            line="167"
             column="26"/>
     </issue>
 
@@ -728,7 +748,7 @@
         errorLine2="                       ~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="160"
+            line="168"
             column="24"/>
     </issue>
 
@@ -739,7 +759,7 @@
         errorLine2="                       ~~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="161"
+            line="169"
             column="24"/>
     </issue>
 
@@ -750,18 +770,18 @@
         errorLine2="                 ~~~~~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="164"
+            line="172"
             column="18"/>
     </issue>
 
     <issue
         id="SyntheticAccessor"
         message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
-        errorLine1="            id = str(&quot;_id&quot;) ?: return@read null,"
+        errorLine1="        val id = str(&quot;_id&quot;) ?: return@read null"
         errorLine2="                 ~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="166"
+            line="173"
             column="18"/>
     </issue>
 
@@ -772,7 +792,7 @@
         errorLine2="                        ~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="167"
+            line="176"
             column="25"/>
     </issue>
 
@@ -783,7 +803,7 @@
         errorLine2="                       ~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="168"
+            line="177"
             column="24"/>
     </issue>
 
@@ -794,7 +814,7 @@
         errorLine2="                       ~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="169"
+            line="178"
             column="24"/>
     </issue>
 
@@ -805,7 +825,7 @@
         errorLine2="                       ~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="170"
+            line="179"
             column="24"/>
     </issue>
 
@@ -816,19 +836,19 @@
         errorLine2="                         ~~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="171"
+            line="180"
             column="26"/>
     </issue>
 
     <issue
         id="SyntheticAccessor"
         message="Access to `private` method `int` of class `LegacyDataImporterKt` requires synthetic accessor"
-        errorLine1="            favorite = int(&quot;favorite&quot;),"
-        errorLine2="                       ~~~">
+        errorLine1="            favorite = if (id in favoriteRouteIds) 1 else int(&quot;favorite&quot;),"
+        errorLine2="                                                          ~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="172"
-            column="24"/>
+            line="181"
+            column="59"/>
     </issue>
 
     <issue
@@ -838,7 +858,7 @@
         errorLine2="                  ~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="173"
+            line="182"
             column="19"/>
     </issue>
 
@@ -849,7 +869,7 @@
         errorLine2="                       ~~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="174"
+            line="183"
             column="24"/>
     </issue>
 
@@ -860,7 +880,7 @@
         errorLine2="                ~~~~~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="177"
+            line="186"
             column="17"/>
     </issue>
 
@@ -871,7 +891,7 @@
         errorLine2="                 ~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="179"
+            line="188"
             column="18"/>
     </issue>
 
@@ -879,105 +899,6 @@
         id="SyntheticAccessor"
         message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
         errorLine1="            stopId = str(&quot;stop_id&quot;) ?: return@read null,"
-        errorLine2="                     ~~~">
-        <location
-            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="180"
-            column="22"/>
-    </issue>
-
-    <issue
-        id="SyntheticAccessor"
-        message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
-        errorLine1="            routeId = str(&quot;route_id&quot;),"
-        errorLine2="                      ~~~">
-        <location
-            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="181"
-            column="23"/>
-    </issue>
-
-    <issue
-        id="SyntheticAccessor"
-        message="Access to `private` method `int` of class `LegacyDataImporterKt` requires synthetic accessor"
-        errorLine1="            departure = int(&quot;departure&quot;) ?: 0,"
-        errorLine2="                        ~~~">
-        <location
-            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="182"
-            column="25"/>
-    </issue>
-
-    <issue
-        id="SyntheticAccessor"
-        message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
-        errorLine1="            headsign = str(&quot;headsign&quot;),"
-        errorLine2="                       ~~~">
-        <location
-            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="183"
-            column="24"/>
-    </issue>
-
-    <issue
-        id="SyntheticAccessor"
-        message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
-        errorLine1="            name = str(&quot;name&quot;).orEmpty(),"
-        errorLine2="                   ~~~">
-        <location
-            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="184"
-            column="20"/>
-    </issue>
-
-    <issue
-        id="SyntheticAccessor"
-        message="Access to `private` method `int` of class `LegacyDataImporterKt` requires synthetic accessor"
-        errorLine1="            reminder = int(&quot;reminder&quot;) ?: 0,"
-        errorLine2="                       ~~~">
-        <location
-            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="185"
-            column="24"/>
-    </issue>
-
-    <issue
-        id="SyntheticAccessor"
-        message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
-        errorLine1="            alarmDeletePath = str(&quot;alarm_delete_path&quot;).orEmpty(),"
-        errorLine2="                              ~~~">
-        <location
-            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="186"
-            column="31"/>
-    </issue>
-
-    <issue
-        id="SyntheticAccessor"
-        message="Access to `private` method `long` of class `LegacyDataImporterKt` requires synthetic accessor"
-        errorLine1="            serviceDate = long(&quot;service_date&quot;) ?: 0,"
-        errorLine2="                          ~~~~">
-        <location
-            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="187"
-            column="27"/>
-    </issue>
-
-    <issue
-        id="SyntheticAccessor"
-        message="Access to `private` method `int` of class `LegacyDataImporterKt` requires synthetic accessor"
-        errorLine1="            stopSequence = int(&quot;stop_sequence&quot;) ?: 0,"
-        errorLine2="                           ~~~">
-        <location
-            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="188"
-            column="28"/>
-    </issue>
-
-    <issue
-        id="SyntheticAccessor"
-        message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
-        errorLine1="            tripId = str(&quot;trip_id&quot;).orEmpty(),"
         errorLine2="                     ~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
@@ -988,45 +909,111 @@
     <issue
         id="SyntheticAccessor"
         message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
-        errorLine1="            vehicleId = str(&quot;vehicle_id&quot;),"
-        errorLine2="                        ~~~">
+        errorLine1="            routeId = str(&quot;route_id&quot;),"
+        errorLine2="                      ~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
             line="190"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `int` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            departure = int(&quot;departure&quot;) ?: 0,"
+        errorLine2="                        ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="191"
             column="25"/>
     </issue>
 
     <issue
         id="SyntheticAccessor"
-        message="Access to `private` method `read` of class `LegacyDataImporterKt` requires synthetic accessor"
-        errorLine1="        stopRouteFilters = db.read(&quot;stop_routes_filter&quot;) {"
-        errorLine2="                           ~~~~~~~">
+        message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            headsign = str(&quot;headsign&quot;),"
+        errorLine2="                       ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="192"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            name = str(&quot;name&quot;).orEmpty(),"
+        errorLine2="                   ~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
             line="193"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `int` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            reminder = int(&quot;reminder&quot;) ?: 0,"
+        errorLine2="                       ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="194"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            alarmDeletePath = str(&quot;alarm_delete_path&quot;).orEmpty(),"
+        errorLine2="                              ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="195"
+            column="31"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `long` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            serviceDate = long(&quot;service_date&quot;) ?: 0,"
+        errorLine2="                          ~~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="196"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `int` of class `LegacyDataImporterKt` requires synthetic accessor"
+        errorLine1="            stopSequence = int(&quot;stop_sequence&quot;) ?: 0,"
+        errorLine2="                           ~~~">
+        <location
+            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
+            line="197"
             column="28"/>
     </issue>
 
     <issue
         id="SyntheticAccessor"
         message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
-        errorLine1="            stopId = str(&quot;stop_id&quot;) ?: return@read null,"
+        errorLine1="            tripId = str(&quot;trip_id&quot;).orEmpty(),"
         errorLine2="                     ~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="195"
+            line="198"
             column="22"/>
     </issue>
 
     <issue
         id="SyntheticAccessor"
         message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
-        errorLine1="            routeId = str(&quot;route_id&quot;) ?: return@read null,"
-        errorLine2="                      ~~~">
+        errorLine1="            vehicleId = str(&quot;vehicle_id&quot;),"
+        errorLine2="                        ~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="196"
-            column="23"/>
+            line="199"
+            column="25"/>
     </issue>
 
     <issue
@@ -1036,7 +1023,7 @@
         errorLine2="                     ~~~~~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="199"
+            line="202"
             column="22"/>
     </issue>
 
@@ -1047,7 +1034,7 @@
         errorLine2="                 ~~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="201"
+            line="204"
             column="18"/>
     </issue>
 
@@ -1058,7 +1045,7 @@
         errorLine2="                     ~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="202"
+            line="205"
             column="22"/>
     </issue>
 
@@ -1069,7 +1056,7 @@
         errorLine2="                     ~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="203"
+            line="206"
             column="22"/>
     </issue>
 
@@ -1080,7 +1067,7 @@
         errorLine2="                        ~~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="204"
+            line="207"
             column="25"/>
     </issue>
 
@@ -1091,7 +1078,7 @@
         errorLine2="                    ~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="205"
+            line="208"
             column="21"/>
     </issue>
 
@@ -1102,7 +1089,7 @@
         errorLine2="                        ~~~~~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="208"
+            line="211"
             column="25"/>
     </issue>
 
@@ -1113,7 +1100,7 @@
         errorLine2="                 ~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="210"
+            line="213"
             column="18"/>
     </issue>
 
@@ -1124,7 +1111,7 @@
         errorLine2="                             ~~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="211"
+            line="214"
             column="30"/>
     </issue>
 
@@ -1135,7 +1122,7 @@
         errorLine2="                     ~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="212"
+            line="215"
             column="22"/>
     </issue>
 
@@ -1146,7 +1133,7 @@
         errorLine2="                  ~~~~~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="215"
+            line="218"
             column="19"/>
     </issue>
 
@@ -1157,7 +1144,7 @@
         errorLine2="                 ~~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="217"
+            line="220"
             column="18"/>
     </issue>
 
@@ -1168,7 +1155,7 @@
         errorLine2="                   ~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="218"
+            line="221"
             column="20"/>
     </issue>
 
@@ -1179,7 +1166,7 @@
         errorLine2="                         ~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="219"
+            line="222"
             column="26"/>
     </issue>
 
@@ -1190,7 +1177,7 @@
         errorLine2="                          ~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="220"
+            line="223"
             column="27"/>
     </issue>
 
@@ -1201,7 +1188,7 @@
         errorLine2="                       ~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="221"
+            line="224"
             column="24"/>
     </issue>
 
@@ -1212,7 +1199,7 @@
         errorLine2="                           ~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="222"
+            line="225"
             column="28"/>
     </issue>
 
@@ -1223,7 +1210,7 @@
         errorLine2="                                   ~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="223"
+            line="226"
             column="36"/>
     </issue>
 
@@ -1234,7 +1221,7 @@
         errorLine2="                                  ~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="224"
+            line="227"
             column="35"/>
     </issue>
 
@@ -1245,7 +1232,7 @@
         errorLine2="                                   ~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="225"
+            line="228"
             column="36"/>
     </issue>
 
@@ -1256,7 +1243,7 @@
         errorLine2="                         ~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="226"
+            line="229"
             column="26"/>
     </issue>
 
@@ -1267,7 +1254,7 @@
         errorLine2="                           ~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="227"
+            line="230"
             column="28"/>
     </issue>
 
@@ -1278,7 +1265,7 @@
         errorLine2="                          ~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="228"
+            line="231"
             column="27"/>
     </issue>
 
@@ -1289,7 +1276,7 @@
         errorLine2="                         ~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="229"
+            line="232"
             column="26"/>
     </issue>
 
@@ -1300,7 +1287,7 @@
         errorLine2="                              ~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="230"
+            line="233"
             column="31"/>
     </issue>
 
@@ -1311,7 +1298,7 @@
         errorLine2="                                   ~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="231"
+            line="234"
             column="36"/>
     </issue>
 
@@ -1322,7 +1309,7 @@
         errorLine2="                                     ~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="232"
+            line="235"
             column="38"/>
     </issue>
 
@@ -1333,7 +1320,7 @@
         errorLine2="                                  ~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="233"
+            line="236"
             column="35"/>
     </issue>
 
@@ -1344,7 +1331,7 @@
         errorLine2="                                  ~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="234"
+            line="237"
             column="35"/>
     </issue>
 
@@ -1355,7 +1342,7 @@
         errorLine2="                                 ~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="235"
+            line="238"
             column="34"/>
     </issue>
 
@@ -1366,7 +1353,7 @@
         errorLine2="                             ~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="236"
+            line="239"
             column="30"/>
     </issue>
 
@@ -1377,7 +1364,7 @@
         errorLine2="                                          ~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="237"
+            line="240"
             column="43"/>
     </issue>
 
@@ -1388,7 +1375,7 @@
         errorLine2="                                ~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="238"
+            line="241"
             column="33"/>
     </issue>
 
@@ -1399,7 +1386,7 @@
         errorLine2="                               ~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="239"
+            line="242"
             column="32"/>
     </issue>
 
@@ -1410,7 +1397,7 @@
         errorLine2="                       ~~~~~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="242"
+            line="245"
             column="24"/>
     </issue>
 
@@ -1421,7 +1408,7 @@
         errorLine2="                 ~~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="244"
+            line="247"
             column="18"/>
     </issue>
 
@@ -1432,7 +1419,7 @@
         errorLine2="                       ~~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="245"
+            line="248"
             column="24"/>
     </issue>
 
@@ -1443,7 +1430,7 @@
         errorLine2="                       ~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="246"
+            line="249"
             column="24"/>
     </issue>
 
@@ -1454,7 +1441,7 @@
         errorLine2="                        ~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="247"
+            line="250"
             column="25"/>
     </issue>
 
@@ -1465,7 +1452,7 @@
         errorLine2="                      ~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="248"
+            line="251"
             column="23"/>
     </issue>
 
@@ -1476,7 +1463,7 @@
         errorLine2="                      ~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="249"
+            line="252"
             column="23"/>
     </issue>
 
@@ -1487,7 +1474,7 @@
         errorLine2="                         ~~~~~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="252"
+            line="255"
             column="26"/>
     </issue>
 
@@ -1498,7 +1485,7 @@
         errorLine2="                 ~~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="254"
+            line="257"
             column="18"/>
     </issue>
 
@@ -1509,7 +1496,7 @@
         errorLine2="                       ~~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="255"
+            line="258"
             column="24"/>
     </issue>
 
@@ -1520,7 +1507,7 @@
         errorLine2="                           ~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="256"
+            line="259"
             column="28"/>
     </issue>
 
@@ -1531,7 +1518,7 @@
         errorLine2="                     ~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="257"
+            line="260"
             column="22"/>
     </issue>
 
@@ -1542,62 +1529,7 @@
         errorLine2="                      ~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="258"
-            column="23"/>
-    </issue>
-
-    <issue
-        id="SyntheticAccessor"
-        message="Access to `private` method `read` of class `LegacyDataImporterKt` requires synthetic accessor"
-        errorLine1="        routeHeadsignFavorites = db.read(&quot;route_headsign_favorites&quot;) {"
-        errorLine2="                                 ~~~~~~~">
-        <location
-            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
             line="261"
-            column="34"/>
-    </issue>
-
-    <issue
-        id="SyntheticAccessor"
-        message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
-        errorLine1="            routeId = str(&quot;route_id&quot;) ?: return@read null,"
-        errorLine2="                      ~~~">
-        <location
-            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="263"
-            column="23"/>
-    </issue>
-
-    <issue
-        id="SyntheticAccessor"
-        message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
-        errorLine1="            headsign = str(&quot;headsign&quot;).orEmpty(),"
-        errorLine2="                       ~~~">
-        <location
-            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="264"
-            column="24"/>
-    </issue>
-
-    <issue
-        id="SyntheticAccessor"
-        message="Access to `private` method `str` of class `LegacyDataImporterKt` requires synthetic accessor"
-        errorLine1="            stopId = str(&quot;stop_id&quot;).orEmpty(),"
-        errorLine2="                     ~~~">
-        <location
-            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="265"
-            column="22"/>
-    </issue>
-
-    <issue
-        id="SyntheticAccessor"
-        message="Access to `private` method `int` of class `LegacyDataImporterKt` requires synthetic accessor"
-        errorLine1="            exclude = int(&quot;exclude&quot;) ?: 0,"
-        errorLine2="                      ~~~">
-        <location
-            file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="266"
             column="23"/>
     </issue>
 
@@ -1608,7 +1540,7 @@
         errorLine2="                   ~~~~~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="269"
+            line="264"
             column="20"/>
     </issue>
 
@@ -1619,7 +1551,7 @@
         errorLine2="                 ~~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="271"
+            line="266"
             column="18"/>
     </issue>
 
@@ -1630,7 +1562,7 @@
         errorLine2="                    ~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="272"
+            line="267"
             column="21"/>
     </issue>
 
@@ -1641,7 +1573,7 @@
         errorLine2="                        ~~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="273"
+            line="268"
             column="25"/>
     </issue>
 
@@ -1652,7 +1584,7 @@
         errorLine2="                     ~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="274"
+            line="269"
             column="22"/>
     </issue>
 
@@ -1663,7 +1595,7 @@
         errorLine2="                            ~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="275"
+            line="270"
             column="29"/>
     </issue>
 
@@ -1674,7 +1606,7 @@
         errorLine2="                       ~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="276"
+            line="271"
             column="24"/>
     </issue>
 
@@ -1685,7 +1617,7 @@
         errorLine2="                       ~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="277"
+            line="272"
             column="24"/>
     </issue>
 
@@ -1696,7 +1628,7 @@
         errorLine2="                     ~~~">
         <location
             file="src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt"
-            line="278"
+            line="273"
             column="22"/>
     </issue>
 
@@ -1724,35 +1656,13 @@
 
     <issue
         id="SyntheticAccessor"
-        message="Access to `private` method `recentCutoff` of class `MyListRepositoryKt` requires synthetic accessor"
-        errorLine1="        region.flatMapLatest { r -> stopDao.recents(recentCutoff(), r?.id) }"
-        errorLine2="                                                    ~~~~~~~~~~~~">
-        <location
-            file="src/main/java/org/onebusaway/android/ui/mylists/MyListRepository.kt"
-            line="117"
-            column="53"/>
-    </issue>
-
-    <issue
-        id="SyntheticAccessor"
         message="Access to `private` method `toStopItem` of class `MyListRepositoryKt` requires synthetic accessor"
         errorLine1="            .map { rows -> rows.map { it.toStopItem(context) } }"
         errorLine2="                                      ~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/onebusaway/android/ui/mylists/MyListRepository.kt"
-            line="118"
+            line="185"
             column="39"/>
-    </issue>
-
-    <issue
-        id="SyntheticAccessor"
-        message="Access to `private` method `recentCutoff` of class `MyListRepositoryKt` requires synthetic accessor"
-        errorLine1="        region.flatMapLatest { r -> routeDao.recents(recentCutoff(), r?.id) }"
-        errorLine2="                                                     ~~~~~~~~~~~~">
-        <location
-            file="src/main/java/org/onebusaway/android/ui/mylists/MyListRepository.kt"
-            line="144"
-            column="54"/>
     </issue>
 
     <issue
@@ -1762,7 +1672,7 @@
         errorLine2="                                      ~~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/onebusaway/android/ui/mylists/MyListRepository.kt"
-            line="145"
+            line="212"
             column="39"/>
     </issue>
 
@@ -1773,7 +1683,7 @@
         errorLine2="        ~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/onebusaway/android/ui/mylists/MyListRepository.kt"
-            line="175"
+            line="242"
             column="9"/>
     </issue>
 
@@ -1784,7 +1694,7 @@
         errorLine2="                                              ~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/onebusaway/android/ui/mylists/MyListRepository.kt"
-            line="188"
+            line="255"
             column="47"/>
     </issue>
 
@@ -1795,7 +1705,7 @@
         errorLine2="                    ~~~~~~~~~~~~">
         <location
             file="src/main/java/org/onebusaway/android/ui/mylists/MyListRepository.kt"
-            line="196"
+            line="263"
             column="21"/>
     </issue>
 
@@ -1806,7 +1716,7 @@
         errorLine2="        ~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/onebusaway/android/ui/mylists/MyListRepository.kt"
-            line="227"
+            line="293"
             column="9"/>
     </issue>
 
@@ -1817,7 +1727,7 @@
         errorLine2="                                      ~~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/onebusaway/android/ui/mylists/MyListRepository.kt"
-            line="241"
+            line="307"
             column="39"/>
     </issue>
 
@@ -1828,7 +1738,7 @@
         errorLine2="        ~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/onebusaway/android/ui/mylists/MyListRepository.kt"
-            line="267"
+            line="330"
             column="9"/>
     </issue>
 
@@ -1839,7 +1749,7 @@
         errorLine2="                                      ~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/onebusaway/android/ui/mylists/MyListRepository.kt"
-            line="276"
+            line="339"
             column="39"/>
     </issue>
 
@@ -2059,7 +1969,7 @@
         errorLine2="                        ~~~~~~~~~~~">
         <location
             file="src/main/java/org/onebusaway/android/nav/NavigationUploadWorker.java"
-            line="115"
+            line="113"
             column="25"/>
     </issue>
 
@@ -2070,7 +1980,7 @@
         errorLine2="                                             ~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/onebusaway/android/api/adapters/TripAdapters.kt"
-            line="49"
+            line="53"
             column="46"/>
     </issue>
 
@@ -2081,7 +1991,7 @@
         errorLine2="                                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/onebusaway/android/api/adapters/TripAdapters.kt"
-            line="61"
+            line="65"
             column="55"/>
     </issue>
 
@@ -2092,7 +2002,7 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/onebusaway/android/api/data/TripVehiclesDataSource.kt"
-            line="48"
+            line="50"
             column="9"/>
     </issue>
 
@@ -2173,7 +2083,7 @@
             column="5"/>
         <location
             file="src/main/res/values/strings.xml"
-            line="28"
+            line="27"
             column="5"
             message="Duplicates value in `analytics_label_button_press_settings` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
     </issue>
@@ -2189,12 +2099,12 @@
             column="5"/>
         <location
             file="src/main/res/values/strings.xml"
-            line="29"
+            line="28"
             column="5"
             message="Duplicates value in `analytics_label_button_press_help` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
         <location
             file="src/main/res/values/strings.xml"
-            line="101"
+            line="102"
             column="5"
             message="Duplicates value in `analytics_label_button_press_help`"/>
     </issue>
@@ -2210,7 +2120,7 @@
             column="5"/>
         <location
             file="src/main/res/values/strings.xml"
-            line="347"
+            line="349"
             column="5"
             message="Duplicates value in `analytics_label_stop_category` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
     </issue>
@@ -2242,7 +2152,7 @@
             column="5"/>
         <location
             file="src/main/res/values/strings.xml"
-            line="420"
+            line="419"
             column="5"
             message="Duplicates value in `ri_selected_service_stop` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
     </issue>
@@ -2258,17 +2168,17 @@
             column="5"/>
         <location
             file="src/main/res/values/strings.xml"
-            line="287"
+            line="283"
             column="5"
             message="Duplicates value in `analytics_label_destination_reminder_yes` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
         <location
             file="src/main/res/values/strings.xml"
-            line="305"
+            line="301"
             column="5"
             message="Duplicates value in `analytics_label_destination_reminder_yes`"/>
         <location
             file="src/main/res/values/strings.xml"
-            line="746"
+            line="750"
             column="5"
             message="Duplicates value in `analytics_label_destination_reminder_yes` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
     </issue>
@@ -2284,12 +2194,12 @@
             column="5"/>
         <location
             file="src/main/res/values/strings.xml"
-            line="304"
+            line="300"
             column="5"
             message="Duplicates value in `analytics_label_destination_reminder_no` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
         <location
             file="src/main/res/values/strings.xml"
-            line="747"
+            line="751"
             column="5"
             message="Duplicates value in `analytics_label_destination_reminder_no` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
     </issue>
@@ -2301,11 +2211,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-pl/strings.xml"
-            line="7"
+            line="6"
             column="5"/>
         <location
             file="src/main/res/values-pl/strings.xml"
-            line="380"
+            line="369"
             column="5"
             message="Duplicates value in `navdrawer_item_starred_stops`"/>
     </issue>
@@ -2317,11 +2227,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-pl/strings.xml"
-            line="10"
+            line="9"
             column="5"/>
         <location
             file="src/main/res/values-pl/strings.xml"
-            line="69"
+            line="68"
             column="5"
             message="Duplicates value in `navdrawer_item_help`"/>
     </issue>
@@ -2333,11 +2243,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="24"
+            line="23"
             column="5"/>
         <location
             file="src/main/res/values-it/strings.xml"
-            line="340"
+            line="329"
             column="5"
             message="Duplicates value in `navdrawer_item_starred_stops`"/>
     </issue>
@@ -2349,11 +2259,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="24"
+            line="23"
             column="5"/>
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="354"
+            line="343"
             column="5"
             message="Duplicates value in `navdrawer_item_starred_stops`"/>
     </issue>
@@ -2365,11 +2275,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="25"
+            line="24"
             column="5"/>
         <location
             file="src/main/res/values/strings.xml"
-            line="423"
+            line="422"
             column="5"
             message="Duplicates value in `navdrawer_item_starred_stops` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
     </issue>
@@ -2381,11 +2291,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-es/strings.xml"
-            line="26"
+            line="25"
             column="5"/>
         <location
             file="src/main/res/values-es/strings.xml"
-            line="413"
+            line="402"
             column="5"
             message="Duplicates value in `navdrawer_item_starred_stops`"/>
     </issue>
@@ -2397,11 +2307,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="28"
+            line="27"
             column="5"/>
         <location
             file="src/main/res/values-it/strings.xml"
-            line="68"
+            line="67"
             column="5"
             message="Duplicates value in `navdrawer_item_help`"/>
     </issue>
@@ -2413,11 +2323,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-es/strings.xml"
-            line="30"
+            line="29"
             column="5"/>
         <location
             file="src/main/res/values-es/strings.xml"
-            line="102"
+            line="101"
             column="5"
             message="Duplicates value in `navdrawer_item_help`"/>
     </issue>
@@ -2429,11 +2339,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="67"
+            line="66"
             column="5"/>
         <location
             file="src/main/res/values-it/strings.xml"
-            line="289"
+            line="280"
             column="5"
             message="Duplicates value in `map_option_search`"/>
     </issue>
@@ -2445,11 +2355,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-pl/strings.xml"
-            line="67"
+            line="66"
             column="5"/>
         <location
             file="src/main/res/values-pl/strings.xml"
-            line="310"
+            line="301"
             column="5"
             message="Duplicates value in `map_option_search`"/>
     </issue>
@@ -2461,116 +2371,21 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-pl/strings.xml"
-            line="68"
+            line="67"
             column="5"/>
         <location
             file="src/main/res/values-pl/strings.xml"
-            line="250"
-            column="5"
-            message="Duplicates value in `cancel`"/>
-        <location
-            file="src/main/res/values-pl/strings.xml"
-            line="728"
+            line="249"
             column="5"
             message="Duplicates value in `cancel`"/>
         <location
             file="src/main/res/values-pl/strings.xml"
-            line="810"
-            column="5"
-            message="Duplicates value in `cancel`"/>
-    </issue>
-    <issue
-        id="DuplicateStrings"
-        message="Duplicate string value `Annulla`, used in `alert_hidden_snackbar_action`, `cancel`, `destination_reminder_cancel`, `donation_dismiss_dialog_cancel_button` and `night_light_cancel`. Use `android:inputType` or `android:capitalize` to treat these as the same and avoid string duplication."
-        errorLine1="    &lt;string name=&quot;destination_reminder_cancel&quot;>Annulla&lt;/string>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values-it/strings.xml"
-            line="229"
-            column="5"/>
-        <location
-            file="src/main/res/values-it/strings.xml"
-            line="307"
-            column="5"
-            message="Duplicates value in `destination_reminder_cancel` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
-        <location
-            file="src/main/res/values-it/strings.xml"
-            line="630"
-            column="5"
-            message="Duplicates value in `destination_reminder_cancel` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
-        <location
-            file="src/main/res/values-it/strings.xml"
-            line="898"
-            column="5"
-            message="Duplicates value in `destination_reminder_cancel`"/>
-        <location
-            file="src/main/res/values-it/strings.xml"
-            line="911"
-            column="5"
-            message="Duplicates value in `destination_reminder_cancel`"/>
-    </issue>
-    <issue
-        id="DuplicateStrings"
-        message="Duplicate string value `Cancel`, used in `cancel`, `destination_reminder_cancel`, `donation_dismiss_dialog_cancel_button` and `night_light_cancel`"
-        errorLine1="    &lt;string name=&quot;destination_reminder_cancel&quot;>Cancel&lt;/string>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="285"
-            column="5"/>
-        <location
-            file="src/main/res/values/strings.xml"
-            line="803"
-            column="5"
-            message="Duplicates value in `destination_reminder_cancel`"/>
-        <location
-            file="src/main/res/values/strings.xml"
-            line="1120"
-            column="5"
-            message="Duplicates value in `destination_reminder_cancel`"/>
-        <location
-            file="src/main/res/values/strings.xml"
-            line="1135"
-            column="5"
-            message="Duplicates value in `destination_reminder_cancel`"/>
-    </issue>
-    <issue
-        id="DuplicateStrings"
-        message="Duplicate string value `Peruuta`, used in `cancel`, `destination_reminder_cancel`, `donation_dismiss_dialog_cancel_button` and `night_light_cancel`"
-        errorLine1="    &lt;string name=&quot;cancel&quot;>Peruuta&lt;/string>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values-fi/strings.xml"
-            line="453"
-            column="5"/>
-        <location
-            file="src/main/res/values-fi/strings.xml"
-            line="613"
+            line="727"
             column="5"
             message="Duplicates value in `cancel`"/>
         <location
-            file="src/main/res/values-fi/strings.xml"
-            line="693"
-            column="5"
-            message="Duplicates value in `cancel`"/>
-        <location
-            file="src/main/res/values-fi/strings.xml"
-            line="936"
-            column="5"
-            message="Duplicates value in `cancel`"/>
-    </issue>
-    <issue
-        id="DuplicateStrings"
-        message="Duplicate string value `Cancelar`, used in `cancel` and `donation_dismiss_dialog_cancel_button`"
-        errorLine1="    &lt;string name=&quot;cancel&quot;>Cancelar&lt;/string>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values-es/strings.xml"
-            line="557"
-            column="5"/>
-        <location
-            file="src/main/res/values-es/strings.xml"
-            line="1064"
+            file="src/main/res/values-pl/strings.xml"
+            line="809"
             column="5"
             message="Duplicates value in `cancel`"/>
     </issue>
@@ -2582,11 +2397,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="71"
+            line="70"
             column="5"/>
         <location
             file="src/main/res/values-it/strings.xml"
-            line="314"
+            line="303"
             column="5"
             message="Duplicates value in `main_help_close`"/>
     </issue>
@@ -2598,11 +2413,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-pl/strings.xml"
-            line="79"
+            line="78"
             column="5"/>
         <location
             file="src/main/res/values-pl/strings.xml"
-            line="349"
+            line="338"
             column="5"
             message="Duplicates value in `main_help_close`"/>
     </issue>
@@ -2614,11 +2429,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="82"
+            line="81"
             column="5"/>
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="905"
+            line="888"
             column="5"
             message="Duplicates value in `direction_n` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
     </issue>
@@ -2630,11 +2445,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="83"
+            line="82"
             column="5"/>
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="906"
+            line="889"
             column="5"
             message="Duplicates value in `direction_ne` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
     </issue>
@@ -2646,11 +2461,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="84"
+            line="83"
             column="5"/>
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="904"
+            line="887"
             column="5"
             message="Duplicates value in `direction_e` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
     </issue>
@@ -2662,11 +2477,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="85"
+            line="84"
             column="5"/>
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="909"
+            line="892"
             column="5"
             message="Duplicates value in `direction_se` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
     </issue>
@@ -2678,11 +2493,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="86"
+            line="85"
             column="5"/>
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="908"
+            line="891"
             column="5"
             message="Duplicates value in `direction_s` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
     </issue>
@@ -2694,11 +2509,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-es/strings.xml"
-            line="86"
+            line="85"
             column="5"/>
         <location
             file="src/main/res/values-es/strings.xml"
-            line="975"
+            line="958"
             column="5"
             message="Duplicates value in `direction_n` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
     </issue>
@@ -2710,11 +2525,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-es/strings.xml"
-            line="87"
+            line="86"
             column="5"/>
         <location
             file="src/main/res/values-es/strings.xml"
-            line="977"
+            line="960"
             column="5"
             message="Duplicates value in `direction_ne`"/>
     </issue>
@@ -2726,11 +2541,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="87"
+            line="86"
             column="5"/>
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="910"
+            line="893"
             column="5"
             message="Duplicates value in `direction_sw` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
     </issue>
@@ -2742,11 +2557,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-es/strings.xml"
-            line="88"
+            line="87"
             column="5"/>
         <location
             file="src/main/res/values-es/strings.xml"
-            line="974"
+            line="957"
             column="5"
             message="Duplicates value in `direction_e` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
     </issue>
@@ -2758,11 +2573,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="88"
+            line="87"
             column="5"/>
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="911"
+            line="894"
             column="5"
             message="Duplicates value in `direction_w` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
     </issue>
@@ -2774,11 +2589,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="89"
+            line="88"
             column="5"/>
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="907"
+            line="890"
             column="5"
             message="Duplicates value in `direction_nw` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
     </issue>
@@ -2790,11 +2605,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-es/strings.xml"
-            line="89"
+            line="88"
             column="5"/>
         <location
             file="src/main/res/values-es/strings.xml"
-            line="980"
+            line="963"
             column="5"
             message="Duplicates value in `direction_se` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
     </issue>
@@ -2806,11 +2621,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-es/strings.xml"
-            line="90"
+            line="89"
             column="5"/>
         <location
             file="src/main/res/values-es/strings.xml"
-            line="978"
+            line="961"
             column="5"
             message="Duplicates value in `direction_s` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
     </issue>
@@ -2822,11 +2637,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-es/strings.xml"
-            line="91"
+            line="90"
             column="5"/>
         <location
             file="src/main/res/values-es/strings.xml"
-            line="979"
+            line="962"
             column="5"
             message="Duplicates value in `direction_sw` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
     </issue>
@@ -2838,11 +2653,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-es/strings.xml"
-            line="92"
+            line="91"
             column="5"/>
         <location
             file="src/main/res/values-es/strings.xml"
-            line="981"
+            line="964"
             column="5"
             message="Duplicates value in `direction_w` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
     </issue>
@@ -2854,11 +2669,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-es/strings.xml"
-            line="93"
+            line="92"
             column="5"/>
         <location
             file="src/main/res/values-es/strings.xml"
-            line="976"
+            line="959"
             column="5"
             message="Duplicates value in `direction_nw`"/>
     </issue>
@@ -2870,27 +2685,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="97"
+            line="96"
             column="5"/>
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="295"
-            column="5"
-            message="Duplicates value in `map_option_search`"/>
-    </issue>
-
-    <issue
-        id="DuplicateStrings"
-        message="Duplicate string value `Search`, used in `map_option_search` and `my_search_title`"
-        errorLine1="    &lt;string name=&quot;map_option_search&quot;>Search&lt;/string>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="100"
-            column="5"/>
-        <location
-            file="src/main/res/values/strings.xml"
-            line="350"
+            line="286"
             column="5"
             message="Duplicates value in `map_option_search`"/>
     </issue>
@@ -2902,11 +2701,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-es/strings.xml"
-            line="101"
+            line="100"
             column="5"/>
         <location
             file="src/main/res/values-es/strings.xml"
-            line="345"
+            line="336"
             column="5"
             message="Duplicates value in `map_option_search`"/>
     </issue>
@@ -2918,11 +2717,43 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="101"
+            line="100"
             column="5"/>
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="334"
+            line="323"
+            column="5"
+            message="Duplicates value in `main_help_close`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Search`, used in `map_option_search` and `my_search_title`"
+        errorLine1="    &lt;string name=&quot;map_option_search&quot;>Search&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="101"
+            column="5"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="352"
+            column="5"
+            message="Duplicates value in `map_option_search`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Cerrar`, used in `close` and `main_help_close`"
+        errorLine1="    &lt;string name=&quot;main_help_close&quot;>Cerrar&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="104"
+            column="5"/>
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="372"
             column="5"
             message="Duplicates value in `main_help_close`"/>
     </issue>
@@ -2934,27 +2765,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="104"
+            line="105"
             column="5"/>
         <location
             file="src/main/res/values/strings.xml"
             line="395"
-            column="5"
-            message="Duplicates value in `main_help_close`"/>
-    </issue>
-
-    <issue
-        id="DuplicateStrings"
-        message="Duplicate string value `Cerrar`, used in `close` and `main_help_close`"
-        errorLine1="    &lt;string name=&quot;main_help_close&quot;>Cerrar&lt;/string>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values-es/strings.xml"
-            line="105"
-            column="5"/>
-        <location
-            file="src/main/res/values-es/strings.xml"
-            line="383"
             column="5"
             message="Duplicates value in `main_help_close`"/>
     </issue>
@@ -2966,16 +2781,16 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="182"
+            line="178"
             column="5"/>
         <location
             file="src/main/res/values-it/strings.xml"
-            line="280"
+            line="271"
             column="5"
             message="Duplicates value in `stop_info_option_showonmap`"/>
         <location
             file="src/main/res/values-it/strings.xml"
-            line="305"
+            line="294"
             column="5"
             message="Duplicates value in `stop_info_option_showonmap`"/>
     </issue>
@@ -2987,11 +2802,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-pl/strings.xml"
-            line="183"
+            line="179"
             column="5"/>
         <location
             file="src/main/res/values-pl/strings.xml"
-            line="185"
+            line="181"
             column="5"
             message="Duplicates value in `stop_info_time_arriving_at`"/>
     </issue>
@@ -3003,11 +2818,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="184"
+            line="180"
             column="5"/>
         <location
             file="src/main/res/values-it/strings.xml"
-            line="426"
+            line="415"
             column="5"
             message="Duplicates value in `stop_info_option_refresh`"/>
     </issue>
@@ -3019,11 +2834,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-pl/strings.xml"
-            line="184"
+            line="180"
             column="5"/>
         <location
             file="src/main/res/values-pl/strings.xml"
-            line="186"
+            line="182"
             column="5"
             message="Duplicates value in `stop_info_time_departing_at`"/>
     </issue>
@@ -3035,11 +2850,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="191"
+            line="186"
             column="5"/>
         <location
             file="src/main/res/values-it/strings.xml"
-            line="207"
+            line="202"
             column="5"
             message="Duplicates value in `stop_info_nodata_minutes_short_format`"/>
     </issue>
@@ -3051,16 +2866,16 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-pl/strings.xml"
-            line="201"
+            line="197"
             column="5"/>
         <location
             file="src/main/res/values-pl/strings.xml"
-            line="300"
+            line="291"
             column="5"
             message="Duplicates value in `stop_info_option_showonmap`"/>
         <location
             file="src/main/res/values-pl/strings.xml"
-            line="340"
+            line="329"
             column="5"
             message="Duplicates value in `stop_info_option_showonmap`"/>
     </issue>
@@ -3072,11 +2887,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-pl/strings.xml"
-            line="203"
+            line="199"
             column="5"/>
         <location
             file="src/main/res/values-pl/strings.xml"
-            line="468"
+            line="457"
             column="5"
             message="Duplicates value in `stop_info_option_refresh`"/>
     </issue>
@@ -3088,16 +2903,16 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-pl/strings.xml"
-            line="206"
+            line="201"
             column="5"/>
         <location
             file="src/main/res/values-pl/strings.xml"
-            line="657"
+            line="644"
             column="5"
             message="Duplicates value in `stop_info_option_report_problem`"/>
         <location
             file="src/main/res/values-pl/strings.xml"
-            line="659"
+            line="646"
             column="5"
             message="Duplicates value in `stop_info_option_report_problem`"/>
     </issue>
@@ -3109,11 +2924,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-pl/strings.xml"
-            line="210"
+            line="205"
             column="5"/>
         <location
             file="src/main/res/values-pl/strings.xml"
-            line="228"
+            line="223"
             column="5"
             message="Duplicates value in `stop_info_nodata_minutes_short_format`"/>
     </issue>
@@ -3125,16 +2940,16 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="222"
+            line="218"
             column="5"/>
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="285"
+            line="276"
             column="5"
             message="Duplicates value in `stop_info_option_showonmap`"/>
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="325"
+            line="314"
             column="5"
             message="Duplicates value in `stop_info_option_showonmap`"/>
     </issue>
@@ -3146,16 +2961,35 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="224"
+            line="220"
             column="5"/>
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="426"
+            line="415"
             column="5"
             message="Duplicates value in `stop_info_option_refresh`"/>
     </issue>
 
-
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Ilmoita pysäkkiongelma`, used in `rt_infrastructure_problem`, `rt_stop_problem` and `stop_info_option_report_problem`"
+        errorLine1="    &lt;string name=&quot;stop_info_option_report_problem&quot;>Ilmoita pysäkkiongelma&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="224"
+            column="5"/>
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="783"
+            column="5"
+            message="Duplicates value in `stop_info_option_report_problem`"/>
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="785"
+            column="5"
+            message="Duplicates value in `stop_info_option_report_problem`"/>
+    </issue>
 
     <issue
         id="DuplicateStrings"
@@ -3164,11 +2998,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="227"
+            line="226"
             column="5"/>
         <location
             file="src/main/res/values/strings.xml"
-            line="355"
+            line="357"
             column="5"
             message="Duplicates value in `stop_info_eta_now`"/>
     </issue>
@@ -3180,11 +3014,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="228"
+            line="227"
             column="5"/>
         <location
             file="src/main/res/values/strings.xml"
-            line="336"
+            line="332"
             column="5"
             message="Duplicates value in `stop_info_option_showonmap`"/>
         <location
@@ -3196,23 +3030,54 @@
 
     <issue
         id="DuplicateStrings"
-        message="Duplicate string value `Ilmoita pysäkkiongelma`, used in `rt_infrastructure_problem`, `rt_stop_problem` and `stop_info_option_report_problem`"
-        errorLine1="    &lt;string name=&quot;stop_info_option_report_problem&quot;>Ilmoita pysäkkiongelma&lt;/string>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Duplicate string value `SÌ`, used in `destination_reminder_confirm`, `feedback_action_reply_yes` and `rt_yes`. Use `android:inputType` or `android:capitalize` to treat these as the same and avoid string duplication."
+        errorLine1="    &lt;string name=&quot;destination_reminder_confirm&quot;>Sì&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="src/main/res/values-fi/strings.xml"
-            line="229"
+            file="src/main/res/values-it/strings.xml"
+            line="227"
             column="5"/>
         <location
-            file="src/main/res/values-fi/strings.xml"
-            line="800"
+            file="src/main/res/values-it/strings.xml"
+            line="245"
             column="5"
-            message="Duplicates value in `stop_info_option_report_problem`"/>
+            message="Duplicates value in `destination_reminder_confirm`"/>
         <location
-            file="src/main/res/values-fi/strings.xml"
-            line="802"
+            file="src/main/res/values-it/strings.xml"
+            line="578"
             column="5"
-            message="Duplicates value in `stop_info_option_report_problem`"/>
+            message="Duplicates value in `destination_reminder_confirm` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Annulla`, used in `alert_hidden_snackbar_action`, `cancel`, `destination_reminder_cancel`, `donation_dismiss_dialog_cancel_button` and `night_light_cancel`. Use `android:inputType` or `android:capitalize` to treat these as the same and avoid string duplication."
+        errorLine1="    &lt;string name=&quot;destination_reminder_cancel&quot;>Annulla&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="228"
+            column="5"/>
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="306"
+            column="5"
+            message="Duplicates value in `destination_reminder_cancel` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="629"
+            column="5"
+            message="Duplicates value in `destination_reminder_cancel` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="897"
+            column="5"
+            message="Duplicates value in `destination_reminder_cancel`"/>
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="910"
+            column="5"
+            message="Duplicates value in `destination_reminder_cancel`"/>
     </issue>
 
     <issue
@@ -3222,11 +3087,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="230"
+            line="229"
             column="5"/>
         <location
             file="src/main/res/values/strings.xml"
-            line="512"
+            line="511"
             column="5"
             message="Duplicates value in `stop_info_option_refresh`"/>
     </issue>
@@ -3238,34 +3103,13 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="235"
+            line="230"
             column="5"/>
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="253"
+            line="248"
             column="5"
             message="Duplicates value in `stop_info_nodata_minutes_short_format`"/>
-    </issue>
-
-    <issue
-        id="DuplicateStrings"
-        message="Duplicate string value `SÌ`, used in `destination_reminder_confirm`, `feedback_action_reply_yes` and `rt_yes`. Use `android:inputType` or `android:capitalize` to treat these as the same and avoid string duplication."
-        errorLine1="    &lt;string name=&quot;destination_reminder_confirm&quot;>Sì&lt;/string>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values-it/strings.xml"
-            line="236"
-            column="5"/>
-        <location
-            file="src/main/res/values-it/strings.xml"
-            line="254"
-            column="5"
-            message="Duplicates value in `destination_reminder_confirm`"/>
-        <location
-            file="src/main/res/values-it/strings.xml"
-            line="591"
-            column="5"
-            message="Duplicates value in `destination_reminder_confirm` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
     </issue>
 
     <issue
@@ -3284,7 +3128,6 @@
             message="Duplicates value in `stop_info_nodata_minutes_short_format`"/>
     </issue>
 
-
     <issue
         id="DuplicateStrings"
         message="Duplicate string value `NO`, used in `feedback_action_reply_no` and `rt_no`. Use `android:inputType` or `android:capitalize` to treat these as the same and avoid string duplication."
@@ -3292,11 +3135,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="253"
+            line="244"
             column="5"/>
         <location
             file="src/main/res/values-it/strings.xml"
-            line="592"
+            line="579"
             column="5"
             message="Duplicates value in `feedback_action_reply_no` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
     </issue>
@@ -3308,16 +3151,16 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-pl/strings.xml"
-            line="257"
+            line="248"
             column="5"/>
         <location
             file="src/main/res/values-pl/strings.xml"
-            line="275"
+            line="266"
             column="5"
             message="Duplicates value in `destination_reminder_confirm`"/>
         <location
             file="src/main/res/values-pl/strings.xml"
-            line="669"
+            line="656"
             column="5"
             message="Duplicates value in `destination_reminder_confirm` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
     </issue>
@@ -3329,16 +3172,16 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-es/strings.xml"
-            line="260"
+            line="256"
             column="5"/>
         <location
             file="src/main/res/values-es/strings.xml"
-            line="335"
+            line="326"
             column="5"
             message="Duplicates value in `stop_info_option_showonmap` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
         <location
             file="src/main/res/values-es/strings.xml"
-            line="363"
+            line="352"
             column="5"
             message="Duplicates value in `stop_info_option_showonmap`"/>
     </issue>
@@ -3350,11 +3193,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-es/strings.xml"
-            line="262"
+            line="258"
             column="5"/>
         <location
             file="src/main/res/values-es/strings.xml"
-            line="517"
+            line="506"
             column="5"
             message="Duplicates value in `stop_info_option_refresh`"/>
     </issue>
@@ -3366,13 +3209,29 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-es/strings.xml"
-            line="267"
+            line="262"
             column="5"/>
         <location
             file="src/main/res/values-es/strings.xml"
-            line="667"
+            line="654"
             column="5"
             message="Duplicates value in `stop_info_option_hide_alerts`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `NIE`, used in `feedback_action_reply_no` and `rt_no`. Use `android:inputType` or `android:capitalize` to treat these as the same and avoid string duplication."
+        errorLine1="    &lt;string name=&quot;feedback_action_reply_no&quot;>Nie&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="265"
+            column="5"/>
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="657"
+            column="5"
+            message="Duplicates value in `feedback_action_reply_no` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
     </issue>
 
     <issue
@@ -3382,34 +3241,30 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-es/strings.xml"
-            line="272"
+            line="267"
             column="5"/>
         <location
             file="src/main/res/values-es/strings.xml"
-            line="296"
+            line="291"
             column="5"
             message="Duplicates value in `stop_info_nodata_minutes_short_format`"/>
     </issue>
 
-
-
     <issue
         id="DuplicateStrings"
-        message="Duplicate string value `NIE`, used in `feedback_action_reply_no` and `rt_no`. Use `android:inputType` or `android:capitalize` to treat these as the same and avoid string duplication."
-        errorLine1="    &lt;string name=&quot;feedback_action_reply_no&quot;>Nie&lt;/string>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Duplicate string value `Mostra informazioni sull\&apos;arrivo`, used in `my_context_get_stop_info` and `route_info_context_get_stop_info`"
+        errorLine1="    &lt;string name=&quot;route_info_context_get_stop_info&quot;>Mostra informazioni sull\&apos;arrivo&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="src/main/res/values-pl/strings.xml"
-            line="274"
+            file="src/main/res/values-it/strings.xml"
+            line="270"
             column="5"/>
         <location
-            file="src/main/res/values-pl/strings.xml"
-            line="670"
+            file="src/main/res/values-it/strings.xml"
+            line="291"
             column="5"
-            message="Duplicates value in `feedback_action_reply_no` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
+            message="Duplicates value in `route_info_context_get_stop_info`"/>
     </issue>
-
-
 
     <issue
         id="DuplicateStrings"
@@ -3418,7 +3273,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="279"
+            line="275"
             column="5"/>
         <location
             file="src/main/res/values/strings.xml"
@@ -3429,21 +3284,29 @@
 
     <issue
         id="DuplicateStrings"
-        message="Duplicate string value `Mostra informazioni sull\&apos;arrivo`, used in `my_context_get_stop_info` and `route_info_context_get_stop_info`"
-        errorLine1="    &lt;string name=&quot;route_info_context_get_stop_info&quot;>Mostra informazioni sull\&apos;arrivo&lt;/string>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Duplicate string value `Cancel`, used in `cancel`, `destination_reminder_cancel`, `donation_dismiss_dialog_cancel_button` and `night_light_cancel`"
+        errorLine1="    &lt;string name=&quot;destination_reminder_cancel&quot;>Cancel&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="src/main/res/values-it/strings.xml"
-            line="279"
+            file="src/main/res/values/strings.xml"
+            line="284"
             column="5"/>
         <location
-            file="src/main/res/values-it/strings.xml"
-            line="302"
+            file="src/main/res/values/strings.xml"
+            line="807"
             column="5"
-            message="Duplicates value in `route_info_context_get_stop_info`"/>
+            message="Duplicates value in `destination_reminder_cancel`"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1124"
+            column="5"
+            message="Duplicates value in `destination_reminder_cancel`"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1139"
+            column="5"
+            message="Duplicates value in `destination_reminder_cancel`"/>
     </issue>
-
-
 
     <issue
         id="DuplicateStrings"
@@ -3452,11 +3315,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="324"
+            line="313"
             column="5"/>
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="623"
+            line="610"
             column="5"
             message="Duplicates value in `my_context_create_shortcut`"/>
     </issue>
@@ -3468,13 +3331,29 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="331"
+            line="320"
             column="5"/>
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="740"
+            line="723"
             column="5"
             message="Duplicates value in `situation_more_details`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Linea`, used in `connector_before_route` and `route_shortcut`"
+        errorLine1="    &lt;string name=&quot;route_shortcut&quot;>Linea&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="325"
+            column="5"/>
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="862"
+            column="5"
+            message="Duplicates value in `route_shortcut`"/>
     </issue>
 
     <issue
@@ -3484,13 +3363,45 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-es/strings.xml"
-            line="334"
+            line="325"
             column="5"/>
         <location
             file="src/main/res/values-es/strings.xml"
-            line="360"
+            line="349"
             column="5"
             message="Duplicates value in `route_info_context_get_stop_info`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Utwórz skrót`, used in `my_context_create_shortcut` and `night_light_create_shortcut`"
+        errorLine1="    &lt;string name=&quot;my_context_create_shortcut&quot;>Utwórz skrót&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="328"
+            column="5"/>
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="725"
+            column="5"
+            message="Duplicates value in `my_context_create_shortcut`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Linea %s`, used in `route_name` and `trip_info_route`"
+        errorLine1="    &lt;string name=&quot;route_name&quot;>Linea %s&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="331"
+            column="5"/>
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="335"
+            column="5"
+            message="Duplicates value in `route_name`"/>
     </issue>
 
     <issue
@@ -3500,7 +3411,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="335"
+            line="331"
             column="5"/>
         <location
             file="src/main/res/values/strings.xml"
@@ -3511,66 +3422,18 @@
 
     <issue
         id="DuplicateStrings"
-        message="Duplicate string value `Linea`, used in `connector_before_route` and `route_shortcut`"
-        errorLine1="    &lt;string name=&quot;route_shortcut&quot;>Linea&lt;/string>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values-it/strings.xml"
-            line="336"
-            column="5"/>
-        <location
-            file="src/main/res/values-it/strings.xml"
-            line="877"
-            column="5"
-            message="Duplicates value in `route_shortcut`"/>
-    </issue>
-
-    <issue
-        id="DuplicateStrings"
-        message="Duplicate string value `Utwórz skrót`, used in `my_context_create_shortcut` and `night_light_create_shortcut`"
-        errorLine1="    &lt;string name=&quot;my_context_create_shortcut&quot;>Utwórz skrót&lt;/string>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values-pl/strings.xml"
-            line="339"
-            column="5"/>
-        <location
-            file="src/main/res/values-pl/strings.xml"
-            line="738"
-            column="5"
-            message="Duplicates value in `my_context_create_shortcut`"/>
-    </issue>
-
-    <issue
-        id="DuplicateStrings"
         message="Duplicate string value `Paradas y rutas recientes`, used in `my_recent_menu_title` and `tutorial_recent_stops_routes_title`. Use `android:inputType` or `android:capitalize` to treat these as the same and avoid string duplication."
         errorLine1="    &lt;string name=&quot;my_recent_menu_title&quot;>Paradas y Rutas recientes&lt;/string>"
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-es/strings.xml"
-            line="341"
+            line="332"
             column="5"/>
         <location
             file="src/main/res/values-es/strings.xml"
-            line="809"
+            line="792"
             column="5"
             message="Duplicates value in `my_recent_menu_title` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
-    </issue>
-
-    <issue
-        id="DuplicateStrings"
-        message="Duplicate string value `Linea %s`, used in `route_name` and `trip_info_route`"
-        errorLine1="    &lt;string name=&quot;route_name&quot;>Linea %s&lt;/string>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values-it/strings.xml"
-            line="342"
-            column="5"/>
-        <location
-            file="src/main/res/values-it/strings.xml"
-            line="346"
-            column="5"
-            message="Duplicates value in `route_name`"/>
     </issue>
 
     <issue
@@ -3580,11 +3443,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="354"
+            line="343"
             column="5"/>
         <location
             file="src/main/res/values-it/strings.xml"
-            line="368"
+            line="357"
             column="5"
             message="Duplicates value in `trip_info_option_showroute`"/>
     </issue>
@@ -3596,11 +3459,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="355"
+            line="344"
             column="5"/>
         <location
             file="src/main/res/values-it/strings.xml"
-            line="367"
+            line="356"
             column="5"
             message="Duplicates value in `trip_info_option_showstop`"/>
     </issue>
@@ -3612,11 +3475,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="356"
+            line="345"
             column="5"/>
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="360"
+            line="349"
             column="5"
             message="Duplicates value in `route_name`"/>
     </issue>
@@ -3628,11 +3491,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="368"
+            line="357"
             column="5"/>
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="379"
+            line="368"
             column="5"
             message="Duplicates value in `trip_info_option_showroute`"/>
     </issue>
@@ -3644,11 +3507,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="369"
+            line="358"
             column="5"/>
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="378"
+            line="367"
             column="5"
             message="Duplicates value in `trip_info_option_showstop`"/>
     </issue>
@@ -3660,11 +3523,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-pl/strings.xml"
-            line="381"
+            line="370"
             column="5"/>
         <location
             file="src/main/res/values-pl/strings.xml"
-            line="385"
+            line="374"
             column="5"
             message="Duplicates value in `route_name`"/>
     </issue>
@@ -3676,11 +3539,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="382"
+            line="371"
             column="5"/>
         <location
             file="src/main/res/values-it/strings.xml"
-            line="944"
+            line="929"
             column="5"
             message="Duplicates value in `report_problem_send`"/>
     </issue>
@@ -3692,11 +3555,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="383"
+            line="372"
             column="5"/>
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="728"
+            line="711"
             column="5"
             message="Duplicates value in `report_problem_send`"/>
     </issue>
@@ -3708,11 +3571,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-pl/strings.xml"
-            line="393"
+            line="382"
             column="5"/>
         <location
             file="src/main/res/values-pl/strings.xml"
-            line="404"
+            line="393"
             column="5"
             message="Duplicates value in `trip_info_option_showroute`"/>
     </issue>
@@ -3724,11 +3587,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-pl/strings.xml"
-            line="394"
+            line="383"
             column="5"/>
         <location
             file="src/main/res/values-pl/strings.xml"
-            line="403"
+            line="392"
             column="5"
             message="Duplicates value in `trip_info_option_showstop`"/>
     </issue>
@@ -3740,11 +3603,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-es/strings.xml"
-            line="409"
+            line="398"
             column="5"/>
         <location
             file="src/main/res/values-es/strings.xml"
-            line="1036"
+            line="1019"
             column="5"
             message="Duplicates value in `route_shortcut`"/>
     </issue>
@@ -3756,29 +3619,13 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-es/strings.xml"
-            line="415"
+            line="404"
             column="5"/>
         <location
             file="src/main/res/values-es/strings.xml"
-            line="419"
+            line="408"
             column="5"
             message="Duplicates value in `route_name`"/>
-    </issue>
-
-    <issue
-        id="DuplicateStrings"
-        message="Duplicate string value `Route`, used in `connector_before_route` and `route_shortcut`"
-        errorLine1="    &lt;string name=&quot;route_shortcut&quot;>Route&lt;/string>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="419"
-            column="5"/>
-        <location
-            file="src/main/res/values/strings.xml"
-            line="1080"
-            column="5"
-            message="Duplicates value in `route_shortcut`"/>
     </issue>
 
     <issue
@@ -3788,11 +3635,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-pl/strings.xml"
-            line="423"
+            line="412"
             column="5"/>
         <location
             file="src/main/res/values-pl/strings.xml"
-            line="430"
+            line="419"
             column="5"
             message="Duplicates value in `report_problem_comment_hint`"/>
     </issue>
@@ -3804,29 +3651,13 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-pl/strings.xml"
-            line="424"
+            line="413"
             column="5"/>
         <location
             file="src/main/res/values-pl/strings.xml"
-            line="844"
+            line="828"
             column="5"
             message="Duplicates value in `report_problem_send`"/>
-    </issue>
-
-    <issue
-        id="DuplicateStrings"
-        message="Duplicate string value `Route %s`, used in `route_name` and `trip_info_route`"
-        errorLine1="    &lt;string name=&quot;route_name&quot;>Route %s&lt;/string>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="425"
-            column="5"/>
-        <location
-            file="src/main/res/values/strings.xml"
-            line="429"
-            column="5"
-            message="Duplicates value in `route_name`"/>
     </issue>
 
     <issue
@@ -3836,13 +3667,45 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-es/strings.xml"
-            line="427"
+            line="416"
             column="5"/>
         <location
             file="src/main/res/values-es/strings.xml"
-            line="443"
+            line="432"
             column="5"
             message="Duplicates value in `trip_info_option_showroute`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Route`, used in `connector_before_route` and `route_shortcut`"
+        errorLine1="    &lt;string name=&quot;route_shortcut&quot;>Route&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="418"
+            column="5"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1086"
+            column="5"
+            message="Duplicates value in `route_shortcut`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Route %s`, used in `route_name` and `trip_info_route`"
+        errorLine1="    &lt;string name=&quot;route_name&quot;>Route %s&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="424"
+            column="5"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="428"
+            column="5"
+            message="Duplicates value in `route_name`"/>
     </issue>
 
     <issue
@@ -3852,11 +3715,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="437"
+            line="436"
             column="5"/>
         <location
             file="src/main/res/values/strings.xml"
-            line="453"
+            line="452"
             column="5"
             message="Duplicates value in `trip_info_option_showroute` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
     </issue>
@@ -3868,11 +3731,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="438"
+            line="437"
             column="5"/>
         <location
             file="src/main/res/values/strings.xml"
-            line="452"
+            line="451"
             column="5"
             message="Duplicates value in `trip_info_option_showstop` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
     </issue>
@@ -3884,11 +3747,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-es/strings.xml"
-            line="457"
+            line="446"
             column="5"/>
         <location
             file="src/main/res/values-es/strings.xml"
-            line="1099"
+            line="1082"
             column="5"
             message="Duplicates value in `report_problem_send`"/>
     </issue>
@@ -3900,18 +3763,44 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="458"
+            line="447"
             column="5"/>
         <location
             file="src/main/res/values-it/strings.xml"
-            line="533"
+            line="520"
             column="5"
             message="Duplicates value in `preferences_category_about`"/>
         <location
             file="src/main/res/values-it/strings.xml"
-            line="704"
+            line="689"
             column="5"
             message="Duplicates value in `preferences_category_about`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Peruuta`, used in `cancel`, `destination_reminder_cancel`, `donation_dismiss_dialog_cancel_button` and `night_light_cancel`"
+        errorLine1="    &lt;string name=&quot;cancel&quot;>Peruuta&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="452"
+            column="5"/>
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="612"
+            column="5"
+            message="Duplicates value in `cancel`"/>
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="692"
+            column="5"
+            message="Duplicates value in `cancel`"/>
+        <location
+            file="src/main/res/values-fi/strings.xml"
+            line="935"
+            column="5"
+            message="Duplicates value in `cancel`"/>
     </issue>
 
     <issue
@@ -3921,11 +3810,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="470"
+            line="459"
             column="5"/>
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="820"
+            line="803"
             column="5"
             message="Duplicates value in `preferences_category_advanced`"/>
     </issue>
@@ -3937,11 +3826,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-pl/strings.xml"
-            line="519"
+            line="508"
             column="5"/>
         <location
             file="src/main/res/values-pl/strings.xml"
-            line="612"
+            line="599"
             column="5"
             message="Duplicates value in `preferences_category_about`"/>
     </issue>
@@ -3953,34 +3842,29 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="532"
+            line="519"
             column="5"/>
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="696"
+            line="679"
             column="5"
             message="Duplicates value in `preferences_about_title`"/>
     </issue>
 
     <issue
         id="DuplicateStrings"
-        message="Duplicate string value `About`, used in `preferences_about_title`, `preferences_category_about` and `title_activity_about`"
-        errorLine1="    &lt;string name=&quot;preferences_category_about&quot;>About&lt;/string>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Duplicate string value `Cancelar`, used in `cancel` and `donation_dismiss_dialog_cancel_button`"
+        errorLine1="    &lt;string name=&quot;cancel&quot;>Cancelar&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="src/main/res/values/strings.xml"
-            line="573"
+            file="src/main/res/values-es/strings.xml"
+            line="556"
             column="5"/>
         <location
-            file="src/main/res/values/strings.xml"
-            line="683"
+            file="src/main/res/values-es/strings.xml"
+            line="1063"
             column="5"
-            message="Duplicates value in `preferences_category_about`"/>
-        <location
-            file="src/main/res/values/strings.xml"
-            line="851"
-            column="5"
-            message="Duplicates value in `preferences_category_about`"/>
+            message="Duplicates value in `cancel`"/>
     </issue>
 
     <issue
@@ -3990,16 +3874,16 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-es/strings.xml"
-            line="577"
+            line="566"
             column="5"/>
         <location
             file="src/main/res/values-es/strings.xml"
-            line="660"
+            line="647"
             column="5"
             message="Duplicates value in `preferences_category_about`"/>
         <location
             file="src/main/res/values-es/strings.xml"
-            line="861"
+            line="844"
             column="5"
             message="Duplicates value in `preferences_category_about`"/>
     </issue>
@@ -4011,13 +3895,34 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="579"
+            line="566"
             column="5"/>
         <location
             file="src/main/res/values-it/strings.xml"
-            line="581"
+            line="568"
             column="5"
             message="Duplicates value in `rt_infrastructure_problem`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `About`, used in `preferences_about_title`, `preferences_category_about` and `title_activity_about`"
+        errorLine1="    &lt;string name=&quot;preferences_category_about&quot;>About&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="572"
+            column="5"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="684"
+            column="5"
+            message="Duplicates value in `preferences_category_about`"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="851"
+            column="5"
+            message="Duplicates value in `preferences_category_about`"/>
     </issue>
 
     <issue
@@ -4027,11 +3932,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="708"
+            line="693"
             column="5"/>
         <location
             file="src/main/res/values-it/strings.xml"
-            line="763"
+            line="748"
             column="5"
             message="Duplicates value in `trip_plan_to`"/>
     </issue>
@@ -4043,11 +3948,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-es/strings.xml"
-            line="716"
+            line="703"
             column="5"/>
         <location
             file="src/main/res/values-es/strings.xml"
-            line="718"
+            line="705"
             column="5"
             message="Duplicates value in `rt_infrastructure_problem`"/>
     </issue>
@@ -4059,11 +3964,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="720"
+            line="705"
             column="5"/>
         <location
             file="src/main/res/values-it/strings.xml"
-            line="721"
+            line="706"
             column="5"
             message="Duplicates value in `tripplanner_error_request_timeout`"/>
     </issue>
@@ -4075,11 +3980,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-es/strings.xml"
-            line="729"
+            line="716"
             column="5"/>
         <location
             file="src/main/res/values-es/strings.xml"
-            line="1137"
+            line="1120"
             column="5"
             message="Duplicates value in `rt_no` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
     </issue>
@@ -4091,11 +3996,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="734"
+            line="738"
             column="5"/>
         <location
             file="src/main/res/values/strings.xml"
-            line="736"
+            line="740"
             column="5"
             message="Duplicates value in `rt_infrastructure_problem`"/>
     </issue>
@@ -4107,16 +4012,16 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="766"
+            line="751"
             column="5"/>
         <location
             file="src/main/res/values-it/strings.xml"
-            line="789"
+            line="774"
             column="5"
             message="Duplicates value in `step_by_step_transit_connector_headsign`"/>
         <location
             file="src/main/res/values-it/strings.xml"
-            line="797"
+            line="782"
             column="5"
             message="Duplicates value in `step_by_step_transit_connector_headsign`"/>
     </issue>
@@ -4128,11 +4033,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-es/strings.xml"
-            line="785"
+            line="772"
             column="5"/>
         <location
             file="src/main/res/values-es/strings.xml"
-            line="822"
+            line="805"
             column="5"
             message="Duplicates value in `tutorial_welcome_title`"/>
     </issue>
@@ -4144,11 +4049,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="796"
+            line="781"
             column="5"/>
         <location
             file="src/main/res/values-it/strings.xml"
-            line="874"
+            line="859"
             column="5"
             message="Duplicates value in `step_by_step_non_transit_connector_street_name`"/>
     </issue>
@@ -4160,29 +4065,13 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="800"
+            line="785"
             column="5"/>
         <location
             file="src/main/res/values-it/strings.xml"
-            line="801"
+            line="786"
             column="5"
             message="Duplicates value in `step_by_step_non_transit_dir_relative_circle_clockwise`"/>
-    </issue>
-
-    <issue
-        id="DuplicateStrings"
-        message="Duplicate string value `Welcome to %1$s!`, used in `about_welcome_title` and `tutorial_welcome_title`"
-        errorLine1="    &lt;string name=&quot;tutorial_welcome_title&quot;>Welcome to %1$s!&lt;/string>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="807"
-            column="5"/>
-        <location
-            file="src/main/res/values/strings.xml"
-            line="854"
-            column="5"
-            message="Duplicates value in `tutorial_welcome_title`"/>
     </issue>
 
     <issue
@@ -4192,16 +4081,16 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="812"
+            line="795"
             column="5"/>
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="951"
+            line="934"
             column="5"
             message="Duplicates value in `rt_yes` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="959"
+            line="942"
             column="5"
             message="Duplicates value in `rt_yes`"/>
     </issue>
@@ -4213,11 +4102,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="813"
+            line="796"
             column="5"/>
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="960"
+            line="943"
             column="5"
             message="Duplicates value in `rt_no` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
     </issue>
@@ -4229,13 +4118,29 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-pl/strings.xml"
-            line="824"
+            line="808"
             column="5"/>
         <location
             file="src/main/res/values-pl/strings.xml"
-            line="1026"
+            line="1010"
             column="5"
             message="Duplicates value in `donation_dismiss_dialog_remind_me_later_button`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Welcome to %1$s!`, used in `about_welcome_title` and `tutorial_welcome_title`"
+        errorLine1="    &lt;string name=&quot;tutorial_welcome_title&quot;>Welcome to %1$s!&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="811"
+            column="5"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="854"
+            column="5"
+            message="Duplicates value in `tutorial_welcome_title`"/>
     </issue>
 
     <issue
@@ -4245,11 +4150,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="832"
+            line="815"
             column="5"/>
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="833"
+            line="816"
             column="5"
             message="Duplicates value in `tripplanner_error_request_timeout`"/>
     </issue>
@@ -4261,11 +4166,11 @@
         errorLine2="    ^">
         <location
             file="src/main/res/values-pl/strings.xml"
-            line="873"
+            line="857"
             column="5"/>
         <location
             file="src/main/res/values-pl/strings.xml"
-            line="875"
+            line="859"
             column="5"
             message="Duplicates value in `tripplanner_error_request_timeout`"/>
     </issue>
@@ -4277,11 +4182,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="891"
+            line="874"
             column="5"/>
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="892"
+            line="875"
             column="5"
             message="Duplicates value in `step_by_step_non_transit_dir_relative_circle_clockwise`"/>
     </issue>
@@ -4293,11 +4198,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="899"
+            line="884"
             column="5"/>
         <location
             file="src/main/res/values-it/strings.xml"
-            line="906"
+            line="891"
             column="5"
             message="Duplicates value in `transit_directions_bikeshare_label`"/>
     </issue>
@@ -4309,11 +4214,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-pl/strings.xml"
-            line="904"
+            line="888"
             column="5"/>
         <location
             file="src/main/res/values-pl/strings.xml"
-            line="925"
+            line="909"
             column="5"
             message="Duplicates value in `step_by_step_transit_connector_stop_name` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
     </issue>
@@ -4325,16 +4230,16 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-pl/strings.xml"
-            line="905"
+            line="889"
             column="5"/>
         <location
             file="src/main/res/values-pl/strings.xml"
-            line="922"
+            line="906"
             column="5"
             message="Duplicates value in `step_by_step_transit_connector_headsign`"/>
         <location
             file="src/main/res/values-pl/strings.xml"
-            line="926"
+            line="910"
             column="5"
             message="Duplicates value in `step_by_step_transit_connector_headsign`"/>
     </issue>
@@ -4346,29 +4251,13 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-es/strings.xml"
-            line="922"
+            line="905"
             column="5"/>
         <location
             file="src/main/res/values-es/strings.xml"
-            line="947"
+            line="930"
             column="5"
             message="Duplicates value in `step_by_step_transit_connector_stop_name` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
-    </issue>
-
-    <issue
-        id="DuplicateStrings"
-        message="Duplicate string value `Ricordamelo più tardi`, used in `donation_dismiss_dialog_remind_me_later_button` and `remind_me_latter`. Use `android:inputType` or `android:capitalize` to treat these as the same and avoid string duplication."
-        errorLine1="    &lt;string name=&quot;donation_dismiss_dialog_remind_me_later_button&quot;>Ricordamelo Più Tardi&lt;/string>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values-it/strings.xml"
-            line="924"
-            column="5"/>
-        <location
-            file="src/main/res/values-it/strings.xml"
-            line="949"
-            column="5"
-            message="Duplicates value in `donation_dismiss_dialog_remind_me_later_button` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
     </issue>
 
     <issue
@@ -4378,13 +4267,29 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-es/strings.xml"
-            line="925"
+            line="908"
             column="5"/>
         <location
             file="src/main/res/values-es/strings.xml"
-            line="948"
+            line="931"
             column="5"
             message="Duplicates value in `step_by_step_transit_connector_headsign`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Ricordamelo più tardi`, used in `donation_dismiss_dialog_remind_me_later_button` and `remind_me_latter`. Use `android:inputType` or `android:capitalize` to treat these as the same and avoid string duplication."
+        errorLine1="    &lt;string name=&quot;donation_dismiss_dialog_remind_me_later_button&quot;>Ricordamelo Più Tardi&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="909"
+            column="5"/>
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="934"
+            column="5"
+            message="Duplicates value in `donation_dismiss_dialog_remind_me_later_button` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
     </issue>
 
     <issue
@@ -4394,11 +4299,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="928"
+            line="911"
             column="5"/>
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="941"
+            line="924"
             column="5"
             message="Duplicates value in `street_type_path`"/>
     </issue>
@@ -4410,11 +4315,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-pl/strings.xml"
-            line="929"
+            line="913"
             column="5"/>
         <location
             file="src/main/res/values-pl/strings.xml"
-            line="930"
+            line="914"
             column="5"
             message="Duplicates value in `step_by_step_non_transit_dir_relative_circle_clockwise`"/>
     </issue>
@@ -4426,13 +4331,29 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-es/strings.xml"
-            line="959"
+            line="942"
             column="5"/>
         <location
             file="src/main/res/values-es/strings.xml"
-            line="960"
+            line="943"
             column="5"
             message="Duplicates value in `step_by_step_non_transit_dir_relative_circle_clockwise`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `chodnik`, used in `street_type_footpath` and `street_type_sidewalk`"
+        errorLine1="    &lt;string name=&quot;street_type_footpath&quot;>chodnik&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="956"
+            column="5"/>
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="968"
+            column="5"
+            message="Duplicates value in `street_type_footpath`"/>
     </issue>
 
     <issue
@@ -4442,11 +4363,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="966"
+            line="972"
             column="5"/>
         <location
             file="src/main/res/values/strings.xml"
-            line="1076"
+            line="1082"
             column="5"
             message="Duplicates value in `step_by_step_transit_connector_stop_name` (case varies, but you can use `android:inputType` or `android:capitalize` in the presentation)"/>
     </issue>
@@ -4458,34 +4379,34 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="969"
+            line="975"
             column="5"/>
         <location
             file="src/main/res/values/strings.xml"
-            line="992"
+            line="998"
             column="5"
             message="Duplicates value in `step_by_step_transit_connector_headsign`"/>
         <location
             file="src/main/res/values/strings.xml"
-            line="1000"
+            line="1006"
             column="5"
             message="Duplicates value in `step_by_step_transit_connector_headsign`"/>
     </issue>
 
     <issue
         id="DuplicateStrings"
-        message="Duplicate string value `chodnik`, used in `street_type_footpath` and `street_type_sidewalk`"
-        errorLine1="    &lt;string name=&quot;street_type_footpath&quot;>chodnik&lt;/string>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Duplicate string value `Rower miejski`, used in `layers_speedial_bikeshare_label` and `transit_directions_bikeshare_label`"
+        errorLine1="    &lt;string name=&quot;transit_directions_bikeshare_label&quot;>Rower miejski&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-pl/strings.xml"
-            line="972"
+            line="999"
             column="5"/>
         <location
             file="src/main/res/values-pl/strings.xml"
-            line="984"
+            line="1004"
             column="5"
-            message="Duplicates value in `street_type_footpath`"/>
+            message="Duplicates value in `transit_directions_bikeshare_label`"/>
     </issue>
 
     <issue
@@ -4495,11 +4416,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="999"
+            line="1005"
             column="5"/>
         <location
             file="src/main/res/values/strings.xml"
-            line="1077"
+            line="1083"
             column="5"
             message="Duplicates value in `step_by_step_non_transit_connector_street_name`"/>
     </issue>
@@ -4511,29 +4432,13 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="1003"
+            line="1009"
             column="5"/>
         <location
             file="src/main/res/values/strings.xml"
-            line="1004"
+            line="1010"
             column="5"
             message="Duplicates value in `step_by_step_non_transit_dir_relative_circle_clockwise`"/>
-    </issue>
-
-    <issue
-        id="DuplicateStrings"
-        message="Duplicate string value `Rower miejski`, used in `layers_speedial_bikeshare_label` and `transit_directions_bikeshare_label`"
-        errorLine1="    &lt;string name=&quot;transit_directions_bikeshare_label&quot;>Rower miejski&lt;/string>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values-pl/strings.xml"
-            line="1015"
-            column="5"/>
-        <location
-            file="src/main/res/values-pl/strings.xml"
-            line="1020"
-            column="5"
-            message="Duplicates value in `transit_directions_bikeshare_label`"/>
     </issue>
 
     <issue
@@ -4543,27 +4448,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-es/strings.xml"
-            line="1058"
+            line="1041"
             column="5"/>
         <location
             file="src/main/res/values-es/strings.xml"
-            line="1065"
-            column="5"
-            message="Duplicates value in `transit_directions_bikeshare_label`"/>
-    </issue>
-
-    <issue
-        id="DuplicateStrings"
-        message="Duplicate string value `Bikeshare`, used in `layers_speedial_bikeshare_label` and `transit_directions_bikeshare_label`"
-        errorLine1="    &lt;string name=&quot;transit_directions_bikeshare_label&quot;>Bikeshare&lt;/string>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="1102"
-            column="5"/>
-        <location
-            file="src/main/res/values/strings.xml"
-            line="1109"
+            line="1048"
             column="5"
             message="Duplicates value in `transit_directions_bikeshare_label`"/>
     </issue>
@@ -4575,13 +4464,29 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-es/strings.xml"
-            line="1122"
+            line="1105"
             column="5"/>
         <location
             file="src/main/res/values-es/strings.xml"
-            line="1124"
+            line="1107"
             column="5"
             message="Duplicates value in `destination_reminder_beta_title`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `Bikeshare`, used in `layers_speedial_bikeshare_label` and `transit_directions_bikeshare_label`"
+        errorLine1="    &lt;string name=&quot;transit_directions_bikeshare_label&quot;>Bikeshare&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1110"
+            column="5"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1117"
+            column="5"
+            message="Duplicates value in `transit_directions_bikeshare_label`"/>
     </issue>
 
     <issue
@@ -4591,11 +4496,11 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="1130"
+            line="1138"
             column="5"/>
         <location
             file="src/main/res/values/strings.xml"
-            line="1157"
+            line="1165"
             column="5"
             message="Duplicates value in `donation_dismiss_dialog_remind_me_later_button`"/>
     </issue>
@@ -4629,7 +4534,7 @@
         errorLine2="                ~">
         <location
             file="src/main/res/values-it/arrays.xml"
-            line="76"
+            line="60"
             column="17"/>
     </issue>
 
@@ -4640,7 +4545,7 @@
         errorLine2="                ~">
         <location
             file="src/main/res/values-it/arrays.xml"
-            line="80"
+            line="64"
             column="17"/>
     </issue>
 
@@ -4651,7 +4556,7 @@
         errorLine2="                            ~">
         <location
             file="src/main/res/values/arrays.xml"
-            line="81"
+            line="65"
             column="29"/>
     </issue>
 
@@ -4662,7 +4567,7 @@
         errorLine2="                                                   ^">
         <location
             file="src/main/res/values-pl/strings.xml"
-            line="25"
+            line="24"
             column="52"/>
     </issue>
 
@@ -4673,7 +4578,7 @@
         errorLine2="                                                          ^">
         <location
             file="src/main/res/values-pl/strings.xml"
-            line="30"
+            line="29"
             column="59"/>
     </issue>
 
@@ -4684,7 +4589,7 @@
         errorLine2="                                                  ^">
         <location
             file="src/main/res/values-pl/strings.xml"
-            line="33"
+            line="32"
             column="51"/>
     </issue>
 
@@ -4695,7 +4600,7 @@
         errorLine2="                                                              ~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="36"
+            line="35"
             column="63"/>
     </issue>
 
@@ -4706,7 +4611,7 @@
         errorLine2="                                                         ^">
         <location
             file="src/main/res/values-pl/strings.xml"
-            line="37"
+            line="36"
             column="58"/>
     </issue>
 
@@ -4717,7 +4622,7 @@
         errorLine2="                                                                                        ~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="39"
+            line="38"
             column="89"/>
     </issue>
 
@@ -4728,7 +4633,7 @@
         errorLine2="                                                                                                                                                                                                               ~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="40"
+            line="39"
             column="208"/>
     </issue>
 
@@ -4739,7 +4644,7 @@
         errorLine2="                                                                                                                                                                                     ~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="41"
+            line="40"
             column="182"/>
     </issue>
 
@@ -4750,7 +4655,7 @@
         errorLine2="                                                                                                                                                                                                                ~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="42"
+            line="41"
             column="209"/>
     </issue>
 
@@ -4761,7 +4666,7 @@
         errorLine2="                                                                                        ~">
         <location
             file="src/main/res/values/strings.xml"
-            line="42"
+            line="41"
             column="89"/>
     </issue>
 
@@ -4772,7 +4677,7 @@
         errorLine2="                                                                                                                                                                                      ~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="43"
+            line="42"
             column="183"/>
     </issue>
 
@@ -4783,7 +4688,7 @@
         errorLine2="                                                   ^">
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="44"
+            line="43"
             column="52"/>
     </issue>
 
@@ -4794,7 +4699,7 @@
         errorLine2="                                                   ^">
         <location
             file="src/main/res/values/strings.xml"
-            line="45"
+            line="44"
             column="52"/>
     </issue>
 
@@ -4805,7 +4710,7 @@
         errorLine2="                                                   ^">
         <location
             file="src/main/res/values-es/strings.xml"
-            line="46"
+            line="45"
             column="52"/>
     </issue>
 
@@ -4816,7 +4721,7 @@
         errorLine2="                                                          ^">
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="50"
+            line="49"
             column="59"/>
     </issue>
 
@@ -4827,7 +4732,7 @@
         errorLine2="                                                          ^">
         <location
             file="src/main/res/values/strings.xml"
-            line="51"
+            line="50"
             column="59"/>
     </issue>
 
@@ -4838,7 +4743,7 @@
         errorLine2="                                                          ^">
         <location
             file="src/main/res/values-es/strings.xml"
-            line="52"
+            line="51"
             column="59"/>
     </issue>
 
@@ -4849,7 +4754,7 @@
         errorLine2="                                                  ^">
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="56"
+            line="55"
             column="51"/>
     </issue>
 
@@ -4860,7 +4765,7 @@
         errorLine2="                                                  ^">
         <location
             file="src/main/res/values/strings.xml"
-            line="57"
+            line="56"
             column="51"/>
     </issue>
 
@@ -4871,7 +4776,7 @@
         errorLine2="                                                  ^">
         <location
             file="src/main/res/values-es/strings.xml"
-            line="58"
+            line="57"
             column="51"/>
     </issue>
 
@@ -4882,7 +4787,7 @@
         errorLine2="                                                         ^">
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="62"
+            line="61"
             column="58"/>
     </issue>
 
@@ -4893,7 +4798,7 @@
         errorLine2="                                                         ^">
         <location
             file="src/main/res/values/strings.xml"
-            line="63"
+            line="62"
             column="58"/>
     </issue>
 
@@ -4904,7 +4809,7 @@
         errorLine2="                                                         ^">
         <location
             file="src/main/res/values-es/strings.xml"
-            line="64"
+            line="63"
             column="58"/>
     </issue>
 
@@ -4915,7 +4820,7 @@
         errorLine2="                                                        ~">
         <location
             file="src/main/res/values/strings.xml"
-            line="70"
+            line="69"
             column="57"/>
     </issue>
 
@@ -4926,7 +4831,7 @@
         errorLine2="                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="73"
+            line="72"
             column="44"/>
     </issue>
 
@@ -4937,7 +4842,7 @@
         errorLine2="                                          ~">
         <location
             file="src/main/res/values/strings.xml"
-            line="74"
+            line="73"
             column="43"/>
     </issue>
 
@@ -4948,7 +4853,7 @@
         errorLine2="                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="74"
+            line="73"
             column="42"/>
     </issue>
 
@@ -4959,7 +4864,7 @@
         errorLine2="                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="75"
+            line="74"
             column="43"/>
     </issue>
 
@@ -4970,7 +4875,7 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-pl/strings.xml"
-            line="75"
+            line="74"
             column="9"/>
     </issue>
 
@@ -4981,7 +4886,7 @@
         errorLine2="                                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="76"
+            line="75"
             column="47"/>
     </issue>
 
@@ -4992,7 +4897,7 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-pl/strings.xml"
-            line="77"
+            line="76"
             column="9"/>
     </issue>
 
@@ -5003,7 +4908,7 @@
         errorLine2="                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="84"
+            line="83"
             column="43"/>
     </issue>
 
@@ -5014,19 +4919,8 @@
         errorLine2="                                                                                      ~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="98"
+            line="94"
             column="87"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
-        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
-        errorLine1="    &lt;string name=&quot;main_help_whatsnew_title&quot;>What\&apos;s New?&lt;/string>"
-        errorLine2="                                                 ~">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="102"
-            column="50"/>
     </issue>
 
     <issue
@@ -5036,8 +4930,19 @@
         errorLine2="                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="103"
+            line="102"
             column="44"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;main_help_whatsnew_title&quot;>What\&apos;s New?&lt;/string>"
+        errorLine2="                                                 ~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="103"
+            column="50"/>
     </issue>
 
     <issue
@@ -5047,7 +4952,7 @@
         errorLine2="                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="104"
+            line="103"
             column="42"/>
     </issue>
 
@@ -5058,7 +4963,7 @@
         errorLine2="                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="105"
+            line="104"
             column="43"/>
     </issue>
 
@@ -5069,19 +4974,8 @@
         errorLine2="                                              ^">
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="106"
+            line="105"
             column="47"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
-        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
-        errorLine1="    &lt;string name=&quot;main_help_legend_ontime&quot;>Green means \&quot;On time\&quot;&lt;/string>"
-        errorLine2="                                           ~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="106"
-            column="44"/>
     </issue>
 
     <issue
@@ -5091,19 +4985,8 @@
         errorLine2="                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-es/strings.xml"
-            line="107"
+            line="106"
             column="44"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
-        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
-        errorLine1="    &lt;string name=&quot;main_help_legend_late&quot;>Blue means \&quot;Running late\&quot;&lt;/string>"
-        errorLine2="                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="107"
-            column="42"/>
     </issue>
 
     <issue
@@ -5113,8 +4996,52 @@
         errorLine2="                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-es/strings.xml"
+            line="107"
+            column="42"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
+        errorLine1="    &lt;string name=&quot;main_help_legend_ontime&quot;>Green means \&quot;On time\&quot;&lt;/string>"
+        errorLine2="                                           ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="107"
+            column="44"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
+        errorLine1="    &lt;string name=&quot;main_help_legend_early&quot;>Rojo significa \&quot;Llegando antes\&quot;&lt;/string>"
+        errorLine2="                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="108"
+            column="43"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
+        errorLine1="    &lt;string name=&quot;main_help_legend_late&quot;>Blue means \&quot;Running late\&quot;&lt;/string>"
+        errorLine2="                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
             line="108"
             column="42"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
+        errorLine1="    &lt;string name=&quot;main_help_legend_scheduled&quot;>Gris significa \&quot;Llegada planificada\&quot; - No sabemos"
+        errorLine2="                                              ^">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="109"
+            column="47"/>
     </issue>
 
     <issue
@@ -5124,7 +5051,7 @@
         errorLine2="                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="108"
+            line="109"
             column="43"/>
     </issue>
 
@@ -5135,30 +5062,8 @@
         errorLine2="                                                                                        ~">
         <location
             file="src/main/res/values/strings.xml"
-            line="109"
-            column="89"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
-        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
-        errorLine1="    &lt;string name=&quot;main_help_legend_early&quot;>Rojo significa \&quot;Llegando antes\&quot;&lt;/string>"
-        errorLine2="                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values-es/strings.xml"
-            line="109"
-            column="43"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
-        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
-        errorLine1="    &lt;string name=&quot;main_help_legend_scheduled&quot;>Gris significa \&quot;Llegada planificada\&quot; - No sabemos"
-        errorLine2="                                              ^">
-        <location
-            file="src/main/res/values-es/strings.xml"
             line="110"
-            column="47"/>
+            column="89"/>
     </issue>
 
     <issue
@@ -5168,7 +5073,7 @@
         errorLine2="                                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-es/strings.xml"
-            line="113"
+            line="112"
             column="46"/>
     </issue>
 
@@ -5179,7 +5084,7 @@
         errorLine2="                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="120"
+            line="119"
             column="44"/>
     </issue>
 
@@ -5190,7 +5095,7 @@
         errorLine2="                                       ~">
         <location
             file="src/main/res/values/strings.xml"
-            line="124"
+            line="125"
             column="40"/>
     </issue>
 
@@ -5201,7 +5106,7 @@
         errorLine2="                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="262"
+            line="253"
             column="39"/>
     </issue>
 
@@ -5212,7 +5117,7 @@
         errorLine2="                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="271"
+            line="262"
             column="44"/>
     </issue>
 
@@ -5223,7 +5128,7 @@
         errorLine2="                                                                             ~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="279"
+            line="270"
             column="78"/>
     </issue>
 
@@ -5234,7 +5139,7 @@
         errorLine2="                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-pl/strings.xml"
-            line="281"
+            line="272"
             column="39"/>
     </issue>
 
@@ -5245,30 +5150,8 @@
         errorLine2="                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-pl/strings.xml"
-            line="290"
+            line="281"
             column="44"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
-        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
-        errorLine1="    &lt;string name=&quot;route_favorite_options_title_star&quot;>Aggiungi linea \&amp;quot;%s\&amp;quot; ai preferiti per:&lt;/string>"
-        errorLine2="                                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values-it/strings.xml"
-            line="294"
-            column="54"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
-        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
-        errorLine1="    &lt;string name=&quot;route_favorite_options_title_unstar&quot;>Rimuovi \&amp;quot;%s\&amp;quot; dai preferiti per:&lt;/string>"
-        errorLine2="                                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values-it/strings.xml"
-            line="295"
-            column="56"/>
     </issue>
 
     <issue
@@ -5278,41 +5161,8 @@
         errorLine2="                                                                     ~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="302"
+            line="291"
             column="70"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
-        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
-        errorLine1="    &lt;string name=&quot;route_favorite_options_title_star&quot;>Lisää suosikki \&quot;%s\&quot;:&lt;/string>"
-        errorLine2="                                                     ~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values-fi/strings.xml"
-            line="302"
-            column="54"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
-        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
-        errorLine1="    &lt;string name=&quot;route_favorite_options_title_unstar&quot;>Poista suosikki \&quot;%s\&quot;:&lt;/string>"
-        errorLine2="                                                       ~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values-fi/strings.xml"
-            line="303"
-            column="56"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
-        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
-        errorLine1="    &lt;string name=&quot;feedback_log_guide&quot;>Your feedback will be sent to %1$s. If you check \&quot;Include system logs\&quot;, real-time location information from your device recorded as you approached your destination stop will be shared with %1$s so developers can improve the destination reminder feature.\n\nChange your preference for sharing system logs in Settings.&lt;/string>"
-        errorLine2="                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="314"
-            column="39"/>
     </issue>
 
     <issue
@@ -5322,30 +5172,19 @@
         errorLine2="                                                ~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="315"
+            line="304"
             column="49"/>
     </issue>
 
     <issue
         id="TypographyQuotes"
         message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
-        errorLine1="    &lt;string name=&quot;route_favorite_options_title_star&quot;>Dodaj do ulubionych \&quot;%s\&quot; do:&lt;/string>"
-        errorLine2="                                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        errorLine1="    &lt;string name=&quot;feedback_log_guide&quot;>Your feedback will be sent to %1$s. If you check \&quot;Include system logs\&quot;, real-time location information from your device recorded as you approached your destination stop will be shared with %1$s so developers can improve the destination reminder feature.\n\nChange your preference for sharing system logs in Settings.&lt;/string>"
+        errorLine2="                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="src/main/res/values-pl/strings.xml"
-            line="317"
-            column="54"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
-        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
-        errorLine1="    &lt;string name=&quot;route_favorite_options_title_unstar&quot;>Usuń ulubione od \&quot;%s\&quot; do:&lt;/string>"
-        errorLine2="                                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values-pl/strings.xml"
-            line="318"
-            column="56"/>
+            file="src/main/res/values/strings.xml"
+            line="310"
+            column="39"/>
     </issue>
 
     <issue
@@ -5355,7 +5194,7 @@
         errorLine2="                                           ^">
         <location
             file="src/main/res/values/strings.xml"
-            line="324"
+            line="320"
             column="44"/>
     </issue>
 
@@ -5366,52 +5205,8 @@
         errorLine2="                                                                       ~">
         <location
             file="src/main/res/values/strings.xml"
-            line="337"
+            line="333"
             column="72"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
-        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
-        errorLine1="    &lt;string name=&quot;route_favorite_options_title_star&quot;>Marcar como favorito a \&quot;%s\&quot; para:&lt;/string>"
-        errorLine2="                                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values-es/strings.xml"
-            line="352"
-            column="54"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
-        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
-        errorLine1="    &lt;string name=&quot;route_favorite_options_title_unstar&quot;>Remover de favoritos a \&quot;%s\&quot; para:&lt;/string>"
-        errorLine2="                                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values-es/strings.xml"
-            line="353"
-            column="56"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
-        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
-        errorLine1="    &lt;string name=&quot;route_favorite_options_title_star&quot;>Star Route \&quot;%s\&quot; for:&lt;/string>"
-        errorLine2="                                                     ~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="363"
-            column="54"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
-        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
-        errorLine1="    &lt;string name=&quot;route_favorite_options_title_unstar&quot;>Remove star from \&quot;%s\&quot; for:&lt;/string>"
-        errorLine2="                                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="364"
-            column="56"/>
     </issue>
 
     <issue
@@ -5421,7 +5216,7 @@
         errorLine2="                                                 ~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="427"
+            line="416"
             column="50"/>
     </issue>
 
@@ -5432,7 +5227,7 @@
         errorLine2="                                                                            ~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="428"
+            line="417"
             column="77"/>
     </issue>
 
@@ -5443,7 +5238,7 @@
         errorLine2="                                                                                                                                                                                                                                                                                                                                                            ~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="440"
+            line="429"
             column="349"/>
     </issue>
 
@@ -5454,7 +5249,7 @@
         errorLine2="                                                                                                                                                                                                                                                                                                                                           ~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="441"
+            line="430"
             column="332"/>
     </issue>
 
@@ -5465,7 +5260,7 @@
         errorLine2="                                                                                                                                                                                                                                                   ~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="442"
+            line="431"
             column="244"/>
     </issue>
 
@@ -5476,19 +5271,8 @@
         errorLine2="                                                                                                                                                                                                                                                                    ~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="443"
+            line="432"
             column="261"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
-        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
-        errorLine1="    &lt;string name=&quot;trip_list_notrips&quot;>You don\&apos;t have any reminders.\n\nYou can create reminders by"
-        errorLine2="                                             ~">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="447"
-            column="46"/>
     </issue>
 
     <issue
@@ -5498,8 +5282,19 @@
         errorLine2="                                   ~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="448"
+            line="437"
             column="36"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;trip_list_notrips&quot;>You don\&apos;t have any reminders.\n\nYou can create reminders by"
+        errorLine2="                                             ~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="446"
+            column="46"/>
     </issue>
 
     <issue
@@ -5509,7 +5304,7 @@
         errorLine2="                                                                                                                                 ~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="484"
+            line="473"
             column="130"/>
     </issue>
 
@@ -5520,7 +5315,7 @@
         errorLine2="                                                                                           ~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="490"
+            line="479"
             column="92"/>
     </issue>
 
@@ -5531,7 +5326,7 @@
         errorLine2="                                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="506"
+            line="493"
             column="48"/>
     </issue>
 
@@ -5542,7 +5337,7 @@
         errorLine2="                                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="507"
+            line="494"
             column="48"/>
     </issue>
 
@@ -5553,7 +5348,7 @@
         errorLine2="                                                                      ~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="517"
+            line="504"
             column="71"/>
     </issue>
 
@@ -5564,7 +5359,7 @@
         errorLine2="                                                                        ~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="519"
+            line="506"
             column="73"/>
     </issue>
 
@@ -5575,7 +5370,7 @@
         errorLine2="                                                   ~">
         <location
             file="src/main/res/values/strings.xml"
-            line="520"
+            line="519"
             column="52"/>
     </issue>
 
@@ -5586,7 +5381,7 @@
         errorLine2="                                                       ~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="553"
+            line="540"
             column="56"/>
     </issue>
 
@@ -5597,7 +5392,7 @@
         errorLine2="                                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="554"
+            line="541"
             column="53"/>
     </issue>
 
@@ -5608,19 +5403,8 @@
         errorLine2="                                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="560"
+            line="547"
             column="53"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
-        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
-        errorLine1="    &lt;string name=&quot;no_play_store&quot;>Your device doesn\&apos;t have the Play Store installed. Please find"
-        errorLine2="                                                   ~">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="561"
-            column="52"/>
     </issue>
 
     <issue
@@ -5630,7 +5414,7 @@
         errorLine2="                                                                           ~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="563"
+            line="550"
             column="76"/>
     </issue>
 
@@ -5641,8 +5425,19 @@
         errorLine2="                                                         ~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="568"
+            line="555"
             column="58"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;no_play_store&quot;>Your device doesn\&apos;t have the Play Store installed. Please find"
+        errorLine2="                                                   ~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="560"
+            column="52"/>
     </issue>
 
     <issue
@@ -5652,7 +5447,7 @@
         errorLine2="                                                                              ~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="575"
+            line="562"
             column="79"/>
     </issue>
 
@@ -5663,7 +5458,7 @@
         errorLine2="                                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-pl/strings.xml"
-            line="580"
+            line="567"
             column="48"/>
     </issue>
 
@@ -5674,7 +5469,7 @@
         errorLine2="                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="582"
+            line="569"
             column="39"/>
     </issue>
 
@@ -5685,7 +5480,7 @@
         errorLine2="                                                       ~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="584"
+            line="571"
             column="56"/>
     </issue>
 
@@ -5696,7 +5491,7 @@
         errorLine2="                                                                        ~">
         <location
             file="src/main/res/values/strings.xml"
-            line="608"
+            line="607"
             column="73"/>
     </issue>
 
@@ -5707,7 +5502,7 @@
         errorLine2="                                                       ~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="621"
+            line="608"
             column="56"/>
     </issue>
 
@@ -5718,7 +5513,7 @@
         errorLine2="                                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-pl/strings.xml"
-            line="633"
+            line="620"
             column="53"/>
     </issue>
 
@@ -5729,7 +5524,7 @@
         errorLine2="                                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-es/strings.xml"
-            line="634"
+            line="621"
             column="48"/>
     </issue>
 
@@ -5740,7 +5535,7 @@
         errorLine2="                                                                                  ~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="635"
+            line="622"
             column="83"/>
     </issue>
 
@@ -5751,7 +5546,7 @@
         errorLine2="                                                                   ~">
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="638"
+            line="625"
             column="68"/>
     </issue>
 
@@ -5762,7 +5557,7 @@
         errorLine2="                                                              ~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="638"
+            line="625"
             column="63"/>
     </issue>
 
@@ -5773,19 +5568,8 @@
         errorLine2="                                                                                                                  ~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="639"
+            line="626"
             column="115"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
-        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
-        errorLine1="    &lt;string name=&quot;preferences_restore_summary&quot;>Restores from a previous backup. After selecting this option, you\&apos;ll be asked to pick a file. Please select the backup file (e.g., &quot;db.backup&quot; or &quot;%1$s.backup&quot;), which may be in your &quot;Documents&quot; folder or any location where you saved the backup.&lt;/string>"
-        errorLine2="                                                                                                                 ~">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="642"
-            column="114"/>
     </issue>
 
     <issue
@@ -5795,19 +5579,8 @@
         errorLine2="                                                                                                      ~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="648"
+            line="635"
             column="103"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
-        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
-        errorLine1="    &lt;string name=&quot;tutorial_recent_stops_routes_text&quot;>Ruudun oikeasta laidasta löytyvän \&quot;Lisää\&quot; napin "
-        errorLine2="                                                     ^">
-        <location
-            file="src/main/res/values-fi/strings.xml"
-            line="648"
-            column="54"/>
     </issue>
 
     <issue
@@ -5817,7 +5590,7 @@
         errorLine2="                                                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="649"
+            line="636"
             column="63"/>
     </issue>
 
@@ -5828,19 +5601,19 @@
         errorLine2="                                                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="650"
+            line="637"
             column="62"/>
     </issue>
 
     <issue
         id="TypographyQuotes"
-        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
-        errorLine1="    &lt;string name=&quot;tutorial_recent_stops_routes_text&quot;>Per ritrovare le fermate e le linee cercate di recente, tocca il pulsante \&amp;quot;Altro\&amp;quot; in alto a destra.&lt;/string>"
-        errorLine2="                                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;preferences_restore_summary&quot;>Restores from a previous backup. After selecting this option, you\&apos;ll be asked to pick a file. Please select the backup file (e.g., &quot;db.backup&quot; or &quot;%1$s.backup&quot;), which may be in your &quot;Documents&quot; folder or any location where you saved the backup.&lt;/string>"
+        errorLine2="                                                                                                                 ~">
         <location
-            file="src/main/res/values-it/strings.xml"
-            line="656"
-            column="54"/>
+            file="src/main/res/values/strings.xml"
+            line="643"
+            column="114"/>
     </issue>
 
     <issue
@@ -5850,19 +5623,8 @@
         errorLine2="                                                                                            ~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="660"
+            line="645"
             column="93"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
-        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
-        errorLine1="        won\&apos;t be available! Go ahead?"
-        errorLine2="            ~">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="664"
-            column="13"/>
     </issue>
 
     <issue
@@ -5872,8 +5634,19 @@
         errorLine2="                                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="669"
+            line="654"
             column="45"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="        won\&apos;t be available! Go ahead?"
+        errorLine2="            ~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="665"
+            column="13"/>
     </issue>
 
     <issue
@@ -5883,8 +5656,19 @@
         errorLine2="                                                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="714"
+            line="697"
             column="66"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;tripplanner_no_contact&quot;>Non c\&apos;è un contatto per la pianificazione del viaggio in ques\&apos;area.&lt;/string>"
+        errorLine2="                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="723"
+            column="43"/>
     </issue>
 
     <issue
@@ -5894,7 +5678,7 @@
         errorLine2="                                                        ~">
         <location
             file="src/main/res/values/strings.xml"
-            line="719"
+            line="723"
             column="57"/>
     </issue>
 
@@ -5905,41 +5689,8 @@
         errorLine2="                                                        ~">
         <location
             file="src/main/res/values/strings.xml"
-            line="720"
+            line="724"
             column="57"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
-        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
-        errorLine1="    &lt;string name=&quot;tripplanner_no_contact&quot;>Non c\&apos;è un contatto per la pianificazione del viaggio in ques\&apos;area.&lt;/string>"
-        errorLine2="                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values-it/strings.xml"
-            line="738"
-            column="43"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
-        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
-        errorLine1="    &lt;string name=&quot;tutorial_recent_stops_routes_text&quot;>Znajdź przystanki i trasy które ostatnio"
-        errorLine2="                                                     ^">
-        <location
-            file="src/main/res/values-pl/strings.xml"
-            line="760"
-            column="54"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
-        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
-        errorLine1="        couldn\&apos;t see you in the dark? Hold up your flashing Night Light and make yourself visible!"
-        errorLine2="               ~">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="798"
-            column="16"/>
     </issue>
 
     <issue
@@ -5949,19 +5700,8 @@
         errorLine2="                                                                           ~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="804"
+            line="789"
             column="76"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
-        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
-        errorLine1="    &lt;string name=&quot;tutorial_recent_stops_routes_text&quot;>Encuentra las paradas y rutas que recientemente has mirado"
-        errorLine2="                                                     ^">
-        <location
-            file="src/main/res/values-es/strings.xml"
-            line="810"
-            column="54"/>
     </issue>
 
     <issue
@@ -5971,7 +5711,7 @@
         errorLine2="                                                                           ~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="811"
+            line="796"
             column="76"/>
     </issue>
 
@@ -5982,19 +5722,19 @@
         errorLine2="                                                                            ~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="812"
+            line="797"
             column="77"/>
     </issue>
 
     <issue
         id="TypographyQuotes"
         message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
-        errorLine1="        if the bus is early (red) or late (blue). On time = green background. If we don\&apos;t know"
-        errorLine2="                                                                                        ~">
+        errorLine1="        couldn\&apos;t see you in the dark? Hold up your flashing Night Light and make yourself visible!"
+        errorLine2="               ~">
         <location
             file="src/main/res/values/strings.xml"
-            line="817"
-            column="89"/>
+            line="802"
+            column="16"/>
     </issue>
 
     <issue
@@ -6004,8 +5744,19 @@
         errorLine2="                                                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-pl/strings.xml"
-            line="830"
+            line="814"
             column="66"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="        if the bus is early (red) or late (blue). On time = green background. If we don\&apos;t know"
+        errorLine2="                                                                                        ~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="821"
+            column="89"/>
     </issue>
 
     <issue
@@ -6048,8 +5799,41 @@
         errorLine2="                                                          ~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="922"
+            line="907"
             column="59"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;donation_learn_more_explanation&quot; tools:ignore=&quot;TypographyOther&quot;>&quot;Abbiamo grandi piani per migliorare %1$s, ma non possiamo farlo senza il tuo aiuto. Questa app è attualmente sviluppata con il 100%% di lavoro volontario, e abbiamo bisogno del tuo aiuto per finanziare lo sviluppo futuro.\n\nCome progetto chiave della Open Transit Software Foundation, un&apos;organizzazione non profit 501(c)(3), ci affidiamo alla buona volontà di utenti come te per continuare a funzionare e migliorare questo software.\n\nOgni anno, solo una piccola frazione dei nostri utenti dona, ma ogni contributo, grande o piccolo, aiuta a garantire che %1$s rimanga gratuito, aggiornato e accessibile a tutti. Una piccola donazione, anche solo il costo di una settimana di pendolarismo, $27.50, può fare tutta la differenza.\n\nIl tuo contributo deducibile dalle tasse assicura che %1$s rimanga libero e accessibile per tutti. Modelliamo insieme il futuro del trasporto pubblico!\n\nGrazie,\nIl Team di %1$s&quot;&lt;/string>"
+        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                   ~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="913"
+            column="372"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&apos;&apos;) with directional quotes (‘’, &amp;#8216; and &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;preferences_reset_donation_timestamps_summary&quot;>Toccando questa opzione verranno cancellati i timestamp di \&apos;Ricordamelo più tardi\&apos; e \&apos;Non disturbarmi\&apos; associati alle richieste di donazione.&lt;/string>"
+        errorLine2="                                                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="915"
+            column="66"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;preferences_show_available_studies_body&quot;>Partecipa agli studi per aiutare a migliorare la tua esperienza di trasporto e con l\&apos;app.&lt;/string>"
+        errorLine2="                                                                                                                                                ~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="924"
+            column="145"/>
     </issue>
 
     <issue
@@ -6066,44 +5850,11 @@
     <issue
         id="TypographyQuotes"
         message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
-        errorLine1="    &lt;string name=&quot;donation_learn_more_explanation&quot; tools:ignore=&quot;TypographyOther&quot;>&quot;Abbiamo grandi piani per migliorare %1$s, ma non possiamo farlo senza il tuo aiuto. Questa app è attualmente sviluppata con il 100%% di lavoro volontario, e abbiamo bisogno del tuo aiuto per finanziare lo sviluppo futuro.\n\nCome progetto chiave della Open Transit Software Foundation, un&apos;organizzazione non profit 501(c)(3), ci affidiamo alla buona volontà di utenti come te per continuare a funzionare e migliorare questo software.\n\nOgni anno, solo una piccola frazione dei nostri utenti dona, ma ogni contributo, grande o piccolo, aiuta a garantire che %1$s rimanga gratuito, aggiornato e accessibile a tutti. Una piccola donazione, anche solo il costo di una settimana di pendolarismo, $27.50, può fare tutta la differenza.\n\nIl tuo contributo deducibile dalle tasse assicura che %1$s rimanga libero e accessibile per tutti. Modelliamo insieme il futuro del trasporto pubblico!\n\nGrazie,\nIl Team di %1$s&quot;&lt;/string>"
-        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                   ~">
-        <location
-            file="src/main/res/values-it/strings.xml"
-            line="928"
-            column="372"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
-        message="Replace straight quotes (&apos;&apos;) with directional quotes (‘’, &amp;#8216; and &amp;#8217;) ?"
-        errorLine1="    &lt;string name=&quot;preferences_reset_donation_timestamps_summary&quot;>Toccando questa opzione verranno cancellati i timestamp di \&apos;Ricordamelo più tardi\&apos; e \&apos;Non disturbarmi\&apos; associati alle richieste di donazione.&lt;/string>"
-        errorLine2="                                                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values-it/strings.xml"
-            line="930"
-            column="66"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
-        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
-        errorLine1="    &lt;string name=&quot;preferences_show_available_studies_body&quot;>Partecipa agli studi per aiutare a migliorare la tua esperienza di trasporto e con l\&apos;app.&lt;/string>"
-        errorLine2="                                                                                                                                                ~">
-        <location
-            file="src/main/res/values-it/strings.xml"
-            line="939"
-            column="145"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
-        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
         errorLine1="    &lt;string name=&quot;dismiss_survey_dialog_body&quot;>Il tuo feedback aiuta a migliorare i servizi di trasporto e le esperienze con l\&apos;app.&lt;/string>"
         errorLine2="                                                                                                                              ~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="951"
+            line="936"
             column="127"/>
     </issue>
 
@@ -6114,7 +5865,7 @@
         errorLine2="                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-fi/strings.xml"
-            line="965"
+            line="948"
             column="39"/>
     </issue>
 
@@ -6125,51 +5876,7 @@
         errorLine2="                                                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-es/strings.xml"
-            line="1085"
-            column="66"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
-        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
-        errorLine1="    &lt;string name=&quot;donation_dismiss_dialog_title&quot;>Please don\&apos;t dismiss this request&lt;/string>"
-        errorLine2="                                                            ~">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="1126"
-            column="61"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
-        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
-        errorLine1="    &lt;string name=&quot;donation_dismiss_dialog_dont_want_to_help_button&quot;>I Don\&apos;t Want to Help&lt;/string>"
-        errorLine2="                                                                          ~">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="1129"
-            column="75"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
-        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
-        errorLine1="    &lt;string name=&quot;donation_learn_more_explanation&quot; tools:ignore=&quot;TypographyOther&quot;>We have big plans to improve %1$s, but we can\&apos;t do it without your help. This app is currently built with 100%% volunteer labor, and we need you to help us fund future development.\n\nAs a key project of the Open Transit Software Foundation, a 501(c)(3) non-profit, we rely on the goodwill of users like you to keep running and making this software better.\n\nEvery year, only a small fraction of our users donate, but every contribution, big or small, helps ensure that %1$s remains free, updated, and accessible to everyone. A small donation, even just the cost of one week of commuting, $27.50, can make all the difference.\n\nYour tax-deductible contribution ensures that %1$s remains free and accessible for everyone. Let\&apos;s shape the future of transit together!\n\nThank you,\nThe %1$s Team&lt;/string>"
-        errorLine2="                                                                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="1135"
-            column="83"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
-        message="Replace straight quotes (&apos;&apos;) with directional quotes (‘’, &amp;#8216; and &amp;#8217;) ?"
-        errorLine1="    &lt;string name=&quot;preferences_reset_donation_timestamps_summary&quot;>Tapping this option will clear both the \&apos;Remind Me Later\&apos; and \&apos;Don\&apos;t Bother Me\&apos; timestamps associated with donation requests.&lt;/string>"
-        errorLine2="                                                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="1137"
+            line="1068"
             column="66"/>
     </issue>
 
@@ -6180,8 +5887,52 @@
         errorLine2="                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-es/strings.xml"
-            line="1142"
+            line="1125"
             column="39"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;donation_dismiss_dialog_title&quot;>Please don\&apos;t dismiss this request&lt;/string>"
+        errorLine2="                                                            ~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1134"
+            column="61"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;donation_dismiss_dialog_dont_want_to_help_button&quot;>I Don\&apos;t Want to Help&lt;/string>"
+        errorLine2="                                                                          ~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1137"
+            column="75"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;donation_learn_more_explanation&quot; tools:ignore=&quot;TypographyOther&quot;>We have big plans to improve %1$s, but we can\&apos;t do it without your help. This app is currently built with 100%% volunteer labor, and we need you to help us fund future development.\n\nAs a key project of the Open Transit Software Foundation, a 501(c)(3) non-profit, we rely on the goodwill of users like you to keep running and making this software better.\n\nEvery year, only a small fraction of our users donate, but every contribution, big or small, helps ensure that %1$s remains free, updated, and accessible to everyone. A small donation, even just the cost of one week of commuting, $27.50, can make all the difference.\n\nYour tax-deductible contribution ensures that %1$s remains free and accessible for everyone. Let\&apos;s shape the future of transit together!\n\nThank you,\nThe %1$s Team&lt;/string>"
+        errorLine2="                                                                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1143"
+            column="83"/>
+    </issue>
+
+    <issue
+        id="TypographyQuotes"
+        message="Replace straight quotes (&apos;&apos;) with directional quotes (‘’, &amp;#8216; and &amp;#8217;) ?"
+        errorLine1="    &lt;string name=&quot;preferences_reset_donation_timestamps_summary&quot;>Tapping this option will clear both the \&apos;Remind Me Later\&apos; and \&apos;Don\&apos;t Bother Me\&apos; timestamps associated with donation requests.&lt;/string>"
+        errorLine2="                                                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1145"
+            column="66"/>
     </issue>
 
     <issue
@@ -6198,30 +5949,30 @@
         errorLine2="                                                  ~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/onebusaway/android/util/ArrivalInfoUtils.java"
-            line="47"
+            line="50"
             column="51"/>
     </issue>
 
     <issue
         id="UnknownNullness"
         message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static ArrayList&lt;Integer> findPreferredArrivalIndexes(ArrayList&lt;ArrivalInfo> infoList) {"
+        errorLine1="    public static ArrayList&lt;Integer> findPreferredArrivalIndexes("
         errorLine2="                  ~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/onebusaway/android/util/ArrivalInfoUtils.java"
-            line="70"
+            line="74"
             column="19"/>
     </issue>
 
     <issue
         id="UnknownNullness"
         message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static ArrayList&lt;Integer> findPreferredArrivalIndexes(ArrayList&lt;ArrivalInfo> infoList) {"
-        errorLine2="                                                                 ~~~~~~~~~~~~~~~~~~~~~~">
+        errorLine1="            ArrayList&lt;ArrivalInfo> infoList, @NonNull Set&lt;String> favoriteRouteIds) {"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/onebusaway/android/util/ArrivalInfoUtils.java"
-            line="70"
-            column="66"/>
+            line="75"
+            column="13"/>
     </issue>
 
     <issue
@@ -6231,7 +5982,7 @@
         errorLine2="                  ~~~~~~">
         <location
             file="src/main/java/org/onebusaway/android/util/ArrivalInfoUtils.java"
-            line="170"
+            line="175"
             column="19"/>
     </issue>
 
@@ -6242,7 +5993,7 @@
         errorLine2="                                                      ~~~~~~~~~">
         <location
             file="src/main/java/org/onebusaway/android/util/ArrivalInfoUtils.java"
-            line="170"
+            line="175"
             column="55"/>
     </issue>
 
@@ -6326,61 +6077,6 @@
     <issue
         id="UnknownNullness"
         message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static String getPreferenceOptionForArrivalInfoBuildFlavorStyle(Context context, int buildFlavorStyle) {"
-        errorLine2="                  ~~~~~~">
-        <location
-            file="src/main/java/org/onebusaway/android/util/BuildFlavorUtils.java"
-            line="52"
-            column="19"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static String getPreferenceOptionForArrivalInfoBuildFlavorStyle(Context context, int buildFlavorStyle) {"
-        errorLine2="                                                                           ~~~~~~~">
-        <location
-            file="src/main/java/org/onebusaway/android/util/BuildFlavorUtils.java"
-            line="52"
-            column="76"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static void applyDefaultArrivalInfoStyleIfUnset(Context context) {"
-        errorLine2="                                                           ~~~~~~~">
-        <location
-            file="src/main/java/org/onebusaway/android/util/BuildFlavorUtils.java"
-            line="72"
-            column="60"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static int getArrivalInfoStyleFromPreferences(Context context) {"
-        errorLine2="                                                         ~~~~~~~">
-        <location
-            file="src/main/java/org/onebusaway/android/util/BuildFlavorUtils.java"
-            line="91"
-            column="58"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static void setArrivalInfoStyle(Context context, int style) {"
-        errorLine2="                                           ~~~~~~~">
-        <location
-            file="src/main/java/org/onebusaway/android/util/BuildFlavorUtils.java"
-            line="120"
-            column="44"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
         errorLine1="            @ApplicationContext Context context,"
         errorLine2="                                ~~~~~~~">
         <location
@@ -6451,7 +6147,7 @@
         errorLine2="           ~~~~~~">
         <location
             file="src/main/java/org/onebusaway/android/donations/DonationsManager.java"
-            line="166"
+            line="168"
             column="12"/>
     </issue>
 
@@ -6462,30 +6158,8 @@
         errorLine2="           ~~~~~~">
         <location
             file="src/main/java/org/onebusaway/android/donations/DonationsManager.java"
-            line="175"
+            line="177"
             column="12"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static Bundle getIntentArgs(Intent intent) {"
-        errorLine2="                  ~~~~~~">
-        <location
-            file="src/main/java/org/onebusaway/android/util/FragmentUtils.java"
-            line="28"
-            column="19"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static Bundle getIntentArgs(Intent intent) {"
-        errorLine2="                                       ~~~~~~">
-        <location
-            file="src/main/java/org/onebusaway/android/util/FragmentUtils.java"
-            line="28"
-            column="40"/>
     </issue>
 
     <issue
@@ -6865,22 +6539,11 @@
     <issue
         id="UnknownNullness"
         message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public LocationHelper(Context context) {"
-        errorLine2="                          ~~~~~~~">
-        <location
-            file="src/main/java/org/onebusaway/android/util/LocationHelper.java"
-            line="75"
-            column="27"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
         errorLine1="    public LocationHelper(Context context, int interval) {"
         errorLine2="                          ~~~~~~~">
         <location
             file="src/main/java/org/onebusaway/android/util/LocationHelper.java"
-            line="84"
+            line="78"
             column="27"/>
     </issue>
 
@@ -6891,7 +6554,7 @@
         errorLine2="                                                 ~~~~~~~~">
         <location
             file="src/main/java/org/onebusaway/android/util/LocationHelper.java"
-            line="105"
+            line="99"
             column="50"/>
     </issue>
 
@@ -6902,7 +6565,7 @@
         errorLine2="                                                ~~~~~~~~">
         <location
             file="src/main/java/org/onebusaway/android/util/LocationHelper.java"
-            line="122"
+            line="116"
             column="49"/>
     </issue>
 
@@ -6913,7 +6576,7 @@
         errorLine2="                                  ~~~~~~~~">
         <location
             file="src/main/java/org/onebusaway/android/util/LocationHelper.java"
-            line="160"
+            line="132"
             column="35"/>
     </issue>
 
@@ -6924,7 +6587,7 @@
         errorLine2="                                  ~~~~~~">
         <location
             file="src/main/java/org/onebusaway/android/util/LocationHelper.java"
-            line="183"
+            line="155"
             column="35"/>
     </issue>
 
@@ -6935,371 +6598,8 @@
         errorLine2="                                   ~~~~~~">
         <location
             file="src/main/java/org/onebusaway/android/util/LocationHelper.java"
-            line="188"
+            line="160"
             column="36"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static Location getDefaultSearchCenter(Context context) {"
-        errorLine2="                  ~~~~~~~~">
-        <location
-            file="src/main/java/org/onebusaway/android/util/LocationUtils.java"
-            line="66"
-            column="19"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static Location getDefaultSearchCenter(Context context) {"
-        errorLine2="                                                  ~~~~~~~">
-        <location
-            file="src/main/java/org/onebusaway/android/util/LocationUtils.java"
-            line="66"
-            column="51"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static Location getSearchCenter(Context context) {"
-        errorLine2="                  ~~~~~~~~">
-        <location
-            file="src/main/java/org/onebusaway/android/util/LocationUtils.java"
-            line="81"
-            column="19"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static Location getSearchCenter(Context context) {"
-        errorLine2="                                           ~~~~~~~">
-        <location
-            file="src/main/java/org/onebusaway/android/util/LocationUtils.java"
-            line="81"
-            column="44"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static boolean compareLocationsByTime(Location a, Location b) {"
-        errorLine2="                                                 ~~~~~~~~">
-        <location
-            file="src/main/java/org/onebusaway/android/util/LocationUtils.java"
-            line="96"
-            column="50"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static boolean compareLocationsByTime(Location a, Location b) {"
-        errorLine2="                                                             ~~~~~~~~">
-        <location
-            file="src/main/java/org/onebusaway/android/util/LocationUtils.java"
-            line="96"
-            column="62"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static boolean compareLocations(Location a, Location b) {"
-        errorLine2="                                           ~~~~~~~~">
-        <location
-            file="src/main/java/org/onebusaway/android/util/LocationUtils.java"
-            line="110"
-            column="44"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static boolean compareLocations(Location a, Location b) {"
-        errorLine2="                                                       ~~~~~~~~">
-        <location
-            file="src/main/java/org/onebusaway/android/util/LocationUtils.java"
-            line="110"
-            column="56"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static boolean isDuplicate(Location a, Location b) {"
-        errorLine2="                                      ~~~~~~~~">
-        <location
-            file="src/main/java/org/onebusaway/android/util/LocationUtils.java"
-            line="142"
-            column="39"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static boolean isDuplicate(Location a, Location b) {"
-        errorLine2="                                                  ~~~~~~~~">
-        <location
-            file="src/main/java/org/onebusaway/android/util/LocationUtils.java"
-            line="142"
-            column="51"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static Location makeLocation(double lat, double lon) {"
-        errorLine2="                  ~~~~~~~~">
-        <location
-            file="src/main/java/org/onebusaway/android/util/LocationUtils.java"
-            line="162"
-            column="19"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static boolean fuzzyEquals(Location a, Location b) {"
-        errorLine2="                                      ~~~~~~~~">
-        <location
-            file="src/main/java/org/onebusaway/android/util/LocationUtils.java"
-            line="177"
-            column="39"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static boolean fuzzyEquals(Location a, Location b) {"
-        errorLine2="                                                  ~~~~~~~~">
-        <location
-            file="src/main/java/org/onebusaway/android/util/LocationUtils.java"
-            line="177"
-            column="51"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static boolean isLocationEnabled(Context context) {"
-        errorLine2="                                            ~~~~~~~">
-        <location
-            file="src/main/java/org/onebusaway/android/util/LocationUtils.java"
-            line="190"
-            column="45"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static int getLocationMode(Context context) {"
-        errorLine2="                                      ~~~~~~~">
-        <location
-            file="src/main/java/org/onebusaway/android/util/LocationUtils.java"
-            line="200"
-            column="39"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static String printLocationDetails(Location loc) {"
-        errorLine2="                  ~~~~~~">
-        <location
-            file="src/main/java/org/onebusaway/android/util/LocationUtils.java"
-            line="217"
-            column="19"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static String printLocationDetails(Location loc) {"
-        errorLine2="                                              ~~~~~~~~">
-        <location
-            file="src/main/java/org/onebusaway/android/util/LocationUtils.java"
-            line="217"
-            column="47"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static List&lt;CustomAddress> processGooglePlacesGeocoding(Context context, Region region,"
-        errorLine2="                  ~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/java/org/onebusaway/android/util/LocationUtils.java"
-            line="242"
-            column="19"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static List&lt;CustomAddress> processGooglePlacesGeocoding(Context context, Region region,"
-        errorLine2="                                                                   ~~~~~~~">
-        <location
-            file="src/main/java/org/onebusaway/android/util/LocationUtils.java"
-            line="242"
-            column="68"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static List&lt;CustomAddress> processGooglePlacesGeocoding(Context context, Region region,"
-        errorLine2="                                                                                    ~~~~~~">
-        <location
-            file="src/main/java/org/onebusaway/android/util/LocationUtils.java"
-            line="242"
-            column="85"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="                                                                   String... reqs) {"
-        errorLine2="                                                                   ~~~~~~~~~">
-        <location
-            file="src/main/java/org/onebusaway/android/util/LocationUtils.java"
-            line="243"
-            column="68"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static List&lt;CustomAddress> processGeocoding(Context context, Region region, boolean geocodingForMarker, String... reqs) {"
-        errorLine2="                  ~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/java/org/onebusaway/android/util/LocationUtils.java"
-            line="247"
-            column="19"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static List&lt;CustomAddress> processGeocoding(Context context, Region region, boolean geocodingForMarker, String... reqs) {"
-        errorLine2="                                                       ~~~~~~~">
-        <location
-            file="src/main/java/org/onebusaway/android/util/LocationUtils.java"
-            line="247"
-            column="56"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static List&lt;CustomAddress> processGeocoding(Context context, Region region, boolean geocodingForMarker, String... reqs) {"
-        errorLine2="                                                                        ~~~~~~">
-        <location
-            file="src/main/java/org/onebusaway/android/util/LocationUtils.java"
-            line="247"
-            column="73"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static List&lt;CustomAddress> processGeocoding(Context context, Region region, boolean geocodingForMarker, String... reqs) {"
-        errorLine2="                                                                                                                   ~~~~~~~~~">
-        <location
-            file="src/main/java/org/onebusaway/android/util/LocationUtils.java"
-            line="247"
-            column="116"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static List&lt;CustomAddress> processPeliasGeocoding(Context context, Region region,"
-        errorLine2="                  ~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/java/org/onebusaway/android/util/LocationUtils.java"
-            line="362"
-            column="19"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static List&lt;CustomAddress> processPeliasGeocoding(Context context, Region region,"
-        errorLine2="                                                             ~~~~~~~">
-        <location
-            file="src/main/java/org/onebusaway/android/util/LocationUtils.java"
-            line="362"
-            column="62"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static List&lt;CustomAddress> processPeliasGeocoding(Context context, Region region,"
-        errorLine2="                                                                              ~~~~~~">
-        <location
-            file="src/main/java/org/onebusaway/android/util/LocationUtils.java"
-            line="362"
-            column="79"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="            String... reqs) {"
-        errorLine2="            ~~~~~~~~~">
-        <location
-            file="src/main/java/org/onebusaway/android/util/LocationUtils.java"
-            line="363"
-            column="13"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static List&lt;CustomAddress> processPeliasGeocoding(Context context, Region region, boolean geocodingForMarker, String... reqs) {"
-        errorLine2="                  ~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/java/org/onebusaway/android/util/LocationUtils.java"
-            line="367"
-            column="19"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static List&lt;CustomAddress> processPeliasGeocoding(Context context, Region region, boolean geocodingForMarker, String... reqs) {"
-        errorLine2="                                                             ~~~~~~~">
-        <location
-            file="src/main/java/org/onebusaway/android/util/LocationUtils.java"
-            line="367"
-            column="62"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static List&lt;CustomAddress> processPeliasGeocoding(Context context, Region region, boolean geocodingForMarker, String... reqs) {"
-        errorLine2="                                                                              ~~~~~~">
-        <location
-            file="src/main/java/org/onebusaway/android/util/LocationUtils.java"
-            line="367"
-            column="79"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static List&lt;CustomAddress> processPeliasGeocoding(Context context, Region region, boolean geocodingForMarker, String... reqs) {"
-        errorLine2="                                                                                                                         ~~~~~~~~~">
-        <location
-            file="src/main/java/org/onebusaway/android/util/LocationUtils.java"
-            line="367"
-            column="122"/>
     </issue>
 
     <issue
@@ -7540,7 +6840,7 @@
         errorLine2="                                                   ~~~~~~~">
         <location
             file="src/main/java/org/onebusaway/android/util/PermissionUtils.java"
-            line="51"
+            line="40"
             column="52"/>
     </issue>
 
@@ -7551,7 +6851,7 @@
         errorLine2="                                                                    ~~~~~~~~">
         <location
             file="src/main/java/org/onebusaway/android/util/PermissionUtils.java"
-            line="51"
+            line="40"
             column="69"/>
     </issue>
 
@@ -7562,7 +6862,7 @@
         errorLine2="                                                         ~~~~~~~">
         <location
             file="src/main/java/org/onebusaway/android/util/PermissionUtils.java"
-            line="66"
+            line="55"
             column="58"/>
     </issue>
 
@@ -7573,7 +6873,7 @@
         errorLine2="                                                                          ~~~~~~~~">
         <location
             file="src/main/java/org/onebusaway/android/util/PermissionUtils.java"
-            line="66"
+            line="55"
             column="75"/>
     </issue>
 
@@ -7584,7 +6884,7 @@
         errorLine2="                                               ~~~~~~~">
         <location
             file="src/main/java/org/onebusaway/android/util/PermissionUtils.java"
-            line="81"
+            line="70"
             column="48"/>
     </issue>
 
@@ -7595,7 +6895,7 @@
         errorLine2="                                                                ~~~~~~">
         <location
             file="src/main/java/org/onebusaway/android/util/PermissionUtils.java"
-            line="81"
+            line="70"
             column="65"/>
     </issue>
 
@@ -8361,22 +7661,22 @@
     <issue
         id="UnknownNullness"
         message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static String[] getReminderTimes(Context context, long departTime) {"
+        errorLine1="    public static String[] getReminderTimes(Context context, long departTimeMs, long nowMs) {"
         errorLine2="                  ~~~~~~~~">
         <location
             file="src/main/java/org/onebusaway/android/util/ReminderUtils.java"
-            line="83"
+            line="89"
             column="19"/>
     </issue>
 
     <issue
         id="UnknownNullness"
         message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static String[] getReminderTimes(Context context, long departTime) {"
+        errorLine1="    public static String[] getReminderTimes(Context context, long departTimeMs, long nowMs) {"
         errorLine2="                                            ~~~~~~~">
         <location
             file="src/main/java/org/onebusaway/android/util/ReminderUtils.java"
-            line="83"
+            line="89"
             column="45"/>
     </issue>
 
@@ -8510,303 +7810,6 @@
             file="src/main/java/org/onebusaway/android/report/ui/util/ServiceUtils.java"
             line="211"
             column="58"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static synchronized void ensureLoaded(Context context) {"
-        errorLine2="                                                 ~~~~~~~">
-        <location
-            file="src/google/java/org/onebusaway/android/map/googlemapsv2/StopIconFactory.java"
-            line="198"
-            column="50"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static synchronized BitmapDescriptor stopIcon(Context context, String direction, int routeType) {"
-        errorLine2="                               ~~~~~~~~~~~~~~~~">
-        <location
-            file="src/google/java/org/onebusaway/android/map/googlemapsv2/StopIconFactory.java"
-            line="206"
-            column="32"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static synchronized BitmapDescriptor stopIcon(Context context, String direction, int routeType) {"
-        errorLine2="                                                         ~~~~~~~">
-        <location
-            file="src/google/java/org/onebusaway/android/map/googlemapsv2/StopIconFactory.java"
-            line="206"
-            column="58"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static synchronized BitmapDescriptor stopIcon(Context context, String direction, int routeType) {"
-        errorLine2="                                                                          ~~~~~~">
-        <location
-            file="src/google/java/org/onebusaway/android/map/googlemapsv2/StopIconFactory.java"
-            line="206"
-            column="75"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static synchronized BitmapDescriptor focusedStopIcon(Context context, String direction, int routeType) {"
-        errorLine2="                               ~~~~~~~~~~~~~~~~">
-        <location
-            file="src/google/java/org/onebusaway/android/map/googlemapsv2/StopIconFactory.java"
-            line="212"
-            column="32"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static synchronized BitmapDescriptor focusedStopIcon(Context context, String direction, int routeType) {"
-        errorLine2="                                                                ~~~~~~~">
-        <location
-            file="src/google/java/org/onebusaway/android/map/googlemapsv2/StopIconFactory.java"
-            line="212"
-            column="65"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static synchronized BitmapDescriptor focusedStopIcon(Context context, String direction, int routeType) {"
-        errorLine2="                                                                                 ~~~~~~">
-        <location
-            file="src/google/java/org/onebusaway/android/map/googlemapsv2/StopIconFactory.java"
-            line="212"
-            column="82"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static synchronized BitmapDescriptor dotStopIcon(Context context) {"
-        errorLine2="                               ~~~~~~~~~~~~~~~~">
-        <location
-            file="src/google/java/org/onebusaway/android/map/googlemapsv2/StopIconFactory.java"
-            line="221"
-            column="32"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static synchronized BitmapDescriptor dotStopIcon(Context context) {"
-        errorLine2="                                                            ~~~~~~~">
-        <location
-            file="src/google/java/org/onebusaway/android/map/googlemapsv2/StopIconFactory.java"
-            line="221"
-            column="61"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static synchronized BitmapDescriptor focusedDotStopIcon(Context context) {"
-        errorLine2="                               ~~~~~~~~~~~~~~~~">
-        <location
-            file="src/google/java/org/onebusaway/android/map/googlemapsv2/StopIconFactory.java"
-            line="227"
-            column="32"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static synchronized BitmapDescriptor focusedDotStopIcon(Context context) {"
-        errorLine2="                                                                   ~~~~~~~">
-        <location
-            file="src/google/java/org/onebusaway/android/map/googlemapsv2/StopIconFactory.java"
-            line="227"
-            column="68"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static synchronized BitmapDescriptor favoriteStopIcon(Context context, String direction) {"
-        errorLine2="                               ~~~~~~~~~~~~~~~~">
-        <location
-            file="src/google/java/org/onebusaway/android/map/googlemapsv2/StopIconFactory.java"
-            line="233"
-            column="32"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static synchronized BitmapDescriptor favoriteStopIcon(Context context, String direction) {"
-        errorLine2="                                                                 ~~~~~~~">
-        <location
-            file="src/google/java/org/onebusaway/android/map/googlemapsv2/StopIconFactory.java"
-            line="233"
-            column="66"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static synchronized BitmapDescriptor favoriteStopIcon(Context context, String direction) {"
-        errorLine2="                                                                                  ~~~~~~">
-        <location
-            file="src/google/java/org/onebusaway/android/map/googlemapsv2/StopIconFactory.java"
-            line="233"
-            column="83"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static synchronized BitmapDescriptor focusedFavoriteStopIcon(Context context, String direction) {"
-        errorLine2="                               ~~~~~~~~~~~~~~~~">
-        <location
-            file="src/google/java/org/onebusaway/android/map/googlemapsv2/StopIconFactory.java"
-            line="239"
-            column="32"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static synchronized BitmapDescriptor focusedFavoriteStopIcon(Context context, String direction) {"
-        errorLine2="                                                                        ~~~~~~~">
-        <location
-            file="src/google/java/org/onebusaway/android/map/googlemapsv2/StopIconFactory.java"
-            line="239"
-            column="73"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static synchronized BitmapDescriptor focusedFavoriteStopIcon(Context context, String direction) {"
-        errorLine2="                                                                                         ~~~~~~">
-        <location
-            file="src/google/java/org/onebusaway/android/map/googlemapsv2/StopIconFactory.java"
-            line="239"
-            column="90"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static synchronized BitmapDescriptor favoriteDotStopIcon(Context context) {"
-        errorLine2="                               ~~~~~~~~~~~~~~~~">
-        <location
-            file="src/google/java/org/onebusaway/android/map/googlemapsv2/StopIconFactory.java"
-            line="245"
-            column="32"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static synchronized BitmapDescriptor favoriteDotStopIcon(Context context) {"
-        errorLine2="                                                                    ~~~~~~~">
-        <location
-            file="src/google/java/org/onebusaway/android/map/googlemapsv2/StopIconFactory.java"
-            line="245"
-            column="69"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static synchronized BitmapDescriptor focusedFavoriteDotStopIcon(Context context) {"
-        errorLine2="                               ~~~~~~~~~~~~~~~~">
-        <location
-            file="src/google/java/org/onebusaway/android/map/googlemapsv2/StopIconFactory.java"
-            line="251"
-            column="32"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static synchronized BitmapDescriptor focusedFavoriteDotStopIcon(Context context) {"
-        errorLine2="                                                                           ~~~~~~~">
-        <location
-            file="src/google/java/org/onebusaway/android/map/googlemapsv2/StopIconFactory.java"
-            line="251"
-            column="76"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static float anchorX(String direction) {"
-        errorLine2="                                ~~~~~~">
-        <location
-            file="src/google/java/org/onebusaway/android/map/googlemapsv2/StopIconFactory.java"
-            line="257"
-            column="33"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static float anchorY(String direction) {"
-        errorLine2="                                ~~~~~~">
-        <location
-            file="src/google/java/org/onebusaway/android/map/googlemapsv2/StopIconFactory.java"
-            line="262"
-            column="33"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static void waitForLoadFinished(Context context) throws InterruptedException {"
-        errorLine2="                                           ~~~~~~~">
-        <location
-            file="src/main/java/org/onebusaway/android/util/TestUtils.java"
-            line="52"
-            column="44"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static void waitForBroadcast(Context context, String action, String category)"
-        errorLine2="                                        ~~~~~~~">
-        <location
-            file="src/main/java/org/onebusaway/android/util/TestUtils.java"
-            line="56"
-            column="41"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static void waitForBroadcast(Context context, String action, String category)"
-        errorLine2="                                                         ~~~~~~">
-        <location
-            file="src/main/java/org/onebusaway/android/util/TestUtils.java"
-            line="56"
-            column="58"/>
-    </issue>
-
-    <issue
-        id="UnknownNullness"
-        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
-        errorLine1="    public static void waitForBroadcast(Context context, String action, String category)"
-        errorLine2="                                                                        ~~~~~~">
-        <location
-            file="src/main/java/org/onebusaway/android/util/TestUtils.java"
-            line="56"
-            column="73"/>
     </issue>
 
     <issue
@@ -9017,6 +8020,5 @@
             line="173"
             column="53"/>
     </issue>
-
 
 </issues>

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/mylists/MyListRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/mylists/MyListRepository.kt
@@ -84,7 +84,7 @@ private val RECENT_WINDOW_MS = 7 * DateUtils.DAY_IN_MILLIS
 
 // Device-clock recent-window cutoff, compared against locally-stamped access times (same clock).
 @Suppress("RawClockArithmetic")
-private fun recentCutoff(): Long = System.currentTimeMillis() - RECENT_WINDOW_MS
+internal fun recentCutoff(): Long = System.currentTimeMillis() - RECENT_WINDOW_MS
 
 private fun StopListRow.toStopItem(context: Context): StopListItem {
     val directionText = direction?.takeIf { it.isNotEmpty() }
@@ -110,10 +110,10 @@ private fun RouteListRow.toRouteItem() = RouteListItem(
 
 // The recent-row variants embed the list row + access_time, so reuse the exact list-row mappers on the
 // embedded [row] and keep the display formatting in one place.
-private fun StopRecentRow.toRecentItem(context: Context) =
+internal fun StopRecentRow.toRecentItem(context: Context) =
     RecentItem.Stop(row.toStopItem(context), accessTime)
 
-private fun RouteRecentRow.toRecentItem() =
+internal fun RouteRecentRow.toRecentItem() =
     RecentItem.Route(row.toRouteItem(), accessTime)
 
 /** How many recents the search dropdown holds; ~4 are visible, the rest scroll (matches the list caps). */

--- a/onebusaway-android/src/main/res/values-es/strings.xml
+++ b/onebusaway-android/src/main/res/values-es/strings.xml
@@ -22,7 +22,6 @@
     <string name="app_name">OneBusAway</string>
 
     <!-- Navigation Drawer -->
-    <string name="navdrawer_item_nearby">Cerca</string>
     <string name="navdrawer_item_starred_stops">Paradas favoritas</string>
     <string name="navdrawer_item_starred_routes">Rutas favoritas</string>
     <string name="navdrawer_item_my_reminders">Mis recordatorios</string>

--- a/onebusaway-android/src/main/res/values-fi/strings.xml
+++ b/onebusaway-android/src/main/res/values-fi/strings.xml
@@ -20,7 +20,6 @@
     <string name="app_name">OneBusAway</string>
 
     <!-- Navigation Drawer -->
-    <string name="navdrawer_item_nearby">Lähistöllä</string>
     <string name="navdrawer_item_starred_stops">Suosikkipysäkit</string>
     <string name="navdrawer_item_my_reminders">Muistutukseni</string>
     <string name="navdrawer_item_settings">Asetukset</string>

--- a/onebusaway-android/src/main/res/values-it/strings.xml
+++ b/onebusaway-android/src/main/res/values-it/strings.xml
@@ -20,7 +20,6 @@
     <string name="app_name">OneBusAway</string>
 
     <!-- Navigation Drawer -->
-    <string name="navdrawer_item_nearby">Nei dintorni</string>
     <string name="navdrawer_item_starred_stops">Fermate preferite</string>
     <string name="navdrawer_item_starred_routes">Linee preferite</string>
     <string name="navdrawer_item_my_reminders">I miei promemoria</string>

--- a/onebusaway-android/src/main/res/values-pl/strings.xml
+++ b/onebusaway-android/src/main/res/values-pl/strings.xml
@@ -3,7 +3,6 @@
     <string name="app_name">OneBusAway</string>
 
     <!-- Navigation Drawer -->
-    <string name="navdrawer_item_nearby">W pobliżu</string>
     <string name="navdrawer_item_starred_stops">Ulubione przystanki</string>
     <string name="navdrawer_item_my_reminders">Moje przypomnienia</string>
     <string name="navdrawer_item_settings">Ustawienia</string>

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -21,7 +21,6 @@
     <string name="app_name">OneBusAway</string>
 
     <!-- Navigation Drawer -->
-    <string name="navdrawer_item_nearby">Nearby</string>
     <string name="navdrawer_item_starred_stops">Starred stops</string>
     <string name="navdrawer_item_starred_routes">Starred routes</string>
     <string name="navdrawer_item_my_reminders">My reminders</string>


### PR DESCRIPTION
## What

Regenerates `onebusaway-android/lint-baseline.xml` to remove **90 stale entries** — issues that the baseline still listed but lint no longer finds in the project (fixed since, or whose checks changed). Lint had been reporting them as *"listed in the baseline file … but not found in the project; perhaps they have been fixed?"*

Stale baseline entries are dead weight and, worse, can silently re-absorb a genuinely reintroduced issue (an entry that "matches again"), so CLAUDE.md calls for regenerating rather than letting them accumulate.

## Stale entries dropped (742 → 652)

| Issue type | Count |
|---|---|
| `UnknownNullness` | 68 |
| `TypographyQuotes` | 14 |
| `SyntheticAccessor` | 7 |
| `ComposableLambdaParameterNaming` | 1 |

## How

Per CLAUDE.md's procedure: delete `lint-baseline.xml`, run `:onebusaway-android:lintObaGoogleDebug` (recreates the file, intentionally fails that one run), then verify the next run passes.

## Verification — no new issues silently absorbed

The raw git diff is large (line-number refresh on every retained entry), so I diffed old vs new **semantically**, keyed on `(id, file, message)` rather than line number:

- **0 genuinely new signatures added** — nothing snuck into the baseline.
- Exactly **90 stale signatures removed**.
- The two errors fixed in the base PR (`MyListRepository` `SyntheticAccessor`, `navdrawer_item_nearby` `UnusedResources`) were **not** re-absorbed.

Then `:onebusaway-android:lintObaGoogleDebug -PwarningsAsErrors=true` → **"Lint found no new issues"**, build succeeds, and the stale-entry warning is gone.

## Stacking

Targets **`fix/lint-synthetic-accessor-unused-resource`** (PR #1873), not `main`, so regeneration happens on top of those fixes and doesn't re-baseline them. Rebase onto `main` once #1873 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)