### PR TITLE
Derive the focused-trip set from the current focus (#1908)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
@@ -155,10 +155,32 @@ class HomeViewModel @Inject constructor(
     // camera position would look wrong).
     private var animatePendingMapFocus: Boolean = false
 
-    /** Exact displayed trips for the focused stop; arrivals reload it after restore and refreshes. */
-    var focusedTrips: Set<FocusedTrip> = emptySet()
-        private set
+    // The last arrivals load's exact trips, paired with the stop they were loaded for. Set only by
+    // [onArrivalsLoaded]; never cleared imperatively. [focusedTrips] scopes it to the *current* focus,
+    // so any focus transition empties the exposed set by construction — no per-transition reset to
+    // forget (the "forgot to clear on transition X" bug class this replaces).
+    private var loadedTrips: LoadedTrips? = null
+
+    /**
+     * Exact displayed trips for the *currently focused* stop — the loaded set when it belongs to the
+     * focused stop, else empty. Derived from [currentFocus] rather than mirrored into a manually-reset
+     * field, so it can't outlive its stop: focusing another stop, a route, or nothing reads as empty
+     * until that stop's own arrivals load.
+     */
+    val focusedTrips: Set<FocusedTrip>
+        get() {
+            val stopId = (_currentFocus.value as? CurrentFocus.Stop)?.stop?.id ?: return emptySet()
+            val loaded = loadedTrips ?: return emptySet()
+            return if (loaded.stopId.equals(stopId, ignoreCase = true)) loaded.trips else emptySet()
+        }
+
+    // The route-directions currently drawn for the focused-stop presentation. Unlike [focusedTrips]
+    // this deliberately *persists* across a continuing stop-to-stop handoff (the old routes stay on the
+    // map until the new stop's arrivals replace them), so it stays an explicitly-managed field.
     private var presentedRoutes: Set<RouteDirectionKey> = emptySet()
+
+    /** An arrivals load's exact trips, tagged with the stop id they were loaded for. */
+    private data class LoadedTrips(val stopId: String, val trips: Set<FocusedTrip>)
 
     /**
      * A map stop gained focus. When it shares any presented route-direction with the current stop,
@@ -176,7 +198,6 @@ class HomeViewModel @Inject constructor(
             null -> current != null && presentedRoutes.any(continuingRoutes::contains)
             else -> selected.currentLeg.routeDirection in continuingRoutes
         }
-        focusedTrips = emptySet()
         if (!continuePresentation) {
             presentedRoutes = emptySet()
             emitMapDirective(MapDirective.ClearStopRoutes)
@@ -303,7 +324,7 @@ class HomeViewModel @Inject constructor(
     ) {
         val focus = _currentFocus.value as? CurrentFocus.Stop ?: return
         if (!focus.stop.id.equals(stop.id, ignoreCase = true)) return
-        focusedTrips = trips
+        loadedTrips = LoadedTrips(focus.stop.id, trips)
         presentedRoutes = trips.mapTo(linkedSetOf(), FocusedTrip::routeDirection)
         val preserveViewport = pendingMapFocus && preserveViewportForPendingMapFocus
         // Frame the selected route only when this load is the initial (restore/deep-link) focus
@@ -372,7 +393,6 @@ class HomeViewModel @Inject constructor(
 
     /** Enter route focus from a route-oriented surface (search, recents, deep link, route info). */
     fun focusStandaloneRoute(request: ShowRouteRequest, undoViewport: MapViewport? = null) {
-        focusedTrips = emptySet()
         pushFocus(CurrentFocus.Route(request.toRouteTarget()), undoViewport)
         emitMapDirective(MapDirective.ShowRoute(request, stopScoped = false))
     }
@@ -480,7 +500,6 @@ class HomeViewModel @Inject constructor(
         if (target is CurrentFocus.Stop) {
             emitMapDirective(MapDirective.ClearSelectedRoute)
         } else {
-            focusedTrips = emptySet()
             presentedRoutes = emptySet()
             emitMapDirective(MapDirective.ClearFocus)
         }
@@ -490,7 +509,6 @@ class HomeViewModel @Inject constructor(
     fun clearMapFocus() {
         if (_currentFocus.value == CurrentFocus.None) return
         pushFocus(CurrentFocus.None)
-        focusedTrips = emptySet()
         presentedRoutes = emptySet()
         // Drop any pending restore/deep-link latch too; otherwise a stop closed before its arrivals
         // load leaves it set, and the next stop's onArrivalsLoaded would consume it and recenter.
@@ -567,7 +585,6 @@ class HomeViewModel @Inject constructor(
                 )
             )
         } else {
-            focusedTrips = emptySet()
             when (target) {
                 is CurrentFocus.Stop -> {
                     markPendingMapFocus()

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
@@ -911,6 +911,20 @@ class HomeViewModelTest {
         assertEquals(emptySet<FocusedTrip>(), vm.focusedTrips)
     }
 
+    @Test
+    fun `focused trips follow the current focus with no explicit reset`() = runTest {
+        // The set is derived from the current focus, not a manually-cleared field: leaving the stop
+        // for a standalone route empties it by construction (focusStandaloneRoute has no reset call),
+        // and the same load re-scoped to a different stop id never leaks across.
+        val vm = viewModel()
+        vm.onStopFocused(FocusedStop("1", "Main St", "100", 47.6, -122.3))
+        vm.onArrivalsLoaded(obaStop, null, setOf(FocusedTrip("trip", "40", "shape", null)))
+        assertTrue(vm.focusedTrips.isNotEmpty())
+
+        vm.focusStandaloneRoute(ShowRouteRequest("65"))
+        assertEquals(emptySet<FocusedTrip>(), vm.focusedTrips)
+    }
+
     // --- focus + SavedStateHandle ---
 
     @Test


### PR DESCRIPTION
Addresses **item 3** of #1908 (debt review finding 8) — the last of three separate PRs closing that issue.

## Problem

`HomeViewModel.focusedTrips` was a plain `var` mirroring `ArrivalsLoaded.focusedTrips`, cleared imperatively at **five** focus-transition sites — `onStopFocused`, `focusStandaloneRoute`, `unfocusMapOneLevel`, `clearMapFocus`, `restoreMapAfterBack`. Every new transition had to *remember* to clear it: the "forgot to clear on transition X" bug class.

## Change

Make `focusedTrips` a **computed property scoped to the current focus**. A single `loadedTrips` field records the last arrivals load (the trips + the stop id they were loaded for), set **only** by `onArrivalsLoaded`. `focusedTrips` returns those trips only while that stop is the currently focused one — otherwise empty. So focusing another stop, a route, or nothing empties the exposed set *by construction*, and all five manual resets are removed (and can't be forgotten).

`presentedRoutes` intentionally stays an explicitly-managed field. Unlike `focusedTrips`, it must **persist across a continuing stop-to-stop handoff** — the old routes stay drawn until the new stop's arrivals replace them (#1893's adjacency continuation) — which a purely focus-derived value can't express. Keeping the two mechanisms separate is deliberate; the comments spell out why.

## Tests

Existing `HomeViewModelTest` cases already assert the derived behavior — `focusedTrips` empties on a different-stop focus (`focusing a different stop resets exact trips`), on a *continuing* handoff (`adjacent stop … continues the map presentation`), and on unfocus — and still pass unchanged. Added `focused trips follow the current focus with no explicit reset` to lock in the derivation (entering a standalone route empties the set although `focusStandaloneRoute` no longer clears anything).

- `./gradlew :onebusaway-android:compileObaGoogleDebugKotlin -PwarningsAsErrors=true` — clean; full `testObaGoogleDebugUnitTest` — green.

## Relation to the other #1908 PRs

Independent of #1919 and #1921 (this touches only `HomeViewModel`; those touch the data layer), so it merges in any order with no conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)