### PR TITLE
Swap the archived JakeWharton kotlinx-serialization converter for Retrofit's upstream converter (#1910)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -69,7 +69,6 @@ composeBom = "2026.06.01"
 materialIcons = "1.7.8"
 retrofit = "3.0.0"
 okhttp = "5.4.0"
-retrofitKotlinxConverter = "1.0.0"
 kotlinxSerializationJson = "1.11.0"
 coroutines = "1.11.0"
 material = "1.14.0"
@@ -151,7 +150,7 @@ hilt-android-compiler = { module = "com.google.dagger:hilt-android-compiler", ve
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 okhttp-logging-interceptor = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttp" }
-retrofit-kotlinx-serialization-converter = { module = "com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter", version.ref = "retrofitKotlinxConverter" }
+retrofit-kotlinx-serialization-converter = { module = "com.squareup.retrofit2:converter-kotlinx-serialization", version.ref = "retrofit" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 apollo-runtime = { module = "com.apollographql.apollo:apollo-runtime", version.ref = "apollo" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/net/ObaApiProvider.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/net/ObaApiProvider.kt
@@ -16,7 +16,6 @@
 package org.onebusaway.android.api.net
 
 import android.net.Uri
-import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -24,6 +23,7 @@ import kotlinx.serialization.json.Json
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import org.onebusaway.android.api.contract.ObaWebService
+import retrofit2.converter.kotlinx.serialization.asConverterFactory
 import retrofit2.Retrofit
 
 /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/app/di/NetworkModule.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/app/di/NetworkModule.kt
@@ -35,7 +35,7 @@ import org.onebusaway.android.api.contract.RegionsWebService
 import org.onebusaway.android.api.contract.ReminderWebService
 import org.onebusaway.android.api.contract.SurveyWebService
 import org.onebusaway.android.api.contract.WeatherWebService
-import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
+import retrofit2.converter.kotlinx.serialization.asConverterFactory
 import retrofit2.Retrofit
 
 /**


### PR DESCRIPTION
Fixes #1910.

## What

Swaps the archived `com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter:1.0.0` for Retrofit's upstream converter, `com.squareup.retrofit2:converter-kotlinx-serialization`.

## Why

The JakeWharton artifact was archived when the converter was upstreamed into Retrofit itself. It's frozen at 1.0.0 (built against Retrofit 2.x / OkHttp 4.x), and Dependabot will never update it — so after the retrofit 2→3 (#1855) and okhttp 4→5 (#1854) major bumps it was the one leg of the network stack still pinned to the old majors. Binary-compatible today, but that's luck, not a contract.

## Changes

- **`gradle/libs.versions.toml`** — point the `retrofit-kotlinx-serialization-converter` library at `com.squareup.retrofit2:converter-kotlinx-serialization`. Because the upstream converter is versioned in lockstep with Retrofit, it now uses `version.ref = "retrofit"` (currently `3.0.0`) and tracks the same Dependabot bumps. Removed the now-orphaned `retrofitKotlinxConverter = "1.0.0"` version entry.
- **`NetworkModule.kt`** and **`ObaApiProvider.kt`** — update the `asConverterFactory` import to `retrofit2.converter.kotlinx.serialization`. The API is identical, so the call sites are otherwise unchanged. (The issue named only `NetworkModule.kt`; the second call site in `ObaApiProvider.kt` was caught at compile time and migrated too.)

## Verification

- `compileObaGoogleDebugKotlin` and `compileObaMaplibreDebugKotlin` both build clean with `-PwarningsAsErrors=true` (the CI gate).
- Confirmed the runtime classpath now resolves `com.squareup.retrofit2:converter-kotlinx-serialization:3.0.0`; the archived JakeWharton artifact is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)