### PR TITLE
MapLibre: implement the adjacency route-badge layer (parity with Google, #1827)

### DIFF
--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
@@ -112,8 +112,9 @@ class GoogleMapRenderer(
     // the single selected vehicle), but kept as a map like the other *ByMarker lookups for symmetry.
     private val continuationBadgeByMarker = HashMap<Marker, ContinuationBadge>()
 
-    // Google-first adjacency route badge tap targets (#1827). Their geographic anchors are laid out
-    // once upstream; these markers then move naturally with the map through pan and zoom.
+    // Adjacency route badge tap targets (#1827), mirrored by the maplibre flavor (#1913). Their
+    // geographic anchors are laid out once upstream; these markers then move naturally with the map
+    // through pan and zoom.
     private val routeBadgeByMarker = HashMap<Marker, RouteBadge>()
 
     // The latest trips-for-route poll, published as it changes (after the markers are reconciled). The

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteViewGeometry.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteViewGeometry.kt
@@ -99,9 +99,9 @@ internal fun FocusedTripGeometry.toTripFocusedRoutePolylines(
         .toRoutePolylines(selectedRoute, routeColors) + selectedRouteUnderlay + selectedTrip
 
 /**
- * One Google-first badge model per successfully drawn route-direction, preserving the focused-trip
- * order that mirrors the arrivals drawer. The shared layout chooses stable geographic line-center
- * anchors; flavor renderers only draw them.
+ * One badge model per successfully drawn route-direction, preserving the focused-trip order that
+ * mirrors the arrivals drawer. The shared layout chooses stable geographic line-center anchors;
+ * flavor renderers only draw them.
  */
 internal fun FocusedTripGeometry.toRouteBadges(
     routes: List<ObaRoute>,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
@@ -180,8 +180,7 @@ data class ContinuationBadge(
 
 /**
  * A tappable label for one route in focused-stop adjacency view (#1827), anchored once in geographic
- * space so the map SDK naturally carries it through pan and zoom. Google renders these in the first
- * badge phase; MapLibre deliberately ignores the layer until its follow-up (#1913).
+ * space so the map SDK naturally carries it through pan and zoom. Rendered by both flavors (#1913).
  */
 data class RouteBadge(
     val routeId: String,
@@ -397,7 +396,7 @@ class MapRenderState {
 
     fun clearRoutePolylines() = setRoutePolylines(emptyList())
 
-    /** Sets the Google-first adjacency route badges (#1827); MapLibre currently ignores this layer (#1913). */
+    /** Sets the adjacency route badges (#1827), rendered by both flavors (#1913). */
     fun setRouteBadges(badges: List<RouteBadge>) {
         _snapshot.update { it.copy(routeBadges = badges) }
     }

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
@@ -42,6 +42,7 @@ import org.onebusaway.android.map.compose.formatDataAge
 import org.onebusaway.android.map.render.BikeBand
 import org.onebusaway.android.map.render.BikeBitmaps
 import org.onebusaway.android.map.render.BikeMarker
+import org.onebusaway.android.map.render.ContinuationBadgeBitmaps
 import org.onebusaway.android.map.render.CorrectionSmoother
 import org.onebusaway.android.map.render.GeoPoint
 import org.onebusaway.android.map.render.MapPing
@@ -49,6 +50,7 @@ import org.onebusaway.android.map.render.MapRenderSnapshot
 import org.onebusaway.android.map.render.MapRenderState
 import org.onebusaway.android.map.render.PingTarget
 import org.onebusaway.android.map.render.MapVehicles
+import org.onebusaway.android.map.render.RouteBadge
 import org.onebusaway.android.map.render.RoutePolyline
 import org.onebusaway.android.map.render.StopMarker
 import org.onebusaway.android.map.render.TripMarkerBitmaps
@@ -60,6 +62,7 @@ import org.onebusaway.android.map.render.RoutePolylineReconciler
 import org.onebusaway.android.map.render.routeLineWidthScale
 import org.onebusaway.android.time.WallTime
 import org.onebusaway.android.util.MyTextUtils
+import org.onebusaway.android.util.ThemeUtils
 import org.onebusaway.android.util.getRouteDisplayName
 
 /**
@@ -97,6 +100,11 @@ class MapLibreRenderer(
     private val bikeByMarker = HashMap<Marker, BikeMarker>()
 
     private val vehicleByMarker = HashMap<Marker, VehicleMarker>()
+
+    // Adjacency route badge tap targets (#1827), mirroring the Google flavor's routeBadgeByMarker.
+    // Their geographic anchors are laid out once upstream; these markers then move naturally with the
+    // map through pan and zoom.
+    private val routeBadgeByMarker = HashMap<Marker, RouteBadge>()
 
     // The non-route static annotations added by the last [renderStatic], removed (not map.clear()) on
     // the next so the retained route and per-frame dynamic layers survive a static redraw.
@@ -173,8 +181,9 @@ class MapLibreRenderer(
             staticAnnotations.clear()
         }
         // Stop markers are reconciled in place (not in staticAnnotations), so they survive this; only
-        // the bike tap map is cleared here.
+        // the bike / route-badge tap maps are cleared here.
         bikeByMarker.clear()
+        routeBadgeByMarker.clear()
 
         stopMarkerLayer.render(snapshot.stops, snapshot.focusedStopId, snapshot.stopBand)
         routeStopCircleLayer.render(
@@ -216,7 +225,35 @@ class MapLibreRenderer(
                 )
             )
         }
+
+        renderRouteBadges(snapshot.routeBadges)
     }
+
+    // Parity with the Google flavor's renderRouteBadges (#1827/#1913): the classic Marker centers its
+    // icon on the point by default, so no anchor call is needed here (contrast Google's explicit
+    // .anchor(0.5f, 0.5f)). Draw order is add-order in maplibre (no z-index on classic markers), so
+    // adding these last keeps them on top of the stops/bikes/generics drawn above.
+    private fun renderRouteBadges(badges: List<RouteBadge>) {
+        for (badge in badges) {
+            val marker = map.addMarker(
+                MarkerOptions()
+                    .position(badge.point.toLatLng())
+                    .icon(routeBadgeIcon(badge.routeShortName, badge.color))
+            )
+            staticAnnotations.add(marker)
+            routeBadgeByMarker[marker] = badge
+        }
+    }
+
+    private fun routeBadgeIcon(routeShortName: String, color: Int): Icon =
+        iconFactory.fromBitmap(
+            ContinuationBadgeBitmaps.badge(
+                routeShortName,
+                color,
+                density,
+                darkMode = ThemeUtils.isInDarkMode(context),
+            )
+        )
 
     /** Reconcile the independently collected route layer, retaining equal native polylines. */
     fun renderRoutePolylines(next: List<RoutePolyline> = renderState.snapshot.value.routePolylines) {
@@ -265,6 +302,7 @@ class MapLibreRenderer(
         bandPolylines.clear()
         vehicleByMarker.clear()
         bikeByMarker.clear()
+        routeBadgeByMarker.clear()
         vehicleIconDirection.clear()
         mostRecentDataMarker = null
         lastVehicleResponse = null
@@ -556,6 +594,9 @@ class MapLibreRenderer(
     fun bikeForMarker(marker: Marker): BikeMarker? = bikeByMarker[marker]
 
     fun vehicleForMarker(marker: Marker): VehicleMarker? = vehicleByMarker[marker]
+
+    /** The adjacency route badge (#1827) tapped, or null if [marker] isn't one. */
+    fun routeBadgeForMarker(marker: Marker): RouteBadge? = routeBadgeByMarker[marker]
 
     /**
      * If [marker] is the ping ripple, the vehicle marker it's centered on (else null) — so a tap on the

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreComposeAdapter.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreComposeAdapter.kt
@@ -324,6 +324,11 @@ private fun wireClicks(
             }
             return@setOnMarkerClickListener true
         }
+        val routeBadge = renderer.routeBadgeForMarker(marker)
+        if (routeBadge != null) {
+            callbacks.onRouteBadgeClick(routeBadge.routeId, routeBadge.routeShortName, routeBadge.directionId)
+            return@setOnMarkerClickListener true
+        }
         // Titled markers (the trip-focus estimate markers + the most-recent-data dot) fall through to
         // the SDK's default title window. Untitled decorations (generic start/end markers) have
         // nothing to show, so consume the tap (return true) — a no-op, not an empty bubble.


### PR DESCRIPTION
## Summary
- Implements the focused-stop adjacency route-badge layer (`RouteBadge`, #1827) in `MapLibreRenderer`, previously rendered only by `GoogleMapRenderer`.
- `renderRouteBadges()` mirrors the Google flavor: a `routeBadgeByMarker` tap-target map, drawn last (no z-index in maplibre's classic annotation API, so draw order is the ordering mechanism), reusing the shared `ContinuationBadgeBitmaps.badge(...)` bitmap generator via `iconFactory.fromBitmap(...)`. No `.anchor()` call is needed since maplibre's classic `Marker` centers its icon by default.
- Wires the tap in `MapLibreComposeAdapter`'s marker-click listener to `ObaMapCallbacks.onRouteBadgeClick(...)`, same callback the Google flavor already fires — no changes needed to the shared callback interface or `MapFeature`'s handler.
- Cleans up doc comments in `MapRenderState.kt`, `GoogleMapRenderer.kt`, and `RouteViewGeometry.kt` that described this as a Google-only / MapLibre-deferred layer, since both flavors now render it.

Closes #1913.

## Test plan
- [x] `./gradlew :onebusaway-android:compileObaGoogleDebugKotlin -PwarningsAsErrors=true` — clean
- [x] `./gradlew :onebusaway-android:compileObaMaplibreDebugKotlin -PwarningsAsErrors=true` — clean
- [x] `./gradlew :onebusaway-android:testObaGoogleDebugUnitTest :onebusaway-android:testObaMaplibreDebugUnitTest` — pass
- [ ] Manual verification on device (focused-stop adjacency view, MapLibre flavor): badges render at the correct route line midpoints and tapping one enters route mode on that route's direction

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added route badges to MapLibre maps, including light and dark theme support.
  * Route badge taps now open the corresponding route and direction.

* **Documentation**
  * Updated map rendering documentation to accurately describe route badge behavior across supported map types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->