### PR TITLE
Tap an itinerary line item to focus the map on that step

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/DirectionRowFocusTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/DirectionRowFocusTest.kt
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.tripresults
+
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Rule
+import org.junit.Test
+import org.onebusaway.android.time.ServerTime
+import org.onebusaway.android.util.GeoPoint
+import org.onebusaway.android.ui.compose.createUnconfinedComposeRule
+
+/**
+ * Verifies the itinerary line items are tap-to-focus at the leaf level only: tapping a leaf
+ * [DirectionItem] (no sub-steps) invokes `onFocusPoint` with its point, an expandable row only toggles
+ * its sub-steps (never focuses the map), and a revealed leaf sub-item focuses its own point. Exercises
+ * the real [TripResultsList] click wiring by node text (identity), not screen coordinates.
+ */
+class DirectionRowFocusTest {
+
+    // See createUnconfinedComposeRule for why Unconfined composition is used here (issue #1792).
+    @get:Rule
+    val composeRule = createUnconfinedComposeRule()
+
+    private val walkPoint = GeoPoint(47.6100, -122.3300)
+    private val stopAPoint = GeoPoint(47.6200, -122.3400)
+    private val boardPoint = GeoPoint(47.6150, -122.3350)
+
+    private val walk = DirectionItem(
+        iconRes = DirectionItem.NO_ICON,
+        text = "1. Walk to Pine St & 3rd Ave",
+        focusPoint = walkPoint,
+    )
+
+    private val stopA = DirectionItem(
+        iconRes = DirectionItem.NO_ICON,
+        text = "Capitol Hill Station",
+        focusPoint = stopAPoint,
+    )
+
+    private val board = DirectionItem(
+        iconRes = DirectionItem.NO_ICON,
+        text = "2. Board Route 8",
+        isTransit = true,
+        subItems = listOf(stopA),
+        focusPoint = boardPoint,
+    )
+
+    // The option card is incidental here (this test drives the directions list, not the header); any
+    // valid ItineraryOption suffices.
+    private val state = TripResultsUiState.Success(
+        options = listOf(
+            ItineraryOption(
+                mode = ModeSummary.Label("Route 8"),
+                durationMinutes = 32L,
+                startTime = ServerTime(0L),
+                endTime = ServerTime(0L),
+            )
+        ),
+        selectedIndex = 0,
+        directions = listOf(walk, board),
+    )
+
+    @Test
+    fun tappingWalkRowFocusesItsPoint() {
+        var focused: GeoPoint? = null
+        composeRule.setContent {
+            TripResultsList(state = state, onFocusPoint = { focused = it })
+        }
+
+        composeRule.onNodeWithText(walk.text).performClick()
+
+        assertEquals(walkPoint, focused)
+    }
+
+    @Test
+    fun tappingExpandableRowOnlyExpands_thenLeafSubStopFocusesItsOwnPoint() {
+        var focused: GeoPoint? = null
+        composeRule.setContent {
+            TripResultsList(state = state, onFocusPoint = { focused = it })
+        }
+
+        // Sub-steps are collapsed to start.
+        composeRule.onNodeWithText(stopA.text).assertDoesNotExist()
+
+        // An expandable row (chevron) only reveals its sub-steps — it does NOT move the map, even though
+        // it carries a boarding point.
+        composeRule.onNodeWithText(board.text).performClick()
+        assertNull(focused)
+        composeRule.onNodeWithText(stopA.text).assertExists()
+
+        // The revealed leaf sub-step focuses its own point.
+        composeRule.onNodeWithText(stopA.text).performClick()
+        assertEquals(stopAPoint, focused)
+    }
+
+    @Test
+    fun rowWithoutAPointDoesNotFocus() {
+        val pointless = DirectionItem(iconRes = DirectionItem.NO_ICON, text = "No coordinates here")
+        var focused: GeoPoint? = null
+        composeRule.setContent {
+            TripResultsList(
+                state = state.copy(directions = listOf(pointless)),
+                onFocusPoint = { focused = it },
+            )
+        }
+
+        composeRule.onNodeWithText(pointless.text).performClick()
+
+        assertNull(focused)
+    }
+}

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleCameraCommands.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleCameraCommands.kt
@@ -71,6 +71,8 @@ fun applyCameraCommand(
 
         is CameraCommand.MoveToLocation -> {
             val zoom = if (cmd.useDefaultZoom) CAMERA_DEFAULT_ZOOM else map.cameraPosition.zoom
+            // newCameraPosition centers the target within the map's content padding (applied globally via
+            // setPadding), so the point lands in the visible band above the directions results sheet.
             val update = CameraUpdateFactory.newCameraPosition(
                 CameraPosition.Builder().target(cmd.point.toLatLng()).zoom(zoom).build()
             )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/model/Direction.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/model/Direction.kt
@@ -44,6 +44,13 @@ class Direction() {
 
     var isRealTimeInfo = false
 
+    // The geographic point this step refers to (a leg endpoint, an intermediate stop, or a walk
+    // step), set by DirectionsGenerator so the results UI can focus the map on the step when tapped.
+    // Null when the underlying place carries no coordinates.
+    var focusLat: Double? = null
+
+    var focusLon: Double? = null
+
     constructor(
         icon: Int,
         service: CharSequence?,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/DirectionsGenerator.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/DirectionsGenerator.kt
@@ -96,6 +96,10 @@ class DirectionsGenerator(
 
         direction.icon = icon
 
+        // Focus the non-transit step on where it starts (the leg's origin).
+        direction.focusLat = leg.from.lat
+        direction.focusLon = leg.from.lon
+
         // Main direction
         val fromPlace = leg.from
         val toPlace = leg.to
@@ -198,6 +202,10 @@ class DirectionsGenerator(
 
             dir.icon = subdirectionIcon
 
+            // Each turn-by-turn step carries its own point, so a tapped sub-step focuses the map on it.
+            dir.focusLat = step.lat
+            dir.focusLon = step.lon
+
             // Add new sub-direction
             subDirections.add(dir)
         }
@@ -240,6 +248,10 @@ class DirectionsGenerator(
         var placeAndHeadsign: String?
         var extra = ""
 
+        // The "get on" step focuses the boarding stop, the "get off" step the alighting stop.
+        direction.focusLat = if (isOnDirection) from.lat else to.lat
+        direction.focusLon = if (isOnDirection) from.lon else to.lon
+
         if (isOnDirection) {
             action = applicationContext.getString(R.string.step_by_step_transit_get_on)
             placeAndHeadsign = from.name
@@ -268,6 +280,8 @@ class DirectionsGenerator(
                 }
                 subDirection.directionText = subDirectionText
                 subDirection.icon = stopIcon
+                subDirection.focusLat = stop.lat
+                subDirection.focusLon = stop.lon
 
                 subDirections.add(subDirection)
             }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapHost.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapHost.kt
@@ -199,6 +199,8 @@ class MapHost(
 
     fun setBottomPadding(px: Int) = renderState.setBottomPadding(px)
 
+    fun setDirectionsBottomInset(px: Int) = renderState.setDirectionsBottomInset(px)
+
     /** Dispatch a transient camera gesture (zoom step / recenter / my-location move / stop-tap center). */
     fun dispatchGesture(command: CameraCommand) = renderState.dispatchGesture(command)
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
@@ -475,6 +475,19 @@ class MapViewModel @Inject constructor(
         )
     }
 
+    /**
+     * Recenter the map on a tapped itinerary step's point (recenter + zoom to street level). The move
+     * centers within the map's content padding, so the point lands in the visible band above the
+     * directions results sheet. Guarded on an active directions session so a stray directive outside
+     * directions can't move the camera.
+     */
+    fun focusItineraryPoint(point: GeoPoint) {
+        if (!directionsActive) return
+        mapHost.dispatchGesture(
+            CameraCommand.MoveToLocation(point, useDefaultZoom = true, animate = true)
+        )
+    }
+
     /** Clear the drawn itinerary while staying in directions mode (e.g. the plan became unsubmittable). */
     fun clearShownItinerary() {
         if (!directionsActive) return

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/CameraCommand.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/CameraCommand.kt
@@ -44,7 +44,12 @@ sealed interface CameraCommand {
         val applyRouteBias: Boolean,
     ) : CameraCommand
 
-    /** Move to the user's location at either the default zoom or the current zoom (the my-location FAB). */
+    /**
+     * Move to a point at either the default zoom or the current zoom (the my-location FAB, and the
+     * trip-plan itinerary-step focus). The target is centered within the map's content padding, so a
+     * point lands in the visible band above/below any chrome (e.g. above the directions results sheet)
+     * rather than at the true screen center.
+     */
     data class MoveToLocation(
         val point: GeoPoint,
         val useDefaultZoom: Boolean,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
@@ -303,7 +303,27 @@ class MapRenderState {
         applyTopPadding()
     }
 
-    fun setBottomPadding(px: Int) = _padding.update { it.copy(bottomPx = px) }
+    // Bottom padding is the greater of two independently reported insets — the arrivals sheet and the
+    // directions results sheet — mirroring [applyTopPadding]. They're mutually exclusive today (a focused
+    // stop and directions focus never coexist), but combining by max means neither writer has to know
+    // that, and a stale 0 from the inactive source can't clobber the active inset on a focus transition.
+    private var arrivalsBottomInsetPx = 0
+    private var directionsBottomInsetPx = 0
+
+    private fun applyBottomPadding() =
+        _padding.update { it.copy(bottomPx = maxOf(arrivalsBottomInsetPx, directionsBottomInsetPx)) }
+
+    /** The arrivals sheet's bottom inset (keeps the focused stop above the sheet). */
+    fun setBottomPadding(px: Int) {
+        arrivalsBottomInsetPx = px
+        applyBottomPadding()
+    }
+
+    /** The directions results sheet's bottom inset (keeps a focused itinerary step above the sheet). */
+    fun setDirectionsBottomInset(px: Int) {
+        directionsBottomInsetPx = px
+        applyBottomPadding()
+    }
 
     // The live lat/lng -> screen projector, published by the flavor adapter once the map is laid out
     // (backed by the map's Projection). Lets map-SDK-agnostic callers locate a marker on screen without

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -56,12 +56,16 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.boundsInWindow
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import kotlin.math.roundToInt
 import kotlinx.coroutines.launch
 import org.onebusaway.android.R
 import org.onebusaway.android.ui.arrivals.ArrivalsLoaded
@@ -233,9 +237,13 @@ fun HomeScreen(
         // on currentFocus would reset this to 0 when switching between two equal-height banners, framing
         // the map as if no banner showed. The disappearance case resets it via the banner's else branch.
         var focusBannerBottomPx by remember { mutableIntStateOf(0) }
+        // The directions trip-plan form card's absolute bottom edge (window px), so the map's top inset
+        // covers the form/FAB during directions (the itinerary-step focus centers in the band below it).
+        var directionsFormBottomPx by remember { mutableIntStateOf(0) }
         val focusTopEdgePx = focusBannerTopEdge(
             currentFocus,
             focusBannerBottomPx,
+            directionsFormBottomPx,
         )
         LaunchedEffect(focusTopEdgePx) {
             mapViewModel.setFocusBannerBottomEdge(focusTopEdgePx)
@@ -567,6 +575,15 @@ fun HomeScreen(
                     LaunchedEffect(fromPoint, toPoint) {
                         homeViewModel.setDirectionsEndpointsOnMap(fromPoint, toPoint)
                     }
+                    // The results sheet's measured height, published as the map's bottom inset so a tapped
+                    // itinerary step centers in the band above it (0 whenever the sheet isn't shown).
+                    var directionsSheetHeightPx by remember { mutableIntStateOf(0) }
+                    val showResultsSheet = directionsActive && pickTarget == null && directionsResults != null
+                    LaunchedEffect(showResultsSheet, directionsSheetHeightPx) {
+                        homeViewModel.setDirectionsResultsInset(
+                            if (showResultsSheet) directionsSheetHeightPx else 0
+                        )
+                    }
                     // Back cancels an in-progress map pick, else exits directions focus (to nearby stops).
                     BackHandler(enabled = directionsActive) {
                         if (pickTarget != null) pickTarget = null else homeViewModel.exitDirections()
@@ -653,7 +670,12 @@ fun HomeScreen(
                                         modifier = Modifier
                                             .align(Alignment.TopCenter)
                                             .statusBarsPadding()
-                                            .padding(horizontal = 8.dp, vertical = 8.dp),
+                                            .padding(horizontal = 8.dp, vertical = 8.dp)
+                                            // Report the card's bottom edge as the map's top inset (see
+                                            // directionsFormBottomPx) so a focused step clears the form.
+                                            .onGloballyPositioned {
+                                                directionsFormBottomPx = it.boundsInWindow().bottom.roundToInt()
+                                            },
                                     )
                                 }
                             } else {
@@ -680,7 +702,10 @@ fun HomeScreen(
                                     itineraries = directionsResults.itineraries,
                                     params = directionsResults.params,
                                     showItinerary = homeViewModel::showItineraryOnMap,
-                                    modifier = Modifier.align(Alignment.BottomCenter),
+                                    onFocusPoint = homeViewModel::focusItineraryPointOnMap,
+                                    modifier = Modifier
+                                        .align(Alignment.BottomCenter)
+                                        .onSizeChanged { directionsSheetHeightPx = it.height },
                                 )
                                 directionsError != null -> DirectionsErrorSnackbar(
                                     error = directionsError,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeSheetLogic.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeSheetLogic.kt
@@ -34,13 +34,19 @@ enum class ArrivalsSheetState { Hidden, Collapsed, Expanded }
  *  translates this into an animated peek height (the sheet has no `Hidden` drag anchor). */
 internal fun shouldShowSheet(focus: CurrentFocus): Boolean = focus is CurrentFocus.Stop
 
-/** Bottom edge used to keep map framing below the active stop/route focus banner. */
+/**
+ * Bottom edge used to keep map content below the active top chrome: the stop/route focus banner, or —
+ * in directions — the trip-plan form card ([directionsFormBottomPx]), so the map's top content padding
+ * reflects the form/FAB and a focused itinerary step centers in the band below it.
+ */
 internal fun focusBannerTopEdge(
     focus: CurrentFocus,
     focusBannerBottomPx: Int,
+    directionsFormBottomPx: Int = 0,
 ): Int = when (focus) {
     is CurrentFocus.Route, is CurrentFocus.Stop -> focusBannerBottomPx
-    CurrentFocus.None, is CurrentFocus.BikeStation, CurrentFocus.Directions -> 0
+    CurrentFocus.Directions -> directionsFormBottomPx
+    CurrentFocus.None, is CurrentFocus.BikeStation -> 0
 }
 
 /** The drag-handle toggle target: a full sheet collapses to peek; anything else expands to full. */

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
@@ -107,10 +107,21 @@ class HomeViewModel @Inject constructor(
     private val _canUndoMapAction = MutableStateFlow(mapUndoHistory.isNotEmpty())
     val canUndoMapAction: StateFlow<Boolean> = _canUndoMapAction.asStateFlow()
 
-    // The map's bottom inset (driven by the arrivals sheet) — idempotent last-wins state, applied by
-    // MapFeature. A StateFlow (not an event) so a re-entering map re-reads the latest value.
+    // The map's bottom inset from the arrivals sheet — idempotent last-wins state, applied by MapFeature.
+    // A StateFlow (not an event) so a re-entering map re-reads the latest value. The directions results
+    // sheet reports its own inset ([directionsBottomInset]); MapRenderState combines the two by max.
     private val _mapBottomPadding = MutableStateFlow(0)
     val mapBottomPadding: StateFlow<Int> = _mapBottomPadding.asStateFlow()
+
+    // The map's bottom inset from the directions results sheet — its own source (not shared with the
+    // arrivals inset above), so neither has to assume the two never coexist.
+    private val _directionsBottomInset = MutableStateFlow(0)
+    val directionsBottomInset: StateFlow<Int> = _directionsBottomInset.asStateFlow()
+
+    /** The directions results sheet's height as the map's bottom inset (0 when it isn't shown). */
+    fun setDirectionsResultsInset(px: Int) {
+        _directionsBottomInset.value = px
+    }
 
     // One-shot outbound map interactions (recenter / show route / adjacency / focus) that can't be
     // modeled as state. MapFeature collects these and calls the map view model — so this VM needs no
@@ -541,6 +552,10 @@ class HomeViewModel @Inject constructor(
     fun showItineraryOnMap(itinerary: TripItinerary) =
         emitMapDirective(MapDirective.ShowItinerary(itinerary))
 
+    /** Recenter the map on a tapped itinerary step's point (only while in [CurrentFocus.Directions]). */
+    fun focusItineraryPointOnMap(point: GeoPoint) =
+        emitMapDirective(MapDirective.FocusItineraryPoint(point))
+
     /** Clear the drawn itinerary while staying in directions (the plan became unsubmittable). */
     fun clearShownItineraryOnMap() = emitMapDirective(MapDirective.ClearItinerary)
 
@@ -759,6 +774,9 @@ sealed interface MapDirective {
 
     /** Draw [itinerary]'s legs + start/end pins on the home map (trip-plan directions focus). */
     data class ShowItinerary(val itinerary: TripItinerary) : MapDirective
+
+    /** Recenter the map on a tapped itinerary step's point (recenter + zoom to street level). */
+    data class FocusItineraryPoint(val point: GeoPoint) : MapDirective
 
     /** Clear the drawn itinerary but stay in directions mode (the plan became unsubmittable). */
     data object ClearItinerary : MapDirective

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
@@ -86,6 +86,7 @@ import java.util.TimeZone
 import org.onebusaway.android.R
 import org.onebusaway.android.app.di.LocationEntryPoint
 import org.onebusaway.android.directions.model.TripItinerary
+import org.onebusaway.android.util.GeoPoint
 import org.onebusaway.android.directions.util.ConversionUtils
 import org.onebusaway.android.ui.compose.components.DRAG_HANDLE_HEIGHT
 import org.onebusaway.android.ui.compose.components.DRAG_HANDLE_VERTICAL_PADDING
@@ -249,6 +250,7 @@ fun DirectionsResultsSheet(
     itineraries: List<TripItinerary>,
     params: TripPlanParams?,
     showItinerary: (TripItinerary) -> Unit,
+    onFocusPoint: (GeoPoint) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     // The system nav-bar inset: the surface reaches the bottom edge (continuous background), but its
@@ -275,6 +277,7 @@ fun DirectionsResultsSheet(
                 params = params,
                 resultsViewModel = resultsViewModel,
                 showItinerary = showItinerary,
+                onFocusPoint = onFocusPoint,
                 modifier = Modifier.fillMaxWidth(),
             )
         }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
@@ -242,6 +242,9 @@ fun MapFeature(
     LaunchedEffect(mapViewModel, homeViewModel) {
         homeViewModel.mapBottomPadding.collect { mapViewModel.host.setBottomPadding(it) }
     }
+    LaunchedEffect(mapViewModel, homeViewModel) {
+        homeViewModel.directionsBottomInset.collect { mapViewModel.host.setDirectionsBottomInset(it) }
+    }
     // Publish the floating top chrome's footprint (status-bar inset + FAB-row clearance) as the map's
     // baseline top inset, so the Google compass and centered content clear the FABs instead of drawing at
     // topPx=0 behind them. The status-bar inset read is confined to a snapshotFlow (not composition), so
@@ -286,6 +289,8 @@ fun MapFeature(
                     )
                 is MapDirective.ShowItinerary ->
                     mapViewModel.showItinerary(directive.itinerary)
+                is MapDirective.FocusItineraryPoint ->
+                    mapViewModel.focusItineraryPoint(directive.point)
                 MapDirective.ClearItinerary -> mapViewModel.clearShownItinerary()
                 is MapDirective.SetDirectionsEndpoints ->
                     mapViewModel.setDirectionsEndpoints(directive.from, directive.to)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsRepository.kt
@@ -24,6 +24,7 @@ import org.onebusaway.android.directions.model.Direction
 import org.onebusaway.android.directions.model.TripItinerary
 import org.onebusaway.android.directions.model.TripLeg
 import org.onebusaway.android.directions.model.TripMode
+import org.onebusaway.android.util.GeoPoint
 import org.onebusaway.android.directions.util.DirectionsGenerator
 import org.onebusaway.android.util.parseObaHexColor
 import org.onebusaway.android.util.runCatchingCancellable
@@ -103,7 +104,8 @@ class DefaultTripResultsRepository @Inject constructor(@param:ApplicationContext
                 iconRes = icon,
                 text = "$index. ${directionText.orEmptyString()}",
                 isTransit = false,
-                subItems = subItemsOf(subDirections)
+                subItems = subItemsOf(subDirections),
+                focusPoint = focusPoint,
             )
         } else {
             val time = (if (isRealTimeInfo && newTime != null) newTime else oldTime).orEmptyString()
@@ -114,15 +116,28 @@ class DefaultTripResultsRepository @Inject constructor(@param:ApplicationContext
                 agency = agency?.toString()?.takeIf { it.isNotEmpty() },
                 extra = extra?.toString()?.takeIf { it.isNotEmpty() },
                 isTransit = true,
-                subItems = subItemsOf(subDirections)
+                subItems = subItemsOf(subDirections),
+                focusPoint = focusPoint,
             )
         }
     }
 
     private fun subItemsOf(subDirections: List<Direction>?): List<DirectionItem> =
         subDirections?.map {
-            DirectionItem(iconRes = it.icon, text = it.directionText.orEmptyString())
+            DirectionItem(
+                iconRes = it.icon,
+                text = it.directionText.orEmptyString(),
+                focusPoint = it.focusPoint,
+            )
         }.orEmpty()
+
+    /** The step's focus point, or null when the underlying place carried no coordinates. */
+    private val Direction.focusPoint: GeoPoint?
+        get() {
+            val lat = focusLat ?: return null
+            val lon = focusLon ?: return null
+            return GeoPoint(lat, lon)
+        }
 
     private fun CharSequence?.orEmptyString(): String = this?.toString().orEmpty()
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
@@ -78,6 +78,7 @@ import org.onebusaway.android.ui.compose.components.LoadingContent
 import org.onebusaway.android.ui.compose.components.RouteBadgeChip
 import org.onebusaway.android.ui.compose.findActivity
 import org.onebusaway.android.util.DisplayFormat
+import org.onebusaway.android.util.GeoPoint
 import org.onebusaway.android.ui.compose.theme.ObaTheme
 import org.onebusaway.android.ui.tripplan.TripPlanParams
 
@@ -215,6 +216,7 @@ fun TripResultsList(
     state: TripResultsUiState,
     modifier: Modifier = Modifier,
     bottomInset: Dp = 0.dp,
+    onFocusPoint: (GeoPoint) -> Unit = {},
 ) {
     Box(
         modifier
@@ -240,7 +242,7 @@ fun TripResultsList(
                 contentPadding = PaddingValues(bottom = bottomInset),
             ) {
                 itemsIndexed(state.directions) { _, item ->
-                    DirectionRow(item)
+                    DirectionRow(item, onFocusPoint)
                     HorizontalDivider()
                 }
             }
@@ -265,6 +267,7 @@ fun TripResultsSheet(
     params: TripPlanParams?,
     resultsViewModel: TripResultsViewModel,
     showItinerary: (TripItinerary) -> Unit,
+    onFocusPoint: (GeoPoint) -> Unit,
     modifier: Modifier = Modifier,
     listBottomInset: Dp = 0.dp,
 ) {
@@ -298,7 +301,7 @@ fun TripResultsSheet(
             state = state,
             onSelectOption = resultsViewModel::selectOption,
         )
-        TripResultsList(state, Modifier.weight(1f), bottomInset = listBottomInset)
+        TripResultsList(state, Modifier.weight(1f), bottomInset = listBottomInset, onFocusPoint = onFocusPoint)
     }
 }
 
@@ -334,14 +337,23 @@ private fun maybeStartTripUpdates(
 }
 
 @Composable
-private fun DirectionRow(item: DirectionItem) {
+private fun DirectionRow(item: DirectionItem, onFocusPoint: (GeoPoint) -> Unit) {
     var expanded by remember { mutableStateOf(false) }
     val hasSubItems = item.subItems.isNotEmpty()
+    val point = item.focusPoint
     Column {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .clickable(enabled = hasSubItems) { expanded = !expanded }
+                // An expandable row (a chevron) only toggles its sub-steps; only leaf rows send the map
+                // to their point. So a parent never moves the map — its expanded leaves do.
+                .clickable(enabled = hasSubItems || point != null) {
+                    if (hasSubItems) {
+                        expanded = !expanded
+                    } else {
+                        point?.let(onFocusPoint)
+                    }
+                }
                 .padding(horizontal = 12.dp, vertical = 10.dp)
         ) {
             DirectionIcon(item.iconRes)
@@ -377,16 +389,20 @@ private fun DirectionRow(item: DirectionItem) {
             }
         }
         if (expanded) {
-            item.subItems.forEach { sub -> SubDirectionRow(sub) }
+            item.subItems.forEach { sub -> SubDirectionRow(sub, onFocusPoint) }
         }
     }
 }
 
 @Composable
-private fun SubDirectionRow(item: DirectionItem) {
+private fun SubDirectionRow(item: DirectionItem, onFocusPoint: (GeoPoint) -> Unit) {
+    val point = item.focusPoint
     Row(
         modifier = Modifier
             .fillMaxWidth()
+            .clickable(enabled = point != null) {
+                point?.let(onFocusPoint)
+            }
             .padding(start = 36.dp, end = 12.dp, top = 6.dp, bottom = 6.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
@@ -338,7 +338,10 @@ private fun maybeStartTripUpdates(
 
 @Composable
 private fun DirectionRow(item: DirectionItem, onFocusPoint: (GeoPoint) -> Unit) {
-    var expanded by remember { mutableStateOf(false) }
+    // Rows are keyed by index in the LazyColumn, so switching itineraries reuses this slot for a
+    // different DirectionItem. Key the expansion state on the item so it resets on that swap instead
+    // of leaking a stale expanded state into the new itinerary's row.
+    var expanded by remember(item) { mutableStateOf(false) }
     val hasSubItems = item.subItems.isNotEmpty()
     val point = item.focusPoint
     Column {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
@@ -16,6 +16,7 @@
 package org.onebusaway.android.ui.tripresults
 
 import org.onebusaway.android.time.ServerTime
+import org.onebusaway.android.util.GeoPoint
 
 /**
  * One of the (up to three) itinerary option cards shown above the directions. Carries structured data
@@ -55,7 +56,9 @@ data class RouteBadge(val shortName: String, val routeColor: Int?)
  * `DirectionExpandableListAdapter`. [text] is the primary line (already prefixed with the step
  * number and, for transit, the time); transit steps add [placeAndHeadsign]/[agency]/[extra] detail
  * lines, and [subItems] holds the expandable sub-steps (intermediate stops / turn-by-turn).
- * [iconRes] is -1 when the step has no icon.
+ * [iconRes] is -1 when the step has no icon. [focusPoint] is the geographic point the step refers to
+ * (a leg endpoint, an intermediate stop, or a walk step) — non-null when the step can focus the map,
+ * null when the underlying place had no coordinates.
  */
 data class DirectionItem(
     val iconRes: Int,
@@ -64,7 +67,8 @@ data class DirectionItem(
     val agency: String? = null,
     val extra: String? = null,
     val isTransit: Boolean = false,
-    val subItems: List<DirectionItem> = emptyList()
+    val subItems: List<DirectionItem> = emptyList(),
+    val focusPoint: GeoPoint? = null,
 ) {
     companion object {
         /** Sentinel for "no icon", matching the legacy Direction.getIcon() contract. */

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreCameraCommands.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreCameraCommands.kt
@@ -46,7 +46,7 @@ private const val CAMERA_DEFAULT_ZOOM = 16.0
  * (not suspending), so this isn't a suspend function. The route-header recenter bias reads the live
  * viewport from [map]. Retained framing is applied by [applyFramingIntent].
  */
-fun applyCameraCommand(cmd: CameraCommand, map: MapLibreMap) {
+fun applyCameraCommand(cmd: CameraCommand, map: MapLibreMap, renderState: MapRenderState) {
     when (cmd) {
         is CameraCommand.Recenter -> {
             val cp = map.cameraPosition
@@ -64,7 +64,15 @@ fun applyCameraCommand(cmd: CameraCommand, map: MapLibreMap) {
 
         is CameraCommand.MoveToLocation -> {
             val zoom = if (cmd.useDefaultZoom) CAMERA_DEFAULT_ZOOM else map.cameraPosition.zoom
-            val pos = CameraPosition.Builder().target(cmd.point.toLatLng()).zoom(zoom).build()
+            // maplibre's newCameraPosition does NOT consult a persistent map padding (unlike Google's
+            // setPadding), so fold the map's content padding into the CameraPosition here — that centers
+            // the point in the visible band above the directions results sheet, matching the Google flavor.
+            val overlay = renderState.padding.value
+            val pos = CameraPosition.Builder()
+                .target(cmd.point.toLatLng())
+                .zoom(zoom)
+                .padding(0.0, overlay.topPx.toDouble(), 0.0, overlay.bottomPx.toDouble())
+                .build()
             val update = CameraUpdateFactory.newCameraPosition(pos)
             if (cmd.animate) map.animateCamera(update) else map.moveCamera(update)
         }

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreComposeAdapter.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreComposeAdapter.kt
@@ -263,7 +263,7 @@ class MapLibreComposeAdapter : ObaComposeMapAdapter {
         val map = mapLibreMap
         if (map != null) {
             LaunchedEffect(map) {
-                renderState.cameraGestures.collect { command -> applyCameraCommand(command, map) }
+                renderState.cameraGestures.collect { command -> applyCameraCommand(command, map, renderState) }
             }
             LaunchedEffect(map) {
                 renderState.framingIntent.filterNotNull().collect { applyFramingIntent(it, map, renderState, context) }


### PR DESCRIPTION
## What

Adds reactivity to the trip planner's directions list: tapping a **leaf** line item recenters the map on that step's location and zooms to a street-level default. Expandable rows (with a chevron) keep toggling their sub-steps and never move the map — only leaves send-to-map (in practice the walk-leg / board rows expand; their turn-by-turn steps and intermediate stops focus).

## How

- **Coordinates through the projection.** Each step's point is threaded from the domain legs (`TripLeg`/`TripPlace`/`TripStep`) via `DirectionsGenerator`/`Direction` into a single `DirectionItem.focusPoint: GeoPoint?` (leg endpoint for board/alight/walk rows; each intermediate stop / turn-by-turn step for sub-items).
- **Tap wiring reuses the existing seam.** A new `onFocusPoint` callback rides the same path as the existing itinerary selection: `DirectionRow` → `TripResultsSheet`/`DirectionsResultsSheet` → `HomeViewModel.focusItineraryPointOnMap` → `MapDirective.FocusItineraryPoint(GeoPoint)` → `MapViewModel.focusItineraryPoint` → `CameraCommand.MoveToLocation`. Reuses the flavor-neutral camera command, so no per-flavor code.
- **Centers within map content padding** so the point lands in the visible band, not behind the results sheet or the directions form:
  - The directions form card reports its bottom edge as the map's top inset (folded into `focusBannerTopEdge` / `setFocusBannerBottomEdge`).
  - The results sheet reports its height as an **independent** bottom inset; `MapRenderState` combines the arrivals and directions bottom insets by `max` (mirroring `applyTopPadding`), so neither writer has to assume the two never coexist.
  - Google honors content padding on `newCameraPosition` automatically; MapLibre folds `renderState.padding` into the `CameraPosition` (it ignores persistent map padding on point moves).

## Testing

- New on-device Compose test `DirectionRowFocusTest` (drives rows by node text, not coordinates): a leaf row focuses its point; an expandable row only expands (asserts no focus) and its revealed leaf sub-step focuses its own point; a point-less row is inert. **3/3 passing on a physical Pixel 7 Pro.**
- Clean launch on device; both `obaGoogle` and `obaMaplibre` compile clean under `-PwarningsAsErrors=true`; JVM unit suite green.

## Follow-up

While wiring the padding centering, noticed a pre-existing, separate issue: the route zoom-to that fires on a route request returning doesn't respect map padding (it races the route-header inset). Filed as #1954.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tapping a trip direction now focuses and recenters the map on that step when coordinates are available.
  * Map positioning now accounts for directions UI spacing so focused points stay visible above/below the panels.
  * Directions results provide focus points for walking steps, boarding/alighting stops, and intermediate stops.
* **Bug Fixes**
  * Directions steps without coordinates no longer trigger map focusing.
  * Expanding a direction no longer causes unintended map movement.
* **Tests**
  * Added UI coverage for direction-row focus and expandable/leaf interaction behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->