### PR TITLE
Stop route focus: show the headsign when entered from a map route-label tap

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/RouteRowGroup.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/RouteRowGroup.kt
@@ -194,3 +194,19 @@ internal fun resolveSelectedRouteGroupKey(
     if (routeId == null) return null
     return groups.filter { it.routeId == routeId }.singleOrNull()?.key
 }
+
+/**
+ * The selected row's *group* (not just its key) — the single identity→row resolution every stop-focus
+ * surface shares. The drawer promotes this row and the focus banner reads its shown headsign from the
+ * same resolver, so a map route-label tap and an arrivals-row tap that name the same (route, direction)
+ * can never disagree on the headsign shown: it's projected from the resolved row, never carried on the
+ * selection. Null when the selection resolves to no row (see [resolveSelectedRouteGroupKey]).
+ */
+internal fun resolveSelectedRouteGroup(
+    groups: List<RouteRowGroup>,
+    requestedKey: String?,
+    routeId: String?,
+): RouteRowGroup? {
+    val key = resolveSelectedRouteGroupKey(groups, requestedKey, routeId) ?: return null
+    return groups.firstOrNull { it.key == key }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/CurrentFocus.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/CurrentFocus.kt
@@ -75,8 +75,11 @@ data class RouteLeg(
 
 /** A route selected inside stop focus, anchored to its original arrivals row across continuations. */
 data class StopRouteSelection(
-    // The first leg already owns the row's route + direction identity. Headsign is only the legacy
-    // fallback for responses that omit directionId, so don't duplicate the rest of the row here.
+    // Row *identity*, never display: with [originLeg]'s route + directionId it forms the row key
+    // ([selectedArrivalRowKey]) fed to `resolveSelectedRouteGroup`, disambiguating the legacy case where
+    // a response omits directionId and only the headsign string tells two directions apart. The headsign
+    // the banner *shows* is read back from the resolved arrivals row, not from here — so don't render
+    // this and don't duplicate the rest of the row onto the selection.
     val originHeadsign: String?,
     val legs: List<RouteLeg>,
 ) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -70,6 +70,7 @@ import kotlinx.coroutines.launch
 import org.onebusaway.android.R
 import org.onebusaway.android.ui.arrivals.ArrivalsLoaded
 import org.onebusaway.android.ui.arrivals.ArrivalsUiState
+import org.onebusaway.android.ui.arrivals.resolveSelectedRouteGroup
 import org.onebusaway.android.ui.nav.ReminderEditorArgs
 import org.onebusaway.android.map.RouteHeader
 import org.onebusaway.android.map.MapViewModel
@@ -84,6 +85,7 @@ import org.onebusaway.android.ui.compose.navigationBarBottomPadding
 import org.onebusaway.android.ui.compose.theme.ObaTheme
 import org.onebusaway.android.ui.home.arrivals.ArrivalsSheetHost
 import org.onebusaway.android.ui.home.arrivals.rememberArrivalsSession
+import org.onebusaway.android.ui.home.arrivals.selectedArrivalRowKey
 import org.onebusaway.android.ui.home.arrivals.ServiceAlertsDialog
 import org.onebusaway.android.ui.home.chrome.MAP_TOP_CHROME_CLEARANCE
 import org.onebusaway.android.ui.home.chrome.MapTopChrome
@@ -396,7 +398,16 @@ fun HomeScreen(
                             ?.routeColor,
                     )
                 }.orEmpty(),
-                subordinateHeadsign = currentFocus.selectedRoute?.originHeadsign,
+                subordinateHeadsign = currentFocus.selectedRoute?.let { selection ->
+                    // Resolve the shown headsign from the loaded arrivals via the same row resolver the
+                    // drawer highlight uses, so every entry point (arrivals row, map route-label tap)
+                    // projects it identically instead of each carrying its own copy.
+                    resolveSelectedRouteGroup(
+                        arrivalsContent?.routeGroups.orEmpty(),
+                        selection.selectedArrivalRowKey(),
+                        selection.originLeg.routeId,
+                    )?.headsign
+                },
             )
             is CurrentFocus.Route -> routeHeader?.let { header ->
                 FocusBannerState.Route(

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/RouteRowGroupingTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/RouteRowGroupingTest.kt
@@ -343,6 +343,29 @@ class RouteRowGroupingTest {
     }
 
     @Test
+    fun selectedRouteGroup_suppliesRowHeadsign_forMapBadgeDirectionKey() {
+        // A map route-label tap names (route, direction) with no headsign string; the resolved group
+        // supplies the headsign the focus banner shows — the same row the drawer promotes.
+        val groups = listOf(
+            RouteRowGroup(listOf(previewArrival("11", "Madison Park", 2, routeId = "11", directionId = 0))),
+            RouteRowGroup(listOf(previewArrival("11", "Downtown", 5, routeId = "11", directionId = 1))),
+        )
+
+        val group = resolveSelectedRouteGroup(groups, routeRowKey("11", 1, null), "11")
+        assertEquals("Downtown", group?.headsign)
+    }
+
+    @Test
+    fun selectedRouteGroup_null_whenNoRowResolves() {
+        val groups = listOf(
+            RouteRowGroup(listOf(previewArrival("11", "Madison Park", 2, routeId = "11"))),
+            RouteRowGroup(listOf(previewArrival("11", "Downtown", 5, routeId = "11"))),
+        )
+
+        assertEquals(null, resolveSelectedRouteGroup(groups, routeRowKey("11", "Different label"), "11"))
+    }
+
+    @Test
     fun grouping_usesNumericDirectionRatherThanDisplayHeadsign() {
         val arrivals = listOf(
             previewArrival("11", "Same label", 2, routeId = "11", directionId = 0),


### PR DESCRIPTION
## The bug

In a focused stop, there are two ways to drill into a route's sub-focus, and they disagreed about the header subtitle:

- **Tap a route's arrivals row** → the focus banner shows the route badge **and its headsign** (the direction label).
- **Tap the same route's label on the map** → the banner shows the badge but **no headsign**, even though it's the identical (route, direction).

## Root cause

The banner read the raw stored `StopRouteSelection.originHeadsign`. The arrivals-row path (`selectArrivalRoute`) sets it from the tapped arrival; the map route-label path (`MapFeature.onRouteBadgeClick` → `HomeViewModel.requestShowFocusedStopRouteOnMap`) hardcodes it to `null`, because the map badge carries only route id + direction, not the headsign string. So the banner's subtitle came back null and fell through to a spacer.

The deeper smell: **derived display data (the headsign) was stored on the focus and populated per entry point**, so two producers could — and did — disagree.

## Fix (done at the right altitude)

The shared identity this needs already exists: `routeRowKey(routeId, directionId, headsign)` keys grouping, the LazyColumn, **and the drawer's selection highlight**, and `resolveSelectedRouteGroupKey` is the one resolver (with a single-row-by-route fallback for when map and arrivals direction labels differ). The drawer highlight *already* resolved a map-label selection correctly through it — the focus banner was the **only** surface bypassing it.

So route the banner through the same resolver:

- Add `resolveSelectedRouteGroup` (returns the resolved `RouteRowGroup`, wrapping the existing key resolver).
- The banner reads its headsign from that resolver, fed the exact identity the drawer already feeds it (`selectedArrivalRowKey()` + `originLeg.routeId`).
- `originHeadsign` stays, but purely as an **identity-key component** (disambiguating the legacy null-`directionId` row), never rendered — its doc now says so.

Every stop-focus surface now projects the shown headsign from **one** identity→row resolution. The entry points supply only row *identity* (`StopRouteSelection`); the headsign is always read back from the resolved arrivals row. No entry point carries a display headsign, so they can't disagree — the class of bug is gone by construction, and it generalizes to any future entry point (deep link, search): it resolves through the same function or it doesn't render the row.

The per-leg route **color** stays a route-level `actions` lookup — `RouteRowGroup` has no color field and color has no direction variance, so it isn't a candidate for the same resolver.

## Testing

- Compiles clean under the CI gate (`-PwarningsAsErrors=true`) on both `obaGoogle` and `obaMaplibre`.
- `RouteRowGroupingTest` extended: the resolved group supplies the row headsign for a map-badge `(route, direction)` key (no headsign string), and resolves to null when the route is ambiguous.
- Not yet re-exercised on-device — worth a quick check that the map route-label tap now shows the headsign.
