### PR TITLE
Replace route-row overflow with centered long-press menus

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/arrivals/RouteArrivalRowLongPressTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/arrivals/RouteArrivalRowLongPressTest.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.arrivals
+
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.longClick
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.onebusaway.android.R
+import org.onebusaway.android.ui.arrivals.components.ArrivalRowCallbacks
+import org.onebusaway.android.ui.arrivals.components.RouteArrivalRow
+import org.onebusaway.android.ui.arrivals.components.previewArrival
+
+class RouteArrivalRowLongPressTest {
+
+    @Suppress("DEPRECATION")
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun longPressOpensScheduleWithoutOverflowButton() {
+        val trip = previewArrival("40", "Northgate", etaMinutes = 3)
+        val scheduleUrl = "https://example.com/routes/40"
+        var openedScheduleUrl: String? = null
+        val callbacks = ArrivalRowCallbacks(
+            onRouteFavorite = {},
+            onShowVehiclesOnMap = {},
+            onEtaClick = {},
+            onShowTripStatus = {},
+            onSetReminder = {},
+            onShowRouteSchedule = { openedScheduleUrl = it },
+            onReportArrivalProblem = {},
+            onShowAlert = {},
+        )
+        val actions = ArrivalActions(
+            tripId = trip.tripId,
+            routeId = trip.routeId,
+            routeShortName = trip.shortName.orEmpty(),
+            routeLongName = "Downtown Seattle",
+            routeColor = 0xFF0A5B3E.toInt(),
+            scheduleUrl = scheduleUrl,
+            agencyName = null,
+            blockId = null,
+        )
+
+        composeRule.setContent {
+            RouteArrivalRow(
+                group = RouteRowGroup(listOf(trip)),
+                actionsFor = { actions },
+                isFavorite = false,
+                callbacks = callbacks,
+            )
+        }
+
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        composeRule.onAllNodesWithContentDescription(
+            context.getString(R.string.stop_info_item_options_title)
+        ).assertCountEquals(0)
+
+        composeRule.onNodeWithText("Northgate").performTouchInput { longClick() }
+        composeRule.onNodeWithText(
+            context.getString(R.string.bus_options_menu_show_route_schedule)
+        ).assertIsDisplayed().performClick()
+
+        assertEquals(scheduleUrl, openedScheduleUrl)
+    }
+}

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/arrivals/RouteArrivalRowLongPressTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/arrivals/RouteArrivalRowLongPressTest.kt
@@ -15,14 +15,16 @@
  */
 package org.onebusaway.android.ui.arrivals
 
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.compose.ui.test.longClick
 import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
-import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.performSemanticsAction
 import androidx.test.platform.app.InstrumentationRegistry
 import org.junit.Assert.assertEquals
 import org.junit.Rule
@@ -75,16 +77,29 @@ class RouteArrivalRowLongPressTest {
         }
 
         val context = InstrumentationRegistry.getInstrumentation().targetContext
+        // The route-level action moved off a dedicated overflow button and onto the row's long press,
+        // so the overflow affordance must be gone.
         composeRule.onAllNodesWithContentDescription(
             context.getString(R.string.stop_info_item_options_title)
         ).assertCountEquals(0)
 
-        composeRule.onNodeWithText("Northgate").performTouchInput { longClick() }
+        // Drive the long press through the row's OnLongClick *semantics action* rather than an injected
+        // longClick() gesture. combinedClickable registers the same lambda as both the gesture and the
+        // accessibility action, so invoking the action exercises the real wiring — but deterministically,
+        // without depending on the long-press timeout elapsing against the test's virtual frame clock
+        // (that timing was racy on the CI emulator: the hold sometimes registered as a plain tap, so the
+        // menu never opened). onLongClickLabel disambiguates the row's schedule action from the ETA
+        // pill's own trip-actions long press.
+        val scheduleLabel = context.getString(R.string.bus_options_menu_show_route_schedule)
+        composeRule.onNode(
+            SemanticsMatcher("has long-press action labeled \"$scheduleLabel\"") { node ->
+                node.config.getOrNull(SemanticsActions.OnLongClick)?.label == scheduleLabel
+            }
+        ).performSemanticsAction(SemanticsActions.OnLongClick)
 
         // The centered menu opens in a Dialog (a separate window); on slower devices (e.g. the CI
         // emulator) the main composition can report idle a frame before that window is laid out, so
