### PR TITLE
Lintbust FINALE: retire lint-baseline.xml

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,15 +71,16 @@ only prints them. The codebase is kept at **zero** compiler warnings (#1692); do
   - **Don't run lint locally just to pre-empt a CI failure.** `lintObaGoogleDebug` takes ~5–15 minutes
     (worse when other builds are contending for the machine), which stalls the loop for little gain.
     Compile clean locally (the command above), then **let CI run lint** and react to its report.
-    Reproduce lint locally *only* when you're specifically iterating on a lint finding CI already flagged,
-    or regenerating the baseline (below): `./gradlew :onebusaway-android:lintObaGoogleDebug -PwarningsAsErrors=true`.
-  - Lint runs the **full catalog** (`checkAllWarnings true`), and the ~760 pre-existing findings are
-    grandfathered in `onebusaway-android/lint-baseline.xml`. Only **new** issues (not in the baseline)
-    are reported — so don't introduce new ones, and prefer fixing over baselining.
-  - After an AGP/lint bump that adds or changes checks, **regenerate the baseline**: delete
-    `lint-baseline.xml` and run `./gradlew :onebusaway-android:lintObaGoogleDebug` (it recreates the
-    file and intentionally fails that one run; the next run passes). Then review the diff before
-    committing so genuinely new issues aren't silently absorbed.
+    Reproduce lint locally *only* when you're specifically iterating on a lint finding CI already flagged:
+    `./gradlew :onebusaway-android:lintObaGoogleDebug -PwarningsAsErrors=true`.
+  - Lint runs the **full catalog** (`checkAllWarnings true`) with **no baseline** — the codebase is kept
+    lint-clean, so *every* finding is reported and (under `-PwarningsAsErrors`) fails the build; nothing is
+    grandfathered. The old whole-project `lint-baseline.xml` was retired once its findings were all fixed
+    or their checks opted out (a lint-busting campaign); a handful of genuinely-unactionable checks are
+    disabled in the `lint { disable += … }` block, each with a rationale.
+  - So don't introduce new findings. If an AGP/lint bump adds a check with unavoidable pre-existing hits,
+    **fix them, or opt that check out** in the `lint {}` block with a one-line rationale — don't
+    reintroduce a whole-project baseline.
 
 ## Automated Publishing (gradle-play-publisher)
 
@@ -213,9 +214,9 @@ follow that pattern when adding server-domain time math.
   (a local, field, return, or default parameter) instead of a domain type. The value classes make
   cross-domain math a *compile* error; these checks close the complementary gap where a producer reading
   never got minted. A reading passed straight through to a consuming API (DAO/prefs write, alarm, a
-  domain mint) is not flagged — it never rests, so no domain is lost. Pre-existing sites are grandfathered
-  in the lint baseline; a genuinely-sanctioned boundary mints into `WallTime`/`ElapsedTime` (domain made
-  explicit) or suppresses the issue with a one-line rationale. See `lint-rules/README.md`.
+  domain mint) is not flagged — it never rests, so no domain is lost. A genuinely-sanctioned boundary
+  mints into `WallTime`/`ElapsedTime` (domain made explicit) or carries an inline `@Suppress` with a
+  one-line rationale (there is no lint baseline — these live at the site). See `lint-rules/README.md`.
 
 ## No unsanctioned heuristics
 

--- a/lint-rules/README.md
+++ b/lint-rules/README.md
@@ -104,15 +104,16 @@ CLAUDE.md. The checks are a latch discipline, not a suggestion.
 
 ## Status: enforced
 
-Wired into the app via `lintChecks project(':lint-rules')` in `onebusaway-android/build.gradle`, so a
+Wired into the app via `lintChecks(project(":lint-rules"))` in `onebusaway-android/build.gradle.kts`, so a
 **new** violation of any of the four issues fails the build under the strict `-PwarningsAsErrors` gate
-(verified). The pre-existing sites present when each check landed are grandfathered in
-`onebusaway-android/lint-baseline.xml`:
+(verified). There is **no lint baseline** — the app is kept clean under the full catalog, so every
+sanctioned pre-existing site is handled *at the site*, not grandfathered in a file:
 
-- **13** `RawClockArithmetic` + **11** `UnwrappedClockValue` — nearly all same-domain / sanctioned
-  device-clock timers or conversion helpers; one, `ReminderUtils.java:86`
-  (`departTime − System.currentTimeMillis()`, a scheduled/predicted departure minus device now), is a
-  genuine #1612 candidate flagged for a dedicated fix (it needs a server clock threaded to the call site).
+- **0** `RawClockArithmetic` / `UnwrappedClockValue` baselined. The sites that once were: the genuine
+  #1612 candidate `ReminderUtils` (`departTime − System.currentTimeMillis()`) was fixed by threading the
+  clock to the call site (`getReminderTimes` now takes a same-domain `nowMs` param and reads no clock
+  itself); the remaining same-domain / sanctioned device-clock timers and conversion helpers carry an
+  inline `@Suppress("RawClockArithmetic")` / `@Suppress("UnwrappedClockValue")` with a one-line rationale.
 - **0** `PrematureUnwrap` — a skeptical pass retired every one of the 18 initial findings rather than
   baselining them: the `TypedTime` operators are now rule-exempt (the domain defining its own algebra);
   the `.epochMs > 0` "is this instant set / did the server predict" sentinels became **nullable**
