### PR TITLE
Keep zoom() at top level in route-stop circle expressions (#1927)

### DIFF
--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRouteStopCircleLayer.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRouteStopCircleLayer.kt
@@ -64,18 +64,14 @@ internal class MapLibreRouteStopCircleLayer(
     private var renderedScaleWithZoom = false
 
     init {
-        val radius = radiusExpression()
         style.addSource(source)
         style.addLayer(
             CircleLayer(OUTER_LAYER_ID, SOURCE_ID).withProperties(
-                circleRadius(radius),
+                circleRadius(radiusExpression()),
                 circleColor(RouteStopCircles.FILL_COLOR),
                 circleStrokeColor(RouteStopCircles.STROKE_COLOR),
                 circleStrokeWidth(
-                    product(
-                        radius,
-                        literal(RouteStopCircles.STROKE_WIDTH_PX / RouteStopCircles.RADIUS_PX),
-                    )
+                    radiusExpression(RouteStopCircles.STROKE_WIDTH_PX / RouteStopCircles.RADIUS_PX)
                 ),
                 circleSortKey(get(MAX_RADIUS_PROPERTY)),
             )
@@ -84,12 +80,7 @@ internal class MapLibreRouteStopCircleLayer(
             CircleLayer(INNER_LAYER_ID, SOURCE_ID)
                 .withFilter(eq(get(SELECTED_PROPERTY), true))
                 .withProperties(
-                    circleRadius(
-                        product(
-                            radius,
-                            literal(RouteStopCircles.INNER_RADIUS_SCALE),
-                        )
-                    ),
+                    circleRadius(radiusExpression(RouteStopCircles.INNER_RADIUS_SCALE)),
                     circleColor(RouteStopCircles.STROKE_COLOR),
                     circleSortKey(get(MAX_RADIUS_PROPERTY)),
                 )
@@ -147,12 +138,24 @@ internal class MapLibreRouteStopCircleLayer(
         renderedScaleWithZoom = false
     }
 
-    private fun radiusExpression(): Expression = interpolate(
+    /**
+     * A `zoom()`-driven radius interpolation, optionally scaled by [scale].
+     *
+     * The scale is folded into each interpolation stop's output rather than wrapping the whole
+     * interpolation in a `product()`. MapLibre 13 rejects a `zoom()` expression nested inside
+     * anything but a top-level step/interpolate ("zoom expression may only be used as input to a
+     * top-level step or interpolate expression"), so keeping `zoom()` at the top level is required;
+     * scaling the stop outputs is mathematically equivalent for a linear interpolation. (#1927)
+     */
+    private fun radiusExpression(scale: Float = 1f): Expression = interpolate(
         linear(),
         zoom(),
-        stop(DETAIL_RAMP_START_ZOOM, get(MIN_RADIUS_PROPERTY)),
-        stop(DETAIL_RAMP_END_ZOOM, get(MAX_RADIUS_PROPERTY)),
+        stop(DETAIL_RAMP_START_ZOOM, scaledRadius(MIN_RADIUS_PROPERTY, scale)),
+        stop(DETAIL_RAMP_END_ZOOM, scaledRadius(MAX_RADIUS_PROPERTY, scale)),
     )
+
+    private fun scaledRadius(property: String, scale: Float): Expression =
+        if (scale == 1f) get(property) else product(get(property), literal(scale))
 
     private companion object {
         const val SOURCE_ID = "oba-route-stops"


### PR DESCRIPTION
Fixes #1927

## Problem

After the MapLibre 11 → 13 upgrade, `MapLibreRouteStopCircleLayer` fails runtime style-expression validation at launch:

> zoom expression may only be used as input to a top-level step or interpolate expression

The layer built a `zoom()`-driven radius interpolation once, then wrapped that whole interpolation inside `product()` to derive two properties:

- the outer circle's `circleStrokeWidth` (radius × stroke/radius ratio)
- the selected-stop inner circle's `circleRadius` (radius × inner scale)

MapLibre 11.5.2 tolerated a `zoom()` nested inside `product()`; 13.3.1 rejects it. The top-level `circleRadius()` interpolation still validated, so only those two nested usages broke — **route-stop circles rendered without their stroke ring, and selected stops lost their zoom-scaled radius highlighting.**

## Fix

`radiusExpression(scale)` now folds the scale factor into each interpolation **stop output** rather than wrapping the interpolation:

```
interpolate(linear(), zoom(),
    stop(START, get(prop) × scale),
    stop(END,   get(prop) × scale))
```

`zoom()` stays at the top level (valid). Because the interpolation is linear, scaling each endpoint is mathematically identical to scaling the whole interpolation — including the clamped regions outside the zoom band. The default `scale = 1f` reproduces the original bare-`get()` outputs for the outer radius.

## Testing

- ✅ Compiles clean under the CI gate: `./gradlew :onebusaway-android:compileObaMaplibreDebugKotlin -PwarningsAsErrors=true`
- This is a MapLibre-runtime style-validation bug with a purely visual symptom, so there is no unit-test surface. Confirming the rendered result (logcat clear of the validation error, stroke rings present, selected-stop highlight scaling with zoom) requires launching the `obaMaplibreDebug` build on a device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved map stop-circle rendering across zoom levels.
  * Updated stop markers and outlines to maintain more consistent sizing and proportions as the map scale changes.
  * Improved visual alignment between the outer stop circle, inner circle, and border.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->