### PR TITLE
Give FocusedStop a GeoPoint instead of loose lat/lon (#1949)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.kt
@@ -70,6 +70,7 @@ import org.onebusaway.android.ui.nav.IntentRouteMapper
 import org.onebusaway.android.ui.nav.NavRoutes
 import org.onebusaway.android.ui.survey.SurveyViewModel
 import org.onebusaway.android.util.ExternalIntents
+import org.onebusaway.android.util.GeoPoint
 import org.onebusaway.android.util.PermissionUtils
 import org.onebusaway.android.util.ReminderUtils
 import org.onebusaway.android.ui.tutorial.TutorialPrefs
@@ -347,7 +348,7 @@ class HomeActivity : AppCompatActivity() {
         // The VM picks the report target (focused stop → last location → nothing); the host just launches.
         when (val target = viewModel.reportTarget()) {
             is ReportTarget.Stop -> target.stop.let {
-                ReportLauncher.start(this, it.id, it.name, it.code, it.lat, it.lon)
+                ReportLauncher.start(this, it.id, it.name, it.code, it.point.latitude, it.point.longitude)
             }
             is ReportTarget.Location -> ReportLauncher.start(this, target.point.latitude, target.point.longitude)
             ReportTarget.Generic -> ReportLauncher.start(this)
@@ -408,5 +409,5 @@ private fun FocusedStop.Companion.fromIntent(intent: Intent): FocusedStop? {
     val lat = extras.getDouble(MapParams.CENTER_LAT)
     val lon = extras.getDouble(MapParams.CENTER_LON)
     if (lat == 0.0 || lon == 0.0) return null
-    return FocusedStop(id, extras.getString(MapParams.STOP_NAME), extras.getString(MapParams.STOP_CODE), lat, lon)
+    return FocusedStop(id, extras.getString(MapParams.STOP_NAME), extras.getString(MapParams.STOP_CODE), GeoPoint(lat, lon))
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/CurrentFocusPersistence.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/CurrentFocusPersistence.kt
@@ -17,6 +17,7 @@ package org.onebusaway.android.ui.home
 
 import androidx.lifecycle.SavedStateHandle
 import org.onebusaway.android.map.MapParams
+import org.onebusaway.android.util.GeoPoint
 
 /** Mechanical SavedStateHandle encoding for [CurrentFocus], kept out of focus transition logic. */
 internal object CurrentFocusPersistence {
@@ -68,8 +69,8 @@ internal object CurrentFocusPersistence {
         state[KEY_STOP_ID] = stop?.id
         state[KEY_STOP_NAME] = stop?.name
         state[KEY_STOP_CODE] = stop?.code
-        state[KEY_STOP_LAT] = stop?.lat
-        state[KEY_STOP_LON] = stop?.lon
+        state[KEY_STOP_LAT] = stop?.point?.latitude
+        state[KEY_STOP_LON] = stop?.point?.longitude
         state[KEY_BIKE_STATION] = (focus as? CurrentFocus.BikeStation)?.id
 
         val target = (focus as? CurrentFocus.Route)?.target
@@ -139,8 +140,10 @@ internal object CurrentFocusPersistence {
             id = id,
             name = state[KEY_STOP_NAME],
             code = state[KEY_STOP_CODE],
-            lat = state.get<Double>(KEY_STOP_LAT) ?: 0.0,
-            lon = state.get<Double>(KEY_STOP_LON) ?: 0.0,
+            point = GeoPoint(
+                state.get<Double>(KEY_STOP_LAT) ?: 0.0,
+                state.get<Double>(KEY_STOP_LON) ?: 0.0,
+            ),
         )
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/FocusedStop.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/FocusedStop.kt
@@ -15,8 +15,10 @@
  */
 package org.onebusaway.android.ui.home
 
+import org.onebusaway.android.util.GeoPoint
+
 /**
- * The stop the user tapped on the map, decoupled from the io/elements `ObaStop`. Carries lat/lon so
+ * The stop the user tapped on the map, decoupled from the io/elements `ObaStop`. Carries its [point] so
  * the host can recenter the map and launch feedback without holding the `ObaStop` object, and so the
  * focus survives process death via the ViewModel's `SavedStateHandle`.
  */
@@ -24,8 +26,7 @@ data class FocusedStop(
     val id: String,
     val name: String?,
     val code: String?,
-    val lat: Double,
-    val lon: Double,
+    val point: GeoPoint,
 ) {
     // Empty companion so intent/extras parsing can hang off it as a `FocusedStop.fromIntent(...)`
     // extension where that contract lives (HomeActivity), without this model knowing about intents.

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeNavHost.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeNavHost.kt
@@ -151,7 +151,7 @@ fun HomeNavHost(
                     // An in-session reveal (search result / recents / route-info tap): pan the camera
                     // over to the stop rather than jump, since the map is already on screen.
                     home.homeViewModel.revealStop(
-                        FocusedStop(reveal.stopId, null, null, reveal.point.latitude, reveal.point.longitude),
+                        FocusedStop(reveal.stopId, null, null, reveal.point),
                         animate = true,
                     )
                 } else {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
@@ -379,7 +379,7 @@ class HomeViewModel @Inject constructor(
     fun recenterOnFocusedStop(undoViewport: MapViewport? = null) {
         _currentFocus.value.focusedStop?.let {
             recordViewportUndo(undoViewport)
-            emitMapDirective(MapDirective.RecenterOnFocusedStop(GeoPoint(it.lat, it.lon)))
+            emitMapDirective(MapDirective.RecenterOnFocusedStop(it.point))
         }
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
@@ -150,7 +150,7 @@ fun MapFeature(
             override fun onStopClick(marker: StopMarker) {
                 val stop = marker.stop
                 val transition = homeViewModel.onStopFocused(
-                    FocusedStop(stop.id, stop.name, stop.stopCode, stop.latitude, stop.longitude),
+                    FocusedStop(stop.id, stop.name, stop.stopCode, marker.point),
                     continuingRoutes = marker.presentedRoutes,
                 )
                 if (transition == StopFocusTransition.ReplacePresentation) {

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeSheetLogicTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeSheetLogicTest.kt
@@ -19,6 +19,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.onebusaway.android.util.GeoPoint
 
 /**
  * Decision-table tests for the pure arrivals-sheet logic extracted from [HomeScreen]. These cover
@@ -28,7 +29,7 @@ import org.junit.Test
  */
 class HomeSheetLogicTest {
 
-    private val stop = FocusedStop("1", "Main St", "100", 47.6, -122.3)
+    private val stop = FocusedStop("1", "Main St", "100", GeoPoint(47.6, -122.3))
 
     // --- shouldShowSheet ---
 

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
@@ -117,7 +117,7 @@ class HomeViewModelTest {
         val map = MapDirectiveRecorder(vm)
         val job = launch { map.collect() }
         advanceUntilIdle()
-        vm.onStopFocused(FocusedStop("1", "Main St", "100", 47.6, -122.3))
+        vm.onStopFocused(FocusedStop("1", "Main St", "100", GeoPoint(47.6, -122.3)))
 
         vm.onSheetSettled(ArrivalsSheetState.Collapsed, 120) // reveal, skipped
         vm.onSheetSettled(ArrivalsSheetState.Expanded, 120)
@@ -165,7 +165,7 @@ class HomeViewModelTest {
         val map = MapDirectiveRecorder(vm)
         val job = launch { map.collect() }
         advanceUntilIdle()
-        val stop = FocusedStop("1", "Main St", "100", 47.6, -122.3)
+        val stop = FocusedStop("1", "Main St", "100", GeoPoint(47.6, -122.3))
         vm.applyInitialFocus(stop)
         assertEquals(stop, vm.currentFocus.value.focusedStop)
         vm.onArrivalsLoaded(obaStop, null, emptySet())
@@ -177,7 +177,7 @@ class HomeViewModelTest {
     @Test
     fun `applyInitialFocus keeps a restored focus and marks it pending`() = runTest {
         val handle = SavedStateHandle()
-        val restored = FocusedStop("42", "Pike St", "577", 47.61, -122.34)
+        val restored = FocusedStop("42", "Pike St", "577", GeoPoint(47.61, -122.34))
         viewModel(savedState = handle).onStopFocused(restored)
         val vm = viewModel(savedState = handle) // recreation: focus restored from the handle
         val map = MapDirectiveRecorder(vm)
@@ -213,7 +213,7 @@ class HomeViewModelTest {
         val map = MapDirectiveRecorder(vm)
         val job = launch { map.collect() }
         advanceUntilIdle()
-        vm.onStopFocused(FocusedStop("1", "Main St", "100", 47.6, -122.3))
+        vm.onStopFocused(FocusedStop("1", "Main St", "100", GeoPoint(47.6, -122.3)))
         advanceUntilIdle()
         map.sent.clear()
         vm.markPendingMapFocus()
@@ -246,7 +246,7 @@ class HomeViewModelTest {
         val map = MapDirectiveRecorder(vm)
         val job = launch { map.collect() }
         advanceUntilIdle()
-        vm.onStopFocused(FocusedStop("1", "Main St", "100", 47.6, -122.3))
+        vm.onStopFocused(FocusedStop("1", "Main St", "100", GeoPoint(47.6, -122.3)))
         vm.onSheetSettled(ArrivalsSheetState.Collapsed, 120) // reveal, skipped
         vm.onSheetSettled(ArrivalsSheetState.Expanded, 120)
 
@@ -297,7 +297,7 @@ class HomeViewModelTest {
         val map = MapDirectiveRecorder(vm)
         val mapJob = launch { map.collect() }
         advanceUntilIdle()
-        vm.onStopFocused(FocusedStop("stop", "Main St", "100", 47.6, -122.3))
+        vm.onStopFocused(FocusedStop("stop", "Main St", "100", GeoPoint(47.6, -122.3)))
 
         vm.requestShowFocusedStopRouteOnMap("42", directionId = 1)
         advanceUntilIdle()
@@ -316,7 +316,7 @@ class HomeViewModelTest {
         val map = MapDirectiveRecorder(vm)
         val mapJob = launch { map.collect() }
         advanceUntilIdle()
-        vm.onStopFocused(FocusedStop("stop", "Main St", "100", 47.6, -122.3))
+        vm.onStopFocused(FocusedStop("stop", "Main St", "100", GeoPoint(47.6, -122.3)))
         advanceUntilIdle()
         vm.selectArrivalRoute(
             request = ShowRouteRequest("65", directionStopId = "stop", initialDirectionId = 0),
@@ -343,7 +343,7 @@ class HomeViewModelTest {
         val map = MapDirectiveRecorder(vm)
         val mapJob = launch { map.collect() }
         advanceUntilIdle()
-        val stop = FocusedStop("stop", "Main St", "100", 47.6, -122.3)
+        val stop = FocusedStop("stop", "Main St", "100", GeoPoint(47.6, -122.3))
         vm.onStopFocused(stop)
         advanceUntilIdle()
         map.sent.clear()
@@ -372,7 +372,7 @@ class HomeViewModelTest {
         val map = MapDirectiveRecorder(vm)
         val mapJob = launch { map.collect() }
         advanceUntilIdle()
-        val stop = FocusedStop("stop", "Main St", "100", 47.6, -122.3)
+        val stop = FocusedStop("stop", "Main St", "100", GeoPoint(47.6, -122.3))
         vm.onStopFocused(stop)
         vm.requestShowFocusedStopRouteOnMap("65", null, "65")
 
@@ -390,7 +390,7 @@ class HomeViewModelTest {
         val map = MapDirectiveRecorder(vm)
         val mapJob = launch { map.collect() }
         advanceUntilIdle()
-        val stop = FocusedStop("stop", "Main St", "100", 47.6, -122.3)
+        val stop = FocusedStop("stop", "Main St", "100", GeoPoint(47.6, -122.3))
         vm.onStopFocused(stop)
         vm.requestShowFocusedStopRouteOnMap("65", directionId = 0, shortName = "65")
         advanceUntilIdle()
@@ -416,7 +416,7 @@ class HomeViewModelTest {
         val map = MapDirectiveRecorder(vm)
         val mapJob = launch { map.collect() }
         advanceUntilIdle()
-        val stop = FocusedStop("stop", "Main St", "100", 47.6, -122.3)
+        val stop = FocusedStop("stop", "Main St", "100", GeoPoint(47.6, -122.3))
         val viewport = MapViewport(GeoPoint(47.61, -122.31), 14.5)
         vm.onStopFocused(stop)
         vm.requestShowFocusedStopRouteOnMap("65", directionId = 0, shortName = "65")
@@ -445,7 +445,7 @@ class HomeViewModelTest {
         val map = MapDirectiveRecorder(vm)
         val mapJob = launch { map.collect() }
         advanceUntilIdle()
-        val stop = FocusedStop("stop", "Main St", "100", 47.6, -122.3)
+        val stop = FocusedStop("stop", "Main St", "100", GeoPoint(47.6, -122.3))
         val viewport = MapViewport(GeoPoint(47.62, -122.32), 13.25)
         vm.onStopFocused(stop)
         vm.requestShowFocusedStopRouteOnMap("65", directionId = 0, undoViewport = viewport)
@@ -491,7 +491,7 @@ class HomeViewModelTest {
         val map = MapDirectiveRecorder(vm)
         val mapJob = launch { map.collect() }
         advanceUntilIdle()
-        val stop = FocusedStop("1", "Main St", "100", 47.6, -122.3)
+        val stop = FocusedStop("1", "Main St", "100", GeoPoint(47.6, -122.3))
         vm.onStopFocused(stop)
         vm.focusStandaloneRoute(ShowRouteRequest("65"))
         advanceUntilIdle()
@@ -515,7 +515,7 @@ class HomeViewModelTest {
         val map = MapDirectiveRecorder(vm)
         val mapJob = launch { map.collect() }
         advanceUntilIdle()
-        val stop = FocusedStop("1", "Main St", "100", 47.6, -122.3)
+        val stop = FocusedStop("1", "Main St", "100", GeoPoint(47.6, -122.3))
         val viewport = MapViewport(GeoPoint(47.64, -122.34), 13.0)
         vm.onStopFocused(stop)
         vm.focusStandaloneRoute(ShowRouteRequest("65"), undoViewport = viewport)
@@ -537,7 +537,7 @@ class HomeViewModelTest {
         val map = MapDirectiveRecorder(vm)
         val mapJob = launch { map.collect() }
         advanceUntilIdle()
-        val stop = FocusedStop("stop", "Main St", "100", 47.6, -122.3)
+        val stop = FocusedStop("stop", "Main St", "100", GeoPoint(47.6, -122.3))
         vm.onStopFocused(stop)
         vm.requestShowFocusedStopRouteOnMap("65", directionId = 0)
 
@@ -557,7 +557,7 @@ class HomeViewModelTest {
     @Test
     fun `map taps drop route attention then stop attention`() = runTest {
         val vm = viewModel()
-        val stop = FocusedStop("stop", "Main St", "100", 47.6, -122.3)
+        val stop = FocusedStop("stop", "Main St", "100", GeoPoint(47.6, -122.3))
         vm.onStopFocused(stop)
         vm.requestShowFocusedStopRouteOnMap("65", directionId = 0)
 
@@ -575,7 +575,7 @@ class HomeViewModelTest {
         val map = MapDirectiveRecorder(vm)
         val mapJob = launch { map.collect() }
         advanceUntilIdle()
-        val stop = FocusedStop("stop", "Main St", "100", 47.6, -122.3)
+        val stop = FocusedStop("stop", "Main St", "100", GeoPoint(47.6, -122.3))
         vm.onStopFocused(stop)
         vm.requestShowFocusedStopRouteOnMap("65", directionId = 0)
         advanceUntilIdle()
@@ -596,8 +596,8 @@ class HomeViewModelTest {
     @Test
     fun `map tap from plain stop preserves older focus as undo history`() = runTest {
         val vm = viewModel()
-        val first = FocusedStop("first", "1st Ave", "100", 47.6, -122.3)
-        val second = FocusedStop("second", "2nd Ave", "200", 47.61, -122.31)
+        val first = FocusedStop("first", "1st Ave", "100", GeoPoint(47.6, -122.3))
+        val second = FocusedStop("second", "2nd Ave", "200", GeoPoint(47.61, -122.31))
         vm.onStopFocused(first)
         vm.onStopFocused(second)
 
@@ -612,7 +612,7 @@ class HomeViewModelTest {
     @Test
     fun `restored stop route reconstructs its stop and root parents`() = runTest {
         val state = SavedStateHandle()
-        val stop = FocusedStop("stop", "Main St", "100", 47.6, -122.3)
+        val stop = FocusedStop("stop", "Main St", "100", GeoPoint(47.6, -122.3))
         viewModel(savedState = state).apply {
             onStopFocused(stop)
             requestShowFocusedStopRouteOnMap("65", directionId = 0)
@@ -629,7 +629,7 @@ class HomeViewModelTest {
     fun `standalone route replaces stop focus and is restored`() = runTest {
         val handle = SavedStateHandle()
         val vm = viewModel(savedState = handle)
-        vm.onStopFocused(FocusedStop("stop", "Main St", "100", 47.6, -122.3))
+        vm.onStopFocused(FocusedStop("stop", "Main St", "100", GeoPoint(47.6, -122.3)))
 
         vm.focusStandaloneRoute(ShowRouteRequest("65", initialDirectionId = 1))
 
@@ -644,7 +644,7 @@ class HomeViewModelTest {
         val map = MapDirectiveRecorder(vm)
         val job = launch { map.collect() }
         advanceUntilIdle()
-        vm.onStopFocused(FocusedStop("1", "Main St", "100", 47.6, -122.3))
+        vm.onStopFocused(FocusedStop("1", "Main St", "100", GeoPoint(47.6, -122.3)))
 
         vm.unfocusMapOneLevel()
         advanceUntilIdle()
@@ -668,7 +668,7 @@ class HomeViewModelTest {
             FocusedTrip("trip-40", "40", "shape-40-express", 0xFF112233.toInt()),
             FocusedTrip("trip-44", "44", "shape-44-local", null),
         )
-        vm.onStopFocused(FocusedStop("1", "Main St", "100", 47.6, -122.3))
+        vm.onStopFocused(FocusedStop("1", "Main St", "100", GeoPoint(47.6, -122.3)))
         advanceUntilIdle()
         map.sent.clear()
         vm.onArrivalsLoaded(obaStop, null, trips)
@@ -686,7 +686,7 @@ class HomeViewModelTest {
         val map = MapDirectiveRecorder(vm)
         val job = launch { map.collect() }
         advanceUntilIdle()
-        vm.onStopFocused(FocusedStop("1", "Main St", "100", 47.6, -122.3))
+        vm.onStopFocused(FocusedStop("1", "Main St", "100", GeoPoint(47.6, -122.3)))
         advanceUntilIdle()
         map.sent.clear()
         vm.markPendingMapFocus()
@@ -708,13 +708,13 @@ class HomeViewModelTest {
         val map = MapDirectiveRecorder(vm)
         val job = launch { map.collect() }
         advanceUntilIdle()
-        vm.onStopFocused(FocusedStop("1", "Main St", "100", 47.6, -122.3))
+        vm.onStopFocused(FocusedStop("1", "Main St", "100", GeoPoint(47.6, -122.3)))
         advanceUntilIdle()
         map.sent.clear()
         vm.onArrivalsLoaded(obaStop, null, setOf(FocusedTrip("trip", "40", "shape", null)))
         assertTrue(vm.focusedTrips.isNotEmpty())
 
-        vm.onStopFocused(FocusedStop("2", "2nd Ave", "200", 47.6, -122.3))
+        vm.onStopFocused(FocusedStop("2", "2nd Ave", "200", GeoPoint(47.6, -122.3)))
         advanceUntilIdle()
         assertEquals(emptySet<FocusedTrip>(), vm.focusedTrips)
         assertEquals(1, map.clearStopRoutesCount)
@@ -727,7 +727,7 @@ class HomeViewModelTest {
         val map = MapDirectiveRecorder(vm)
         val job = launch { map.collect() }
         advanceUntilIdle()
-        vm.onStopFocused(FocusedStop("1", "Main St", "100", 47.6, -122.3))
+        vm.onStopFocused(FocusedStop("1", "Main St", "100", GeoPoint(47.6, -122.3)))
         vm.onArrivalsLoaded(
             obaStop,
             null,
@@ -737,7 +737,7 @@ class HomeViewModelTest {
         map.sent.clear()
 
         val transition = vm.onStopFocused(
-            FocusedStop("2", "2nd Ave", "200", 47.61, -122.31),
+            FocusedStop("2", "2nd Ave", "200", GeoPoint(47.61, -122.31)),
             continuingRoutes = setOf(RouteDirectionKey("40", null)),
         )
         advanceUntilIdle()
@@ -755,7 +755,7 @@ class HomeViewModelTest {
         val map = MapDirectiveRecorder(vm)
         val job = launch { map.collect() }
         advanceUntilIdle()
-        vm.onStopFocused(FocusedStop("1", "Main St", "100", 47.6, -122.3))
+        vm.onStopFocused(FocusedStop("1", "Main St", "100", GeoPoint(47.6, -122.3)))
         vm.onArrivalsLoaded(
             obaStop,
             null,
@@ -768,7 +768,7 @@ class HomeViewModelTest {
         map.sent.clear()
 
         val transition = vm.onStopFocused(
-            FocusedStop("2", "2nd Ave", "200", 47.61, -122.31),
+            FocusedStop("2", "2nd Ave", "200", GeoPoint(47.61, -122.31)),
             continuingRoutes = setOf(RouteDirectionKey("44", null)),
         )
         advanceUntilIdle()
@@ -784,7 +784,7 @@ class HomeViewModelTest {
         val map = MapDirectiveRecorder(vm)
         val job = launch { map.collect() }
         advanceUntilIdle()
-        vm.onStopFocused(FocusedStop("1", "Main St", "100", 47.6, -122.3))
+        vm.onStopFocused(FocusedStop("1", "Main St", "100", GeoPoint(47.6, -122.3)))
         vm.onArrivalsLoaded(
             obaStop,
             null,
@@ -798,7 +798,7 @@ class HomeViewModelTest {
         val selection = (vm.currentFocus.value as CurrentFocus.Stop).selectedRoute
         map.sent.clear()
 
-        val nextStop = FocusedStop("2", "2nd Ave", "200", 47.61, -122.31)
+        val nextStop = FocusedStop("2", "2nd Ave", "200", GeoPoint(47.61, -122.31))
         val transition = vm.onStopFocused(
             nextStop,
             continuingRoutes = setOf(RouteDirectionKey("79", 0)),
@@ -828,7 +828,7 @@ class HomeViewModelTest {
         val map = MapDirectiveRecorder(vm)
         val job = launch { map.collect() }
         advanceUntilIdle()
-        vm.onStopFocused(FocusedStop("1", "Main St", "100", 47.6, -122.3))
+        vm.onStopFocused(FocusedStop("1", "Main St", "100", GeoPoint(47.6, -122.3)))
         vm.onArrivalsLoaded(
             obaStop,
             null,
@@ -843,7 +843,7 @@ class HomeViewModelTest {
         map.sent.clear()
 
         val transition = vm.onStopFocused(
-            FocusedStop("2", "2nd Ave", "200", 47.61, -122.31),
+            FocusedStop("2", "2nd Ave", "200", GeoPoint(47.61, -122.31)),
             continuingRoutes = setOf(RouteDirectionKey("11", 1)),
         )
         advanceUntilIdle()
@@ -860,7 +860,7 @@ class HomeViewModelTest {
         val map = MapDirectiveRecorder(vm)
         val job = launch { map.collect() }
         advanceUntilIdle()
-        vm.onStopFocused(FocusedStop("1", "Main St", "100", 47.6, -122.3))
+        vm.onStopFocused(FocusedStop("1", "Main St", "100", GeoPoint(47.6, -122.3)))
         vm.onArrivalsLoaded(
             obaStop,
             null,
@@ -875,7 +875,7 @@ class HomeViewModelTest {
         advanceUntilIdle()
         map.sent.clear()
 
-        val nextStop = FocusedStop("2", "2nd Ave", "200", 47.61, -122.31)
+        val nextStop = FocusedStop("2", "2nd Ave", "200", GeoPoint(47.61, -122.31))
         val transition = vm.onStopFocused(
             nextStop,
             continuingRoutes = setOf(RouteDirectionKey("75", 1)),
@@ -896,7 +896,7 @@ class HomeViewModelTest {
         val map = MapDirectiveRecorder(vm)
         val job = launch { map.collect() }
         advanceUntilIdle()
-        vm.onStopFocused(FocusedStop("1", "Main St", "100", 47.6, -122.3))
+        vm.onStopFocused(FocusedStop("1", "Main St", "100", GeoPoint(47.6, -122.3)))
         vm.onArrivalsLoaded(
             obaStop,
             null,
@@ -909,7 +909,7 @@ class HomeViewModelTest {
         map.sent.clear()
 
         val transition = vm.onStopFocused(
-            FocusedStop("2", "2nd Ave", "200", 47.61, -122.31),
+            FocusedStop("2", "2nd Ave", "200", GeoPoint(47.61, -122.31)),
             continuingRoutes = setOf(RouteDirectionKey("62", null)),
         )
         advanceUntilIdle()
@@ -922,7 +922,7 @@ class HomeViewModelTest {
     @Test
     fun `map unfocus resets exact trips`() = runTest {
         val vm = viewModel()
-        vm.onStopFocused(FocusedStop("1", "Main St", "100", 47.6, -122.3))
+        vm.onStopFocused(FocusedStop("1", "Main St", "100", GeoPoint(47.6, -122.3)))
         vm.onArrivalsLoaded(obaStop, null, setOf(FocusedTrip("trip", "40", "shape", null)))
         assertTrue(vm.focusedTrips.isNotEmpty())
 
@@ -936,7 +936,7 @@ class HomeViewModelTest {
         // for a standalone route empties it by construction (focusStandaloneRoute has no reset call),
         // and the same load re-scoped to a different stop id never leaks across.
         val vm = viewModel()
-        vm.onStopFocused(FocusedStop("1", "Main St", "100", 47.6, -122.3))
+        vm.onStopFocused(FocusedStop("1", "Main St", "100", GeoPoint(47.6, -122.3)))
         vm.onArrivalsLoaded(obaStop, null, setOf(FocusedTrip("trip", "40", "shape", null)))
         assertTrue(vm.focusedTrips.isNotEmpty())
 
@@ -949,7 +949,7 @@ class HomeViewModelTest {
     @Test
     fun `onStopFocused sets the focused stop`() = runTest {
         val vm = viewModel()
-        val stop = FocusedStop("1", "Main St", "100", 47.6, -122.3)
+        val stop = FocusedStop("1", "Main St", "100", GeoPoint(47.6, -122.3))
         vm.onStopFocused(stop)
         assertEquals(stop, vm.currentFocus.value.focusedStop)
     }
@@ -959,14 +959,14 @@ class HomeViewModelTest {
         val vm = viewModel()
         vm.onBikeStationFocused("bike-7")
         assertEquals("bike-7", vm.currentFocus.value.focusedBikeStationId)
-        vm.onStopFocused(FocusedStop("1", null, null, 1.0, 2.0))
+        vm.onStopFocused(FocusedStop("1", null, null, GeoPoint(1.0, 2.0)))
         assertNull(vm.currentFocus.value.focusedBikeStationId)
     }
 
     @Test
     fun `focused stop is restored from SavedStateHandle on recreation`() = runTest {
         val handle = SavedStateHandle()
-        val stop = FocusedStop("42", "Pike St", "577", 47.61, -122.34)
+        val stop = FocusedStop("42", "Pike St", "577", GeoPoint(47.61, -122.34))
         viewModel(savedState = handle).onStopFocused(stop)
         // A fresh ViewModel over the same handle simulates process-death recreation.
         assertEquals(stop, viewModel(savedState = handle).currentFocus.value.focusedStop)
@@ -1074,7 +1074,7 @@ class HomeViewModelTest {
     @Test
     fun `reportTarget is the focused stop when one is focused`() {
         val vm = viewModel()
-        val stop = FocusedStop("1_123", "Main St & 1st", "123", 47.6, -122.3)
+        val stop = FocusedStop("1_123", "Main St & 1st", "123", GeoPoint(47.6, -122.3))
         vm.onStopFocused(stop)
 
         assertEquals(ReportTarget.Stop(stop), vm.reportTarget())

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/map/MapStopsBannerTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/map/MapStopsBannerTest.kt
@@ -20,10 +20,11 @@ import org.junit.Test
 import org.onebusaway.android.map.StopsBanner
 import org.onebusaway.android.ui.home.CurrentFocus
 import org.onebusaway.android.ui.home.FocusedStop
+import org.onebusaway.android.util.GeoPoint
 
 class MapStopsBannerTest {
 
-    private val stopFocus = CurrentFocus.Stop(FocusedStop("stop", null, null, 0.0, 0.0))
+    private val stopFocus = CurrentFocus.Stop(FocusedStop("stop", null, null, GeoPoint(0.0, 0.0)))
 
     @Test
     fun `stop focus hides the zoom-in banner`() {


### PR DESCRIPTION
Closes #1949.

> [!IMPORTANT]
> **Stacked on #1948** — base branch is `geopoint-reform-1944`, not `main`. Review/merge #1948 first; I'll rebase this onto `main` once it lands (the diff below is only this change's commit).

## What

Follow-up to the GeoPoint reform. #1948 standardized the loose `(lat, lon)` data-class *carriers* on `GeoPoint`, but deliberately stopped short of the type they all cluster around: **`FocusedStop`**, which still modeled position as two bare `Double`s. That left a ring of wrap/unwrap churn around it.

This replaces `FocusedStop.lat`/`lon` with a single `point: GeoPoint`, so the carriers speak `GeoPoint` end-to-end:

- **`HomeViewModel`** emits `RecenterOnFocusedStop(it.point)` — was re-wrapping `GeoPoint(it.lat, it.lon)`.
- **`HomeNavHost`** builds the stop straight from `reveal.point` — was unwrapping it into `FocusedStop(..., reveal.point.latitude, reveal.point.longitude)`.
- **`ReportTarget.Stop`** now sits consistently beside its `ReportTarget.Location(point: GeoPoint)` sibling.

## Boundaries kept (intentional)

The sites that read/write a genuine boundary keep their conversion there — only the in-memory type changed, the wire/persistence keys are untouched:
- `HomeActivity.fromIntent` — from Intent extras (`CENTER_LAT`/`LON`)
- `CurrentFocusPersistence` — the persisted `home.focusedStop.lat`/`lon` keys
- `ReportLauncher.start(..., lat, lon)` — Intent-extras launch (still unwraps `it.point.latitude/longitude`)

## Verification
- `compileObaGoogleDebugKotlin` + `compileObaMaplibreDebugKotlin` + both test source sets compile with `-PwarningsAsErrors=true`.
- Full `testObaGoogleDebugUnitTest` (JVM) suite passes (the ~48 `FocusedStop(...)` test constructions were updated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved consistency when selecting, restoring, and reporting a focused stop’s map location.
  * Preserved focused-stop locations more reliably across navigation and app state restoration.
* **Tests**
  * Updated coverage for map focus, stop selection, saved state restoration, and reporting workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->