### PR TITLE
RouteMapController: make presentation assembly pure and testable (#1907)

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/map/RouteStopProjectionTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/map/RouteStopProjectionTest.kt
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.map
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.onebusaway.android.api.adapters.ObaStopElement
+import org.onebusaway.android.map.render.GeoPoint
+
+/**
+ * Instrumented coverage for the route-map stop projection geometry ([projectStopsOntoPolylines] and
+ * [projectFocusedStops]) — the pure nearest-point-across-polylines kernel and its fall-backs. Runs on a
+ * device because [org.onebusaway.android.util.Polyline] snaps against `android.location.Location`, which
+ * this project's plain-JVM unit tests can't construct (the presentation-assembly logic that consumes the
+ * result is JVM-tested in [RouteMapPresentationPlanTest]).
+ */
+@RunWith(AndroidJUnit4::class)
+class RouteStopProjectionTest {
+
+    // A meridian segment: latitude 0, longitude 0..10.
+    private val meridian = listOf(GeoPoint(0.0, 0.0), GeoPoint(0.0, 10.0))
+
+    @Test
+    fun projectStopsOntoPolylines_snapsEachStopOntoTheLine() {
+        val stops = listOf(stop("a", lat = 1.0, lon = 5.0), stop("b", lat = -2.0, lon = 8.0))
+
+        val projected = projectStopsOntoPolylines(stops, listOf(meridian))
+
+        // Each stop drops perpendicularly onto the meridian: same longitude, latitude pulled to 0.
+        assertClose(GeoPoint(0.0, 5.0), projected.getValue("a"))
+        assertClose(GeoPoint(0.0, 8.0), projected.getValue("b"))
+    }
+
+    @Test
+    fun projectStopsOntoPolylines_picksTheNearerCandidateShape() {
+        val far = listOf(GeoPoint(10.0, 0.0), GeoPoint(10.0, 10.0))
+        val stops = listOf(stop("a", lat = 1.0, lon = 5.0))
+
+        val projected = projectStopsOntoPolylines(stops, listOf(far, meridian))
+
+        // The stop at latitude 1 is nearer the meridian (lat 0) than the far line (lat 10).
+        assertClose(GeoPoint(0.0, 5.0), projected.getValue("a"))
+    }
+
+    @Test
+    fun projectStopsOntoPolylines_withNoDrawableShapeReturnsEmpty() {
+        val stops = listOf(stop("a", lat = 1.0, lon = 5.0))
+
+        // A single-point "line" is not drawable (< 2 points), so nothing projects.
+        assertTrue(projectStopsOntoPolylines(stops, listOf(listOf(GeoPoint(0.0, 0.0)))).isEmpty())
+        assertTrue(projectStopsOntoPolylines(stops, emptyList()).isEmpty())
+    }
+
+    @Test
+    fun projectFocusedStops_snapsScheduledStopOntoItsTripShape() {
+        val trips = setOf(focusedTrip("t1", "r1", shapeId = "s1"))
+        val geometry = FocusedTripGeometry(listOf(shape("s1", "r1", meridian)))
+        val stops = FocusedTripStops(
+            stopIdsByTripId = mapOf("t1" to listOf("a")),
+            stopsById = mapOf("a" to stop("a", lat = 1.0, lon = 5.0)),
+        )
+
+        val projected = projectFocusedStops(trips, geometry, stops)
+
+        assertClose(GeoPoint(0.0, 5.0), projected.getValue("a"))
+    }
+
+    @Test
+    fun projectFocusedStops_picksNearestAcrossEveryTripThatServesTheStop() {
+        val trips = setOf(
+            focusedTrip("t1", "r1", shapeId = "s1"),
+            focusedTrip("t2", "r2", shapeId = "s2"),
+        )
+        val geometry = FocusedTripGeometry(
+            listOf(
+                shape("s1", "r1", listOf(GeoPoint(10.0, 0.0), GeoPoint(10.0, 10.0))),
+                shape("s2", "r2", meridian),
+            )
+        )
+        // The stop is served by both trips; it must snap to whichever shape is nearer (the meridian).
+        val stops = FocusedTripStops(
+            stopIdsByTripId = mapOf("t1" to listOf("a"), "t2" to listOf("a")),
+            stopsById = mapOf("a" to stop("a", lat = 1.0, lon = 5.0)),
+        )
+
+        val projected = projectFocusedStops(trips, geometry, stops)
+
+        assertClose(GeoPoint(0.0, 5.0), projected.getValue("a"))
+    }
+
+    @Test
+    fun projectFocusedStops_omitsStopsWithNoDrawableCandidate() {
+        val trips = setOf(
+            focusedTrip("t-missing", "r1", shapeId = "s-absent"),
+            focusedTrip("t-degenerate", "r2", shapeId = "s-degenerate"),
+            focusedTrip("t-noshape", "r3", shapeId = null),
+        )
+        val geometry = FocusedTripGeometry(
+            // s-absent isn't present at all; s-degenerate has < 2 points.
+            listOf(shape("s-degenerate", "r2", listOf(GeoPoint(0.0, 0.0))))
+        )
+        val stops = FocusedTripStops(
+            stopIdsByTripId = mapOf(
+                "t-missing" to listOf("a"),
+                "t-degenerate" to listOf("b"),
+                "t-noshape" to listOf("c"),
+            ),
+            stopsById = mapOf(
+                "a" to stop("a", lat = 1.0, lon = 5.0),
+                "b" to stop("b", lat = 1.0, lon = 5.0),
+                "c" to stop("c", lat = 1.0, lon = 5.0),
+            ),
+        )
+
+        val projected = projectFocusedStops(trips, geometry, stops)
+
+        assertTrue(projected.isEmpty())
+        assertNull(projected["a"])
+        assertFalse(projected.containsKey("b"))
+    }
+
+    private fun assertClose(expected: GeoPoint, actual: GeoPoint) {
+        assertEquals(expected.latitude, actual.latitude, 1e-6)
+        assertEquals(expected.longitude, actual.longitude, 1e-6)
+    }
+
+    private fun stop(id: String, lat: Double, lon: Double) = ObaStopElement(id = id, lat = lat, lon = lon)
+
+    private fun shape(shapeId: String, routeId: String, points: List<GeoPoint>) =
+        FocusedTripShape(shapeId, routeId, routeColor = null, points = points)
+
+    private fun focusedTrip(tripId: String, routeId: String, shapeId: String?) =
+        org.onebusaway.android.models.FocusedTrip(tripId, routeId, shapeId, routeColor = null)
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
@@ -624,8 +624,11 @@ class RouteMapController(
         return SelectedTripRenderInput(
             presentation = selected,
             routeColorFallback = currentRouteColor(),
-            directionUnderlay = selectedDirectionUnderlay(selected.routeDirection.directionId),
-            stopPresentation = selectedTripStopPresentation(selected),
+            // Deferred: the assembler resolves the underlay only when selectedTripStyle keeps it (stop
+            // focus inactive) and the stop projection only for a drawable trip, so neither is computed on
+            // the branches that skip it.
+            directionUnderlay = { selectedDirectionUnderlay(selected.routeDirection.directionId) },
+            stopPresentation = { selectedTripStopPresentation(selected) },
         )
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
@@ -126,12 +126,6 @@ class RouteMapController(
     private var basePolylines: List<RoutePolyline> = emptyList()
     private var baseStopPresentation: RouteStopPresentation? = null
 
-    private data class SelectedTripPresentation(
-        val points: List<GeoPoint>,
-        val stopIds: List<String>,
-        val routeDirection: RouteDirectionKey,
-    )
-
     private data class StopFocusSession(
         val stopId: String,
         val trips: Set<FocusedTrip>,
@@ -590,73 +584,48 @@ class RouteMapController(
         publishMapPresentation()
     }
 
+    // Assemble the render plan from the current controller state (pure — see
+    // [assembleRouteMapPresentation]) and forward each field to the render/stop layers. IO/retained
+    // state is resolved into plain data first ([selectedTripRenderInput]); the mode-merging policy lives
+    // in the pure function, so this stays a plumb-through.
     private fun publishMapPresentation() {
-        val focus = stopFocusSession
-        val emphasizedRoute = routeId?.let { RouteDirectionKey(it, presentationDirectionId) }
-        val routeColors = _focusedRouteColors.value
-        val selected = selectedTripPresentation()
-        if (selected != null) {
-            // See selectedTripStyle: stop focus alone gates the underlay, not whether an adjacency
-            // color happened to be found for this exact direction (#1902).
-            val style = selectedTripStyle(focus != null, selected.routeDirection, routeColors, currentRouteColor())
-            val selectedTrip = selected.points
-                .takeIf { it.size >= 2 }
-                ?.let { points -> focusedRoutePolyline(style.color, points, directional = true) }
-            // A selected vehicle shows its exact trip everywhere: the trip line, framed to that trip,
-            // over its scheduled stops.
-            if (selectedTrip != null) {
-                renderState.setRoutePolylines(
-                    polylines = focusedGeometry.toTripFocusedRoutePolylines(
-                        selected.routeDirection,
-                        routeColors,
-                        if (style.includeUnderlay) {
-                            selectedDirectionUnderlay(selected.routeDirection.directionId)
-                        } else emptyList(),
-                        selectedTrip,
-                    ),
-                    framingPolylines = listOf(selectedTrip),
-                    routeModeScalesStopsWithZoom = isActive,
-                )
-                // A selected trip is only reachable in single-route mode, where emphasizedRoute is
-                // always non-null too — the badges below are always suppressed here regardless.
-                renderState.setRouteBadges(emptyList())
-                stopsController.setRoutePresentation(selectedTripStopPresentation(selected))
-                return
-            }
-        }
-        val badges = if (emphasizedRoute == null) {
-            focusedGeometry.toRouteBadges(focusedRoutes, routeColors)
-        } else emptyList()
-        if (focus == null) {
-            renderState.setRoutePolylines(basePolylines, routeModeScalesStopsWithZoom = isActive)
-            renderState.setRouteBadges(emptyList())
-            stopsController.setRoutePresentation(baseStopPresentation)
-            return
-        }
-        val showBaseRoute = isActive && emphasizedRoute != null &&
-            focus.trips.none { it.routeDirection == emphasizedRoute }
-        val routesByStopId = focusedStops.routeDirectionsByStopId(focus.trips, emphasizedRoute)
-        renderState.setRoutePolylines(
-            polylines = focusedGeometry.toRoutePolylines(emphasizedRoute, routeColors) +
-                if (showBaseRoute) basePolylines else emptyList(),
-            // Adjacency remains visible underneath route mode, but the active route's fully loaded
-            // shape alone defines FramingIntent.Route. Using the displayed adjacency lines here would
-            // fit the union of every route serving the focused stop.
-            framingPolylines = if (isActive) basePolylines else emptyList(),
-            routeModeScalesStopsWithZoom = isActive,
+        val plan = assembleRouteMapPresentation(
+            isActive = isActive,
+            emphasizedRoute = routeId?.let { RouteDirectionKey(it, presentationDirectionId) },
+            basePolylines = basePolylines,
+            baseStopPresentation = baseStopPresentation,
+            focusTrips = stopFocusSession?.trips,
+            focusedGeometry = focusedGeometry,
+            focusedStops = focusedStops,
+            focusedRoutes = focusedRoutes,
+            routeColors = _focusedRouteColors.value,
+            selected = selectedTripRenderInput(),
+            projectedFocusStops = {
+                stopFocusSession?.let { projectFocusedStops(it.trips, focusedGeometry, focusedStops) }.orEmpty()
+            },
         )
-        renderState.setRouteBadges(badges)
-        stopsController.setRoutePresentation(
-            if (showBaseRoute) {
-                baseStopPresentation
-            } else {
-                RouteStopPresentation(
-                    stops = routesByStopId.keys.mapNotNull(focusedStops.stopsById::get),
-                    routes = focusedRoutes,
-                    routeDirectionsByStopId = routesByStopId,
-                    projectedPoints = projectFocusedStops(focus.trips, focusedGeometry, focusedStops),
-                )
-            }
+        renderState.setRoutePolylines(
+            polylines = plan.polylines,
+            framingPolylines = plan.framingPolylines,
+            routeModeScalesStopsWithZoom = plan.routeModeScalesStopsWithZoom,
+        )
+        renderState.setRouteBadges(plan.badges)
+        stopsController.setRoutePresentation(plan.stopPresentation)
+    }
+
+    /**
+     * The selected vehicle's render inputs, or null when no vehicle is selected or its exact shape +
+     * schedule haven't both resolved yet. Resolves the IO-backed pieces ([selectedTripPresentation],
+     * the GTFS colour fallback, the direction underlay, the projected stop presentation) so the pure
+     * assembler gets plain data.
+     */
+    private fun selectedTripRenderInput(): SelectedTripRenderInput? {
+        val selected = selectedTripPresentation() ?: return null
+        return SelectedTripRenderInput(
+            presentation = selected,
+            routeColorFallback = currentRouteColor(),
+            directionUnderlay = selectedDirectionUnderlay(selected.routeDirection.directionId),
+            stopPresentation = selectedTripStopPresentation(selected),
         )
     }
 
@@ -698,32 +667,6 @@ class RouteMapController(
             routeDirectionsByStopId = stops.associate { it.id to setOf(selected.routeDirection) },
             projectedPoints = projectStopsOntoPolylines(stops, listOf(selected.points)),
         )
-    }
-
-    /** Snap each exact scheduled stop to the closest successful shape of a trip that serves it. */
-    private fun projectFocusedStops(
-        trips: Set<FocusedTrip>,
-        geometry: FocusedTripGeometry,
-        stops: FocusedTripStops,
-    ): Map<String, GeoPoint> {
-        val tripById = trips.associateBy(FocusedTrip::tripId)
-        val candidates = LinkedHashMap<String, MutableList<Polyline>>()
-        for ((tripId, stopIds) in stops.stopIdsByTripId) {
-            val shapeId = tripById[tripId]?.shapeId ?: continue
-            val points = geometry.shapes.firstOrNull { it.shapeId == shapeId }?.points ?: continue
-            if (points.size < 2) continue
-            val polyline = Polyline(points.map(GeoPoint::toLocation))
-            stopIds.forEach { candidates.getOrPut(it, ::mutableListOf).add(polyline) }
-        }
-        return buildMap {
-            for ((stopId, shapes) in candidates) {
-                val stop = stops.stopsById[stopId] ?: continue
-                val location = stop.location
-                val point = shapes.mapNotNull { it.nearestPoint(location.latitude, location.longitude) }
-                    .minByOrNull(location::distanceTo)
-                if (point != null) put(stopId, point.toGeoPoint())
-            }
-        }
     }
 
     /** Restart the vehicle poll if a route is shown and the poll isn't running (the host's onResume). */
@@ -816,23 +759,6 @@ class RouteMapController(
     private fun projectStopsOntoShape(stops: List<ObaStop>): Map<String, GeoPoint> {
         val route = routeShape ?: return emptyMap()
         return projectStopsOntoPolylines(stops, route.shapeForDirection(currentDirectionId).polylines)
-    }
-
-    private fun projectStopsOntoPolylines(
-        stops: List<ObaStop>,
-        points: List<List<GeoPoint>>,
-    ): Map<String, GeoPoint> {
-        val shapes = points
-            .filter { it.size >= 2 }
-            .map { line -> Polyline(line.map(GeoPoint::toLocation)) }
-        if (shapes.isEmpty()) return emptyMap()
-        return stops.associate { stop ->
-            val loc = stop.location
-            val nearest = shapes
-                .mapNotNull { it.nearestPoint(loc.latitude, loc.longitude) }
-                .minByOrNull { loc.distanceTo(it) }
-            stop.id to (nearest?.toGeoPoint() ?: loc.toGeoPoint())
-        }
     }
 
     /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapPresentationPlan.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapPresentationPlan.kt
@@ -15,15 +15,12 @@
  */
 package org.onebusaway.android.map
 
-import android.location.Location
 import org.onebusaway.android.map.render.GeoPoint
 import org.onebusaway.android.map.render.RouteBadge
 import org.onebusaway.android.map.render.RoutePolyline
 import org.onebusaway.android.models.FocusedTrip
 import org.onebusaway.android.models.ObaRoute
-import org.onebusaway.android.models.ObaStop
 import org.onebusaway.android.models.RouteDirectionKey
-import org.onebusaway.android.util.Polyline
 
 /**
  * The complete render plan for one publish of the route map's line/badge/stop layers — the pure output
@@ -49,16 +46,19 @@ internal data class SelectedTripPresentation(
 
 /**
  * Everything the selected-vehicle branch of [assembleRouteMapPresentation] needs that the controller
- * must resolve from IO/retained state first: the [presentation] itself (from the trip-observation
- * store), the GTFS-colour fallback ([routeColorFallback]) when the selected route carries no adjacency
- * colour, the selected direction's thinned [directionUnderlay], and the projected-onto-shape
- * [stopPresentation]. Bundled so the pure function stays a function of plain data.
+ * must resolve from IO/retained state: the [presentation] itself (from the trip-observation store) and
+ * the GTFS-colour fallback ([routeColorFallback]) when the selected route carries no adjacency colour,
+ * both cheap and always needed to decide drawability; plus the selected direction's thinned
+ * [directionUnderlay] and the projected-onto-shape [stopPresentation], each of which the assembler uses
+ * on only some branches — so they're deferred as thunks and computed only when that branch is taken
+ * (the underlay does a per-segment copy, the stop presentation a `Location` projection). Bundled so the
+ * pure function stays a function of plain data + lazily-resolved dependencies.
  */
 internal data class SelectedTripRenderInput(
     val presentation: SelectedTripPresentation,
     val routeColorFallback: Int,
-    val directionUnderlay: List<RoutePolyline>,
-    val stopPresentation: RouteStopPresentation,
+    val directionUnderlay: () -> List<RoutePolyline>,
+    val stopPresentation: () -> RouteStopPresentation,
 )
 
 /**
@@ -75,10 +75,10 @@ internal data class SelectedTripRenderInput(
  * 3. **Stop-focus session**: adjacency geometry for the focused stop's trips, drawn over the emphasized
  *    base route only when that route isn't itself one of the focused trips ([showBaseRoute]).
  *
- * Pure so the precedence table is unit-tested without standing up the controller. The focused-stop
- * projection is the one Location-dependent step, so it enters as a lazy [projectedFocusStops] thunk
- * (invoked only on the branch that draws focused-stop siblings) — the merge policy itself stays plain
- * data, JVM-testable across every branch. The projection geometry is covered by instrumented tests.
+ * Pure so the precedence table is unit-tested without standing up the controller. The `Location`-backed
+ * work enters lazily so the merge policy itself stays plain data, JVM-testable across every branch: the
+ * focused-stop projection as the [projectedFocusStops] thunk, the selected-trip underlay/stop projection
+ * as thunks on [SelectedTripRenderInput]. That projection geometry is covered by instrumented tests.
  */
 internal fun assembleRouteMapPresentation(
     isActive: Boolean,
@@ -91,7 +91,7 @@ internal fun assembleRouteMapPresentation(
     focusedRoutes: List<ObaRoute>,
     routeColors: Map<RouteDirectionKey, Int>,
     selected: SelectedTripRenderInput?,
-    projectedFocusStops: () -> Map<String, GeoPoint> = { emptyMap() },
+    projectedFocusStops: () -> Map<String, GeoPoint>,
 ): RouteMapPresentation {
     // Route badges accompany adjacency geometry; a whole-route emphasis has no adjacency entry to badge.
     val badges = if (emphasizedRoute == null) {
@@ -101,28 +101,28 @@ internal fun assembleRouteMapPresentation(
     // 1. Selected vehicle: draw its exact trip in place of the direction geometry. Stop focus alone
     // gates the underlay, not whether an adjacency color happened to be found for this exact
     // direction — see selectedTripStyle (#1902).
-    val selectedTrip = selected?.let { input ->
-        input.presentation.points.takeIf { it.size >= 2 }?.let { points ->
-            val style = selectedTripStyle(
-                focusTrips != null, input.presentation.routeDirection, routeColors, input.routeColorFallback,
-            )
-            focusedRoutePolyline(style.color, points, directional = true) to style
-        }
-    }
-    if (selected != null && selectedTrip != null) {
-        val (polyline, style) = selectedTrip
-        return RouteMapPresentation(
-            polylines = focusedGeometry.toTripFocusedRoutePolylines(
-                selected.presentation.routeDirection,
-                routeColors,
-                if (style.includeUnderlay) selected.directionUnderlay else emptyList(),
-                polyline,
-            ),
-            framingPolylines = listOf(polyline),
-            routeModeScalesStopsWithZoom = isActive,
-            badges = badges,
-            stopPresentation = selected.stopPresentation,
+    if (selected != null) {
+        val style = selectedTripStyle(
+            focusTrips != null, selected.presentation.routeDirection, routeColors, selected.routeColorFallback,
         )
+        val selectedTrip = selected.presentation.points
+            .takeIf { it.size >= 2 }
+            ?.let { points -> focusedRoutePolyline(style.color, points, directional = true) }
+        if (selectedTrip != null) {
+            return RouteMapPresentation(
+                polylines = focusedGeometry.toTripFocusedRoutePolylines(
+                    selected.presentation.routeDirection,
+                    routeColors,
+                    if (style.includeUnderlay) selected.directionUnderlay() else emptyList(),
+                    selectedTrip,
+                ),
+                framingPolylines = listOf(selectedTrip),
+                routeModeScalesStopsWithZoom = isActive,
+                badges = badges,
+                stopPresentation = selected.stopPresentation(),
+            )
+        }
+        // A resolved-but-undrawable (< 2-point) trip falls through to the base/focus branches.
     }
 
     // 2. No stop-focus session: the base route (or ordinary nearby stops when not in route mode).
@@ -161,59 +161,3 @@ internal fun assembleRouteMapPresentation(
         },
     )
 }
-
-/**
- * Snap each of a focused stop's exact scheduled stops to the closest successful shape of a trip that
- * serves it. A stop that can't be placed on any candidate shape is omitted (not carried at its raw
- * location — the caller keeps only stops it can draw on the focused geometry). Pure; unit-tested.
- */
-internal fun projectFocusedStops(
-    trips: Set<FocusedTrip>,
-    geometry: FocusedTripGeometry,
-    stops: FocusedTripStops,
-): Map<String, GeoPoint> {
-    val tripById = trips.associateBy(FocusedTrip::tripId)
-    val candidates = LinkedHashMap<String, MutableList<Polyline>>()
-    for ((tripId, stopIds) in stops.stopIdsByTripId) {
-        val shapeId = tripById[tripId]?.shapeId ?: continue
-        val points = geometry.shapes.firstOrNull { it.shapeId == shapeId }?.points ?: continue
-        if (points.size < 2) continue
-        val polyline = Polyline(points.map(GeoPoint::toLocation))
-        stopIds.forEach { candidates.getOrPut(it, ::mutableListOf).add(polyline) }
-    }
-    return buildMap {
-        for ((stopId, shapes) in candidates) {
-            val stop = stops.stopsById[stopId] ?: continue
-            nearestPointAcross(shapes, stop.location)?.let { put(stopId, it) }
-        }
-    }
-}
-
-/**
- * Project [stops] onto the nearest point across [points]' drawable shapes (each candidate line needs
- * ≥2 points), keyed by stop id. A stop that can't be placed (no drawable shape) falls back to its own
- * location, so it still shows — just off the line. Pure; unit-tested.
- */
-internal fun projectStopsOntoPolylines(
-    stops: List<ObaStop>,
-    points: List<List<GeoPoint>>,
-): Map<String, GeoPoint> {
-    val shapes = points
-        .filter { it.size >= 2 }
-        .map { line -> Polyline(line.map(GeoPoint::toLocation)) }
-    if (shapes.isEmpty()) return emptyMap()
-    return stops.associate { stop ->
-        val loc = stop.location
-        stop.id to (nearestPointAcross(shapes, loc) ?: loc.toGeoPoint())
-    }
-}
-
-/**
- * The nearest point to [location] across [shapes] (the shared nearest-point-across-polylines kernel of
- * [projectFocusedStops] and [projectStopsOntoPolylines]), or null when no shape yields a point.
- */
-private fun nearestPointAcross(shapes: List<Polyline>, location: Location): GeoPoint? =
-    shapes
-        .mapNotNull { it.nearestPoint(location.latitude, location.longitude) }
-        .minByOrNull(location::distanceTo)
-        ?.toGeoPoint()

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapPresentationPlan.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapPresentationPlan.kt
@@ -136,8 +136,15 @@ internal fun assembleRouteMapPresentation(
         )
     }
 
-    // 3. Stop-focus session: adjacency geometry, over the emphasized base route when that route is not
-    //    itself one of the focused trips (otherwise its shape is already drawn by the adjacency layer).
+    // 3. Stop-focus session: adjacency geometry, over the emphasized base route when that route's shape
+    //    isn't already fully drawn by the adjacency layer. The equality is exact (direction included) on
+    //    purpose: in direction mode [emphasizedRoute] is a concrete-direction key, and when a focused
+    //    trip matches it exactly the adjacency layer already draws that shape, so the base is dropped.
+    //    In whole-route mode [emphasizedRoute] carries a null direction that no concrete focused-trip key
+    //    equals — deliberately keeping the base route, because [basePolylines] is then the merged
+    //    both-directions shape and the single-direction adjacency lines cover only part of it (dropping
+    //    it would erase the unfocused direction, and the null-direction key would also empty
+    //    routeDirectionsByStopId's exact-match filter below).
     val showBaseRoute = isActive && emphasizedRoute != null &&
         focusTrips.none { it.routeDirection == emphasizedRoute }
     val routesByStopId = focusedStops.routeDirectionsByStopId(focusTrips, emphasizedRoute)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapPresentationPlan.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapPresentationPlan.kt
@@ -1,0 +1,219 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.map
+
+import android.location.Location
+import org.onebusaway.android.map.render.GeoPoint
+import org.onebusaway.android.map.render.RouteBadge
+import org.onebusaway.android.map.render.RoutePolyline
+import org.onebusaway.android.models.FocusedTrip
+import org.onebusaway.android.models.ObaRoute
+import org.onebusaway.android.models.ObaStop
+import org.onebusaway.android.models.RouteDirectionKey
+import org.onebusaway.android.util.Polyline
+
+/**
+ * The complete render plan for one publish of the route map's line/badge/stop layers — the pure output
+ * of [assembleRouteMapPresentation]. [RouteMapController] does nothing with it but forward each field to
+ * [org.onebusaway.android.map.render.MapRenderState] and the [StopsMapController], so all the
+ * mode-merging policy (which of the three presentation modes wins, whether the base route stays visible
+ * underneath, which colour the selected trip keeps) lives in the pure function and is unit-tested.
+ */
+internal data class RouteMapPresentation(
+    val polylines: List<RoutePolyline>,
+    val framingPolylines: List<RoutePolyline>,
+    val routeModeScalesStopsWithZoom: Boolean,
+    val badges: List<RouteBadge>,
+    val stopPresentation: RouteStopPresentation?,
+)
+
+/** A selected vehicle's exact trip, as read fresh after its shape/schedule resolve. */
+internal data class SelectedTripPresentation(
+    val points: List<GeoPoint>,
+    val stopIds: List<String>,
+    val routeDirection: RouteDirectionKey,
+)
+
+/**
+ * Everything the selected-vehicle branch of [assembleRouteMapPresentation] needs that the controller
+ * must resolve from IO/retained state first: the [presentation] itself (from the trip-observation
+ * store), the GTFS-colour fallback ([routeColorFallback]) when the selected route carries no adjacency
+ * colour, the selected direction's thinned [directionUnderlay], and the projected-onto-shape
+ * [stopPresentation]. Bundled so the pure function stays a function of plain data.
+ */
+internal data class SelectedTripRenderInput(
+    val presentation: SelectedTripPresentation,
+    val routeColorFallback: Int,
+    val directionUnderlay: List<RoutePolyline>,
+    val stopPresentation: RouteStopPresentation,
+)
+
+/**
+ * Merge the three route-map presentation modes into one render plan. Precedence:
+ *
+ * 1. **Selected vehicle** ([selected] resolved, with a drawable ≥2-point trip): the exact trip line
+ *    replaces the direction geometry, framed to that trip, styled via [selectedTripStyle] — its colour
+ *    keeps the emphasized route's adjacency colour when one exists, falling back to the GTFS colour
+ *    otherwise, but the thinned direction underlay is gated on stop-focus being active at all, not on
+ *    whether an adjacency colour happened to be found for this exact direction. (The #1899 regression
+ *    was exactly that: the underlay decision proxied off the colour lookup instead of the real
+ *    stop-focus state, see #1902.)
+ * 2. **No stop-focus session** ([focusTrips] null): the plain base route (or ordinary nearby stops).
+ * 3. **Stop-focus session**: adjacency geometry for the focused stop's trips, drawn over the emphasized
+ *    base route only when that route isn't itself one of the focused trips ([showBaseRoute]).
+ *
+ * Pure so the precedence table is unit-tested without standing up the controller. The focused-stop
+ * projection is the one Location-dependent step, so it enters as a lazy [projectedFocusStops] thunk
+ * (invoked only on the branch that draws focused-stop siblings) — the merge policy itself stays plain
+ * data, JVM-testable across every branch. The projection geometry is covered by instrumented tests.
+ */
+internal fun assembleRouteMapPresentation(
+    isActive: Boolean,
+    emphasizedRoute: RouteDirectionKey?,
+    basePolylines: List<RoutePolyline>,
+    baseStopPresentation: RouteStopPresentation?,
+    focusTrips: Set<FocusedTrip>?,
+    focusedGeometry: FocusedTripGeometry,
+    focusedStops: FocusedTripStops,
+    focusedRoutes: List<ObaRoute>,
+    routeColors: Map<RouteDirectionKey, Int>,
+    selected: SelectedTripRenderInput?,
+    projectedFocusStops: () -> Map<String, GeoPoint> = { emptyMap() },
+): RouteMapPresentation {
+    // Route badges accompany adjacency geometry; a whole-route emphasis has no adjacency entry to badge.
+    val badges = if (emphasizedRoute == null) {
+        focusedGeometry.toRouteBadges(focusedRoutes, routeColors)
+    } else emptyList()
+
+    // 1. Selected vehicle: draw its exact trip in place of the direction geometry. Stop focus alone
+    // gates the underlay, not whether an adjacency color happened to be found for this exact
+    // direction — see selectedTripStyle (#1902).
+    val selectedTrip = selected?.let { input ->
+        input.presentation.points.takeIf { it.size >= 2 }?.let { points ->
+            val style = selectedTripStyle(
+                focusTrips != null, input.presentation.routeDirection, routeColors, input.routeColorFallback,
+            )
+            focusedRoutePolyline(style.color, points, directional = true) to style
+        }
+    }
+    if (selected != null && selectedTrip != null) {
+        val (polyline, style) = selectedTrip
+        return RouteMapPresentation(
+            polylines = focusedGeometry.toTripFocusedRoutePolylines(
+                selected.presentation.routeDirection,
+                routeColors,
+                if (style.includeUnderlay) selected.directionUnderlay else emptyList(),
+                polyline,
+            ),
+            framingPolylines = listOf(polyline),
+            routeModeScalesStopsWithZoom = isActive,
+            badges = badges,
+            stopPresentation = selected.stopPresentation,
+        )
+    }
+
+    // 2. No stop-focus session: the base route (or ordinary nearby stops when not in route mode).
+    if (focusTrips == null) {
+        return RouteMapPresentation(
+            polylines = basePolylines,
+            framingPolylines = basePolylines,
+            routeModeScalesStopsWithZoom = isActive,
+            badges = emptyList(),
+            stopPresentation = baseStopPresentation,
+        )
+    }
+
+    // 3. Stop-focus session: adjacency geometry, over the emphasized base route when that route is not
+    //    itself one of the focused trips (otherwise its shape is already drawn by the adjacency layer).
+    val showBaseRoute = isActive && emphasizedRoute != null &&
+        focusTrips.none { it.routeDirection == emphasizedRoute }
+    val routesByStopId = focusedStops.routeDirectionsByStopId(focusTrips, emphasizedRoute)
+    return RouteMapPresentation(
+        polylines = focusedGeometry.toRoutePolylines(emphasizedRoute, routeColors) +
+            if (showBaseRoute) basePolylines else emptyList(),
+        // Adjacency stays visible under route mode, but only the active route's fully loaded shape
+        // defines the route-frame extent (the displayed adjacency would fit every route at the stop).
+        framingPolylines = if (isActive) basePolylines else emptyList(),
+        routeModeScalesStopsWithZoom = isActive,
+        badges = badges,
+        stopPresentation = if (showBaseRoute) {
+            baseStopPresentation
+        } else {
+            RouteStopPresentation(
+                stops = routesByStopId.keys.mapNotNull(focusedStops.stopsById::get),
+                routes = focusedRoutes,
+                routeDirectionsByStopId = routesByStopId,
+                projectedPoints = projectedFocusStops(),
+            )
+        },
+    )
+}
+
+/**
+ * Snap each of a focused stop's exact scheduled stops to the closest successful shape of a trip that
+ * serves it. A stop that can't be placed on any candidate shape is omitted (not carried at its raw
+ * location — the caller keeps only stops it can draw on the focused geometry). Pure; unit-tested.
+ */
+internal fun projectFocusedStops(
+    trips: Set<FocusedTrip>,
+    geometry: FocusedTripGeometry,
+    stops: FocusedTripStops,
+): Map<String, GeoPoint> {
+    val tripById = trips.associateBy(FocusedTrip::tripId)
+    val candidates = LinkedHashMap<String, MutableList<Polyline>>()
+    for ((tripId, stopIds) in stops.stopIdsByTripId) {
+        val shapeId = tripById[tripId]?.shapeId ?: continue
+        val points = geometry.shapes.firstOrNull { it.shapeId == shapeId }?.points ?: continue
+        if (points.size < 2) continue
+        val polyline = Polyline(points.map(GeoPoint::toLocation))
+        stopIds.forEach { candidates.getOrPut(it, ::mutableListOf).add(polyline) }
+    }
+    return buildMap {
+        for ((stopId, shapes) in candidates) {
+            val stop = stops.stopsById[stopId] ?: continue
+            nearestPointAcross(shapes, stop.location)?.let { put(stopId, it) }
+        }
+    }
+}
+
+/**
+ * Project [stops] onto the nearest point across [points]' drawable shapes (each candidate line needs
+ * ≥2 points), keyed by stop id. A stop that can't be placed (no drawable shape) falls back to its own
+ * location, so it still shows — just off the line. Pure; unit-tested.
+ */
+internal fun projectStopsOntoPolylines(
+    stops: List<ObaStop>,
+    points: List<List<GeoPoint>>,
+): Map<String, GeoPoint> {
+    val shapes = points
+        .filter { it.size >= 2 }
+        .map { line -> Polyline(line.map(GeoPoint::toLocation)) }
+    if (shapes.isEmpty()) return emptyMap()
+    return stops.associate { stop ->
+        val loc = stop.location
+        stop.id to (nearestPointAcross(shapes, loc) ?: loc.toGeoPoint())
+    }
+}
+
+/**
+ * The nearest point to [location] across [shapes] (the shared nearest-point-across-polylines kernel of
+ * [projectFocusedStops] and [projectStopsOntoPolylines]), or null when no shape yields a point.
+ */
+private fun nearestPointAcross(shapes: List<Polyline>, location: Location): GeoPoint? =
+    shapes
+        .mapNotNull { it.nearestPoint(location.latitude, location.longitude) }
+        .minByOrNull(location::distanceTo)
+        ?.toGeoPoint()

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteStopProjection.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteStopProjection.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.map
+
+import android.location.Location
+import org.onebusaway.android.map.render.GeoPoint
+import org.onebusaway.android.models.FocusedTrip
+import org.onebusaway.android.models.ObaStop
+import org.onebusaway.android.util.Polyline
+
+/**
+ * Snapping route stops onto their drawn shapes for the route-map overlays. Kept out of
+ * [RouteMapPresentationPlan] (which is deliberately `android.location.Location`-free so it stays
+ * JVM-testable): these snap against [Polyline], so they're covered by the instrumented
+ * `RouteStopProjectionTest` rather than a plain-JVM unit test.
+ */
+
+/**
+ * Snap each of a focused stop's exact scheduled stops to the closest successful shape of a trip that
+ * serves it. A stop that can't be placed on any candidate shape is omitted (not carried at its raw
+ * location — the caller keeps only stops it can draw on the focused geometry).
+ */
+internal fun projectFocusedStops(
+    trips: Set<FocusedTrip>,
+    geometry: FocusedTripGeometry,
+    stops: FocusedTripStops,
+): Map<String, GeoPoint> {
+    val tripById = trips.associateBy(FocusedTrip::tripId)
+    val candidates = LinkedHashMap<String, MutableList<Polyline>>()
+    for ((tripId, stopIds) in stops.stopIdsByTripId) {
+        val shapeId = tripById[tripId]?.shapeId ?: continue
+        val points = geometry.shapes.firstOrNull { it.shapeId == shapeId }?.points ?: continue
+        if (points.size < 2) continue
+        val polyline = Polyline(points.map(GeoPoint::toLocation))
+        stopIds.forEach { candidates.getOrPut(it, ::mutableListOf).add(polyline) }
+    }
+    return buildMap {
+        for ((stopId, shapes) in candidates) {
+            val stop = stops.stopsById[stopId] ?: continue
+            nearestPointAcross(shapes, stop.location)?.let { put(stopId, it) }
+        }
+    }
+}
+
+/**
+ * Project [stops] onto the nearest point across [points]' drawable shapes (each candidate line needs
+ * ≥2 points), keyed by stop id. A stop that can't be placed (no drawable shape) falls back to its own
+ * location, so it still shows — just off the line.
+ */
+internal fun projectStopsOntoPolylines(
+    stops: List<ObaStop>,
+    points: List<List<GeoPoint>>,
+): Map<String, GeoPoint> {
+    val shapes = points
+        .filter { it.size >= 2 }
+        .map { line -> Polyline(line.map(GeoPoint::toLocation)) }
+    if (shapes.isEmpty()) return emptyMap()
+    return stops.associate { stop ->
+        val loc = stop.location
+        stop.id to (nearestPointAcross(shapes, loc) ?: loc.toGeoPoint())
+    }
+}
+
+/**
+ * The nearest point to [location] across [shapes] (the shared nearest-point-across-polylines kernel of
+ * [projectFocusedStops] and [projectStopsOntoPolylines]), or null when no shape yields a point.
+ */
+private fun nearestPointAcross(shapes: List<Polyline>, location: Location): GeoPoint? =
+    shapes
+        .mapNotNull { it.nearestPoint(location.latitude, location.longitude) }
+        .minByOrNull(location::distanceTo)
+        ?.toGeoPoint()

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteMapPresentationPlanTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteMapPresentationPlanTest.kt
@@ -140,8 +140,8 @@ class RouteMapPresentationPlanTest {
             selected = SelectedTripRenderInput(
                 presentation = selectedTrip("45", 0),
                 routeColorFallback = 0xFF00FF00.toInt(),
-                directionUnderlay = underlay,
-                stopPresentation = selectedStops,
+                directionUnderlay = { underlay },
+                stopPresentation = { selectedStops },
             ),
         )
 
@@ -166,8 +166,8 @@ class RouteMapPresentationPlanTest {
             selected = SelectedTripRenderInput(
                 presentation = selectedTrip("45", 0),
                 routeColorFallback = 0xFF00FF00.toInt(),
-                directionUnderlay = underlay,
-                stopPresentation = RouteStopPresentation(emptyList(), emptyList(), emptyMap(), emptyMap()),
+                directionUnderlay = { underlay },
+                stopPresentation = { RouteStopPresentation(emptyList(), emptyList(), emptyMap(), emptyMap()) },
             ),
         )
 
@@ -190,8 +190,8 @@ class RouteMapPresentationPlanTest {
             selected = SelectedTripRenderInput(
                 presentation = selectedTrip("45", 0),
                 routeColorFallback = 0xFF00FF00.toInt(),
-                directionUnderlay = underlay,
-                stopPresentation = RouteStopPresentation(emptyList(), emptyList(), emptyMap(), emptyMap()),
+                directionUnderlay = { underlay },
+                stopPresentation = { RouteStopPresentation(emptyList(), emptyList(), emptyMap(), emptyMap()) },
             ),
         )
 
@@ -213,8 +213,8 @@ class RouteMapPresentationPlanTest {
                     routeDirection = RouteDirectionKey("45", 0),
                 ),
                 routeColorFallback = 0xFF00FF00.toInt(),
-                directionUnderlay = emptyList(),
-                stopPresentation = RouteStopPresentation(emptyList(), emptyList(), emptyMap(), emptyMap()),
+                directionUnderlay = { fail("an undrawable trip must not build the underlay") },
+                stopPresentation = { fail("an undrawable trip must not project its stops") },
             ),
         )
 
@@ -233,8 +233,8 @@ class RouteMapPresentationPlanTest {
             selected = SelectedTripRenderInput(
                 presentation = selectedTrip("45", 0),
                 routeColorFallback = 0xFF00FF00.toInt(),
-                directionUnderlay = emptyList(),
-                stopPresentation = selectedStops,
+                directionUnderlay = { emptyList() },
+                stopPresentation = { selectedStops },
             ),
             projectedFocusStops = { fail("selection branch must not project focused stops") },
         )

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteMapPresentationPlanTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteMapPresentationPlanTest.kt
@@ -79,6 +79,26 @@ class RouteMapPresentationPlanTest {
     }
 
     @Test
+    fun `whole-route mode keeps the base route under a focused stop on the same route`() {
+        // In whole-route mode the emphasized key carries a null direction, which no concrete focused-trip
+        // key equals. That deliberately keeps the base route: basePolylines is then the merged
+        // both-directions shape, so the single-direction adjacency line covers only part of it — dropping
+        // it would erase the unfocused direction and empty the focused-stop presentation.
+        val plan = assemble(
+            emphasizedRoute = RouteDirectionKey("45", null),
+            focusTrips = setOf(trip("t-45", "45", directionId = 0)),
+            focusedGeometry = geometryFor("45", 0),
+            selected = null,
+            projectedFocusStops = { fail("base route stays, so no focused-stop projection") },
+        )
+
+        // Adjacency line for the focused direction + the merged base route drawn underneath it.
+        assertEquals(2, plan.polylines.size)
+        assertSame(baseStops, plan.stopPresentation)
+        assertSame(basePolylines, plan.framingPolylines)
+    }
+
+    @Test
     fun `emphasized route among focused trips drops the base route and builds focused-stop presentation`() {
         val emphasized = RouteDirectionKey("45", 0)
         val projected = mapOf("stop-a" to GeoPoint(2.0, 2.0))

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteMapPresentationPlanTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteMapPresentationPlanTest.kt
@@ -1,0 +1,309 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.map
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.onebusaway.android.map.render.GeoPoint
+import org.onebusaway.android.map.render.ROUTE_LINE_WIDTH_PROFILE
+import org.onebusaway.android.map.render.RouteBadge
+import org.onebusaway.android.map.render.RoutePolyline
+import org.onebusaway.android.models.FocusedTrip
+import org.onebusaway.android.models.ObaRoute
+import org.onebusaway.android.models.RouteDirectionKey
+
+/**
+ * Unit tests for the pure route-map presentation assembler — the three-mode precedence and the
+ * adjacency-colour/underlay interaction that produced the #1899 regression. No controller, no IO, no
+ * Android — the Location-dependent focused-stop projection enters as a thunk (its geometry is covered by
+ * the instrumented [RouteStopProjectionTest]).
+ */
+class RouteMapPresentationPlanTest {
+
+    private val basePolylines = listOf(line(GeoPoint(0.0, 0.0), GeoPoint(0.0, 1.0)))
+    private val baseStops = RouteStopPresentation(emptyList(), emptyList(), emptyMap(), emptyMap())
+
+    // --- Mode 2: no stop-focus session ---
+
+    @Test
+    fun `no focus and no selection draws the plain base route`() {
+        val plan = assemble(focusTrips = null, selected = null)
+
+        assertSame(basePolylines, plan.polylines)
+        assertSame(basePolylines, plan.framingPolylines)
+        assertSame(baseStops, plan.stopPresentation)
+        assertEquals(emptyList<RouteBadge>(), plan.badges)
+        assertTrue(plan.routeModeScalesStopsWithZoom)
+    }
+
+    @Test
+    fun `outside route mode the base branch does not scale stops with zoom`() {
+        val plan = assemble(isActive = false, emphasizedRoute = null, focusTrips = null, selected = null)
+
+        assertFalse(plan.routeModeScalesStopsWithZoom)
+    }
+
+    // --- Mode 3: stop-focus session ---
+
+    @Test
+    fun `emphasized route not among focused trips keeps the base route and its stops underneath`() {
+        val emphasized = RouteDirectionKey("45", 0)
+        val plan = assemble(
+            emphasizedRoute = emphasized,
+            focusTrips = setOf(trip("t-79", "79", directionId = 1)),
+            focusedGeometry = geometryFor("79", 1),
+            selected = null,
+            projectedFocusStops = { fail("projection is only computed when focused-stop siblings draw") },
+        )
+
+        // Adjacency line for route 79 + the base route drawn underneath it.
+        assertEquals(2, plan.polylines.size)
+        assertSame(baseStops, plan.stopPresentation)
+        assertSame(basePolylines, plan.framingPolylines)
+    }
+
+    @Test
+    fun `emphasized route among focused trips drops the base route and builds focused-stop presentation`() {
+        val emphasized = RouteDirectionKey("45", 0)
+        val projected = mapOf("stop-a" to GeoPoint(2.0, 2.0))
+        var projections = 0
+        val plan = assemble(
+            emphasizedRoute = emphasized,
+            focusTrips = setOf(trip("t-45", "45", directionId = 0)),
+            focusedGeometry = geometryFor("45", 0),
+            focusedStops = FocusedTripStops(
+                stopIdsByTripId = mapOf("t-45" to listOf("stop-a")),
+                stopsById = mapOf("stop-a" to stop("stop-a")),
+            ),
+            focusedRoutes = listOf(route("45", "45")),
+            selected = null,
+            projectedFocusStops = { projections++; projected },
+        )
+
+        // Only the adjacency line — the base route is not drawn underneath its own focus.
+        assertEquals(1, plan.polylines.size)
+        val stops = plan.stopPresentation!!
+        assertEquals(listOf("stop-a"), stops.stops.map { it.id })
+        assertEquals(projected, stops.projectedPoints)
+        assertEquals(1, projections)
+    }
+
+    @Test
+    fun `stop focus without route mode emits badges and no base underlay`() {
+        val plan = assemble(
+            isActive = false,
+            emphasizedRoute = null,
+            focusTrips = setOf(trip("t-79", "79", directionId = 1)),
+            focusedGeometry = geometryFor("79", 1),
+            focusedStops = FocusedTripStops(
+                stopIdsByTripId = mapOf("t-79" to listOf("stop-b")),
+                stopsById = mapOf("stop-b" to stop("stop-b")),
+            ),
+            focusedRoutes = listOf(route("79", "79")),
+            selected = null,
+            projectedFocusStops = { emptyMap() },
+        )
+
+        // No emphasized route -> route badges are emitted, and there's no active base route to frame to.
+        assertEquals(listOf("79"), plan.badges.map { it.routeId })
+        assertEquals(emptyList<RoutePolyline>(), plan.framingPolylines)
+        assertEquals(1, plan.polylines.size)
+    }
+
+    // --- Mode 1: selected vehicle, and the #1899 adjacency-colour/underlay interaction ---
+
+    @Test
+    fun `whole-route selection sits on the direction underlay with the GTFS fallback colour`() {
+        val underlay = listOf(line(GeoPoint(9.0, 9.0), GeoPoint(9.0, 10.0)))
+        val selectedStops = RouteStopPresentation(emptyList(), emptyList(), emptyMap(), emptyMap())
+        val plan = assemble(
+            emphasizedRoute = RouteDirectionKey("45", 0),
+            focusTrips = null,
+            focusedGeometry = FocusedTripGeometry(emptyList()),
+            routeColors = emptyMap(), // no adjacency entry -> GTFS fallback + underlay kept
+            selected = SelectedTripRenderInput(
+                presentation = selectedTrip("45", 0),
+                routeColorFallback = 0xFF00FF00.toInt(),
+                directionUnderlay = underlay,
+                stopPresentation = selectedStops,
+            ),
+        )
+
+        // Underlay + exact trip, in that order; the trip carries the GTFS fallback colour.
+        assertEquals(2, plan.polylines.size)
+        assertSame(underlay.single(), plan.polylines.first())
+        val trip = plan.polylines.last()
+        assertEquals(0xFF00FF00.toInt(), trip.color)
+        assertEquals(listOf(trip), plan.framingPolylines)
+        assertSame(selectedStops, plan.stopPresentation)
+    }
+
+    @Test
+    fun `selection inside stop focus keeps the adjacency colour and drops the generic underlay`() {
+        val underlay = listOf(line(GeoPoint(9.0, 9.0), GeoPoint(9.0, 10.0)))
+        val adjacencyColor = 0xFF123456.toInt()
+        val plan = assemble(
+            emphasizedRoute = RouteDirectionKey("45", 0),
+            focusTrips = setOf(trip("t-45", "45", directionId = 0)),
+            focusedGeometry = FocusedTripGeometry(emptyList()),
+            routeColors = mapOf(RouteDirectionKey("45", 0) to adjacencyColor),
+            selected = SelectedTripRenderInput(
+                presentation = selectedTrip("45", 0),
+                routeColorFallback = 0xFF00FF00.toInt(),
+                directionUnderlay = underlay,
+                stopPresentation = RouteStopPresentation(emptyList(), emptyList(), emptyMap(), emptyMap()),
+            ),
+        )
+
+        // Only the exact trip — the generic direction underlay is dropped because the route already
+        // reads via its adjacency colour (the #1899 regression case).
+        assertEquals(1, plan.polylines.size)
+        assertEquals(adjacencyColor, plan.polylines.single().color)
+    }
+
+    @Test
+    fun `selection inside stop focus with no adjacency entry for its own direction still drops the underlay`() {
+        val underlay = listOf(line(GeoPoint(9.0, 9.0), GeoPoint(9.0, 10.0)))
+        val plan = assemble(
+            emphasizedRoute = RouteDirectionKey("45", 0),
+            // The focused stop's own trips don't include this exact direction (e.g. an
+            // opposite-direction vehicle) -> routeColors carries no adjacency entry for it.
+            focusTrips = setOf(trip("t-79", "79", directionId = 1)),
+            focusedGeometry = FocusedTripGeometry(emptyList()),
+            routeColors = emptyMap(),
+            selected = SelectedTripRenderInput(
+                presentation = selectedTrip("45", 0),
+                routeColorFallback = 0xFF00FF00.toInt(),
+                directionUnderlay = underlay,
+                stopPresentation = RouteStopPresentation(emptyList(), emptyList(), emptyMap(), emptyMap()),
+            ),
+        )
+
+        // Stop focus being active alone gates the underlay -- not whether an adjacency colour was
+        // found for this exact direction (the #1899 regression fixed by #1902). Only the exact trip
+        // draws, in the GTFS fallback colour since there's no adjacency entry to carry instead.
+        assertEquals(1, plan.polylines.size)
+        assertEquals(0xFF00FF00.toInt(), plan.polylines.single().color)
+    }
+
+    @Test
+    fun `a degenerate selected trip falls through to the base route`() {
+        val plan = assemble(
+            focusTrips = null,
+            selected = SelectedTripRenderInput(
+                presentation = SelectedTripPresentation(
+                    points = listOf(GeoPoint(0.0, 0.0)), // < 2 points: not drawable
+                    stopIds = emptyList(),
+                    routeDirection = RouteDirectionKey("45", 0),
+                ),
+                routeColorFallback = 0xFF00FF00.toInt(),
+                directionUnderlay = emptyList(),
+                stopPresentation = RouteStopPresentation(emptyList(), emptyList(), emptyMap(), emptyMap()),
+            ),
+        )
+
+        assertSame(basePolylines, plan.polylines)
+        assertSame(baseStops, plan.stopPresentation)
+    }
+
+    @Test
+    fun `a drawable selection wins over a stop-focus session`() {
+        val selectedStops = RouteStopPresentation(emptyList(), emptyList(), emptyMap(), emptyMap())
+        val plan = assemble(
+            emphasizedRoute = RouteDirectionKey("45", 0),
+            focusTrips = setOf(trip("t-45", "45", directionId = 0)),
+            focusedGeometry = geometryFor("45", 0),
+            routeColors = emptyMap(),
+            selected = SelectedTripRenderInput(
+                presentation = selectedTrip("45", 0),
+                routeColorFallback = 0xFF00FF00.toInt(),
+                directionUnderlay = emptyList(),
+                stopPresentation = selectedStops,
+            ),
+            projectedFocusStops = { fail("selection branch must not project focused stops") },
+        )
+
+        assertSame(selectedStops, plan.stopPresentation)
+        assertEquals(1, plan.framingPolylines.size)
+    }
+
+    // --- helpers ---
+
+    private fun assemble(
+        isActive: Boolean = true,
+        emphasizedRoute: RouteDirectionKey? = RouteDirectionKey("45", 0),
+        focusTrips: Set<FocusedTrip>?,
+        focusedGeometry: FocusedTripGeometry = FocusedTripGeometry(emptyList()),
+        focusedStops: FocusedTripStops = FocusedTripStops(emptyMap(), emptyMap()),
+        focusedRoutes: List<ObaRoute> = emptyList(),
+        routeColors: Map<RouteDirectionKey, Int> = emptyMap(),
+        selected: SelectedTripRenderInput?,
+        projectedFocusStops: () -> Map<String, GeoPoint> = { emptyMap() },
+    ) = assembleRouteMapPresentation(
+        isActive = isActive,
+        emphasizedRoute = emphasizedRoute,
+        basePolylines = basePolylines,
+        baseStopPresentation = baseStops,
+        focusTrips = focusTrips,
+        focusedGeometry = focusedGeometry,
+        focusedStops = focusedStops,
+        focusedRoutes = focusedRoutes,
+        routeColors = routeColors,
+        selected = selected,
+        projectedFocusStops = projectedFocusStops,
+    )
+
+    private fun geometryFor(routeId: String, directionId: Int) = FocusedTripGeometry(
+        listOf(
+            FocusedTripShape(
+                "$routeId-shape", routeId, 0xFF808080.toInt(),
+                listOf(GeoPoint(1.0, 0.0), GeoPoint(1.0, 1.0)), directionId,
+            )
+        )
+    )
+
+    private fun selectedTrip(routeId: String, directionId: Int) = SelectedTripPresentation(
+        points = listOf(GeoPoint(4.0, 0.0), GeoPoint(4.0, 1.0)),
+        stopIds = emptyList(),
+        routeDirection = RouteDirectionKey(routeId, directionId),
+    )
+
+    private fun line(vararg points: GeoPoint) =
+        RoutePolyline(color = 1, points = points.toList(), widthProfile = ROUTE_LINE_WIDTH_PROFILE)
+
+    private fun trip(tripId: String, routeId: String, directionId: Int) =
+        FocusedTrip(tripId, routeId, "$routeId-shape", 0xFF808080.toInt(), directionId)
+
+    private fun fail(message: String): Nothing = throw AssertionError(message)
+
+    private fun stop(id: String): org.onebusaway.android.models.ObaStop =
+        org.onebusaway.android.api.adapters.ObaStopElement(id = id, lat = 47.0, lon = -122.0)
+
+    private fun route(id: String, shortName: String) = object : ObaRoute {
+        override val id = id
+        override val shortName = shortName
+        override val longName: String? = null
+        override val description: String? = null
+        override val type = ObaRoute.TYPE_BUS
+        override val url: String? = null
+        override val color: Int? = null
+        override val textColor: Int? = null
+        override val agencyId = "agency"
+    }
+}


### PR DESCRIPTION
Fixes #1907.

## What

`RouteMapController.publishMapPresentation()` merged three presentation modes — selected-vehicle exact trip, plain base route, and stop-focus adjacency geometry — through a chain of early returns, with no JVM test. The #1899 regression was precisely a missed interaction between two of those modes (the emphasized route's adjacency colour vs. the generic direction underlay under a selected vehicle).

This PR follows the issue's "make presentation assembly pure" cut rather than splitting the class:

- **New `RouteMapPresentationPlan.kt`** (beside `RouteViewGeometry.kt`) with a pure `assembleRouteMapPresentation(...)` → `RouteMapPresentation` render plan. It takes base polylines/stops, the focus session's trips, focused geometry/stops/routes, the palette, mode flags, and the selected-trip render inputs, and returns the polylines + framing + badges + stop presentation to publish. All the mode-precedence and colour/underlay policy lives here.
- **The controller keeps IO/lifecycle.** `publishMapPresentation()` is now a plumb-through: it resolves the IO-backed pieces (`selectedTripRenderInput()` reads the trip-observation store) and forwards each plan field to `MapRenderState` / `StopsMapController`. The one Location-dependent step — the focused-stop projection — enters the pure function as a lazy thunk, so the assembler is plain-data and JVM-testable across every branch.
- **Dedup:** the nearest-point-across-polylines kernel shared by `projectFocusedStops` and `projectStopsOntoPolylines` (called out in the issue) is now one function; both projections moved to the new file.

No behaviour change — the assembler is a faithful extraction of the prior branching.

## Tests

- **`RouteMapPresentationPlanTest`** (JVM unit): the three-mode precedence; the adjacency-colour-keeps-vs-underlay-drops interaction (both sides of the #1899 case); a degenerate (<2-point) selection falling through to the base route; and a drawable selection winning over a stop-focus session.
- **`RouteStopProjectionTest`** (instrumented): the projection geometry — nearest-point snapping, nearer-of-two-candidates, no-drawable-shape fall-backs, and per-stop omission. It snaps against `android.location.Location`, which this module's plain-JVM tests can't construct (this project deliberately avoids Robolectric — see the `HomeViewModelTest` note), so it lives in `androidTest`. Verified on-device: 6/6 pass.

Local: `compileObaGoogleDebugKotlin -PwarningsAsErrors=true` clean, full `map.*` unit-test package green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved route map rendering when selecting trips or focusing on stops.
  * Stops now align more accurately with displayed route geometry, including across multiple trip shapes.
  * Added fallback behavior for routes or trips without drawable geometry.
  * Refined route underlays, framing, badges, stop scaling, and focused-route presentation across viewing modes.

* **Tests**
  * Added comprehensive coverage for route projection and map presentation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->