### PR TITLE
Keep stop-focus color when a vehicle is selected (#1893 regression)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
@@ -598,21 +598,27 @@ class RouteMapController(
             focusedGeometry.toRouteBadges(focusedRoutes, routeColors)
         } else emptyList()
         val selected = selectedTripPresentation()
+        // A route emphasized inside stop focus carries an adjacency color (keyed on the focused stop's
+        // trips); the selected trip keeps that color so selecting a vehicle doesn't drop the route back
+        // to its GTFS hue. In whole-route mode there is no adjacency entry, so fall back to GTFS.
+        val selectedAdjacencyColor = selected?.let { routeColors[it.routeDirection] }
         val selectedTrip = selected?.points
             ?.takeIf { it.size >= 2 }
             ?.let { points ->
-                focusedRoutePolyline(currentRouteColor(), points, directional = true)
+                focusedRoutePolyline(selectedAdjacencyColor ?: currentRouteColor(), points, directional = true)
             }
-        // A selected vehicle shows its exact trip everywhere: the trip line over its thin
-        // same-direction underlay (with any focused-stop siblings beneath), framed to that trip,
-        // and only its scheduled stops. In whole-route mode the empty [focusedGeometry] collapses
-        // toTripFocusedRoutePolylines to just the underlay + trip.
+        // A selected vehicle shows its exact trip everywhere: the trip line, framed to that trip, over
+        // its scheduled stops. In whole-route mode it sits on a thin same-direction underlay; inside
+        // stop focus the emphasized route already reads via its adjacency color, so the generic
+        // direction underlay is dropped (it would otherwise look like standalone route mode) and only
+        // the focused-stop siblings remain beneath the exact trip.
         if (selected != null && selectedTrip != null) {
             renderState.setRoutePolylines(
                 polylines = focusedGeometry.toTripFocusedRoutePolylines(
                     selected.routeDirection,
                     routeColors,
-                    selectedDirectionUnderlay(selected.routeDirection.directionId),
+                    if (selectedAdjacencyColor != null) emptyList()
+                    else selectedDirectionUnderlay(selected.routeDirection.directionId),
                     selectedTrip,
                 ),
                 framingPolylines = listOf(selectedTrip),


### PR DESCRIPTION
## Problem

After #1893 ("Focus vehicles on exact trip geometry and stops"), tapping a vehicle while a route is emphasized **inside stop focus** reverted the route line to its **GTFS color** and layered the exact trip over a **generic route-direction underlay** — so it read as if the map had dropped into standalone route mode. The intuitive behavior is that the route keeps its stop-focus (adjacency) color and does not print the generic route-direction geometry.

## Root cause

#1893 added `showSelectionPresentation(tripId)` to the selection collector, so every vehicle tap now calls `publishMapPresentation()`, whose new selected-trip branch unconditionally:

- colored the exact trip with `currentRouteColor()` (the route's **GTFS** color), and
- drew `selectedDirectionUnderlay(...)` (the whole direction shape, also GTFS-colored) beneath it.

In whole-route standalone mode that's correct (there's no adjacency color). But inside stop focus the emphasized route is drawn from the adjacency palette (`_focusedRouteColors`), so selecting a vehicle visibly swapped the adjacency-colored route for a GTFS trip over a generic underlay.

## Fix

In `RouteMapController.publishMapPresentation()`, resolve the selected trip's color from the adjacency palette (`routeColors[selected.routeDirection]`) when the route is emphasized in stop focus, falling back to the GTFS color only in whole-route mode where no adjacency entry exists. In that emphasized case, also drop the generic direction underlay — the adjacency-colored trip already reads on its own, and the underlay is what made it look like route mode.

- **Stop focus + vehicle selected:** exact trip in adjacency color, focused-stop siblings beneath, no generic underlay.
- **Whole-route standalone + vehicle selected:** unchanged (GTFS trip + direction underlay).

As a small bonus this skips the O(n) underlay geometry build in the stop-focus case.

## Testing

- `./gradlew :onebusaway-android:compileObaGoogleDebugKotlin -PwarningsAsErrors=true` — clean (CI warnings gate).
- Built + installed `obaGoogleDebug` on device for on-device confirmation of the rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved selected trip highlighting when viewing a stop’s route details.
  * Preserved stop-specific route colors for selected vehicles and trips.
  * Retained appropriate fallback coloring and directional styling when stop-specific colors are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->