### PR TITLE
Fix lint errors surfaced by the new nightly lint job

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/AdjacencyRouteColors.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/AdjacencyRouteColors.kt
@@ -52,6 +52,9 @@ internal fun <K : Any> adjacencyRouteColors(
     return keys.associateWith(assigned::getValue)
 }
 
+// Hct is Material Components' vendored color-science util (LIBRARY_GROUP); no public equivalent
+// exists, so this is deliberate long-term use, not a migration to track (same as LineBadge).
+@SuppressLint("RestrictedApi")
 private fun routeColor(hue: Double): Int =
     Hct.from(hue, ADJACENCY_ROUTE_CHROMA, ADJACENCY_ROUTE_TONE).toInt()
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsScreen.kt
@@ -340,6 +340,7 @@ internal fun ArrivalsList(
     /** Whether a load-more request is in flight, for the footer button's spinner. Collected only by
      *  the footer item below, so a toggle recomposes just that item, not the whole list. */
     loadingMore: StateFlow<Boolean>,
+    modifier: Modifier = Modifier,
     /** Stop-focus map colors keyed by route-direction. Empty outside the home drawer. */
     mapRouteColors: Map<RouteDirectionKey, Int> = emptyMap(),
     /** Exact route-direction row selected over the home map's stop focus; null outside that state. */
@@ -348,7 +349,6 @@ internal fun ArrivalsList(
     selectedRouteId: String? = null,
     /** Route names in the selected vehicle block, beginning with the route on this row. */
     selectedRouteNames: List<String> = emptyList(),
-    modifier: Modifier = Modifier,
     listState: LazyListState = rememberLazyListState(),
     /** Hosts that show the stop's direction elsewhere (e.g. in their own header) set this false to
      *  avoid duplicating it as a list item. */

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
@@ -260,10 +260,10 @@ fun RouteArrivalRow(
     actionsFor: (ArrivalInfo) -> ArrivalActions?,
     isFavorite: Boolean,
     callbacks: ArrivalRowCallbacks,
+    modifier: Modifier = Modifier,
     mapRouteColor: Int? = null,
     selected: Boolean = false,
     selectedRouteNames: List<String> = emptyList(),
-    modifier: Modifier = Modifier,
     etaAnchor: Modifier = Modifier,
 ) {
     val representative = group.representative


### PR DESCRIPTION
## Summary

The nightly `lint` job (added in #1914) is the first run of `lintObaGoogleDebug` since lint was pulled off the PR/push path in #1843, so two unrelated regressions that accumulated in that gap surfaced together and broke [today's nightly run](https://github.com/OneBusAway/onebusaway-android/actions/runs/29563863473):

- **`AdjacencyRouteColors.kt`** (2 `RestrictedApi` errors): the file's `@SuppressLint("RestrictedApi")` covers `adjacencyRouteColors()`, but the actual restricted `Hct.from(...).toInt()` calls live in the private `routeColor()` it calls — suppressions don't propagate across function boundaries. Added the same annotation directly to `routeColor()`, matching the existing rationale/pattern used there and in `LineBadge.kt`.
- **`ArrivalRows.kt` / `ArrivalsScreen.kt`** (2 `ModifierParameter` errors): #1865 added new optional parameters ahead of the existing `modifier: Modifier = Modifier` parameter in `RouteArrivalRow` and `ArrivalsList`, violating the Compose convention that `modifier` be the first optional parameter. Moved `modifier` back into position in both. All call sites use named arguments, so this is a safe reorder.

## Test plan
- [x] `./gradlew :onebusaway-android:compileObaGoogleDebugKotlin -PwarningsAsErrors=true` — clean
- [x] `./gradlew :onebusaway-android:lintObaGoogleDebug -PwarningsAsErrors=true` — clean (was failing with 4 errors before this fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved internal lint handling without changing route color behavior.
  * Updated arrivals list and route row configuration for more consistent UI composition.
* **Refactor**
  * Reordered arrivals component parameters to support clearer and more reliable customization.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->