### PR TITLE
Restore private on #1875's widened members; disable SyntheticAccessor (#1912)

### DIFF
--- a/onebusaway-android/build.gradle.kts
+++ b/onebusaway-android/build.gradle.kts
@@ -190,11 +190,20 @@ android {
         //    (RouteMapController's `vehicleJob?.isActive`). The one hit is benign and has no cleaner call.
         //  - ConvertToWebp: an advisory "this image could be smaller as WebP" nudge (wmata.jpg), not a
         //    correctness signal. Declined.
+        //  - SyntheticAccessor: flags a `private` member accessed across the class/file boundary, whose
+        //    only cost is a compiler-generated accessor method. Satisfying it forces widening real
+        //    encapsulation — file-`private` Kotlin helpers → `internal` (app-global in this single-module
+        //    app) and Java `private` → package-private — for a micro-optimization the toolchain already
+        //    erases: release enables R8 with `-allowaccessmodification` (#1868), which inlines/strips the
+        //    accessors, and in debug the cost is a handful of trivial methods. Leaving it enabled taxes
+        //    every future file-private helper called from a sibling class. #1875 widened 34 declarations
+        //    to clear it; #1912 restored their `private` and opts the check out here.
         disable += setOf(
             "MissingTranslation", "ExtraTranslation", "LogNotTimber",
             "GradleDependency", "NewerVersionAvailable", "AndroidGradlePluginVersion",
             "OldTargetApi", "DuplicateStrings",
-            "InvalidPackage", "PermissionNamingConvention", "MemberExtensionConflict", "ConvertToWebp"
+            "InvalidPackage", "PermissionNamingConvention", "MemberExtensionConflict", "ConvertToWebp",
+            "SyntheticAccessor"
         )
         // Run the FULL lint catalog — including checks that are off by default and library-provided
         // ones (Compose, UseKtx, …) — so the checked set is comprehensive and current for the installed

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleComposeAdapter.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleComposeAdapter.kt
@@ -313,7 +313,7 @@ class GoogleComposeAdapter : ObaComposeMapAdapter {
  * routes through [routeMarkerTap] (reliable for every marker, static and dynamic, because the dynamic
  * markers move at only ~20Hz — see [FRAME_INTERVAL_NANOS]); an info-window tap deep links.
  */
-internal fun wireClicks(
+private fun wireClicks(
     map: GoogleMap,
     renderer: GoogleMapRenderer,
     infoWindows: GoogleInfoWindows,
@@ -395,7 +395,7 @@ private fun routeMarkerTap(
  * render, so the bubble reflects the latest poll (re-rendered via [GoogleInfoWindows.refresh]), not a
  * tap-time snapshot.
  */
-internal fun GoogleInfoWindows.openVehicleWindow(renderer: GoogleMapRenderer, marker: Marker) {
+private fun GoogleInfoWindows.openVehicleWindow(renderer: GoogleMapRenderer, marker: Marker) {
     open(marker) {
         val live = renderer.vehicleForMarker(marker)
         // Deliberate snapshot read, not a reactive subscription: this content is rendered to a bitmap on
@@ -408,7 +408,7 @@ internal fun GoogleInfoWindows.openVehicleWindow(renderer: GoogleMapRenderer, ma
 }
 
 /** Builds a [CameraSnapshot] from the Google map's current camera + visible region. */
-internal fun snapshot(map: GoogleMap): CameraSnapshot {
+private fun snapshot(map: GoogleMap): CameraSnapshot {
     val pos = map.cameraPosition
     val bounds = map.projection.visibleRegion.latLngBounds
     val sw = bounds.southwest
@@ -424,13 +424,13 @@ internal fun snapshot(map: GoogleMap): CameraSnapshot {
 }
 
 @SuppressLint("MissingPermission")
-internal fun applyMyLocation(map: GoogleMap, context: Context, enabled: Boolean) {
+private fun applyMyLocation(map: GoogleMap, context: Context, enabled: Boolean) {
     val granted = PermissionUtils.hasGrantedAtLeastOnePermission(context, PermissionUtils.LOCATION_PERMISSIONS)
     map.isMyLocationEnabled = enabled && granted
 }
 
 /** The map style for the current night-mode state: the dark theme, or POI removal in light mode. */
-internal fun resolveMapStyle(context: Context): MapStyleOptions =
+private fun resolveMapStyle(context: Context): MapStyleOptions =
     if (ThemeUtils.isInDarkMode(context)) {
         MapStyleOptions.loadRawResourceStyle(context, R.raw.dark_map)
     } else {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/analytics/UmamiAnalytics.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/analytics/UmamiAnalytics.java
@@ -82,7 +82,7 @@ public class UmamiAnalytics {
         });
     }
 
-    void post(String payload) {
+    private void post(String payload) {
         HttpURLConnection conn = null;
         try {
             conn = (HttpURLConnection) new URL(mSendUrl).openConnection();

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/adapters/TripAdapters.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/adapters/TripAdapters.kt
@@ -39,7 +39,7 @@ import kotlin.time.Duration.Companion.seconds
  * one-DTO-implements-the-interface pattern the map boundary uses for stops/routes.
  */
 
-internal fun Position.toLocation(): Location = locationOf(lat, lon)
+private fun Position.toLocation(): Location = locationOf(lat, lon)
 
 /** Presents a [TripStatus] DTO as an [ObaTripStatus]. */
 internal class DtoTripStatus(private val dto: TripStatus) : ObaTripStatus {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/data/TripVehiclesDataSource.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/data/TripVehiclesDataSource.kt
@@ -66,7 +66,7 @@ private fun routeTripsOf(
  * double-record). Keying the dedup on `activeTripId` at this one wire→model seam fixes every consumer
  * at once; fall back to `tripId` when a status is absent, and preserve first-seen order.
  */
-internal fun List<TripDetailsEntry>.dedupeByActiveTripKeepingBestFix(): List<TripDetailsEntry> {
+private fun List<TripDetailsEntry>.dedupeByActiveTripKeepingBestFix(): List<TripDetailsEntry> {
     if (size < 2) return this
     val byKey = LinkedHashMap<String, TripDetailsEntry>(size)
     for (entry in this) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/app/di/LocationEntryPoint.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/app/di/LocationEntryPoint.kt
@@ -52,7 +52,7 @@ interface LocationEntryPoint {
         fun getSink(context: Context): LocationSink =
             accessor(context).locationSink()
 
-        internal fun accessor(context: Context): LocationEntryPoint =
+        private fun accessor(context: Context): LocationEntryPoint =
             EntryPointAccessors.fromApplication(context, LocationEntryPoint::class.java)
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/database/oba/LegacyDataImporter.kt
@@ -289,7 +289,7 @@ class LegacyDataImporter(
  * [map]; a null return from [map] drops that row. Returns an empty list for a missing table so a
  * legacy file at any historical schema version imports cleanly.
  */
-internal inline fun <T> SQLiteDatabase.read(table: String, map: Cursor.() -> T?): List<T> {
+private inline fun <T> SQLiteDatabase.read(table: String, map: Cursor.() -> T?): List<T> {
     if (!tableExists(table)) return emptyList()
     return query(table, null, null, null, null, null, null).use { c ->
         buildList { while (c.moveToNext()) c.map()?.let { add(it) } }
@@ -300,16 +300,16 @@ private fun SQLiteDatabase.tableExists(table: String): Boolean =
     rawQuery("SELECT name FROM sqlite_master WHERE type='table' AND name=?", arrayOf(table))
         .use { it.moveToFirst() }
 
-internal fun Cursor.str(name: String): String? =
+private fun Cursor.str(name: String): String? =
     columnIndex(name)?.takeIf { !isNull(it) }?.let { getString(it) }
 
-internal fun Cursor.int(name: String): Int? =
+private fun Cursor.int(name: String): Int? =
     columnIndex(name)?.takeIf { !isNull(it) }?.let { getInt(it) }
 
-internal fun Cursor.long(name: String): Long? =
+private fun Cursor.long(name: String): Long? =
     columnIndex(name)?.takeIf { !isNull(it) }?.let { getLong(it) }
 
-internal fun Cursor.dbl(name: String): Double? =
+private fun Cursor.dbl(name: String): Double? =
     columnIndex(name)?.takeIf { !isNull(it) }?.let { getDouble(it) }
 
 /** The column's index, or null when the legacy file's schema version predates that column. */

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/DirectionsGenerator.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/DirectionsGenerator.kt
@@ -357,7 +357,7 @@ class DirectionsGenerator(
 
         private const val TAG = "DirectionsGenerator"
 
-        internal fun getOrdinal(number: Int, resources: Resources): String? {
+        private fun getOrdinal(number: Int, resources: Resources): String? {
             return when (number) {
                 1 -> resources.getString(R.string.step_by_step_non_transit_roundabout_ordinal_first)
                 2 -> resources.getString(R.string.step_by_step_non_transit_roundabout_ordinal_second)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/GammaExtrapolator.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/GammaExtrapolator.kt
@@ -125,7 +125,7 @@ internal fun buildH34SpeedDistribution(schedSpeedMps: Double): ProbDistribution 
  * The scheduled segment speed (m/s) at a given distance along the trip, or null if the schedule has
  * too few stops or the distance is out of bounds. Only the gamma model conditions on schedule speed.
  */
-internal fun ObaTripSchedule.speedAtDistance(distanceAlongTrip: Double): Double? {
+private fun ObaTripSchedule.speedAtDistance(distanceAlongTrip: Double): Double? {
     if (stopTimes.size < 2) return null
 
     val segmentStart = try {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/math/prob/GammaDistribution.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/math/prob/GammaDistribution.kt
@@ -56,7 +56,7 @@ class GammaDistribution(@JvmField val alpha: Double, @JvmField val scale: Double
         private const val MAX_ITERATIONS = 200
         private const val EPSILON = 1e-10
 
-        internal fun regularizedGammaP(a: Double, x: Double): Double {
+        private fun regularizedGammaP(a: Double, x: Double): Double {
             if (x <= 0) return 0.0
 
             return if (x < a + 1) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/nav/NavigationServiceProvider.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/nav/NavigationServiceProvider.java
@@ -77,14 +77,14 @@ public class NavigationServiceProvider implements TextToSpeech.OnInitListener {
     private int mTimeout = 60;  //Timeout value for service provider action (default = 60 seconds);
 
     // Index that defines the current path link within the path (i.e. First link in a path will have index = 0, second link index = 1, etc.)
-    int mPathLinkIndex = 0;
+    private int mPathLinkIndex = 0;
 
     // Path links being navigated
-    Path mPath;
+    private Path mPath;
 
     private float mAlertDistance = -1;
 
-    boolean mWaitingForConfirm = false;
+    private boolean mWaitingForConfirm = false;
 
     private Location mCurrentLocation = null;
 
@@ -101,7 +101,7 @@ public class NavigationServiceProvider implements TextToSpeech.OnInitListener {
     private String mStopId;             // Stop ID
 
     // Application context, threaded from the hosting NavigationService (replaces the Application static).
-    final Context mContext;
+    private final Context mContext;
 
 
     public NavigationServiceProvider(@NonNull Context context, @Nullable String tripId, @Nullable String stopId) {
@@ -227,7 +227,7 @@ public class NavigationServiceProvider implements TextToSpeech.OnInitListener {
     /**
      * Tells the NavigationProvider to navigate the next PathLink in the Path
      */
-    void navigateNextPathLink() {
+    private void navigateNextPathLink() {
         Log.d(TAG, "Attempting to navigate next path link");
         if (mPath != null && mPathLinkIndex < mPath.getPathLinks().size()) {
             mPathLinkIndex++;
@@ -282,7 +282,7 @@ public class NavigationServiceProvider implements TextToSpeech.OnInitListener {
         private float readyRadius = 300;
         //Defines radius(in meters) for which the Proximity listener should trigger "Get Ready Alert"
 
-        boolean mTrigger = false;
+        private boolean mTrigger = false;
         //Defines whether the Proximity Listener has been triggered (true) or not (false)
 
         private Location secondToLastCoords = null;
@@ -297,10 +297,10 @@ public class NavigationServiceProvider implements TextToSpeech.OnInitListener {
         private float directDistance = -1;
         //Direct distance to second to last stop coords, used for radius detection
 
-        float endDistance = -1;
+        private float endDistance = -1;
         //Direct distance to last bus stop coords, used for link navigation
 
-        boolean mReady = false; //Has get ready alert been played?
+        private boolean mReady = false; //Has get ready alert been played?
 
         private boolean m100_a, m50_a, m20_a, m20_d, m50_d, m100_d = false;
         // Variables for handling arrival/departure from 2nd to last stop
@@ -487,7 +487,7 @@ public class NavigationServiceProvider implements TextToSpeech.OnInitListener {
          *
          * @return the status update (EVENT_TYPE_*) that was triggered by the proximity to this location (if any).
          */
-        int checkProximityAll(Location currentLocation) {
+        private int checkProximityAll(Location currentLocation) {
             if (!mWaitingForConfirm) {
                 //re-calculate the distance to the final bus stop from the current location
                 endDistance = lastCoords.distanceTo(currentLocation);
@@ -574,7 +574,7 @@ public class NavigationServiceProvider implements TextToSpeech.OnInitListener {
      * @param eventType EVENT_TYPE_* variable defining the eventType update to act upon
      * @return the notification to use for the foreground service if eventType == EVENT_TYPE_INITIAL_STARTUP, otherwise returns null
      */
-    Notification updateUi(int eventType) {
+    private Notification updateUi(int eventType) {
         TripDetailsLauncher.Builder bldr = new TripDetailsLauncher.Builder(
                 mContext, mTripId);
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/nav/NavigationUploadWorker.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/nav/NavigationUploadWorker.java
@@ -125,7 +125,7 @@ public class NavigationUploadWorker extends Worker {
         }
     }
 
-    void logFeedback(String feedbackText, String userResponse, String fileName) {
+    private void logFeedback(String feedbackText, String userResponse, String fileName) {
         Boolean wasGoodReminder;
         if (userResponse.equals(getApplicationContext().getString(R.string.analytics_label_destination_reminder_yes))) {
             wasGoodReminder = true;

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.kt
@@ -350,7 +350,7 @@ fun Context.startHomeActivity(route: String) {
  * when it carries no usable stop — an id plus a real (non-zero) location. A plain launch carries
  * neither, so focus stays null. Parsing lives here with the intent contract, off HomeModels.
  */
-internal fun FocusedStop.Companion.fromIntent(intent: Intent): FocusedStop? {
+private fun FocusedStop.Companion.fromIntent(intent: Intent): FocusedStop? {
     val extras = intent.extras ?: return null
     val id = extras.getString(MapParams.STOP_ID) ?: return null
     val lat = extras.getDouble(MapParams.CENTER_LAT)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/mylists/MyListRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/mylists/MyListRepository.kt
@@ -86,7 +86,7 @@ private val RECENT_WINDOW_MS = 7 * DateUtils.DAY_IN_MILLIS
 @Suppress("RawClockArithmetic")
 internal fun recentCutoff(): Long = System.currentTimeMillis() - RECENT_WINDOW_MS
 
-internal fun StopListRow.toStopItem(context: Context): StopListItem {
+private fun StopListRow.toStopItem(context: Context): StopListItem {
     val directionText = direction?.takeIf { it.isNotEmpty() }
         ?.let { context.getString(DisplayFormat.getStopDirectionText(it)) }
         ?.takeIf { it.isNotEmpty() }
@@ -101,7 +101,7 @@ internal fun StopListRow.toStopItem(context: Context): StopListItem {
     )
 }
 
-internal fun RouteListRow.toRouteItem() = RouteListItem(
+private fun RouteListRow.toRouteItem() = RouteListItem(
     id = id,
     shortName = shortName,
     longName = longName?.takeIf { it.isNotEmpty() },
@@ -224,7 +224,7 @@ class RecentRoutesRepository(private val context: Context) : MyListRepository<Ro
 }
 
 /** Persists the chosen sort order as the matching [optionsRes] string under [prefKeyRes] (legacy format). */
-internal fun saveSortOrder(context: Context, order: Int, @ArrayRes optionsRes: Int, @StringRes prefKeyRes: Int) {
+private fun saveSortOrder(context: Context, order: Int, @ArrayRes optionsRes: Int, @StringRes prefKeyRes: Int) {
     val options = context.resources.getStringArray(optionsRes)
     PreferenceUtils.saveString(context.getString(prefKeyRes), options[order.coerceIn(options.indices)])
 }
@@ -340,7 +340,7 @@ class RemindersRepository(private val context: Context) : MyListRepository<Remin
             .flowOn(Dispatchers.IO)
 }
 
-internal fun ReminderRow.toReminderItem(context: Context): ReminderItem {
+private fun ReminderRow.toReminderItem(context: Context): ReminderItem {
     val departureMs = TripDepartureTime.toEpochMillis(departure)
     return ReminderItem(
         tripId = tripId,
@@ -360,7 +360,7 @@ private const val ARRIVALS_MINUTES_AFTER = 35
 private const val MAX_ARRIVALS_PER_STOP = 3
 
 /** Emits the per-stop arrival badges immediately, then re-emits every [ARRIVALS_REFRESH_MS]. */
-internal fun arrivalsPoll(context: Context, stopIds: List<String>): Flow<Map<String, List<ArrivalBadge>>> = flow {
+private fun arrivalsPoll(context: Context, stopIds: List<String>): Flow<Map<String, List<ArrivalBadge>>> = flow {
     while (true) {
         emit(fetchArrivals(context, stopIds))
         delay(ARRIVALS_REFRESH_MS)


### PR DESCRIPTION
Fixes #1912.

#1875 widened 34 declarations to clear lint's `SyntheticAccessor` findings: file-`private` Kotlin helpers → `internal` (effectively app-global in this single-module app) and Java `private` → package-private. That traded real encapsulation for a micro-optimization the toolchain already erases — release builds enable R8 with `-allowaccessmodification` (#1868), which inlines/strips the synthetic accessors, and in debug the cost is a handful of trivial methods. Leaving the check enabled also taxed every future file-private helper called from a sibling class, forcing the same anti-encapsulation edit.

## Changes

- **Opt `SyntheticAccessor` out** in the lint `disable {}` block, with a one-line rationale (R8 optimize + single module).
- **Revert all 34 declarations to `private`**: 23 Kotlin `internal`→`private` (the `Cursor.str/int/long/dbl` + `SQLiteDatabase.read` extensions in `LegacyDataImporter`, the `MyListRepository` helpers, map-adapter/gamma-math helpers, `FocusedStop.fromIntent`, …) and 11 Java package-private→`private` (`NavigationServiceProvider` ×10, `UmamiAnalytics.post`, `NavigationUploadWorker.logFeedback`).

## Safety

No behavior change — visibility only. Before narrowing each member I verified it is accessed **only within its own file** (Kotlin top-level/extension helpers are file-scoped) or **only inner↔outer within its own class** (Java), so nothing breaks by re-privatizing.

Compile (`:onebusaway-android:compileObaGoogleDebugKotlin` + `compileObaGoogleDebugJavaWithJavac`, `-PwarningsAsErrors=true`) passes clean. Lint is left for CI per the repo's guidance on local lint cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)