### PR TITLE
Test DefaultArrivalsRepository's stale-fallback/CAS concurrency against the real class (#1909)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/app/di/AppModule.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/app/di/AppModule.kt
@@ -33,11 +33,14 @@ import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import org.onebusaway.android.time.ElapsedClock
+import org.onebusaway.android.time.ElapsedTime
 import org.onebusaway.android.util.TimeProvider
 
 /**
  * Provides process-wide infrastructure singletons that aren't a repository binding: the app-lifetime
- * [AppScope] coroutine scope, the Preferences [DataStore], and the wall-clock [TimeProvider]. (Feature
+ * [AppScope] coroutine scope, the Preferences [DataStore], and the clock sources ([TimeProvider],
+ * [ElapsedClock]). (Feature
  * singletons like `RegionRepository`/`LocationRepository`/`DonationsManager` are real Hilt
  * `@Singleton`s — bound in `RepositoryModule` or constructed from their own `@Inject` constructors, not
  * sourced from `Application` here.)
@@ -79,6 +82,11 @@ object AppModule {
     @Provides
     @Singleton
     fun provideTimeProvider(): TimeProvider = TimeProvider { System.currentTimeMillis() }
+
+    /** Monotonic-clock source — the [ElapsedClock] counterpart of [TimeProvider] (see #1909). */
+    @Provides
+    @Singleton
+    fun provideElapsedClock(): ElapsedClock = ElapsedClock { ElapsedTime.now() }
 
     @Provides
     @Singleton

--- a/onebusaway-android/src/main/java/org/onebusaway/android/app/di/RepositoryModule.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/app/di/RepositoryModule.kt
@@ -51,7 +51,11 @@ import org.onebusaway.android.extrapolation.data.DefaultTripObservationFetcher
 import org.onebusaway.android.extrapolation.data.DefaultTripObservationRepository
 import org.onebusaway.android.extrapolation.data.TripObservationFetcher
 import org.onebusaway.android.extrapolation.data.TripObservationRepository
+import org.onebusaway.android.database.oba.RouteFavorites
+import org.onebusaway.android.database.oba.RouteFavoritesRepository
+import org.onebusaway.android.ui.arrivals.ArrivalsDisplay
 import org.onebusaway.android.ui.arrivals.ArrivalsRepository
+import org.onebusaway.android.ui.arrivals.DefaultArrivalsDisplay
 import org.onebusaway.android.ui.arrivals.DefaultArrivalsRepository
 import org.onebusaway.android.ui.home.drawer.DefaultNavItemsRepository
 import org.onebusaway.android.ui.home.DefaultStartupPreferencesRepository
