### PR TITLE
CI: add nightly Android Lint job

### DIFF
--- a/.github/workflows/android-nightly.yml
+++ b/.github/workflows/android-nightly.yml
@@ -15,6 +15,13 @@ name: Android Nightly
 #    suite (org.onebusaway.android.SmokeTest — see that annotation + issue #1818). Small and stable
 #    on purpose: it answers "does the app boot and do the core flows run on the floor?", not "re-run
 #    everything". Both instrumented suites otherwise remain oba-only in android.yml.
+#
+# 3. lint — every `./gradlew` invocation on the PR/push and other nightly legs passes `-x lint`
+#    because lintObaGoogleDebug is heavyweight (~7-15 min) and would dominate those jobs' wall-clock
+#    (see the NOTE in android.yml). This leg is the promised home for it: no emulator, so it's cheap
+#    to run nightly and catches lint regressions (including `abortOnError` NewApi/minSdk violations
+#    the Kotlin warnings gate can't see) that would otherwise sit invisible until someone runs lint
+#    by hand. See issue #1901.
 
 on:
   schedule:
@@ -50,6 +57,37 @@ jobs:
 
       - name: Full-grid tests + check (all brands)
         run: ./gradlew test check -PbuildAllBrands=true --build-cache -x lint -PwarningsAsErrors=true --stacktrace
+
+  lint:
+    # No emulator needed: lint is a static analysis task. Independent of the other legs, so it runs
+    # in parallel. See the header for why this exists.
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v7
+        with:
+          # This job only runs lint; it never pushes, so don't leave the token in git config.
+          persist-credentials: false
+
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          java-version: 21
+          distribution: 'temurin'
+
+      - name: Gradle cache
+        uses: gradle/actions/setup-gradle@v6
+
+      - name: Android Lint (obaGoogleDebug)
+        run: ./gradlew :onebusaway-android:lintObaGoogleDebug --build-cache -PwarningsAsErrors=true --stacktrace
+
+      - name: Upload lint report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lint-report-obaGoogleDebug
+          path: onebusaway-android/build/reports/lint-results-obaGoogleDebug.html
+          retention-days: 14
 
   smoke-api23:
     # Boot the minSdk floor: install obaGoogleDebug on an API 23 emulator and run the @SmokeTest
@@ -114,7 +152,7 @@ jobs:
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
           # Select only the @SmokeTest-annotated classes; -x lint keeps the ~10-min lint off this leg.
-          # (Lint no longer runs on the PR path either — it's slated for its own nightly heavyweight run.)
+          # (Lint runs separately in the `lint` job above, which needs no emulator.)
           script: >-
             ./gradlew connectedObaGoogleDebugAndroidTest
             -Pandroid.testInstrumentationRunnerArguments.annotation=org.onebusaway.android.SmokeTest

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -36,9 +36,10 @@ jobs:
         uses: gradle/actions/setup-gradle@v6
 
       # NOTE: Android Lint intentionally does NOT run on the PR/push path. lintObaGoogleDebug is
-      # heavyweight (~7-15 min) and dominates this job's wall-clock; it's being moved to a dedicated
-      # nightly heavyweight run instead. The "run tests" step below keeps `-x lint` so `check` doesn't
-      # pull lint back in. (Kotlin `-PwarningsAsErrors` compile gating still runs here via `check`.)
+      # heavyweight (~7-15 min) and dominates this job's wall-clock; it runs instead in the `lint` job
+      # in android-nightly.yml (no emulator needed there). The "run tests" step below keeps `-x lint`
+      # so `check` doesn't pull lint back in. (Kotlin `-PwarningsAsErrors` compile gating still runs
+      # here via `check`.)
 
       - name: AVD cache
         uses: actions/cache@v6


### PR DESCRIPTION
## Summary
- Adds a `lint` job to `android-nightly.yml` that runs `./gradlew :onebusaway-android:lintObaGoogleDebug -PwarningsAsErrors=true` and uploads the HTML report as an artifact. No emulator needed, so it's cheap to run nightly.
- Updates the now-stale comments in `android.yml` and `android-nightly.yml` that described the nightly lint job as "slated"/"never landed" to point at the new job.

Fixes #1901. Every PR/push and nightly Gradle invocation passes `-x lint`, so the lint-clean, baseline-free state won by the earlier lint campaign (#1875) has had nothing enforcing it since lint was pulled off the PR path — this closes that gap without slowing down the PR critical path.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/android-nightly.yml'))"` — YAML parses
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/android.yml'))"` — YAML parses
- [x] `./gradlew :onebusaway-android:tasks --all` confirms `lintObaGoogleDebug` exists as a task
- [ ] Confirm the new `lint` job runs green on the next scheduled nightly (or via manual `workflow_dispatch`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)