### PR TITLE
Cleanup: small-exhaust sweep from the 2026-07-16 debt review

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -253,7 +253,7 @@ domain model is unambiguously millis. See `situationEpochToMillis` and `Situatio
 - **Application ID**: `com.joulespersecond.seattlebusbot` (historical, must keep for Google Play)
 - **Namespace**: `org.onebusaway.android`
 - **Java compatibility**: 17
-- **Kotlin version**: see `kotlin` in `gradle/libs.versions.toml` (2.3.20)
+- **Kotlin version**: see `kotlin` in `gradle/libs.versions.toml` (2.4.10)
 
 ## Multi-Region Support
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,10 +20,10 @@ jdk = "17"
 
 # --- Build tooling / plugins ---
 agp = "9.3.0"
-# Kotlin Gradle plugin + its compiler plugins (serialization, compose) all track the Kotlin
-# version; kotlin-stdlib-jdk7 below pins to this too.
+# Kotlin Gradle plugin + its compiler plugins (serialization, compose) all track this version.
 kotlin = "2.4.10"
-# KSP version is Kotlin-version-coupled but published on its own cadence (kotlinVersion-kspVersion).
+# KSP2 is versioned independently of Kotlin — plain semver, not the old kotlinVersion-kspVersion
+# format. Bump on its own cadence against the compatibility range in the KSP release notes.
 ksp = "2.3.10"
 googleServices = "4.5.0"
 hilt = "2.60.1"
@@ -37,7 +37,6 @@ lint = "32.3.0"
 
 # --- Libraries ---
 desugar = "2.1.5"
-firebaseCore = "21.1.1"
 firebaseAnalytics = "23.2.0"
 firebaseFirestore = "26.4.1"
 firebaseAuth = "24.2.0"
@@ -91,7 +90,6 @@ junit = "4.13.2"
 desugar-jdk-libs = { module = "com.android.tools:desugar_jdk_libs", version.ref = "desugar" }
 
 # --- Firebase / Google Play services ---
-firebase-core = { module = "com.google.firebase:firebase-core", version.ref = "firebaseCore" }
 firebase-analytics = { module = "com.google.firebase:firebase-analytics", version.ref = "firebaseAnalytics" }
 firebase-firestore = { module = "com.google.firebase:firebase-firestore", version.ref = "firebaseFirestore" }
 firebase-auth = { module = "com.google.firebase:firebase-auth", version.ref = "firebaseAuth" }
@@ -133,7 +131,6 @@ androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-
 androidx-lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "lifecycle" }
 androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigationCompose" }
 androidx-hilt-navigation-compose = { module = "androidx.hilt:hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
-kotlin-stdlib-jdk7 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk7", version.ref = "kotlin" }
 
 # --- Jetpack Compose (versions from the BOM unless noted) ---
 compose-bom = { module = "androidx.compose:compose-bom", version.ref = "composeBom" }

--- a/onebusaway-android/build.gradle.kts
+++ b/onebusaway-android/build.gradle.kts
@@ -336,7 +336,6 @@ dependencies {
     // Core library desugaring: backports java.time.* to minSdk 23 (issue #1693)
     "coreLibraryDesugaring"(libs.desugar.jdk.libs)
     // Firebase Analytics
-    implementation(libs.firebase.core)
     implementation(libs.firebase.analytics)
     // Plausible Analytics
     implementation(libs.plausible.android.sdk)
@@ -406,10 +405,8 @@ dependencies {
     implementation(libs.androidx.concurrent.listenablefuture.callback)
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.preference)
-    // Preferences DataStore — the backing store behind PreferencesRepository. 1.0.0 was the minSdk-21
-    // pin; now that minSdk is 23 a newer DataStore is eligible to be adopted as a follow-up.
+    // Preferences DataStore — the backing store behind PreferencesRepository.
     implementation(libs.androidx.datastore.preferences)
-    implementation(libs.kotlin.stdlib.jdk7)
     // RoomDB
     implementation(libs.androidx.room.runtime)
     ksp(libs.androidx.room.compiler)

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
@@ -52,6 +52,7 @@ import org.onebusaway.android.map.render.ContinuationBadgeBitmaps
 import org.onebusaway.android.map.render.CorrectionSmoother
 import org.onebusaway.android.map.render.GeoPoint
 import org.onebusaway.android.map.render.MapPing
+import org.onebusaway.android.map.render.METERS_PER_PIXEL_AT_EQUATOR_ZOOM_ZERO
 import org.onebusaway.android.map.render.MapRenderSnapshot
 import org.onebusaway.android.map.render.MapRenderState
 import org.onebusaway.android.map.render.MarkerRendering
@@ -83,8 +84,8 @@ import java.util.concurrent.TimeUnit
  * Three redraw paths split by update cadence:
  *  - [renderRoutePolylines] independently reconciles the infrequently-changing route layer, so
  *    stop-only viewport updates retain every long native line.
- *  - [renderStatic] clear-and-redraws the remaining static annotations (bikes / generics / trip-stop
- *    dots); [GoogleStopMarkerLayer] reconciles stops in place so unchanged stops neither blink nor
+ *  - [renderStatic] clear-and-redraws the remaining static annotations (bikes / generics);
+ *    [GoogleStopMarkerLayer] reconciles stops in place so unchanged stops neither blink nor
  *    receive redundant native position/z-index writes.
  *  - [renderDynamic] (the live route vehicles + the selected vehicle's band/fast-estimate marker) is pulled at
  *    ~20Hz by the adapter's frame loop. It moves native markers **in place** to their freshly
@@ -225,8 +226,8 @@ class GoogleMapRenderer(
     private val descriptorCache =
         BitmapDescriptorCache(DESCRIPTOR_CACHE_SIZE) { BitmapDescriptorFactory.fromBitmap(it) }
 
-    // Remove the redrawn non-route static annotations — continuation polylines, trip-stop dots, bikes,
-    // generic markers (not map.clear(), which would also wipe the retained route and per-frame dynamic
+    // Remove the redrawn non-route static annotations — continuation polylines, bikes, generic markers
+    // (not map.clear(), which would also wipe the retained route and per-frame dynamic
     // layers) — and clear their tap maps. Reconciled route/stop annotations deliberately survive.
     // Shared by [renderStatic] (before it redraws) and [dispose].
     private fun clearStatic() {
@@ -493,7 +494,8 @@ class GoogleMapRenderer(
         val progress = MapPing.progress(elapsed)
         val radiusPx = MapPing.MAX_RADIUS_DP * density * MapPing.radiusFraction(progress)
         val metersPerPx =
-            156543.03392 * cos(Math.toRadians(center.latitude)) / 2.0.pow(map.cameraPosition.zoom.toDouble())
+            METERS_PER_PIXEL_AT_EQUATOR_ZOOM_ZERO * cos(Math.toRadians(center.latitude)) /
+                2.0.pow(map.cameraPosition.zoom.toDouble())
         val radiusMeters = radiusPx * metersPerPx
         val color = MapPing.withAlpha(pingColor, MapPing.alpha(progress))
         val existing = pingCircle

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/FocusedTripRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/FocusedTripRepository.kt
@@ -57,10 +57,7 @@ data class FocusedTripGeometry(val shapes: List<FocusedTripShape>)
 data class FocusedTripStops(
     val stopIdsByTripId: Map<String, List<String>>,
     val stopsById: Map<String, ObaStop>,
-) {
-    val stopIds: Set<String>
-        get() = buildSet { stopIdsByTripId.values.forEach(::addAll) }
-}
+)
 
 /** Exact shape and scheduled-stop pass-throughs for the trips displayed at a focused stop. */
 interface FocusedTripRepository {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/GeoMath.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/GeoMath.kt
@@ -24,3 +24,10 @@ import org.onebusaway.android.util.haversineDistance
  */
 fun haversineMeters(a: GeoPoint, b: GeoPoint): Double =
     haversineDistance(a.latitude, a.longitude, b.latitude, b.longitude)
+
+/**
+ * Web-Mercator ground resolution at zoom 0 on the equator, in meters per pixel (256px tiles). Scale to
+ * a given zoom/latitude with `× cos(lat) / 2^zoom`. The single source for this constant, shared by the
+ * route-render pipeline and the map-ping radius math.
+ */
+internal const val METERS_PER_PIXEL_AT_EQUATOR_ZOOM_ZERO = 156543.03392804097

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
@@ -181,7 +181,7 @@ data class ContinuationBadge(
 /**
  * A tappable label for one route in focused-stop adjacency view (#1827), anchored once in geographic
  * space so the map SDK naturally carries it through pan and zoom. Google renders these in the first
- * badge phase; MapLibre deliberately ignores the layer until its follow-up.
+ * badge phase; MapLibre deliberately ignores the layer until its follow-up (#1913).
  */
 data class RouteBadge(
     val routeId: String,
@@ -397,7 +397,7 @@ class MapRenderState {
 
     fun clearRoutePolylines() = setRoutePolylines(emptyList())
 
-    /** Sets the Google-first adjacency route badges (#1827); MapLibre currently ignores this layer. */
+    /** Sets the Google-first adjacency route badges (#1827); MapLibre currently ignores this layer (#1913). */
     fun setRouteBadges(badges: List<RouteBadge>) {
         _snapshot.update { it.copy(routeBadges = badges) }
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/RoutePolylineRenderPipeline.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/RoutePolylineRenderPipeline.kt
@@ -39,7 +39,6 @@ private const val MAX_MERCATOR_LATITUDE = 85.05112878
 private const val VIEWPORT_MARGIN_MULTIPLIER = 1.0
 private const val SIMPLIFICATION_ERROR_PIXELS = 0.75
 private const val MIN_SIMPLIFICATION_METERS = 2.0
-private const val METERS_PER_PIXEL_AT_EQUATOR_ZOOM_ZERO = 156543.03392804097
 private const val COORDINATE_EPSILON = 1e-12
 
 internal data class RoutePolylineRenderContext(val camera: CameraSnapshot?)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/MaterialSymbols.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/MaterialSymbols.kt
@@ -23,7 +23,13 @@ import androidx.compose.ui.graphics.vector.PathBuilder
 import androidx.compose.ui.graphics.vector.path
 import androidx.compose.ui.unit.dp
 
-/** Material Symbols used by secondary-action menus, generated at 24dp with outlined styling. */
+/**
+ * Material Symbols used by secondary-action menus. Each path is transcribed by hand from the Material
+ * Symbols set at **24dp, weight 400, grade 0, optical size 24, "outlined" style** — record any icon's
+ * source glyph + those axes here when adding one, so the paths can be regenerated or verified. Prefer a
+ * `baseline_*_24.xml` vector drawable (the mechanism used elsewhere in this module) for new icons; keep
+ * these inline `ImageVector`s only where a menu needs them without a drawable round-trip.
+ */
 internal object MaterialSymbols {
     val Schedule: ImageVector by lazy {
         symbol("schedule") {

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
@@ -71,8 +71,8 @@ import org.onebusaway.android.util.getRouteDisplayName
  * Three redraw paths split by update cadence:
  *  - [renderRoutePolylines] independently reconciles the infrequently-changing route layer, so
  *    stop-only viewport updates retain every long native line.
- *  - [renderStatic] clear-and-redraws the remaining static annotations (bikes / generics / trip-stop
- *    dots); [MapLibreStopMarkerLayer] reconciles stops in place so unchanged stops neither blink nor
+ *  - [renderStatic] clear-and-redraws the remaining static annotations (bikes / generics);
+ *    [MapLibreStopMarkerLayer] reconciles stops in place so unchanged stops neither blink nor
  *    receive redundant native position writes.
  *  - [renderDynamic] (the live vehicle markers + the selected vehicle's band/fast-estimate marker) is pulled each
  *    display frame by the adapter's vsync loop. It updates marker positions **in place** (so an open

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreComposeAdapter.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreComposeAdapter.kt
@@ -325,8 +325,8 @@ private fun wireClicks(
             return@setOnMarkerClickListener true
         }
         // Titled markers (the trip-focus estimate markers + the most-recent-data dot) fall through to
-        // the SDK's default title window. Untitled decorations (trip-stop dots, generic start/end
-        // markers) have nothing to show, so consume the tap (return true) — a no-op, not an empty bubble.
+        // the SDK's default title window. Untitled decorations (generic start/end markers) have
+        // nothing to show, so consume the tap (return true) — a no-op, not an empty bubble.
         marker.title.isNullOrEmpty()
     }
     map.setOnInfoWindowClickListener { marker ->

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/FocusedTripRepositoryTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/FocusedTripRepositoryTest.kt
@@ -70,7 +70,7 @@ class FocusedTripRepositoryTest {
         val result = repository.getStops(setOf(FocusedTrip("trip", "route", "shape", null)))
 
         assertEquals(listOf("a", "c"), result.stopIdsByTripId["trip"])
-        assertEquals(setOf("a", "c"), result.stopIds)
+        assertEquals(setOf("a", "c"), result.stopIdsByTripId.values.flatten().toSet())
         assertEquals(setOf("a", "b", "c"), result.stopsById.keys)
     }
 
@@ -122,7 +122,7 @@ class FocusedTripRepositoryTest {
             )
         )
 
-        assertEquals(setOf("served"), result.stopIds)
+        assertEquals(setOf("served"), result.stopIdsByTripId.values.flatten().toSet())
         assertEquals(setOf("good"), result.stopIdsByTripId.keys)
         // The omission leaves a log trail, so a fetch failure stays distinguishable from no data.
         assertEquals(listOf("Focused-trip schedule failed fetch failed"), loggedFailures)


### PR DESCRIPTION
Mechanical, behavior-neutral cleanup of the "exhaust" left by the map-focus sprint (#1865/#1892/#1893) and the dependency-bump wave. This is the batch of small quick-wins from the 2026-07-16 debt review; the substantive findings are filed separately as #1901–#1912.

**No functional change.** Verified: `obaGoogle` + `obaMaplibre` Kotlin compile clean under `-PwarningsAsErrors=true`, and `FocusedTripRepositoryTest` passes.

### Docs / comment drift
- `CLAUDE.md`: Kotlin version parenthetical `2.3.20` → `2.4.10`.
- `libs.versions.toml`: drop the stale "kotlin-stdlib-jdk7 pins to this" clause; correct the KSP comment — KSP2 is versioned independently of Kotlin (plain semver), not the old `kotlinVersion-kspVersion` format.
- `build.gradle.kts`: drop the DataStore "1.0.0 was the minSdk-21 pin / adopt a newer one as a follow-up" comment — that bump (to 1.2.1) already landed.
- Remove orphaned **"trip-stop dots"** references in both renderers' class docs and the `clearStatic()` / info-window comments (`TripStopBitmaps.kt` was deleted in #1865; stops are now reconciled in place).
- `MaterialSymbols`: document the Symbols source axes (24dp / weight 400 / grade 0 / outlined) so the hand-transcribed paths can be regenerated or verified, and steer new icons toward `baseline_*_24.xml` drawables.
- `MapRenderState`: point the two MapLibre route-badge deferral comments at the new tracking issue #1913.

### Dead code / dedup
- Delete the test-only `FocusedTripStops.stopIds` convenience property (production code uses `stopIdsByTripId` directly); inline the flatten into its two test assertions.
- Hoist the duplicated Web-Mercator constant (`156543.033…`) into a single shared `METERS_PER_PIXEL_AT_EQUATOR_ZOOM_ZERO` in `map/render/GeoMath.kt`. `GoogleMapRenderer` now uses it instead of an inlined, less-precise literal (`156543.03392`).

### Frozen dependencies
- Remove `firebase-core` 21.1.1 — a discontinued empty umbrella artifact; `firebase-analytics` is already a direct dependency.
- Remove `kotlin-stdlib-jdk7` — merged into `kotlin-stdlib` since Kotlin 1.8; the Kotlin Gradle plugin adds the stdlib automatically.

### Deliberately left out of this PR
These appeared in the review's "small exhaust" list but are secretly medium-effort or behavior-touching, so they stay as their own follow-ups rather than riding in a mechanical cleanup:
- `CurrentFocusPersistence` parallel-arrays → `@Parcelize` (serialization change; its legacy-migration branch has no test).
- The copy-pasted `async` fetch blocks in `RouteMapController.focusStop` (folds naturally into the controller refactor, #1907).
- `RouteBadgeLayout.MeasuredPath` ↔ `util/Polyline` arc-length merge (needs a GeoPoint-based `Polyline`).
- `start()`'s 5-param mirror of `ShowRouteRequest` (behavior-touching; tracked at #1797).
- Moving `BoundedLruCache` from `extrapolation/data/` to `util/` (cross-package import churn for low value).

🤖 Generated with [Claude Code](https://claude.com/claude-code)