### PR TITLE
Replace commons-io with Kotlin stdlib / java.io

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -68,7 +68,6 @@ kotlinxSerializationJson = "1.11.0"
 coroutines = "1.11.0"
 material = "1.14.0"
 gson = "2.14.0"
-commonsIo = "2.22.0"
 gtfsRealtime = "0.1.0"
 protoGoogleCommonProtos = "2.73.0"
 maplibre = "13.3.1"
@@ -146,7 +145,6 @@ kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutine
 # --- Misc ---
 material = { module = "com.google.android.material:material", version.ref = "material" }
 gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
-commons-io = { module = "commons-io:commons-io", version.ref = "commonsIo" }
 maplibre-android-sdk = { module = "org.maplibre.gl:android-sdk", version.ref = "maplibre" }
 
 # --- Testing ---

--- a/onebusaway-android/build.gradle.kts
+++ b/onebusaway-android/build.gradle.kts
@@ -364,7 +364,6 @@ dependencies {
     // Support libraries
     implementation(libs.androidx.activity.ktx)
     implementation(libs.androidx.exifinterface)
-    implementation(libs.commons.io)
     // Open311 client library
     implementation(libs.open311.client)
     // The OBA REST stack (api/): Retrofit + OkHttp + kotlinx.serialization. Every OBA "where"

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/nav/test/NavigationTest.java
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/nav/test/NavigationTest.java
@@ -29,7 +29,6 @@ import android.util.Log;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
-import org.apache.commons.io.IOUtils;
 import org.junit.Assume;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -793,7 +792,13 @@ public class NavigationTest extends ObaTestCase {
      */
     private void runSimulation(String csvFileName, int expectedGetReadyIndex, int expectedPullCordIndex) throws IOException {
         Reader reader = Resources.read(InstrumentationRegistry.getInstrumentation().getTargetContext(), Resources.getTestUri(csvFileName));
-        String csv = IOUtils.toString(reader);
+        StringBuilder sb = new StringBuilder();
+        char[] buffer = new char[8192];
+        int read;
+        while ((read = reader.read(buffer)) != -1) {
+            sb.append(buffer, 0, read);
+        }
+        String csv = sb.toString();
         NavigationSimulation trip = new NavigationSimulation(csv);
         trip.runSimulation(expectedGetReadyIndex, expectedPullCordIndex);
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/backup/BackupUtil.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/backup/BackupUtil.kt
@@ -14,7 +14,9 @@ fun uriToTempFile(context: Context, uri: Uri): File? {
     return try {
         val stream = context.contentResolver.openInputStream(uri)
         val file = File.createTempFile("temp", "", context.cacheDir)
-        org.apache.commons.io.FileUtils.copyInputStreamToFile(stream,file)
+        stream.use { input ->
+            file.outputStream().use { output -> input!!.copyTo(output) }
+        }
         file
     } catch (e: Exception) {
         e.printStackTrace()

--- a/onebusaway-android/src/main/java/org/onebusaway/android/nav/FeedbackReceiver.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/nav/FeedbackReceiver.java
@@ -23,7 +23,6 @@ import android.os.Bundle;
 import android.util.Log;
 
 
-import org.apache.commons.io.FileUtils;
 import org.onebusaway.android.BuildConfig;
 import org.onebusaway.android.R;
 import org.onebusaway.android.notifications.NotificationChannels;
@@ -31,7 +30,10 @@ import org.onebusaway.android.app.di.AnalyticsEntryPoint;
 import org.onebusaway.android.util.PreferenceUtils;
 
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
 
@@ -132,7 +134,10 @@ public class FeedbackReceiver extends BroadcastReceiver {
     private void moveLog(Context context, String feedback, String userResponse, String logFile) {
         try {
             File lFile = new File(logFile);
-            FileUtils.write(lFile, System.getProperty("line.separator") + "User Feedback - " + feedback, StandardCharsets.UTF_8, true);
+            try (Writer writer = new OutputStreamWriter(
+                    new FileOutputStream(lFile, true), StandardCharsets.UTF_8)) {
+                writer.write(System.getProperty("line.separator") + "User Feedback - " + feedback);
+            }
             Log.d(TAG, "Feedback appended");
 
             File destFolder = new File(context.getFilesDir()
@@ -142,9 +147,11 @@ public class FeedbackReceiver extends BroadcastReceiver {
             if (BuildConfig.DEBUG) Log.d(TAG, "targetLocation: " + destFolder);
 
             try {
-                FileUtils.moveFileToDirectory(
-                        FileUtils.getFile(lFile),
-                        FileUtils.getFile(destFolder), true);
+                destFolder.mkdirs();
+                File movedFile = new File(destFolder, lFile.getName());
+                if (!lFile.renameTo(movedFile)) {
+                    throw new IOException("Failed to move " + lFile + " to " + destFolder);
+                }
                 Log.d(TAG, "Move file successful.");
             } catch (Exception e) {
                 Log.d(TAG, "File move failed");

--- a/onebusaway-android/src/main/java/org/onebusaway/android/nav/NavigationService.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/nav/NavigationService.kt
@@ -43,7 +43,6 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
-import org.apache.commons.io.FileUtils
 import org.onebusaway.android.BuildConfig
 import org.onebusaway.android.R
 import org.onebusaway.android.notifications.NotificationChannels
@@ -63,7 +62,6 @@ import org.onebusaway.android.ui.tripdetails.TripDetailsLauncher
 import org.onebusaway.android.util.PreferenceUtils
 import java.io.File
 import java.io.IOException
-import java.nio.charset.StandardCharsets
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Locale
@@ -319,7 +317,7 @@ class NavigationService : Service() {
                 last?.latitude ?: 0.0, last?.longitude ?: 0.0
             )
 
-            FileUtils.write(file, header, StandardCharsets.UTF_8, false)
+            file.writeText(header)
         } catch (e: IOException) {
             Log.e(TAG, "File write failed: $e")
         }
@@ -348,7 +346,7 @@ class NavigationService : Service() {
 
             val file = logFile
             if (file != null && file.canWrite()) {
-                FileUtils.write(file, log, StandardCharsets.UTF_8, true)
+                file.appendText(log)
             } else {
                 Log.e(TAG, "Failed to write to file")
             }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/feedback/Feedback.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/feedback/Feedback.kt
@@ -54,9 +54,7 @@ import androidx.work.PeriodicWorkRequest
 import androidx.work.WorkManager
 import java.io.File
 import java.io.IOException
-import java.nio.charset.StandardCharsets
 import java.util.concurrent.TimeUnit
-import org.apache.commons.io.FileUtils
 import org.onebusaway.android.BuildConfig
 import org.onebusaway.android.R
 import org.onebusaway.android.app.di.AnalyticsEntryPoint
@@ -150,13 +148,16 @@ class FeedbackSubmitter(
         )
         try {
             val file = File(logFilePath)
-            FileUtils.write(file, System.lineSeparator() + feedback, StandardCharsets.UTF_8, true)
+            file.appendText(System.lineSeparator() + feedback)
             val destFolder = File(
                 context.filesDir.absolutePath
                         + File.separator + NavigationService.LOG_DIRECTORY + File.separator + response
             )
             try {
-                FileUtils.moveFileToDirectory(file, destFolder, true)
+                destFolder.mkdirs()
+                if (!file.renameTo(File(destFolder, file.name))) {
+                    throw IOException("Failed to move $file to $destFolder")
+                }
             } catch (e: Exception) {
                 Log.e(FeedbackLauncher.TAG, "File move failed")
             }


### PR DESCRIPTION
## Summary

Apache Commons IO was pulled in for a handful of trivial file operations that the Kotlin standard library and `java.io` cover natively. This replaces every call site and drops the dependency (`commons-io:commons-io`), following on from the dead-dependency cleanup in #1963.

## Call sites

| Before | After |
|---|---|
| `FileUtils.write(f, s, UTF_8, false)` | `f.writeText(s)` (Kotlin) |
| `FileUtils.write(f, s, UTF_8, true)` | `f.appendText(s)` (Kotlin) |
| `FileUtils.copyInputStreamToFile(in, f)` | `in.use { … copyTo(f.outputStream()) }` |
| `FileUtils.moveFileToDirectory(f, dir, true)` | `dir.mkdirs()` + `renameTo` (throws on failure) |
| `FileUtils.write(…, append)` (Java) | `OutputStreamWriter(FileOutputStream(f, true), UTF_8)` |
| `IOUtils.toString(Reader)` (test) | char-buffer read loop |

Touched: `BackupUtil.kt`, `NavigationService.kt`, `Feedback.kt`, `FeedbackReceiver.java`, and `NavigationTest.java`.

## Why not `java.nio.file`

`Files`/`Path` would be the obvious modern choice, but the project ships the **standard** `desugar_jdk_libs`, **not** the `_nio` variant — so those APIs aren't backported to the **minSdk 23** floor and would `NewApi`-fail / crash below API 26. Kotlin stdlib + `java.io` work at every API level.

## Behavior preserved

- UTF-8 write semantics kept (`writeText`/`appendText` default to UTF-8).
- Moves keep the "create destination dir, fail loudly on move failure" behavior; the failure is caught and logged at the same call sites as before.
- Input-stream close semantics preserved (`use { }` closes, matching `copyInputStreamToFile`).

## Testing

- `./gradlew :onebusaway-android:compileObaGoogleDebugKotlin :onebusaway-android:compileObaGoogleDebugAndroidTestSources -PwarningsAsErrors=true` passes clean.
- The navigation instrumented suite (`NavigationTest`) — the one test that used `IOUtils` — runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)