### PR TITLE
Enforce cancellation-safe runCatching: runCatchingCancellable + SwallowedCancellation lint check

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,6 +218,24 @@ follow that pattern when adding server-domain time math.
   mints into `WallTime`/`ElapsedTime` (domain made explicit) or carries an inline `@Suppress` with a
   one-line rationale (there is no lint baseline — these live at the site). See `lint-rules/README.md`.
 
+## Coroutines: never swallow CancellationException (#1908 / #1921)
+
+`kotlin.runCatching` catches **every** `Throwable`, and a broad `catch (Exception | Throwable |
+RuntimeException | IllegalStateException)` catches `CancellationException` too — it's a plain
+`java.util.concurrent.CancellationException`, i.e. an `IllegalStateException` subtype. So in coroutine code
+either one silently converts a cancelled coroutine's `CancellationException` into a `Result.failure` /
+caught value: the cancelled work keeps running and callers read the cancellation as an ordinary
+error/empty state (structured concurrency breaks). It passes compilation and review and only misbehaves
+under real cancellation.
+
+- **Use `runCatchingCancellable`** (`org.onebusaway.android.util`) instead of bare `runCatching` in any
+  `suspend`/coroutine code. It's behaviour-identical but rethrows `CancellationException`. The custom lint
+  check `SwallowedCancellation` (module `:lint-rules`, no baseline) fails the build on a bare `runCatching`
+  in a `suspend` function, so this is the enforced path.
+- For a broad `try/catch` in coroutine code, put a leading `catch (e: CancellationException) { throw e }`
+  before the broad catch (the lint check covers `runCatching` only). Narrow catches (`IOException`, …)
+  don't catch cancellation and are fine.
+
 ## No unsanctioned heuristics
 
 Do **not** introduce heuristics — magic thresholds, magnitude guesses, or "good enough" inference of

--- a/lint-rules/README.md
+++ b/lint-rules/README.md
@@ -81,6 +81,29 @@ is a property of the *endpoint* — the two same-named `StopTime` (seconds) and 
 millis) DTOs are the proof — so only the endpoint-aware adapter can mint correctly, and reading the raw
 field elsewhere, even to pass it straight on, is the escape.
 
