### PR TITLE
Never advise walking: map the too-close case to TOO_CLOSE (#1947)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/Otp2Planner.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/Otp2Planner.kt
@@ -111,8 +111,9 @@ class Otp2Planner @Inject constructor(
  * (which folds in wait/transfer/boarding penalties, not just distance) beats every transit option,
  * the filter chain deletes the *transit* itineraries and attaches this error while **keeping the
  * walk-only itinerary in `edges`**. Surfacing the error there would throw away a valid walk route and
- * show a "Try walking instead" advisory with no result — even for trips too long to actually walk.
- * Returning whatever itineraries came back shows that walk route as a normal option instead.
+ * show a no-result message — even for trips too long to actually walk. Returning whatever itineraries
+ * came back shows that walk route as a normal option instead; the code only classifies as an error
+ * (the same-location "too close" case) when there is genuinely nothing to show.
  *
  * This is safe for every *fatal* code — `LOCATION_NOT_FOUND`, `OUTSIDE_BOUNDS`,
  * `NO_TRANSIT_CONNECTION`, the same-location `WALKING_BETTER_THAN_TRANSIT` raised by OTP's
@@ -136,10 +137,14 @@ internal fun resolveOtp2Plan(data: PlanQuery.Data): List<TripItinerary> {
 /**
  * Classifies an OTP2 `routingErrors` entry into a [TripPlanError]: reuses OTP1's existing detail
  * strings where [RoutingErrorCode] names a genuinely equivalent failure, and an OTP2-specific string
- * where it doesn't — [RoutingErrorCode.OUTSIDE_SERVICE_PERIOD] and
- * [RoutingErrorCode.WALKING_BETTER_THAN_TRANSIT] have no OTP1-era concept, so folding them into the
- * generic fallback would silently discard information OTP2 is actually telling the user. Top-level and
- * `internal` (not a `Context`-bound method) so it's exhaustively JVM-unit-testable without Apollo.
+ * where it doesn't — [RoutingErrorCode.OUTSIDE_SERVICE_PERIOD] has no OTP1-era concept, so folding it
+ * into the generic fallback would silently discard information OTP2 is actually telling the user.
+ *
+ * [RoutingErrorCode.WALKING_BETTER_THAN_TRANSIT] reaches here only when there are no itineraries
+ * (see [resolveOtp2Plan] — when a walk route survives we return it rather than classify an error),
+ * i.e. only OTP's same-location `SameEdgeAdjuster` case, which is exactly OTP1's `TOO_CLOSE`. So it
+ * maps to the same too-close result and never advises walking (#1947). Top-level and `internal` (not a
+ * `Context`-bound method) so it's exhaustively JVM-unit-testable without Apollo.
  */
 internal fun otp2ErrorFor(code: RoutingErrorCode, inputField: InputField?): TripPlanError = when (code) {
     RoutingErrorCode.OUTSIDE_BOUNDS ->
@@ -162,7 +167,7 @@ internal fun otp2ErrorFor(code: RoutingErrorCode, inputField: InputField?): Trip
         TripPlanError(TripPlanError.Category.SCHEDULE, R.string.tripplanner_error_outside_service_period)
 
     RoutingErrorCode.WALKING_BETTER_THAN_TRANSIT ->
-        TripPlanError(TripPlanError.Category.ADVISORY, R.string.tripplanner_error_walking_better_than_transit)
+        TripPlanError(TripPlanError.Category.NO_ROUTE, R.string.tripplanner_error_too_close)
 
     RoutingErrorCode.UNKNOWN__ -> TripPlanError.Unknown
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/Otp2Planner.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/Otp2Planner.kt
@@ -95,16 +95,42 @@ class Otp2Planner @Inject constructor(
             throw TripPlanException(TripPlanError.Unknown, e)
         }
 
-        data.planConnection?.routingErrors?.firstOrNull()?.let {
-            throw TripPlanException(otp2ErrorFor(it.code, it.inputField))
-        }
+        return resolveOtp2Plan(data)
+    }
+}
 
-        val itineraries = data.toTripItineraries()
-        if (itineraries.isEmpty()) {
-            throw TripPlanException(TripPlanError.NoRoute)
-        }
+/**
+ * Resolves an OTP2 `planConnection` [PlanQuery.Data] into itineraries, or throws a classified
+ * [TripPlanException] when there is genuinely nothing to show.
+ *
+ * **Itineraries win over routing errors.** A `routingErrors` entry can accompany a perfectly good
+ * result, so we must return the result rather than surface the error. The motivating case (#1947) is
+ * [RoutingErrorCode.WALKING_BETTER_THAN_TRANSIT]: OTP2 always computes a direct WALK itinerary
+ * alongside transit — the `planConnection.modes` default is documented as "all transit modes are
+ * usable and WALK is used for direct street suggestions" — and when that walk's *generalized* cost
+ * (which folds in wait/transfer/boarding penalties, not just distance) beats every transit option,
+ * the filter chain deletes the *transit* itineraries and attaches this error while **keeping the
+ * walk-only itinerary in `edges`**. Surfacing the error there would throw away a valid walk route and
+ * show a "Try walking instead" advisory with no result — even for trips too long to actually walk.
+ * Returning whatever itineraries came back shows that walk route as a normal option instead.
+ *
+ * This is safe for every *fatal* code — `LOCATION_NOT_FOUND`, `OUTSIDE_BOUNDS`,
+ * `NO_TRANSIT_CONNECTION`, the same-location `WALKING_BETTER_THAN_TRANSIT` raised by OTP's
+ * `SameEdgeAdjuster`, … — because those always come back with empty `edges`, so consulting
+ * `routingErrors` only when there are no itineraries still classifies them exactly as before.
+ *
+ * Top-level and `internal` (no [Context] dependency) so it's JVM-unit-testable from a
+ * [PlanQuery.Data] fixture without Apollo, like [otp2ErrorFor].
+ */
+internal fun resolveOtp2Plan(data: PlanQuery.Data): List<TripItinerary> {
+    val itineraries = data.toTripItineraries()
+    if (itineraries.isNotEmpty()) {
         return itineraries
     }
+    data.planConnection?.routingErrors?.firstOrNull()?.let {
+        throw TripPlanException(otp2ErrorFor(it.code, it.inputField))
+    }
+    throw TripPlanException(TripPlanError.NoRoute)
 }
 
 /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanError.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanError.kt
@@ -61,20 +61,16 @@ data class TripPlanError(
         /** No usable route between the two points (no path, no stops in range, out of coverage). */
         NO_ROUTE(R.string.tripplanner_error_header_no_route, Severity.WARNING),
 
-        /** Not a failure so much as advice — walking beats transit for this trip. */
-        ADVISORY(R.string.tripplanner_error_header_advisory, Severity.INFO),
-
         /** The request itself was rejected or unclassified (bad parameter, no server, unknown). */
         REQUEST(R.string.tripplanner_error_header_request, Severity.ERROR),
     }
 
     /**
      * How alarming the failure is; [colorRes] is the header colour it maps to (a `md_theme_severity*`
-     * text colour tuned for the inverting `inverseSurface` snackbar bar): [INFO] blue (a tip — not a
-     * failure), [WARNING] amber (a valid, user-actionable non-result), [ERROR] red (something failed).
+     * text colour tuned for the inverting `inverseSurface` snackbar bar): [WARNING] amber (a valid,
+     * user-actionable non-result), [ERROR] red (something failed).
      */
     enum class Severity(@get:ColorRes val colorRes: Int) {
-        INFO(R.color.md_theme_severityInfo),
         WARNING(R.color.md_theme_severityWarning),
         ERROR(R.color.md_theme_severityError),
     }

--- a/onebusaway-android/src/main/res/values-night/colors.xml
+++ b/onebusaway-android/src/main/res/values-night/colors.xml
@@ -57,7 +57,6 @@
 
     <!-- Dark-theme severity header colours (see values/colors.xml). The inverseSurface bar turns light
          here, so the header text flips to the deep tone-40 values to stay legible on it. -->
-    <color name="md_theme_severityInfo">#0B57D0</color>
     <color name="md_theme_severityWarning">#7A4E00</color>
     <color name="md_theme_severityError">#BA1A1A</color>
 

--- a/onebusaway-android/src/main/res/values/colors.xml
+++ b/onebusaway-android/src/main/res/values/colors.xml
@@ -132,7 +132,6 @@
          error = red (a failure). These are *text* colours read against the dark inverseSurface bar, so
          the light theme uses the bright tone-80 values; values-night flips to the deep tone-40 values
          for the bar that turns light there. -->
-    <color name="md_theme_severityInfo">#A9C7FF</color>
     <color name="md_theme_severityWarning">#F0C173</color>
     <color name="md_theme_severityError">#FFB4AB</color>
 

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -927,7 +927,6 @@
     <string name="tripplanner_error_header_location">Can&#8217;t find that location</string>
     <string name="tripplanner_error_header_schedule">No transit at this time</string>
     <string name="tripplanner_error_header_no_route">Cannot find route</string>
-    <string name="tripplanner_error_header_advisory">Try walking instead</string>
     <string name="tripplanner_error_header_request">Couldn&#8217;t plan this trip</string>
     <string name="tripplanner_error_not_defined">Sorry, something went wrong.  Please try again.</string>
     <string name="tripplanner_error_request_timeout">Please check your Internet connection and try
@@ -940,9 +939,6 @@
     <string name="tripplanner_error_no_transit_times">Transit times for selected date are not available</string>
     <string name="tripplanner_error_outside_service_period">Selected date is outside the available
         transit schedule
-    </string>
-    <string name="tripplanner_error_walking_better_than_transit">Walking is faster than transit for
-        this trip
     </string>
     <string name="tripplanner_error_bogus_parameter">Something went wrong.  Change your trip options and try again.</string>
     <string name="tripplanner_error_geocode_from_not_found">Origin not found</string>

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/Otp2PlanResolveTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/Otp2PlanResolveTest.kt
@@ -56,18 +56,19 @@ class Otp2PlanResolveTest {
 
     /**
      * The same-location degenerate case (OTP's `SameEdgeAdjuster`) emits the same code but with no
-     * itineraries — with nothing to show, the advisory still surfaces.
+     * itineraries — with nothing to show, it surfaces as the "too close" no-route result, never as a
+     * "try walking" advisory (#1947).
      */
     @Test
-    fun walkingBetterThanTransit_withoutItineraries_throwsAdvisory() {
+    fun walkingBetterThanTransit_withoutItineraries_throwsTooClose() {
         val data = planData(
             routingErrors = listOf(routingError(RoutingErrorCode.WALKING_BETTER_THAN_TRANSIT)),
             edges = emptyList(),
         )
 
         val error = assertThrows(TripPlanException::class.java) { resolveOtp2Plan(data) }.error
-        assertEquals(TripPlanError.Category.ADVISORY, error.category)
-        assertEquals(R.string.tripplanner_error_walking_better_than_transit, error.detailRes)
+        assertEquals(TripPlanError.Category.NO_ROUTE, error.category)
+        assertEquals(R.string.tripplanner_error_too_close, error.detailRes)
     }
 
     /** A fatal error (always empty `edges`) still classifies exactly as before the fix. */

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/Otp2PlanResolveTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/Otp2PlanResolveTest.kt
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.tripplan
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+import org.onebusaway.android.R
+import org.onebusaway.android.api.graphql.PlanQuery
+import org.onebusaway.android.api.graphql.fragment.PlaceFields
+import org.onebusaway.android.api.graphql.type.InputField
+import org.onebusaway.android.api.graphql.type.Mode
+import org.onebusaway.android.api.graphql.type.RoutingErrorCode
+import org.onebusaway.android.directions.model.TripMode
+
+/**
+ * Covers [resolveOtp2Plan]: the rule that OTP2 itineraries win over a coexisting `routingErrors`
+ * entry, and that fatal errors (which always arrive with empty `edges`) still classify as before.
+ *
+ * The regression this guards is #1947: OTP2 emits [RoutingErrorCode.WALKING_BETTER_THAN_TRANSIT]
+ * *while keeping* the walk-only itinerary in the response, and the old code threw that advisory
+ * before ever reading the itinerary — hiding a valid walk route behind a "Try walking instead"
+ * message. Pure JVM: builds Apollo-generated [PlanQuery.Data] fixtures directly, no Apollo/HTTP.
+ */
+class Otp2PlanResolveTest {
+
+    /**
+     * The core fix: a `WALKING_BETTER_THAN_TRANSIT` error alongside a surviving walk itinerary must
+     * yield the walk itinerary, not throw the advisory.
+     */
+    @Test
+    fun walkingBetterThanTransit_withWalkItinerary_returnsTheWalk() {
+        val data = planData(
+            routingErrors = listOf(routingError(RoutingErrorCode.WALKING_BETTER_THAN_TRANSIT)),
+            edges = listOf(walkEdge()),
+        )
+
+        val itineraries = resolveOtp2Plan(data)
+
+        assertEquals(1, itineraries.size)
+        assertEquals(TripMode.WALK, itineraries[0].legs[0].mode)
+    }
+
+    /**
+     * The same-location degenerate case (OTP's `SameEdgeAdjuster`) emits the same code but with no
+     * itineraries — with nothing to show, the advisory still surfaces.
+     */
+    @Test
+    fun walkingBetterThanTransit_withoutItineraries_throwsAdvisory() {
+        val data = planData(
+            routingErrors = listOf(routingError(RoutingErrorCode.WALKING_BETTER_THAN_TRANSIT)),
+            edges = emptyList(),
+        )
+
+        val error = assertThrows(TripPlanException::class.java) { resolveOtp2Plan(data) }.error
+        assertEquals(TripPlanError.Category.ADVISORY, error.category)
+        assertEquals(R.string.tripplanner_error_walking_better_than_transit, error.detailRes)
+    }
+
+    /** A fatal error (always empty `edges`) still classifies exactly as before the fix. */
+    @Test
+    fun fatalError_withoutItineraries_throwsClassifiedError() {
+        val data = planData(
+            routingErrors = listOf(routingError(RoutingErrorCode.LOCATION_NOT_FOUND, InputField.FROM)),
+            edges = emptyList(),
+        )
+
+        val error = assertThrows(TripPlanException::class.java) { resolveOtp2Plan(data) }.error
+        assertEquals(TripPlanError.Category.LOCATION, error.category)
+        assertEquals(R.string.tripplanner_error_geocode_from_not_found, error.detailRes)
+    }
+
+    /** No itineraries and no error is a plain no-route result. */
+    @Test
+    fun noItinerariesNoError_throwsNoRoute() {
+        val data = planData(routingErrors = emptyList(), edges = emptyList())
+
+        val error = assertThrows(TripPlanException::class.java) { resolveOtp2Plan(data) }.error
+        assertEquals(TripPlanError.NoRoute, error)
+    }
+
+    // ---- fixtures ----
+
+    private fun planData(
+        routingErrors: List<PlanQuery.RoutingError>,
+        edges: List<PlanQuery.Edge>,
+    ) = PlanQuery.Data(
+        planConnection = PlanQuery.PlanConnection(
+            searchDateTime = "2026-07-11T10:00:00-07:00",
+            routingErrors = routingErrors,
+            edges = edges,
+        ),
+    )
+
+    private fun routingError(code: RoutingErrorCode, inputField: InputField? = null) =
+        PlanQuery.RoutingError(code = code, description = code.name, inputField = inputField)
+
+    private fun walkEdge(): PlanQuery.Edge {
+        val leg = PlanQuery.Leg(
+            mode = Mode.WALK,
+            duration = 2400.0,
+            distance = 3200.0,
+            realTime = null,
+            start = PlanQuery.Start(scheduledTime = "2026-07-11T10:00:00-07:00", estimated = null),
+            end = PlanQuery.End(scheduledTime = "2026-07-11T10:40:00-07:00", estimated = null),
+            from = from("Origin", 47.60, -122.30),
+            to = to("Destination", 47.62, -122.34),
+            route = null,
+            trip = null,
+            legGeometry = null,
+            steps = null,
+        )
+        val node = PlanQuery.Node(
+            start = "2026-07-11T10:00:00-07:00",
+            end = "2026-07-11T10:40:00-07:00",
+            duration = 2400L,
+            numberOfTransfers = 0,
+            legs = listOf(leg),
+        )
+        return PlanQuery.Edge(node = node)
+    }
+
+    private fun placeFields(name: String, lat: Double, lon: Double) =
+        PlaceFields(name, lat, lon, null, null, null, null)
+
+    private fun from(name: String, lat: Double, lon: Double) =
+        PlanQuery.From(__typename = "Place", placeFields = placeFields(name, lat, lon))
+
+    private fun to(name: String, lat: Double, lon: Double) =
+        PlanQuery.To(__typename = "Place", placeFields = placeFields(name, lat, lon))
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripPlanErrorMappingTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripPlanErrorMappingTest.kt
@@ -107,9 +107,16 @@ class TripPlanErrorMappingTest {
     }
 
     @Test
-    fun otp2_advisory_and_unknown() {
-        assertError(Category.ADVISORY, R.string.tripplanner_error_walking_better_than_transit,
+    fun otp2_walking_better_than_transit_maps_to_too_close() {
+        // Reaches otp2ErrorFor only in the same-location (no-itinerary) case — the too-close result,
+        // matching OTP1's TOO_CLOSE; it never advises walking (#1947). When a walk route survives it
+        // is returned as a normal itinerary by resolveOtp2Plan and this code is never hit.
+        assertError(Category.NO_ROUTE, R.string.tripplanner_error_too_close,
             otp2ErrorFor(RoutingErrorCode.WALKING_BETTER_THAN_TRANSIT, null))
+    }
+
+    @Test
+    fun otp2_unknown_falls_back() {
         assertEquals(TripPlanError.Unknown, otp2ErrorFor(RoutingErrorCode.UNKNOWN__, null))
     }
 }


### PR DESCRIPTION
## Summary

Second half of #1947 — **stacked on #1959** (base is `feature/1947-walk-better-than-transit`, so this PR's diff is only this change). Completes the goal: the app **never advises walking**. Either it shows a walking itinerary (via #1959) or it says the endpoints are too close.

## Rationale

#1959 makes `resolveOtp2Plan` return OTP2's direct walk itinerary as a normal result whenever one survives the filter chain. That means `otp2ErrorFor(WALKING_BETTER_THAN_TRANSIT)` is now **only reachable when there are no itineraries at all** — i.e. OTP's same-location `SameEdgeAdjuster` path, which is semantically identical to OTP1's existing `TOO_CLOSE`.

## Changes

- Map `WALKING_BETTER_THAN_TRANSIT` → `(NO_ROUTE, tripplanner_error_too_close)`, reusing OTP1's already-translated **"Trip is too short"** message. Result: header *"Cannot find route"*, detail *"Trip is too short"* — never "Try walking instead".
- Delete the now-dead advisory machinery (would otherwise fail the lint unused-resources gate): `Category.ADVISORY`, `Severity.INFO`, the `md_theme_severityInfo` colour (light + night), and the two advisory strings.
- Update KDocs and the `Otp2PlanResolveTest` / `TripPlanErrorMappingTest` cases.

## Tests

`Otp2PlanResolveTest` (4) + `TripPlanErrorMappingTest` (7) pass. Compiles clean under `-PwarningsAsErrors=true`.

> Note: depends on #1959; merge that first (or this base retargets to `main` once #1959 lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)