### PR TITLE
Migrate Compose tests off deprecated createComposeRule (#1792)

### DIFF
--- a/onebusaway-android/build.gradle.kts
+++ b/onebusaway-android/build.gradle.kts
@@ -428,13 +428,13 @@ dependencies {
     implementation(libs.gtfs.realtime.bindings)
     implementation(libs.proto.google.common.protos)
 
-    // Jetpack Compose on the 1.11.x line (BOM 2026.05.00 -> compose-ui/foundation 1.11.2, material3
+    // Jetpack Compose on the 1.11.x line (BOM 2026.06.01 -> compose-ui/foundation 1.11.4, material3
     // 1.4.0). This required the coordinated toolchain bump to compileSdk 37 + AGP 9.2.0 + Gradle 9.4.1.
     // The BOM manages compose-ui + material3 (no explicit versions).
     val composeBom = platform(libs.compose.bom)
     implementation(composeBom)
     androidTestImplementation(composeBom)
-    implementation(libs.compose.ui)                     // 1.11.2 via BOM
+    implementation(libs.compose.ui)                     // 1.11.4 via BOM
     implementation(libs.compose.ui.tooling.preview)     // @Preview support
     debugImplementation(libs.compose.ui.tooling)        // preview renderer (debug only)
     // Compose UI instrumented testing (createComposeRule): semantic tree assertions on real devices,

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/arrivals/ArrivalAlertIndicatorTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/arrivals/ArrivalAlertIndicatorTest.kt
@@ -18,7 +18,6 @@ package org.onebusaway.android.ui.arrivals
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.getUnclippedBoundsInRoot
-import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.test.platform.app.InstrumentationRegistry
 import org.junit.Assert.assertEquals
@@ -28,6 +27,7 @@ import org.onebusaway.android.R
 import org.onebusaway.android.ui.arrivals.components.RouteArrivalRow
 import org.onebusaway.android.ui.arrivals.components.previewArrival
 import org.onebusaway.android.ui.arrivals.components.previewRowCallbacks
+import org.onebusaway.android.ui.compose.createUnconfinedComposeRule
 
 /**
  * On-device regression test for the per-row service-alert indicator (issue #1687 Bug 2), which sits
@@ -39,10 +39,9 @@ import org.onebusaway.android.ui.arrivals.components.previewRowCallbacks
  */
 class ArrivalAlertIndicatorTest {
 
-    // See EtaStripJustifyTest for why the v1 (Unconfined) rule is used here (issue #1792).
-    @Suppress("DEPRECATION")
+    // See createUnconfinedComposeRule for why Unconfined composition is used here (issue #1792).
     @get:Rule
-    val composeRule = createComposeRule()
+    val composeRule = createUnconfinedComposeRule()
 
     @Test
     fun showsTappableAlertIndicatorWhenArrivalHasActiveAlert() {

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/arrivals/EtaStripJustifyTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/arrivals/EtaStripJustifyTest.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import org.junit.Rule
@@ -28,6 +27,7 @@ import org.junit.Test
 import org.onebusaway.android.ui.arrivals.components.EtaStrip
 import org.onebusaway.android.ui.arrivals.components.previewArrival
 import org.onebusaway.android.ui.arrivals.components.previewRowCallbacks
+import org.onebusaway.android.ui.compose.createUnconfinedComposeRule
 
 /**
  * On-device regression test for the strip justifying to its first non-negative ETA (recent-past
@@ -38,14 +38,10 @@ import org.onebusaway.android.ui.arrivals.components.previewRowCallbacks
  */
 class EtaStripJustifyTest {
 
-    // The suggested androidx.compose.ui.test.junit4.v2.createComposeRule runs composition on a
-    // StandardTestDispatcher instead of Unconfined; under it, this composable's Modifier.onGloballyPositioned
-    // callback never fires at all (confirmed via on-device logcat — composition reaches the pill, but the
-    // callback never runs within a 5s poll), not just the expected LaunchedEffect timing shift. Tracked in
-    // https://github.com/OneBusAway/onebusaway-android/issues/1792.
-    @Suppress("DEPRECATION")
+    // Unconfined composition — see createUnconfinedComposeRule for why (this composable's
+    // measure -> onGloballyPositioned -> LaunchedEffect -> scrollTo chain, and issue #1792).
     @get:Rule
-    val composeRule = createComposeRule()
+    val composeRule = createUnconfinedComposeRule()
 
     /** A strip that overflows its host: the recent-past pills must scroll off to justify. */
     @Test

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/arrivals/RouteArrivalRowLongPressTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/arrivals/RouteArrivalRowLongPressTest.kt
@@ -19,7 +19,6 @@ import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assertCountEquals
-import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
@@ -33,13 +32,13 @@ import org.onebusaway.android.R
 import org.onebusaway.android.ui.arrivals.components.ArrivalRowCallbacks
 import org.onebusaway.android.ui.arrivals.components.RouteArrivalRow
 import org.onebusaway.android.ui.arrivals.components.previewArrival
+import org.onebusaway.android.ui.compose.createUnconfinedComposeRule
 
 class RouteArrivalRowLongPressTest {
 
-    // See EtaStripJustifyTest for why the v1 (Unconfined) rule is used here (issue #1792).
-    @Suppress("DEPRECATION")
+    // See createUnconfinedComposeRule for why Unconfined composition is used here (issue #1792).
     @get:Rule
-    val composeRule = createComposeRule()
+    val composeRule = createUnconfinedComposeRule()
 
     @Test
     fun longPressOpensScheduleWithoutOverflowButton() {

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/compose/ComposeTestRules.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/compose/ComposeTestRules.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.compose
+
+import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+
+/**
+ * The Compose test rule this project's on-device UI tests should use.
+ *
+ * It calls the non-deprecated v2 `createComposeRule`, but pins composition to an
+ * `UnconfinedTestDispatcher` through the rule's `effectContext` parameter (which, per its contract,
+ * uses any `TestDispatcher` found there for composition and the `MainTestClock`). This runs
+ * composition coroutines eagerly, matching the semantics these tests were written and validated
+ * against, and matching the old — now deprecated — v1 `createComposeRule`. The point of this helper
+ * is to drop that deprecation suppression suite-wide (issue #1792) without changing test behavior.
+ *
+ * Note on the v2 default (`StandardTestDispatcher`, which *queues* composition coroutines rather than
+ * running them eagerly): when #1792 was filed, the `onGloballyPositioned` -> `LaunchedEffect` ->
+ * `animateScrollTo` chains in `EtaStrip`/`SlideBox` never advanced to completion under it. That
+ * upstream gap is gone on compose-ui-test 1.11.4 (the rule's `waitUntil`/idle machinery now pumps the
+ * dispatcher) and all six tests pass under the plain default too — but we pin Unconfined because
+ * `SlideBoxTest` is an `@SmokeTest` on the API 23 floor emulator, whose StandardTestDispatcher timing
+ * is unvalidated.
+ *
+ * See https://github.com/OneBusAway/onebusaway-android/issues/1792 for the investigation.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+fun createUnconfinedComposeRule(): ComposeContentTestRule =
+    createComposeRule(UnconfinedTestDispatcher())

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/compose/components/SlideBoxTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/compose/components/SlideBoxTest.kt
@@ -22,11 +22,11 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.unit.dp
 import org.junit.Rule
 import org.junit.Test
 import org.onebusaway.android.SmokeTest
+import org.onebusaway.android.ui.compose.createUnconfinedComposeRule
 
 /**
  * On-device tests for the SlideBox's single-owner anchor-chasing glide. This is the regression test
@@ -37,11 +37,10 @@ import org.onebusaway.android.SmokeTest
 @SmokeTest // API-23 floor smoke subset (#1818): exercises Compose rendering on a 2015-era runtime
 class SlideBoxTest {
 
-    // See EtaStripJustifyTest for why the deprecated rule (Unconfined composition) is kept — under
-    // the v2 rule this project's onGloballyPositioned/effect chains never run (#1792).
-    @Suppress("DEPRECATION")
+    // See createUnconfinedComposeRule for why Unconfined composition is used here — this is the
+    // API 23 floor @SmokeTest, so eager execution matters most (issue #1792).
     @get:Rule
-    val composeRule = createComposeRule()
+    val composeRule = createUnconfinedComposeRule()
 
     /** The anchor offset the content declares, in px — mutated mid-test to drive the glide. */
     private val anchor = mutableIntStateOf(ANCHOR_PX)

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/home/arrivals/ServiceAlertsDialogTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/home/arrivals/ServiceAlertsDialogTest.kt
@@ -10,7 +10,6 @@
 package org.onebusaway.android.ui.home.arrivals
 
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -21,14 +20,14 @@ import org.onebusaway.android.ui.arrivals.AlertItem
 import org.onebusaway.android.ui.arrivals.AlertSeverity
 import org.onebusaway.android.ui.arrivals.ArrivalsUiState
 import org.onebusaway.android.ui.arrivals.StopHeader
+import org.onebusaway.android.ui.compose.createUnconfinedComposeRule
 import org.onebusaway.android.time.ServerTime
 
 class ServiceAlertsDialogTest {
 
-    // See EtaStripJustifyTest for why the v1 (Unconfined) rule is used here (issue #1792).
-    @Suppress("DEPRECATION")
+    // See createUnconfinedComposeRule for why Unconfined composition is used here (issue #1792).
     @get:Rule
-    val composeRule = createComposeRule()
+    val composeRule = createUnconfinedComposeRule()
 
     @Test
     fun summaryOpensTheSelectedAlert() {

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/home/map/FocusBannerTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/home/map/FocusBannerTest.kt
@@ -20,7 +20,6 @@ import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.getUnclippedBoundsInRoot
-import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.platform.app.InstrumentationRegistry
@@ -29,13 +28,13 @@ import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.onebusaway.android.R
+import org.onebusaway.android.ui.compose.createUnconfinedComposeRule
 
 class FocusBannerTest {
 
-    // See EtaStripJustifyTest for why the v1 (Unconfined) rule is used here (issue #1792).
-    @Suppress("DEPRECATION")
+    // See createUnconfinedComposeRule for why Unconfined composition is used here (issue #1792).
     @get:Rule
-    val composeRule = createComposeRule()
+    val composeRule = createUnconfinedComposeRule()
 
     private val context = InstrumentationRegistry.getInstrumentation().targetContext
 


### PR DESCRIPTION
Closes #1792.

## What

Six on-device Compose tests used the deprecated v1 `androidx.compose.ui.test.junit4.createComposeRule` behind a `@Suppress("DEPRECATION")`. This routes all six through a new shared helper and removes every suppression:

```kotlin
@OptIn(ExperimentalCoroutinesApi::class)
fun createUnconfinedComposeRule(): ComposeContentTestRule =
    createComposeRule(UnconfinedTestDispatcher())   // the non-deprecated v2 rule
```

The v2 `createComposeRule(effectContext)` uses any `TestDispatcher` found in `effectContext` for composition and the `MainTestClock`, so passing `UnconfinedTestDispatcher()` reproduces the old v1 eager-execution semantics on the supported API — no behavior change, no deprecation suppression. No new dependencies (`kotlinx-coroutines-test` was already an `androidTestImplementation` dep).

Migrated files:
- `ui/arrivals/EtaStripJustifyTest.kt`
- `ui/compose/components/SlideBoxTest.kt` (`@SmokeTest`)
- `ui/arrivals/ArrivalAlertIndicatorTest.kt`
- `ui/arrivals/RouteArrivalRowLongPressTest.kt`
- `ui/home/map/FocusBannerTest.kt`
- `ui/home/arrivals/ServiceAlertsDialogTest.kt`

## The investigation #1792 asked for

The original blocker was that the v2 rule's default `StandardTestDispatcher` *queues* composition coroutines rather than running them eagerly, and the `onGloballyPositioned` → `LaunchedEffect` → `animateScrollTo` chains in `EtaStrip`/`SlideBox` never advanced under it.

I re-characterized this on the current stack (compose-ui-test 1.11.4, BOM 2026.06.01): **plain v2 with `StandardTestDispatcher` now passes all six tests on-device too.** 1.11.4's reworked `waitUntil`/idle machinery actively pumps the dispatcher (`runCurrent()` + `advanceTimeByFrame()`), which the BOM at filing time did not — so the breakage was an upstream compose-ui-test gap that has since been fixed. **There is no upstream bug left to file.**

I still pin `UnconfinedTestDispatcher` because `SlideBoxTest` runs as an `@SmokeTest` on the API 23 floor emulator, whose `StandardTestDispatcher` frame/animation timing hasn't been validated. Unconfined keeps the eager-execution contract the smoke floor relies on. A future switch to the plain default is low-risk but should be checked on the floor emulator first — the helper KDoc documents this.

## Also

Corrected a stale BOM version comment in `build.gradle.kts` (`2026.05.00`/`1.11.2` → the catalog's actual `2026.06.01`/`1.11.4`).

## Verification

- `./gradlew :onebusaway-android:compileObaGoogleDebugAndroidTestKotlin -PwarningsAsErrors=true` — clean.
- On-device (Pixel 7 Pro / Android 16): **all 12 tests across the six classes pass** under the shipped Unconfined config; also verified passing under plain v2 during the investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the reliability and timing consistency of Compose-based UI tests.

- **Tests**
  - Updated UI tests to use an eager, unconfined test execution mode.
  - Preserved existing coverage for arrival alerts, route rows, arrival displays, dialogs, maps, and interactive components.
  - Added shared test support for consistent Compose coroutine behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->