@@ -228,6 +232,16 @@ abstract class RepositoryModule {
     // (assisted) ArrivalsViewModel, so each VM gets its own. Do NOT make this @Singleton.
     @Binds
     abstract fun bindArrivalsRepository(impl: DefaultArrivalsRepository): ArrivalsRepository
+
+    // The Android presentation edge of the arrivals load path — the seam that keeps Context out of
+    // DefaultArrivalsRepository so its stale-fallback/CAS logic is JVM-unit-testable (#1909).
+    @Binds
+    abstract fun bindArrivalsDisplay(impl: DefaultArrivalsDisplay): ArrivalsDisplay
+
+    // The narrow route-starring surface (interface segregation, #1909); the implementation is the
+    // @Singleton owner of the favorite bit, so this binding shares that one instance.
+    @Binds
+    abstract fun bindRouteFavorites(impl: RouteFavoritesRepository): RouteFavorites
 
     // Speed-estimation trip data layer: both @Singleton — the repository owns the process-wide trip
     // store (the LRU cache shared across screens), and the fetcher owns the SingleFlight dedup maps.

--- a/onebusaway-android/src/main/java/org/onebusaway/android/database/oba/RouteFavoritesRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/database/oba/RouteFavoritesRepository.kt
@@ -34,6 +34,27 @@ import org.onebusaway.android.region.RegionRepository
 import org.onebusaway.android.util.routeDisplayNames
 
 /**
+ * The narrow route-starring surface a consumer needs (the live starred-id set plus the wholesale
+ * star/unstar write), segregated from [RouteFavoritesRepository]'s full dependency set (Context,
+ * analytics, app scope) so a repository that only stars routes — e.g. the arrivals repository — is
+ * JVM-unit-testable with a fake (#1909).
+ */
+interface RouteFavorites {
+
+    /** The starred route ids, live (see [RouteFavoritesRepository.favoriteRouteIds]). */
+    fun favoriteRouteIds(): Flow<Set<String>>
+
+    /** Stars (or unstars) [routeId] wholesale (see [RouteFavoritesRepository.setFavorite]). */
+    suspend fun setFavorite(
+        routeId: String,
+        shortName: String?,
+        longName: String?,
+        url: String?,
+        favorite: Boolean,
+    )
+}
+
+/**
  * The single owner of route-favorite membership — a wholesale `routes.favorite` bit (#1751). The
  * arrival-row star writes through [setFavorite] so the import gating, the row-existence guarantee, and
  * the bookmark analytics live in one place instead of being re-implemented (and drifting) per surface;
@@ -49,11 +70,11 @@ class RouteFavoritesRepository @Inject constructor(
     private val obaAnalytics: ObaAnalytics,
     @param:AppScope private val appScope: CoroutineScope,
     @param:ApplicationContext private val context: Context,
-) {
+) : RouteFavorites {
 
     /** The starred route ids, live: import-gated, and deduped so an unrelated `routes` write (a route
      *  recorded on an arrivals load) doesn't re-emit an identical set. */
-    fun favoriteRouteIds(): Flow<Set<String>> =
+    override fun favoriteRouteIds(): Flow<Set<String>> =
         routeDao.favoriteRouteIds()
             .onStart { importGate.awaitReady() }
             .map { it.toSet() }
@@ -67,7 +88,7 @@ class RouteFavoritesRepository @Inject constructor(
      * then backfilled from the network so the folder always shows a proper long name — regardless of
      * which surface starred it (a starring surface's loaded route often carries an empty long name).
      */
-    suspend fun setFavorite(
+    override suspend fun setFavorite(
         routeId: String,
         shortName: String?,
         longName: String?,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/time/ElapsedClock.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/time/ElapsedClock.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.time
+
+/**
+ * Injectable monotonic-clock source — the [ElapsedTime]-domain counterpart of
+ * [org.onebusaway.android.util.TimeProvider]. A class that measures real elapsed intervals (e.g. the
+ * arrivals stale-fallback projection) takes its readings from this seam instead of calling
+ * [ElapsedTime.now] inline, the class-boundary form of the "pass the now in as a parameter" rule —
+ * so a JVM test can drive the interval with an exact, controlled delta (see #1909).
+ */
+fun interface ElapsedClock {
+    /** The current monotonic reading; [ElapsedTime.now] in production. */
+    fun now(): ElapsedTime
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsDisplay.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsDisplay.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.arrivals
+
+import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import org.onebusaway.android.models.ArrivalData
+import org.onebusaway.android.time.ServerTime
+import org.onebusaway.android.util.ObaRequestErrors
+
+/**
+ * The Android-flavored presentation edge of the arrivals load path: building the display
+ * [ArrivalInfo]s (label strings and connectivity-aware error messages both need a [Context]).
+ * Extracted as an interface so [DefaultArrivalsRepository] carries no [Context] and its
+ * stale-fallback/CAS concurrency is JVM-unit-testable with a fake (#1909). [ArrivalInfo] itself
+ * tolerates a null context (empty labels), so a fake can still build real display models — real
+ * ETA/prediction math — on the JVM.
+ */
+interface ArrivalsDisplay {
+
+    /** Builds the display models for [arrivals] against the server-clock [now] (see [convertArrivals]). */
+    fun convert(
+        arrivals: List<ArrivalData>,
+        now: ServerTime,
+        includeArrivalDepartureInStatusLabel: Boolean,
+    ): List<ArrivalInfo>
+
+    /** The user-facing message for a failed arrivals fetch (see [ObaRequestErrors]). */
+    fun stopErrorMessage(code: Int): String
+}
+
+/** Production implementation over the app [Context] — where the arrivals load path touches Android. */
+class DefaultArrivalsDisplay @Inject constructor(
+    @param:ApplicationContext private val context: Context,
+) : ArrivalsDisplay {
+
+    override fun convert(
+        arrivals: List<ArrivalData>,
+        now: ServerTime,
+        includeArrivalDepartureInStatusLabel: Boolean,
+    ): List<ArrivalInfo> =
+        convertArrivals(context, arrivals, now, includeArrivalDepartureInStatusLabel)
+
+    override fun stopErrorMessage(code: Int): String =
+        ObaRequestErrors.getStopErrorString(context, code)
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsRepository.kt
@@ -18,8 +18,6 @@ package org.onebusaway.android.ui.arrivals
 import org.onebusaway.android.api.data.StopArrivalsDataSource
 import org.onebusaway.android.api.data.StopArrivals
 
-import android.content.Context
-import dagger.hilt.android.qualifiers.ApplicationContext
 import java.io.IOException
 import java.util.concurrent.atomic.AtomicReference
 import javax.inject.Inject
@@ -33,7 +31,7 @@ import org.onebusaway.android.R
 import org.onebusaway.android.api.ObaApi
 import org.onebusaway.android.api.ObaApiException
 import org.onebusaway.android.database.oba.ImportGate
-import org.onebusaway.android.database.oba.RouteFavoritesRepository
+import org.onebusaway.android.database.oba.RouteFavorites
 import org.onebusaway.android.database.oba.ServiceAlertDao
 import org.onebusaway.android.database.oba.StopDao
 import org.onebusaway.android.database.oba.markStopUsed
@@ -41,13 +39,13 @@ import org.onebusaway.android.models.ObaRoute
 import org.onebusaway.android.models.ObaSituation
 import org.onebusaway.android.models.ObaStop
 import org.onebusaway.android.models.FocusedTrip
+import org.onebusaway.android.time.ElapsedClock
 import org.onebusaway.android.time.ElapsedTime
 import org.onebusaway.android.time.ServerTime
 import org.onebusaway.android.models.contentKey
 import org.onebusaway.android.preferences.PreferencesRepository
 import org.onebusaway.android.region.RegionRepository
 import org.onebusaway.android.util.MyTextUtils
-import org.onebusaway.android.util.ObaRequestErrors
 import org.onebusaway.android.util.SituationUtils
 import org.onebusaway.android.util.getRouteDisplayName
 
@@ -223,22 +221,25 @@ data class AlertDetails(
  * Default implementation over the api [StopArrivalsDataSource]. Ports ArrivalsListLoader's
  * behavior: widen the time window until arrivals are found, and fall back to the last good response
  * when a refresh fails. Builds the [ArrivalInfo] display model plus the per-arrival actions and service
- * alerts on the IO thread (their constructors read ContentProviders). All Android statics are
- * quarantined here so [ArrivalsViewModel] stays JVM-testable.
+ * alerts on the IO thread (their constructors read ContentProviders). The Android edges live behind
+ * the injected [ArrivalsDisplay]/[ElapsedClock] seams, so this class itself — including the
+ * stale-fallback/CAS concurrency below — is JVM-unit-testable with fakes (#1909; see
+ * `DefaultArrivalsRepositoryTest`), and [ArrivalsViewModel] stays JVM-testable above it.
  *
  * Note: this repo is **stateful** ([lastGood]) and 1:1 with its [ArrivalsViewModel], so its
  * `@Binds` is intentionally **unscoped** (a fresh instance per VM) — do NOT make it `@Singleton`,
  * which would share `lastGood` across stops and corrupt per-stop state.
  */
 class DefaultArrivalsRepository @Inject constructor(
-    @param:ApplicationContext private val context: Context,
     private val regionRepository: RegionRepository,
     private val stopArrivals: StopArrivalsDataSource,
     private val serviceAlertDao: ServiceAlertDao,
     private val stopDao: StopDao,
-    private val routeFavorites: RouteFavoritesRepository,
+    private val routeFavorites: RouteFavorites,
     private val importGate: ImportGate,
     private val preferences: PreferencesRepository,
+    private val display: ArrivalsDisplay,
+    private val elapsedClock: ElapsedClock,
 ) : ArrivalsRepository {
 
     /**
@@ -288,7 +289,7 @@ class DefaultArrivalsRepository @Inject constructor(
             onSuccess = { snapshot ->
                 // Stamp the receipt time as close to the response as possible (before the DB reads in
                 // toData), then publish the whole consistent set with one write once [data] is built.
-                val receivedAt = ElapsedTime.now()
+                val receivedAt = elapsedClock.now()
                 // Record the stop once per session so favoriting persists (setFavorite is an
                 // UPDATE — it needs the row to exist) and the stop shows in Recent stops.
                 if (!stopRecorded) {
@@ -306,7 +307,7 @@ class DefaultArrivalsRepository @Inject constructor(
                     // reintroducing device clock skew (#1612) — a same-domain ElapsedTime subtraction,
                     // so the typed API allows it directly.
                     val now = ServerTime(stale.snapshot.currentTime) +
-                        (ElapsedTime.now() - stale.receivedAt)
+                        (elapsedClock.now() - stale.receivedAt)
                     val data = toData(stale.snapshot, isStale = true, now = now)
                     // Keep the same snapshot/receipt time; refresh only the derived map snapshot so its
                     // stale ETAs advance. CAS so this can't roll back a fresh snapshot a concurrent
@@ -316,8 +317,8 @@ class DefaultArrivalsRepository @Inject constructor(
                 }
                     ?: Result.failure(
                         IOException(
-                            ObaRequestErrors.getStopErrorString(
-                                context, (error as? ObaApiException)?.code ?: ObaApi.OBA_IO_EXCEPTION
+                            display.stopErrorMessage(
+                                (error as? ObaApiException)?.code ?: ObaApi.OBA_IO_EXCEPTION
                             )
                         )
                     )
@@ -340,9 +341,7 @@ class DefaultArrivalsRepository @Inject constructor(
         val includeArrivalDepartureLabel = false
         // Favorite state is a live overlay applied in the ViewModel (from the reactive starred-route
         // set), not baked here — so a star toggle re-flags the list without this re-fetch.
-        val arrivals = convertArrivals(
-            context, snapshot.arrivals, now, includeArrivalDepartureLabel
-        )
+        val arrivals = display.convert(snapshot.arrivals, now, includeArrivalDepartureLabel)
         val stop = snapshot.stop
         val userInfo = stopDao.userInfo(snapshot.stopId)
         val header = StopHeader(

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/DefaultArrivalsRepositoryTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/DefaultArrivalsRepositoryTest.kt
@@ -1,0 +1,401 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.arrivals
+
+import java.io.IOException
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.onebusaway.android.api.ObaApiException
+import org.onebusaway.android.api.contract.AgencyReference
+import org.onebusaway.android.api.contract.ArrivalDeparture
+import org.onebusaway.android.api.contract.ArrivalsForStop
+import org.onebusaway.android.api.contract.EntryWithReferences
+import org.onebusaway.android.api.contract.References
+import org.onebusaway.android.api.contract.RouteReference
+import org.onebusaway.android.api.contract.StopReference
+import org.onebusaway.android.api.contract.TripReference
+import org.onebusaway.android.api.data.StopArrivals
+import org.onebusaway.android.api.data.StopArrivalsDataSource
+import org.onebusaway.android.database.oba.ImportGate
+import org.onebusaway.android.database.oba.RouteFavorites
+import org.onebusaway.android.database.oba.ServiceAlertDao
+import org.onebusaway.android.database.oba.ServiceAlertRecord
+import org.onebusaway.android.database.oba.StopDao
+import org.onebusaway.android.database.oba.StopListRow
+import org.onebusaway.android.database.oba.StopLocationRow
+import org.onebusaway.android.database.oba.StopRecentRow
+import org.onebusaway.android.database.oba.StopRecord
+import org.onebusaway.android.database.oba.StopUserInfoMapRow
+import org.onebusaway.android.database.oba.StopUserInfoRow
+import org.onebusaway.android.models.ArrivalData
+import org.onebusaway.android.models.FocusedTrip
+import org.onebusaway.android.region.FakeRegionRepository
+import org.onebusaway.android.testing.FakePreferencesRepository
+import org.onebusaway.android.time.ElapsedClock
+import org.onebusaway.android.time.ElapsedTime
+import org.onebusaway.android.time.ServerTime
+
+/**
+ * Tests for [DefaultArrivalsRepository]'s stale-fallback/CAS concurrency against the REAL class
+ * (issue #1909) — the single-write [DefaultArrivalsRepository] `LastGood` holder, the
+ * fresh-wins-over-stale `compareAndSet`, the elapsed-time re-projection of stale ETAs (#1612), and
+ * the `lastLoaded()` trip derivation. The Android edges come in through the [ArrivalsDisplay] /
+ * [ElapsedClock] seams; [ArrivalInfo] tolerates a null context, so the display fake below builds
+ * real display models with real ETA math on the JVM.
+ *
+ * The interleaving tests hold the stale-fallback path *between* its `lastGood` read and its CAS by
+ * gating the fake [StopDao.userInfo] (a suspension point inside `toData`) — the same
+ * [CompletableDeferred] gate technique `ArrivalsViewModelTest` uses one layer up.
+ */
+class DefaultArrivalsRepositoryTest {
+
+    private companion object {
+        const val STOP_ID = "1_100"
+
+        /** A server clock on a whole minute, so the floored-minutes ETA math asserts exactly. */
+        const val T0 = 1_200_000_000_000L
+    }
+
+    // --- Fakes ------------------------------------------------------------------------------------
+
+    /** Scripted [StopArrivalsDataSource]: answers with [respond] and records each requested window. */
+    private class FakeStopArrivalsDataSource : StopArrivalsDataSource {
+        val requestedMinutes = mutableListOf<Int>()
+        lateinit var respond: (minutesAfter: Int) -> Result<StopArrivals>
+
+        override suspend fun arrivals(stopId: String, minutesAfter: Int): Result<StopArrivals> {
+            requestedMinutes.add(minutesAfter)
+            return respond(minutesAfter)
+        }
+    }
+
+    /**
+     * A [StopDao] whose [userInfo] — a suspension point on every `toData` — can be gated one-shot:
+     * the next call signals [userInfoEntered] and parks on [userInfoGate] until the test releases it,
+     * consuming the gate so subsequent (e.g. concurrent fresh-load) calls pass straight through.
+     */
+    private class FakeStopDao : StopDao {
+        val markStopUsedCalls = mutableListOf<String>()
+
+        @Volatile
+        var userInfoGate: CompletableDeferred<Unit>? = null
+        val userInfoEntered = CompletableDeferred<Unit>()
+
+        override suspend fun userInfo(stopId: String): StopUserInfoRow? {
+            val gate = userInfoGate
+            if (gate != null) {
+                userInfoGate = null
+                userInfoEntered.complete(Unit)
+                gate.await()
+            }
+            return null
+        }
+
+        override suspend fun markStopUsed(
+            id: String,
+            code: String,
+            name: String,
+            direction: String,
+            latitude: Double,
+            longitude: Double,
+            regionId: Long?,
+            now: Long,
+        ) {
+            markStopUsedCalls.add(id)
+        }
+
+        override suspend fun setFavorite(stopId: String, favorite: Int) {}
+        override suspend fun userInfoMap(): List<StopUserInfoMapRow> = emptyList()
+        override suspend fun location(stopId: String): StopLocationRow? = null
+        override suspend fun nameForStop(stopId: String): String? = null
+        override suspend fun getStop(stopId: String): StopRecord? = null
+        override suspend fun upsert(stop: StopRecord) {}
+        override fun recents(cutoff: Long, regionId: Long?): Flow<List<StopListRow>> = flowOf(emptyList())
+        override fun recentsForSearch(cutoff: Long, regionId: Long?): Flow<List<StopRecentRow>> =
+            flowOf(emptyList())
+        override fun starredByName(regionId: Long?): Flow<List<StopListRow>> = flowOf(emptyList())
+        override fun starredByFrequency(regionId: Long?): Flow<List<StopListRow>> = flowOf(emptyList())
+        override fun favoriteStopIds(): Flow<List<String>> = flowOf(emptyList())
+        override suspend fun markUnused(stopId: String) {}
+        override suspend fun markAllUnused() {}
+        override suspend fun clearAllFavorites() {}
+    }
+
+    private class FakeServiceAlertDao : ServiceAlertDao {
+        override suspend fun insertIfAbsent(row: ServiceAlertRecord) {}
+        override fun hideDecisions(): Flow<List<ServiceAlertRecord>> = flowOf(emptyList())
+        override suspend fun updateMarkedReadTime(id: String, time: Long) {}
+        override suspend fun updateHidden(id: String, hidden: Int) {}
+        override suspend fun isHidden(id: String): Boolean = false
+        override suspend fun setAllHidden(hidden: Int) {}
+    }
+
+    private class FakeRouteFavorites : RouteFavorites {
+        override fun favoriteRouteIds(): Flow<Set<String>> = flowOf(emptySet())
+        override suspend fun setFavorite(
+            routeId: String,
+            shortName: String?,
+            longName: String?,
+            url: String?,
+            favorite: Boolean,
+        ) {}
+    }
+
+    private object NoopImportGate : ImportGate {
+        override suspend fun awaitReady() {}
+        override fun start() {}
+    }
+
+    /**
+     * Builds REAL [ArrivalInfo]s with a null context (labels degrade to empty strings; the ETA and
+     * prediction math is untouched), and applies the production negative-ETA filter with
+     * show-negative-arrivals off — so a stale re-projection observably *drops* an arrival whose time
+     * has passed, making the CAS write to the derived map snapshot assertable.
+     */
+    private class FakeArrivalsDisplay : ArrivalsDisplay {
+        override fun convert(
+            arrivals: List<ArrivalData>,
+            now: ServerTime,
+            includeArrivalDepartureInStatusLabel: Boolean,
+        ): List<ArrivalInfo> =
+            arrivals.map { ArrivalInfo(null, it, now, includeArrivalDepartureInStatusLabel) }
+                .filter { it.eta >= 0 }
+
+        override fun stopErrorMessage(code: Int): String = "stop-error-$code"
+    }
+
+    /** A manually-advanced monotonic clock, so the stale projection's delta is exact. */
+    private class FakeElapsedClock : ElapsedClock {
+        private var current = ElapsedTime(100_000L)
+        override fun now(): ElapsedTime = current
+        fun advance(duration: Duration) {
+            current = ElapsedTime(current.ms + duration.inWholeMilliseconds)
+        }
+    }
+
+    private fun repository(
+        dataSource: FakeStopArrivalsDataSource,
+        stopDao: FakeStopDao = FakeStopDao(),
+        clock: FakeElapsedClock = FakeElapsedClock(),
+    ) = DefaultArrivalsRepository(
+        regionRepository = FakeRegionRepository(),
+        stopArrivals = dataSource,
+        serviceAlertDao = FakeServiceAlertDao(),
+        stopDao = stopDao,
+        routeFavorites = FakeRouteFavorites(),
+        importGate = NoopImportGate,
+        preferences = FakePreferencesRepository(),
+        display = FakeArrivalsDisplay(),
+        elapsedClock = clock,
+    )
+
+    // --- Fixtures ---------------------------------------------------------------------------------
+
+    /** A real [StopArrivals] snapshot (wire fixtures, no Android): one arrival [arrivalAt] on a trip. */
+    private fun snapshot(
+        currentTime: Long = T0,
+        tripId: String = "trip-A",
+        shapeId: String = "shape-A",
+        arrivalAt: Long = currentTime + 10 * 60_000L,
+        hasArrivals: Boolean = true,
+        minutesAfter: Int = 65,
+    ) = StopArrivals(
+        data = EntryWithReferences(
+            entry = ArrivalsForStop(
+                stopId = STOP_ID,
+                arrivalsAndDepartures = if (hasArrivals) {
+                    listOf(
+                        ArrivalDeparture(
+                            routeId = "route-1",
+                            tripId = tripId,
+                            stopId = STOP_ID,
+                            stopSequence = 3,
+                            scheduledArrivalTime = arrivalAt,
+                            scheduledDepartureTime = arrivalAt,
+                        )
+                    )
+                } else {
+                    emptyList()
+                },
+            ),
+            references = References(
+                agencies = listOf(AgencyReference(id = "agency-1", name = "Metro")),
+                stops = listOf(
+                    StopReference(
+                        id = STOP_ID, name = "Pine St & 3rd Ave",
+                        lat = 47.61, lon = -122.33, routeIds = listOf("route-1"),
+                    )
+                ),
+                routes = listOf(RouteReference(id = "route-1", shortName = "5", agencyId = "agency-1")),
+                trips = listOf(TripReference(id = tripId, routeId = "route-1", shapeId = shapeId, directionId = "0")),
+            ),
+        ),
+        currentTime = currentTime,
+        minutesAfter = minutesAfter,
+    )
+
+    // --- Fresh loads ------------------------------------------------------------------------------
+
+    @Test
+    fun `a fresh load publishes a lastLoaded snapshot consistent with the displayed trips`() = runTest {
+        val dataSource = FakeStopArrivalsDataSource()
+        dataSource.respond = { Result.success(snapshot()) }
+        val repository = repository(dataSource)
+        assertNull(repository.lastLoaded())
+
+        val data = repository.getArrivals(STOP_ID, 65).getOrThrow()
+
+        assertEquals(10L, data.arrivals.single().eta)
+        val loaded = repository.lastLoaded()!!
+        assertEquals(STOP_ID, loaded.stop?.id)
+        assertEquals(listOf("route-1"), loaded.routes?.map { it.id })
+        assertTrue(loaded.hasArrivals)
+        // The exact displayed trips, derived from the same data the drawer shows.
+        assertEquals(
+            setOf(FocusedTrip("trip-A", "route-1", "shape-A", null, directionId = 0)),
+            loaded.focusedTrips,
+        )
+    }
+
+    @Test
+    fun `the empty-window widen loop grows the window until arrivals appear`() = runTest {
+        val dataSource = FakeStopArrivalsDataSource()
+        dataSource.respond = { minutes ->
+            Result.success(snapshot(hasArrivals = minutes >= 185, minutesAfter = minutes))
+        }
+        val repository = repository(dataSource)
+
+        val data = repository.getArrivals(STOP_ID, 65).getOrThrow()
+
+        assertEquals(listOf(65, 125, 185), dataSource.requestedMinutes)
+        assertEquals(185, data.minutesAfter)
+    }
+
+    @Test
+    fun `the stop is recorded once per session, not on every poll`() = runTest {
+        val dataSource = FakeStopArrivalsDataSource()
+        dataSource.respond = { Result.success(snapshot()) }
+        val stopDao = FakeStopDao()
+        val repository = repository(dataSource, stopDao = stopDao)
+
+        repository.getArrivals(STOP_ID, 65).getOrThrow()
+        repository.getArrivals(STOP_ID, 65).getOrThrow()
+
+        assertEquals(listOf(STOP_ID), stopDao.markStopUsedCalls)
+    }
+
+    // --- The stale-fallback path ------------------------------------------------------------------
+
+    @Test
+    fun `a failed refresh with no prior data fails with the display error message`() = runTest {
+        val dataSource = FakeStopArrivalsDataSource()
+        dataSource.respond = { Result.failure(ObaApiException(404)) }
+        val repository = repository(dataSource)
+
+        val result = repository.getArrivals(STOP_ID, 65)
+
+        assertEquals("stop-error-404", result.exceptionOrNull()!!.message)
+        assertNull(repository.lastLoaded())
+    }
+
+    @Test
+    fun `a failed refresh serves the stale snapshot with ETAs projected forward by elapsed device time`() = runTest {
+        val dataSource = FakeStopArrivalsDataSource()
+        val clock = FakeElapsedClock()
+        val repository = repository(dataSource, clock = clock)
+        dataSource.respond = { Result.success(snapshot()) }
+        // Arrival 10 minutes out at load time.
+        assertEquals(10L, repository.getArrivals(STOP_ID, 65).getOrThrow().arrivals.single().eta)
+
+        // 4 minutes of device time pass, then the refresh fails.
+        clock.advance(4.minutes)
+        dataSource.respond = { Result.failure(IOException("down")) }
+        val stale = repository.getArrivals(STOP_ID, 65).getOrThrow()
+
+        assertTrue(stale.isStale)
+        // The last good server clock projected forward by exactly the elapsed device time (#1612).
+        assertEquals(6L, stale.arrivals.single().eta)
+        // The footnote window still names the boundary of the (old) data actually shown.
+        assertEquals(ServerTime(T0) + 65.minutes, stale.windowEnd)
+    }
+
+    @Test
+    fun `an uncontended stale re-projection refreshes the derived map snapshot`() = runTest {
+        val dataSource = FakeStopArrivalsDataSource()
+        val clock = FakeElapsedClock()
+        val repository = repository(dataSource, clock = clock)
+        dataSource.respond = { Result.success(snapshot()) }
+        repository.getArrivals(STOP_ID, 65).getOrThrow()
+        assertEquals(1, repository.lastLoaded()!!.focusedTrips.size)
+
+        // The 10-minute arrival's time passes; the re-projection drops it (negative ETA), so the
+        // CAS-published refresh of [loaded] must show the focused trip gone.
+        clock.advance(11.minutes)
+        dataSource.respond = { Result.failure(IOException("down")) }
+        val stale = repository.getArrivals(STOP_ID, 65).getOrThrow()
+
+        assertTrue(stale.isStale)
+        assertTrue(stale.arrivals.isEmpty())
+        val loaded = repository.lastLoaded()!!
+        assertTrue(loaded.focusedTrips.isEmpty())
+        // The rest of the holder is the same last good snapshot, unrolled.
+        assertEquals(STOP_ID, loaded.stop?.id)
+        assertTrue(loaded.hasArrivals)
+    }
+
+    @Test
+    fun `a stale re-projection cannot roll back a concurrently published fresh load`() = runTest {
+        val dataSource = FakeStopArrivalsDataSource()
+        val stopDao = FakeStopDao()
+        val repository = repository(dataSource, stopDao = stopDao)
+        dataSource.respond = { Result.success(snapshot(tripId = "trip-A", shapeId = "shape-A")) }
+        repository.getArrivals(STOP_ID, 65).getOrThrow()
+
+        // Park the next load — a failing refresh, i.e. the stale-fallback path — inside toData,
+        // after it has read the lastGood holder but before its compareAndSet.
+        val gate = CompletableDeferred<Unit>()
+        stopDao.userInfoGate = gate
+        dataSource.respond = { Result.failure(IOException("down")) }
+        val staleLoad = async(Dispatchers.Default) { repository.getArrivals(STOP_ID, 65) }
+        stopDao.userInfoEntered.await()
+
+        // While it is parked, a fresh load lands and publishes trip-B unconditionally.
+        dataSource.respond = { Result.success(snapshot(tripId = "trip-B", shapeId = "shape-B")) }
+        repository.getArrivals(STOP_ID, 65).getOrThrow()
+        val freshTrips = setOf(FocusedTrip("trip-B", "route-1", "shape-B", null, directionId = 0))
+        assertEquals(freshTrips, repository.lastLoaded()!!.focusedTrips)
+
+        // Release the stale path: its CAS must lose, leaving the fresh holder standing.
+        gate.complete(Unit)
+        val stale = staleLoad.await().getOrThrow()
+
+        // The caller still gets the stale-projected data (of the OLD snapshot it read)...
+        assertTrue(stale.isStale)
+        assertEquals("trip-A", stale.arrivals.single().tripId)
+        // ...but the published holder is NOT rolled back to it.
+        assertEquals(freshTrips, repository.lastLoaded()!!.focusedTrips)
+    }
+}


### PR DESCRIPTION
Fixes #1909 (from the 2026-07-16 debt review, finding 9).

## Problem

The single-write `LastGood` holder and the fresh-wins-over-stale `compareAndSet` in `DefaultArrivalsRepository` were subtle race fixes (#1865) whose reasoning existed only in comments. `ArrivalsViewModelTest` uses a fake repository; nothing constructed the real class, so a future simplification could re-break the concurrency invisibly.

## Why the class wasn't testable, and the fix

The real class couldn't be built on the JVM because of three incidental Android tendrils. Each is now a small, independently-justified seam — behavior unchanged, verified by the full unit suite on both flavors plus an on-device smoke test:

- **`ArrivalsDisplay`** — the Android presentation edge (`convertArrivals` + stop error strings) behind an interface. `DefaultArrivalsDisplay` holds the `Context`, which leaves `DefaultArrivalsRepository`'s constructor entirely — completing the quarantine its docstring already claimed. Key discovery: `ArrivalInfo` already tolerates a null context (the "Activity destroyed" guard), so the test fake builds **real** display models with real ETA math.
- **`ElapsedClock`** (`time/`) — the injectable `ElapsedTime.now()` source, the monotonic counterpart of the existing `TimeProvider` and the class-boundary form of the "pass the now in" rule — so the stale projection is testable with an exact elapsed delta.
- **`RouteFavorites`** — the narrow starring surface (interface segregation) of `RouteFavoritesRepository`, whose full dependency set (Context/analytics/app scope) isn't JVM-constructible. Its `getArrivals`-path use is nil; the `@Singleton` impl is `@Binds`-bound.

## The tests (`DefaultArrivalsRepositoryTest`, 7, all against the real class)

Hand-rolled fakes (house style) over real `StopArrivals` wire fixtures:

1. Fresh load publishes a `lastLoaded()` consistent with the displayed trips (real `focusedTrips` derivation)
2. Empty-window widen loop grows the window (65 → 125 → 185)
3. Stop recorded once per session, not per poll
4. Failure with no prior data → the display error message
5. **Stale fallback**: ETAs projected forward by *exactly* the elapsed device time (#1612), `windowEnd` unmoved
6. **Uncontended CAS**: the re-projection observably refreshes the derived map snapshot (a passed arrival drops out of `focusedTrips`)
7. **The interleaved race**: the stale path is parked between its `lastGood` read and its CAS (a gated fake `StopDao.userInfo` — the same `CompletableDeferred` gate technique `ArrivalsViewModelTest` uses), a fresh load publishes, and the released CAS loses — a stale re-projection can never roll back a concurrently-published fresh snapshot.

## Verification

- `testObaGoogleDebugUnitTest` + `testObaMaplibreDebugUnitTest` green with `-PwarningsAsErrors=true`; Hilt graph compiles.
- On-device smoke test (Puget Sound stop `1_75403`): arrivals render fully through the new wiring — header, route rows with real labels, ETA pills, "Showing trips until…" footnote, Load more.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved arrival updates with more accurate elapsed-time handling and stale-data ETA projections.
  * Added clearer separation for arrival display formatting and route favorites services.
  * Failed refreshes now provide user-facing stop error messages while preserving available stale arrival data.

* **Bug Fixes**
  * Prevented stale arrival data from overwriting newer results during concurrent updates.
  * Improved handling of empty arrival windows and expired projected arrivals.

* **Tests**
  * Added coverage for refresh behavior, fallback data, ETA projections, favorite usage, and concurrency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->