### PR TITLE
Remove unused deps: firebase-firestore, proto-google-common-protos, androidx.preference

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -52,7 +52,6 @@ activity = "1.13.0"
 exifinterface = "1.4.2"
 appcompat = "1.7.1"
 coreKtx = "1.19.0"
-preference = "1.2.1"
 datastore = "1.2.1"
 work = "2.11.2"
 room = "2.8.4"
@@ -101,7 +100,6 @@ androidx-activity-compose = { module = "androidx.activity:activity-compose", ver
 androidx-exifinterface = { module = "androidx.exifinterface:exifinterface", version.ref = "exifinterface" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "coreKtx" }
-androidx-preference = { module = "androidx.preference:preference", version.ref = "preference" }
 androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastore" }
 androidx-work-runtime = { module = "androidx.work:work-runtime", version.ref = "work" }
 androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "room" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,7 +38,6 @@ lint = "32.3.0"
 # --- Libraries ---
 desugar = "2.1.5"
 firebaseAnalytics = "23.2.0"
-firebaseFirestore = "26.4.1"
 firebaseAuth = "24.2.0"
 firebaseStorage = "22.0.1"
 firebaseCrashlytics = "20.1.0"
@@ -67,10 +66,8 @@ okhttp = "5.4.0"
 kotlinxSerializationJson = "1.11.0"
 coroutines = "1.11.0"
 material = "1.14.0"
-gson = "2.14.0"
 commonsIo = "2.22.0"
 gtfsRealtime = "0.1.0"
-protoGoogleCommonProtos = "2.73.0"
 maplibre = "13.3.1"
 # Test-only
 androidxTestRunner = "1.7.0"
@@ -84,7 +81,6 @@ desugar-jdk-libs = { module = "com.android.tools:desugar_jdk_libs", version.ref 
 
 # --- Firebase / Google Play services ---
 firebase-analytics = { module = "com.google.firebase:firebase-analytics", version.ref = "firebaseAnalytics" }
-firebase-firestore = { module = "com.google.firebase:firebase-firestore", version.ref = "firebaseFirestore" }
 firebase-auth = { module = "com.google.firebase:firebase-auth", version.ref = "firebaseAuth" }
 firebase-storage = { module = "com.google.firebase:firebase-storage", version.ref = "firebaseStorage" }
 firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics", version.ref = "firebaseCrashlytics" }
@@ -98,7 +94,6 @@ open311-client = { module = "com.github.OneBusAway:open311-client", version.ref 
 pelias-client-library = { module = "com.github.OneBusAway:pelias-client-library", version.ref = "pelias" }
 comparators = { module = "org.onebusaway.util:comparators", version.ref = "comparators" }
 gtfs-realtime-bindings = { module = "org.mobilitydata:gtfs-realtime-bindings", version.ref = "gtfsRealtime" }
-proto-google-common-protos = { module = "com.google.api.grpc:proto-google-common-protos", version.ref = "protoGoogleCommonProtos" }
 
 # --- AndroidX ---
 androidx-activity-ktx = { module = "androidx.activity:activity-ktx", version.ref = "activity" }
@@ -145,7 +140,6 @@ kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutine
 
 # --- Misc ---
 material = { module = "com.google.android.material:material", version.ref = "material" }
-gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
 commons-io = { module = "commons-io:commons-io", version.ref = "commonsIo" }
 maplibre-android-sdk = { module = "org.maplibre.gl:android-sdk", version.ref = "maplibre" }
 

--- a/onebusaway-android/build.gradle.kts
+++ b/onebusaway-android/build.gradle.kts
@@ -393,7 +393,6 @@ dependencies {
     // WorkManager (Java only)
     implementation(libs.androidx.work.runtime)
     implementation(libs.androidx.core.ktx)
-    implementation(libs.androidx.preference)
     // Preferences DataStore — the backing store behind PreferencesRepository.
     implementation(libs.androidx.datastore.preferences)
     // RoomDB

--- a/onebusaway-android/build.gradle.kts
+++ b/onebusaway-android/build.gradle.kts
@@ -176,12 +176,9 @@ android {
         // so consolidating them is unwanted, and the ~140 hits are pure noise. Opt out rather than
         // baseline them.
         //
-        // The next four are the tail of the lint-baseline cleanup (the goal being to delete the baseline
+        // The next three are the tail of the lint-baseline cleanup (the goal being to delete the baseline
         // entirely): each is a single/handful of findings that is either not our code to fix or not worth
         // fixing, so we opt out of the check rather than carry a baseline entry for it:
-        //  - InvalidPackage: emitted from grpc-core.jar, which references javax.naming[.directory] (JNDI)
-        //    — packages absent on Android — on a name-resolution path the app never exercises. It's
-        //    third-party library bytecode, not fixable here.
         //  - PermissionNamingConvention: the app's `${applicationId}.permission.TRIP_SERVICE` custom
         //    permission predates the convention; renaming a shipped permission is a compatibility break,
         //    so the name stays.
@@ -202,7 +199,7 @@ android {
             "MissingTranslation", "ExtraTranslation", "LogNotTimber",
             "GradleDependency", "NewerVersionAvailable", "AndroidGradlePluginVersion",
             "OldTargetApi", "DuplicateStrings",
-            "InvalidPackage", "PermissionNamingConvention", "MemberExtensionConflict", "ConvertToWebp",
+            "PermissionNamingConvention", "MemberExtensionConflict", "ConvertToWebp",
             "SyntheticAccessor"
         )
         // Run the FULL lint catalog — including checks that are off by default and library-provided
@@ -348,13 +345,6 @@ dependencies {
     implementation(libs.firebase.analytics)
     // Plausible Analytics
     implementation(libs.plausible.android.sdk)
-    // Cloud Firestore (for storing destination alert test data)
-    implementation(libs.firebase.firestore) {
-        // Exclude protobuf-lite and protolite-well-known-types to avoid conflicts with GTFS-realtime bindings
-        // See https://github.com/firebase/firebase-android-sdk/issues/5997
-        exclude(group = "com.google.firebase", module = "protolite-well-known-types")
-        exclude(group = "com.google.protobuf", module = "protobuf-javalite")
-    }
     implementation(libs.firebase.auth)
     implementation(libs.firebase.storage)
     // Firebase Crashlytics
@@ -392,15 +382,6 @@ dependencies {
     "maplibreImplementation"(libs.maplibre.android.sdk)
     // Autocomplete text views with clear button for trip planning
     implementation(libs.material)
-    // Gson is not used directly in app source. It arrives transitively via
-    // firebase-firestore -> io.grpc:grpc-core, which requests 2.10.1. We don't add it as a
-    // dependency; instead a constraint pins the transitive up to the catalog version so a future
-    // grpc/Firebase bump can't silently drag Gson back below the 2.8.9 CVE-2022-25647 fix.
-    constraints {
-        implementation(libs.gson) {
-            because("CVE-2022-25647: floor transitive Gson at the catalog version; not a direct dependency")
-        }
-    }
     // Unit tests - seems like this is still necessary w/ Android X even though useLibrary is declared earlier
     androidTestImplementation(libs.androidx.test.runner)
     androidTestImplementation(libs.androidx.test.ext.junit)
@@ -425,7 +406,6 @@ dependencies {
     ksp(libs.hilt.android.compiler)
     // GTFS Realtime bindings for parsing GTFS-realtime data
     implementation(libs.gtfs.realtime.bindings)
-    implementation(libs.proto.google.common.protos)
 
     // Jetpack Compose on the 1.11.x line (BOM 2026.06.01 -> compose-ui/foundation 1.11.4, material3
     // 1.4.0). This required the coordinated toolchain bump to compileSdk 37 + AGP 9.2.0 + Gradle 9.4.1.


### PR DESCRIPTION
## Summary

Removes three dead external dependencies (zero usage in the codebase) and the build cruft that existed only to support them.

### `firebase-firestore`
Added in #988 (2019) for the opt-in travel-behavior data collection feature (it pushed activity transitions, arrivals/departures, trip plans, and device info to a Firestore collection). That feature was removed, but the dependency lingered. The current tree has **zero** references to `Firestore` / `CollectionReference` / `DocumentReference`.

### `proto-google-common-protos`
Added only to satisfy Firestore's classes in the release R8 build (commit `93d71214`, *"fix: OBAGoogle-release -missing classes for firestore"*). Goes away with Firestore.

### `androidx.preference`
The settings UI was migrated to Compose — the `PreferenceCategory` / `EditTextPreferenceItem` / single-choice-row components in `ui/settings/components/PreferenceItems.kt` are the app's **own** Compose replacements for the legacy `androidx.preference` XML widgets. Nothing imports `androidx.preference`: no `PreferenceFragmentCompat`, no `res/xml` preference screens, zero API usage.

## Ripple cleanups (all downstream of Firestore leaving)

Firestore was the sole path for `io.grpc:grpc-core` into the dependency graph. Verified via `dependencies --configuration obaGoogleReleaseRuntimeClasspath` that neither `grpc-core` nor Gson resolve anymore, which makes these obsolete:

- **Gson version-floor constraint** (+ its `libs.versions.toml` entries) — floored a transitive that no longer exists, so it was a no-op.
- **`InvalidPackage` lint opt-out** (+ its note) — existed only for `grpc-core.jar`'s JNDI references.
- **Firestore's two protobuf `exclude` blocks** (`protolite-well-known-types`, `protobuf-javalite`) — removed with the dependency block they were attached to.

`firebase-auth` and `firebase-storage` are **kept** — they back the live destination-reminders feature, not Firestore.

## Testing

- `./gradlew :onebusaway-android:compileObaGoogleDebugKotlin -PwarningsAsErrors=true` passes clean.
- Full lint + instrumented suite runs in CI, which now exercises `InvalidPackage` against the real (grpc-free) graph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Re-enabled Android lint checks for invalid package declarations by removing the corresponding lint suppression.

* **Chores**
  * Removed Firebase Cloud Firestore, Gson, Google protobuf, and AndroidX preference dependencies.
  * Dropped the related transitive dependency constraint/pinning and protobuf-related exclusions.
  * Cleaned up the version catalog by removing the now-unused library/version entries.
  * Updated lint configuration notes to reflect the remaining lint settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->