### PR TITLE
Unify route focus rendering

### DIFF
--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
@@ -131,7 +131,7 @@ class GoogleMapRenderer(
     // making the common stop-only update an O(1) identity check; equal republished values are retained too.
     private val routePolylines = mutableListOf<Polyline>()
     private var renderedRoutePolylines: List<RoutePolyline> = emptyList()
-    private var renderedRouteWidthScale: Float? = null
+    private var renderedRouteWidths: List<Float> = emptyList()
 
     // The dynamic layer, tracked by identity so [renderDynamic] can move markers in place: route vehicles
     // keyed by active trip id, and the band's (interaction-free) polylines re-added each frame. The
@@ -244,7 +244,12 @@ class GoogleMapRenderer(
         clearStatic()
 
         stopMarkerLayer.render(snapshot.stops, snapshot.focusedStopId, snapshot.stopBand)
-        routeStopLayer.render(snapshot.stops, snapshot.focusedStopId, map.cameraPosition.zoom)
+        routeStopLayer.render(
+            snapshot.stops,
+            snapshot.focusedStopId,
+            snapshot.routeStopsScaleWithZoom,
+            map.cameraPosition.zoom,
+        )
 
         if (snapshot.bikeshareVisible) {
             val band = bikeZoomBand(map.cameraPosition.zoom)
@@ -298,26 +303,29 @@ class GoogleMapRenderer(
         if (renderedRoutePolylines === next || renderedRoutePolylines == next) return
 
         val previousNative = routePolylines.toList()
+        val previousWidths = renderedRouteWidths
         val reconciliation = reconcileEqualItems(renderedRoutePolylines, next)
         reconciliation.removedPreviousIndices.forEach { previousNative[it].remove() }
-        renderedRoutePolylines = next
-        val widthScale = routeLineWidthScale(map.cameraPosition.zoom)
-        // Retained natives carry the previously stamped scale; bring them to the new one before
-        // recording it, or a later onCameraSettled at this zoom would skip the resize they still need.
-        val retainedStale = renderedRouteWidthScale != widthScale
-        renderedRouteWidthScale = widthScale
+        val nextWidths = next.map { routeWidthPx(it, map.cameraPosition.zoom) }
         val reconciled = next.mapIndexed { index, polyline ->
-            reconciliation.previousIndexForNext[index]?.let(previousNative::get)
-                ?.also { if (retainedStale) it.width = widthPx(polyline) * widthScale }
-                ?: addRoutePolyline(polyline, widthScale)
+            val previousIndex = reconciliation.previousIndexForNext[index]
+            previousIndex?.let(previousNative::get)
+                ?.also {
+                    if (previousWidths.getOrNull(previousIndex) != nextWidths[index]) {
+                        it.width = nextWidths[index]
+                    }
+                }
+                ?: addRoutePolyline(polyline, nextWidths[index])
         }
+        renderedRoutePolylines = next
+        renderedRouteWidths = nextWidths
         routePolylines.clear()
         routePolylines.addAll(reconciled)
     }
 
-    private fun addRoutePolyline(polyline: RoutePolyline, widthScale: Float): Polyline {
+    private fun addRoutePolyline(polyline: RoutePolyline, widthPx: Float): Polyline {
         val options = PolylineOptions()
-            .width(widthPx(polyline) * widthScale)
+            .width(widthPx)
             .addPoints(polyline.points)
             .applyDashPattern(polyline)
         if (polyline.directional) {
@@ -345,7 +353,7 @@ class GoogleMapRenderer(
         val polyline = continuation.polyline
         val line = PolylineOptions()
             .color(polyline.resolvedColor)
-            .width(widthPx(polyline))
+            .width(routeWidthPx(polyline, map.cameraPosition.zoom))
             .addPoints(polyline.points)
             .applyDashPattern(polyline)
         staticPolylines.add(map.addPolyline(line))
@@ -390,9 +398,10 @@ class GoogleMapRenderer(
             ContinuationBadgeBitmaps.arrow(color)
         }
 
-    /** [RoutePolyline.widthDp] scaled to screen pixels, or the shared default when it carries none. */
-    private fun widthPx(polyline: RoutePolyline): Float =
-        polyline.widthDp?.let { it * density } ?: DEFAULT_ROUTE_WIDTH_PX
+    /** Resolve one line's complete width profile at [zoom]. */
+    private fun routeWidthPx(polyline: RoutePolyline, zoom: Float): Float = polyline.widthProfile
+        ?.let { it.thicknessAt(zoom) * density }
+        ?: (DEFAULT_ROUTE_WIDTH_PX * routeLineWidthScale(zoom))
 
     /** Appends [points] to the receiver, shared by every static polyline draw. */
     private fun PolylineOptions.addPoints(points: List<GeoPoint>): PolylineOptions {
@@ -421,7 +430,7 @@ class GoogleMapRenderer(
         routePolylines.forEach { it.remove() }
         routePolylines.clear()
         renderedRoutePolylines = emptyList()
-        renderedRouteWidthScale = null
+        renderedRouteWidths = emptyList()
 
         stopMarkerLayer.dispose()
 
@@ -769,13 +778,14 @@ class GoogleMapRenderer(
 
     fun onCameraSettled(zoom: Float) {
         routeStopLayer.onCameraSettled(zoom)
-        val detailScale = routeLineWidthScale(zoom)
-        if (detailScale != renderedRouteWidthScale) {
-            renderedRouteWidthScale = detailScale
+        val nextWidths = renderedRoutePolylines.map { routeWidthPx(it, zoom) }
+        if (nextWidths != renderedRouteWidths) {
+            renderedRouteWidths = nextWidths
             for (index in routePolylines.indices) {
-                routePolylines[index].width = widthPx(renderedRoutePolylines[index]) * detailScale
+                routePolylines[index].width = nextWidths[index]
             }
         }
+        val detailScale = routeLineWidthScale(zoom)
         updateVehicleScale(detailScale)
     }
 

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleRouteStopBitmapLayer.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleRouteStopBitmapLayer.kt
@@ -60,17 +60,28 @@ internal class GoogleRouteStopBitmapLayer(
     private val icons = HashMap<IconKey, BitmapDescriptor>()
     private var renderedStops: List<StopMarker> = emptyList()
     private var renderedFocusedStopId: String? = null
+    private var renderedScaleWithZoom = false
     private var renderedSizes: StampSizes? = null
 
-    override fun render(stops: List<StopMarker>, focusedStopId: String?, zoom: Float) {
+    override fun render(
+        stops: List<StopMarker>,
+        focusedStopId: String?,
+        scaleWithZoom: Boolean,
+        zoom: Float,
+    ) {
         val routeStops = stops.filter(StopMarker::routeStop)
-        if (routeStops == renderedStops && focusedStopId == renderedFocusedStopId) return
+        if (
+            routeStops == renderedStops &&
+            focusedStopId == renderedFocusedStopId &&
+            scaleWithZoom == renderedScaleWithZoom
+        ) return
         val previousFocusedStopId = renderedFocusedStopId
         val previousSizes = renderedSizes
         renderedStops = routeStops
         renderedFocusedStopId = focusedStopId
+        renderedScaleWithZoom = scaleWithZoom
 
-        val sizes = stampSizes(zoom, focusedStopId != null)
+        val sizes = stampSizes(zoom, scaleWithZoom)
         val liveIds = routeStops.mapTo(HashSet(), StopMarker::id)
         val gone = stopsById.iterator()
         while (gone.hasNext()) {
@@ -114,7 +125,7 @@ internal class GoogleRouteStopBitmapLayer(
     }
 
     override fun onCameraSettled(zoom: Float) {
-        val sizes = stampSizes(zoom, renderedFocusedStopId != null)
+        val sizes = stampSizes(zoom, renderedScaleWithZoom)
         if (sizes == renderedSizes) return
         renderedSizes = sizes
         stamp(sizes)
@@ -129,6 +140,7 @@ internal class GoogleRouteStopBitmapLayer(
         icons.clear()
         renderedStops = emptyList()
         renderedFocusedStopId = null
+        renderedScaleWithZoom = false
         renderedSizes = null
     }
 
@@ -159,19 +171,19 @@ internal class GoogleRouteStopBitmapLayer(
 
     private fun StampSizes.forSelection(selected: Boolean): Int = if (selected) this.selected else normal
 
-    private fun stampSizes(zoom: Float, stopFocused: Boolean): StampSizes = StampSizes(
-        normal = routeStopDiameterPx(zoom, stopFocused, selected = false, density),
-        selected = routeStopDiameterPx(zoom, stopFocused, selected = true, density),
+    private fun stampSizes(zoom: Float, scaleWithZoom: Boolean): StampSizes = StampSizes(
+        normal = routeStopDiameterPx(zoom, scaleWithZoom, selected = false, density),
+        selected = routeStopDiameterPx(zoom, scaleWithZoom, selected = true, density),
     )
 }
 
 internal fun routeStopDiameterPx(
     zoom: Float,
-    stopFocused: Boolean,
+    scaleWithZoom: Boolean,
     selected: Boolean,
     density: Float,
 ): Int {
-    val focusScale = if (stopFocused) focusedRouteStopScale(zoom) else 1f
+    val focusScale = if (scaleWithZoom) focusedRouteStopScale(zoom) else 1f
     val selectedScale = if (selected) RouteStopCircles.FOCUSED_SCALE else 1f
     return (2f * RouteStopCircles.RADIUS_PX * focusScale * selectedScale * density)
         .roundToInt()

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleRouteStopLayer.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleRouteStopLayer.kt
@@ -20,7 +20,7 @@ import org.onebusaway.android.map.render.StopMarker
 
 /** Renderer-independent boundary for interchangeable Google route-stop drawing strategies. */
 internal interface GoogleRouteStopLayer {
-    fun render(stops: List<StopMarker>, focusedStopId: String?, zoom: Float)
+    fun render(stops: List<StopMarker>, focusedStopId: String?, scaleWithZoom: Boolean, zoom: Float)
 
     fun onCameraMoveStarted() = Unit
 

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleComposeAdapter.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleComposeAdapter.kt
@@ -192,9 +192,10 @@ class GoogleComposeAdapter : ObaComposeMapAdapter {
         val activeRenderer = renderer
         val activeInfoWindows = infoWindows
         if (activeRenderer != null && activeInfoWindows != null) {
-            // Non-route static layer (stops / bikes / generics): strip route lines before distinctness
-            // so a route-only change never churns these annotations, and stop-only emissions cannot
-            // touch the independently collected native route layer below.
+            // Non-route static layer (stops / bikes / generics): strip route geometry before
+            // distinctness so geometry-only changes do not churn these annotations. The derived
+            // route-stop zoom-scale flag remains, allowing a route-focus change to restyle its stops;
+            // stop-only emissions still cannot touch the independently collected route layer below.
             LaunchedEffect(activeRenderer) {
                 renderState.snapshot
                     .map { it.copy(routePolylines = emptyList()) }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
@@ -51,6 +51,7 @@ import org.onebusaway.android.map.render.GeoPoint
 import org.onebusaway.android.map.render.MapRenderState
 import org.onebusaway.android.map.render.MapVehicles
 import org.onebusaway.android.map.render.ROUTE_LINE_WIDTH_DP
+import org.onebusaway.android.map.render.RouteLineWidthProfile
 import org.onebusaway.android.map.render.RouteContinuation
 import org.onebusaway.android.map.render.RoutePolyline
 import org.onebusaway.android.map.render.VehicleMarker
@@ -412,7 +413,7 @@ class RouteMapController(
             polyline = RoutePolyline(
                 color = lineColor,
                 points = listOf(anchor) + tail.map { it.toGeoPoint() },
-                widthDp = CONTINUATION_LINE_WIDTH_DP,
+                widthProfile = CONTINUATION_LINE_WIDTH_PROFILE,
                 dashed = true,
             ),
             arrow = ContinuationArrow(arrowPoint.toGeoPoint(), neighborShape.bearingAt(endSeg)),
@@ -569,7 +570,10 @@ class RouteMapController(
     private fun publishMapPresentation() {
         val focus = stopFocusSession
         if (focus == null) {
-            renderState.setRoutePolylines(basePolylines)
+            renderState.setRoutePolylines(
+                basePolylines,
+                routeModeScalesStopsWithZoom = isActive,
+            )
             renderState.setRouteBadges(emptyList())
             stopsController.setRoutePresentation(baseStopPresentation)
             return
@@ -586,6 +590,7 @@ class RouteMapController(
             // shape alone defines FramingIntent.Route. Using the displayed adjacency lines here would
             // fit the union of every route serving the focused stop.
             framingPolylines = if (isActive) basePolylines else emptyList(),
+            routeModeScalesStopsWithZoom = isActive,
         )
         renderState.setRouteBadges(
             if (emphasizedRoute == null) {
@@ -739,8 +744,8 @@ class RouteMapController(
      * Re-draw the route shape for [currentDirectionId]: the selected direction's own travel-ordered
      * shape (with direction arrows), or the whole-route merged shape drawn undirected when none is
      * selected. Passes the route's raw GTFS color through; the render layer picks the fallback when
-     * it's absent. Drawn at the shared [ROUTE_LINE_WIDTH_DP] so the overview map's route reads the same
-     * as the trip-focus map (#1752). Called on load and on every direction switch.
+     * it's absent. Uses [focusedRoutePolyline], the same complete line presentation as a route selected
+     * from focused-stop mode. Called on load and on every direction switch.
      */
     private fun showDirectionPolylines() {
         val route = routeShape ?: return
@@ -749,12 +754,10 @@ class RouteMapController(
         // merged fallback (a direction that carried no shape on the wire).
         val shape = route.shapeForDirection(currentDirectionId)
         basePolylines = shape.polylines.map { points ->
-            RoutePolyline(
-                route.route?.color,
-                points,
-                widthDp = ROUTE_LINE_WIDTH_DP,
+            focusedRoutePolyline(
+                color = route.route?.color,
+                points = points,
                 directional = shape.directional,
-                transforms = ROUTE_VIEW_TRANSFORMS,
             )
         }
         publishMapPresentation()
@@ -874,6 +877,10 @@ private const val CONTINUATION_LINE_LENGTH_METERS = 900.0
 // Drawn narrower than the shown route's own line ([ROUTE_LINE_WIDTH_DP]) so a continuation reads as a
 // preview/hint rather than as equally-weighted with the route the rider is actually looking at.
 private const val CONTINUATION_LINE_WIDTH_DP = ROUTE_LINE_WIDTH_DP * 0.7f
+private val CONTINUATION_LINE_WIDTH_PROFILE = RouteLineWidthProfile(
+    thicknessDp = CONTINUATION_LINE_WIDTH_DP,
+    distantThicknessMultiplier = 1f,
+)
 
 // Used only when the neighbor route carries no GTFS color to draw the continuation line in its own
 // color with.

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteViewGeometry.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteViewGeometry.kt
@@ -9,7 +9,10 @@ import org.onebusaway.android.map.layout.RouteBadgeLayoutInput
 import org.onebusaway.android.map.layout.RouteBadgePath
 import org.onebusaway.android.map.layout.layoutRouteBadges
 import org.onebusaway.android.map.render.DEFAULT_ROUTE_LINE_COLOR
-import org.onebusaway.android.map.render.ROUTE_LINE_WIDTH_DP
+import org.onebusaway.android.map.render.DEEMPHASIZED_ROUTE_LINE_WIDTH_PROFILE
+import org.onebusaway.android.map.render.FOCUSED_ROUTE_LINE_WIDTH_PROFILE
+import org.onebusaway.android.map.render.GeoPoint
+import org.onebusaway.android.map.render.ROUTE_LINE_WIDTH_PROFILE
 import org.onebusaway.android.map.render.RouteBadge
 import org.onebusaway.android.map.render.RoutePolyline
 import org.onebusaway.android.map.render.RoutePolylineTransform
@@ -23,8 +26,18 @@ internal val ROUTE_VIEW_TRANSFORMS = setOf(
     RoutePolylineTransform.ZOOM_SIMPLIFY,
 )
 
-internal const val ROUTE_DEEMPHASIZED_LINE_WIDTH_DP = ROUTE_LINE_WIDTH_DP * 0.275f
-internal const val ROUTE_EMPHASIZED_LINE_WIDTH_DP = ROUTE_LINE_WIDTH_DP * 1.5f
+/** The line presentation shared by single-route view and a selected route in focused-stop mode. */
+internal fun focusedRoutePolyline(
+    color: Int?,
+    points: List<GeoPoint>,
+    directional: Boolean,
+) = RoutePolyline(
+    color = color,
+    points = points,
+    widthProfile = FOCUSED_ROUTE_LINE_WIDTH_PROFILE,
+    directional = directional,
+    transforms = ROUTE_VIEW_TRANSFORMS,
+)
 
 /**
  * Convert exact trip shapes into uniform-width directional route lines. When [emphasizedRoute] is
@@ -43,20 +56,27 @@ internal fun FocusedTripGeometry.toRoutePolylines(
     orderedShapes.forEach { shape ->
         if (shape.points.size < 2) return@forEach
         val emphasized = emphasizedRoute == shape.routeDirection
-        val widthDp = when {
-            emphasizedRoute == null -> ROUTE_LINE_WIDTH_DP
-            emphasized -> ROUTE_EMPHASIZED_LINE_WIDTH_DP
-            else -> ROUTE_DEEMPHASIZED_LINE_WIDTH_DP
-        }
-        add(
+        val polyline = if (emphasized) {
+            focusedRoutePolyline(
+                routeColors[shape.routeDirection] ?: shape.routeColor,
+                shape.points,
+                directional = true,
+            )
+        } else {
+            val widthProfile = if (emphasizedRoute == null) {
+                ROUTE_LINE_WIDTH_PROFILE
+            } else {
+                DEEMPHASIZED_ROUTE_LINE_WIDTH_PROFILE
+            }
             RoutePolyline(
                 routeColors[shape.routeDirection] ?: shape.routeColor,
                 shape.points,
-                widthDp,
-                directional = emphasizedRoute == null || emphasized,
+                widthProfile,
+                directional = emphasizedRoute == null,
                 transforms = ROUTE_VIEW_TRANSFORMS,
             )
-        )
+        }
+        add(polyline)
     }
 }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/DetailZoomRamp.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/DetailZoomRamp.kt
@@ -22,14 +22,47 @@ const val DETAIL_RAMP_END_ZOOM = 16f
 /** Route-line scale: half width when zoomed out, full width at zoom 16 and above. */
 const val ROUTE_DETAIL_DISTANT_SCALE = 0.5f
 
-/** Route-line width policy; stop circles use the same machinery with their own endpoint scale. */
-fun routeDetailScale(zoom: Float): Float = detailZoomRamp(
-    zoom,
-    startZoom = DETAIL_RAMP_START_ZOOM,
-    endZoom = DETAIL_RAMP_END_ZOOM,
-    distantValue = ROUTE_DETAIL_DISTANT_SCALE,
-    closeValue = 1f,
+/** The ordinary route stroke thickness at the close end of the detail ramp. */
+const val ROUTE_LINE_WIDTH_DP = 10f
+
+/**
+ * A complete route-line width policy: its close-zoom [thicknessDp], the zoom interval over which it
+ * grows, and its distant-zoom multiplier. Keeping these together lets presentation modes share an
+ * exact policy instead of independently copying a base width and relying on renderer-global ramp
+ * constants.
+ */
+data class RouteLineWidthProfile(
+    val thicknessDp: Float,
+    val rampStartZoom: Float = DETAIL_RAMP_START_ZOOM,
+    val fullThicknessZoom: Float = DETAIL_RAMP_END_ZOOM,
+    val distantThicknessMultiplier: Float = ROUTE_DETAIL_DISTANT_SCALE,
+) {
+    fun multiplierAt(zoom: Float): Float = detailZoomRamp(
+        zoom,
+        startZoom = rampStartZoom,
+        endZoom = fullThicknessZoom,
+        distantValue = distantThicknessMultiplier,
+        closeValue = 1f,
+    )
+
+    fun thicknessAt(zoom: Float): Float = thicknessDp * multiplierAt(zoom)
+}
+
+/** Ordinary route presentation, before a route is selected from a focused stop. */
+val ROUTE_LINE_WIDTH_PROFILE = RouteLineWidthProfile(ROUTE_LINE_WIDTH_DP)
+
+/** Shared by single-route view and a route selected from focused-stop mode. */
+val FOCUSED_ROUTE_LINE_WIDTH_PROFILE = ROUTE_LINE_WIDTH_PROFILE.copy(
+    thicknessDp = ROUTE_LINE_WIDTH_DP * 1.5f,
 )
+
+/** Contextual sibling routes shown underneath a route selected from focused-stop mode. */
+val DEEMPHASIZED_ROUTE_LINE_WIDTH_PROFILE = ROUTE_LINE_WIDTH_PROFILE.copy(
+    thicknessDp = ROUTE_LINE_WIDTH_DP * 0.275f,
+)
+
+/** Route-line scale retained for unprofiled lines and vehicle markers. */
+fun routeLineWidthScale(zoom: Float): Float = ROUTE_LINE_WIDTH_PROFILE.multiplierAt(zoom)
 
 /** Linear interpolation machinery for zoom-dependent map-detail styling. */
 internal fun detailZoomRamp(

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
@@ -57,16 +57,6 @@ data class MapPadding(val topPx: Int = 0, val bottomPx: Int = 0)
 /** The route line color a renderer falls back to when a [RoutePolyline] carries no color of its own. */
 const val DEFAULT_ROUTE_LINE_COLOR: Int = 0xFF0000FF.toInt()
 
-/**
- * The width (dp) a route line draws at on the home map when a route is shown (#1752). Passed as
- * [RoutePolyline.widthDp]; lines that carry no width (a directions itinerary) keep the renderer's
- * thinner default.
- */
-const val ROUTE_LINE_WIDTH_DP: Float = 10f
-
-/** Route lines use the shared proportional route-detail scale. */
-fun routeLineWidthScale(zoom: Float): Float = routeDetailScale(zoom)
-
 /** Optional renderer-bound geometry transforms. Lines opt in explicitly; the default is pass-through. */
 enum class RoutePolylineTransform {
     VIEWPORT_CLIP,
@@ -77,7 +67,8 @@ enum class RoutePolylineTransform {
  * One route/itinerary polyline: an ordered list of points and an optional [color]. A null [color]
  * means "use the [DEFAULT_ROUTE_LINE_COLOR]" — choosing the fallback is a display decision, so producers
  * can pass a route's raw (possibly absent) GTFS color straight through and renderers draw [resolvedColor].
- * [widthDp] overrides the renderer's default line width when set (the trip-focus map draws a thicker line).
+ * [widthProfile] overrides the renderer's default line width when set, including its zoom-dependent
+ * multiplier schedule.
  *
  * [directional] asks the flavor renderer to stamp travel-direction arrows/chevrons along the line — set
  * it only when [points] are ordered in the direction of travel and that orientation is meaningful (a
@@ -97,7 +88,7 @@ enum class RoutePolylineTransform {
 data class RoutePolyline(
     val color: Int?,
     val points: List<GeoPoint>,
-    val widthDp: Float? = null,
+    val widthProfile: RouteLineWidthProfile? = null,
     val directional: Boolean = false,
     val dashed: Boolean = false,
     val transforms: Set<RoutePolylineTransform> = emptySet(),
@@ -224,6 +215,9 @@ data class MapRenderSnapshot(
     val bikeStations: List<BikeMarker> = emptyList(),
     val bikeshareVisible: Boolean = false,
     val stops: List<StopMarker> = emptyList(),
+    // True when route mode asks stop circles to follow the focused-route zoom ramp even without an
+    // individually focused stop.
+    val routeModeScalesStopsWithZoom: Boolean = false,
     // The currently focused stop id, couriered so the vehicle info-window's "more info" tap can deep
     // link into TripDetails scoped to that stop (the legacy VehicleOverlay.Controller hook).
     val focusedStopId: String? = null,
@@ -235,7 +229,11 @@ data class MapRenderSnapshot(
     // annotation like the fields above, so it rides the same renderStatic() redraw path rather than
     // the 20Hz vehicle-motion sampler.
     val routeContinuation: RouteContinuation? = null,
-)
+) {
+    /** Focused-stop adjacency and route focus use the same route-stop zoom scale. */
+    val routeStopsScaleWithZoom: Boolean
+        get() = routeModeScalesStopsWithZoom || focusedStopId != null
+}
 
 /**
  * The route-mode vehicle **set**: which vehicles exist and the [response] their icons/info-windows
@@ -386,9 +384,15 @@ class MapRenderState {
     fun setRoutePolylines(
         polylines: List<RoutePolyline>,
         framingPolylines: List<RoutePolyline> = polylines,
+        routeModeScalesStopsWithZoom: Boolean = false,
     ) {
         routeFramingPolylines = framingPolylines
-        _snapshot.update { it.copy(routePolylines = polylines) }
+        _snapshot.update {
+            it.copy(
+                routePolylines = polylines,
+                routeModeScalesStopsWithZoom = routeModeScalesStopsWithZoom,
+            )
+        }
     }
 
     fun clearRoutePolylines() = setRoutePolylines(emptyList())

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/StopZoomBand.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/StopZoomBand.kt
@@ -43,8 +43,9 @@ fun stopZoomBand(zoom: Float): StopBand =
     if (zoom < STOP_DOT_ZOOM_THRESHOLD) StopBand.DOT else StopBand.FULL
 
 /**
- * Stop-circle-specific detail scale applied only while a stop is focused. Ordinary single-route mode
- * stays 1x; interpolation machinery and zoom bounds remain shared with route-line width.
+ * Stop-circle-specific detail scale applied while a route is focused, whether through focused-stop
+ * adjacency or the single-route view. Interpolation machinery and zoom bounds remain shared with
+ * route-line width.
  */
 fun focusedRouteStopScale(zoom: Float): Float = detailZoomRamp(
     zoom,

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
@@ -107,7 +107,7 @@ class MapLibreRenderer(
     // making the common stop-only update an O(1) identity check; equal republished values are retained too.
     private val routePolylines = mutableListOf<Polyline>()
     private var renderedRoutePolylines: List<RoutePolyline> = emptyList()
-    private var renderedRouteWidthScale: Float? = null
+    private var renderedRouteWidths: List<Float> = emptyList()
 
     // The dynamic layer, tracked by identity so [renderDynamic] can move markers in place: route
     // vehicles keyed by active trip id, the trip-focus estimate markers keyed by role, and the band's
@@ -166,7 +166,11 @@ class MapLibreRenderer(
         bikeByMarker.clear()
 
         stopMarkerLayer.render(snapshot.stops, snapshot.focusedStopId, snapshot.stopBand)
-        routeStopCircleLayer.render(snapshot.stops, snapshot.focusedStopId)
+        routeStopCircleLayer.render(
+            snapshot.stops,
+            snapshot.focusedStopId,
+            snapshot.routeStopsScaleWithZoom,
+        )
 
         if (snapshot.bikeshareVisible) {
             val band = bikeZoomBand(map.cameraPosition.zoom.toFloat())
@@ -208,25 +212,28 @@ class MapLibreRenderer(
         if (renderedRoutePolylines === next || renderedRoutePolylines == next) return
 
         val previousNative = routePolylines.toList()
+        val previousWidths = renderedRouteWidths
         val reconciliation = reconcileEqualItems(renderedRoutePolylines, next)
         val removed = reconciliation.removedPreviousIndices.map(previousNative::get)
         if (removed.isNotEmpty()) map.removeAnnotations(removed)
-        renderedRoutePolylines = next
-        val widthScale = routeLineWidthScale(map.cameraPosition.zoom.toFloat())
-        // Retained natives carry the previously stamped scale; bring them to the new one before
-        // recording it, or a later onCameraSettled at this zoom would skip the resize they still need.
-        val retainedStale = renderedRouteWidthScale != widthScale
-        renderedRouteWidthScale = widthScale
+        val nextWidths = next.map { routeWidth(it, map.cameraPosition.zoom.toFloat()) }
         val reconciled = next.mapIndexed { index, polyline ->
-            reconciliation.previousIndexForNext[index]?.let(previousNative::get)
-                ?.also { if (retainedStale) it.width = baseRouteWidth(polyline) * widthScale }
+            val previousIndex = reconciliation.previousIndexForNext[index]
+            previousIndex?.let(previousNative::get)
+                ?.also {
+                    if (previousWidths.getOrNull(previousIndex) != nextWidths[index]) {
+                        it.width = nextWidths[index]
+                    }
+                }
                 ?: map.addPolyline(
                     PolylineOptions()
                         .color(polyline.resolvedColor)
-                        .width(baseRouteWidth(polyline) * widthScale)
+                        .width(nextWidths[index])
                         .addPoints(polyline.points)
                 )
         }
+        renderedRoutePolylines = next
+        renderedRouteWidths = nextWidths
         routePolylines.clear()
         routePolylines.addAll(reconciled)
     }
@@ -237,17 +244,19 @@ class MapLibreRenderer(
     }
 
     fun onCameraSettled(zoom: Float) {
-        val detailScale = routeLineWidthScale(zoom)
-        if (detailScale != renderedRouteWidthScale) {
-            renderedRouteWidthScale = detailScale
+        val nextWidths = renderedRoutePolylines.map { routeWidth(it, zoom) }
+        if (nextWidths != renderedRouteWidths) {
+            renderedRouteWidths = nextWidths
             for (index in routePolylines.indices) {
-                routePolylines[index].width = baseRouteWidth(renderedRoutePolylines[index]) * detailScale
+                routePolylines[index].width = nextWidths[index]
             }
         }
+        val detailScale = routeLineWidthScale(zoom)
         updateVehicleScale(detailScale)
     }
 
-    private fun baseRouteWidth(polyline: RoutePolyline): Float = polyline.widthDp ?: ROUTE_WIDTH_DP
+    private fun routeWidth(polyline: RoutePolyline, zoom: Float): Float =
+        polyline.widthProfile?.thicknessAt(zoom) ?: (ROUTE_WIDTH_DP * routeLineWidthScale(zoom))
 
     /**
      * Update the dynamic layer for one display frame: the route's live [vehicles] (null off route mode)
@@ -272,7 +281,7 @@ class MapLibreRenderer(
         staticAnnotations.clear()
         routePolylines.clear()
         renderedRoutePolylines = emptyList()
-        renderedRouteWidthScale = null
+        renderedRouteWidths = emptyList()
         vehicleMarkersByTripId.clear()
         tripMarkersByRole.clear()
         bandPolylines.clear()

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRouteStopCircleLayer.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRouteStopCircleLayer.kt
@@ -46,7 +46,8 @@ import org.onebusaway.android.map.render.StopMarker
 
 /**
  * Owns MapLibre's GPU route-stop circle source, style expressions, and rendered-feature tap lookup.
- * Zoom interpolation stays entirely in the style layer; renderer snapshots update only stop data/focus.
+ * Zoom interpolation stays entirely in the style layer; renderer snapshots update stop data, selection,
+ * and whether the focused-route scale is active.
  */
 internal class MapLibreRouteStopCircleLayer(
     private val map: MapLibreMap,
@@ -60,6 +61,7 @@ internal class MapLibreRouteStopCircleLayer(
     private var stopById: Map<String, StopMarker> = emptyMap()
     private var renderedStops: List<StopMarker> = emptyList()
     private var renderedFocusedStopId: String? = null
+    private var renderedScaleWithZoom = false
 
     init {
         val radius = radiusExpression()
@@ -94,14 +96,19 @@ internal class MapLibreRouteStopCircleLayer(
         )
     }
 
-    fun render(stops: List<StopMarker>, focusedStopId: String?) {
+    fun render(stops: List<StopMarker>, focusedStopId: String?, scaleWithZoom: Boolean) {
         val routeStops = stops.filter(StopMarker::routeStop)
-        if (routeStops == renderedStops && focusedStopId == renderedFocusedStopId) return
+        if (
+            routeStops == renderedStops &&
+            focusedStopId == renderedFocusedStopId &&
+            scaleWithZoom == renderedScaleWithZoom
+        ) return
         renderedStops = routeStops
         renderedFocusedStopId = focusedStopId
+        renderedScaleWithZoom = scaleWithZoom
         stopById = routeStops.associateBy(StopMarker::id)
 
-        val stopFocusMinScale = if (focusedStopId == null) 1f else STOP_FOCUS_ROUTE_MIN_SCALE
+        val stopFocusMinScale = if (scaleWithZoom) STOP_FOCUS_ROUTE_MIN_SCALE else 1f
         val features = routeStops.map { stop ->
             val selectedScale = if (stop.id == focusedStopId) RouteStopCircles.FOCUSED_SCALE else 1f
             Feature.fromGeometry(Point.fromLngLat(stop.point.longitude, stop.point.latitude)).apply {
@@ -137,6 +144,7 @@ internal class MapLibreRouteStopCircleLayer(
         stopById = emptyMap()
         renderedStops = emptyList()
         renderedFocusedStopId = null
+        renderedScaleWithZoom = false
     }
 
     private fun radiusExpression(): Expression = interpolate(

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreComposeAdapter.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreComposeAdapter.kt
@@ -190,9 +190,10 @@ class MapLibreComposeAdapter : ObaComposeMapAdapter {
         // Re-render the maplibre annotations, and enable the blue dot from the view model's permission flag.
         val activeRenderer = renderer
         if (activeRenderer != null) {
-            // Non-route static layer (stops / bikes / generics): strip route lines before distinctness
-            // so a route-only change never churns these annotations, and stop-only emissions cannot
-            // touch the independently collected native route layer below.
+            // Non-route static layer (stops / bikes / generics): strip route geometry before
+            // distinctness so geometry-only changes do not churn these annotations. The derived
+            // route-stop zoom-scale flag remains, allowing a route-focus change to restyle its stops;
+            // stop-only emissions still cannot touch the independently collected route layer below.
             LaunchedEffect(activeRenderer) {
                 renderState.snapshot
                     .map { it.copy(routePolylines = emptyList()) }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteViewGeometryTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteViewGeometryTest.kt
@@ -2,10 +2,13 @@
 package org.onebusaway.android.map
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.onebusaway.android.map.render.GeoPoint
-import org.onebusaway.android.map.render.ROUTE_LINE_WIDTH_DP
+import org.onebusaway.android.map.render.DEEMPHASIZED_ROUTE_LINE_WIDTH_PROFILE
+import org.onebusaway.android.map.render.FOCUSED_ROUTE_LINE_WIDTH_PROFILE
+import org.onebusaway.android.map.render.ROUTE_LINE_WIDTH_PROFILE
 import org.onebusaway.android.map.render.RoutePolylineTransform
 import org.onebusaway.android.map.render.haversineMeters
 import org.onebusaway.android.models.FocusedTrip
@@ -13,6 +16,17 @@ import org.onebusaway.android.models.ObaRoute
 import org.onebusaway.android.models.RouteDirectionKey
 
 class RouteViewGeometryTest {
+
+    @Test
+    fun `single route view and focused-stop route share the focused width profile`() {
+        val line = focusedRoutePolyline(
+            color = 1,
+            points = listOf(GeoPoint(0.0, 0.0), GeoPoint(0.0, 1.0)),
+            directional = true,
+        )
+
+        assertSame(FOCUSED_ROUTE_LINE_WIDTH_PROFILE, line.widthProfile)
+    }
 
     @Test
     fun `focused trip shape uses one uniform directional line`() {
@@ -27,7 +41,7 @@ class RouteViewGeometryTest {
 
         val lines = geometry.toRoutePolylines()
 
-        assertEquals(listOf(ROUTE_LINE_WIDTH_DP), lines.map { it.widthDp })
+        assertEquals(listOf(ROUTE_LINE_WIDTH_PROFILE), lines.map { it.widthProfile })
         assertEquals(
             listOf(GeoPoint(0.0, 0.0), GeoPoint(0.0, 1.0), GeoPoint(0.0, 2.0)),
             lines.single().points,
@@ -67,10 +81,10 @@ class RouteViewGeometryTest {
         assertEquals(listOf(20, 10), lines.map { it.color })
         assertEquals(
             listOf(
-                ROUTE_DEEMPHASIZED_LINE_WIDTH_DP,
-                ROUTE_LINE_WIDTH_DP * 1.5f,
+                DEEMPHASIZED_ROUTE_LINE_WIDTH_PROFILE,
+                FOCUSED_ROUTE_LINE_WIDTH_PROFILE,
             ),
-            lines.map { it.widthDp },
+            lines.map { it.widthProfile },
         )
         assertEquals(listOf(false, true), lines.map { it.directional })
     }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/render/MapRenderStateRouteStopScaleTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/render/MapRenderStateRouteStopScaleTest.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.map.render
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MapRenderStateRouteStopScaleTest {
+
+    @Test
+    fun `route mode and focused-stop adjacency share the route stop zoom scale`() {
+        val state = MapRenderState()
+        val route = RoutePolyline(
+            color = 1,
+            points = listOf(GeoPoint(0.0, 0.0), GeoPoint(1.0, 1.0)),
+        )
+
+        state.setRoutePolylines(listOf(route), routeModeScalesStopsWithZoom = true)
+        assertTrue(state.snapshot.value.routeStopsScaleWithZoom)
+
+        state.setRoutePolylines(listOf(route))
+        assertFalse(state.snapshot.value.routeStopsScaleWithZoom)
+
+        state.setFocusedStopId("stop")
+        assertTrue(state.snapshot.value.routeStopsScaleWithZoom)
+    }
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/render/RouteLineWidthProfileTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/render/RouteLineWidthProfileTest.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.map.render
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class RouteLineWidthProfileTest {
+
+    @Test
+    fun `route width ramps proportionally from half at zoom 11 to full at 16`() {
+        assertEquals(0.5f, routeLineWidthScale(10f), 0f)
+        assertEquals(0.5f, routeLineWidthScale(11f), 0f)
+        assertEquals(0.75f, routeLineWidthScale(13.5f), 0f)
+        assertEquals(1f, routeLineWidthScale(16f), 0f)
+        assertEquals(1f, routeLineWidthScale(20f), 0f)
+    }
+
+    @Test
+    fun `focused route profile owns thickness zoom stop and multiplier schedule`() {
+        assertEquals(15f, FOCUSED_ROUTE_LINE_WIDTH_PROFILE.thicknessDp, 0f)
+        assertEquals(11f, FOCUSED_ROUTE_LINE_WIDTH_PROFILE.rampStartZoom, 0f)
+        assertEquals(16f, FOCUSED_ROUTE_LINE_WIDTH_PROFILE.fullThicknessZoom, 0f)
+        assertEquals(0.5f, FOCUSED_ROUTE_LINE_WIDTH_PROFILE.multiplierAt(10f), 0f)
+        assertEquals(0.75f, FOCUSED_ROUTE_LINE_WIDTH_PROFILE.multiplierAt(13.5f), 0f)
+        assertEquals(1f, FOCUSED_ROUTE_LINE_WIDTH_PROFILE.multiplierAt(16f), 0f)
+        assertEquals(7.5f, FOCUSED_ROUTE_LINE_WIDTH_PROFILE.thicknessAt(10f), 0f)
+        assertEquals(11.25f, FOCUSED_ROUTE_LINE_WIDTH_PROFILE.thicknessAt(13.5f), 0f)
+        assertEquals(15f, FOCUSED_ROUTE_LINE_WIDTH_PROFILE.thicknessAt(16f), 0f)
+    }
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/render/RoutePolylineRenderPipelineTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/render/RoutePolylineRenderPipelineTest.kt
@@ -35,15 +35,6 @@ class RoutePolylineRenderPipelineTest {
     )
 
     @Test
-    fun `route width ramps proportionally from half at zoom 11 to full at 16`() {
-        assertEquals(0.5f, routeLineWidthScale(10f), 0f)
-        assertEquals(0.5f, routeLineWidthScale(11f), 0f)
-        assertEquals(0.75f, routeLineWidthScale(13.5f), 0f)
-        assertEquals(1f, routeLineWidthScale(16f), 0f)
-        assertEquals(1f, routeLineWidthScale(20f), 0f)
-    }
-
-    @Test
     fun `unmarked lines pass through with their list identity`() {
         val line = RoutePolyline(0xFF123456.toInt(), listOf(point(0.0, 0.0), point(0.0, 1.0)))
         val lines = listOf(line)
@@ -96,7 +87,7 @@ class RoutePolylineRenderPipelineTest {
         assertEquals(-3.0, result.points.first().longitude, 1e-8)
         assertEquals(3.0, result.points.last().longitude, 1e-8)
         assertEquals(line.color, result.color)
-        assertEquals(line.widthDp, result.widthDp)
+        assertEquals(line.widthProfile, result.widthProfile)
         assertEquals(line.transforms, result.transforms)
     }
 
@@ -163,7 +154,7 @@ class RoutePolylineRenderPipelineTest {
     private fun viewportLine(vararg points: GeoPoint) = RoutePolyline(
         color = 0xFF123456.toInt(),
         points = points.toList(),
-        widthDp = 10f,
+        widthProfile = ROUTE_LINE_WIDTH_PROFILE,
         transforms = setOf(
             RoutePolylineTransform.VIEWPORT_CLIP,
             RoutePolylineTransform.ZOOM_SIMPLIFY,


### PR DESCRIPTION
## Summary

- introduce reusable route-line width profiles that own thickness and zoom scaling
- render single-route view with the same focused profile used when selecting a route from stop mode
- apply the focused route-stop circle zoom ramp in route view across Google Maps and MapLibre
- keep per-polyline native widths reconciled correctly as zoom changes
- add focused tests for width profiles, route geometry, and route-stop scale state

## Why

Single-route view used a thinner base line and kept route-stop circles at full size while a route focused from stop mode used a thicker, zoom-scaled presentation. This made equivalent route-focus states look inconsistent.

The rendering policy is now explicit and shared, so the line thickness, zoom endpoint, multiplier schedule, and stop-circle behavior remain aligned between both entry points.

## Validation

- `./gradlew :onebusaway-android:testObaGoogleDebugUnitTest --tests org.onebusaway.android.map.RouteViewGeometryTest --tests org.onebusaway.android.map.render.RouteLineWidthProfileTest --tests org.onebusaway.android.map.render.MapRenderStateRouteStopScaleTest --tests org.onebusaway.android.map.render.StopZoomBandTest --tests org.onebusaway.android.map.render.RoutePolylineRenderPipelineTest`
- `./gradlew :onebusaway-android:compileObaMaplibreDebugKotlin`
- `git diff --check`
- installed and visually verified the Google debug build on a Pixel 7 Pro


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Route lines now resize smoothly based on map zoom level.
  * Focused routes appear more prominent, while alternate routes are visually de-emphasized.
  * Route continuation lines now follow the same zoom-aware sizing.
  * Stop markers and circles now scale consistently during route-focused views and zoom changes.

* **Bug Fixes**
  * Improved map rendering updates when zooming or changing route focus, reducing unnecessary visual refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
