### PR TITLE
Revert case-insensitive stop/route-ID comparisons to exact equality

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
@@ -382,7 +382,7 @@ class MapViewModel @Inject constructor(
         trips: Set<FocusedTrip>,
     ) {
         val focusedStopId = renderState.snapshot.value.focusedStopId
-        if (focusedStopId == null || !focusedStopId.equals(stopId, ignoreCase = true)) return
+        if (focusedStopId != stopId) return
         routeController.focusStop(stopId, trips, routes)
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/RouteRowGroup.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/RouteRowGroup.kt
@@ -190,7 +190,7 @@ internal fun resolveSelectedRouteGroupKey(
     requestedKey: String?,
     routeId: String?,
 ): String? {
-    groups.firstOrNull { it.key.equals(requestedKey, ignoreCase = true) }?.let { return it.key }
+    groups.firstOrNull { it.key == requestedKey }?.let { return it.key }
     if (routeId == null) return null
-    return groups.filter { it.routeId.equals(routeId, ignoreCase = true) }.singleOrNull()?.key
+    return groups.filter { it.routeId == routeId }.singleOrNull()?.key
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
@@ -176,7 +176,7 @@ class HomeViewModel @Inject constructor(
         get() {
             val stopId = (_currentFocus.value as? CurrentFocus.Stop)?.stop?.id ?: return emptySet()
             val loaded = loadedTrips ?: return emptySet()
-            return if (loaded.stopId.equals(stopId, ignoreCase = true)) loaded.trips else emptySet()
+            return if (loaded.stopId == stopId) loaded.trips else emptySet()
         }
 
     // The route-directions currently drawn for the focused-stop presentation. Unlike [focusedTrips]
@@ -196,7 +196,7 @@ class HomeViewModel @Inject constructor(
         continuingRoutes: Set<RouteDirectionKey> = emptySet(),
     ): StopFocusTransition {
         val previousId = _currentFocus.value.focusedStop?.id
-        val sameStop = previousId?.equals(stop.id, ignoreCase = true) == true
+        val sameStop = previousId == stop.id
         if (sameStop) return StopFocusTransition.Unchanged
         val current = _currentFocus.value as? CurrentFocus.Stop
         val continuePresentation = when (val selected = current?.selectedRoute) {
@@ -328,7 +328,7 @@ class HomeViewModel @Inject constructor(
         trips: Set<FocusedTrip> = emptySet(),
     ) {
         val focus = _currentFocus.value as? CurrentFocus.Stop ?: return
-        if (!focus.stop.id.equals(stop.id, ignoreCase = true)) return
+        if (focus.stop.id != stop.id) return
         loadedTrips = LoadedTrips(focus.stop.id, trips)
         presentedRoutes = trips.mapTo(linkedSetOf(), FocusedTrip::routeDirection)
         val pending = pendingFocus
@@ -575,7 +575,7 @@ class HomeViewModel @Inject constructor(
             return
         }
         val returnsToSameStop = from is CurrentFocus.Stop && target is CurrentFocus.Stop &&
-            from.stop.id.equals(target.stop.id, ignoreCase = true)
+            from.stop.id == target.stop.id
         if (returnsToSameStop) {
             val selected = target.selectedRoute
             emitMapDirective(


### PR DESCRIPTION
## Summary
- #1865 introduced `ignoreCase = true` at six stop/route-ID comparison sites with no documented rationale, and #1908 later copied the same pattern into a seventh (`HomeViewModel.focusedTrips`). CLAUDE.md calls out "fuzzy string matching where an exact key exists" as a heuristic that needs human sign-off before merge; none exists here, and there's no wire evidence that OBA stop/route IDs vary in case.
- It's also internally inconsistent: `RouteMapController.focusStop` already dedups stop-focus sessions via case-sensitive data-class equality, so a mixed-case ID could pass these gates while defeating that dedup — silent edge-only misbehavior.
- Reverts all seven call sites to exact (`==`) equality: `MapViewModel.showStopRoutes`, `HomeViewModel` (`focusedTrips`, `onStopFocused`, `onArrivalsLoaded`, `restoreMapAfterBack`), and `RouteRowGroup.resolveSelectedRouteGroupKey`.

Fixes #1905

## Test plan
- [x] `./gradlew :onebusaway-android:compileObaGoogleDebugKotlin -PwarningsAsErrors=true` — compiles clean
- [x] `./gradlew :onebusaway-android:testObaGoogleDebugUnitTest --tests "org.onebusaway.android.ui.home.HomeViewModelTest" --tests "org.onebusaway.android.map.MapViewModelTest" --tests "org.onebusaway.android.ui.arrivals.*"` — all pass (no test depended on case-insensitive matching)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stop and route selection accuracy by requiring exact identifier matches.
  * Prevented arrival and trip information from being displayed or restored for similarly named but different stops or routes.
  * Ensured map and arrivals views remain synchronized with the precisely selected stop.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->