+### `SwallowedCancellation` (warning)
+Fires when `kotlin.runCatching` is called inside a `suspend` function. `runCatching` catches every
+`Throwable`, so in a coroutine it also swallows the `CancellationException` a cancelled coroutine throws
+from a suspend call — converting cancellation into an ordinary `Result.failure`, so the cancelled work
+keeps running and callers read the cancellation as a normal error/empty state (structured concurrency
+breaks). `CancellationException` is a plain `IllegalStateException` subtype, so nothing at the type level
+catches this; it passes compilation and review and only misbehaves under real cancellation (screen closed,
+search superseded by a keystroke, poll tick outrun). This is the #1908 / #1921 bug class.
+
+Fix by using **`runCatchingCancellable`** (`org.onebusaway.android.util`) — behaviour-identical to
+`runCatching` but it rethrows `CancellationException` (a real failure still resolves to `Result.failure`).
+The wrapper is the single sanctioned path, so the check degrades to a symbol ban: any bare `runCatching`
+in a suspend function is flagged. For a broad `try/catch (Exception)` in a suspend function, add a leading
+`catch (e: CancellationException) { throw e }` — this check covers `runCatching` only.
+
+Scope is the **nearest enclosing named function** being `suspend` (matching detekt's
+`SuspendFunSwallowedCancellation`), detected via the `Continuation` parameter on its light method — so
+`async { runCatching { … } }` inside a suspend function is caught (lambdas are transparent), while a
+`runCatching` in a coroutine-builder lambda inside a *non-suspend* function is deliberately out of scope
+(the boundary isn't visible without heuristics; guard those by hand). A `runCatching` around purely
+non-suspending work in a suspend function is still flagged — the wrapper is a strict superset, so it's
+never wrong, and the rule stays a simple ban rather than a fragile "does this lambda suspend" analysis.
+
 ## Lifecycle
 
 Each check names its reason to exist and its reason to die. Regenerate the baseline after landing a
@@ -92,6 +115,7 @@ check, then only ever shrink it.
 | `UnwrappedClockValue` | foreign clock namespace, coming to rest   | never (can't forbid `Long`)                           |
 | `PrematureUnwrap`     | the elimination door of the typed region  | a real module boundary makes `.epochMs` cross-module  |
 | `WireTimeEscape`      | adapter-only consumption of wire DTOs     | `:api` becomes a Gradle module with `internal` DTOs   |
+| `SwallowedCancellation` | `runCatching` swallowing cancellation in suspend code | Kotlin/lint ships an equivalent built-in check |
 
 **Enrollment sweep — nothing left to enroll.** The plan anticipated adding the legacy Jackson
 `io/elements` getters (`ObaArrivalInfo#getScheduledArrivalTime`, …) to `CLOCK_SOURCES`. That surface has
@@ -105,7 +129,7 @@ CLAUDE.md. The checks are a latch discipline, not a suggestion.
 ## Status: enforced
 
 Wired into the app via `lintChecks(project(":lint-rules"))` in `onebusaway-android/build.gradle.kts`, so a
-**new** violation of any of the four issues fails the build under the strict `-PwarningsAsErrors` gate
+**new** violation of any of the five issues fails the build under the strict `-PwarningsAsErrors` gate
 (verified). There is **no lint baseline** — the app is kept clean under the full catalog, so every
 sanctioned pre-existing site is handled *at the site*, not grandfathered in a file:
 
@@ -123,8 +147,11 @@ sanctioned pre-existing site is handled *at the site*, not grandfathered in a fi
   visible at the site, not hidden in this file. Keep it empty.
 - **0** `WireTimeEscape` — the migration left no wire-field read in app logic; the check starts empty and
   exists to keep it that way.
+- **0** `SwallowedCancellation` — every bare `runCatching` in a suspend function was migrated to
+  `runCatchingCancellable` (#1908 / #1921 audit); the check starts empty and keeps new coroutine code on
+  the sanctioned wrapper.
 
-Keep all four checks at zero: mint each new site (or inline-`@Suppress` a genuinely-sanctioned one with a
+Keep all five checks at zero: mint each new site (or inline-`@Suppress` a genuinely-sanctioned one with a
 rationale) — don't reintroduce a baseline.
 
 ## Develop

--- a/lint-rules/build.gradle.kts
+++ b/lint-rules/build.gradle.kts
@@ -35,6 +35,6 @@ dependencies {
 // Lint discovers the registry through this manifest attribute when the jar is loaded via lintChecks.
 tasks.jar {
     manifest {
-        attributes(mapOf("Lint-Registry-v2" to "org.onebusaway.lint.TimeDomainIssueRegistry"))
+        attributes(mapOf("Lint-Registry-v2" to "org.onebusaway.lint.OneBusAwayIssueRegistry"))
     }
 }

--- a/lint-rules/src/main/java/org/onebusaway/lint/OneBusAwayIssueRegistry.kt
+++ b/lint-rules/src/main/java/org/onebusaway/lint/OneBusAwayIssueRegistry.kt
@@ -24,7 +24,7 @@ import com.android.tools.lint.detector.api.Issue
  * Registry that publishes onebusaway-android's custom lint checks. Discovered via the
  * `Lint-Registry-v2` manifest attribute set in this module's `build.gradle`.
  */
-class TimeDomainIssueRegistry : IssueRegistry() {
+class OneBusAwayIssueRegistry : IssueRegistry() {
 
     override val issues: List<Issue> =
         listOf(
@@ -32,6 +32,7 @@ class TimeDomainIssueRegistry : IssueRegistry() {
             RawTimeDetector.ISSUE_VALUE,
             PrematureUnwrapDetector.ISSUE,
             WireTimeEscapeDetector.ISSUE,
+            SwallowedCancellationDetector.ISSUE,
         )
 
     override val api: Int = CURRENT_API

--- a/lint-rules/src/main/java/org/onebusaway/lint/SwallowedCancellationDetector.kt
+++ b/lint-rules/src/main/java/org/onebusaway/lint/SwallowedCancellationDetector.kt
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.lint
+
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Scope
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import com.intellij.psi.PsiMethod
+import org.jetbrains.uast.UCallExpression
+import org.jetbrains.uast.UMethod
+import org.jetbrains.uast.getParentOfType
+
+/**
+ * Gives the app a phobia of bare `runCatching` in coroutine code. `kotlin.runCatching` catches every
+ * `Throwable`, so inside a `suspend` function it also swallows the `CancellationException` a cancelled
+ * coroutine throws from a suspend call — turning cancellation into an ordinary `Result.failure`. The
+ * cancelled coroutine then keeps running and its callers read the cancellation as a normal error/empty
+ * state; structured concurrency breaks. That is the #1908/#1921 bug class, and it's invisible on the
+ * happy path and in review.
+ *
+ * `CancellationException` is a plain `IllegalStateException` subtype, so there is no type-level guard —
+ * the compiler can't tell a swallow from a legitimate catch. So this detector keys on the shape: a
+ * `runCatching` whose **nearest enclosing named function is `suspend`** (the coroutine boundary lint can
+ * see deterministically). The sanctioned replacement is `runCatchingCancellable` (in
+ * `org.onebusaway.android.util`), which is behaviour-identical but rethrows `CancellationException`.
+ *
+ * Scope is the enclosing `suspend` function, matching detekt's `SuspendFunSwallowedCancellation`. A
+ * `runCatching` in a coroutine-builder lambda inside a *non-suspend* function (e.g. `scope.launch { … }`)
+ * is deliberately out of scope — the enclosing named function isn't `suspend`, so lint can't see the
+ * boundary without heuristics; guard those by hand.
+ */
+class SwallowedCancellationDetector : Detector(), SourceCodeScanner {
+
+    override fun getApplicableMethodNames(): List<String> = listOf("runCatching")
+
+    override fun visitMethodCall(context: JavaContext, node: UCallExpression, method: PsiMethod) {
+        // Both the receiverless `runCatching` and the `T.runCatching` extension live in kotlin.ResultKt;
+        // confirm the owner so a same-named function elsewhere doesn't match.
+        if (method.containingClass?.qualifiedName != KOTLIN_RESULT_KT) return
+        // Only inside a suspend function — that's where a CancellationException can be thrown and where
+        // swallowing it breaks cancellation. Lambdas are skipped, so `async { runCatching { … } }` in a
+        // suspend function is still attributed to that suspend function.
+        val enclosing = node.getParentOfType<UMethod>() ?: return
+        if (!enclosing.isSuspendFunction()) return
+        context.report(
+            ISSUE,
+            node,
+            context.getLocation(node),
+            "`runCatching` in a `suspend` function also catches `CancellationException`, converting a " +
+                "cancelled coroutine into a `Result.failure` (the cancellation stops propagating and the " +
+                "work keeps running). Use `runCatchingCancellable` " +
+                "(org.onebusaway.android.util), which rethrows cancellation and is otherwise identical.",
+        )
+    }
+
+    /**
+     * True when this function carries the `suspend` modifier. A Kotlin `suspend fun` compiles with a
+     * trailing `kotlin.coroutines.Continuation` parameter on its light (`javaPsi`) method, which is how
+     * lint sees suspension without depending on Kotlin compiler PSI.
+     */
+    private fun UMethod.isSuspendFunction(): Boolean =
+        javaPsi.parameterList.parameters.lastOrNull()
+            ?.type?.canonicalText?.startsWith(CONTINUATION_FQN) == true
+
+    companion object {
+        private const val KOTLIN_RESULT_KT = "kotlin.ResultKt"
+        private const val CONTINUATION_FQN = "kotlin.coroutines.Continuation"
+
+        @JvmField
+        val ISSUE: Issue = Issue.create(
+            id = "SwallowedCancellation",
+            briefDescription = "runCatching in a suspend function swallows CancellationException",
+            explanation = """
+                `kotlin.runCatching` catches every `Throwable`. Inside a `suspend` function that includes \
+                the `CancellationException` a cancelled coroutine throws from a suspend call, so the \
+                cancellation is captured into the returned `Result` instead of propagating. The cancelled \
+                coroutine keeps running, structured concurrency breaks, and callers see the cancellation \
+                as an ordinary failure/empty result. `CancellationException` is a plain \
+                `IllegalStateException` subtype, so nothing at the type level catches this — it passes \
+                compilation and review, and only misbehaves under real cancellation (screen closed, \
+                search superseded, poll tick outrun). This is the #1908 / #1921 bug class.
+
+                Replace it with `runCatchingCancellable` from `org.onebusaway.android.util`: it is \
+                behaviour-identical to `runCatching` but rethrows `CancellationException` (a real failure \
+                still resolves to `Result.failure`). For a broad `try/catch (Exception)` in a suspend \
+                function, add a leading `catch (e: CancellationException) { throw e }` instead — this \
+                check covers `runCatching` only.
+
+                If a `suspend` function genuinely must capture cancellation (extremely rare), suppress \
+                this id at the site with a one-line rationale and a tracking issue.
+            """,
+            category = Category.CORRECTNESS,
+            priority = 6,
+            severity = Severity.WARNING,
+            implementation = Implementation(
+                SwallowedCancellationDetector::class.java,
+                Scope.JAVA_FILE_SCOPE,
+            ),
+        )
+    }
+}

--- a/lint-rules/src/test/java/org/onebusaway/lint/SwallowedCancellationDetectorTest.kt
+++ b/lint-rules/src/test/java/org/onebusaway/lint/SwallowedCancellationDetectorTest.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.lint
+
+import com.android.tools.lint.checks.infrastructure.TestFiles.kotlin
+import com.android.tools.lint.checks.infrastructure.TestLintTask.lint
+import org.junit.Test
+
+class SwallowedCancellationDetectorTest {
+
+    private fun lintKotlin(vararg sources: String) =
+        lint()
+            .files(*sources.map { kotlin(it).indented() }.toTypedArray())
+            .issues(SwallowedCancellationDetector.ISSUE)
+            .allowMissingSdk()
+            .run()
+
+    /** The motivating case: bare `runCatching` directly in a suspend function body. */
+    @Test
+    fun flagsRunCatchingInSuspendFunction() {
+        lintKotlin(
+            """
+            package test
+            suspend fun load(): Result<Int> = runCatching { fetch() }
+            suspend fun fetch(): Int = 1
+            """,
+        ).expectWarningCount(1)
+    }
+
+    /** Nested in an `async { … }` lambda, but the enclosing named function is still suspend — flagged. */
+    @Test
+    fun flagsRunCatchingInLambdaInsideSuspendFunction() {
+        lintKotlin(
+            """
+            package test
+            suspend fun load(): Result<Int> {
+                lateinit var r: Result<Int>
+                run { r = runCatching { fetch() } }
+                return r
+            }
+            suspend fun fetch(): Int = 1
+            """,
+        ).expectWarningCount(1)
+    }
+
+    /** The sanctioned wrapper must not be flagged (different symbol). */
+    @Test
+    fun doesNotFlagRunCatchingCancellable() {
+        lintKotlin(
+            """
+            package test
+            fun <T> runCatchingCancellable(block: () -> T): Result<T> = runCatching(block)
+            suspend fun load(): Result<Int> = runCatchingCancellable { fetch() }
+            suspend fun fetch(): Int = 1
+            """,
+        ).expectClean()
+    }
+
+    /** `runCatching` in a plain (non-suspend) function is fine — no coroutine, no cancellation. */
+    @Test
+    fun doesNotFlagRunCatchingInNonSuspendFunction() {
+        lintKotlin(
+            """
+            package test
+            fun parse(s: String): Result<Int> = runCatching { s.toInt() }
+            """,
+        ).expectClean()
+    }
+
+    /** The wrapper's own body: `runCatching` inside a non-suspend inline fun is not flagged. */
+    @Test
+    fun doesNotFlagInsideNonSuspendInlineWrapper() {
+        lintKotlin(
+            """
+            package test
+            inline fun <T> guard(block: () -> T): Result<T> =
+                runCatching(block).onFailure { }
+            """,
+        ).expectClean()
+    }
+
+    /** A same-named `runCatching` that is not kotlin.runCatching must not be flagged. */
+    @Test
+    fun doesNotFlagUnrelatedRunCatchingFunction() {
+        lintKotlin(
+            """
+            package test
+            class Helper { fun runCatching(block: () -> Int): Int = block() }
+            suspend fun load(h: Helper): Int = h.runCatching { 1 }
+            """,
+        ).expectClean()
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/data/StopsForRouteRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/data/StopsForRouteRepository.kt
@@ -18,7 +18,6 @@ package org.onebusaway.android.api.data
 import android.location.Location
 import javax.inject.Inject
 import javax.inject.Singleton
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -38,6 +37,7 @@ import org.onebusaway.android.models.RouteMapStop
 import org.onebusaway.android.models.RouteStopGroup
 import org.onebusaway.android.util.PolylineDecoder
 import org.onebusaway.android.util.SingleFlight
+import org.onebusaway.android.util.runCatchingCancellable
 import java.io.IOException
 
 /**
@@ -111,10 +111,9 @@ class DefaultStopsForRouteRepository internal constructor(
         val fetched = entry(routeId).getOrElse { return Result.failure(it) }
             ?: return Result.success(null) // no endpoint — nothing to show
         // Decoding the route's shape polylines is the one bit of non-trivial CPU work in this layer.
-        // runCatching swallows everything, so rethrow a CancellationException (raised by withContext if
-        // the caller is cancelled mid-decode) rather than reporting the abandoned work as a failure.
-        return runCatching { withContext(Dispatchers.Default) { fetched.toRouteMapData(routeId) } }
-            .onFailure { if (it is CancellationException) throw it }
+        // runCatchingCancellable rethrows a CancellationException (raised by withContext if the caller is
+        // cancelled mid-decode) rather than reporting the abandoned work as a failure.
+        return runCatchingCancellable { withContext(Dispatchers.Default) { fetched.toRouteMapData(routeId) } }
     }
 
     /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/data/SurveyDataSource.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/data/SurveyDataSource.kt
@@ -17,7 +17,6 @@ package org.onebusaway.android.api.data
 
 import android.util.Log
 import javax.inject.Inject
-import kotlinx.coroutines.CancellationException
 import org.onebusaway.android.api.contract.StudyResponse
 import org.onebusaway.android.api.contract.SurveyWebService
 import org.onebusaway.android.models.Survey
@@ -25,6 +24,7 @@ import org.onebusaway.android.models.SurveyContent
 import org.onebusaway.android.models.SurveyQuestion
 import org.onebusaway.android.models.SurveyStudy
 import org.onebusaway.android.models.SurveySubmitResult
+import org.onebusaway.android.util.runCatchingCancellable
 
 /**
  * Fetches/submits surveys via [SurveyWebService], adapting the wire [StudyResponse] /
@@ -52,12 +52,9 @@ class DefaultSurveyDataSource @Inject constructor(
     private val service: SurveyWebService,
 ) : SurveyDataSource {
 
-    override suspend fun studies(url: String, userId: String?): Result<List<Survey>> = runCatching {
+    override suspend fun studies(url: String, userId: String?): Result<List<Survey>> = runCatchingCancellable {
         service.getStudy(url, userId).toSurveys()
-    }.onFailure {
-        if (it is CancellationException) throw it
-        Log.e(TAG, "studies failed", it)
-    }
+    }.onFailure { Log.e(TAG, "studies failed", it) }
 
     override suspend fun submit(
         url: String,
@@ -67,7 +64,7 @@ class DefaultSurveyDataSource @Inject constructor(
         stopLatitude: Double,
         stopLongitude: Double,
         responses: String,
-    ): Result<SurveySubmitResult> = runCatching {
+    ): Result<SurveySubmitResult> = runCatchingCancellable {
         service.submitSurvey(
             url = url,
             userIdentifier = userIdentifier,
@@ -77,10 +74,7 @@ class DefaultSurveyDataSource @Inject constructor(
             stopLongitude = stopLongitude,
             responses = responses,
         ).let { SurveySubmitResult(it.surveyResponse?.id) }
-    }.onFailure {
-        if (it is CancellationException) throw it
-        Log.e(TAG, "submit failed", it)
-    }
+    }.onFailure { Log.e(TAG, "submit failed", it) }
 
     private companion object {
         const val TAG = "SurveyDataSource"

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/net/ObaApiProvider.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/net/ObaApiProvider.kt
@@ -19,13 +19,13 @@ import android.net.Uri
 import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Singleton
-import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.json.Json
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import org.onebusaway.android.api.contract.ObaWebService
-import retrofit2.converter.kotlinx.serialization.asConverterFactory
+import org.onebusaway.android.util.runCatchingCancellable
 import retrofit2.Retrofit
+import retrofit2.converter.kotlinx.serialization.asConverterFactory
 
 /**
  * Builds — and rebuilds — the region-bound [ObaWebService]. The OBA host isn't known until a region
@@ -53,9 +53,7 @@ class ObaApiProvider @Inject constructor(
      */
     suspend fun <T> call(block: suspend (ObaWebService) -> T): Result<T> {
         val service = service() ?: return Result.failure(noEndpoint())
-        // runCatching catches everything, so a cancelled coroutine's CancellationException would become
-        // a Result.failure and stop propagating; rethrow it so cancellation still unwinds normally.
-        return runCatching { block(service) }.onFailure { if (it is CancellationException) throw it }
+        return runCatchingCancellable { block(service) }
     }
 
     /**
@@ -64,7 +62,7 @@ class ObaApiProvider @Inject constructor(
      */
     suspend fun <T> callOrNull(block: suspend (ObaWebService) -> T): Result<T?> {
         val service = service() ?: return Result.success(null)
-        return runCatching { block(service) }.onFailure { if (it is CancellationException) throw it }
+        return runCatchingCancellable { block(service) }
     }
 
     /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/bike/BikeStationsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/bike/BikeStationsRepository.kt
@@ -24,6 +24,7 @@ import org.onebusaway.android.api.contract.BikeWebService
 import org.onebusaway.android.preferences.PreferencesRepository
 import org.onebusaway.android.region.RegionRepository
 import org.onebusaway.android.util.RegionUtils
+import org.onebusaway.android.util.runCatchingCancellable
 
 /**
  * Loads bike rental stations from OpenTripPlanner for a map bounding box. Replaces the
@@ -43,7 +44,7 @@ class DefaultBikeStationsRepository @Inject constructor(
 ) : BikeStationsRepository {
 
     override suspend fun getStations(southWest: Location, northEast: Location):
-            Result<List<BikeStation>> = runCatching {
+            Result<List<BikeStation>> = runCatchingCancellable {
         val base = otpBaseUrl() ?: error("No OTP base URL for the current region")
 
         // OTP servers differ in how their base URL is rooted (see TripPlanRepository): the "new"
@@ -63,7 +64,7 @@ class DefaultBikeStationsRepository @Inject constructor(
             fetch(base, useOldUrlStructure = true, southWest, northEast)
                 .also { prefs.setBoolean(R.string.preference_key_otp_api_url_version, true) }
         }
-    }.onFailure { if (it is CancellationException) throw it }
+    }
 
     private suspend fun fetch(
         base: String,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/weather/WeatherRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/weather/WeatherRepository.kt
@@ -19,10 +19,10 @@ import android.content.Context
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.io.IOException
 import javax.inject.Inject
-import kotlinx.coroutines.CancellationException
 import org.onebusaway.android.R
 import org.onebusaway.android.api.contract.WeatherWebService
 import org.onebusaway.android.region.RegionRepository
+import org.onebusaway.android.util.runCatchingCancellable
 
 /**
  * The current weather forecast, decoupled from the io/elements response. The raw icon string and
@@ -49,7 +49,7 @@ class DefaultWeatherRepository @Inject constructor(
     private val weatherService: WeatherWebService,
 ) : WeatherRepository {
 
-    override suspend fun currentForecast(regionId: Long): Result<WeatherData> = runCatching {
+    override suspend fun currentForecast(regionId: Long): Result<WeatherData> = runCatchingCancellable {
         val base = regionRepository.region.value?.sidecarBaseUrl
             ?: throw IOException("No sidecar base URL for region $regionId")
         val url = base + context.getString(R.string.weather_api_endpoint)
@@ -57,5 +57,5 @@ class DefaultWeatherRepository @Inject constructor(
         val forecast = weatherService.getWeather(url).current_forecast
             ?: throw IOException("No weather forecast for region $regionId")
         WeatherData(forecast.icon ?: "", forecast.temperature, forecast.summary)
-    }.onFailure { if (it is CancellationException) throw it }
+    }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/mylists/MyListRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/mylists/MyListRepository.kt
@@ -20,7 +20,6 @@ import android.text.format.DateUtils
 import androidx.annotation.ArrayRes
 import androidx.annotation.ColorRes
 import androidx.annotation.StringRes
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
@@ -53,6 +52,7 @@ import org.onebusaway.android.util.DisplayFormat
 import org.onebusaway.android.util.MyTextUtils
 import org.onebusaway.android.util.PreferenceUtils
 import org.onebusaway.android.util.getRouteDisplayName
+import org.onebusaway.android.util.runCatchingCancellable
 
 /**
  * A My-tab list backed by the unified Room database: [observe] re-emits whenever the underlying table
@@ -381,7 +381,7 @@ private suspend fun fetchArrivals(
 
 /** One stop's badges. [convertArrivals] already sorts by ETA; a non-OK code/error yields no badges. */
 private suspend fun fetchStopBadges(context: Context, stopId: String): List<ArrivalBadge> =
-    runCatching {
+    runCatchingCancellable {
         val snapshot = NetworkEntryPoint.getStopArrivals(context)
             .arrivals(stopId, ARRIVALS_MINUTES_AFTER)
             .getOrThrow()
@@ -390,10 +390,7 @@ private suspend fun fetchStopBadges(context: Context, stopId: String): List<Arri
         convertArrivals(context, snapshot.arrivals, ServerTime(snapshot.currentTime), false)
             .take(MAX_ARRIVALS_PER_STOP)
             .map { it.toBadge(context) }
-    }.getOrElse {
-        if (it is CancellationException) throw it
-        emptyList()
-    }
+    }.getOrDefault(emptyList())
 
 private fun ArrivalInfo.toBadge(context: Context): ArrivalBadge {
     val etaText = if (eta <= 0) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/routeinfo/RouteInfoRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/routeinfo/RouteInfoRepository.kt
@@ -23,7 +23,6 @@ import android.util.Log
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.io.IOException
 import javax.inject.Inject
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
@@ -39,6 +38,7 @@ import org.onebusaway.android.region.RegionRepository
 import org.onebusaway.android.util.MyTextUtils
 import org.onebusaway.android.util.ObaRequestErrors
 import org.onebusaway.android.util.routeDisplayNames
+import org.onebusaway.android.util.runCatchingCancellable
 
 /** Loads a route's metadata and its stops grouped by direction. */
 interface RouteInfoRepository {
@@ -64,7 +64,7 @@ class DefaultRouteInfoRepository @Inject constructor(
 
     override suspend fun loadRouteInfo(routeId: String): Result<RouteInfo> =
         withContext(Dispatchers.IO) {
-            runCatching {
+            runCatchingCancellable {
                 // Fetch route metadata and stops-for-route in parallel; both complete before unwrap.
                 val (routeResult, stopsResult) = coroutineScope {
                     val routeDeferred = async { routeRepository.getRoute(routeId) }
@@ -76,9 +76,8 @@ class DefaultRouteInfoRepository @Inject constructor(
                 registerRouteUsage(route)
                 toRouteInfo(route, directions)
             }
-                // Let a cancelled load unwind instead of logging it and disguising it (below) as a
-                // "route not found" error string.
-                .onFailure { if (it is CancellationException) throw it }
+                // runCatchingCancellable rethrows a cancelled load, so it isn't logged and disguised
+                // (below) as a "route not found" error string.
                 .onFailure { Log.e(TAG, "loadRouteInfo($routeId) failed", it) }
                 // The VM renders Result.failure's message, so surface a user-facing route error
                 // string. Preserve the OBA code when we have one (e.g. 404 -> "route not found");

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/search/RouteSearchRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/search/RouteSearchRepository.kt
@@ -19,10 +19,10 @@ import org.onebusaway.android.api.data.LocationSearchDataSource
 
 import android.util.Log
 import java.io.IOException
-import kotlinx.coroutines.CancellationException
 import org.onebusaway.android.location.SearchCenter
 import org.onebusaway.android.models.ObaRoute
 import org.onebusaway.android.util.routeDisplayNames
+import org.onebusaway.android.util.runCatchingCancellable
 
 /**
  * A route search match.
@@ -60,7 +60,7 @@ class DefaultRouteSearchRepository(
     private val search: LocationSearchDataSource,
 ) : RouteSearchRepository {
 
-    override suspend fun search(query: String): Result<List<RouteSearchResult>> = runCatching {
+    override suspend fun search(query: String): Result<List<RouteSearchResult>> = runCatchingCancellable {
         val center = searchCenter.current()
             ?: throw IOException("No search location available")
         var routes = search.routesNearOrEmpty(center.latitude, center.longitude, query, null)
@@ -74,12 +74,9 @@ class DefaultRouteSearchRepository(
             }
         }
         routes.map(::toResult)
-    }.onFailure {
-        // transformLatest cancels the in-flight search on each keystroke; let that cancellation
-        // propagate instead of reporting it to the UI as a search Error.
-        if (it is CancellationException) throw it
-        Log.e(TAG, "route search failed", it)
-    }
+        // runCatchingCancellable lets transformLatest's per-keystroke cancellation propagate instead of
+        // reporting it to the UI as a search Error.
+    }.onFailure { Log.e(TAG, "route search failed", it) }
 
     private fun toResult(route: ObaRoute): RouteSearchResult {
         val names = routeDisplayNames(route.shortName, route.longName, route.description)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/search/StopSearchRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/search/StopSearchRepository.kt
@@ -20,7 +20,6 @@ import org.onebusaway.android.api.data.LocationSearchDataSource
 import android.content.Context
 import android.util.Log
 import java.io.IOException
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.onebusaway.android.app.di.DatabaseEntryPoint
@@ -29,6 +28,7 @@ import org.onebusaway.android.models.ObaStop
 import org.onebusaway.android.database.oba.StopUserInfo
 import org.onebusaway.android.database.oba.stopDisplayName
 import org.onebusaway.android.database.oba.toStopUserInfoMap
+import org.onebusaway.android.util.runCatchingCancellable
 
 /**
  * A stop search match.
@@ -72,7 +72,7 @@ class DefaultStopSearchRepository(
 
     override suspend fun search(query: String): Result<List<StopSearchResult>> =
         withContext(Dispatchers.IO) {
-            runCatching {
+            runCatchingCancellable {
                 val center = searchCenter.current()
                     ?: throw IOException("No search location available")
                 val stops = search.stopsNearOrEmpty(center.latitude, center.longitude, query, null)
@@ -81,10 +81,7 @@ class DefaultStopSearchRepository(
                 db.importGate().awaitReady()
                 val userInfo = db.stopDao().userInfoMap().toStopUserInfoMap()
                 stops.map { it.toStopSearchResult(userInfo[it.id]) }
-            }.onFailure {
-                if (it is CancellationException) throw it
-                Log.e(TAG, "stop search failed", it)
-            }
+            }.onFailure { Log.e(TAG, "stop search failed", it) }
         }
 
     private companion object {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/searchresults/SearchResultsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/searchresults/SearchResultsRepository.kt
@@ -21,7 +21,6 @@ import org.onebusaway.android.api.data.RoutesNearResult
 import javax.inject.Inject
 import android.location.Location
 import java.io.IOException
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import org.onebusaway.android.database.oba.ImportGate
@@ -33,6 +32,7 @@ import org.onebusaway.android.database.oba.StopUserInfo
 import org.onebusaway.android.database.oba.stopDisplayName
 import org.onebusaway.android.database.oba.toStopUserInfoMap
 import org.onebusaway.android.util.routeDisplayNames
+import org.onebusaway.android.util.runCatchingCancellable
 
 /** Searches routes and stops near the user and combines them into one result list. */
 interface SearchResultsRepository {
@@ -58,14 +58,10 @@ class DefaultSearchResultsRepository @Inject constructor(
             ?: return@coroutineScope Result.failure(IOException("No search location available"))
 
         // Each search resolves a non-OK code / transport failure to Result.failure (requireData).
-        // Keep a cancelled search from being coalesced into Result.failure here; rethrowing lets it
-        // propagate through await() and cancel the sibling search too.
-        val routes = async {
-            runCatching { searchRoutes(query, center) }.onFailure { if (it is CancellationException) throw it }
-        }
-        val stops = async {
-            runCatching { searchStops(query, center) }.onFailure { if (it is CancellationException) throw it }
-        }
+        // runCatchingCancellable keeps a cancelled search out of that Result.failure, so cancellation
+        // propagates through await() and cancels the sibling search too.
+        val routes = async { runCatchingCancellable { searchRoutes(query, center) } }
+        val stops = async { runCatchingCancellable { searchStops(query, center) } }
         val routeResult = routes.await()
         val stopResult = stops.await()
 
@@ -80,11 +76,8 @@ class DefaultSearchResultsRepository @Inject constructor(
         // The favourite/custom-name enrichment is best-effort: a DB hiccup here must not fail a search
         // that already has route/stop results, so treat it as a soft miss (empty map) like the lookups.
         importGate.awaitReady()
-        val userInfo = runCatching { stopDao.userInfoMap().toStopUserInfoMap() }
-            .getOrElse {
-                if (it is CancellationException) throw it
-                emptyMap()
-            }
+        val userInfo = runCatchingCancellable { stopDao.userInfoMap().toStopUserInfoMap() }
+            .getOrDefault(emptyMap())
         val items = buildList {
             routeResult.getOrNull()?.let { result ->
                 result.routes.forEach { add(toRoute(it, result.agencyNames)) }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripinfo/TripInfoRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripinfo/TripInfoRepository.kt
@@ -19,7 +19,6 @@ import android.content.Context
 import android.text.format.DateUtils
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.onebusaway.android.R
@@ -37,6 +36,7 @@ import org.onebusaway.android.time.WallTime
 import org.onebusaway.android.util.PreferenceUtils
 import org.onebusaway.android.util.MyTextUtils
 import org.onebusaway.android.util.ReminderUtils
+import org.onebusaway.android.util.runCatchingCancellable
 
 /** The reminder lead times (minutes) backing each spinner position, as stored in the Trips table. */
 internal val REMINDER_MINUTES = listOf(1, 3, 5, 10, 15, 20, 25, 30)
@@ -260,7 +260,8 @@ class DefaultTripInfoRepository @Inject constructor(
         if (userPushId.isEmpty()) return null
         val url = base + context.getString(R.string.arrivals_reminders_api_endpoint) +
             region.id + "/alarms"
-        return runCatching {
+        // runCatchingCancellable keeps a cancelled save from being reported to the UI as a save failure.
+        return runCatchingCancellable {
             reminderService.createAlarm(
                 url = url,
                 stopId = args.stopId,
@@ -271,11 +272,7 @@ class DefaultTripInfoRepository @Inject constructor(
                 secondsBefore = reminderSeconds,
                 vehicleId = data.vehicleId,
             ).url
-        }.getOrElse {
-            // Don't let a cancelled save be reported to the UI as a save failure; propagate cancellation.
-            if (it is CancellationException) throw it
-            null
-        }
+        }.getOrNull()
     }
 
     companion object {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/GeocodeRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/GeocodeRepository.kt
@@ -31,6 +31,7 @@ import org.onebusaway.android.region.span
 import org.onebusaway.android.util.BuildFlavorUtils
 import org.onebusaway.android.util.RegionUtils
 import org.onebusaway.android.util.locationOf
+import org.onebusaway.android.util.runCatchingCancellable
 
 /** Address-autocomplete suggestions for the trip-plan endpoints. */
 interface GeocodeRepository {
@@ -57,8 +58,8 @@ class DefaultGeocodeRepository @Inject constructor(
 
     override suspend fun suggest(query: String): Result<List<TripEndpoint.Geocoded>> =
         withContext(Dispatchers.IO) {
-            runCatching {
-                if (query.isBlank()) return@runCatching emptyList()
+            runCatchingCancellable {
+                if (query.isBlank()) return@runCatchingCancellable emptyList()
                 val region = regionRepository.region.value
                 val addresses = if (BuildFlavorUtils.isPeliasApiKeyDefined()) {
                     peliasSuggestions(query, region)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanRepository.kt
@@ -36,6 +36,7 @@ import org.onebusaway.android.directions.model.TripMode
 import org.onebusaway.android.directions.util.CustomAddress
 import org.onebusaway.android.directions.util.TripRequestBuilder
 import org.onebusaway.android.preferences.PreferencesRepository
+import org.onebusaway.android.util.runCatchingCancellable
 
 /** Plans a trip against the region's OpenTripPlanner server. */
 interface TripPlanRepository {
@@ -68,7 +69,7 @@ class DefaultTripPlanRepository @Inject constructor(
 
     override suspend fun plan(params: TripPlanParams): Result<List<TripItinerary>> =
         withContext(Dispatchers.IO) {
-            runCatching { planInternal(builderFor(params)) }
+            runCatchingCancellable { planInternal(builderFor(params)) }
         }
 
     @WorkerThread

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsRepository.kt
@@ -28,6 +28,7 @@ import org.onebusaway.android.directions.model.TripItinerary
 import org.onebusaway.android.directions.util.ConversionUtils
 import org.onebusaway.android.directions.util.DirectionsGenerator
 import org.onebusaway.android.directions.util.OTPConstants
+import org.onebusaway.android.util.runCatchingCancellable
 
 /**
  * Projects [TripItinerary] objects onto the Compose results model. Reuses the legacy
@@ -49,7 +50,7 @@ class DefaultTripResultsRepository @Inject constructor(@param:ApplicationContext
     override suspend fun summarize(
         itineraries: List<TripItinerary>
     ): Result<List<ItineraryOption>> = withContext(Dispatchers.IO) {
-        runCatching {
+        runCatchingCancellable {
             itineraries.map { itinerary ->
                 val durationSec = itinerary.duration.inWholeSeconds
                 ItineraryOption(
@@ -65,7 +66,7 @@ class DefaultTripResultsRepository @Inject constructor(@param:ApplicationContext
     override suspend fun directionsFor(
         itinerary: TripItinerary
     ): Result<List<DirectionItem>> = withContext(Dispatchers.IO) {
-        runCatching {
+        runCatchingCancellable {
             DirectionsGenerator(itinerary.legs, context).directions.map { it.toItem() }
         }
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/RunCatchingCancellable.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/RunCatchingCancellable.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.util
+
+import kotlinx.coroutines.CancellationException
+
+/**
+ * [runCatching], but coroutine-safe. Kotlin's [runCatching] catches every [Throwable] — including the
+ * [CancellationException] a cancelled coroutine throws from a suspend call — and captures it into the
+ * returned [Result]. In coroutine code that is a bug: the cancellation is converted into an ordinary
+ * `Result.failure`, so the cancelled coroutine keeps running and its callers see the cancellation as a
+ * normal error/empty state (structured concurrency breaks). See #1908/#1921 for the class of bug this
+ * caused across the api/repository layer.
+ *
+ * This wrapper is behaviour-identical to [runCatching] except it **rethrows** [CancellationException]
+ * instead of capturing it, so a real failure still resolves to `Result.failure` while cancellation
+ * propagates normally. Use it in any `suspend` function / coroutine in place of bare `runCatching`; the
+ * `SwallowedCancellation` lint check (module `:lint-rules`) fails the build on a bare `runCatching`
+ * inside a `suspend` function to keep this the only path.
+ *
+ * It is `inline` (mirroring `kotlin.runCatching`), so [block] may call suspend functions when invoked
+ * from a suspend context and the cancellation guard costs nothing.
+ */
+inline fun <T> runCatchingCancellable(block: () -> T): Result<T> =
+    runCatching(block).onFailure { if (it is CancellationException) throw it }


### PR DESCRIPTION
Makes the "`runCatching` swallows `CancellationException` in coroutine code" bug class — audited in #1928, first fixed in #1921 — impossible to reintroduce, deterministically, in CI. The "easy to get wrong" pattern becomes a build failure with a one-line fix.

## Two parts

### 1. `runCatchingCancellable` — the sanctioned wrapper
`org.onebusaway.android.util`. Behaviour-identical to `kotlin.runCatching` but rethrows `CancellationException`, so a cancelled coroutine propagates instead of being captured into `Result.failure`. `inline` (mirrors `runCatching`), so `block` may call suspend functions and the guard costs nothing.

```kotlin
inline fun <T> runCatchingCancellable(block: () -> T): Result<T> =
    runCatching(block).onFailure { if (it is CancellationException) throw it }
```

### 2. `SwallowedCancellation` lint check (`:lint-rules`)
Fails the build on a bare `runCatching` whose **nearest enclosing named function is `suspend`** — matching detekt's `SuspendFunSwallowedCancellation`, but in the module's existing custom-lint infrastructure (no new tool, same strict `-PwarningsAsErrors` gate, no baseline). Suspend is detected via the `Continuation` parameter on the light method.

- Lambdas are transparent, so `async { runCatching { … } }` inside a suspend function **is** caught.
- A `runCatching` in a coroutine-builder lambda inside a *non-suspend* function is deliberately out of scope (boundary not visible without heuristics) — e.g. `RouteMapController`'s launch-lambda sites keep their correct inline guards; the Compose sheet-animation `runCatching`s in `HomeScreen` sit in `@Composable`s and are correctly ignored.
- With one sanctioned wrapper the rule is a **symbol ban** — no fragile "does this lambda suspend" analysis, no guard-detection. A `runCatching` around purely non-suspending work in a suspend function is still flagged; the wrapper is a strict superset, so it's never wrong.

## Migration

Every flagged site moved onto the wrapper — the api/repository sites from the #1928 audit plus four pure-but-in-`suspend`-fn sites the rule newly surfaced (`GeocodeRepository`, `TripResultsRepository` ×2, `TripPlanRepository.plan`), and **`StopsForRouteRepository.routeMap`** (from #1921, which merged meanwhile — the safeguard immediately caught it, exactly as intended). Net reduction in lines: the wrapper reads cleaner than the inline guards. `BikeStationsRepository` keeps its inner `catch (CancellationException) { throw e }` (the check covers `runCatching`, not `try/catch` — for those, add a leading cancellation catch by hand).

Also renamed `TimeDomainIssueRegistry` → `OneBusAwayIssueRegistry` (no longer time-only) + manifest attribute; added detector unit tests, a `lint-rules/README` section, and a CLAUDE.md section.

## Validation

- `:lint-rules:test` — green (6 new detector tests: fires in a suspend fn, fires through a lambda, ignores the wrapper, ignores non-suspend fns and a same-named non-kotlin `runCatching`).
- App compiles clean under `-PwarningsAsErrors`; unit suite green.
- **A full app lint run flagged exactly one `SwallowedCancellation`** — a temporary probe (since removed) — and **zero real sites**, confirming in one pass: registry discovery, the rule firing, and complete migration. (It also surfaced 2 pre-existing `RestrictedApi` errors on `Hct` from #1865 and 2 `ModifierParameter` warnings in untouched files — a known local-vs-CI lint discrepancy, unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved coroutine cancellation handling across network, search, trip-planning, weather, and data-loading flows.
  * Prevented cancelled operations from being incorrectly reported as ordinary failures, improving structured concurrency and cancellation propagation.

* **New Features**
  * Added automated checks to flag unsafe cancellation handling in coroutine code.

* **Documentation**
  * Added guidance for safely handling cancellation and using the cancellation-aware error-handling approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->