@@ -123,7 +124,8 @@ Wired into the app via `lintChecks project(':lint-rules')` in `onebusaway-androi
 - **0** `WireTimeEscape` — the migration left no wire-field read in app logic; the check starts empty and
   exists to keep it that way.
 
-Drive the baseline down by minting each site; don't add new entries.
+Keep all four checks at zero: mint each new site (or inline-`@Suppress` a genuinely-sanctioned one with a
+rationale) — don't reintroduce a baseline.
 
 ## Develop
 

--- a/onebusaway-android/build.gradle.kts
+++ b/onebusaway-android/build.gradle.kts
@@ -200,20 +200,18 @@ android {
         )
         // Run the FULL lint catalog — including checks that are off by default and library-provided
         // ones (Compose, UseKtx, …) — so the checked set is comprehensive and current for the installed
-        // lint, not just its (drifting) default-enabled subset. Pre-existing hits are grandfathered by
-        // the baseline below; only NEW issues are reported.
-        checkAllWarnings = true
-        // Checked-in record of the issues present when it was generated. New issues aren't in it, so
-        // they're reported (and, under -PwarningsAsErrors, fail the build). After an AGP/lint bump that
-        // adds/changes checks, regenerate it: delete the file and re-run lint (it recreates + passes).
-        baseline = file("lint-baseline.xml")
+        // lint, not just its (drifting) default-enabled subset. The codebase is kept lint-clean under
+        // this full catalog, so there is NO baseline: every finding was either fixed in code or, where
+        // fixing wasn't warranted, its check opted out above (the lint-busting campaign). Any NEW issue
+        // is therefore reported and — under -PwarningsAsErrors — fails the build, with nothing
+        // grandfathered. (If an AGP/lint bump adds checks with unavoidable pre-existing hits, prefer
+        // fixing or a scoped opt-out over reintroducing a whole-project baseline.)
         // Fail the build (and CI, #1692) on any lint error — notably NewApi minSdk violations,
         // which compile + API-33 instrumented tests can't catch.
         abortOnError = true
         // Under -PwarningsAsErrors=true (CI passes it; see .github/workflows/android.yml), promote lint
         // warnings to errors too, matching the Kotlin-compiler gate below. Local builds default to off so
-        // an AGP/lint bump that adds new (non-baselined) warnings surfaces in CI rather than blocking
-        // day-to-day work.
+        // an AGP/lint bump that adds new warnings surfaces in CI rather than blocking day-to-day work.
         warningsAsErrors = project.hasProperty("warningsAsErrors") &&
             project.property("warningsAsErrors") == "true"
     }

--- a/onebusaway-android/lint-baseline.xml
+++ b/onebusaway-android/lint-baseline.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.3.0" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.0)" variant="all" version="9.3.0">
-
-</issues>


### PR DESCRIPTION
The capstone of the lint-busting campaign. Every baselined finding has been **fixed in code** or its **check opted out**, so the whole-project baseline is no longer needed — this deletes it.

## What

- Delete `onebusaway-android/lint-baseline.xml` (down to an empty `<issues>` shell after the preceding PRs).
- Drop `baseline = file("lint-baseline.xml")` from the `lint {}` block.

Lint now runs the **full catalog** (`checkAllWarnings`) with **no baseline** and passes clean under `-PwarningsAsErrors=true` — nothing grandfathered, any new finding fails the build. Verified locally.

## Docs corrected

These described the baseline and a "regenerate the baseline" workflow that no longer exists:

- **`CLAUDE.md`** — the lint section (full-catalog/baseline/regenerate bullets) and the typed-time custom-checks note.
- **`lint-rules/README.md`** — the "Status: enforced" section claimed *13 `RawClockArithmetic` + 11 `UnwrappedClockValue`* were grandfathered in the baseline. They actually weren't (the `main` baseline held **0**): the #1612 candidate `ReminderUtils` was fixed by threading `nowMs` to the call site (`getReminderTimes` reads no clock itself), and the remaining sanctioned sites carry inline `@Suppress` with a rationale. Corrected to reflect the at-the-site reality.

## The campaign (this is the top of the stack)

| # | PR | Category | Result |
|---|---|---|---|
| 1 | #1875 | SyntheticAccessor | 150 → 0 (fixed: `private`→`internal`/package-private) |
| 2 | #1876 | LogConditional | 25 → 0 (fixed: `if (BuildConfig.DEBUG)`) |
| 3 | #1877 | ComposableLambdaParameterNaming | 5 → 0 (fixed: `content`) |
| 4 | #1878 | UnusedIds | 5 → 0 (fixed: deleted `ids.xml`) |
| 5 | #1879 | TypographyQuotes | 130 → 0 (fixed: typographic glyphs) |
| 6 | #1880 | DuplicateStrings | 143 → 0 (check disabled) |
| 7 | #1881 | 4 stragglers | 5 → 0 (checks disabled) |
| 8–12 | #1882–#1886 | UnknownNullness | 189 → 0 (fixed: `@Nullable`/`@NonNull`, file-by-file) |
| 13 | **this** | — | baseline retired |

Baseline **652 → 0 → gone**. Each PR was verified with a message-keyed semantic diff (0 new issues absorbed) and a clean `-PwarningsAsErrors=true` lint run.

## Stacking

Targets **`lintbust/unknownnullness-misc`** (PR #1886) → … → `main`. **Merge the whole stack bottom-up** (#1873 first); GitHub will auto-retarget each PR to `main` as its base merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)