### PR TITLE
Don't reframe the route on ordinary arrivals polls (#1895)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
@@ -297,6 +297,10 @@ class HomeViewModel @Inject constructor(
         focusedTrips = trips
         presentedRoutes = trips.mapTo(linkedSetOf(), FocusedTrip::routeDirection)
         val preserveViewport = pendingMapFocus && preserveViewportForPendingMapFocus
+        // Frame the selected route only when this load is the initial (restore/deep-link) focus
+        // establishment; an ordinary arrivals poll must refresh the presentation without reframing the
+        // camera to the whole route (#1895). A restore carrying a saved viewport already declines to frame.
+        val frameSelectedRoute = pendingMapFocus && !preserveViewportForPendingMapFocus
         if (pendingMapFocus) {
             pendingMapFocus = false
             preserveViewportForPendingMapFocus = false
@@ -323,7 +327,7 @@ class HomeViewModel @Inject constructor(
                 MapDirective.ShowRoute(
                     it.target(focus.stop.id).toRequest(),
                     stopScoped = true,
-                    frameRoute = !preserveViewport,
+                    frameRoute = frameSelectedRoute,
                 )
             )
         }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
@@ -292,6 +292,32 @@ class HomeViewModelTest {
     }
 
     @Test
+    fun `an ordinary arrivals poll refreshes the selected route without reframing`() = runTest {
+        val vm = viewModel()
+        val map = MapDirectiveRecorder(vm)
+        val mapJob = launch { map.collect() }
+        advanceUntilIdle()
+        vm.onStopFocused(FocusedStop("stop", "Main St", "100", 47.6, -122.3))
+        advanceUntilIdle()
+        vm.selectArrivalRoute(
+            request = ShowRouteRequest("65", directionStopId = "stop", initialDirectionId = 0),
+            shortName = "65",
+            headsign = "Downtown",
+        )
+        advanceUntilIdle()
+        // Selecting the route frames it once.
+        assertEquals(true, map.routeCommands.single().frameRoute)
+        map.sent.clear()
+
+        // A subsequent arrivals poll (no pending focus) re-shows the selected route but must not reframe.
+        vm.onArrivalsLoaded(ObaStopElement("stop", 47.6, -122.3, "Main St", "100"), emptyList(), emptySet())
+        advanceUntilIdle()
+
+        assertEquals(false, map.routeCommands.single().frameRoute)
+        mapJob.cancel()
+    }
+
+    @Test
     fun `drawer route selection and continuation remain subordinate to stop focus`() = runTest {
         val savedState = SavedStateHandle()
         val vm = viewModel(savedState = savedState)


### PR DESCRIPTION
## Summary

Fixes #1895. In **stop + route focus**, an ordinary background arrivals poll
reframed the camera to the whole route's extent, throwing away the pan/zoom the
rider had set.

## Root cause

`HomeViewModel.onArrivalsLoaded` runs on **every** arrivals load. When a route
is selected within a focused stop, it re-emits `MapDirective.ShowRoute(...,
stopScoped = true, frameRoute = !preserveViewport)`. On an ordinary poll
`preserveViewport` is `false`, so `frameRoute` was `true`. That routes through
`MapViewModel.toRoute` → `RouteMapController.reframe(frameRoute = true)` →
`host.frameRoute()`, re-fitting the camera to the whole route on every poll.

(The retained-`FramingIntent.Route` theory in the issue was a red herring — the
real trigger is the per-poll `ShowRoute` re-emission.)

## Fix

Frame the selected route only when the load is the **initial** (restore /
deep-link) focus establishment:

```kotlin
val frameSelectedRoute = pendingMapFocus && !preserveViewportForPendingMapFocus
```

- Ordinary poll → `pendingMapFocus == false` → `frameSelectedRoute == false`.
  The `ShowRoute` re-emission still refreshes presentation, but `reframe()` is a
  no-op (direction unchanged, no `focusTripId`), so the camera stays put.
- Initial pending-focus establishment without a saved viewport → frames (unchanged).
- Pending focus that carries a saved viewport → still declines to frame (unchanged).

The initial route selection continues to frame via `selectStopRoute`'s default
`frameRoute = true`; the back/undo restore paths already pass their own explicit
`frameRoute`, so they're unaffected.

## Tests

Added `an ordinary arrivals poll refreshes the selected route without reframing`
to `HomeViewModelTest`: selects a route in stop focus (asserts the initial
`ShowRoute` frames), then a subsequent `onArrivalsLoaded` with no pending focus
re-shows the route with `frameRoute = false`.

- `./gradlew :onebusaway-android:testObaGoogleDebugUnitTest --tests 'org.onebusaway.android.ui.home.*' --tests 'org.onebusaway.android.map.*' -PwarningsAsErrors=true`

## Note

Root cause was found by reading the code, not reproduced on-device — worth a
manual confirmation on the shared phone before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved map behavior when refreshing arrivals for a selected route.
  * Prevented the map from unnecessarily reframing to the full route during routine arrivals updates.
  * Preserved the initial map focus when selecting a route or restoring a focused stop.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->