### PR TITLE
Remove unused dependencies; enforce the Gson version floor with a constraint

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -50,17 +50,12 @@ open311 = "1.0.10"
 pelias = "v1.1.0"
 comparators = "1.0.0"
 activity = "1.13.0"
-fragment = "1.8.9"
-cardview = "1.0.0"
-constraintlayout = "2.2.1"
 exifinterface = "1.4.2"
 appcompat = "1.7.1"
 coreKtx = "1.19.0"
 preference = "1.2.1"
 datastore = "1.2.1"
 work = "2.11.2"
-concurrentFutures = "1.3.0"
-concurrentListenablefuture = "1.0.0-beta01"
 room = "2.8.4"
 lifecycle = "2.11.0"
 navigationCompose = "2.9.8"
@@ -74,7 +69,6 @@ coroutines = "1.11.0"
 material = "1.14.0"
 gson = "2.14.0"
 commonsIo = "2.22.0"
-commonsLang3 = "3.20.0"
 gtfsRealtime = "0.1.0"
 protoGoogleCommonProtos = "2.73.0"
 maplibre = "13.3.1"
@@ -109,18 +103,12 @@ proto-google-common-protos = { module = "com.google.api.grpc:proto-google-common
 # --- AndroidX ---
 androidx-activity-ktx = { module = "androidx.activity:activity-ktx", version.ref = "activity" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activity" }
-androidx-fragment-ktx = { module = "androidx.fragment:fragment-ktx", version.ref = "fragment" }
-androidx-cardview = { module = "androidx.cardview:cardview", version.ref = "cardview" }
-androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "constraintlayout" }
 androidx-exifinterface = { module = "androidx.exifinterface:exifinterface", version.ref = "exifinterface" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "coreKtx" }
 androidx-preference = { module = "androidx.preference:preference", version.ref = "preference" }
 androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastore" }
 androidx-work-runtime = { module = "androidx.work:work-runtime", version.ref = "work" }
-androidx-concurrent-futures = { module = "androidx.concurrent:concurrent-futures", version.ref = "concurrentFutures" }
-androidx-concurrent-listenablefuture = { module = "androidx.concurrent:concurrent-listenablefuture", version.ref = "concurrentListenablefuture" }
-androidx-concurrent-listenablefuture-callback = { module = "androidx.concurrent:concurrent-listenablefuture-callback", version.ref = "concurrentListenablefuture" }
 androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "room" }
 androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref = "room" }
 androidx-room-ktx = { module = "androidx.room:room-ktx", version.ref = "room" }
@@ -159,7 +147,6 @@ kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutine
 material = { module = "com.google.android.material:material", version.ref = "material" }
 gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
 commons-io = { module = "commons-io:commons-io", version.ref = "commonsIo" }
-commons-lang3 = { module = "org.apache.commons:commons-lang3", version.ref = "commonsLang3" }
 maplibre-android-sdk = { module = "org.maplibre.gl:android-sdk", version.ref = "maplibre" }
 
 # --- Testing ---

