### PR TITLE
Pin resolved trip-plan endpoints on the map as they're set

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/contract/OtpPlanModels.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/contract/OtpPlanModels.kt
@@ -64,9 +64,8 @@ data class OtpErrorDto(
  * Mirrors OTP1's `org.opentripplanner.api.ws.Message` wire error-id vocabulary exactly — the legal
  * values of [OtpErrorDto.id] — ids verified against the vendored jar's enum constructor arguments
  * (`Message(String, int)`), not guessed. Only the codes
- * [org.onebusaway.android.ui.tripplan.DefaultTripPlanRepository]'s `errorMessage` maps to a
- * user-facing string are included; the vendored enum also has a `PLAN_OK` (200) success code this app
- * never needs to name.
+ * [org.onebusaway.android.ui.tripplan.otp1ErrorFor] classifies into a user-facing error are included;
+ * the vendored enum also has a `PLAN_OK` (200) success code this app never needs to name.
  */
 internal enum class OtpErrorId(val id: Int) {
     SYSTEM_ERROR(500),

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/DirectionsMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/DirectionsMapController.kt
@@ -38,6 +38,8 @@ import org.onebusaway.android.map.render.RoutePolyline
  * [start] draws an itinerary; [frameDirections] (re-appliable, since the [start]-time camera command
  * is lost before the adapter subscribes) fits it; [clear] removes its start/end pins. The leg
  * polylines are cleared generically by the owner (they share the render state's polyline list).
+ * [setEndpoints] additionally draws standalone From/To pins as the endpoints resolve, before an
+ * itinerary exists (superseded by the itinerary's own start/end pins once [start] runs).
  */
 class DirectionsMapController(private val host: MapHost) {
 
@@ -48,6 +50,16 @@ class DirectionsMapController(private val host: MapHost) {
     private var directionsHasRoute = false
 
     private var directionsStart: GeoPoint? = null
+
+    // The standalone From (green) / To (red) endpoint pins, shown as each endpoint resolves — before,
+    // or without, a full itinerary. Tracked apart from the itinerary's own [directionsMarkerIds] pins so
+    // they can be diffed and cleared independently; the itinerary's pins supersede them once [start]
+    // runs (the owner calls [clearEndpoints]). See [setEndpoints].
+    private var fromEndpoint: EndpointMarker? = null
+
+    private var toEndpoint: EndpointMarker? = null
+
+    private class EndpointMarker(val point: GeoPoint, val id: Int)
 
     /** Draw [itinerary]'s leg polylines + start/end pins and frame it. */
     fun start(itinerary: TripItinerary) {
@@ -118,6 +130,26 @@ class DirectionsMapController(private val host: MapHost) {
     fun clear() {
         directionsMarkerIds.forEach { host.removeMarker(it) }
         directionsMarkerIds.clear()
+    }
+
+    /**
+     * Draw or update the standalone From (green) / To (red) endpoint pins as the user's endpoints
+     * resolve, before an itinerary exists. Diffs against the current pins so an unchanged endpoint keeps
+     * its marker (no flicker) and a null endpoint drops its pin. Reuses the same green/red hues as the
+     * itinerary's start/end pins.
+     */
+    fun setEndpoints(from: GeoPoint?, to: GeoPoint?) {
+        fromEndpoint = reconcileEndpoint(fromEndpoint, from, HUE_GREEN)
+        toEndpoint = reconcileEndpoint(toEndpoint, to, HUE_RED)
+    }
+
+    /** Remove both endpoint pins (leaving directions, or the itinerary's own pins took over). */
+    fun clearEndpoints() = setEndpoints(from = null, to = null)
+
+    private fun reconcileEndpoint(current: EndpointMarker?, point: GeoPoint?, hue: Float): EndpointMarker? {
+        if (current?.point == point) return current
+        current?.let { host.removeMarker(it.id) }
+        return point?.let { EndpointMarker(it, host.addMarker(it.latitude, it.longitude, hue)) }
     }
 
     private fun resolveLegColor(leg: TripLeg): Int {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
@@ -331,6 +331,9 @@ class MapViewModel @Inject constructor(
      */
     private fun leaveCurrentView(clearStopFocus: Boolean) {
         if (clearStopFocus) routeController.clearStopFocus()
+        // Endpoint pins belong only to the directions-before-a-plan state; drop them on any transition
+        // out (they can exist without [directionsActive], which is only set once an itinerary draws).
+        directionsController.clearEndpoints()
         if (directionsActive) {
             directionsController.clear()
             renderState.clearRoutePolylines()
@@ -463,6 +466,7 @@ class MapViewModel @Inject constructor(
             directionsActive = true
         }
         directionsController.clear()
+        directionsController.clearEndpoints()
         renderState.clearRoutePolylines()
         directionsController.start(itinerary)
         bikeController.start(
@@ -477,6 +481,14 @@ class MapViewModel @Inject constructor(
         directionsController.clear()
         renderState.clearRoutePolylines()
     }
+
+    /**
+     * Show the resolved trip-plan From (green) / To (red) endpoints as pins on the home map before a
+     * full itinerary (a null endpoint drops its pin) — so the first endpoint the user sets appears
+     * immediately. See [DirectionsMapController.setEndpoints] for the supersede/clear lifecycle.
+     */
+    fun setDirectionsEndpoints(from: GeoPoint?, to: GeoPoint?) =
+        directionsController.setEndpoints(from, to)
 
     /** Leave a route selected within stop focus and restore the stop's full adjacency presentation. */
     fun clearSelectedRoute() = showNearbyStops()

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -87,7 +87,7 @@ import org.onebusaway.android.ui.home.chrome.MapTopChrome
 import org.onebusaway.android.ui.home.chrome.mapTopChromeOverlayInset
 import org.onebusaway.android.ui.home.directions.DirectionsFormCard
 import org.onebusaway.android.ui.home.directions.DirectionsLongPressMenu
-import org.onebusaway.android.ui.home.directions.DirectionsMessageCard
+import org.onebusaway.android.ui.home.directions.DirectionsErrorSnackbar
 import org.onebusaway.android.ui.home.directions.DirectionsPickOverlay
 import org.onebusaway.android.ui.home.directions.DirectionsPickTarget
 import org.onebusaway.android.ui.home.directions.DirectionsResultsSheet
@@ -541,15 +541,11 @@ fun HomeScreen(
                     val directionsResults = (tripPlanResult as? PlanResult.Success)?.takeIf {
                         it.itineraries.isNotEmpty()
                     }
-                    // A user-facing message for the non-results plan states (error / no route found), so a
-                    // failed plan (e.g. endpoints outside the transit network) isn't silently swallowed.
-                    val genericPlanError = stringResource(R.string.tripplanner_error_not_defined)
-                    val noRouteMessage = stringResource(R.string.tripplanner_error_path_not_found)
-                    val directionsMessage: String? = when (val r = tripPlanResult) {
-                        is PlanResult.Error -> r.message.ifBlank { genericPlanError }
-                        is PlanResult.Success -> if (r.itineraries.isEmpty()) noRouteMessage else null
-                        else -> null
-                    }
+                    // The classified error for a failed plan (e.g. endpoints outside the transit
+                    // network), so it isn't silently swallowed; the snackbar renders its header + reason.
+                    // Success is always non-empty (both planners throw NoRoute on empty), so only Error
+                    // surfaces a message.
+                    val directionsError = (tripPlanResult as? PlanResult.Error)?.error
                     val directionsLoading = tripPlanResult is PlanResult.Loading
                     // Which endpoint (if any) is being picked directly on the map (crosshair + confirm).
                     var pickTarget by rememberSaveable { mutableStateOf<DirectionsPickTarget?>(null) }
@@ -678,8 +674,9 @@ fun HomeScreen(
                                     showItinerary = homeViewModel::showItineraryOnMap,
                                     modifier = Modifier.align(Alignment.BottomCenter),
                                 )
-                                directionsMessage != null -> DirectionsMessageCard(
-                                    message = directionsMessage,
+                                directionsError != null -> DirectionsErrorSnackbar(
+                                    error = directionsError,
+                                    onDismiss = tripPlanViewModel::clearPlanResult,
                                     modifier = Modifier.align(Alignment.BottomCenter),
                                 )
                             }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -559,6 +559,15 @@ fun HomeScreen(
                             homeViewModel.clearShownItineraryOnMap()
                         }
                     }
+                    // Drop a green/red pin for each resolved From/To endpoint as it's set, before any plan
+                    // (so a single-endpoint state already shows the point). Only while in directions with
+                    // no itinerary yet — the itinerary's own pins supersede these once it draws.
+                    val showEndpointPins = directionsActive && directionsResults == null
+                    val fromPoint = if (showEndpointPins) tripPlanFormState.from.toGeoPoint() else null
+                    val toPoint = if (showEndpointPins) tripPlanFormState.to.toGeoPoint() else null
+                    LaunchedEffect(fromPoint, toPoint) {
+                        homeViewModel.setDirectionsEndpointsOnMap(fromPoint, toPoint)
+                    }
                     // Back cancels an in-progress map pick, else exits directions focus (to nearby stops).
                     BackHandler(enabled = directionsActive) {
                         if (pickTarget != null) pickTarget = null else homeViewModel.exitDirections()
@@ -938,4 +947,11 @@ private fun ArrivalsDragHandle(onToggle: () -> Unit, modifier: Modifier = Modifi
             Box(Modifier.size(width = 32.dp, height = DRAG_HANDLE_BAR_HEIGHT))
         }
     }
+}
+
+/** A resolved endpoint's map point, or null while it's still free text (no coordinates yet). */
+private fun TripEndpoint.toGeoPoint(): GeoPoint? {
+    val lat = lat
+    val lon = lon
+    return if (lat != null && lon != null) GeoPoint(lat, lon) else null
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
@@ -34,6 +34,7 @@ import kotlinx.coroutines.launch
 import org.onebusaway.android.directions.model.TripItinerary
 import org.onebusaway.android.location.LocationRepository
 import org.onebusaway.android.map.ShowRouteRequest
+import org.onebusaway.android.map.render.GeoPoint
 import org.onebusaway.android.map.render.MapViewport
 import org.onebusaway.android.models.FocusedTrip
 import org.onebusaway.android.models.RouteDirectionKey
@@ -542,6 +543,10 @@ class HomeViewModel @Inject constructor(
     /** Clear the drawn itinerary while staying in directions (the plan became unsubmittable). */
     fun clearShownItineraryOnMap() = emitMapDirective(MapDirective.ClearItinerary)
 
+    /** Show the resolved From/To endpoints as green/red pins (before a plan); a null endpoint drops it. */
+    fun setDirectionsEndpointsOnMap(from: GeoPoint?, to: GeoPoint?) =
+        emitMapDirective(MapDirective.SetDirectionsEndpoints(from, to))
+
     /** Leave directions focus, returning the map to nearby stops. */
     fun exitDirections() = clearMapFocus()
 
@@ -756,4 +761,7 @@ sealed interface MapDirective {
 
     /** Clear the drawn itinerary but stay in directions mode (the plan became unsubmittable). */
     data object ClearItinerary : MapDirective
+
+    /** Show the resolved trip-plan From/To endpoints as pins before an itinerary (null drops a pin). */
+    data class SetDirectionsEndpoints(val from: GeoPoint?, val to: GeoPoint?) : MapDirective
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
@@ -66,6 +66,9 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import com.google.android.material.datepicker.MaterialDatePicker
@@ -290,7 +293,9 @@ fun DirectionsErrorSnackbar(
     modifier: Modifier = Modifier,
 ) {
     Surface(
-        modifier = modifier.fillMaxWidth().navigationBarsPadding().padding(8.dp),
+        // A polite live region so a screen reader announces a newly surfaced planning failure.
+        modifier = modifier.fillMaxWidth().navigationBarsPadding().padding(8.dp)
+            .semantics { liveRegion = LiveRegionMode.Polite },
         shape = RoundedCornerShape(4.dp),
         color = MaterialTheme.colorScheme.inverseSurface,
         contentColor = MaterialTheme.colorScheme.inverseOnSurface,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
@@ -63,6 +63,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
@@ -83,6 +84,7 @@ import org.onebusaway.android.ui.tripplan.TripEndpoint
 import org.onebusaway.android.ui.tripplan.TripModes
 import org.onebusaway.android.ui.tripplan.TripPlanForm
 import org.onebusaway.android.ui.tripplan.TripPlanFormState
+import org.onebusaway.android.ui.tripplan.TripPlanError
 import org.onebusaway.android.ui.tripplan.TripPlanParams
 import org.onebusaway.android.ui.tripplan.TripPlanViewModel
 import org.onebusaway.android.ui.tripresults.TripResultsSheet
@@ -273,24 +275,52 @@ fun DirectionsLongPressMenu(
 }
 
 /**
- * A compact message over the map for the non-results plan states — a plan error or an empty result
- * (e.g. endpoints outside the transit network). Sits where the results sheet would be so the user
- * always gets feedback that a plan ran.
+ * The trip-plan error surface: a Material 3 snackbar (the `inverseSurface` container, seated at the
+ * bottom of the map where the results sheet would be). It shows a stable, severity-coloured header
+ * naming the category (every no-route failure reads "Cannot find route") over a single reason line —
+ * the exact wire message — with an explicit dismiss. Unlike a toast or an auto-dismissing snackbar it
+ * persists until the user dismisses it (or the plan state changes), so a deterministic failure —
+ * outside coverage, no route, no service at this time — isn't lost if the user glances away. Header =
+ * the "richer ontology" ([TripPlanError.category]); reason = the specifics ([TripPlanError.detailRes]).
  */
 @Composable
-fun DirectionsMessageCard(message: String, modifier: Modifier = Modifier) {
+fun DirectionsErrorSnackbar(
+    error: TripPlanError,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
     Surface(
-        modifier = modifier.fillMaxWidth().navigationBarsPadding().padding(16.dp),
-        shape = RoundedCornerShape(12.dp),
-        color = MaterialTheme.colorScheme.surface,
-        tonalElevation = 2.dp,
+        modifier = modifier.fillMaxWidth().navigationBarsPadding().padding(8.dp),
+        shape = RoundedCornerShape(4.dp),
+        color = MaterialTheme.colorScheme.inverseSurface,
+        contentColor = MaterialTheme.colorScheme.inverseOnSurface,
         shadowElevation = 6.dp,
     ) {
-        Text(
-            text = message,
-            modifier = Modifier.padding(16.dp),
-            style = MaterialTheme.typography.bodyMedium,
-        )
+        Row(
+            modifier = Modifier.padding(start = 16.dp, end = 4.dp, top = 10.dp, bottom = 10.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(Modifier.weight(1f)) {
+                Text(
+                    text = stringResource(error.category.headerRes),
+                    style = MaterialTheme.typography.titleSmall,
+                    color = colorResource(error.category.severity.colorRes),
+                )
+                Text(
+                    text = stringResource(error.detailRes),
+                    modifier = Modifier.padding(top = 2.dp),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = 0.9f),
+                )
+            }
+            IconButton(onClick = onDismiss) {
+                Icon(
+                    imageVector = Icons.Filled.Close,
+                    contentDescription = stringResource(R.string.dismiss),
+                    tint = MaterialTheme.colorScheme.inverseOnSurface,
+                )
+            }
+        }
     }
 }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
@@ -287,6 +287,8 @@ fun MapFeature(
                 is MapDirective.ShowItinerary ->
                     mapViewModel.showItinerary(directive.itinerary)
                 MapDirective.ClearItinerary -> mapViewModel.clearShownItinerary()
+                is MapDirective.SetDirectionsEndpoints ->
+                    mapViewModel.setDirectionsEndpoints(directive.from, directive.to)
             }
         }
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/Otp2Planner.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/Otp2Planner.kt
@@ -21,7 +21,6 @@ import com.apollographql.apollo.exception.ApolloException
 import com.apollographql.apollo.exception.ApolloNetworkException
 import com.apollographql.apollo.network.okHttpClient
 import dagger.hilt.android.qualifiers.ApplicationContext
-import java.io.IOException
 import javax.inject.Inject
 import kotlinx.coroutines.runBlocking
 import okhttp3.OkHttpClient
@@ -43,9 +42,9 @@ import org.onebusaway.android.directions.util.TripRequestBuilder
  * Apollo's `serverUrl` is fixed at client-construction time, so building a lightweight client per
  * distinct URL, reusing the shared [OkHttpClient], is the equivalent seam here), and adapts the
  * response onto the shared [TripItinerary] domain model. Mirrors [DefaultTripPlanRepository]'s OTP1
- * `requestPlan`/`errorMessage` shape: throws [IOException] with a user-facing message on any
- * failure, so [DefaultTripPlanRepository]'s existing `runCatching` wrapping in both `plan()` and
- * `planBlocking()` handles this path the same way as OTP1.
+ * shape: throws a classified [TripPlanException] on any failure (see [otp2ErrorFor]), so
+ * [DefaultTripPlanRepository]'s existing `runCatching` wrapping in both `plan()` and `planBlocking()`
+ * handles this path the same way as OTP1.
  */
 class Otp2Planner @Inject constructor(
     @param:ApplicationContext private val context: Context,
@@ -85,57 +84,61 @@ class Otp2Planner @Inject constructor(
         val data = try {
             runBlocking { apolloClient.query(query).execute() }.dataOrThrow()
         } catch (e: ApolloNetworkException) {
-            // Transport failure (connect/read timeout, DNS, etc.) — the OTP1 path's own
-            // catch-all mapping to the request-timeout message.
-            throw IOException(context.getString(R.string.tripplanner_error_request_timeout), e)
+            // Transport failure (connect/read timeout, DNS, etc.) — a connectivity problem.
+            throw TripPlanException(
+                TripPlanError(TripPlanError.Category.CONNECTIVITY, R.string.tripplanner_error_request_timeout),
+                e,
+            )
         } catch (e: ApolloException) {
-            // A non-network ApolloException (HTTP status, parse failure, GraphQL-protocol
-            // error) isn't a timeout — don't tell the user it is.
-            throw IOException(context.getString(R.string.tripplanner_error_not_defined), e)
+            // A non-network ApolloException (HTTP status, parse failure, GraphQL-protocol error) isn't
+            // a timeout — surface it as an unclassified request failure, not a connectivity one.
+            throw TripPlanException(TripPlanError.Unknown, e)
         }
 
         data.planConnection?.routingErrors?.firstOrNull()?.let {
-            throw IOException(errorMessage(it))
+            throw TripPlanException(otp2ErrorFor(it.code, it.inputField))
         }
 
         val itineraries = data.toTripItineraries()
         if (itineraries.isEmpty()) {
-            throw IOException(context.getString(R.string.tripplanner_error_path_not_found))
+            throw TripPlanException(TripPlanError.NoRoute)
         }
         return itineraries
     }
+}
 
-    /**
-     * Maps a `routingErrors` entry to a user-facing message: OTP1's existing string resources where
-     * `RoutingErrorCode` names a genuinely equivalent failure, and an OTP2-specific string where it
-     * doesn't — [RoutingErrorCode.OUTSIDE_SERVICE_PERIOD] and
-     * [RoutingErrorCode.WALKING_BETTER_THAN_TRANSIT] have no OTP1-era concept, so folding them into
-     * the generic fallback would silently discard information OTP2 is actually telling the user.
-     */
-    private fun errorMessage(error: PlanQuery.RoutingError): String = when (error.code) {
-        RoutingErrorCode.OUTSIDE_BOUNDS ->
-            context.getString(R.string.tripplanner_error_outside_bounds)
+/**
+ * Classifies an OTP2 `routingErrors` entry into a [TripPlanError]: reuses OTP1's existing detail
+ * strings where [RoutingErrorCode] names a genuinely equivalent failure, and an OTP2-specific string
+ * where it doesn't — [RoutingErrorCode.OUTSIDE_SERVICE_PERIOD] and
+ * [RoutingErrorCode.WALKING_BETTER_THAN_TRANSIT] have no OTP1-era concept, so folding them into the
+ * generic fallback would silently discard information OTP2 is actually telling the user. Top-level and
+ * `internal` (not a `Context`-bound method) so it's exhaustively JVM-unit-testable without Apollo.
+ */
+internal fun otp2ErrorFor(code: RoutingErrorCode, inputField: InputField?): TripPlanError = when (code) {
+    RoutingErrorCode.OUTSIDE_BOUNDS ->
+        TripPlanError(TripPlanError.Category.NO_ROUTE, R.string.tripplanner_error_outside_bounds)
 
-        RoutingErrorCode.NO_TRANSIT_CONNECTION, RoutingErrorCode.NO_TRANSIT_CONNECTION_IN_SEARCH_WINDOW ->
-            context.getString(R.string.tripplanner_error_no_transit_times)
+    RoutingErrorCode.NO_TRANSIT_CONNECTION, RoutingErrorCode.NO_TRANSIT_CONNECTION_IN_SEARCH_WINDOW ->
+        TripPlanError(TripPlanError.Category.SCHEDULE, R.string.tripplanner_error_no_transit_times)
 
-        RoutingErrorCode.NO_STOPS_IN_RANGE ->
-            context.getString(R.string.tripplanner_error_path_not_found)
+    RoutingErrorCode.NO_STOPS_IN_RANGE -> TripPlanError.NoRoute
 
-        RoutingErrorCode.LOCATION_NOT_FOUND -> when (error.inputField) {
-            InputField.FROM -> context.getString(R.string.tripplanner_error_geocode_from_not_found)
-            InputField.TO -> context.getString(R.string.tripplanner_error_geocode_to_not_found)
-            else -> context.getString(R.string.tripplanner_error_not_defined)
-        }
-
-        RoutingErrorCode.OUTSIDE_SERVICE_PERIOD ->
-            context.getString(R.string.tripplanner_error_outside_service_period)
-
-        RoutingErrorCode.WALKING_BETTER_THAN_TRANSIT ->
-            context.getString(R.string.tripplanner_error_walking_better_than_transit)
-
-        RoutingErrorCode.UNKNOWN__ -> context.getString(R.string.tripplanner_error_not_defined)
+    RoutingErrorCode.LOCATION_NOT_FOUND -> when (inputField) {
+        InputField.FROM ->
+            TripPlanError(TripPlanError.Category.LOCATION, R.string.tripplanner_error_geocode_from_not_found)
+        InputField.TO ->
+            TripPlanError(TripPlanError.Category.LOCATION, R.string.tripplanner_error_geocode_to_not_found)
+        else -> TripPlanError(TripPlanError.Category.LOCATION, R.string.tripplanner_error_not_defined)
     }
+
+    RoutingErrorCode.OUTSIDE_SERVICE_PERIOD ->
+        TripPlanError(TripPlanError.Category.SCHEDULE, R.string.tripplanner_error_outside_service_period)
+
+    RoutingErrorCode.WALKING_BETTER_THAN_TRANSIT ->
+        TripPlanError(TripPlanError.Category.ADVISORY, R.string.tripplanner_error_walking_better_than_transit)
+
+    RoutingErrorCode.UNKNOWN__ -> TripPlanError.Unknown
 }
 
 /** OTP2's standard gtfs GraphQL mount, relative to the OTP base (`…/otp`). */

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanError.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanError.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.tripplan
+
+import androidx.annotation.ColorRes
+import androidx.annotation.StringRes
+import java.io.IOException
+import org.onebusaway.android.R
+
+/**
+ * A classified trip-plan failure. Two levels of granularity are carried so the UI can be both concise
+ * and specific:
+ *
+ *  - [category] — the coarse *kind* of problem, surfaced to the user as a consistent header (and its
+ *    [severity] colour). This is the "richer ontology": a plan can fail because we couldn't reach the
+ *    planner, because an endpoint is unusable, because there's no service at the chosen time, because
+ *    there's simply no route, or because the request itself was rejected — and those are genuinely
+ *    different situations, each with one stable heading (e.g. every no-route failure reads
+ *    "Cannot find route").
+ *  - [detailRes] — the specific, already-localized explanation (the exact OTP1/OTP2 message), shown as
+ *    the reason line beneath the header, so none of the fine-grained wire information is flattened away.
+ *
+ * Both planner paths — OTP1 REST ([otp1ErrorFor]) and OTP2 GraphQL ([otp2ErrorFor]) — classify their
+ * wire errors into this type and throw it as a [TripPlanException]; [TripPlanViewModel] surfaces it as
+ * [PlanResult.Error], and the directions UI renders the category header above the reason.
+ */
+data class TripPlanError(
+    val category: Category,
+    @get:StringRes val detailRes: Int,
+) {
+    /**
+     * The coarse failure kind. [headerRes] is the stable heading naming the category; [severity]
+     * drives the header's colour.
+     */
+    enum class Category(
+        @get:StringRes val headerRes: Int,
+        val severity: Severity,
+    ) {
+        /** Couldn't reach or get a usable answer from the planner (timeout, transport failure). */
+        CONNECTIVITY(R.string.tripplanner_error_header_connectivity, Severity.ERROR),
+
+        /** An endpoint couldn't be used — not geocoded, ambiguous, or not accessible. */
+        LOCATION(R.string.tripplanner_error_header_location, Severity.WARNING),
+
+        /** Transit doesn't run for the chosen time/date (no times, outside the service period). */
+        SCHEDULE(R.string.tripplanner_error_header_schedule, Severity.WARNING),
+
+        /** No usable route between the two points (no path, no stops in range, out of coverage). */
+        NO_ROUTE(R.string.tripplanner_error_header_no_route, Severity.WARNING),
+
+        /** Not a failure so much as advice — walking beats transit for this trip. */
+        ADVISORY(R.string.tripplanner_error_header_advisory, Severity.INFO),
+
+        /** The request itself was rejected or unclassified (bad parameter, no server, unknown). */
+        REQUEST(R.string.tripplanner_error_header_request, Severity.ERROR),
+    }
+
+    /**
+     * How alarming the failure is; [colorRes] is the header colour it maps to (a `md_theme_severity*`
+     * text colour tuned for the inverting `inverseSurface` snackbar bar): [INFO] blue (a tip — not a
+     * failure), [WARNING] amber (a valid, user-actionable non-result), [ERROR] red (something failed).
+     */
+    enum class Severity(@get:ColorRes val colorRes: Int) {
+        INFO(R.color.md_theme_severityInfo),
+        WARNING(R.color.md_theme_severityWarning),
+        ERROR(R.color.md_theme_severityError),
+    }
+
+    companion object {
+        /** The generic fallback when a failure carries no classified [TripPlanError]. */
+        val Unknown = TripPlanError(Category.REQUEST, R.string.tripplanner_error_not_defined)
+
+        /** No route between the endpoints — also the (defensive) empty-results case. */
+        val NoRoute = TripPlanError(Category.NO_ROUTE, R.string.tripplanner_error_path_not_found)
+    }
+}
+
+/**
+ * Carries a classified [TripPlanError] through the throw-based planner contract. Extends [IOException]
+ * so the existing `runCatching`/`runCatchingCancellable` wrapping in [DefaultTripPlanRepository] (and
+ * the monitor's empty-list-on-failure `planBlocking`) handles it unchanged.
+ */
+class TripPlanException(val error: TripPlanError, cause: Throwable? = null) : IOException(cause)
+
+/** The [TripPlanError] for a thrown [Throwable], falling back to [TripPlanError.Unknown]. */
+fun Throwable.toTripPlanError(): TripPlanError =
+    (this as? TripPlanException)?.error ?: TripPlanError.Unknown

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanFormState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanFormState.kt
@@ -148,5 +148,5 @@ sealed interface PlanResult {
         val itineraries: List<TripItinerary>,
         val params: TripPlanParams? = null,
     ) : PlanResult
-    data class Error(val message: String) : PlanResult
+    data class Error(val error: TripPlanError) : PlanResult
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanRepository.kt
@@ -89,7 +89,9 @@ class DefaultTripPlanRepository @Inject constructor(
      */
     private fun planInternal(builder: TripRequestBuilder): List<TripItinerary> {
         val baseUrl = builder.formattedOtpBaseUrl
-            ?: throw IOException(context.getString(R.string.tripplanner_no_server_selected_error))
+            ?: throw TripPlanException(
+                TripPlanError(TripPlanError.Category.REQUEST, R.string.tripplanner_no_server_selected_error)
+            )
 
         if (builder.usesOtp2) {
             return otp2Planner.plan(builder, baseUrl)
@@ -103,7 +105,7 @@ class DefaultTripPlanRepository @Inject constructor(
         )
         val itineraries = response.plan?.itineraries?.map { it.toTripItinerary() }
         if (itineraries.isNullOrEmpty()) {
-            throw IOException(errorMessage(response.error?.id ?: -1))
+            throw TripPlanException(otp1ErrorFor(response.error?.id ?: -1))
         }
         return itineraries
     }
@@ -163,8 +165,8 @@ class DefaultTripPlanRepository @Inject constructor(
             otpWebService.plan(url).execute()
         } catch (e: IOException) {
             // Transport failure / timeout (SocketTimeoutException is an IOException) — mirror the legacy
-            // catch-all mapping to the request-timeout message.
-            throw IOException(errorMessage(OtpErrorId.REQUEST_TIMEOUT.id), e)
+            // catch-all mapping to a connectivity failure.
+            throw TripPlanException(otp1ErrorFor(OtpErrorId.REQUEST_TIMEOUT.id), e)
         }
 
         // A server-root base we assumed was modern but that failed at the HTTP layer is a pre-1.0
@@ -183,7 +185,7 @@ class DefaultTripPlanRepository @Inject constructor(
             }
             body.use { OtpPlanParser.parse(it.byteStream()) }
         } catch (e: IOException) {
-            throw IOException(errorMessage(OtpErrorId.REQUEST_TIMEOUT.id), e)
+            throw TripPlanException(otp1ErrorFor(OtpErrorId.REQUEST_TIMEOUT.id), e)
         }
 
         // Record a discovered pre-1.0 server so later plans (and the bike layer) skip the probe.
@@ -193,34 +195,46 @@ class DefaultTripPlanRepository @Inject constructor(
         return parsed
     }
 
-    private fun errorMessage(errorCode: Int): String = when (errorCode) {
-        OtpErrorId.SYSTEM_ERROR.id -> context.getString(R.string.tripplanner_error_system)
-        OtpErrorId.OUTSIDE_BOUNDS.id -> context.getString(R.string.tripplanner_error_outside_bounds)
-        OtpErrorId.PATH_NOT_FOUND.id -> context.getString(R.string.tripplanner_error_path_not_found)
-        OtpErrorId.NO_TRANSIT_TIMES.id -> context.getString(R.string.tripplanner_error_no_transit_times)
-        OtpErrorId.REQUEST_TIMEOUT.id -> context.getString(R.string.tripplanner_error_request_timeout)
-        OtpErrorId.BOGUS_PARAMETER.id -> context.getString(R.string.tripplanner_error_bogus_parameter)
-        OtpErrorId.GEOCODE_FROM_NOT_FOUND.id ->
-            context.getString(R.string.tripplanner_error_geocode_from_not_found)
-        OtpErrorId.GEOCODE_TO_NOT_FOUND.id ->
-            context.getString(R.string.tripplanner_error_geocode_to_not_found)
-        OtpErrorId.GEOCODE_FROM_TO_NOT_FOUND.id ->
-            context.getString(R.string.tripplanner_error_geocode_from_to_not_found)
-        OtpErrorId.TOO_CLOSE.id -> context.getString(R.string.tripplanner_error_too_close)
-        OtpErrorId.LOCATION_NOT_ACCESSIBLE.id ->
-            context.getString(R.string.tripplanner_error_location_not_accessible)
-        OtpErrorId.GEOCODE_FROM_AMBIGUOUS.id ->
-            context.getString(R.string.tripplanner_error_geocode_from_ambiguous)
-        OtpErrorId.GEOCODE_TO_AMBIGUOUS.id ->
-            context.getString(R.string.tripplanner_error_geocode_to_ambiguous)
-        OtpErrorId.GEOCODE_FROM_TO_AMBIGUOUS.id ->
-            context.getString(R.string.tripplanner_error_geocode_from_to_ambiguous)
-        OtpErrorId.UNDERSPECIFIED_TRIANGLE.id, OtpErrorId.TRIANGLE_NOT_AFFINE.id,
-        OtpErrorId.TRIANGLE_OPTIMIZE_TYPE_NOT_SET.id, OtpErrorId.TRIANGLE_VALUES_NOT_SET.id ->
-            context.getString(R.string.tripplanner_error_triangle)
-        else -> context.getString(R.string.tripplanner_error_not_defined)
-    }
+}
 
+/**
+ * Classifies an OTP1 error code ([OtpErrorId.id], or `-1` when the server sent no code) into a
+ * [TripPlanError] — the coarse [TripPlanError.Category] plus the specific, already-mapped detail
+ * string. Top-level and `internal` (not a `Context`-bound method) so it's exhaustively
+ * JVM-unit-testable and shares the ontology with the OTP2 path ([otp2ErrorFor]).
+ */
+internal fun otp1ErrorFor(errorCode: Int): TripPlanError = when (errorCode) {
+    OtpErrorId.SYSTEM_ERROR.id ->
+        TripPlanError(TripPlanError.Category.REQUEST, R.string.tripplanner_error_system)
+    OtpErrorId.OUTSIDE_BOUNDS.id ->
+        TripPlanError(TripPlanError.Category.NO_ROUTE, R.string.tripplanner_error_outside_bounds)
+    OtpErrorId.PATH_NOT_FOUND.id -> TripPlanError.NoRoute
+    OtpErrorId.NO_TRANSIT_TIMES.id ->
+        TripPlanError(TripPlanError.Category.SCHEDULE, R.string.tripplanner_error_no_transit_times)
+    OtpErrorId.REQUEST_TIMEOUT.id ->
+        TripPlanError(TripPlanError.Category.CONNECTIVITY, R.string.tripplanner_error_request_timeout)
+    OtpErrorId.BOGUS_PARAMETER.id ->
+        TripPlanError(TripPlanError.Category.REQUEST, R.string.tripplanner_error_bogus_parameter)
+    OtpErrorId.GEOCODE_FROM_NOT_FOUND.id ->
+        TripPlanError(TripPlanError.Category.LOCATION, R.string.tripplanner_error_geocode_from_not_found)
+    OtpErrorId.GEOCODE_TO_NOT_FOUND.id ->
+        TripPlanError(TripPlanError.Category.LOCATION, R.string.tripplanner_error_geocode_to_not_found)
+    OtpErrorId.GEOCODE_FROM_TO_NOT_FOUND.id ->
+        TripPlanError(TripPlanError.Category.LOCATION, R.string.tripplanner_error_geocode_from_to_not_found)
+    OtpErrorId.TOO_CLOSE.id ->
+        TripPlanError(TripPlanError.Category.NO_ROUTE, R.string.tripplanner_error_too_close)
+    OtpErrorId.LOCATION_NOT_ACCESSIBLE.id ->
+        TripPlanError(TripPlanError.Category.LOCATION, R.string.tripplanner_error_location_not_accessible)
+    OtpErrorId.GEOCODE_FROM_AMBIGUOUS.id ->
+        TripPlanError(TripPlanError.Category.LOCATION, R.string.tripplanner_error_geocode_from_ambiguous)
+    OtpErrorId.GEOCODE_TO_AMBIGUOUS.id ->
+        TripPlanError(TripPlanError.Category.LOCATION, R.string.tripplanner_error_geocode_to_ambiguous)
+    OtpErrorId.GEOCODE_FROM_TO_AMBIGUOUS.id ->
+        TripPlanError(TripPlanError.Category.LOCATION, R.string.tripplanner_error_geocode_from_to_ambiguous)
+    OtpErrorId.UNDERSPECIFIED_TRIANGLE.id, OtpErrorId.TRIANGLE_NOT_AFFINE.id,
+    OtpErrorId.TRIANGLE_OPTIMIZE_TYPE_NOT_SET.id, OtpErrorId.TRIANGLE_VALUES_NOT_SET.id ->
+        TripPlanError(TripPlanError.Category.REQUEST, R.string.tripplanner_error_triangle)
+    else -> TripPlanError.Unknown
 }
 
 /** OTP's default-router path segment: present in a router-rooted base, inserted for a server-root one. */

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanRepository.kt
@@ -105,7 +105,10 @@ class DefaultTripPlanRepository @Inject constructor(
         )
         val itineraries = response.plan?.itineraries?.map { it.toTripItinerary() }
         if (itineraries.isNullOrEmpty()) {
-            throw TripPlanException(otp1ErrorFor(response.error?.id ?: -1))
+            // Empty with no error object is a no-route result (mirrors the OTP2 path), not an
+            // unclassified failure — surface "Cannot find route" rather than the generic message.
+            val errorId = response.error?.id
+            throw TripPlanException(if (errorId != null) otp1ErrorFor(errorId) else TripPlanError.NoRoute)
         }
         return itineraries
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanViewModel.kt
@@ -126,7 +126,7 @@ class TripPlanViewModel @Inject constructor(
                         // Carry the request that produced the results so the host can arm the
                         // trip-plan-change monitor to re-plan it (see PlanResult.Success.params).
                         onSuccess = { _planState.value = PlanResult.Success(it, params) },
-                        onFailure = { _planState.value = PlanResult.Error(it.message.orEmpty()) }
+                        onFailure = { _planState.value = PlanResult.Error(it.toTripPlanError()) }
                     )
                 }
             }

--- a/onebusaway-android/src/main/res/values-night/colors.xml
+++ b/onebusaway-android/src/main/res/values-night/colors.xml
@@ -55,6 +55,12 @@
     <color name="md_theme_errorContainer">#93000A</color>
     <color name="md_theme_onErrorContainer">#FFDAD6</color>
 
+    <!-- Dark-theme severity header colours (see values/colors.xml). The inverseSurface bar turns light
+         here, so the header text flips to the deep tone-40 values to stay legible on it. -->
+    <color name="md_theme_severityInfo">#0B57D0</color>
+    <color name="md_theme_severityWarning">#7A4E00</color>
+    <color name="md_theme_severityError">#BA1A1A</color>
+
     <color name="md_theme_background">#10140F</color>
     <color name="md_theme_onBackground">#E0E4DB</color>
     <color name="md_theme_surface">#10140F</color>

--- a/onebusaway-android/src/main/res/values/colors.xml
+++ b/onebusaway-android/src/main/res/values/colors.xml
@@ -127,6 +127,15 @@
     <color name="md_theme_errorContainer">#FFDAD6</color>
     <color name="md_theme_onErrorContainer">#93000A</color>
 
+    <!-- Semantic severity colors Material3 doesn't ship (it only defines `error`), used to colour the
+         trip-plan error snackbar's header text: info = blue (a tip), warning = amber (a non-error),
+         error = red (a failure). These are *text* colours read against the dark inverseSurface bar, so
+         the light theme uses the bright tone-80 values; values-night flips to the deep tone-40 values
+         for the bar that turns light there. -->
+    <color name="md_theme_severityInfo">#A9C7FF</color>
+    <color name="md_theme_severityWarning">#F0C173</color>
+    <color name="md_theme_severityError">#FFB4AB</color>
+
     <color name="md_theme_background">#F7FBF1</color>
     <color name="md_theme_onBackground">#191D17</color>
     <color name="md_theme_surface">#F7FBF1</color>

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -920,6 +920,15 @@
     <string name="tripplanner_no_server_selected_error">No region selected</string>
     <string name="tripplanner_error_dialog_title">Planning not possible</string>
     <!-- Errors -->
+    <!-- Trip-plan error category headers (the consistent heading on the error snackbar; the specific
+         wire message is shown as the reason line beneath). One header per category, so e.g. every
+         no-route failure reads "Cannot find route" with its distinct reason below. -->
+    <string name="tripplanner_error_header_connectivity">Can&#8217;t reach the trip planner</string>
+    <string name="tripplanner_error_header_location">Can&#8217;t find that location</string>
+    <string name="tripplanner_error_header_schedule">No transit at this time</string>
+    <string name="tripplanner_error_header_no_route">Cannot find route</string>
+    <string name="tripplanner_error_header_advisory">Try walking instead</string>
+    <string name="tripplanner_error_header_request">Couldn&#8217;t plan this trip</string>
     <string name="tripplanner_error_not_defined">Sorry, something went wrong.  Please try again.</string>
     <string name="tripplanner_error_request_timeout">Please check your Internet connection and try
         again.

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripPlanErrorMappingTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripPlanErrorMappingTest.kt
@@ -37,42 +37,36 @@ class TripPlanErrorMappingTest {
 
     // ---- OTP1 (REST error codes) ----
 
-    @Test
-    fun otp1_connectivity_and_request() {
-        assertError(Category.CONNECTIVITY, R.string.tripplanner_error_request_timeout,
-            otp1ErrorFor(OtpErrorId.REQUEST_TIMEOUT.id))
-        assertError(Category.REQUEST, R.string.tripplanner_error_system,
-            otp1ErrorFor(OtpErrorId.SYSTEM_ERROR.id))
-        assertError(Category.REQUEST, R.string.tripplanner_error_bogus_parameter,
-            otp1ErrorFor(OtpErrorId.BOGUS_PARAMETER.id))
-        assertError(Category.REQUEST, R.string.tripplanner_error_triangle,
-            otp1ErrorFor(OtpErrorId.TRIANGLE_NOT_AFFINE.id))
-    }
+    // Every OtpErrorId member and the (category, detail) it must classify into. The exhaustiveness
+    // assertion in the test below fails if a new code is added to the enum without an entry here.
+    private val otp1Expected = mapOf(
+        OtpErrorId.SYSTEM_ERROR to (Category.REQUEST to R.string.tripplanner_error_system),
+        OtpErrorId.OUTSIDE_BOUNDS to (Category.NO_ROUTE to R.string.tripplanner_error_outside_bounds),
+        OtpErrorId.PATH_NOT_FOUND to (Category.NO_ROUTE to R.string.tripplanner_error_path_not_found),
+        OtpErrorId.NO_TRANSIT_TIMES to (Category.SCHEDULE to R.string.tripplanner_error_no_transit_times),
+        OtpErrorId.REQUEST_TIMEOUT to (Category.CONNECTIVITY to R.string.tripplanner_error_request_timeout),
+        OtpErrorId.BOGUS_PARAMETER to (Category.REQUEST to R.string.tripplanner_error_bogus_parameter),
+        OtpErrorId.GEOCODE_FROM_NOT_FOUND to (Category.LOCATION to R.string.tripplanner_error_geocode_from_not_found),
+        OtpErrorId.GEOCODE_TO_NOT_FOUND to (Category.LOCATION to R.string.tripplanner_error_geocode_to_not_found),
+        OtpErrorId.GEOCODE_FROM_TO_NOT_FOUND to (Category.LOCATION to R.string.tripplanner_error_geocode_from_to_not_found),
+        OtpErrorId.TOO_CLOSE to (Category.NO_ROUTE to R.string.tripplanner_error_too_close),
+        OtpErrorId.LOCATION_NOT_ACCESSIBLE to (Category.LOCATION to R.string.tripplanner_error_location_not_accessible),
+        OtpErrorId.GEOCODE_FROM_AMBIGUOUS to (Category.LOCATION to R.string.tripplanner_error_geocode_from_ambiguous),
+        OtpErrorId.GEOCODE_TO_AMBIGUOUS to (Category.LOCATION to R.string.tripplanner_error_geocode_to_ambiguous),
+        OtpErrorId.GEOCODE_FROM_TO_AMBIGUOUS to (Category.LOCATION to R.string.tripplanner_error_geocode_from_to_ambiguous),
+        OtpErrorId.UNDERSPECIFIED_TRIANGLE to (Category.REQUEST to R.string.tripplanner_error_triangle),
+        OtpErrorId.TRIANGLE_NOT_AFFINE to (Category.REQUEST to R.string.tripplanner_error_triangle),
+        OtpErrorId.TRIANGLE_OPTIMIZE_TYPE_NOT_SET to (Category.REQUEST to R.string.tripplanner_error_triangle),
+        OtpErrorId.TRIANGLE_VALUES_NOT_SET to (Category.REQUEST to R.string.tripplanner_error_triangle),
+    )
 
     @Test
-    fun otp1_no_route() {
-        assertError(Category.NO_ROUTE, R.string.tripplanner_error_outside_bounds,
-            otp1ErrorFor(OtpErrorId.OUTSIDE_BOUNDS.id))
-        assertError(Category.NO_ROUTE, R.string.tripplanner_error_path_not_found,
-            otp1ErrorFor(OtpErrorId.PATH_NOT_FOUND.id))
-        assertError(Category.NO_ROUTE, R.string.tripplanner_error_too_close,
-            otp1ErrorFor(OtpErrorId.TOO_CLOSE.id))
-    }
-
-    @Test
-    fun otp1_schedule() {
-        assertError(Category.SCHEDULE, R.string.tripplanner_error_no_transit_times,
-            otp1ErrorFor(OtpErrorId.NO_TRANSIT_TIMES.id))
-    }
-
-    @Test
-    fun otp1_location() {
-        assertError(Category.LOCATION, R.string.tripplanner_error_geocode_from_not_found,
-            otp1ErrorFor(OtpErrorId.GEOCODE_FROM_NOT_FOUND.id))
-        assertError(Category.LOCATION, R.string.tripplanner_error_geocode_to_ambiguous,
-            otp1ErrorFor(OtpErrorId.GEOCODE_TO_AMBIGUOUS.id))
-        assertError(Category.LOCATION, R.string.tripplanner_error_location_not_accessible,
-            otp1ErrorFor(OtpErrorId.LOCATION_NOT_ACCESSIBLE.id))
+    fun otp1_classifies_every_error_code() {
+        assertEquals(OtpErrorId.entries.toSet(), otp1Expected.keys)
+        for ((code, expected) in otp1Expected) {
+            val (category, detail) = expected
+            assertError(category, detail, otp1ErrorFor(code.id))
+        }
     }
 
     @Test

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripPlanErrorMappingTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripPlanErrorMappingTest.kt
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.tripplan
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.onebusaway.android.R
+import org.onebusaway.android.api.contract.OtpErrorId
+import org.onebusaway.android.api.graphql.type.InputField
+import org.onebusaway.android.api.graphql.type.RoutingErrorCode
+import org.onebusaway.android.ui.tripplan.TripPlanError.Category
+
+/**
+ * Verifies both planner error classifiers ([otp1ErrorFor], [otp2ErrorFor]) map every wire code onto
+ * the right [TripPlanError.Category] and preserve the specific detail string. Pure JVM — the res IDs
+ * are compared as [R] constants (never resolved to text), so no Android runtime is needed.
+ */
+class TripPlanErrorMappingTest {
+
+    private fun assertError(expectedCategory: Category, expectedDetail: Int, actual: TripPlanError) {
+        assertEquals(expectedCategory, actual.category)
+        assertEquals(expectedDetail, actual.detailRes)
+    }
+
+    // ---- OTP1 (REST error codes) ----
+
+    @Test
+    fun otp1_connectivity_and_request() {
+        assertError(Category.CONNECTIVITY, R.string.tripplanner_error_request_timeout,
+            otp1ErrorFor(OtpErrorId.REQUEST_TIMEOUT.id))
+        assertError(Category.REQUEST, R.string.tripplanner_error_system,
+            otp1ErrorFor(OtpErrorId.SYSTEM_ERROR.id))
+        assertError(Category.REQUEST, R.string.tripplanner_error_bogus_parameter,
+            otp1ErrorFor(OtpErrorId.BOGUS_PARAMETER.id))
+        assertError(Category.REQUEST, R.string.tripplanner_error_triangle,
+            otp1ErrorFor(OtpErrorId.TRIANGLE_NOT_AFFINE.id))
+    }
+
+    @Test
+    fun otp1_no_route() {
+        assertError(Category.NO_ROUTE, R.string.tripplanner_error_outside_bounds,
+            otp1ErrorFor(OtpErrorId.OUTSIDE_BOUNDS.id))
+        assertError(Category.NO_ROUTE, R.string.tripplanner_error_path_not_found,
+            otp1ErrorFor(OtpErrorId.PATH_NOT_FOUND.id))
+        assertError(Category.NO_ROUTE, R.string.tripplanner_error_too_close,
+            otp1ErrorFor(OtpErrorId.TOO_CLOSE.id))
+    }
+
+    @Test
+    fun otp1_schedule() {
+        assertError(Category.SCHEDULE, R.string.tripplanner_error_no_transit_times,
+            otp1ErrorFor(OtpErrorId.NO_TRANSIT_TIMES.id))
+    }
+
+    @Test
+    fun otp1_location() {
+        assertError(Category.LOCATION, R.string.tripplanner_error_geocode_from_not_found,
+            otp1ErrorFor(OtpErrorId.GEOCODE_FROM_NOT_FOUND.id))
+        assertError(Category.LOCATION, R.string.tripplanner_error_geocode_to_ambiguous,
+            otp1ErrorFor(OtpErrorId.GEOCODE_TO_AMBIGUOUS.id))
+        assertError(Category.LOCATION, R.string.tripplanner_error_location_not_accessible,
+            otp1ErrorFor(OtpErrorId.LOCATION_NOT_ACCESSIBLE.id))
+    }
+
+    @Test
+    fun otp1_unknown_code_falls_back() {
+        assertError(Category.REQUEST, R.string.tripplanner_error_not_defined, otp1ErrorFor(-1))
+        assertEquals(TripPlanError.Unknown, otp1ErrorFor(-1))
+    }
+
+    // ---- OTP2 (GraphQL RoutingErrorCode) ----
+
+    @Test
+    fun otp2_no_route() {
+        assertError(Category.NO_ROUTE, R.string.tripplanner_error_outside_bounds,
+            otp2ErrorFor(RoutingErrorCode.OUTSIDE_BOUNDS, null))
+        assertError(Category.NO_ROUTE, R.string.tripplanner_error_path_not_found,
+            otp2ErrorFor(RoutingErrorCode.NO_STOPS_IN_RANGE, null))
+    }
+
+    @Test
+    fun otp2_schedule() {
+        assertError(Category.SCHEDULE, R.string.tripplanner_error_no_transit_times,
+            otp2ErrorFor(RoutingErrorCode.NO_TRANSIT_CONNECTION, null))
+        assertError(Category.SCHEDULE, R.string.tripplanner_error_no_transit_times,
+            otp2ErrorFor(RoutingErrorCode.NO_TRANSIT_CONNECTION_IN_SEARCH_WINDOW, null))
+        assertError(Category.SCHEDULE, R.string.tripplanner_error_outside_service_period,
+            otp2ErrorFor(RoutingErrorCode.OUTSIDE_SERVICE_PERIOD, null))
+    }
+
+    @Test
+    fun otp2_location_depends_on_input_field() {
+        assertError(Category.LOCATION, R.string.tripplanner_error_geocode_from_not_found,
+            otp2ErrorFor(RoutingErrorCode.LOCATION_NOT_FOUND, InputField.FROM))
+        assertError(Category.LOCATION, R.string.tripplanner_error_geocode_to_not_found,
+            otp2ErrorFor(RoutingErrorCode.LOCATION_NOT_FOUND, InputField.TO))
+        // No input field named -> still a location problem, generic detail.
+        assertError(Category.LOCATION, R.string.tripplanner_error_not_defined,
+            otp2ErrorFor(RoutingErrorCode.LOCATION_NOT_FOUND, null))
+    }
+
+    @Test
+    fun otp2_advisory_and_unknown() {
+        assertError(Category.ADVISORY, R.string.tripplanner_error_walking_better_than_transit,
+            otp2ErrorFor(RoutingErrorCode.WALKING_BETTER_THAN_TRANSIT, null))
+        assertEquals(TripPlanError.Unknown, otp2ErrorFor(RoutingErrorCode.UNKNOWN__, null))
+    }
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripPlanViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripPlanViewModelTest.kt
@@ -16,6 +16,7 @@
 package org.onebusaway.android.ui.tripplan
 
 import java.io.IOException
+import org.onebusaway.android.R
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -269,11 +270,20 @@ class TripPlanViewModelTest {
     }
 
     @Test
-    fun `a plan failure surfaces Error with the message`() = runTest {
-        val vm = viewModel(plan = FakeTripPlanRepository(Result.failure(IOException("no route"))))
+    fun `a classified plan failure surfaces its TripPlanError`() = runTest {
+        val error = TripPlanError(TripPlanError.Category.SCHEDULE, R.string.tripplanner_error_no_transit_times)
+        val vm = viewModel(plan = FakeTripPlanRepository(Result.failure(TripPlanException(error))))
         setBothEndpoints(vm)
         advanceUntilIdle()
-        assertEquals(PlanResult.Error("no route"), vm.planState.value)
+        assertEquals(PlanResult.Error(error), vm.planState.value)
+    }
+
+    @Test
+    fun `an unclassified plan failure falls back to Unknown`() = runTest {
+        val vm = viewModel(plan = FakeTripPlanRepository(Result.failure(IOException("boom"))))
+        setBothEndpoints(vm)
+        advanceUntilIdle()
+        assertEquals(PlanResult.Error(TripPlanError.Unknown), vm.planState.value)
     }
 
     @Test


### PR DESCRIPTION
> **Stacked on #1942** (`feature/trip-plan-error-snackbar`). Base this PR against that branch; review/merge #1942 first, then this retargets to `main` automatically.

## What

Drops a **green (From) / red (To) pin** on the home map as soon as each directions endpoint **resolves to coordinates** — a map-tap pick, a long-press "directions from/to here", or a selected placename/address — **before** a full itinerary is planned. So a single-endpoint state already shows the point on the map, and the map isn't empty while you fill in the second endpoint.

## How

Reuses the existing pin machinery rather than adding a new one:

- **`DirectionsMapController.setEndpoints(from, to)`** — draws/updates the two endpoint pins via the same `MapHost.addMarker(lat, lon, hue)` channel and the same green (120) / red (0) hues the itinerary's own start/end pins already use. It **diffs** against the current pins, so an unchanged endpoint keeps its marker (no flicker) and a null endpoint drops its pin.
- Driven from **HomeScreen** (a `LaunchedEffect` on the resolved From/To coords) through the existing **`MapDirective`** channel — `SetDirectionsEndpoints` → `MapViewModel.setDirectionsEndpoints` — matching the interleaved `ShowItinerary`/`ClearItinerary` lifecycle it sits next to.
- The itinerary's own start/end pins **supersede** these once one draws; any transition out of directions clears them.

## Notes

- Presentation-only; no data/ViewModel/endpoint changes.
- **MapLibre caveat:** the MapLibre renderer drops the generic-marker hue, so the pins are green/red on **`obaGoogle`** (the shipping flavor) but color-indistinguishable on **`obaMaplibre`**. This is a **pre-existing gap** — the itinerary's own start/end pins already render identically there. Closing it (teach the MapLibre renderer to build a colored icon) is a separate change that would also fix the existing itinerary pins.

## Testing

- Compiles clean under the strict `-PwarningsAsErrors` gate for **both** `obaGoogle` and `obaMaplibre`; installed and exercised on a Pixel 7 Pro (long-press → directions from/to here, pick-on-map, and address selection each drop the pin; both-set plans and the pins become the itinerary's; clearing an endpoint / leaving directions clears the pins).

🤖 Generated with [Claude Code](https://claude.com/claude-code)