### PR TITLE
Restore trip-change notification tap into the directions focus (#1939)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.kt
@@ -30,10 +30,14 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTagsAsResourceId
+import androidx.core.content.IntentCompat
 import androidx.navigation.compose.rememberNavController
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 import org.onebusaway.android.R
+import org.onebusaway.android.directions.model.toTripItineraries
+import org.onebusaway.android.directions.util.OTPConstants
+import org.onebusaway.android.directions.util.TripRequestBuilder
 import org.onebusaway.android.ui.arrivals.ArrivalsLoaded
 import org.onebusaway.android.map.MapParams
 import org.onebusaway.android.map.MapViewModel
@@ -55,6 +59,7 @@ import org.onebusaway.android.ui.home.HomeViewModel
 import org.onebusaway.android.ui.home.HomeNavHost
 import org.onebusaway.android.ui.home.HomeDestinationDeps
 import org.onebusaway.android.ui.tripplan.TripPlanViewModel
+import org.onebusaway.android.ui.tripplan.toGeocoded
 import org.onebusaway.android.ui.tripresults.TripResultsViewModel
 import org.onebusaway.android.ui.home.LaunchIntentChannel
 import org.onebusaway.android.ui.home.LaunchIntentEffect
@@ -213,9 +218,46 @@ class HomeActivity : AppCompatActivity() {
      */
     private fun applyLaunchIntentSideEffects(intent: Intent) {
         applyIntentSideEffects(intent)
+        maybeRestoreDirectionsFromIntent(intent)
         if (intent.extras?.getBoolean(TutorialPrefs.TUTORIAL_WELCOME) == true) {
             viewModel.requestWelcomeTutorial()
         }
+    }
+
+    /**
+     * Re-entry from a trip-plan monitor "your trip changed" notification (see
+     * [org.onebusaway.android.directions.realtime.TripPlanMonitorService.notifyChange]): the intent
+     * carries the simplified request bundle ([TripRequestBuilder.copyIntoBundleSimple]), the updated
+     * itineraries JSON ([OTPConstants.ITINERARIES]), and [OTPConstants.INTENT_SOURCE] =
+     * [OTPConstants.Source.NOTIFICATION]. Switch HOME into the directions focus and seed the form +
+     * results from those extras — the itineraries are injected as-is (no re-plan). Restores the behavior
+     * the retired standalone screen's `maybeRestoreFromIntent` used to provide (#1939).
+     *
+     * No re-restore guard is needed: the launch-intent channel submits each real intent exactly once
+     * (cold `onCreate` seed gated on a null `savedInstanceState`, warm `onNewIntent`), so a config change
+     * doesn't re-fire this — and the activity-scoped [tripPlanViewModel] keeps the restored results.
+     */
+    // UnwrappedClockValue: the trip-plan time defaults to device "now" only when the intent carries none.
+    @Suppress("UnwrappedClockValue")
+    private fun maybeRestoreDirectionsFromIntent(intent: Intent) {
+        val source = IntentCompat.getSerializableExtra(
+            intent, OTPConstants.INTENT_SOURCE, OTPConstants.Source::class.java
+        )
+        if (source != OTPConstants.Source.NOTIFICATION) return
+
+        val itineraries = intent.getStringExtra(OTPConstants.ITINERARIES)?.toTripItineraries().orEmpty()
+        if (itineraries.isEmpty()) return
+
+        val extras = intent.extras ?: return
+        val builder = TripRequestBuilder.initFromBundleSimple(this, extras)
+        viewModel.enterDirections()
+        tripPlanViewModel.restoreFrom(
+            from = builder.from?.toGeocoded(),
+            to = builder.to?.toGeocoded(),
+            dateTimeMillis = builder.dateTime?.toEpochMilli() ?: System.currentTimeMillis(),
+            arriving = builder.arriveBy,
+            itineraries = itineraries,
+        )
     }
 
     /**


### PR DESCRIPTION
## What & why

Fixes #1939.

PR #1872 embedded directions into the home map and retired the standalone `TripPlanScreen`, whose `maybeRestoreFromIntent` was the **only** consumer of the trip-plan monitor's "your trip changed" notification intent. With that screen gone, tapping the alert opened generic HOME instead of the changed trip — a regression relative to pre-#1872 behavior.

The producer side was left intact and staged for this follow-up: `TripPlanMonitorService.notifyChange` still builds a `HomeActivity` intent carrying the simplified request bundle (`copyIntoBundleSimple`), the updated itineraries (`OTPConstants.ITINERARIES`, JSON), and `OTPConstants.INTENT_SOURCE = Source.NOTIFICATION`. Nothing in HOME read those extras. This PR re-adds the missing consumer.

## Change

One file — `HomeActivity.kt`. A new `maybeRestoreDirectionsFromIntent(intent)` in the launch-intent side-effect path (`applyLaunchIntentSideEffects`, which runs once per real intent, cold and warm, lifecycle-gated to STARTED):

- Guards strictly on `INTENT_SOURCE == Source.NOTIFICATION` (via `IntentCompat.getSerializableExtra`, avoiding the deprecated `getSerializable` so the strict warnings-as-errors gate stays green).
- JSON-decodes `ITINERARIES` with `String.toTripItineraries()`; bails if empty.
- Rehydrates the request via `TripRequestBuilder.initFromBundleSimple`.
- Drives the two Activity-scoped VMs: `homeViewModel.enterDirections()` then `tripPlanViewModel.restoreFrom(...)`, injecting the precomputed itineraries as `PlanResult.Success` — **no re-plan**.

The existing directions render path (directions results sheet → map draw) reacts to the `Directions` focus + `PlanResult.Success` with no further changes. `restoreFrom` was already present but had no callers; this wires it up. Mirrors the deleted `maybeRestoreFromIntent`, and follows the same two-call shape as the recent long-press "directions from/to here" feature (#1938).

## Notes

- **No re-restore guard needed:** the `launchIntents` channel submits each real intent exactly once (cold `onCreate` seed gated on a null `savedInstanceState`, warm `onNewIntent`), so a config change doesn't re-fire the restore; the activity-scoped `TripPlanViewModel` keeps the results across rotation.
- **`params = null`** (trip-update monitor not re-armed from the restore) matches pre-#1872 behavior — out of scope here.
- Kept the original's `@Suppress("UnwrappedClockValue")` + rationale for the "default to device now when the intent carries no time" fallback.

## Verification

- Compiles clean under the CI warning gate: `./gradlew :onebusaway-android:compileObaGoogleDebugKotlin -PwarningsAsErrors=true`.
- Manual end-to-end (not yet run on device): arm a trip watch → trigger a change so the notification fires → background the app → tap the alert. Expect HOME to open in the directions focus with the form pre-filled and the notification's itineraries shown + drawn on the map (no spinner/re-plan), for both cold-launch and warm-relaunch. Non-notification intents (add-region deep link, FCM reminders, ordinary launches) skip the new branch (strict `INTENT_SOURCE` + decodable `ITINERARIES` gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for restoring trip directions when opening a trip-change notification.
  * Restored itineraries, locations, travel date and time, and arrival preferences so updated trip details are readily available.
  * Automatically opens the Directions view with the refreshed trip plan.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->