--- a/onebusaway-android/build.gradle.kts
+++ b/onebusaway-android/build.gradle.kts
@@ -363,12 +363,8 @@ dependencies {
     implementation(libs.play.services.location)
     // Support libraries
     implementation(libs.androidx.activity.ktx)
-    implementation(libs.androidx.fragment.ktx)
-    implementation(libs.androidx.cardview)
-    implementation(libs.androidx.constraintlayout)
     implementation(libs.androidx.exifinterface)
     implementation(libs.commons.io)
-    implementation(libs.commons.lang3)
     // Open311 client library
     implementation(libs.open311.client)
     // The OBA REST stack (api/): Retrofit + OkHttp + kotlinx.serialization. Every OBA "where"
@@ -409,9 +405,6 @@ dependencies {
     androidTestImplementation(libs.espresso.core)
     // WorkManager (Java only)
     implementation(libs.androidx.work.runtime)
-    implementation(libs.androidx.concurrent.futures)
-    implementation(libs.androidx.concurrent.listenablefuture)
-    implementation(libs.androidx.concurrent.listenablefuture.callback)
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.preference)
     // Preferences DataStore — the backing store behind PreferencesRepository.

--- a/onebusaway-android/build.gradle.kts
+++ b/onebusaway-android/build.gradle.kts
@@ -428,13 +428,13 @@ dependencies {
     implementation(libs.gtfs.realtime.bindings)
     implementation(libs.proto.google.common.protos)
 
-    // Jetpack Compose on the 1.11.x line (BOM 2026.05.00 -> compose-ui/foundation 1.11.2, material3
+    // Jetpack Compose on the 1.11.x line (BOM 2026.06.01 -> compose-ui/foundation 1.11.4, material3
     // 1.4.0). This required the coordinated toolchain bump to compileSdk 37 + AGP 9.2.0 + Gradle 9.4.1.
     // The BOM manages compose-ui + material3 (no explicit versions).
     val composeBom = platform(libs.compose.bom)
     implementation(composeBom)
     androidTestImplementation(composeBom)
-    implementation(libs.compose.ui)                     // 1.11.2 via BOM
+    implementation(libs.compose.ui)                     // 1.11.4 via BOM
     implementation(libs.compose.ui.tooling.preview)     // @Preview support
     debugImplementation(libs.compose.ui.tooling)        // preview renderer (debug only)
     // Compose UI instrumented testing (createComposeRule): semantic tree assertions on real devices,

--- a/onebusaway-android/build.gradle.kts
+++ b/onebusaway-android/build.gradle.kts
@@ -392,9 +392,15 @@ dependencies {
     "maplibreImplementation"(libs.maplibre.android.sdk)
     // Autocomplete text views with clear button for trip planning
     implementation(libs.material)
-    // Version pin: a transitive dependency pulls in Gson 2.8.5; this forces it up to 2.10.1.
-    // (Gson is not used directly in app source.)
-    implementation(libs.gson)
+    // Gson is not used directly in app source. It arrives transitively via
+    // firebase-firestore -> io.grpc:grpc-core, which requests 2.10.1. We don't add it as a
+    // dependency; instead a constraint pins the transitive up to the catalog version so a future
+    // grpc/Firebase bump can't silently drag Gson back below the 2.8.9 CVE-2022-25647 fix.
+    constraints {
+        implementation(libs.gson) {
+            because("CVE-2022-25647: floor transitive Gson at the catalog version; not a direct dependency")
+        }
+    }
     // Unit tests - seems like this is still necessary w/ Android X even though useLibrary is declared earlier
     androidTestImplementation(libs.androidx.test.runner)
     androidTestImplementation(libs.androidx.test.ext.junit)

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/arrivals/ArrivalAlertIndicatorTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/arrivals/ArrivalAlertIndicatorTest.kt
@@ -18,7 +18,6 @@ package org.onebusaway.android.ui.arrivals
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.getUnclippedBoundsInRoot
-import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.test.platform.app.InstrumentationRegistry
 import org.junit.Assert.assertEquals
@@ -28,6 +27,7 @@ import org.onebusaway.android.R
 import org.onebusaway.android.ui.arrivals.components.RouteArrivalRow
 import org.onebusaway.android.ui.arrivals.components.previewArrival
 import org.onebusaway.android.ui.arrivals.components.previewRowCallbacks
+import org.onebusaway.android.ui.compose.createUnconfinedComposeRule
 
 /**
  * On-device regression test for the per-row service-alert indicator (issue #1687 Bug 2), which sits
@@ -39,10 +39,9 @@ import org.onebusaway.android.ui.arrivals.components.previewRowCallbacks
  */
 class ArrivalAlertIndicatorTest {
 
-    // See EtaStripJustifyTest for why the v1 (Unconfined) rule is used here (issue #1792).
-    @Suppress("DEPRECATION")
+    // See createUnconfinedComposeRule for why Unconfined composition is used here (issue #1792).
     @get:Rule
-    val composeRule = createComposeRule()
+    val composeRule = createUnconfinedComposeRule()
 
     @Test
     fun showsTappableAlertIndicatorWhenArrivalHasActiveAlert() {

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/arrivals/EtaStripJustifyTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/arrivals/EtaStripJustifyTest.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import org.junit.Rule
@@ -28,6 +27,7 @@ import org.junit.Test
 import org.onebusaway.android.ui.arrivals.components.EtaStrip
 import org.onebusaway.android.ui.arrivals.components.previewArrival
 import org.onebusaway.android.ui.arrivals.components.previewRowCallbacks
+import org.onebusaway.android.ui.compose.createUnconfinedComposeRule
 
 /**
  * On-device regression test for the strip justifying to its first non-negative ETA (recent-past
@@ -38,14 +38,10 @@ import org.onebusaway.android.ui.arrivals.components.previewRowCallbacks
  */
 class EtaStripJustifyTest {
 
-    // The suggested androidx.compose.ui.test.junit4.v2.createComposeRule runs composition on a
-    // StandardTestDispatcher instead of Unconfined; under it, this composable's Modifier.onGloballyPositioned
-    // callback never fires at all (confirmed via on-device logcat — composition reaches the pill, but the
-    // callback never runs within a 5s poll), not just the expected LaunchedEffect timing shift. Tracked in
-    // https://github.com/OneBusAway/onebusaway-android/issues/1792.
-    @Suppress("DEPRECATION")
+    // Unconfined composition — see createUnconfinedComposeRule for why (this composable's
+    // measure -> onGloballyPositioned -> LaunchedEffect -> scrollTo chain, and issue #1792).
     @get:Rule
-    val composeRule = createComposeRule()
+    val composeRule = createUnconfinedComposeRule()
 
     /** A strip that overflows its host: the recent-past pills must scroll off to justify. */
     @Test

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/arrivals/RouteArrivalRowLongPressTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/arrivals/RouteArrivalRowLongPressTest.kt
@@ -19,7 +19,6 @@ import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assertCountEquals
-import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
@@ -33,13 +32,13 @@ import org.onebusaway.android.R
 import org.onebusaway.android.ui.arrivals.components.ArrivalRowCallbacks
 import org.onebusaway.android.ui.arrivals.components.RouteArrivalRow
 import org.onebusaway.android.ui.arrivals.components.previewArrival
+import org.onebusaway.android.ui.compose.createUnconfinedComposeRule
 
 class RouteArrivalRowLongPressTest {
 
-    // See EtaStripJustifyTest for why the v1 (Unconfined) rule is used here (issue #1792).
-    @Suppress("DEPRECATION")
+    // See createUnconfinedComposeRule for why Unconfined composition is used here (issue #1792).
     @get:Rule
-    val composeRule = createComposeRule()
+    val composeRule = createUnconfinedComposeRule()
 
     @Test
     fun longPressOpensScheduleWithoutOverflowButton() {

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/compose/ComposeTestRules.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/compose/ComposeTestRules.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.compose
+
+import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+
+/**
+ * The Compose test rule this project's on-device UI tests should use.
+ *
+ * It calls the non-deprecated v2 `createComposeRule`, but pins composition to an
+ * `UnconfinedTestDispatcher` through the rule's `effectContext` parameter (which, per its contract,
+ * uses any `TestDispatcher` found there for composition and the `MainTestClock`). This runs
+ * composition coroutines eagerly, matching the semantics these tests were written and validated
+ * against, and matching the old — now deprecated — v1 `createComposeRule`. The point of this helper
+ * is to drop that deprecation suppression suite-wide (issue #1792) without changing test behavior.
+ *
+ * Note on the v2 default (`StandardTestDispatcher`, which *queues* composition coroutines rather than
+ * running them eagerly): when #1792 was filed, the `onGloballyPositioned` -> `LaunchedEffect` ->
+ * `animateScrollTo` chains in `EtaStrip`/`SlideBox` never advanced to completion under it. That
+ * upstream gap is gone on compose-ui-test 1.11.4 (the rule's `waitUntil`/idle machinery now pumps the
+ * dispatcher) and all six tests pass under the plain default too — but we pin Unconfined because
+ * `SlideBoxTest` is an `@SmokeTest` on the API 23 floor emulator, whose StandardTestDispatcher timing
+ * is unvalidated.
+ *
+ * See https://github.com/OneBusAway/onebusaway-android/issues/1792 for the investigation.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+fun createUnconfinedComposeRule(): ComposeContentTestRule =
+    createComposeRule(UnconfinedTestDispatcher())

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/compose/components/SlideBoxTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/compose/components/SlideBoxTest.kt
@@ -22,11 +22,11 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.unit.dp
 import org.junit.Rule
 import org.junit.Test
 import org.onebusaway.android.SmokeTest
+import org.onebusaway.android.ui.compose.createUnconfinedComposeRule
 
 /**
  * On-device tests for the SlideBox's single-owner anchor-chasing glide. This is the regression test
@@ -37,11 +37,10 @@ import org.onebusaway.android.SmokeTest
 @SmokeTest // API-23 floor smoke subset (#1818): exercises Compose rendering on a 2015-era runtime
 class SlideBoxTest {
 
-    // See EtaStripJustifyTest for why the deprecated rule (Unconfined composition) is kept — under
-    // the v2 rule this project's onGloballyPositioned/effect chains never run (#1792).
-    @Suppress("DEPRECATION")
+    // See createUnconfinedComposeRule for why Unconfined composition is used here — this is the
+    // API 23 floor @SmokeTest, so eager execution matters most (issue #1792).
     @get:Rule
-    val composeRule = createComposeRule()
+    val composeRule = createUnconfinedComposeRule()
 
     /** The anchor offset the content declares, in px — mutated mid-test to drive the glide. */
     private val anchor = mutableIntStateOf(ANCHOR_PX)

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/home/arrivals/ServiceAlertsDialogTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/home/arrivals/ServiceAlertsDialogTest.kt
@@ -10,7 +10,6 @@
 package org.onebusaway.android.ui.home.arrivals
 
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -21,14 +20,14 @@ import org.onebusaway.android.ui.arrivals.AlertItem
 import org.onebusaway.android.ui.arrivals.AlertSeverity
 import org.onebusaway.android.ui.arrivals.ArrivalsUiState
 import org.onebusaway.android.ui.arrivals.StopHeader
+import org.onebusaway.android.ui.compose.createUnconfinedComposeRule
 import org.onebusaway.android.time.ServerTime
 
 class ServiceAlertsDialogTest {
 
-    // See EtaStripJustifyTest for why the v1 (Unconfined) rule is used here (issue #1792).
-    @Suppress("DEPRECATION")
+    // See createUnconfinedComposeRule for why Unconfined composition is used here (issue #1792).
     @get:Rule
-    val composeRule = createComposeRule()
+    val composeRule = createUnconfinedComposeRule()
 
     @Test
     fun summaryOpensTheSelectedAlert() {

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/home/map/FocusBannerTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/home/map/FocusBannerTest.kt
@@ -20,7 +20,6 @@ import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.getUnclippedBoundsInRoot
-import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.platform.app.InstrumentationRegistry
@@ -29,13 +28,13 @@ import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.onebusaway.android.R
+import org.onebusaway.android.ui.compose.createUnconfinedComposeRule
 
 class FocusBannerTest {
 
-    // See EtaStripJustifyTest for why the v1 (Unconfined) rule is used here (issue #1792).
-    @Suppress("DEPRECATION")
+    // See createUnconfinedComposeRule for why Unconfined composition is used here (issue #1792).
     @get:Rule
-    val composeRule = createComposeRule()
+    val composeRule = createUnconfinedComposeRule()
 
     private val context = InstrumentationRegistry.getInstrumentation().targetContext
 


### PR DESCRIPTION
## Summary

Drops external dependencies that aren't referenced anywhere in app source, resources, or the manifest, and replaces the Gson "version pin via unused dependency" hack with a proper dependency constraint.

This came out of an audit that cross-referenced every catalog coordinate against real usage — necessary because neither the Kotlin compiler nor Android Lint flags an unused *dependency* (they analyze code correctness, not build-graph reachability), so this dead weight is invisible to the normal CI gates.

## Removed (unused)

| Dependency | Why it's safe to drop |
|---|---|
| `androidx.fragment:fragment-ktx` | No `Fragment` subclasses remain; app is fully Activity + Compose. |
| `androidx.cardview:cardview` | Replaced by Compose `Card`; only doc-comment mentions of the legacy `CardView` remained. |
| `androidx.constraintlayout:constraintlayout` | No `app:layout_constraint*` in any XML, no imports; layout is Compose. |
| `org.apache.commons:commons-lang3` | Zero references. (`commons-io` **is** used and is kept.) |
| `androidx.concurrent:concurrent-futures` + `concurrent-listenablefuture` (+ `-callback`) | A `ListenableFuture` pin for WorkManager with no direct usage. The build's `checkDuplicateClasses` + dex merge pass without it, confirming it was **not** resolving a Guava/`ListenableFuture` conflict. |

## Gson: constraint instead of a phantom dependency

Gson had no call sites but was declared `implementation(libs.gson)` purely to force a transitive copy up. That's an unused library standing in for a version requirement. Replaced with a dependency constraint that floors the version **only where Gson actually appears** (transitively via `firebase-firestore → io.grpc:grpc-core`) without adding it to the classpath.

The old rationale was also stale: Gson isn't pulled in at 2.8.5 — it arrives at **2.10.1**, already past the **2.8.9** CVE-2022-25647 fix. The constraint now honestly documents that it floors the transitive up to the catalog version (2.14.0) as forward protection against a future grpc/Firebase downgrade, not as a live-vuln patch.

Resolution is unchanged: Gson still resolves to 2.14.0 (now `(c)` / "By constraint" in `dependencyInsight`, no longer a direct edge).

## Verification

- `assembleObaGoogleDebug -PwarningsAsErrors=true` → `BUILD SUCCESSFUL` (green, no new warnings), including resource merge, `checkDuplicateClasses`, and dex merge.
- After the Gson change the assemble is `UP-TO-DATE`, so the packaged APK is byte-identical — a behavior-preserving refactor.
- Built the `obaGoogle` variant locally; CI covers the rest of the grid + lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed unused and unsupported dependency references.
  - Updated Compose dependencies and strengthened Gson version enforcement.

- **Tests**
  - Migrated Compose UI tests to the newer unconfined test rule.
  - Added a shared test helper to preserve existing test behavior while removing deprecated rule usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->