### PR TITLE
Focus vehicles on exact trip geometry and stops

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
@@ -125,6 +125,12 @@ class RouteMapController(
     private var basePolylines: List<RoutePolyline> = emptyList()
     private var baseStopPresentation: RouteStopPresentation? = null
 
+    private data class SelectedTripPresentation(
+        val points: List<GeoPoint>,
+        val stopIds: List<String>,
+        val routeDirection: RouteDirectionKey,
+    )
+
     private data class StopFocusSession(
         val stopId: String,
         val trips: Set<FocusedTrip>,
@@ -174,8 +180,9 @@ class RouteMapController(
 
     private var vehicleJob: Job? = null
 
-    // Drives everything a tap-selected vehicle shows: the trip overlay (the uncertainty band +
-    // fast-estimate marker, [showSelectionOverlay]) and the route continuation (#1691, [showContinuation]).
+    // Drives everything a tap-selected vehicle shows: its exact shape + scheduled stops
+    // ([showSelectionPresentation]), the trip overlay (the uncertainty band + fast-estimate marker,
+    // [showSelectionOverlay]), and the route continuation (#1691, [showContinuation]).
     // A tap selects a vehicle (renderState.selectedVehicleTripId); collectLatest so a fast reselect
     // cancels an in-flight continuation resolution (a suspending network fetch) for the previous
     // selection instead of racing it — [showSelectionOverlay] has no suspension point, so it's unaffected
@@ -233,14 +240,15 @@ class RouteMapController(
         // route-id filter set is built once here, not per frame, since it's constant for this route;
         // directionState is read live since it's resolved only once the route loads.
         renderState.setVehiclesSampler { nowMs -> sampleVehicles(WallTime(nowMs)) }
-        // A tapped vehicle enters a focused state that shows its extrapolation band + fast-estimate
-        // marker, and resolves its route continuation (#1691); react to the selection state here (a tap
-        // sets it, a map/background tap clears it). Cancel any collector from a prior start() so a
+        // A tapped vehicle enters a focused state that shows its exact shape/stops, extrapolation band
+        // + fast-estimate marker, and route continuation (#1691); react to the selection state here (a
+        // tap sets it, a map/background tap clears it). Cancel any collector from a prior start() so a
         // re-entered session doesn't leak one that stop() can no longer reach.
         selectionJob?.cancel()
         selectionJob = scope.launch {
             renderState.selectedVehicleTripId.collectLatest { tripId ->
                 showSelectionOverlay(tripId)
+                showSelectionPresentation(tripId)
                 showContinuation(tripId)
             }
         }
@@ -357,6 +365,27 @@ class RouteMapController(
             extrapolationFromState(tripObservationRepository.lookupTripState(tripId), WallTime(nowMs), includeMarkers = false)
                 ?.toTripOverlay(bandColor)
         }
+    }
+
+    /** Replace the direction line + stops with the selected vehicle's exact trip presentation. */
+    private suspend fun showSelectionPresentation(tripId: String?) {
+        if (tripId != null) {
+            val state = tripObservationRepository.lookupTripState(tripId)
+            val shapeId = state?.shapeId ?: latestPoll?.response?.trip(tripId)?.shapeId
+            supervisorScope {
+                val shape = async {
+                    state?.polyline ?: shapeId?.let {
+                        tripObservationRepository.ensureShape(tripId, it)
+                    }
+                }
+                val schedule = async {
+                    state?.schedule ?: tripObservationRepository.ensureSchedule(tripId)
+                }
+                shape.await()
+                schedule.await()
+            }
+        }
+        publishMapPresentation()
     }
 
     /** The shown route's GTFS color (the band tint's basis), or the default when it carries none. */
@@ -568,10 +597,31 @@ class RouteMapController(
 
     private fun publishMapPresentation() {
         val focus = stopFocusSession
+        val selected = selectedTripPresentation()
+        val selectedTrip = selected?.points
+            ?.takeIf { it.size >= 2 }
+            ?.let { points ->
+                RoutePolyline(
+                    currentRouteColor(),
+                    points,
+                    widthDp = ROUTE_EMPHASIZED_LINE_WIDTH_DP,
+                    directional = true,
+                    transforms = ROUTE_VIEW_TRANSFORMS,
+                )
+            }
+        val selectedTripStops = selected?.let(::selectedTripStopPresentation)
+        val selectedRouteUnderlay = if (selectedTrip == null) {
+            emptyList()
+        } else basePolylines.asDeemphasizedRouteUnderlay()
         if (focus == null) {
-            renderState.setRoutePolylines(basePolylines)
+            renderState.setRoutePolylines(
+                polylines = if (selectedTrip == null) {
+                    basePolylines
+                } else selectedRouteUnderlay + selectedTrip,
+                framingPolylines = selectedTrip?.let(::listOf) ?: basePolylines,
+            )
             renderState.setRouteBadges(emptyList())
-            stopsController.setRoutePresentation(baseStopPresentation)
+            stopsController.setRoutePresentation(selectedTripStops ?: baseStopPresentation)
             return
         }
         val emphasizedRoute = routeId?.let { RouteDirectionKey(it, presentationDirectionId) }
@@ -580,12 +630,23 @@ class RouteMapController(
         val routesByStopId = focusedStops.routeDirectionsByStopId(focus.trips, emphasizedRoute)
         val routeColors = _focusedRouteColors.value
         renderState.setRoutePolylines(
-            polylines = focusedGeometry.toRoutePolylines(emphasizedRoute, routeColors) +
-                if (showBaseRoute) basePolylines else emptyList(),
+            polylines = if (selected != null && selectedTrip != null) {
+                focusedGeometry.toTripFocusedRoutePolylines(
+                    selected.routeDirection,
+                    routeColors,
+                    selectedRouteUnderlay,
+                    selectedTrip,
+                )
+            } else {
+                focusedGeometry.toRoutePolylines(emphasizedRoute, routeColors) +
+                    if (showBaseRoute) basePolylines else emptyList()
+            },
             // Adjacency remains visible underneath route mode, but the active route's fully loaded
             // shape alone defines FramingIntent.Route. Using the displayed adjacency lines here would
             // fit the union of every route serving the focused stop.
-            framingPolylines = if (isActive) basePolylines else emptyList(),
+            framingPolylines = if (isActive) {
+                selectedTrip?.let(::listOf) ?: basePolylines
+            } else emptyList(),
         )
         renderState.setRouteBadges(
             if (emphasizedRoute == null) {
@@ -594,7 +655,7 @@ class RouteMapController(
             else emptyList()
         )
         stopsController.setRoutePresentation(
-            if (showBaseRoute) {
+            selectedTripStops ?: if (showBaseRoute) {
                 baseStopPresentation
             } else {
                 RouteStopPresentation(
@@ -604,6 +665,34 @@ class RouteMapController(
                     projectedPoints = projectFocusedStops(focus.trips, focusedGeometry, focusedStops),
                 )
             }
+        )
+    }
+
+    /** Current selected-trip data, read fresh after selection's shape/schedule activation. */
+    private fun selectedTripPresentation(): SelectedTripPresentation? {
+        val tripId = renderState.selectedVehicleTripId.value ?: return null
+        val currentRouteId = routeId ?: return null
+        val state = tripObservationRepository.lookupTripState(tripId)
+        // The marker is keyed by activeTripId, which resolves directly through the poll references.
+        val activeTrip = latestPoll?.response?.trip(tripId)
+        return SelectedTripPresentation(
+            points = state?.polyline?.points?.map { it.toGeoPoint() }.orEmpty(),
+            stopIds = state?.schedule?.stopTimes?.map { it.stopId }.orEmpty(),
+            routeDirection = RouteDirectionKey(
+                currentRouteId,
+                activeTrip?.directionId ?: currentDirectionId,
+            ),
+        )
+    }
+
+    /** The selected trip's scheduled stops, projected onto its exact shape in schedule order. */
+    private fun selectedTripStopPresentation(selected: SelectedTripPresentation): RouteStopPresentation {
+        val stops = routeStops.stopsForTrip(selected.stopIds)
+        return RouteStopPresentation(
+            stops = stops,
+            routes = routeStopRoutes,
+            routeDirectionsByStopId = stops.associate { it.id to setOf(selected.routeDirection) },
+            projectedPoints = projectStopsOntoPolylines(stops, listOf(selected.points)),
         )
     }
 
@@ -722,7 +811,14 @@ class RouteMapController(
      */
     private fun projectStopsOntoShape(stops: List<ObaStop>): Map<String, GeoPoint> {
         val route = routeShape ?: return emptyMap()
-        val shapes = route.shapeForDirection(currentDirectionId).polylines
+        return projectStopsOntoPolylines(stops, route.shapeForDirection(currentDirectionId).polylines)
+    }
+
+    private fun projectStopsOntoPolylines(
+        stops: List<ObaStop>,
+        points: List<List<GeoPoint>>,
+    ): Map<String, GeoPoint> {
+        val shapes = points
             .filter { it.size >= 2 }
             .map { line -> Polyline(line.map(GeoPoint::toLocation)) }
         if (shapes.isEmpty()) return emptyMap()

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
@@ -612,7 +612,7 @@ class RouteMapController(
         val selectedTripStops = selected?.let(::selectedTripStopPresentation)
         val selectedRouteUnderlay = if (selectedTrip == null) {
             emptyList()
-        } else basePolylines.asDeemphasizedRouteUnderlay()
+        } else selectedDirectionUnderlay(selected.routeDirection.directionId)
         if (focus == null) {
             renderState.setRoutePolylines(
                 polylines = if (selectedTrip == null) {
@@ -673,16 +673,39 @@ class RouteMapController(
         val tripId = renderState.selectedVehicleTripId.value ?: return null
         val currentRouteId = routeId ?: return null
         val state = tripObservationRepository.lookupTripState(tripId)
+        // Keep the base route visible until both the exact shape and schedule resolve; a
+        // half-loaded presentation would blank the base stops behind an empty selected trip.
+        val polyline = state?.polyline ?: return null
+        val schedule = state.schedule ?: return null
         // The marker is keyed by activeTripId, which resolves directly through the poll references.
         val activeTrip = latestPoll?.response?.trip(tripId)
         return SelectedTripPresentation(
-            points = state?.polyline?.points?.map { it.toGeoPoint() }.orEmpty(),
-            stopIds = state?.schedule?.stopTimes?.map { it.stopId }.orEmpty(),
+            points = polyline.points.map { it.toGeoPoint() },
+            stopIds = schedule.stopTimes.map { it.stopId },
             routeDirection = RouteDirectionKey(
                 currentRouteId,
                 activeTrip?.directionId ?: currentDirectionId,
             ),
         )
+    }
+
+    /**
+     * The selected trip's own direction shape, thinned to sit beneath its exact trip line. In
+     * whole-route mode [basePolylines] is the merged both-directions geometry, so drawing that as
+     * the underlay would surface the opposite direction; resolve the direction shape instead.
+     */
+    private fun selectedDirectionUnderlay(directionId: Int?): List<RoutePolyline> {
+        val route = routeShape ?: return emptyList()
+        val shape = route.shapeForDirection(directionId)
+        return shape.polylines.map { points ->
+            RoutePolyline(
+                route.route?.color,
+                points,
+                widthDp = ROUTE_LINE_WIDTH_DP,
+                directional = shape.directional,
+                transforms = ROUTE_VIEW_TRANSFORMS,
+            )
+        }.asDeemphasizedRouteUnderlay()
     }
 
     /** The selected trip's scheduled stops, projected onto its exact shape in schedule order. */

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
@@ -373,17 +373,11 @@ class RouteMapController(
         if (tripId != null) {
             val state = tripObservationRepository.lookupTripState(tripId)
             val shapeId = state?.shapeId ?: latestPoll?.response?.trip(tripId)?.shapeId
+            // Warm both resources concurrently; supervisorScope joins them and keeps one failing
+            // fetch from cancelling the other. selectedTripPresentation() re-reads the results.
             supervisorScope {
-                val shape = async {
-                    state?.polyline ?: shapeId?.let {
-                        tripObservationRepository.ensureShape(tripId, it)
-                    }
-                }
-                val schedule = async {
-                    state?.schedule ?: tripObservationRepository.ensureSchedule(tripId)
-                }
-                shape.await()
-                schedule.await()
+                launch { shapeId?.let { tripObservationRepository.ensureShape(tripId, it) } }
+                launch { tripObservationRepository.ensureSchedule(tripId) }
             }
         }
         publishMapPresentation()
@@ -598,61 +592,57 @@ class RouteMapController(
 
     private fun publishMapPresentation() {
         val focus = stopFocusSession
+        val emphasizedRoute = routeId?.let { RouteDirectionKey(it, presentationDirectionId) }
+        val routeColors = _focusedRouteColors.value
+        val badges = if (emphasizedRoute == null) {
+            focusedGeometry.toRouteBadges(focusedRoutes, routeColors)
+        } else emptyList()
         val selected = selectedTripPresentation()
         val selectedTrip = selected?.points
             ?.takeIf { it.size >= 2 }
             ?.let { points ->
                 focusedRoutePolyline(currentRouteColor(), points, directional = true)
             }
-        val selectedTripStops = selected?.let(::selectedTripStopPresentation)
-        val selectedRouteUnderlay = if (selectedTrip == null) {
-            emptyList()
-        } else selectedDirectionUnderlay(selected.routeDirection.directionId)
-        if (focus == null) {
+        // A selected vehicle shows its exact trip everywhere: the trip line over its thin
+        // same-direction underlay (with any focused-stop siblings beneath), framed to that trip,
+        // and only its scheduled stops. In whole-route mode the empty [focusedGeometry] collapses
+        // toTripFocusedRoutePolylines to just the underlay + trip.
+        if (selected != null && selectedTrip != null) {
             renderState.setRoutePolylines(
-                polylines = if (selectedTrip == null) {
-                    basePolylines
-                } else selectedRouteUnderlay + selectedTrip,
-                framingPolylines = selectedTrip?.let(::listOf) ?: basePolylines,
+                polylines = focusedGeometry.toTripFocusedRoutePolylines(
+                    selected.routeDirection,
+                    routeColors,
+                    selectedDirectionUnderlay(selected.routeDirection.directionId),
+                    selectedTrip,
+                ),
+                framingPolylines = listOf(selectedTrip),
                 routeModeScalesStopsWithZoom = isActive,
             )
-            renderState.setRouteBadges(emptyList())
-            stopsController.setRoutePresentation(selectedTripStops ?: baseStopPresentation)
+            renderState.setRouteBadges(badges)
+            stopsController.setRoutePresentation(selectedTripStopPresentation(selected))
             return
         }
-        val emphasizedRoute = routeId?.let { RouteDirectionKey(it, presentationDirectionId) }
+        if (focus == null) {
+            renderState.setRoutePolylines(basePolylines, routeModeScalesStopsWithZoom = isActive)
+            renderState.setRouteBadges(emptyList())
+            stopsController.setRoutePresentation(baseStopPresentation)
+            return
+        }
         val showBaseRoute = isActive && emphasizedRoute != null &&
             focus.trips.none { it.routeDirection == emphasizedRoute }
         val routesByStopId = focusedStops.routeDirectionsByStopId(focus.trips, emphasizedRoute)
-        val routeColors = _focusedRouteColors.value
         renderState.setRoutePolylines(
-            polylines = if (selected != null && selectedTrip != null) {
-                focusedGeometry.toTripFocusedRoutePolylines(
-                    selected.routeDirection,
-                    routeColors,
-                    selectedRouteUnderlay,
-                    selectedTrip,
-                )
-            } else {
-                focusedGeometry.toRoutePolylines(emphasizedRoute, routeColors) +
-                    if (showBaseRoute) basePolylines else emptyList()
-            },
+            polylines = focusedGeometry.toRoutePolylines(emphasizedRoute, routeColors) +
+                if (showBaseRoute) basePolylines else emptyList(),
             // Adjacency remains visible underneath route mode, but the active route's fully loaded
             // shape alone defines FramingIntent.Route. Using the displayed adjacency lines here would
             // fit the union of every route serving the focused stop.
-            framingPolylines = if (isActive) {
-                selectedTrip?.let(::listOf) ?: basePolylines
-            } else emptyList(),
+            framingPolylines = if (isActive) basePolylines else emptyList(),
             routeModeScalesStopsWithZoom = isActive,
         )
-        renderState.setRouteBadges(
-            if (emphasizedRoute == null) {
-                focusedGeometry.toRouteBadges(focusedRoutes, routeColors)
-            }
-            else emptyList()
-        )
+        renderState.setRouteBadges(badges)
         stopsController.setRoutePresentation(
-            selectedTripStops ?: if (showBaseRoute) {
+            if (showBaseRoute) {
                 baseStopPresentation
             } else {
                 RouteStopPresentation(
@@ -691,17 +681,8 @@ class RouteMapController(
      * whole-route mode [basePolylines] is the merged both-directions geometry, so drawing that as
      * the underlay would surface the opposite direction; resolve the direction shape instead.
      */
-    private fun selectedDirectionUnderlay(directionId: Int?): List<RoutePolyline> {
-        val route = routeShape ?: return emptyList()
-        val shape = route.shapeForDirection(directionId)
-        return shape.polylines.map { points ->
-            focusedRoutePolyline(
-                color = route.route?.color,
-                points = points,
-                directional = shape.directional,
-            )
-        }.asDeemphasizedRouteUnderlay()
-    }
+    private fun selectedDirectionUnderlay(directionId: Int?): List<RoutePolyline> =
+        directionPolylines(directionId).asDeemphasizedRouteUnderlay()
 
     /** The selected trip's scheduled stops, projected onto its exact shape in schedule order. */
     private fun selectedTripStopPresentation(selected: SelectedTripPresentation): RouteStopPresentation {
@@ -850,25 +831,30 @@ class RouteMapController(
     }
 
     /**
-     * Re-draw the route shape for [currentDirectionId]: the selected direction's own travel-ordered
-     * shape (with direction arrows), or the whole-route merged shape drawn undirected when none is
-     * selected. Passes the route's raw GTFS color through; the render layer picks the fallback when
-     * it's absent. Uses [focusedRoutePolyline], the same complete line presentation as a route selected
-     * from focused-stop mode. Called on load and on every direction switch.
+     * The drawn lines for [directionId]'s shape: the selected direction's own travel-ordered shape
+     * (with direction arrows), or the whole-route merged shape drawn undirected when [directionId] is
+     * null. Passes the route's raw GTFS color through; the render layer picks the fallback when it's
+     * absent. Uses [focusedRoutePolyline], the same complete line presentation as a route selected
+     * from focused-stop mode. shapeForDirection pairs the drawn shape with its directionality, so
+     * arrows are stamped only when the direction's own travel-ordered shape is used — never on the
+     * whole-route merged fallback (a direction that carried no shape on the wire).
      */
-    private fun showDirectionPolylines() {
-        val route = routeShape ?: return
-        // shapeForDirection pairs the drawn shape with its directionality, so arrows are stamped only
-        // when the selected direction's own travel-ordered shape is used — never on the whole-route
-        // merged fallback (a direction that carried no shape on the wire).
-        val shape = route.shapeForDirection(currentDirectionId)
-        basePolylines = shape.polylines.map { points ->
+    private fun directionPolylines(directionId: Int?): List<RoutePolyline> {
+        val route = routeShape ?: return emptyList()
+        val shape = route.shapeForDirection(directionId)
+        return shape.polylines.map { points ->
             focusedRoutePolyline(
                 color = route.route?.color,
                 points = points,
                 directional = shape.directional,
             )
         }
+    }
+
+    /** Re-draw the base route for [currentDirectionId]. Called on load and on every direction switch. */
+    private fun showDirectionPolylines() {
+        if (routeShape == null) return
+        basePolylines = directionPolylines(currentDirectionId)
         publishMapPresentation()
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapRepository.kt
@@ -123,3 +123,9 @@ internal fun List<RouteMapStop>.anchorDirectionId(anchorStopId: String?): Int? {
 internal fun List<RouteMapStop>.stopsForDirection(directionId: Int?): List<ObaStop> =
     if (directionId == null) map { it.stop }
     else filter { directionId in it.directionIds }.map { it.stop }
+
+/** Narrows the route catalog to one trip's scheduled stop ids, preserving schedule order. */
+internal fun List<RouteMapStop>.stopsForTrip(stopIds: List<String>): List<ObaStop> {
+    val stopsById = associateBy { it.stop.id }
+    return stopIds.distinct().mapNotNull { stopsById[it]?.stop }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteViewGeometry.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteViewGeometry.kt
@@ -26,6 +26,14 @@ internal val ROUTE_VIEW_TRANSFORMS = setOf(
 internal const val ROUTE_DEEMPHASIZED_LINE_WIDTH_DP = ROUTE_LINE_WIDTH_DP * 0.275f
 internal const val ROUTE_EMPHASIZED_LINE_WIDTH_DP = ROUTE_LINE_WIDTH_DP * 1.5f
 
+/** The active route's broader geometry retained beneath an exact selected-trip line. */
+internal fun List<RoutePolyline>.asDeemphasizedRouteUnderlay(): List<RoutePolyline> = map { line ->
+    line.copy(
+        widthDp = ROUTE_DEEMPHASIZED_LINE_WIDTH_DP,
+        directional = false,
+    )
+}
+
 /**
  * Convert exact trip shapes into uniform-width directional route lines. When [emphasizedRoute] is
  * set, that route-direction uses a 1.5x stroke while siblings use a thin, plain stroke and render
@@ -59,6 +67,16 @@ internal fun FocusedTripGeometry.toRoutePolylines(
         )
     }
 }
+
+/** Sibling routes, then the selected route's thin underlay, then its exact trip shape. */
+internal fun FocusedTripGeometry.toTripFocusedRoutePolylines(
+    selectedRoute: RouteDirectionKey,
+    routeColors: Map<RouteDirectionKey, Int>,
+    selectedRouteUnderlay: List<RoutePolyline>,
+    selectedTrip: RoutePolyline,
+): List<RoutePolyline> =
+    FocusedTripGeometry(shapes.filterNot { it.routeDirection == selectedRoute })
+        .toRoutePolylines(selectedRoute, routeColors) + selectedRouteUnderlay + selectedTrip
 
 /**
  * One Google-first badge model per successfully drawn route-direction, preserving the focused-trip

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteDirectionFocusTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteDirectionFocusTest.kt
@@ -26,9 +26,10 @@ import org.onebusaway.android.map.render.GeoPoint
 import org.onebusaway.android.models.RouteMapStop
 
 /**
- * [anchorDirectionId] (resolve the launch anchor stop → its direction) and [stopsForDirection]
- * (narrow a route's stops to a direction) — the pure repository/controller direction helpers, plus
- * [RouteMap.shapeForDirection] (pick the drawn shape + its directionality, with the whole-route fallback).
+ * [anchorDirectionId] (resolve the launch anchor stop → its direction), [stopsForDirection]
+ * (narrow a route's stops to a direction), and [stopsForTrip] (narrow them to one schedule) — the
+ * pure repository/controller helpers, plus [RouteMap.shapeForDirection] (pick the drawn shape + its
+ * directionality, with the whole-route fallback).
  */
 class RouteDirectionFocusTest {
 
@@ -94,6 +95,16 @@ class RouteDirectionFocusTest {
         // A stop serving both directions shows for the selected one (not dropped).
         val withShared = stops + stop("s", 0, 1)
         assertEquals(listOf("a", "b", "s"), withShared.stopsForDirection(0).map { it.id })
+    }
+
+    // ----- stopsForTrip -----
+
+    @Test
+    fun tripStopsFollowScheduleRatherThanRouteDirection() {
+        assertEquals(
+            listOf("b", "d"),
+            stops.stopsForTrip(listOf("b", "missing", "d", "b")).map { it.id },
+        )
     }
 
     // ----- shapeForDirection -----

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteViewGeometryTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteViewGeometryTest.kt
@@ -2,10 +2,12 @@
 package org.onebusaway.android.map
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.onebusaway.android.map.render.GeoPoint
 import org.onebusaway.android.map.render.ROUTE_LINE_WIDTH_DP
+import org.onebusaway.android.map.render.RoutePolyline
 import org.onebusaway.android.map.render.RoutePolylineTransform
 import org.onebusaway.android.map.render.haversineMeters
 import org.onebusaway.android.models.FocusedTrip
@@ -73,6 +75,49 @@ class RouteViewGeometryTest {
             lines.map { it.widthDp },
         )
         assertEquals(listOf(false, true), lines.map { it.directional })
+    }
+
+    @Test
+    fun `selected vehicle trip replaces every shape in its route direction`() {
+        val sibling = listOf(GeoPoint(1.0, 0.0), GeoPoint(1.0, 1.0))
+        val firstDirectionVariant = listOf(GeoPoint(2.0, 0.0), GeoPoint(2.0, 1.0))
+        val secondDirectionVariant = listOf(GeoPoint(3.0, 0.0), GeoPoint(3.0, 1.0))
+        val exactTrip = listOf(GeoPoint(4.0, 0.0), GeoPoint(4.0, 1.0))
+        val geometry = FocusedTripGeometry(
+            listOf(
+                FocusedTripShape("sibling", "other", 1, sibling, directionId = 1),
+                FocusedTripShape("variant-a", "selected", 2, firstDirectionVariant, directionId = 0),
+                FocusedTripShape("variant-b", "selected", 2, secondDirectionVariant, directionId = 0),
+            )
+        )
+        val selectedTrip = RoutePolyline(
+            color = 2,
+            points = exactTrip,
+            widthDp = ROUTE_EMPHASIZED_LINE_WIDTH_DP,
+            directional = true,
+        )
+        val underlay = listOf(
+            RoutePolyline(2, secondDirectionVariant, widthDp = ROUTE_LINE_WIDTH_DP, directional = true)
+        ).asDeemphasizedRouteUnderlay()
+
+        val lines = geometry.toTripFocusedRoutePolylines(
+            selectedRoute = RouteDirectionKey("selected", 0),
+            routeColors = emptyMap(),
+            selectedRouteUnderlay = underlay,
+            selectedTrip = selectedTrip,
+        )
+
+        assertEquals(listOf(sibling, secondDirectionVariant, exactTrip), lines.map { it.points })
+        assertEquals(
+            listOf(
+                ROUTE_DEEMPHASIZED_LINE_WIDTH_DP,
+                ROUTE_DEEMPHASIZED_LINE_WIDTH_DP,
+                ROUTE_EMPHASIZED_LINE_WIDTH_DP,
+            ),
+            lines.map { it.widthDp },
+        )
+        assertEquals(listOf(false, false, true), lines.map { it.directional })
+        assertSame(selectedTrip, lines.last())
     }
 
     @Test


### PR DESCRIPTION
## Summary

- render a selected vehicle's exact ordered trip geometry instead of the heterogeneous route-direction union
- narrow focused stops to the selected trip's schedule
- retain the broader route-direction as a thin, non-directional underlay
- keep sibling stop-focus routes beneath the exact trip and use the trip shape for route framing
- resolve shape and schedule data on selection, including the fast-tap case before background prefetch completes

## Why

A selected vehicle previously added its extrapolation and continuation overlays while leaving the route-direction geometry and stops in place. One direction can combine substantially different trip patterns, so the displayed line could diverge from the tracked trip and make a continuation appear to branch from the middle of the route.

## Impact

Vehicle focus now follows the actual trip path and scheduled stops. Riders retain route and stop-focus context through thin underlays, while the selected trip remains visually dominant.

## Validation

- `./gradlew :onebusaway-android:testObaGoogleDebugUnitTest --tests 'org.onebusaway.android.map.*'`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Vehicle selections now display the exact trip path with clearer route highlighting.
  * Selected trips show stops in their scheduled order.
  * Map framing and route badges update to reflect the selected trip.

* **Bug Fixes**
  * Improved stop placement and route geometry when viewing a selected vehicle trip.
  * Preserved surrounding route context while emphasizing the selected trip.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->