### PR TITLE
Rework the directions results sheet: scrollable picker, collapsible drawer, richer option cards

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/OTPConstants.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/OTPConstants.kt
@@ -50,8 +50,6 @@ object OTPConstants {
 
     const val TRIP_RESULTS_TIME_STRING_FORMAT = "MMMM dd '%s' hh:mm a"
 
-    const val TRIP_RESULTS_TIME_STRING_FORMAT_SUMMARY = "hh:mma"
-
     const val ITINERARIES = "org.onebusaway.android.Itineraries"
 
     const val SELECTED_ITINERARY = "org.onebusaway.android.SELECTED_ITINERARY"

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/DragHandle.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/DragHandle.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.compose.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.unit.dp
+import org.onebusaway.android.R
+
+// The drag handle's geometry — the visible bar plus the vertical padding above and below it. Shared by
+// every bottom-sheet grab bar (the arrivals sheet, the directions sheet) and their peek-height math, so
+// the handles can't drift apart.
+val DRAG_HANDLE_BAR_HEIGHT = 4.dp
+val DRAG_HANDLE_VERTICAL_PADDING = 9.dp
+val DRAG_HANDLE_HEIGHT = DRAG_HANDLE_BAR_HEIGHT + DRAG_HANDLE_VERTICAL_PADDING * 2
+
+/**
+ * The short tinted grab-bar pill drawn inside a bottom-sheet drag handle — a muted grey matching the
+ * panel chrome, so it reads as part of the sheet. Callers wrap it in their own padded, gesture-bearing
+ * (tap and/or drag) box.
+ */
+@Composable
+fun DragHandleBar(modifier: Modifier = Modifier) {
+    Surface(
+        modifier = modifier,
+        color = colorResource(R.color.navdrawer_icon_tint),
+        shape = RoundedCornerShape(percent = 50),
+    ) {
+        Box(Modifier.size(width = 32.dp, height = DRAG_HANDLE_BAR_HEIGHT))
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/EtaDurationText.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/EtaDurationText.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.compose.components
+
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.sp
+import org.onebusaway.android.util.DisplayFormat
+
+/**
+ * A duration rendered exactly like the arrivals ETA pill — a bold number with a smaller unit
+ * abbreviation ("32 min", "1 hr 30 min") — reusing the ETA pill's own formatter
+ * ([DisplayFormat.formatEtaParts]) so the two can't diverge. For a trip length, pass the whole-minute
+ * duration.
+ */
+@Composable
+fun EtaDurationText(
+    minutes: Long,
+    modifier: Modifier = Modifier,
+    numberSize: TextUnit = 15.sp,
+    unitSize: TextUnit = 12.sp,
+) {
+    val baseSpan = LocalTextStyle.current.toSpanStyle()
+    val text = buildAnnotatedString {
+        DisplayFormat.formatEtaParts(LocalContext.current, minutes).forEach { part ->
+            val span = if (part.emphasized) {
+                baseSpan.copy(fontSize = numberSize, fontWeight = FontWeight.Bold)
+            } else {
+                baseSpan.copy(fontSize = unitSize)
+            }
+            withStyle(span) { append(part.text) }
+        }
+    }
+    Text(text = text, modifier = modifier)
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/RouteBadgeChip.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/RouteBadgeChip.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.compose.components
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+
+/**
+ * A small route roundel — the route's short name on a chip tinted from its GTFS color (via
+ * [rememberRouteBadgeColors]), or a neutral chip when the route has no color. The compact form used
+ * where several routes sit in a row (the stop-focus header's subordinate routes, the trip-plan option
+ * cards), as opposed to the large square [LineBadge].
+ */
+@Composable
+fun RouteBadgeChip(shortName: String, routeColor: Int?, modifier: Modifier = Modifier) {
+    val (container, content) = rememberRouteBadgeColors(routeColor)
+    Surface(
+        modifier = modifier,
+        color = container,
+        contentColor = content,
+        shape = RoundedCornerShape(1.dp),
+    ) {
+        Text(
+            text = shortName,
+            style = MaterialTheme.typography.labelMedium,
+            fontWeight = FontWeight.Bold,
+            maxLines = 1,
+            modifier = Modifier.padding(horizontal = 3.dp, vertical = 1.dp),
+        )
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -26,8 +26,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.statusBarsPadding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.BottomSheetScaffold
 import androidx.compose.material3.DrawerState
 import androidx.compose.material3.DrawerValue
@@ -40,7 +38,6 @@ import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
-import androidx.compose.material3.Surface
 import androidx.compose.material3.rememberBottomSheetScaffoldState
 import androidx.compose.material3.rememberDrawerState
 import androidx.compose.material3.rememberStandardBottomSheetState
@@ -63,7 +60,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalWindowInfo
-import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
@@ -76,6 +72,9 @@ import org.onebusaway.android.map.MapViewModel
 import org.onebusaway.android.map.render.GeoPoint
 import org.onebusaway.android.ui.arrivals.ArrivalsViewModel
 import org.onebusaway.android.ui.compose.ListUiState
+import org.onebusaway.android.ui.compose.components.DRAG_HANDLE_HEIGHT
+import org.onebusaway.android.ui.compose.components.DRAG_HANDLE_VERTICAL_PADDING
+import org.onebusaway.android.ui.compose.components.DragHandleBar
 import org.onebusaway.android.ui.compose.findActivity
 import org.onebusaway.android.ui.compose.navigationBarBottomPadding
 import org.onebusaway.android.ui.compose.theme.ObaTheme
@@ -909,13 +908,6 @@ private fun SheetValue.toArrivalsSheetState() = when (this) {
     SheetValue.Expanded -> ArrivalsSheetState.Expanded
 }
 
-// The custom drag handle's geometry — the visible bar plus the vertical padding above and below it.
-// Shared by [ArrivalsDragHandle] (what it draws) and the peek-height math (how much room it needs), so
-// the two can't drift apart.
-private val DRAG_HANDLE_BAR_HEIGHT = 4.dp
-private val DRAG_HANDLE_VERTICAL_PADDING = 9.dp
-private val DRAG_HANDLE_HEIGHT = DRAG_HANDLE_BAR_HEIGHT + DRAG_HANDLE_VERTICAL_PADDING * 2
-
 // The collapsed drawer peek is capped at this fraction of the screen height (short stops shrink to
 // fit their content below it). A starting value to tune by eye.
 private const val PEEK_HEIGHT_FRACTION = 0.30f
@@ -939,13 +931,7 @@ private fun ArrivalsDragHandle(onToggle: () -> Unit, modifier: Modifier = Modifi
             .padding(horizontal = 24.dp, vertical = DRAG_HANDLE_VERTICAL_PADDING),
         contentAlignment = Alignment.Center,
     ) {
-        Surface(
-            // Same muted grey as the header's icon tint, so the handle matches the panel chrome.
-            color = colorResource(R.color.navdrawer_icon_tint),
-            shape = RoundedCornerShape(percent = 50),
-        ) {
-            Box(Modifier.size(width = 32.dp, height = DRAG_HANDLE_BAR_HEIGHT))
-        }
+        DragHandleBar()
     }
 }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
@@ -62,6 +62,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
@@ -283,6 +284,9 @@ fun DirectionsResultsSheet(
 /** The drag handle atop [DirectionsResultsSheet]: tap toggles collapse; drag up/down sets it. */
 @Composable
 private fun DirectionsSheetHandle(collapsed: Boolean, onSetCollapsed: (Boolean) -> Unit) {
+    // draggable() reports per-frame deltas, so accumulate them — a slow drag would never cross the
+    // threshold on any single frame. Reset once a threshold crossing snaps the sheet, and at drag end.
+    var dragAccumulated by remember { mutableFloatStateOf(0f) }
     Box(
         modifier = Modifier
             .fillMaxWidth()
@@ -290,9 +294,16 @@ private fun DirectionsSheetHandle(collapsed: Boolean, onSetCollapsed: (Boolean) 
             .draggable(
                 orientation = Orientation.Vertical,
                 state = rememberDraggableState { delta ->
-                    if (delta > DIRECTIONS_SHEET_DRAG_THRESHOLD) onSetCollapsed(true)
-                    else if (delta < -DIRECTIONS_SHEET_DRAG_THRESHOLD) onSetCollapsed(false)
+                    dragAccumulated += delta
+                    if (dragAccumulated > DIRECTIONS_SHEET_DRAG_THRESHOLD) {
+                        onSetCollapsed(true)
+                        dragAccumulated = 0f
+                    } else if (dragAccumulated < -DIRECTIONS_SHEET_DRAG_THRESHOLD) {
+                        onSetCollapsed(false)
+                        dragAccumulated = 0f
+                    }
                 },
+                onDragStopped = { dragAccumulated = 0f },
             )
             .padding(vertical = DRAG_HANDLE_VERTICAL_PADDING),
         contentAlignment = Alignment.Center,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
@@ -19,13 +19,18 @@ import android.content.Context
 import android.text.format.DateFormat
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.draggable
+import androidx.compose.foundation.gestures.rememberDraggableState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
@@ -58,6 +63,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -80,8 +86,12 @@ import org.onebusaway.android.R
 import org.onebusaway.android.app.di.LocationEntryPoint
 import org.onebusaway.android.directions.model.TripItinerary
 import org.onebusaway.android.directions.util.ConversionUtils
+import org.onebusaway.android.ui.compose.components.DRAG_HANDLE_HEIGHT
+import org.onebusaway.android.ui.compose.components.DRAG_HANDLE_VERTICAL_PADDING
+import org.onebusaway.android.ui.compose.components.DragHandleBar
 import org.onebusaway.android.ui.compose.components.SwitchRow
 import org.onebusaway.android.ui.compose.findActivity
+import org.onebusaway.android.ui.compose.navigationBarBottomPadding
 import org.onebusaway.android.ui.tripplan.AdvancedSettings
 import org.onebusaway.android.ui.tripplan.TripEndpoint
 import org.onebusaway.android.ui.tripplan.TripModes
@@ -221,7 +231,17 @@ private fun pickTripTime(activity: AppCompatActivity, viewModel: TripPlanViewMod
     picker.show(activity.supportFragmentManager, "TIME_PICKER")
 }
 
-/** The bottom directions sheet: option cards + the step-by-step list, over the map. */
+/** Collapsed height of the directions sheet content — just the drag handle peeking above the map. */
+private val DIRECTIONS_SHEET_PEEK = DRAG_HANDLE_HEIGHT
+
+/** Net drag (px per gesture event) on the handle past which the sheet snaps collapsed/expanded. */
+private const val DIRECTIONS_SHEET_DRAG_THRESHOLD = 8f
+
+/**
+ * The bottom directions sheet: option cards + the step-by-step list, over the map. Collapsible via the
+ * drag handle at its top — tap or drag it down to collapse to just the handle (revealing the map), up to
+ * restore the full ~40%-height sheet.
+ */
 @Composable
 fun DirectionsResultsSheet(
     resultsViewModel: TripResultsViewModel,
@@ -230,21 +250,54 @@ fun DirectionsResultsSheet(
     showItinerary: (TripItinerary) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val height = (LocalConfiguration.current.screenHeightDp * 0.4f).dp
+    // The system nav-bar inset: the surface reaches the bottom edge (continuous background), but its
+    // content is padded above the nav chrome so the collapsed handle (and the last list row) aren't
+    // stranded under the gesture pill / 3-button bar. Collapsed height includes it so the handle fits.
+    val navBottom = navigationBarBottomPadding()
+    val fullHeight = (LocalConfiguration.current.screenHeightDp * 0.4f).dp
+    var collapsed by rememberSaveable { mutableStateOf(false) }
+    val sheetHeight by animateDpAsState(
+        targetValue = if (collapsed) DIRECTIONS_SHEET_PEEK + navBottom else fullHeight,
+        label = "directionsSheetHeight",
+    )
     Surface(
-        modifier = modifier.fillMaxWidth().heightIn(min = height, max = height),
+        modifier = modifier.fillMaxWidth().height(sheetHeight),
         shape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp),
         color = MaterialTheme.colorScheme.surface,
         tonalElevation = 2.dp,
         shadowElevation = 8.dp,
     ) {
-        TripResultsSheet(
-            itineraries = itineraries,
-            params = params,
-            resultsViewModel = resultsViewModel,
-            showItinerary = showItinerary,
-            modifier = Modifier.fillMaxWidth(),
-        )
+        Column(Modifier.fillMaxWidth().navigationBarsPadding()) {
+            DirectionsSheetHandle(collapsed = collapsed, onSetCollapsed = { collapsed = it })
+            TripResultsSheet(
+                itineraries = itineraries,
+                params = params,
+                resultsViewModel = resultsViewModel,
+                showItinerary = showItinerary,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+    }
+}
+
+/** The drag handle atop [DirectionsResultsSheet]: tap toggles collapse; drag up/down sets it. */
+@Composable
+private fun DirectionsSheetHandle(collapsed: Boolean, onSetCollapsed: (Boolean) -> Unit) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onSetCollapsed(!collapsed) }
+            .draggable(
+                orientation = Orientation.Vertical,
+                state = rememberDraggableState { delta ->
+                    if (delta > DIRECTIONS_SHEET_DRAG_THRESHOLD) onSetCollapsed(true)
+                    else if (delta < -DIRECTIONS_SHEET_DRAG_THRESHOLD) onSetCollapsed(false)
+                },
+            )
+            .padding(vertical = DRAG_HANDLE_VERTICAL_PADDING),
+        contentAlignment = Alignment.Center,
+    ) {
+        DragHandleBar()
     }
 }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/FocusBanner.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/FocusBanner.kt
@@ -66,6 +66,7 @@ import org.onebusaway.android.models.RouteMapDirection
 import org.onebusaway.android.ui.compose.components.DirectionHeadsign
 import org.onebusaway.android.ui.compose.components.LineBadge
 import org.onebusaway.android.ui.compose.components.RadioOptionList
+import org.onebusaway.android.ui.compose.components.RouteBadgeChip
 import org.onebusaway.android.ui.compose.components.rememberRouteBadgeColors
 import org.onebusaway.android.ui.compose.theme.ObaTheme
 
@@ -281,20 +282,7 @@ private fun StopFocusBanner(
 /** A deliberately tiny route chip: only enough padding to distinguish the route from its headsign. */
 @Composable
 private fun CompactRouteBadge(route: FocusBannerState.SubordinateRoute) {
-    val (container, content) = rememberRouteBadgeColors(route.color)
-    Surface(
-        color = container,
-        contentColor = content,
-        shape = RoundedCornerShape(1.dp),
-    ) {
-        Text(
-            text = route.shortName,
-            style = MaterialTheme.typography.labelSmall,
-            fontWeight = FontWeight.Bold,
-            maxLines = 1,
-            modifier = Modifier.padding(horizontal = 3.dp, vertical = 1.dp),
-        )
-    }
+    RouteBadgeChip(shortName = route.shortName, routeColor = route.color)
 }
 
 /** The nested-route dismiss affordance keeps its visible 22dp size as its exact clickable bounds. */

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsRepository.kt
@@ -74,8 +74,8 @@ class DefaultTripResultsRepository @Inject constructor(@param:ApplicationContext
         return ItineraryOption(
             mode = mode,
             durationMinutes = itinerary.duration.inWholeMinutes,
-            startTimeMs = itinerary.startTime.epochMs,
-            endTimeMs = (itinerary.startTime + itinerary.duration).epochMs,
+            startTime = itinerary.startTime,
+            endTime = itinerary.startTime + itinerary.duration,
         )
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsRepository.kt
@@ -18,27 +18,25 @@ package org.onebusaway.android.ui.tripresults
 import android.content.Context
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
-import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.Locale
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.onebusaway.android.directions.model.Direction
 import org.onebusaway.android.directions.model.TripItinerary
-import org.onebusaway.android.directions.util.ConversionUtils
+import org.onebusaway.android.directions.model.TripLeg
+import org.onebusaway.android.directions.model.TripMode
 import org.onebusaway.android.directions.util.DirectionsGenerator
-import org.onebusaway.android.directions.util.OTPConstants
+import org.onebusaway.android.util.parseObaHexColor
 import org.onebusaway.android.util.runCatchingCancellable
 
 /**
- * Projects [TripItinerary] objects onto the Compose results model. Reuses the legacy
- * [DirectionsGenerator]/[ConversionUtils] (which need a [Context] for resources/formatting) and the
- * card interval formatting ported from the old TripResultsFragment, all on the IO thread so
- * [TripResultsViewModel] stays JVM-testable.
+ * Projects [TripItinerary] objects onto the Compose results model. The turn-by-turn directions reuse
+ * the legacy [DirectionsGenerator] (which needs a [Context] for resources), and the option cards carry
+ * structured data (route badges / walk / duration / time range) formatted by the UI. All on the IO
+ * thread so [TripResultsViewModel] stays JVM-testable.
  */
 interface TripResultsRepository {
 
-    /** Summarizes each itinerary into an option card (title, duration, time interval). */
+    /** Summarizes each itinerary into an option card ([ItineraryOption]). */
     suspend fun summarize(itineraries: List<TripItinerary>): Result<List<ItineraryOption>>
 
     /** Builds the turn-by-turn directions for a single itinerary. */
@@ -51,17 +49,39 @@ class DefaultTripResultsRepository @Inject constructor(@param:ApplicationContext
         itineraries: List<TripItinerary>
     ): Result<List<ItineraryOption>> = withContext(Dispatchers.IO) {
         runCatchingCancellable {
-            itineraries.map { itinerary ->
-                val durationSec = itinerary.duration.inWholeSeconds
-                ItineraryOption(
-                    title = DirectionsGenerator(itinerary.legs, context).itineraryTitle,
-                    durationText = ConversionUtils
-                        .getFormattedDurationTextNoSeconds(durationSec, false, context),
-                    intervalText = formatTimeString(itinerary.startTime.epochMs, durationSec * 1000)
-                )
-            }
+            itineraries.map { itinerary -> summarize(itinerary) }
         }
     }
+
+    /** Projects one [TripItinerary] into the structured [ItineraryOption] the card renders. */
+    private fun summarize(itinerary: TripItinerary): ItineraryOption {
+        val transitLegs = itinerary.legs.filter { it.mode?.isTransit == true }
+        // A transit trip shows route badges; a walk-only trip shows the walk glyph; anything else
+        // (bike/car) keeps the legacy mode-label title.
+        val mode = when {
+            transitLegs.isNotEmpty() -> ModeSummary.Routes(
+                transitLegs.map { leg ->
+                    RouteBadge(
+                        shortName = leg.badgeShortName(),
+                        // routeColor is a bare wire hex; tolerate a leading '#' just in case.
+                        routeColor = parseObaHexColor(leg.routeColor?.removePrefix("#")),
+                    )
+                }
+            )
+            itinerary.legs.all { it.mode == TripMode.WALK } -> ModeSummary.Walk
+            else -> ModeSummary.Label(DirectionsGenerator(itinerary.legs, context).itineraryTitle)
+        }
+        return ItineraryOption(
+            mode = mode,
+            durationMinutes = itinerary.duration.inWholeMinutes,
+            startTimeMs = itinerary.startTime.epochMs,
+            endTimeMs = (itinerary.startTime + itinerary.duration).epochMs,
+        )
+    }
+
+    /** The route's display short name (short name, else the route, else the id). */
+    private fun TripLeg.badgeShortName(): String =
+        listOf(routeShortName, route, routeId).firstOrNull { !it.isNullOrEmpty() }.orEmpty()
 
     override suspend fun directionsFor(
         itinerary: TripItinerary
@@ -101,14 +121,4 @@ class DefaultTripResultsRepository @Inject constructor(@param:ApplicationContext
         }.orEmpty()
 
     private fun CharSequence?.orEmptyString(): String = this?.toString().orEmpty()
-
-    // Ported verbatim from the legacy TripResultsFragment (e.g. "3:45p - 4:30p").
-    private fun formatTimeString(startMs: Long, durationMs: Long): String =
-        "${toDateFmt(startMs)} - ${toDateFmt(startMs + durationMs)}"
-
-    private fun toDateFmt(ms: Long): String {
-        val s = SimpleDateFormat(OTPConstants.TRIP_RESULTS_TIME_STRING_FORMAT_SUMMARY, Locale.getDefault())
-            .format(Date(ms))
-        return s.substring(0, 6).lowercase()
-    }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
@@ -66,6 +66,7 @@ import android.content.Context
 import android.os.Build
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import org.onebusaway.android.R
+import org.onebusaway.android.time.ServerTime
 import org.onebusaway.android.notifications.NotificationChannels
 import org.onebusaway.android.app.di.PreferencesEntryPoint
 import org.onebusaway.android.directions.model.TripItinerary
@@ -166,10 +167,10 @@ private fun OptionCard(
                 )
                 EtaDurationText(minutes = option.durationMinutes)
             }
-            // The device-localized departure–arrival range.
+            // The device-localized departure–arrival range (unwrap the server clock only here).
             Text(
-                text = "${DisplayFormat.formatTime(context, option.startTimeMs)} – " +
-                    DisplayFormat.formatTime(context, option.endTimeMs),
+                text = "${DisplayFormat.formatTime(context, option.startTime.epochMs)} – " +
+                    DisplayFormat.formatTime(context, option.endTime.epochMs),
                 style = MaterialTheme.typography.bodySmall,
                 maxLines = 1,
             )
@@ -395,11 +396,11 @@ private fun TripResultsPreview() {
             options = listOf(
                 ItineraryOption(
                     mode = ModeSummary.Routes(listOf(RouteBadge("8", 0xFF1B6EF3.toInt()))),
-                    durationMinutes = 32, startTimeMs = 0L, endTimeMs = 32 * 60_000L,
+                    durationMinutes = 32, startTime = ServerTime(0L), endTime = ServerTime(32 * 60_000L),
                 ),
                 ItineraryOption(
                     mode = ModeSummary.Routes(listOf(RouteBadge("48", null), RouteBadge("11", null))),
-                    durationMinutes = 41, startTimeMs = 0L, endTimeMs = 41 * 60_000L,
+                    durationMinutes = 41, startTime = ServerTime(0L), endTime = ServerTime(41 * 60_000L),
                 )
             ),
             selectedIndex = 0,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
@@ -17,11 +17,12 @@ package org.onebusaway.android.ui.tripresults
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -29,6 +30,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.icons.Icons
@@ -51,10 +53,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -68,8 +70,11 @@ import org.onebusaway.android.notifications.NotificationChannels
 import org.onebusaway.android.app.di.PreferencesEntryPoint
 import org.onebusaway.android.directions.model.TripItinerary
 import org.onebusaway.android.directions.realtime.TripPlanMonitor
+import org.onebusaway.android.ui.compose.components.EtaDurationText
 import org.onebusaway.android.ui.compose.components.LoadingContent
+import org.onebusaway.android.ui.compose.components.RouteBadgeChip
 import org.onebusaway.android.ui.compose.findActivity
+import org.onebusaway.android.util.DisplayFormat
 import org.onebusaway.android.ui.compose.theme.ObaTheme
 import org.onebusaway.android.ui.tripplan.TripPlanParams
 
@@ -85,12 +90,15 @@ fun TripResultsHeader(
     onSelectOption: (Int) -> Unit
 ) {
     val success = state as? TripResultsUiState.Success ?: return
+    // Side-scrollable so options never get squished: each card sizes to its own content (three lines —
+    // route/lines, duration, time) and the row scrolls horizontally when they overflow the width.
     Row(
         modifier = Modifier
             .background(MaterialTheme.colorScheme.surface)
             .fillMaxWidth()
-            .padding(4.dp),
-        horizontalArrangement = Arrangement.spacedBy(2.dp)
+            .horizontalScroll(rememberScrollState())
+            .padding(horizontal = 8.dp, vertical = 6.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
     ) {
         success.options.forEachIndexed { index, option ->
             OptionCard(
@@ -103,7 +111,7 @@ fun TripResultsHeader(
 }
 
 @Composable
-private fun RowScope.OptionCard(
+private fun OptionCard(
     option: ItineraryOption,
     selected: Boolean,
     onClick: () -> Unit
@@ -114,23 +122,57 @@ private fun RowScope.OptionCard(
     val textColor = colorResource(
         if (selected) R.color.trip_plan_header_text_selected else R.color.trip_plan_header_text
     )
+    val context = LocalContext.current
     Surface(
         color = background,
+        contentColor = textColor,
         shape = MaterialTheme.shapes.small,
+        // Wrap to the content width (a sensible floor so short options aren't tiny); the row scrolls.
         modifier = Modifier
-            .weight(1f)
+            .widthIn(min = 104.dp)
             .clickable(onClick = onClick)
     ) {
-        Column(Modifier.padding(8.dp)) {
+        Column(
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            // The modes: transit route badges (no comma between), a walk glyph for a walk-only trip, or
+            // a mode label for other non-transit trips.
+            when (val mode = option.mode) {
+                is ModeSummary.Routes -> Row(horizontalArrangement = Arrangement.spacedBy(3.dp)) {
+                    mode.badges.forEach { RouteBadgeChip(it.shortName, it.routeColor) }
+                }
+                ModeSummary.Walk -> Icon(
+                    painterResource(R.drawable.ic_directions_walk),
+                    contentDescription = stringResource(R.string.step_by_step_non_transit_mode_walk_action),
+                    // Sized to the route-badge row height so a walk-only card's first line matches.
+                    modifier = Modifier.size(20.dp),
+                )
+                is ModeSummary.Label -> Text(
+                    text = mode.text,
+                    style = MaterialTheme.typography.titleMedium,
+                    maxLines = 1,
+                )
+            }
+            // Duration — a leading hourglass + the ETA-pill-formatted trip length.
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                Icon(
+                    painterResource(R.drawable.hourglass_24),
+                    contentDescription = null,
+                    modifier = Modifier.size(16.dp),
+                )
+                EtaDurationText(minutes = option.durationMinutes)
+            }
+            // The device-localized departure–arrival range.
             Text(
-                text = option.title,
-                style = MaterialTheme.typography.titleMedium,
-                color = textColor,
+                text = "${DisplayFormat.formatTime(context, option.startTimeMs)} – " +
+                    DisplayFormat.formatTime(context, option.endTimeMs),
+                style = MaterialTheme.typography.bodySmall,
                 maxLines = 1,
-                overflow = TextOverflow.Ellipsis
             )
-            Text(option.durationText, style = MaterialTheme.typography.bodyMedium, color = textColor)
-            Text(option.intervalText, style = MaterialTheme.typography.bodyMedium, color = textColor)
         }
     }
 }
@@ -351,8 +393,14 @@ private fun TripResultsPreview() {
     ObaTheme {
         val state = TripResultsUiState.Success(
             options = listOf(
-                ItineraryOption("Route 8", "32 min", "3:45p - 4:17p"),
-                ItineraryOption("Route 48", "41 min", "3:50p - 4:31p")
+                ItineraryOption(
+                    mode = ModeSummary.Routes(listOf(RouteBadge("8", 0xFF1B6EF3.toInt()))),
+                    durationMinutes = 32, startTimeMs = 0L, endTimeMs = 32 * 60_000L,
+                ),
+                ItineraryOption(
+                    mode = ModeSummary.Routes(listOf(RouteBadge("48", null), RouteBadge("11", null))),
+                    durationMinutes = 41, startTimeMs = 0L, endTimeMs = 41 * 60_000L,
+                )
             ),
             selectedIndex = 0,
             directions = listOf(

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
@@ -15,12 +15,35 @@
  */
 package org.onebusaway.android.ui.tripresults
 
-/** One of the (up to three) itinerary option cards shown above the directions. */
+/**
+ * One of the (up to three) itinerary option cards shown above the directions. Carries structured data
+ * (not pre-formatted strings) so the card can render route badges / a walk glyph, the ETA-pill duration,
+ * and a device-localized time range:
+ *  - [mode] — what the card's first line shows for the trip (route badges, a walk glyph, or a label).
+ *  - [durationMinutes] — whole-minute trip length, formatted like the arrivals ETA pill.
+ *  - [startTimeMs]/[endTimeMs] — epoch millis for the (device-localized) time range.
+ */
 data class ItineraryOption(
-    val title: String,
-    val durationText: String,
-    val intervalText: String
+    val mode: ModeSummary,
+    val durationMinutes: Long,
+    val startTimeMs: Long,
+    val endTimeMs: Long,
 )
+
+/** What an option card's first line shows for the trip's modes (mutually exclusive by construction). */
+sealed interface ModeSummary {
+    /** A transit trip: its legs' route roundels, in order. */
+    data class Routes(val badges: List<RouteBadge>) : ModeSummary
+
+    /** A walk-only trip — shown as a walk glyph. */
+    data object Walk : ModeSummary
+
+    /** Any other non-transit trip (bike/car), as the legacy mode-label title. */
+    data class Label(val text: String) : ModeSummary
+}
+
+/** A transit leg's route roundel data: its short name and (nullable) GTFS color as an ARGB int. */
+data class RouteBadge(val shortName: String, val routeColor: Int?)
 
 /**
  * One step in the directions list — a Compose-ready projection of the legacy [Direction] +

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
@@ -15,19 +15,21 @@
  */
 package org.onebusaway.android.ui.tripresults
 
+import org.onebusaway.android.time.ServerTime
+
 /**
  * One of the (up to three) itinerary option cards shown above the directions. Carries structured data
  * (not pre-formatted strings) so the card can render route badges / a walk glyph, the ETA-pill duration,
  * and a device-localized time range:
  *  - [mode] — what the card's first line shows for the trip (route badges, a walk glyph, or a label).
  *  - [durationMinutes] — whole-minute trip length, formatted like the arrivals ETA pill.
- *  - [startTimeMs]/[endTimeMs] — epoch millis for the (device-localized) time range.
+ *  - [startTime]/[endTime] — the server-clock trip endpoints, unwrapped only at the time formatter.
  */
 data class ItineraryOption(
     val mode: ModeSummary,
     val durationMinutes: Long,
-    val startTimeMs: Long,
-    val endTimeMs: Long,
+    val startTime: ServerTime,
+    val endTime: ServerTime,
 )
 
 /** What an option card's first line shows for the trip's modes (mutually exclusive by construction). */

--- a/onebusaway-android/src/main/res/drawable/hourglass_24.xml
+++ b/onebusaway-android/src/main/res/drawable/hourglass_24.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M6,2v6h0.01L6,8.01 10,12l-4,4 0.01,0.01H6V22h12v-5.99h-0.01L18,16l-4,-4 4,-3.99L17.99,8H18V2H6zM16,16.5V20H8v-3.5l4,-4 4,4zM12,11.5l-4,-4V4h8v3.5l-4,4z"/>
+</vector>

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/TripResultsViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/TripResultsViewModelTest.kt
@@ -35,8 +35,15 @@ class TripResultsViewModelTest {
     val mainDispatcherRule = MainDispatcherRule()
 
     private val options = listOf(
-        ItineraryOption("Route 8", "30 min", "3:00p - 3:30p"),
-        ItineraryOption("Route 48", "40 min", "3:00p - 3:40p")
+        option("8"),
+        option("48"),
+    )
+
+    private fun option(shortName: String) = ItineraryOption(
+        mode = ModeSummary.Routes(listOf(RouteBadge(shortName, routeColor = null))),
+        durationMinutes = 30,
+        startTimeMs = 0L,
+        endTimeMs = 30 * 60_000L,
     )
 
     /** Treats itineraries as opaque tokens (as the ViewModel does) and returns canned projections. */

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/TripResultsViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/TripResultsViewModelTest.kt
@@ -27,6 +27,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.onebusaway.android.testing.MainDispatcherRule
 import org.onebusaway.android.directions.model.TripItinerary
+import org.onebusaway.android.time.ServerTime
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class TripResultsViewModelTest {
@@ -42,8 +43,8 @@ class TripResultsViewModelTest {
     private fun option(shortName: String) = ItineraryOption(
         mode = ModeSummary.Routes(listOf(RouteBadge(shortName, routeColor = null))),
         durationMinutes = 30,
-        startTimeMs = 0L,
-        endTimeMs = 30 * 60_000L,
+        startTime = ServerTime(0L),
+        endTime = ServerTime(30 * 60_000L),
     )
 
     /** Treats itineraries as opaque tokens (as the ViewModel does) and returns canned projections. */


### PR DESCRIPTION
## What

Reworks the trip-plan **directions results sheet**, which previously stacked a crowded fixed row of option cards on top of a fixed-height list.

### Option picker
- Now **horizontally scrollable**; each card **sizes to its content** (no more equal-width squish).
- Cards carry **structured data** instead of pre-formatted strings, and render:
  - transit routes as **mini colour route badges** (no comma between), tinted from each route's GTFS colour;
  - a **walk glyph** for a walk-only trip; a mode label otherwise;
  - the trip length formatted **like the arrivals ETA pill**, with a leading **hourglass**;
  - a **device-localized** start–end time range (honours locale + 12/24h), replacing a hard-coded `hh:mma`.

### Directions drawer
- **Collapsible** via a drag handle (tap or drag) — animates between the full ~40% height and a handle-only peek to reveal the map.
- Content is padded **above the system nav bar** so the handle (and last list row) aren't stranded under the gesture pill / 3-button chrome.

### Shared pieces (extracted for reuse)
- `DragHandleBar` + `DRAG_HANDLE_*` geometry — shared by the arrivals and directions sheet handles so they can't drift apart.
- `RouteBadgeChip` — used by the option cards **and** the stop-focus header's subordinate-route chips (migrated to it).
- `EtaDurationText` — reuses the ETA pill's `DisplayFormat.formatEtaParts` formatter.

The card's first line is modelled as a sealed `ModeSummary { Routes | Walk | Label }` so the render is an exhaustive match with no invalid states.

## Notes / follow-ups (from a cleanup pass)
- The collapse handle's drag is a lightweight threshold-snap (drag past ~8px snaps collapsed/expanded), not a finger-tracking sheet — deliberately simple, avoids the `AnchoredDraggable` stranding we've hit before. Open to upgrading if desired.
- Two known dedups left as follow-ups (their proper fixes touch files outside this feature): `badgeShortName` re-derives `DirectionsGenerator.getTransitTitle`'s #662 short-name resolution; and `EtaDurationText` re-implements `etaAnnotatedString` (the right fix is to promote that mapper out of the arrivals package so both surfaces share it).

## Testing
- Compiles clean under strict `-PwarningsAsErrors` for **both** `obaGoogle` and `obaMaplibre`.
- `TripResultsViewModelTest` updated for the structured model and passes.
- Installed and exercised on a Pixel 7 Pro (scrollable picker, badge/walk/duration/time rendering, collapse handle above the nav bar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added collapsible, draggable directions and arrivals sheets.
  - Improved itinerary cards with route badges, walking indicators, duration, and localized time details.
  - Added reusable route badge, ETA duration, and drag-handle components.
  - Added an hourglass icon for trip-related displays.

- **Improvements**
  - Itinerary options are now horizontally scrollable and maintain readable card sizing.
  - Standardized route badge and drag-handle presentation across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->