### PR TITLE
Nav: clear three shared-code javac deprecation warnings

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/nav/FeedbackReceiver.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/nav/FeedbackReceiver.java
@@ -32,6 +32,7 @@ import org.onebusaway.android.util.PreferenceUtils;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
 
 import androidx.core.app.NotificationCompat;
@@ -131,7 +132,7 @@ public class FeedbackReceiver extends BroadcastReceiver {
     private void moveLog(Context context, String feedback, String userResponse, String logFile) {
         try {
             File lFile = new File(logFile);
-            FileUtils.write(lFile, System.getProperty("line.separator") + "User Feedback - " + feedback, true);
+            FileUtils.write(lFile, System.getProperty("line.separator") + "User Feedback - " + feedback, StandardCharsets.UTF_8, true);
             Log.d(TAG, "Feedback appended");
 
             File destFolder = new File(context.getFilesDir()
@@ -149,7 +150,7 @@ public class FeedbackReceiver extends BroadcastReceiver {
                 Log.d(TAG, "File move failed");
             }
 
-            setupLogUploadTask();
+            setupLogUploadTask(context);
 
         } catch (IOException e) {
             Log.e(TAG, "File write failed: " + e.toString());
@@ -163,7 +164,7 @@ public class FeedbackReceiver extends BroadcastReceiver {
         if (BuildConfig.DEBUG) Log.v(TAG, "Log deleted " + deleted);
     }
 
-    private void setupLogUploadTask() {
+    private void setupLogUploadTask(Context context) {
         PeriodicWorkRequest.Builder uploadLogsBuilder =
                 new PeriodicWorkRequest.Builder(NavigationUploadWorker.class, 24,
                         TimeUnit.HOURS);
@@ -173,7 +174,7 @@ public class FeedbackReceiver extends BroadcastReceiver {
 
         // Then enqueue the recurring task under a unique name so repeated feedback submissions keep
         // a single upload chain instead of stacking one each time:
-        WorkManager.getInstance().enqueueUniquePeriodicWork(
+        WorkManager.getInstance(context).enqueueUniquePeriodicWork(
                 NavigationUploadWorker.UNIQUE_WORK_NAME,
                 ExistingPeriodicWorkPolicy.KEEP,
                 uploadCheckWork);

--- a/onebusaway-android/src/main/java/org/onebusaway/android/nav/NavigationUploadWorker.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/nav/NavigationUploadWorker.java
@@ -32,8 +32,10 @@ import org.onebusaway.android.app.di.AnalyticsEntryPoint;
 
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileReader;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 
 import androidx.annotation.NonNull;
 import androidx.work.Worker;
@@ -81,8 +83,11 @@ public class NavigationUploadWorker extends Worker {
                 Log.d(TAG, "Location : " + response + logFileName);
 
                 String sCurrentLine, feedbackText = "";
-                try {
-                    BufferedReader br = new BufferedReader(new FileReader(lFile.getAbsolutePath()));
+                // Read as UTF-8 to match how FeedbackReceiver writes the log (FileReader would use the
+                // platform-default charset). FileReader(File, Charset) is API 33+, so wrap a
+                // FileInputStream to stay minSdk-23 safe.
+                try (BufferedReader br = new BufferedReader(
+                        new InputStreamReader(new FileInputStream(lFile), StandardCharsets.UTF_8))) {
                     while ((sCurrentLine = br.readLine()) != null) {
                         feedbackText = sCurrentLine;
                     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/LocationHelper.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/LocationHelper.java
@@ -148,6 +148,9 @@ public class LocationHelper implements android.location.LocationListener {
         }
     }
 
+    // Deprecated (no-op) since API 29, but still abstract on our minSdk-23 floor (it only gained a
+    // default implementation in API 30), so the override must stay to avoid an AbstractMethodError.
+    @SuppressWarnings("deprecation")
     @Override
     public void onStatusChanged(String provider, int status, Bundle extras) {
 


### PR DESCRIPTION
While compiling, javac prints `Note: Some input files use or override a deprecated API` — the summary for a handful of `@Deprecated` API usages. These are javac **notes/warnings**, not errors (the `-PwarningsAsErrors` gate covers Kotlin `w:` and Android Lint, not javac `-Xlint:deprecation`), so they never failed the build — but they're easy to clean up. This clears the three in shared code:

| Site | Deprecated API | Fix |
|---|---|---|
| `FeedbackReceiver.moveLog` | `FileUtils.write(File, CharSequence, boolean)` — deprecated for using the platform-default charset | pass `StandardCharsets.UTF_8` (behaviour-identical on Android) |
| `FeedbackReceiver.setupLogUploadTask` | `WorkManager.getInstance()` (no-arg) | thread the `Context` (already in scope via `onReceive` → `moveLog`) → `WorkManager.getInstance(context)` |
| `LocationHelper.onStatusChanged` | `LocationListener.onStatusChanged` — deprecated no-op since API 29 | **keep** the override (it's still *abstract* on our minSdk-23 floor — default only arrived in API 30, so removing it would risk `AbstractMethodError` on API 23) and `@SuppressWarnings("deprecation")` with a rationale |

## No behaviour change

`FileUtils.write` with an explicit UTF-8 matches Android's existing default; `WorkManager.getInstance(context)` returns the same singleton; `onStatusChanged` is unchanged apart from the annotation.

## Verification

- `compileObaGoogleDebugJavaWithJavac` + `compileObaMaplibreDebugJavaWithJavac` + Kotlin, all clean under `-PwarningsAsErrors=true`.
- Confirmed with `-Xlint:deprecation`: these three are gone; the **only** remaining javac deprecations are the Google Places `.compat` SDK usages in `ProprietaryMapHelpV2` (google flavor), tracked separately for a dedicated migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Ensure feedback appended to log files is written using UTF-8.
  - Ensure uploaded log content is read using UTF-8 for consistent text decoding.
  - Improve reliability of periodic log upload scheduling after logs are moved.
- **Maintenance**
  - Added a deprecation-warning suppression around the location status callback without changing location update behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

The remaining Places `.compat` deprecations are tracked in #1889.