### PR TITLE
Show total walking distance on each itinerary option card

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/ConversionUtils.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/ConversionUtils.kt
@@ -24,6 +24,7 @@ import android.util.Log
 import androidx.core.content.ContextCompat
 import org.onebusaway.android.R
 import org.onebusaway.android.util.ArrivalInfoUtils
+import org.onebusaway.android.util.DisplayFormat
 import org.onebusaway.android.util.PreferenceUtils
 import java.time.Duration
 import java.time.Instant
@@ -61,31 +62,45 @@ object ConversionUtils {
      * @return formatted string of distance
      */
     @JvmStatic
-    fun getFormattedDistance(meters: Double, applicationContext: Context): String {
-        var text = ""
-        var value = meters
+    fun getFormattedDistance(meters: Double, applicationContext: Context): String =
+        getFormattedDistanceParts(meters, applicationContext).joinToString(" ") { it.text }
 
-        if (PreferenceUtils.getUnitsAreMetricFromPreferences(applicationContext)) {
-            if (value < 1000) {
-                text += String.format(Locale.getDefault(), OTPConstants.FORMAT_DISTANCE_METERS, value) + " " +
-                    applicationContext.resources.getString(R.string.meters_abbreviation)
+    /**
+     * The same distance as [getFormattedDistance], but as its structured value + unit parts (mirroring
+     * [DisplayFormat.formatEtaParts]) so a caller that styles the number and unit differently — e.g. a
+     * bold value with a smaller unit — can do so without re-splitting a joined string. The value is the
+     * emphasized part, the unit abbreviation the un-emphasized one.
+     *
+     * @param meters distance in meters
+     * @param applicationContext context to look up resources
+     */
+    @JvmStatic
+    fun getFormattedDistanceParts(
+        meters: Double,
+        applicationContext: Context,
+    ): List<DisplayFormat.EtaPart> {
+        val (value, unitRes) = if (PreferenceUtils.getUnitsAreMetricFromPreferences(applicationContext)) {
+            if (meters < 1000) {
+                String.format(Locale.getDefault(), OTPConstants.FORMAT_DISTANCE_METERS, meters) to
+                    R.string.meters_abbreviation
             } else {
-                value /= 1000
-                text += String.format(Locale.getDefault(), OTPConstants.FORMAT_DISTANCE_KILOMETERS, value) + " " +
-                    applicationContext.resources.getString(R.string.kilometers_abbreviation)
+                String.format(Locale.getDefault(), OTPConstants.FORMAT_DISTANCE_KILOMETERS, meters / 1000) to
+                    R.string.kilometers_abbreviation
             }
         } else {
-            var feet = value * FEET_PER_METER
+            val feet = meters * FEET_PER_METER
             if (feet < 1000) {
-                text += String.format(Locale.getDefault(), OTPConstants.FORMAT_DISTANCE_METERS, feet) + " " +
-                    applicationContext.resources.getString(R.string.feet_abbreviation)
+                String.format(Locale.getDefault(), OTPConstants.FORMAT_DISTANCE_METERS, feet) to
+                    R.string.feet_abbreviation
             } else {
-                feet /= 5280
-                text += String.format(Locale.getDefault(), OTPConstants.FORMAT_DISTANCE_KILOMETERS, feet) + " " +
-                    applicationContext.resources.getString(R.string.miles_abbreviation)
+                String.format(Locale.getDefault(), OTPConstants.FORMAT_DISTANCE_KILOMETERS, feet / 5280) to
+                    R.string.miles_abbreviation
             }
         }
-        return text
+        return listOf(
+            DisplayFormat.EtaPart(value, emphasized = true),
+            DisplayFormat.EtaPart(applicationContext.resources.getString(unitRes), emphasized = false),
+        )
     }
 
     /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStrip.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStrip.kt
@@ -56,14 +56,10 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.PlatformTextStyle
 import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.LineHeightStyle
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import kotlin.math.roundToInt
@@ -76,6 +72,7 @@ import org.onebusaway.android.ui.arrivals.ArrivalInfo
 import org.onebusaway.android.ui.compose.components.CenteredLongPressMenu
 import org.onebusaway.android.ui.compose.components.MaterialSymbols
 import org.onebusaway.android.ui.compose.components.SlideBox
+import org.onebusaway.android.ui.compose.components.tightLineStyle
 import org.onebusaway.android.ui.compose.theme.ObaTheme
 import org.onebusaway.android.util.DisplayFormat
 
@@ -337,21 +334,6 @@ internal fun TripActionsMenu(
         }
     }
 }
-
-/**
- * [base] with Android's default font-metrics padding (extra ascent/descent space reserved beyond a
- * glyph's visible ink) trimmed to [size]'s true line height. Without this, every gap in a small
- * pill/badge — row-to-row, row-to-edge — is a function of opaque per-font-size padding instead of the
- * caller's own explicit spacing.
- */
-private fun tightLineStyle(base: TextStyle, size: TextUnit) = base.copy(
-    lineHeight = size,
-    platformStyle = PlatformTextStyle(includeFontPadding = false),
-    lineHeightStyle = LineHeightStyle(
-        alignment = LineHeightStyle.Alignment.Center,
-        trim = LineHeightStyle.Trim.Both
-    )
-)
 
 /**
  * The prominent white-on-lateness ETA pill — one per trip in a route row's strip (and the Home legend

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/EtaDurationText.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/EtaDurationText.kt
@@ -18,10 +18,14 @@ package org.onebusaway.android.ui.compose.components
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.PlatformTextStyle
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.LineHeightStyle
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.sp
@@ -40,9 +44,29 @@ fun EtaDurationText(
     numberSize: TextUnit = 15.sp,
     unitSize: TextUnit = 12.sp,
 ) {
-    val baseSpan = LocalTextStyle.current.toSpanStyle()
+    EtaPartsText(DisplayFormat.formatEtaParts(LocalContext.current, minutes), modifier, numberSize, unitSize)
+}
+
+/**
+ * Renders value/unit display [parts] as a bold value with a smaller unit abbreviation — the shared ETA
+ * styling, factored out of [EtaDurationText] so other value+unit cards (e.g. a trip's walk distance via
+ * [org.onebusaway.android.directions.util.ConversionUtils.getFormattedDistanceParts]) render identically
+ * without duplicating the span logic or the sizes.
+ */
+@Composable
+fun EtaPartsText(
+    parts: List<DisplayFormat.EtaPart>,
+    modifier: Modifier = Modifier,
+    numberSize: TextUnit = 15.sp,
+    unitSize: TextUnit = 12.sp,
+) {
+    // [tightLineStyle] trims the default font padding so a leading icon centers on the text and stacked
+    // rows sit tight; the spans layer the per-part sizes on top of that same base.
+    val base = LocalTextStyle.current
+    val style = remember(base) { tightLineStyle(base) }
+    val baseSpan = style.toSpanStyle()
     val text = buildAnnotatedString {
-        DisplayFormat.formatEtaParts(LocalContext.current, minutes).forEach { part ->
+        parts.forEach { part ->
             val span = if (part.emphasized) {
                 baseSpan.copy(fontSize = numberSize, fontWeight = FontWeight.Bold)
             } else {
@@ -51,5 +75,21 @@ fun EtaDurationText(
             withStyle(span) { append(part.text) }
         }
     }
-    Text(text = text, modifier = modifier)
+    Text(text = text, modifier = modifier, style = style)
 }
+
+/**
+ * [base] with Android's default font-metrics padding (extra ascent/descent space reserved beyond a
+ * glyph's visible ink) trimmed, so a leading icon centers on the text and stacked rows sit tight instead
+ * of being pushed apart by that padding. Pass [size] to also pin the line height to a small pill/badge's
+ * dominant text size; omit it to keep [base]'s own line height. Shared by the arrivals ETA pill
+ * ([org.onebusaway.android.ui.arrivals.components] EtaStrip) and [EtaPartsText].
+ */
+internal fun tightLineStyle(base: TextStyle, size: TextUnit = TextUnit.Unspecified): TextStyle = base.copy(
+    lineHeight = if (size == TextUnit.Unspecified) base.lineHeight else size,
+    platformStyle = PlatformTextStyle(includeFontPadding = false),
+    lineHeightStyle = LineHeightStyle(
+        alignment = LineHeightStyle.Alignment.Center,
+        trim = LineHeightStyle.Trim.Both,
+    ),
+)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsRepository.kt
@@ -31,8 +31,8 @@ import org.onebusaway.android.util.runCatchingCancellable
 /**
  * Projects [TripItinerary] objects onto the Compose results model. The turn-by-turn directions reuse
  * the legacy [DirectionsGenerator] (which needs a [Context] for resources), and the option cards carry
- * structured data (route badges / walk / duration / time range) formatted by the UI. All on the IO
- * thread so [TripResultsViewModel] stays JVM-testable.
+ * structured data (route badges / walk / duration / time range / walk distance) formatted by the UI. All
+ * on the IO thread so [TripResultsViewModel] stays JVM-testable.
  */
 interface TripResultsRepository {
 
@@ -76,6 +76,10 @@ class DefaultTripResultsRepository @Inject constructor(@param:ApplicationContext
             durationMinutes = itinerary.duration.inWholeMinutes,
             startTime = itinerary.startTime,
             endTime = itinerary.startTime + itinerary.duration,
+            // Total walking (meters) across the trip's WALK legs; the card formats it to the user's units.
+            walkDistanceMeters = itinerary.legs
+                .filter { it.mode == TripMode.WALK }
+                .sumOf { it.distance },
         )
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
@@ -71,7 +71,9 @@ import org.onebusaway.android.notifications.NotificationChannels
 import org.onebusaway.android.app.di.PreferencesEntryPoint
 import org.onebusaway.android.directions.model.TripItinerary
 import org.onebusaway.android.directions.realtime.TripPlanMonitor
+import org.onebusaway.android.directions.util.ConversionUtils
 import org.onebusaway.android.ui.compose.components.EtaDurationText
+import org.onebusaway.android.ui.compose.components.EtaPartsText
 import org.onebusaway.android.ui.compose.components.LoadingContent
 import org.onebusaway.android.ui.compose.components.RouteBadgeChip
 import org.onebusaway.android.ui.compose.findActivity
@@ -91,8 +93,8 @@ fun TripResultsHeader(
     onSelectOption: (Int) -> Unit
 ) {
     val success = state as? TripResultsUiState.Success ?: return
-    // Side-scrollable so options never get squished: each card sizes to its own content (three lines —
-    // route/lines, duration, time) and the row scrolls horizontally when they overflow the width.
+    // Side-scrollable so options never get squished: each card sizes to its own content (route/lines,
+    // duration, walk distance, time) and the row scrolls horizontally when they overflow the width.
     Row(
         modifier = Modifier
             .background(MaterialTheme.colorScheme.surface)
@@ -155,17 +157,24 @@ private fun OptionCard(
                     maxLines = 1,
                 )
             }
-            // Duration — a leading hourglass + the ETA-pill-formatted trip length.
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(4.dp),
-            ) {
-                Icon(
-                    painterResource(R.drawable.hourglass_24),
-                    contentDescription = null,
-                    modifier = Modifier.size(16.dp),
-                )
-                EtaDurationText(minutes = option.durationMinutes)
+            // Duration + walk distance read as one stat group, so they sit tighter together than the
+            // card's other lines.
+            Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                // Duration — a leading hourglass + the ETA-pill-formatted trip length.
+                MetricRow(R.drawable.hourglass_24, contentDescription = null) {
+                    EtaDurationText(minutes = option.durationMinutes)
+                }
+                // Total walking for the trip — a leading walk glyph mirroring the duration row's hourglass,
+                // with the distance styled like the duration (bold value + smaller unit). In the user's units
+                // (miles/km, or feet/meters for short walks). Hidden when the trip has no walking.
+                if (option.walkDistanceMeters > 0.0) {
+                    MetricRow(
+                        R.drawable.ic_directions_walk,
+                        contentDescription = stringResource(R.string.step_by_step_non_transit_mode_walk_action),
+                    ) {
+                        EtaPartsText(ConversionUtils.getFormattedDistanceParts(option.walkDistanceMeters, context))
+                    }
+                }
             }
             // The device-localized departure–arrival range (unwrap the server clock only here).
             Text(
@@ -175,6 +184,25 @@ private fun OptionCard(
                 maxLines = 1,
             )
         }
+    }
+}
+
+/**
+ * One option-card stat line: a 16dp leading glyph followed by its value [content]. Shared by the
+ * duration and walk-distance rows so their icon size and spacing stay in lockstep.
+ */
+@Composable
+private fun MetricRow(iconRes: Int, contentDescription: String?, content: @Composable () -> Unit) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        Icon(
+            painterResource(iconRes),
+            contentDescription = contentDescription,
+            modifier = Modifier.size(16.dp),
+        )
+        content()
     }
 }
 
@@ -397,10 +425,12 @@ private fun TripResultsPreview() {
                 ItineraryOption(
                     mode = ModeSummary.Routes(listOf(RouteBadge("8", 0xFF1B6EF3.toInt()))),
                     durationMinutes = 32, startTime = ServerTime(0L), endTime = ServerTime(32 * 60_000L),
+                    walkDistanceMeters = 800.0,
                 ),
                 ItineraryOption(
                     mode = ModeSummary.Routes(listOf(RouteBadge("48", null), RouteBadge("11", null))),
                     durationMinutes = 41, startTime = ServerTime(0L), endTime = ServerTime(41 * 60_000L),
+                    walkDistanceMeters = 400.0,
                 )
             ),
             selectedIndex = 0,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
@@ -24,12 +24,15 @@ import org.onebusaway.android.time.ServerTime
  *  - [mode] — what the card's first line shows for the trip (route badges, a walk glyph, or a label).
  *  - [durationMinutes] — whole-minute trip length, formatted like the arrivals ETA pill.
  *  - [startTime]/[endTime] — the server-clock trip endpoints, unwrapped only at the time formatter.
+ *  - [walkDistanceMeters] — total walking across the trip's legs, in meters; the card formats it to the
+ *    user's units (miles/km, or feet/meters for short walks). 0 when the trip has no walking.
  */
 data class ItineraryOption(
     val mode: ModeSummary,
     val durationMinutes: Long,
     val startTime: ServerTime,
     val endTime: ServerTime,
+    val walkDistanceMeters: Double = 0.0,
 )
 
 /** What an option card's first line shows for the trip's modes (mutually exclusive by construction). */


### PR DESCRIPTION
## What

Adds a **total walking distance** line to each trip-planner itinerary option card, directly below the trip duration. It shows the total walking for the itinerary in the user's units (miles/km, or feet/meters for short walks, honoring the imperial/metric preference and locale number formatting), with a leading walk glyph that mirrors the duration row's hourglass. The line is hidden for itineraries with no walking.

The walk value is styled like the duration (bold value + smaller unit), and the duration + walk rows are grouped as one tighter "stat" cluster on the card.

## How

- **`TripResultsRepository`** sums the `WALK` legs' distance into a new `ItineraryOption.walkDistanceMeters`; formatting stays in the UI, consistent with the card's other fields (per the results-sheet rework in #1951).
- **`ConversionUtils.getFormattedDistanceParts`** returns structured value/unit parts (mirroring `DisplayFormat.formatEtaParts`) so the card can style the value and unit differently without re-splitting a joined string; `getFormattedDistance` now delegates to it (output unchanged).
- **`EtaPartsText`** — a shared value+unit renderer factored out of `EtaDurationText` — renders both the duration and the walk distance identically. A small `MetricRow` helper backs the icon+value rows.
- **`tightLineStyle`** (the font-padding-trim helper that centers a leading icon on the text and keeps stacked rows tight) is promoted out of `EtaStrip` into the shared `ui/compose/components` package, so the arrivals ETA pill and the trip card share one copy instead of two. Made `size` optional so both call sites render byte-identically.

## Notes / testing

- Built on top of #1951 (rebased onto its squash-merge on `main`).
- Compiles clean under `-PwarningsAsErrors=true`; `TripResultsViewModelTest` passes.
- Manually installed and exercised on a device — trip-planner option cards and the arrivals ETA pill both verified visually (the ETA pill because this touches `EtaStrip`'s shared helper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Trip options now display total walking distance alongside journey duration.
  - Walking distances are formatted according to metric or imperial preferences.
  - Distance values and units use clearer, consistent visual styling.

- **Improvements**
  - Arrival and trip details now share consistent spacing, sizing, and text formatting.
  - Trip option summaries include walking-distance information for more complete journey comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->