### PR TITLE
Guard ArrivalsViewModel.refresh() against out-of-order overlapping refreshes (#1933)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsViewModel.kt
@@ -101,18 +101,33 @@ class ArrivalsViewModel @AssistedInject constructor(
         private set
 
     /**
+     * Bumped at the start of every [refresh]; a refresh applies its result only while it's still the
+     * latest. The poll loop awaits its own `refresh()` sequentially, but [manualRefresh]/[loadMore]
+     * each launch one, so a user refresh can run concurrently with an in-flight poll and finish out of
+     * order — without this guard the older-started one's `loaded.value = data` would clobber the fresher
+     * result (a spurious stale flag / older arrivals). Confined to the ViewModel dispatcher (the only
+     * suspension in [refresh] is the fetch), so a plain `Int` needs no synchronization. See #1933.
+     */
+    private var refreshGeneration = 0
+
+    /**
      * Loads the arrivals once. Suspends until done so the screen's polling loop can measure the
      * 60s interval from completion. A failed refresh keeps any existing content (the repository
      * already returns the last good data as stale); it only surfaces [ArrivalsUiState.Error]
      * when there is nothing to show.
      *
-     * Returns true when a *fresh* network response landed — a stale fallback (the repository
-     * returns the last good data flagged `isStale` on failure-with-content) or a hard failure
-     * returns false. Consumed by [loadMore]; the poll loop ignores it.
+     * Returns true when a *fresh* network response landed and was applied — a stale fallback (the
+     * repository returns the last good data flagged `isStale` on failure-with-content), a hard failure,
+     * or a completion superseded by a newer refresh (#1933) returns false. Consumed by [loadMore]; the
+     * poll loop ignores it.
      */
     suspend fun refresh(): Boolean {
+        val generation = ++refreshGeneration
         val result = repository.getArrivals(stopId, minutesAfter)
         lastResponseTime = WallTime.now()
+        // A newer refresh started while this one was in flight — drop this (now stale) completion so it
+        // can't overwrite the fresher state or emit an out-of-date map snapshot. See #1933.
+        if (generation != refreshGeneration) return false
         return result.fold(
             onSuccess = { data ->
                 minutesAfter = data.minutesAfter

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsViewModel.kt
@@ -124,10 +124,11 @@ class ArrivalsViewModel @AssistedInject constructor(
     suspend fun refresh(): Boolean {
         val generation = ++refreshGeneration
         val result = repository.getArrivals(stopId, minutesAfter)
-        lastResponseTime = WallTime.now()
         // A newer refresh started while this one was in flight — drop this (now stale) completion so it
-        // can't overwrite the fresher state or emit an out-of-date map snapshot. See #1933.
+        // can't overwrite the fresher state, emit an out-of-date map snapshot, or push the poll timer
+        // (measured against the *shown* data) past the fresher completion. See #1933.
         if (generation != refreshGeneration) return false
+        lastResponseTime = WallTime.now()
         return result.fold(
             onSuccess = { data ->
                 minutesAfter = data.minutesAfter

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/ArrivalsViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/ArrivalsViewModelTest.kt
@@ -51,6 +51,12 @@ private class FakeArrivalsRepository(
      *  (e.g. to fire a superseding load-more before the first finishes). */
     var gate: CompletableDeferred<Unit>? = null
 
+    /** Per-call gate/result overrides indexed by call order, for driving *overlapping* loads that
+     *  complete out of order (issue #1933). When a slot is present the Nth [getArrivals] awaits that
+     *  gate and returns that result instead of [gate]/[result]. */
+    val callGates = mutableListOf<CompletableDeferred<Unit>>()
+    val callResults = mutableListOf<Result<ArrivalsData>>()
+
     var lastFavoriteSet: Pair<String, Boolean>? = null
 
     var lastFavoriteRoute: FavoriteRouteCall? = null
@@ -72,9 +78,10 @@ private class FakeArrivalsRepository(
         stopId: String,
         minutesAfter: Int
     ): Result<ArrivalsData> {
+        val call = requestedMinutesAfter.size
         requestedMinutesAfter.add(minutesAfter)
-        gate?.await()
-        return result
+        (callGates.getOrNull(call) ?: gate)?.await()
+        return callResults.getOrNull(call) ?: result
     }
 
     override suspend fun setStopFavorite(stopId: String, favorite: Boolean) {
@@ -252,6 +259,38 @@ class ArrivalsViewModelTest {
 
         // Only one widen (65 -> 125), not two.
         assertEquals(listOf(65, 125), repository.requestedMinutesAfter)
+    }
+
+    // --- Overlapping out-of-order refreshes (latest-wins guard, #1933) -------------------------
+
+    @Test
+    fun `an out-of-order overlapping refresh cannot clobber the fresher result with a stale one`() = runTest {
+        // The poll refresh (call #0) starts first but lands LAST as a stale fallback; a user refresh
+        // (call #1) starts later and lands FIRST with fresh data. The stale, older-started completion
+        // must not overwrite the fresh one it superseded. Regression for #1933.
+        val repository = FakeArrivalsRepository(Result.success(data()))
+        repository.callGates += CompletableDeferred() // call #0 (poll)
+        repository.callGates += CompletableDeferred() // call #1 (user refresh)
+        repository.callResults += Result.success(data(minutesAfter = 65, isStale = true)) // #0 stale fallback
+        repository.callResults += Result.success(data(minutesAfter = 125, isStale = false)) // #1 fresh
+        val viewModel = ArrivalsViewModel("1_100", repository)
+
+        viewModel.manualRefresh() // poll-like refresh, parks on gate #0
+        viewModel.manualRefresh() // superseding refresh, parks on gate #1
+
+        // The later-started refresh lands first with fresh data.
+        repository.callGates[1].complete(Unit)
+        advanceUntilIdle()
+        val fresh = viewModel.state.value as ArrivalsUiState.Content
+        assertFalse(fresh.isStale)
+        assertEquals(ServerTime(125 * 60_000L), fresh.windowEnd)
+
+        // The earlier-started refresh lands last as a stale fallback — it must be dropped, not applied.
+        repository.callGates[0].complete(Unit)
+        advanceUntilIdle()
+        val afterStale = viewModel.state.value as ArrivalsUiState.Content
+        assertFalse(afterStale.isStale)
+        assertEquals(ServerTime(125 * 60_000L), afterStale.windowEnd)
     }
 
     @Test


### PR DESCRIPTION
Fixes #1933 (split out from a CodeRabbit finding on #1932, where it was out of scope).

## Problem

`ArrivalsViewModel.refresh()` applied every completed result unconditionally (`loaded.value = data`). The 60s poll loop awaits its `suspend refresh()` sequentially, so it never overlaps itself — but `manualRefresh()` and `loadMore()` each `viewModelScope.launch { refresh() }`. So a user refresh (toolbar button, or the alert-dialog dismiss in `ArrivalActionHandlers`) can run concurrently with an in-flight poll and finish **out of order**: the older-started completion's `loaded.value = data` then clobbers the fresher result.

**Impact (low, self-correcting):** a spurious `isStale` flag (an overlapping call whose own network failed returns the repo's stale fallback) or momentarily older arrivals, until the next poll corrects it (≤60s). The map snapshot `lastLoaded()` was already protected by the repository's `compareAndSet` (#1932); this closes the same gap one layer up, in the ViewModel's `loaded` StateFlow.

## Fix

A monotonic `refreshGeneration`, bumped at the start of each `refresh()`. A completion applies its result only while it's still the latest; otherwise it drops out — no state write, no map-snapshot emit:

```kotlin
suspend fun refresh(): Boolean {
    val generation = ++refreshGeneration
    val result = repository.getArrivals(stopId, minutesAfter)
    lastResponseTime = WallTime.now()
    if (generation != refreshGeneration) return false   // superseded — drop
    return result.fold( ... )
}
```

All reads/writes are confined to the ViewModel dispatcher (the only suspension in `refresh()` is the fetch), so a plain `Int` needs no synchronization. Chose the generation counter over serializing/cancelling refreshes because it preserves the existing parallelism and is the least behavior-changing — only the superseded completion's *application* is dropped.

## Test

Drives two overlapping refreshes (per-call gates added to the fake repository) completing out of order and asserts the older-started **stale** completion cannot overwrite the fresher one (checks both `isStale` and `windowEnd`). Confirmed **red without the guard** (only that test fails) and green with it.

## Verification

- New + all existing `ArrivalsViewModelTest` cases pass; full unit suites green on `obaGoogle` and `obaMaplibre` with `-PwarningsAsErrors=true`; compiles clean.
- No runtime UI surface beyond the covered logic; the common sequential-refresh path is unchanged (existing tests) — the guard only affects the overlapping case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved arrivals refresh behavior when multiple refreshes overlap, ensuring only the most recent completed request can update the UI.
  * Prevented stale in-flight results from overwriting fresher arrival data.
* **Tests**
  * Added a regression test to confirm out-of-order, overlapping refresh responses can’t clobber the latest results.
  * Enhanced the arrivals test double to simulate per-call completion ordering for reliable coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->