### PR TITLE
Fix silent map-directive drop: use Channel(UNLIMITED) in HomeViewModel (#1904)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
@@ -114,8 +114,11 @@ class HomeViewModel @Inject constructor(
     // reference to the map's VM (the seam the old MapInteractionBus filled). A Channel, not a
     // replay-0 SharedFlow: MapFeature's collector lives in HOME's composition, so a directive emitted
     // before it (re)subscribes — e.g. a route reveal consumed right after popping back from the search
-    // destination — must queue for the single consumer instead of vanishing.
-    private val _mapDirectives = Channel<MapDirective>(capacity = 16)
+    // destination — must queue for the single consumer instead of vanishing. UNLIMITED (not a fixed
+    // capacity): the whole point is to never drop a queued directive, and trySend on a bounded channel
+    // fails silently once it fills — reviving the very drop bug this Channel replaced. Directives are
+    // tiny and low-frequency, so an unbounded buffer costs nothing in practice.
+    private val _mapDirectives = Channel<MapDirective>(capacity = Channel.UNLIMITED)
     val mapDirectives: Flow<MapDirective> = _mapDirectives.receiveAsFlow()
 
     // Telemetry events the host's single HomeAnalyticsEffect reports (region auto-selects, nav/help menu
@@ -533,6 +536,8 @@ class HomeViewModel @Inject constructor(
     }
 
     // trySend keeps these low-frequency one-shot directives synchronous with their semantic action.
+    // On an UNLIMITED channel it can't fail on a full buffer (the drop bug that motivated #1904); it
+    // only returns failure once the channel is closed, which this VM never does.
     private fun emitMapDirective(directive: MapDirective) {
         _mapDirectives.trySend(directive)
     }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
@@ -273,6 +273,25 @@ class HomeViewModelTest {
     }
 
     @Test
+    fun `directives emitted while no collector is subscribed all queue, past the old bound`() = runTest {
+        val vm = viewModel()
+        val map = MapDirectiveRecorder(vm)
+
+        // Emit far more directives than the old Channel(capacity = 16) could hold, with NO collector
+        // subscribed yet — the exact situation #1904 flagged: a directive fired while HOME's collector
+        // is away (e.g. on a pushed search destination) must queue for it, not vanish on a full-channel
+        // trySend. An UNLIMITED channel buffers them all; the old bounded one dropped everything past 16.
+        val count = 40
+        repeat(count) { vm.focusStandaloneRoute(ShowRouteRequest("route-$it")) }
+
+        val mapJob = launch { map.collect() }
+        advanceUntilIdle()
+
+        assertEquals((0 until count).map { "route-$it" }, map.routesShown)
+        mapJob.cancel()
+    }
+
+    @Test
     fun `focused stop route badge preserves stop focus and line direction`() = runTest {
         val vm = viewModel()
         val map = MapDirectiveRecorder(vm)


### PR DESCRIPTION
Fixes #1904.

## Problem

`HomeViewModel._mapDirectives` was a `Channel(capacity = 16)` written with `trySend`. #1865 introduced this Channel (replacing a replay-0 SharedFlow) precisely so a directive emitted while HOME's collector is resubscribing would **queue** instead of vanish. But `trySend` fails **silently** once the bounded channel fills — 17+ directives queued while the user is on a pushed destination reproduces the very drop bug the Channel was introduced to fix, unlogged.

## Fix

Switch to `Channel(capacity = Channel.UNLIMITED)`. Directives are tiny and low-frequency, so an unbounded buffer never drops and costs nothing. `trySend` can then only fail on a *closed* channel (which this VM never does), so it stays a correct synchronous emit — the comments are updated to reflect that.

## Test

Added a regression test that emits 40 directives (past the old bound of 16) with **no collector subscribed**, then subscribes and asserts all 40 are delivered in order. It fails under `capacity = 16` and passes under `UNLIMITED`.

## Verification

`./gradlew :onebusaway-android:testObaGoogleDebugUnitTest --tests "org.onebusaway.android.ui.home.HomeViewModelTest" -PwarningsAsErrors=true` → BUILD SUCCESSFUL, all tests green, no compiler warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured map actions are reliably queued when the map is not actively listening.
  * Prevented queued route-focus actions from being lost during bursts of activity.
  * Preserved the order of map directives for consistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->