-        // wait for the schedule item to appear before clicking it rather than asserting immediately.
-        val scheduleLabel = context.getString(R.string.bus_options_menu_show_route_schedule)
+        // wait for the schedule item to appear before acting on it rather than asserting immediately.
         composeRule.waitUntil(timeoutMillis = 5_000) {
             composeRule.onAllNodesWithText(scheduleLabel).fetchSemanticsNodes().isNotEmpty()
         }

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/arrivals/RouteArrivalRowLongPressTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/arrivals/RouteArrivalRowLongPressTest.kt
@@ -16,10 +16,10 @@
 package org.onebusaway.android.ui.arrivals
 
 import androidx.compose.ui.test.assertCountEquals
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.longClick
 import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTouchInput
@@ -34,6 +34,7 @@ import org.onebusaway.android.ui.arrivals.components.previewArrival
 
 class RouteArrivalRowLongPressTest {
 
+    // See EtaStripJustifyTest for why the v1 (Unconfined) rule is used here (issue #1792).
     @Suppress("DEPRECATION")
     @get:Rule
     val composeRule = createComposeRule()
@@ -79,9 +80,15 @@ class RouteArrivalRowLongPressTest {
         ).assertCountEquals(0)
 
         composeRule.onNodeWithText("Northgate").performTouchInput { longClick() }
-        composeRule.onNodeWithText(
-            context.getString(R.string.bus_options_menu_show_route_schedule)
-        ).assertIsDisplayed().performClick()
+
+        // The centered menu opens in a Dialog (a separate window); on slower devices (e.g. the CI
+        // emulator) the main composition can report idle a frame before that window is laid out, so
+        // wait for the schedule item to appear before clicking it rather than asserting immediately.
+        val scheduleLabel = context.getString(R.string.bus_options_menu_show_route_schedule)
+        composeRule.waitUntil(timeoutMillis = 5_000) {
+            composeRule.onAllNodesWithText(scheduleLabel).fetchSemanticsNodes().isNotEmpty()
+        }
+        composeRule.onNodeWithText(scheduleLabel).performClick()
 
         assertEquals(scheduleUrl, openedScheduleUrl)
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
@@ -17,6 +17,7 @@ package org.onebusaway.android.ui.arrivals.components
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -245,8 +246,7 @@ internal fun ArrivalRowContent(
  * - The top-left corner star toggles the route favorite ([ArrivalRowCallbacks.onRouteFavorite]).
  * - The badge section's top-right corner (by the divider) shows a service-alert warning glyph when
  *   any trip in the group is affected by an active alert; tapping it opens that alert ([ArrivalRowCallbacks.onShowAlert]).
- * - The top-right overflow ⋮ opens the route-level menu (schedule), shown only when the route has a
- *   schedule URL.
+ * - Long-pressing the row body opens the route-level menu (schedule) when the route has a schedule URL.
  *
  * [actionsFor] resolves each trip's [ArrivalActions] (keyed by trip id upstream); the representative
  * trip's actions drive the badge color and the route menu. [etaAnchor] is attached to the first pill
@@ -273,6 +273,10 @@ fun RouteArrivalRow(
     val direction = group.headsign?.takeIf { it.isNotBlank() } ?: routeActions?.routeLongName.orEmpty()
     val onAlertClick = alertClick(group, actionsFor, callbacks)
     val selectionColor = mapRouteColor ?: routeActions?.routeColor
+    val scheduleUrl = routeActions?.scheduleUrl?.takeIf { it.isNotBlank() }
+    val scheduleActionLabel = if (scheduleUrl != null) {
+        stringResource(R.string.bus_options_menu_show_route_schedule)
+    } else null
     val displayedRouteNames = selectedRouteNames.takeIf { selected }.orEmpty()
     val compoundBadge = displayedRouteNames.size > 1
     val selectionBorder = selectionColor
@@ -285,10 +289,13 @@ fun RouteArrivalRow(
                     .fillMaxWidth()
                     // Give the row a definite height (its tallest child) so the divider can fill it.
                     .height(IntrinsicSize.Min)
-                    // Tapping the row body frames the whole route on the map (the pills below focus
-                    // individual trips instead).
-                    .clickable { callbacks.onShowVehiclesOnMap(representative) }
-                    // A little top/end room so the badge and pills clear the overlaid overflow icon.
+                    // Tap frames the whole route; long press opens its schedule menu. The ETA pills
+                    // remain independent children with their own trip-specific tap/long-press actions.
+                    .combinedClickable(
+                        onClick = { callbacks.onShowVehiclesOnMap(representative) },
+                        onLongClickLabel = scheduleActionLabel,
+                        onLongClick = if (scheduleUrl != null) ({ menuExpanded = true }) else null,
+                    )
                     .padding(
                         start = 10.dp,
                         top = ROW_VERTICAL_PADDING,
@@ -339,11 +346,7 @@ fun RouteArrivalRow(
                 Spacer(Modifier.width(10.dp))
                 Column(Modifier.weight(1f)) {
                     if (direction.isNotBlank()) {
-                        // Only the header needs its own clearance from the overlaid overflow icon
-                        // (it sits right under it); the ETA strip below reaches the row's true end —
-                        // its own trailing chevron gutter already reserves that room, and the pills
-                        // sit low enough in the row to clear the icon vertically.
-                        DirectionHeadsign(direction, modifier = Modifier.padding(end = OVERFLOW_ICON_CLEARANCE))
+                        DirectionHeadsign(direction)
                         Spacer(Modifier.height(6.dp))
                     }
                     EtaStrip(
@@ -386,17 +389,10 @@ fun RouteArrivalRow(
                     )
                 }
             }
-            // The route-level overflow menu now offers only "show route schedule", so it appears only
-            // when the route has a schedule URL — no empty menu.
-            val scheduleUrl = routeActions?.scheduleUrl?.takeIf { it.isNotBlank() }
+            // Keep a top-end popup anchor without drawing or reserving an overflow button. The route
+            // body long press above owns the interaction; routes without a schedule expose no menu.
             if (scheduleUrl != null) {
-                Box(Modifier.align(Alignment.TopEnd)) {
-                    CornerIcon(
-                        iconRes = R.drawable.more_vert,
-                        contentDescription = stringResource(R.string.stop_info_item_options_title),
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                        onClick = { menuExpanded = true }
-                    )
+                Box(Modifier.align(Alignment.TopEnd).size(CORNER_ICON_HITBOX_SIZE)) {
                     RouteActionsMenu(
                         expanded = menuExpanded,
                         onDismiss = { menuExpanded = false },
@@ -424,11 +420,6 @@ internal fun alertClick(
 ): (() -> Unit)? =
     group.activeAlertSituationId(actionsFor)?.let { id -> { callbacks.onShowAlert(id) } }
 
-/** Horizontal clearance [RouteArrivalRow] gives the direction header so it doesn't run under the
- *  overlaid corner icon below ([CornerIcon]'s own footprint is 18dp + 4dp padding on each side —
- *  this is a bit tighter, tuned by eye against a device screenshot rather than derived from it). */
-private val OVERFLOW_ICON_CLEARANCE = 20.dp
-
 /** The arrival row's top/bottom padding. The corner alert glyph offsets up by this amount to cancel
  *  it, so its top lines up with the favorite star (which floats above this padding at the card top);
  *  keep the two in sync via this single value rather than a bare literal on each side. */
@@ -436,7 +427,7 @@ private val ROW_VERTICAL_PADDING = 8.dp
 
 private val CORNER_ICON_HITBOX_SIZE = 26.dp
 
-/** A small fixed tap target tucked into a card corner — the legacy star / overflow / close icons. */
+/** A small fixed tap target tucked into a card corner — currently the selected-route close icon. */
 @Composable
 private fun CornerIcon(
     iconRes: Int,
@@ -458,9 +449,9 @@ private fun CornerIcon(
     )
 }
 
-/** The route-level overflow menu (the row's ⋮): open the route's schedule. The route's star lives as
- *  the row's own corner toggle ([FavoriteStarButton]); per-trip actions live on each pill's long-press
- *  menu ([TripActionsMenu]). Shown only when the route has a [scheduleUrl]. */
+/** The route-level long-press menu: open the route's schedule. The route's star lives as the row's own
+ *  corner toggle ([FavoriteStarButton]); per-trip actions live on each pill's long-press menu
+ *  ([TripActionsMenu]). Shown only when the route has a [scheduleUrl]. */
 @Composable
 internal fun RouteActionsMenu(
     expanded: Boolean,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
@@ -32,7 +32,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -49,6 +48,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
@@ -71,11 +71,13 @@ import org.onebusaway.android.models.Status
 import org.onebusaway.android.time.ServerTime
 import org.onebusaway.android.ui.arrivals.ArrivalActions
 import org.onebusaway.android.ui.arrivals.ArrivalInfo
+import org.onebusaway.android.ui.arrivals.RouteRowGroup
+import org.onebusaway.android.ui.compose.components.CenteredLongPressMenu
 import org.onebusaway.android.ui.compose.components.DirectionHeadsign
 import org.onebusaway.android.ui.compose.components.FavoriteStarButton
 import org.onebusaway.android.ui.compose.components.LineBadge
+import org.onebusaway.android.ui.compose.components.MaterialSymbols
 import org.onebusaway.android.ui.compose.components.rememberRouteBadgeColors
-import org.onebusaway.android.ui.arrivals.RouteRowGroup
 import org.onebusaway.android.ui.compose.theme.ObaTheme
 import org.onebusaway.android.util.DisplayFormat
 
@@ -389,17 +391,13 @@ fun RouteArrivalRow(
                     )
                 }
             }
-            // Keep a top-end popup anchor without drawing or reserving an overflow button. The route
-            // body long press above owns the interaction; routes without a schedule expose no menu.
             if (scheduleUrl != null) {
-                Box(Modifier.align(Alignment.TopEnd).size(CORNER_ICON_HITBOX_SIZE)) {
-                    RouteActionsMenu(
-                        expanded = menuExpanded,
-                        onDismiss = { menuExpanded = false },
-                        scheduleUrl = scheduleUrl,
-                        callbacks = callbacks,
-                    )
-                }
+                RouteActionsMenu(
+                    expanded = menuExpanded,
+                    onDismiss = { menuExpanded = false },
+                    scheduleUrl = scheduleUrl,
+                    callbacks = callbacks,
+                )
             }
         }
     }
@@ -459,17 +457,21 @@ internal fun RouteActionsMenu(
     scheduleUrl: String,
     callbacks: ArrivalRowCallbacks
 ) {
-    DropdownMenu(expanded = expanded, onDismissRequest = onDismiss) {
-        MenuRow(R.string.bus_options_menu_show_route_schedule) {
+    CenteredLongPressMenu(expanded = expanded, onDismissRequest = onDismiss) {
+        MenuRow(R.string.bus_options_menu_show_route_schedule, MaterialSymbols.Schedule) {
             onDismiss(); callbacks.onShowRouteSchedule(scheduleUrl)
         }
     }
 }
 
-/** A dropdown item that just shows a string resource; shared by the per-arrival and overflow menus. */
+/** A labelled menu item with an optional decorative leading [icon]. */
 @Composable
-internal fun MenuRow(textRes: Int, onClick: () -> Unit) {
-    DropdownMenuItem(text = { Text(stringResource(textRes)) }, onClick = onClick)
+internal fun MenuRow(textRes: Int, icon: ImageVector? = null, onClick: () -> Unit) {
+    DropdownMenuItem(
+        text = { Text(stringResource(textRes)) },
+        onClick = onClick,
+        leadingIcon = icon?.let { { Icon(imageVector = it, contentDescription = null) } },
+    )
 }
 
 private val PillShape = RoundedCornerShape(6.dp)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStrip.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStrip.kt
@@ -31,7 +31,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
@@ -74,6 +73,8 @@ import org.onebusaway.android.time.ServerTime
 import org.onebusaway.android.time.rememberLiveServerTime
 import org.onebusaway.android.ui.arrivals.ArrivalActions
 import org.onebusaway.android.ui.arrivals.ArrivalInfo
+import org.onebusaway.android.ui.compose.components.CenteredLongPressMenu
+import org.onebusaway.android.ui.compose.components.MaterialSymbols
 import org.onebusaway.android.ui.compose.components.SlideBox
 import org.onebusaway.android.ui.compose.theme.ObaTheme
 import org.onebusaway.android.util.DisplayFormat
@@ -313,7 +314,7 @@ private fun EtaPillWithMenu(
 }
 
 /** The per-trip menu opened by long-pressing a pill: trip details, a reminder, or a problem report
- *  for that specific trip. Route-wide actions live on the row's ⋮ menu ([RouteActionsMenu]). */
+ *  for that specific trip. Route-wide actions live on the row's long-press menu ([RouteActionsMenu]). */
 @Composable
 internal fun TripActionsMenu(
     expanded: Boolean,
@@ -322,15 +323,15 @@ internal fun TripActionsMenu(
     actions: ArrivalActions?,
     callbacks: ArrivalRowCallbacks
 ) {
-    DropdownMenu(expanded = expanded, onDismissRequest = onDismiss) {
-        MenuRow(R.string.bus_options_menu_show_trip_details) {
+    CenteredLongPressMenu(expanded = expanded, onDismissRequest = onDismiss) {
+        MenuRow(R.string.bus_options_menu_show_trip_details, MaterialSymbols.TripStatus) {
             onDismiss(); callbacks.onShowTripStatus(arrival)
         }
-        MenuRow(R.string.bus_options_menu_set_reminder) {
+        MenuRow(R.string.bus_options_menu_set_reminder, MaterialSymbols.AddReminder) {
             onDismiss(); callbacks.onSetReminder(arrival)
         }
         if (actions != null) {
-            MenuRow(R.string.bus_options_menu_report_trip_problem) {
+            MenuRow(R.string.bus_options_menu_report_trip_problem, MaterialSymbols.Report) {
                 onDismiss(); callbacks.onReportArrivalProblem(actions)
             }
         }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/CenteredLongPressMenu.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/CenteredLongPressMenu.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.compose.components
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+
+/**
+ * A secondary-action menu opened by long press. A dialog supplies one consistent screen-centered
+ * position regardless of which row or horizontally scrolled ETA pill launched it; the content stays
+ * ordinary Material [androidx.compose.material3.DropdownMenuItem] rows.
+ */
+@Composable
+internal fun CenteredLongPressMenu(
+    expanded: Boolean,
+    onDismissRequest: () -> Unit,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    if (!expanded) return
+    Dialog(onDismissRequest = onDismissRequest) {
+        Surface(
+            modifier = Modifier.widthIn(min = 196.dp, max = 320.dp),
+            shape = MaterialTheme.shapes.large,
+            color = MaterialTheme.colorScheme.surfaceContainer,
+            border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
+            tonalElevation = 3.dp,
+            shadowElevation = 8.dp,
+        ) {
+            Column(Modifier.padding(vertical = 8.dp), content = content)
+        }
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/MaterialSymbols.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/MaterialSymbols.kt
@@ -1,0 +1,237 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.compose.components
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.PathBuilder
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+
+/** Material Symbols used by secondary-action menus, generated at 24dp with outlined styling. */
+internal object MaterialSymbols {
+    val Schedule: ImageVector by lazy {
+        symbol("schedule") {
+            moveTo(15.3f, 16.7f)
+            lineToRelative(1.4f, -1.4f)
+            lineTo(13f, 11.6f)
+            verticalLineTo(7f)
+            horizontalLineTo(11f)
+            verticalLineToRelative(5.4f)
+            lineToRelative(4.3f, 4.3f)
+            close()
+            moveTo(12f, 22f)
+            quadTo(9.93f, 22f, 8.1f, 21.21f)
+            quadTo(6.28f, 20.43f, 4.93f, 19.08f)
+            quadTo(3.58f, 17.73f, 2.79f, 15.9f)
+            reflectiveQuadTo(2f, 12f)
+            quadTo(2f, 9.92f, 2.79f, 8.1f)
+            quadTo(3.58f, 6.27f, 4.93f, 4.93f)
+            quadTo(6.28f, 3.57f, 8.1f, 2.79f)
+            quadTo(9.93f, 2f, 12f, 2f)
+            reflectiveQuadToRelative(3.9f, 0.79f)
+            reflectiveQuadToRelative(3.17f, 2.14f)
+            quadToRelative(1.35f, 1.35f, 2.14f, 3.17f)
+            quadTo(22f, 9.92f, 22f, 12f)
+            reflectiveQuadToRelative(-0.79f, 3.9f)
+            reflectiveQuadToRelative(-2.14f, 3.17f)
+            quadToRelative(-1.35f, 1.35f, -3.17f, 2.14f)
+            reflectiveQuadTo(12f, 22f)
+            close()
+            moveTo(12f, 12f)
+            close()
+            moveToRelative(0f, 8f)
+            quadToRelative(3.33f, 0f, 5.66f, -2.34f)
+            reflectiveQuadTo(20f, 12f)
+            quadTo(20f, 8.67f, 17.66f, 6.34f)
+            reflectiveQuadTo(12f, 4f)
+            quadTo(8.68f, 4f, 6.34f, 6.34f)
+            reflectiveQuadTo(4f, 12f)
+            reflectiveQuadToRelative(2.34f, 5.66f)
+            reflectiveQuadTo(12f, 20f)
+            close()
+        }
+    }
+
+    val TripStatus: ImageVector by lazy {
+        symbol("list") {
+            moveTo(7f, 9f)
+            verticalLineTo(7f)
+            horizontalLineTo(21f)
+            verticalLineTo(9f)
+            horizontalLineTo(7f)
+            close()
+            moveToRelative(0f, 4f)
+            verticalLineTo(11f)
+            horizontalLineTo(21f)
+            verticalLineToRelative(2f)
+            horizontalLineTo(7f)
+            close()
+            moveToRelative(0f, 4f)
+            verticalLineTo(15f)
+            horizontalLineTo(21f)
+            verticalLineToRelative(2f)
+            horizontalLineTo(7f)
+            close()
+            moveTo(4f, 9f)
+            quadTo(3.58f, 9f, 3.29f, 8.71f)
+            reflectiveQuadTo(3f, 8f)
+            quadTo(3f, 7.57f, 3.29f, 7.29f)
+            reflectiveQuadTo(4f, 7f)
+            reflectiveQuadTo(4.71f, 7.29f)
+            reflectiveQuadTo(5f, 8f)
+            quadTo(5f, 8.42f, 4.71f, 8.71f)
+            reflectiveQuadTo(4f, 9f)
+            close()
+            moveToRelative(0f, 4f)
+            quadTo(3.58f, 13f, 3.29f, 12.71f)
+            quadTo(3f, 12.43f, 3f, 12f)
+            reflectiveQuadTo(3.29f, 11.29f)
+            reflectiveQuadTo(4f, 11f)
+            reflectiveQuadToRelative(0.71f, 0.29f)
+            reflectiveQuadTo(5f, 12f)
+            reflectiveQuadTo(4.71f, 12.71f)
+            reflectiveQuadTo(4f, 13f)
+            close()
+            moveToRelative(0f, 4f)
+            quadTo(3.58f, 17f, 3.29f, 16.71f)
+            quadTo(3f, 16.43f, 3f, 16f)
+            reflectiveQuadTo(3.29f, 15.29f)
+            reflectiveQuadTo(4f, 15f)
+            reflectiveQuadToRelative(0.71f, 0.29f)
+            reflectiveQuadTo(5f, 16f)
+            reflectiveQuadTo(4.71f, 16.71f)
+            reflectiveQuadTo(4f, 17f)
+            close()
+        }
+    }
+
+    val AddReminder: ImageVector by lazy {
+        symbol("add_alert") {
+            moveTo(11f, 15f)
+            horizontalLineToRelative(2f)
+            verticalLineTo(13f)
+            horizontalLineToRelative(2f)
+            verticalLineTo(11f)
+            horizontalLineTo(13f)
+            verticalLineTo(9f)
+            horizontalLineTo(11f)
+            verticalLineToRelative(2f)
+            horizontalLineTo(9f)
+            verticalLineToRelative(2f)
+            horizontalLineToRelative(2f)
+            verticalLineToRelative(2f)
+            close()
+            moveTo(4f, 19f)
+            verticalLineTo(17f)
+            horizontalLineTo(6f)
+            verticalLineTo(10f)
+            quadTo(6f, 7.93f, 7.25f, 6.31f)
+            reflectiveQuadTo(10.5f, 4.2f)
+            verticalLineTo(3.5f)
+            quadToRelative(0f, -0.63f, 0.44f, -1.06f)
+            reflectiveQuadTo(12f, 2f)
+            reflectiveQuadToRelative(1.06f, 0.44f)
+            reflectiveQuadTo(13.5f, 3.5f)
+            verticalLineTo(4.2f)
+            quadToRelative(2f, 0.5f, 3.25f, 2.11f)
+            reflectiveQuadTo(18f, 10f)
+            verticalLineToRelative(7f)
+            horizontalLineToRelative(2f)
+            verticalLineToRelative(2f)
+            horizontalLineTo(4f)
+            close()
+            moveToRelative(8f, -7.5f)
+            close()
+            moveTo(12f, 22f)
+            quadToRelative(-0.82f, 0f, -1.41f, -0.59f)
+            reflectiveQuadTo(10f, 20f)
+            horizontalLineToRelative(4f)
+            quadToRelative(0f, 0.82f, -0.59f, 1.41f)
+            reflectiveQuadTo(12f, 22f)
+            close()
+            moveTo(8f, 17f)
+            horizontalLineToRelative(8f)
+            verticalLineTo(10f)
+            quadTo(16f, 8.35f, 14.83f, 7.18f)
+            reflectiveQuadTo(12f, 6f)
+            reflectiveQuadTo(9.18f, 7.18f)
+            reflectiveQuadTo(8f, 10f)
+            verticalLineToRelative(7f)
+            close()
+        }
+    }
+
+    val Report: ImageVector by lazy {
+        symbol("report") {
+            moveTo(12f, 17f)
+            quadToRelative(0.43f, 0f, 0.71f, -0.29f)
+            quadTo(13f, 16.43f, 13f, 16f)
+            reflectiveQuadTo(12.71f, 15.29f)
+            reflectiveQuadTo(12f, 15f)
+            reflectiveQuadToRelative(-0.71f, 0.29f)
+            reflectiveQuadTo(11f, 16f)
+            reflectiveQuadToRelative(0.29f, 0.71f)
+            reflectiveQuadTo(12f, 17f)
+            close()
+            moveTo(11f, 13f)
+            horizontalLineToRelative(2f)
+            verticalLineTo(7f)
+            horizontalLineTo(11f)
+            verticalLineToRelative(6f)
+            close()
+            moveTo(8.25f, 21f)
+            lineTo(3f, 15.75f)
+            verticalLineTo(8.25f)
+            lineTo(8.25f, 3f)
+            horizontalLineToRelative(7.5f)
+            lineTo(21f, 8.25f)
+            verticalLineToRelative(7.5f)
+            lineTo(15.75f, 21f)
+            horizontalLineTo(8.25f)
+            close()
+            moveTo(9.1f, 19f)
+            horizontalLineToRelative(5.8f)
+            lineTo(19f, 14.9f)
+            verticalLineTo(9.1f)
+            lineTo(14.9f, 5f)
+            horizontalLineTo(9.1f)
+            lineTo(5f, 9.1f)
+            verticalLineToRelative(5.8f)
+            lineTo(9.1f, 19f)
+            close()
+            moveTo(12f, 12f)
+            close()
+        }
+    }
+}
+
+private fun symbol(name: String, pathData: PathBuilder.() -> Unit): ImageVector =
+    ImageVector.Builder(
+        name = name,
+        defaultWidth = 24.dp,
+        defaultHeight = 24.dp,
+        viewportWidth = 24f,
+        viewportHeight = 24f,
+    ).apply {
+        path(
+            fill = SolidColor(Color.Black),
+            pathFillType = PathFillType.NonZero,
+            pathBuilder = pathData,
+        )
+    }.build()

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/mylists/MyListScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/mylists/MyListScreen.kt
@@ -33,7 +33,6 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -57,6 +56,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.onebusaway.android.R
 import org.onebusaway.android.ui.compose.ListUiState
+import org.onebusaway.android.ui.compose.components.CenteredLongPressMenu
 import org.onebusaway.android.ui.compose.components.LineBadge
 import org.onebusaway.android.ui.compose.components.LoadingContent
 import org.onebusaway.android.ui.compose.theme.ObaTheme
@@ -278,10 +278,10 @@ private fun FavoriteStarSlot(favorite: Boolean) {
     }
 }
 
-/** The dropdown of [actions], shared by the stop and route long-press menus. */
+/** The centered list of [actions], shared by the stop, route, and reminder long-press menus. */
 @Composable
 private fun RowActionsMenu(expanded: Boolean, actions: List<RowAction>, onDismiss: () -> Unit) {
-    DropdownMenu(expanded = expanded, onDismissRequest = onDismiss) {
+    CenteredLongPressMenu(expanded = expanded, onDismissRequest = onDismiss) {
         actions.forEach { action ->
             DropdownMenuItem(
                 text = { Text(action.label) },

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/routeinfo/RouteInfoScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/routeinfo/RouteInfoScreen.kt
@@ -33,7 +33,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.KeyboardArrowUp
-import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
@@ -58,6 +57,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import org.onebusaway.android.R
+import org.onebusaway.android.ui.compose.components.CenteredLongPressMenu
 import org.onebusaway.android.ui.compose.components.LineBadge
 import org.onebusaway.android.ui.compose.components.LoadingContent
 import org.onebusaway.android.ui.compose.components.MenuHeader
@@ -275,7 +275,10 @@ private fun StopRow(
                 )
                 .padding(start = 32.dp, end = 16.dp, top = 12.dp, bottom = 12.dp)
         )
-        DropdownMenu(expanded = menuExpanded, onDismissRequest = { menuExpanded = false }) {
+        CenteredLongPressMenu(
+            expanded = menuExpanded,
+            onDismissRequest = { menuExpanded = false },
+        ) {
             MenuHeader(stop.name)
             DropdownMenuItem(
                 text = { Text(stringResource(R.string.route_info_context_get_stop_info)) },

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/search/RouteSearchContent.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/search/RouteSearchContent.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -33,6 +32,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import org.onebusaway.android.R
+import org.onebusaway.android.ui.compose.components.CenteredLongPressMenu
 import org.onebusaway.android.ui.compose.components.MenuHeader
 import org.onebusaway.android.ui.compose.components.RouteRowContent
 
@@ -88,7 +88,10 @@ private fun RouteSearchRow(
                 )
                 .padding(horizontal = 16.dp, vertical = 12.dp)
         )
-        DropdownMenu(expanded = menuExpanded, onDismissRequest = { menuExpanded = false }) {
+        CenteredLongPressMenu(
+            expanded = menuExpanded,
+            onDismissRequest = { menuExpanded = false },
+        ) {
             MenuHeader(stringResource(R.string.route_name, route.shortName))
             DropdownMenuItem(
                 text = { Text(stringResource(R.string.my_context_get_route_info)) },

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/search/StopSearchContent.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/search/StopSearchContent.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -33,6 +32,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import org.onebusaway.android.R
+import org.onebusaway.android.ui.compose.components.CenteredLongPressMenu
 import org.onebusaway.android.ui.compose.components.MenuHeader
 import org.onebusaway.android.ui.compose.components.StopRowContent
 
@@ -82,7 +82,10 @@ private fun StopSearchRow(
                 )
                 .padding(horizontal = 16.dp, vertical = 12.dp)
         )
-        DropdownMenu(expanded = menuExpanded, onDismissRequest = { menuExpanded = false }) {
+        CenteredLongPressMenu(
+            expanded = menuExpanded,
+            onDismissRequest = { menuExpanded = false },
+        ) {
             MenuHeader(stop.name)
             DropdownMenuItem(
                 text = { Text(stringResource(R.string.my_context_get_stop_info)) },


### PR DESCRIPTION
## Summary

- remove the three-dot overflow button from arrivals route rows and open the route schedule action by long-pressing the row
- present row and ETA-pill long-press menus consistently in the center of the screen
- give the shared menu a theme-aware rounded surface, contrasting outline, elevation, and bounded width
- add the supplied outlined Material Symbols for schedule, trip status, reminders, and problem reports without pulling in the full extended-icons dependency
- keep toolbar overflow menus, form dropdowns, and direct long-press actions in their existing presentation

## Why

The route-level overflow contained only one secondary action, but its dedicated corner button added visual noise and reduced room for direction text. Once that action moved to long press, the existing anchor-based popup behavior also made otherwise equivalent context menus appear in different places depending on the row or horizontally scrolled ETA pill that launched them.

A single centered presentation makes these secondary actions predictable and keeps positioning, shape, border, width, and elevation isolated from screen-specific action logic.

## User impact

Tapping route rows and ETA pills retains its existing behavior. Long-pressing a schedule-capable route row or another menu-bearing row now opens a consistent centered menu. The arrivals actions have recognizable leading icons, and rows without an available secondary action do not expose an empty menu.

## Validation

- `./gradlew test :onebusaway-android:compileObaGoogleDebugKotlin :onebusaway-android:compileObaMaplibreDebugKotlin :onebusaway-android:compileObaGoogleDebugAndroidTestKotlin -PwarningsAsErrors=true`
- `./gradlew connectedObaGoogleDebugAndroidTest --no-build-cache -Pandroid.testInstrumentationRunnerArguments.class=org.onebusaway.android.ui.arrivals.RouteArrivalRowLongPressTest`
- focused interaction test passed on the USB-connected Pixel 7 Pro before the behavior-neutral simplification pass
- post-rebase range-diff confirms both commits are patch-identical to their pre-rebase versions

Based directly on `main` after #1865 landed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Long-press an arrival row to access the route schedule, replacing the previous overflow button.
  * Added centered long-press action menus across arrivals, trips, saved lists, route details, and search.
  * Added schedule/trip status/reminder/report icons for improved menu recognition.
* **Accessibility**
  * Added a descriptive long-press label when a route schedule is available.
* **Tests**
  * Added an instrumented UI test verifying the long-press schedule flow opens the expected schedule URL.
* **Bug Fixes**
  * Improved consistency and usability of contextual menus throughout the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->