### PR TITLE
Route stop search + recents to map stop-focus

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
@@ -369,7 +369,8 @@ class MapViewModel @Inject constructor(
         routes: List<ObaRoute>?,
         overlayExpanded: Boolean,
         recenter: Boolean = true,
-    ) = stopsController.focusStop(stop, routes, overlayExpanded, recenter)
+        animate: Boolean = false,
+    ) = stopsController.focusStop(stop, routes, overlayExpanded, recenter, animate)
 
     /**
      * Draw the exact trips with upcoming arrivals at [stopId] without moving the camera. The stop must

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/StopsMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/StopsMapController.kt
@@ -391,20 +391,22 @@ class StopsMapController(
     /**
      * Programmatic focus for a restored/deep-linked stop once its arrivals load (driven by
      * `MapDirective.FocusStop`): ensure the stop is on the map + render-focused, and center on it
-     * (route-header bias only when [routeActive] and the sheet settled expanded).
+     * (route-header bias only when [routeActive] and the sheet settled expanded). [animate] pans the
+     * camera over to the stop (an in-session reveal) rather than jumping to it (a cold-start restore).
      */
     fun focusStop(
         stop: ObaStop,
         routes: List<ObaRoute>?,
         overlayExpanded: Boolean,
         recenter: Boolean = true,
+        animate: Boolean = false,
     ) {
         if (recenter) {
             val loc = stop.location
             host.dispatchGesture(
                 CameraCommand.Recenter(
                     loc.latitude, loc.longitude,
-                    animate = false,
+                    animate = animate,
                     applyRouteBias = routeActive() && overlayExpanded,
                 )
             )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeNavHost.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeNavHost.kt
@@ -76,6 +76,7 @@ import org.onebusaway.android.ui.nav.RESULT_MAP_STOP_ID
 import org.onebusaway.android.ui.nav.consumeStopReveal
 import org.onebusaway.android.ui.nav.navigateFromHome
 import org.onebusaway.android.ui.nav.revealRouteOnMap
+import org.onebusaway.android.ui.nav.revealStopOnMap
 import org.onebusaway.android.ui.settings.settingsGraph
 import org.onebusaway.android.ui.survey.SurveyViewModel
 import org.onebusaway.android.ui.tripdetails.TripDetailsLauncher
@@ -143,8 +144,11 @@ fun HomeNavHost(
                 // was present but lat/lon were missing.
                 val reveal = handle.consumeStopReveal()
                 if (reveal != null) {
+                    // An in-session reveal (search result / recents / route-info tap): pan the camera
+                    // over to the stop rather than jump, since the map is already on screen.
                     home.homeViewModel.revealStop(
-                        FocusedStop(reveal.stopId, null, null, reveal.lat, reveal.lon)
+                        FocusedStop(reveal.stopId, null, null, reveal.lat, reveal.lon),
+                        animate = true,
                     )
                 } else {
                     // Keys already consumed; record the dropped focus so the latent path is findable
@@ -182,9 +186,9 @@ fun HomeNavHost(
                         PreferencesEntryPoint.get(context).setBoolean(ArrivalTutorial.KEY_MORE_MENU, true)
                         navController.navigateFromHome(NavRoutes.myRecent())
                     },
-                    // Recents dropdown taps mirror the My Recent screen: a stop opens its arrivals, a route
-                    // reveals on the map.
-                    onRecentStop = { id, name -> navController.navigateFromHome(NavRoutes.arrivals(id, name)) },
+                    // Recents dropdown taps reveal the stop / route on the map (the same stop-focus the
+                    // search results and map markers use).
+                    onRecentStop = { id, lat, lon -> navController.revealStopOnMap(id, lat, lon) },
                     onRecentRoute = { routeId -> navController.revealRouteOnMap(routeId) },
                     onHelpAction = { action ->
                         if (action == HelpAction.AGENCIES) navController.navigateFromHome(NavRoutes.AGENCIES)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -128,8 +128,8 @@ class HomeCallbacks(
     val onSettings: () -> Unit,
     val onSearch: (String) -> Unit,
     val onRecentStopsRoutes: () -> Unit,
-    // Search-box recents dropdown: tapping a stop opens its arrivals; tapping a route reveals it on the map.
-    val onRecentStop: (id: String, name: String?) -> Unit,
+    // Search-box recents dropdown: tapping a stop or a route reveals it on the map.
+    val onRecentStop: (id: String, lat: Double, lon: Double) -> Unit,
     val onRecentRoute: (routeId: String) -> Unit,
     // Wraps [HomeActivityActions.onHelpActionExternal] with the one branch that's a navigation (AGENCIES).
     val onHelpAction: (HelpAction) -> Unit,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
@@ -150,6 +150,10 @@ class HomeViewModel @Inject constructor(
     // host on each create from the restored focusedStop, so it needn't be persisted).
     private var pendingMapFocus: Boolean = false
     private var preserveViewportForPendingMapFocus: Boolean = false
+    // Whether the pending focus should animate the camera over to the stop (an in-session reveal — a
+    // search/recents tap) rather than jump to it (a cold-start restore, where flying from a default
+    // camera position would look wrong).
+    private var animatePendingMapFocus: Boolean = false
 
     /** Exact displayed trips for the focused stop; arrivals reload it after restore and refreshes. */
     var focusedTrips: Set<FocusedTrip> = emptySet()
@@ -190,11 +194,15 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-    /** A stop opened from navigation replaces any standalone route/bike view before it restores. */
-    fun revealStop(stop: FocusedStop) {
+    /**
+     * A stop opened from navigation replaces any standalone route/bike view before it restores. An
+     * in-session reveal (a search/recents tap while the map is already on screen) passes [animate] so
+     * the camera pans over to the stop instead of jumping; a cold-start restore leaves it false.
+     */
+    fun revealStop(stop: FocusedStop, animate: Boolean = false) {
         emitMapDirective(MapDirective.ClearFocus)
         onStopFocused(stop)
-        markPendingMapFocus()
+        markPendingMapFocus(animate)
     }
 
     /**
@@ -263,8 +271,9 @@ class HomeViewModel @Inject constructor(
      * complete it once the arrivals load (see [onArrivalsLoaded]). A fresh map tap already centers the
      * stop, so it does not call this.
      */
-    fun markPendingMapFocus() {
+    fun markPendingMapFocus(animate: Boolean = false) {
         pendingMapFocus = true
+        animatePendingMapFocus = animate
     }
 
     /**
@@ -302,14 +311,17 @@ class HomeViewModel @Inject constructor(
         // camera to the whole route (#1895). A restore carrying a saved viewport already declines to frame.
         val frameSelectedRoute = pendingMapFocus && !preserveViewportForPendingMapFocus
         if (pendingMapFocus) {
+            val animate = animatePendingMapFocus
             pendingMapFocus = false
             preserveViewportForPendingMapFocus = false
+            animatePendingMapFocus = false
             emitMapDirective(
                 MapDirective.FocusStop(
                     stop,
                     routes,
                     settledSheet == ArrivalsSheetState.Expanded,
                     recenter = !preserveViewport,
+                    animate = animate,
                 )
             )
         }
@@ -545,7 +557,7 @@ class HomeViewModel @Inject constructor(
             focusedTrips = emptySet()
             when (target) {
                 is CurrentFocus.Stop -> {
-                    pendingMapFocus = true
+                    markPendingMapFocus()
                     preserveViewportForPendingMapFocus = !frameFocus
                     emitMapDirective(MapDirective.ClearFocus)
                 }
@@ -668,11 +680,13 @@ sealed interface MapDirective {
     /**
      * Focus a restored / deep-linked stop once its arrivals load: ensure it's on the map, render-focus
      * it, and optionally recenter (route-header bias only when [overlayExpanded] in route mode).
+     * [animate] pans the camera over to the stop (an in-session reveal) instead of jumping (a restore).
      */
     data class FocusStop(
         val stop: ObaStop,
         val routes: List<ObaRoute>?,
         val overlayExpanded: Boolean,
         val recenter: Boolean = true,
+        val animate: Boolean = false,
     ) : MapDirective
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/chrome/MapTopChrome.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/chrome/MapTopChrome.kt
@@ -94,7 +94,7 @@ fun MapTopChrome(
     onSearch: (String) -> Unit,
     // The unified recent stops+routes list for the search dropdown, and the row-tap handlers.
     recents: List<RecentItem>,
-    onRecentStop: (id: String, name: String?) -> Unit,
+    onRecentStop: (id: String, lat: Double, lon: Double) -> Unit,
     onRecentRoute: (routeId: String) -> Unit,
     // Opaque anchor a host may attach to the menu (☰) FAB (e.g. for an onboarding spotlight).
     menuModifier: Modifier = Modifier,
@@ -146,9 +146,9 @@ fun MapTopChrome(
                     focusManager.clearFocus()
                     onSearch(query)
                 },
-                onRecentStop = { id, name ->
+                onRecentStop = { id, lat, lon ->
                     focusManager.clearFocus()
-                    onRecentStop(id, name)
+                    onRecentStop(id, lat, lon)
                 },
                 onRecentRoute = { routeId ->
                     focusManager.clearFocus()
@@ -179,7 +179,7 @@ private fun SearchField(
     focused: Boolean,
     onFocusChange: (Boolean) -> Unit,
     onSubmit: (String) -> Unit,
-    onRecentStop: (id: String, name: String?) -> Unit,
+    onRecentStop: (id: String, lat: Double, lon: Double) -> Unit,
     onRecentRoute: (routeId: String) -> Unit,
     onDismiss: () -> Unit,
     modifier: Modifier = Modifier,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/chrome/SearchRecentsDropdown.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/chrome/SearchRecentsDropdown.kt
@@ -54,8 +54,8 @@ private val DROPDOWN_MAX_HEIGHT = 224.dp
  * clear these are recent shortcuts and submitting the field runs a full, separate search) over a
  * scrollable, height-capped list of the unified recent stops+routes. Each row carries a leading type icon
  * (stop_flag / ic_route — the glyphs the Recent tabs use) so the mixed list scans at a glance, then reuses
- * [StopRowContent] / [RouteRowContent] for the body. Tapping fires [onRecentStop] (→ arrivals) or
- * [onRecentRoute] (→ reveal on map).
+ * [StopRowContent] / [RouteRowContent] for the body. Tapping fires [onRecentStop] or
+ * [onRecentRoute] — both reveal the stop / route on the map.
  *
  * Renders no surface of its own — the caller ([MapTopChrome]'s search field) provides the connected
  * container so the field + dropdown read as one expanded surface.
@@ -63,7 +63,7 @@ private val DROPDOWN_MAX_HEIGHT = 224.dp
 @Composable
 fun SearchRecentsDropdown(
     recents: List<RecentItem>,
-    onRecentStop: (id: String, name: String?) -> Unit,
+    onRecentStop: (id: String, lat: Double, lon: Double) -> Unit,
     onRecentRoute: (routeId: String) -> Unit,
 ) {
     Column(Modifier.fillMaxWidth()) {
@@ -82,7 +82,7 @@ fun SearchRecentsDropdown(
                 when (item) {
                     is RecentItem.Stop -> RecentRow(
                         icon = R.drawable.stop_flag,
-                        onClick = { onRecentStop(item.stop.id, item.stop.name) },
+                        onClick = { onRecentStop(item.stop.id, item.stop.lat, item.stop.lon) },
                     ) {
                         StopRowContent(
                             name = item.stop.name,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
@@ -273,6 +273,7 @@ fun MapFeature(
                         directive.routes,
                         directive.overlayExpanded,
                         directive.recenter,
+                        directive.animate,
                     )
             }
         }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/mylists/MyListBodies.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/mylists/MyListBodies.kt
@@ -85,12 +85,10 @@ fun ReminderListDestination(
 fun StopSearchDestination(
     viewModel: SearchViewModel<StopSearchResult>,
     onShowOnMap: (stopId: String, lat: Double, lon: Double) -> Unit,
-    onOpenStop: (stopId: String, stopName: String?) -> Unit,
 ) {
     StopSearchContent(
         viewModel = viewModel,
-        onStopClick = { openStopSearchResult(it, onOpenStop) },
-        onShowOnMap = { onShowOnMap(it.id, it.latitude, it.longitude) }
+        onStopClick = { onShowOnMap(it.id, it.latitude, it.longitude) },
     )
 }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/mylists/MyListNav.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/mylists/MyListNav.kt
@@ -23,7 +23,6 @@ import org.onebusaway.android.R
 import org.onebusaway.android.app.di.DatabaseEntryPoint
 import org.onebusaway.android.ui.common.Shortcuts
 import org.onebusaway.android.ui.search.RouteSearchResult
-import org.onebusaway.android.ui.search.StopSearchResult
 import org.onebusaway.android.util.ExternalIntents
 
 /**
@@ -113,10 +112,6 @@ internal fun AppCompatActivity.reminderActions(
         onShowRoute(reminder.routeId)
     }
 )
-
-/** Opens a search-result stop's arrivals via [onOpen] (a NavController-backed navigation). */
-internal fun openStopSearchResult(stop: StopSearchResult, onOpen: (stopId: String, stopName: String?) -> Unit) =
-    onOpen(stop.id, stop.serverName)
 
 /** Opens a search-result route via [onOpen] (a NavController-backed navigation). */
 internal fun openRouteSearchResult(route: RouteSearchResult, onOpen: (routeId: String) -> Unit) =

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/mylists/MyListScreens.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/mylists/MyListScreens.kt
@@ -136,13 +136,12 @@ internal fun AppCompatActivity.recentRoutesTab(
 internal fun stopSearchTab(
     viewModel: SearchViewModel<StopSearchResult>,
     onShowOnMap: (stopId: String, lat: Double, lon: Double) -> Unit,
-    onOpenStop: (stopId: String, stopName: String?) -> Unit,
 ): MyTab = MyTab(
     tag = MyTabs.SEARCH,
     titleRes = R.string.my_search_title,
     iconRes = R.drawable.search,
 ) {
-    StopSearchDestination(viewModel, onShowOnMap, onOpenStop)
+    StopSearchDestination(viewModel, onShowOnMap)
 }
 
 internal fun routeSearchTab(
@@ -209,7 +208,7 @@ fun MyStopsDestination(
                 onShowStopOnMap, onOpenStop,
             ),
             activity.starredStopsTab(starred, onShowStopOnMap, onOpenStop),
-            stopSearchTab(search, onShowStopOnMap, onOpenStop),
+            stopSearchTab(search, onShowStopOnMap),
         ),
     )
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/search/StopSearchContent.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/search/StopSearchContent.kt
@@ -15,33 +15,23 @@
  */
 package org.onebusaway.android.ui.search
 
-import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.combinedClickable
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.DropdownMenuItem
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import org.onebusaway.android.R
-import org.onebusaway.android.ui.compose.components.CenteredLongPressMenu
-import org.onebusaway.android.ui.compose.components.MenuHeader
 import org.onebusaway.android.ui.compose.components.StopRowContent
 
-/** The stop search tab: search box + results, with a long-press menu per row. */
+/** The stop search tab: search box + results. Tapping a row reveals that stop on the map. */
 @Composable
 fun StopSearchContent(
     viewModel: SearchViewModel<StopSearchResult>,
     onStopClick: (StopSearchResult) -> Unit,
-    onShowOnMap: (StopSearchResult) -> Unit
 ) {
     val query by viewModel.query.collectAsStateWithLifecycle()
     val state by viewModel.state.collectAsStateWithLifecycle()
@@ -53,54 +43,14 @@ fun StopSearchContent(
         state = state,
         itemKey = { it.id }
     ) { stop ->
-        StopSearchRow(
-            stop = stop,
-            onStopClick = onStopClick,
-            onShowOnMap = onShowOnMap
-        )
-    }
-}
-
-@OptIn(ExperimentalFoundationApi::class)
-@Composable
-private fun StopSearchRow(
-    stop: StopSearchResult,
-    onStopClick: (StopSearchResult) -> Unit,
-    onShowOnMap: (StopSearchResult) -> Unit
-) {
-    var menuExpanded by remember { mutableStateOf(false) }
-    Box {
         StopRowContent(
             name = stop.name,
             direction = stop.direction,
             isFavorite = stop.isFavorite,
             modifier = Modifier
                 .fillMaxWidth()
-                .combinedClickable(
-                    onClick = { onStopClick(stop) },
-                    onLongClick = { menuExpanded = true }
-                )
+                .clickable { onStopClick(stop) }
                 .padding(horizontal = 16.dp, vertical = 12.dp)
         )
-        CenteredLongPressMenu(
-            expanded = menuExpanded,
-            onDismissRequest = { menuExpanded = false },
-        ) {
-            MenuHeader(stop.name)
-            DropdownMenuItem(
-                text = { Text(stringResource(R.string.my_context_get_stop_info)) },
-                onClick = {
-                    menuExpanded = false
-                    onStopClick(stop)
-                }
-            )
-            DropdownMenuItem(
-                text = { Text(stringResource(R.string.my_context_showonmap)) },
-                onClick = {
-                    menuExpanded = false
-                    onShowOnMap(stop)
-                }
-            )
-        }
     }
 }

--- a/onebusaway-android/src/main/res/values-es/strings.xml
+++ b/onebusaway-android/src/main/res/values-es/strings.xml
@@ -347,7 +347,6 @@
     <string name="my_option_clear_starred_stops">Eliminar todas las paradas favoritas</string>
     <!-- <string name="my_option_clear_starred_routes">Eliminar todas las rutas favoritas</string>-->
 
-    <string name="my_context_get_stop_info">Mostrar información de llegadas</string>
     <string name="my_context_get_route_info">Mostrar información de la ruta</string>
     <string name="my_context_create_shortcut">Crear un acceso directo en la pantalla de inicio</string>
     <string name="my_context_showonmap">Mostrar sobre el mapa</string>

--- a/onebusaway-android/src/main/res/values-fi/strings.xml
+++ b/onebusaway-android/src/main/res/values-fi/strings.xml
@@ -309,7 +309,6 @@
     <string name="my_option_clear_starred_routes_title">Poistetaanko kaikki tähdellä merkityt reitit?</string>
     <string name="my_option_clear_starred_routes_confirm">Tämä poistaa pysyvästi kaikki tähdellä merkityt reitit.</string>
 
-    <string name="my_context_get_stop_info">Näytä saapuvien vuorojen tiedot</string>
     <string name="my_context_get_route_info">Näytä reittitiedot</string>
     <string name="my_context_create_shortcut">Luo pikakuvake</string>
     <string name="my_context_showonmap">Näytä kartalla</string>

--- a/onebusaway-android/src/main/res/values-it/strings.xml
+++ b/onebusaway-android/src/main/res/values-it/strings.xml
@@ -289,7 +289,6 @@
     <string name="my_option_clear_starred_stops">Rimuovi tutte le fermate dai preferiti</string>
     <string name="my_option_clear_starred_routes">Rimuovi tutte le linee dai preferiti</string>
 
-    <string name="my_context_get_stop_info">Mostra informazioni sull’arrivo</string>
     <string name="my_context_get_route_info">Mostra informazioni sulla linea</string>
     <string name="my_context_create_shortcut">Crea scorciatoia nella schermata Home</string>
     <string name="my_context_showonmap">Mostra sulla mappa</string>

--- a/onebusaway-android/src/main/res/values-pl/strings.xml
+++ b/onebusaway-android/src/main/res/values-pl/strings.xml
@@ -324,7 +324,6 @@
     <string name="my_option_clear_starred_routes_title">Usunąć wszystkie trasy oznaczone gwiazdką?</string>
     <string name="my_option_clear_starred_routes_confirm">Spowoduje to trwałe usunięcie wszystkich tras oznaczonych gwiazdką.</string>
 
-    <string name="my_context_get_stop_info">Pokaż informację o przyjazdach</string>
     <string name="my_context_get_route_info">Pokaż informację o trasie</string>
     <string name="my_context_create_shortcut">Utwórz skrót</string>
     <string name="my_context_showonmap">Pokaż na mapie</string>

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -373,7 +373,6 @@
     <string name="my_option_clear_starred_stops">Remove all starred stops</string>
     <!-- <string name="my_option_clear_starred_routes">Remove all starred routes</string>-->
 
-    <string name="my_context_get_stop_info">Show arrival information</string>
     <string name="my_context_get_route_info">Show route information</string>
     <string name="my_context_create_shortcut">Create shortcut on home screen</string>
     <string name="my_context_showonmap">Show on map</string>


### PR DESCRIPTION
## What

Tapping a stop in the **My-lists search results** or the **home recents dropdown** now reveals that stop focused on the map (`revealStopOnMap` → stop-focus + arrivals drawer) — the same view you get by tapping a stop marker — instead of pushing the standalone non-map arrivals page. The global top-bar search already revealed on map; this brings the remaining stop-search surfaces in line.

## Why

The standalone arrivals screen is redundant with on-map stop focus (same arrivals in `ArrivalsSheetHost`, centered on the stop). This is the first slice toward retiring that page (tracked in #1898).

## Changes

- **`StopSearchContent`** — the search row is now a single tap → reveal on map. Removed the redundant per-row long-press menu (its "stop info" / "show on map" items both meant "show on map" once the tap revealed the map), plus the now-orphaned `my_context_get_stop_info` string across all locales.
- **Recents dropdown** — `onRecentStop` widened from `(id, name)` to `(id, lat, lon)` through the `SearchRecentsDropdown` → `MapTopChrome` → `HomeCallbacks` → `HomeNavHost` chain, so it can call `revealStopOnMap`. The recent-stop model already carries lat/lon.
- **Animated reveal** — an in-session reveal now animates the camera over to the stop instead of jumping. `focusStop`'s recenter was hard-coded `animate = false` (correct for a cold-start restore, wrong for a reveal while the map is already on screen), so an `animate` flag is threaded from the nav-reveal trigger through `MapDirective.FocusStop` to the camera command. Cold-start restore and back-nav keep the instant jump.

Starred/recent **list** rows, route-info, and trip-details stop taps still open the standalone page for now — those, plus the external FCM/shortcut/deep-link contracts, are covered by the retirement follow-up (#1898).

## Testing

- Compiles clean under the CI gate (`-PwarningsAsErrors=true`).
- Device-verified on a Pixel 7 Pro: tapping a stop search result and a recents-dropdown stop both reveal the stop on the map with an animated camera pan; recent routes still reveal the route as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Recent stops and stop search results now open directly on the map.
  * Map focus can smoothly animate when revealing a selected stop.
  * Stop search results are directly clickable for faster map access.
* **Bug Fixes**
  * Improved map positioning when opening stops from recent searches or in-session reveals.
* **Refactor**
  * Removed the previous arrival-information action from stop context menus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->