### PR TITLE
Vendor the used Material Icons, drop deprecated material-icons-core

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -61,7 +61,6 @@ lifecycle = "2.11.0"
 navigationCompose = "2.9.8"
 hiltNavigationCompose = "1.4.0"
 composeBom = "2026.06.01"
-materialIcons = "1.7.8"
 retrofit = "3.0.0"
 okhttp = "5.4.0"
 kotlinxSerializationJson = "1.11.0"
@@ -127,8 +126,6 @@ compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
 compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4" }
 compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest" }
 compose-material3 = { module = "androidx.compose.material3:material3" }
-# Material icons are frozen at 1.7.8 and no longer BOM-managed, so this one carries an explicit version.
-compose-material-icons-core = { module = "androidx.compose.material:material-icons-core", version.ref = "materialIcons" }
 
 # --- Hilt ---
 hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hilt" }

--- a/onebusaway-android/build.gradle.kts
+++ b/onebusaway-android/build.gradle.kts
@@ -441,10 +441,9 @@ dependencies {
     androidTestImplementation(libs.compose.ui.test.junit4)
     debugImplementation(libs.compose.ui.test.manifest)
     implementation(libs.compose.material3)              // 1.4.0 via BOM
-    // Material icons (Icons.Filled.*, AutoMirrored ArrowBack). Deprecated and frozen at 1.7.8, and
-    // no longer pulled transitively by material3 1.4.0, so pin explicitly. 1.7.8 runs fine on the
-    // 1.11.x Compose runtime; not managed by the BOM, hence the literal version.
-    implementation(libs.compose.material.icons.core)
+    // The handful of Material Icons the app uses are vendored as plain Compose ImageVectors in
+    // org.onebusaway.android.ui.icons.AppIcons, so we no longer depend on the deprecated (and frozen
+    // at 1.7.8) androidx.compose.material:material-icons-core artifact.
     implementation(libs.androidx.activity.compose)      // matches activity-ktx 1.13.0
     // ViewModel + StateFlow for Compose screens (lifecycle 2.10.0; minSdk 23)
     implementation(libs.androidx.lifecycle.viewmodel.ktx)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsScreen.kt
@@ -36,9 +36,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -81,6 +78,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.isActive
 import org.onebusaway.android.R
 import org.onebusaway.android.models.RouteDirectionKey
+import org.onebusaway.android.ui.icons.AppIcons
 import org.onebusaway.android.ui.nightlight.NightLightLauncher
 import org.onebusaway.android.ui.arrivals.components.ArrivalRowCallbacks
 import org.onebusaway.android.ui.arrivals.components.MenuRow
@@ -227,7 +225,7 @@ fun ArrivalsScreen(
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            imageVector = AppIcons.ArrowBack,
                             contentDescription = stringResource(R.string.navigate_up)
                         )
                     }
@@ -557,7 +555,7 @@ private fun AlertList(
                 Text(pluralStringResource(R.plurals.alert_show_more, remaining, remaining))
                 Spacer(Modifier.width(4.dp))
                 Icon(
-                    imageVector = Icons.Filled.KeyboardArrowDown,
+                    imageVector = AppIcons.KeyboardArrowDown,
                     contentDescription = null,
                     modifier = Modifier.size(18.dp)
                 )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/DirectionHeadsign.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/DirectionHeadsign.kt
@@ -19,8 +19,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -31,6 +29,7 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import org.onebusaway.android.ui.icons.AppIcons
 
 /**
  * The "heading toward X" line: a muted forward-arrow (reads as "toward" without asserting a
@@ -46,7 +45,7 @@ import androidx.compose.ui.unit.sp
 internal fun DirectionHeadsign(direction: String, modifier: Modifier = Modifier) {
     Row(modifier = modifier, verticalAlignment = Alignment.CenterVertically) {
         Icon(
-            imageVector = Icons.AutoMirrored.Filled.ArrowForward,
+            imageVector = AppIcons.ArrowForward,
             contentDescription = null,
             tint = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier.size(18.dp)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/ListScreenScaffold.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/ListScreenScaffold.kt
@@ -22,8 +22,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -36,6 +34,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import org.onebusaway.android.R
 import org.onebusaway.android.ui.compose.ListUiState
+import org.onebusaway.android.ui.icons.AppIcons
 
 /**
  * Scaffold for a fetch-once list screen: a back-navigation [TopAppBar] over a body driven by
@@ -64,7 +63,7 @@ fun <T> ListScreenScaffold(
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            imageVector = AppIcons.ArrowBack,
                             contentDescription = stringResource(R.string.navigate_up)
                         )
                     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/ObaTopAppBar.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/ObaTopAppBar.kt
@@ -16,8 +16,6 @@
 package org.onebusaway.android.ui.compose.components
 
 import androidx.compose.foundation.layout.RowScope
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -28,6 +26,7 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
 import org.onebusaway.android.R
+import org.onebusaway.android.ui.icons.AppIcons
 
 /**
  * The app's standard top bar for full-screen Compose hosts: a back arrow, the [title], optional
@@ -49,7 +48,7 @@ fun ObaTopAppBar(
         navigationIcon = {
             IconButton(onClick = onBack) {
                 Icon(
-                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                    imageVector = AppIcons.ArrowBack,
                     contentDescription = stringResource(R.string.navigate_up)
                 )
             }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/dataview/TripTrajectoryScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/dataview/TripTrajectoryScreen.kt
@@ -24,8 +24,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -56,6 +54,7 @@ import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
 import androidx.core.graphics.toColorInt
 import kotlinx.coroutines.delay
+import org.onebusaway.android.ui.icons.AppIcons
 
 private const val UI_TICK_MS = 1_000L
 
@@ -110,7 +109,7 @@ fun TripTrajectoryScreen(state: TripTrajectoryUiState, onBack: () -> Unit) {
                 title = { Text("Trajectory") },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                        Icon(AppIcons.ArrowBack, contentDescription = "Back")
                     }
                 },
             )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/chrome/MapTopChrome.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/chrome/MapTopChrome.kt
@@ -38,10 +38,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Clear
-import androidx.compose.material.icons.filled.Menu
-import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -70,6 +66,7 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
 import org.onebusaway.android.R
+import org.onebusaway.android.ui.icons.AppIcons
 import org.onebusaway.android.ui.mylists.RecentItem
 import org.onebusaway.android.ui.mylists.filterRecents
 
@@ -134,7 +131,7 @@ fun MapTopChrome(
                 contentColor = Color.White,
                 modifier = menuModifier.size(TOP_CHROME_HEIGHT),
             ) {
-                Icon(Icons.Default.Menu, stringResource(R.string.navigation_drawer_open))
+                Icon(AppIcons.Menu, stringResource(R.string.navigation_drawer_open))
             }
             SearchField(
                 recents = recents,
@@ -219,7 +216,7 @@ private fun SearchField(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Icon(
-                    Icons.Default.Search,
+                    AppIcons.Search,
                     contentDescription = stringResource(R.string.map_option_search),
                     tint = LocalContentColor.current.copy(alpha = 0.7f),
                 )
@@ -259,7 +256,7 @@ private fun SearchField(
                     val hasText = query.isNotEmpty()
                     IconButton(onClick = { if (hasText) query = "" else onDismiss() }) {
                         Icon(
-                            Icons.Default.Clear,
+                            AppIcons.Clear,
                             contentDescription = stringResource(
                                 if (hasText) R.string.stop_info_clear else R.string.search_close
                             ),

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
@@ -41,9 +41,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.filled.Place
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.DropdownMenu
@@ -86,6 +83,7 @@ import java.util.TimeZone
 import org.onebusaway.android.R
 import org.onebusaway.android.app.di.LocationEntryPoint
 import org.onebusaway.android.directions.model.TripItinerary
+import org.onebusaway.android.ui.icons.AppIcons
 import org.onebusaway.android.util.GeoPoint
 import org.onebusaway.android.directions.util.ConversionUtils
 import org.onebusaway.android.ui.compose.components.DRAG_HANDLE_HEIGHT
@@ -337,7 +335,7 @@ fun DirectionsLongPressMenu(
             )
             ListItem(
                 headlineContent = { Text(stringResource(R.string.directions_to_here)) },
-                leadingContent = { Icon(Icons.Default.Place, contentDescription = null) },
+                leadingContent = { Icon(AppIcons.Place, contentDescription = null) },
                 modifier = Modifier.clickable(onClick = onToHere),
             )
         }
@@ -387,7 +385,7 @@ fun DirectionsErrorSnackbar(
             }
             IconButton(onClick = onDismiss) {
                 Icon(
-                    imageVector = Icons.Filled.Close,
+                    imageVector = AppIcons.Close,
                     contentDescription = stringResource(R.string.dismiss),
                     tint = MaterialTheme.colorScheme.inverseOnSurface,
                 )
@@ -426,7 +424,7 @@ fun BoxScope.DirectionsPickOverlay(
                 style = MaterialTheme.typography.titleMedium,
             )
             IconButton(onClick = onCancel) {
-                Icon(Icons.Default.Close, contentDescription = stringResource(R.string.close))
+                Icon(AppIcons.Close, contentDescription = stringResource(R.string.close))
             }
         }
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/icons/AppIcons.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/icons/AppIcons.kt
@@ -1,0 +1,318 @@
+package org.onebusaway.android.ui.icons
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.PathBuilder
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+
+/**
+ * The small set of Material Icons the app uses, vendored as Compose [ImageVector]s so the app no
+ * longer depends on the deprecated (and frozen at 1.7.8) androidx.compose.material:material-icons-core
+ * artifact. See #1963-series dependency cleanup.
+ *
+ * These are the classic **Material Icons** glyphs (the same design family the old `Icons.Filled.*` /
+ * `Icons.AutoMirrored.Filled.*` rendered), exported from Google's official Compose icon export at
+ * fonts.google.com. Path data is verbatim; the black [SolidColor] fill is tinted by the `Icon`
+ * composable at the call site exactly as the library icons were. The two directional arrows carry
+ * `autoMirror = true` to preserve RTL mirroring.
+ *
+ * To add or refresh an icon, re-export it from fonts.google.com (Material Icons family, 24dp) and
+ * paste the path body here.
+ */
+object AppIcons {
+
+    val Close: ImageVector by lazy(LazyThreadSafetyMode.NONE) { materialIcon(name = "close") {
+        moveTo(18.98f, 6.42f)
+        lineTo(13.41f, 12f)
+        lineToRelative(5.58f, 5.58f)
+        lineToRelative(-1.41f, 1.41f)
+        lineTo(12f, 13.41f)
+        lineTo(6.42f, 18.98f)
+        lineTo(5.02f, 17.58f)
+        lineTo(10.59f, 12f)
+        lineTo(5.02f, 6.42f)
+        lineTo(6.42f, 5.02f)
+        lineTo(12f, 10.59f)
+        lineTo(17.58f, 5.02f)
+        lineToRelative(1.41f, 1.41f)
+        close()
+    } }
+
+    val Clear: ImageVector by lazy(LazyThreadSafetyMode.NONE) { materialIcon(name = "clear") {
+        moveTo(18.98f, 6.42f)
+        lineTo(13.41f, 12f)
+        lineToRelative(5.58f, 5.58f)
+        lineToRelative(-1.41f, 1.41f)
+        lineTo(12f, 13.41f)
+        lineTo(6.42f, 18.98f)
+        lineTo(5.02f, 17.58f)
+        lineTo(10.59f, 12f)
+        lineTo(5.02f, 6.42f)
+        lineTo(6.42f, 5.02f)
+        lineTo(12f, 10.59f)
+        lineTo(17.58f, 5.02f)
+        lineToRelative(1.41f, 1.41f)
+        close()
+    } }
+
+    val Info: ImageVector by lazy(LazyThreadSafetyMode.NONE) { materialIcon(name = "info") {
+        moveTo(12.98f, 9f)
+        verticalLineTo(6.98f)
+        horizontalLineTo(11.02f)
+        verticalLineTo(9f)
+        horizontalLineToRelative(1.97f)
+        close()
+        moveToRelative(0f, 8.02f)
+        verticalLineToRelative(-6f)
+        horizontalLineTo(11.02f)
+        verticalLineToRelative(6f)
+        horizontalLineToRelative(1.97f)
+        close()
+        moveTo(12f, 2.02f)
+        quadToRelative(4.13f, 0f, 7.05f, 2.93f)
+        reflectiveQuadTo(21.98f, 12f)
+        reflectiveQuadToRelative(-2.93f, 7.05f)
+        reflectiveQuadTo(12f, 21.98f)
+        reflectiveQuadTo(4.95f, 19.05f)
+        reflectiveQuadTo(2.02f, 12f)
+        reflectiveQuadTo(4.95f, 4.95f)
+        reflectiveQuadTo(12f, 2.02f)
+        close()
+    } }
+
+    val KeyboardArrowDown: ImageVector by lazy(LazyThreadSafetyMode.NONE) { materialIcon(name = "keyboard_arrow_down") {
+        moveTo(7.41f, 8.58f)
+        lineTo(12f, 13.17f)
+        lineTo(16.59f, 8.58f)
+        lineTo(18f, 9.98f)
+        lineToRelative(-6f, 6f)
+        lineToRelative(-6f, -6f)
+        lineTo(7.41f, 8.58f)
+        close()
+    } }
+
+    val KeyboardArrowUp: ImageVector by lazy(LazyThreadSafetyMode.NONE) { materialIcon(name = "keyboard_arrow_up") {
+        moveTo(7.41f, 15.42f)
+        lineTo(6f, 14.02f)
+        lineToRelative(6f, -6f)
+        lineToRelative(6f, 6f)
+        lineToRelative(-1.41f, 1.41f)
+        lineTo(12f, 10.83f)
+        lineTo(7.41f, 15.42f)
+        close()
+    } }
+
+    val MoreVert: ImageVector by lazy(LazyThreadSafetyMode.NONE) { materialIcon(name = "more_vert") {
+        moveTo(12f, 15.98f)
+        quadToRelative(0.8f, 0f, 1.41f, 0.61f)
+        reflectiveQuadTo(14.02f, 18f)
+        reflectiveQuadToRelative(-0.61f, 1.41f)
+        reflectiveQuadTo(12f, 20.02f)
+        reflectiveQuadTo(10.59f, 19.41f)
+        reflectiveQuadTo(9.98f, 18f)
+        reflectiveQuadToRelative(0.61f, -1.41f)
+        reflectiveQuadTo(12f, 15.98f)
+        close()
+        moveToRelative(0f, -6f)
+        quadToRelative(0.8f, 0f, 1.41f, 0.61f)
+        reflectiveQuadTo(14.02f, 12f)
+        reflectiveQuadToRelative(-0.61f, 1.41f)
+        reflectiveQuadTo(12f, 14.02f)
+        reflectiveQuadTo(10.59f, 13.41f)
+        reflectiveQuadTo(9.98f, 12f)
+        reflectiveQuadToRelative(0.61f, -1.41f)
+        reflectiveQuadTo(12f, 9.98f)
+        close()
+        moveTo(12f, 8.02f)
+        quadToRelative(-0.8f, 0f, -1.41f, -0.61f)
+        reflectiveQuadTo(9.98f, 6f)
+        reflectiveQuadTo(10.59f, 4.59f)
+        reflectiveQuadTo(12f, 3.98f)
+        reflectiveQuadToRelative(1.41f, 0.61f)
+        reflectiveQuadTo(14.02f, 6f)
+        reflectiveQuadTo(13.41f, 7.41f)
+        reflectiveQuadTo(12f, 8.02f)
+        close()
+    } }
+
+    val Settings: ImageVector by lazy(LazyThreadSafetyMode.NONE) { materialIcon(name = "settings") {
+        moveTo(12f, 15.52f)
+        quadToRelative(1.45f, 0f, 2.48f, -1.03f)
+        reflectiveQuadTo(15.52f, 12f)
+        reflectiveQuadTo(14.48f, 9.52f)
+        reflectiveQuadTo(12f, 8.48f)
+        reflectiveQuadTo(9.52f, 9.52f)
+        reflectiveQuadTo(8.48f, 12f)
+        reflectiveQuadToRelative(1.03f, 2.48f)
+        reflectiveQuadTo(12f, 15.52f)
+        close()
+        moveToRelative(7.45f, -2.53f)
+        lineToRelative(2.11f, 1.64f)
+        quadToRelative(0.33f, 0.23f, 0.09f, 0.66f)
+        lineToRelative(-2.02f, 3.47f)
+        quadToRelative(-0.19f, 0.33f, -0.61f, 0.19f)
+        lineTo(16.55f, 17.95f)
+        quadToRelative(-0.98f, 0.7f, -1.69f, 0.98f)
+        lineToRelative(-0.38f, 2.63f)
+        quadToRelative(-0.09f, 0.42f, -0.47f, 0.42f)
+        horizontalLineTo(9.98f)
+        quadToRelative(-0.38f, 0f, -0.47f, -0.42f)
+        lineTo(9.14f, 18.94f)
+        quadTo(8.25f, 18.56f, 7.45f, 17.95f)
+        lineTo(4.97f, 18.94f)
+        quadTo(4.55f, 19.08f, 4.36f, 18.75f)
+        lineTo(2.34f, 15.28f)
+        quadTo(2.11f, 14.86f, 2.44f, 14.63f)
+        lineTo(4.55f, 12.98f)
+        quadTo(4.5f, 12.66f, 4.5f, 12f)
+        reflectiveQuadTo(4.55f, 11.02f)
+        lineTo(2.44f, 9.38f)
+        quadTo(2.11f, 9.14f, 2.34f, 8.72f)
+        lineTo(4.36f, 5.25f)
+        quadTo(4.55f, 4.92f, 4.97f, 5.06f)
+        lineTo(7.45f, 6.05f)
+        quadTo(8.44f, 5.34f, 9.14f, 5.06f)
+        lineTo(9.52f, 2.44f)
+        quadTo(9.61f, 2.02f, 9.98f, 2.02f)
+        horizontalLineToRelative(4.03f)
+        quadToRelative(0.38f, 0f, 0.47f, 0.42f)
+        lineToRelative(0.38f, 2.63f)
+        quadToRelative(0.89f, 0.38f, 1.69f, 0.98f)
+        lineTo(19.03f, 5.06f)
+        quadToRelative(0.42f, -0.14f, 0.61f, 0.19f)
+        lineToRelative(2.02f, 3.47f)
+        quadToRelative(0.23f, 0.42f, -0.09f, 0.66f)
+        lineToRelative(-2.11f, 1.64f)
+        quadTo(19.5f, 11.34f, 19.5f, 12f)
+        reflectiveQuadToRelative(-0.05f, 0.98f)
+        close()
+    } }
+
+    val Search: ImageVector by lazy(LazyThreadSafetyMode.NONE) { materialIcon(name = "search") {
+        moveTo(9.52f, 14.02f)
+        quadToRelative(1.88f, 0f, 3.19f, -1.31f)
+        reflectiveQuadTo(14.02f, 9.52f)
+        reflectiveQuadTo(12.7f, 6.33f)
+        reflectiveQuadTo(9.52f, 5.02f)
+        reflectiveQuadTo(6.33f, 6.33f)
+        reflectiveQuadTo(5.02f, 9.52f)
+        reflectiveQuadTo(6.33f, 12.7f)
+        reflectiveQuadToRelative(3.19f, 1.31f)
+        close()
+        moveToRelative(6f, 0f)
+        lineToRelative(4.97f, 4.97f)
+        lineToRelative(-1.5f, 1.5f)
+        lineTo(14.02f, 15.52f)
+        verticalLineToRelative(-0.8f)
+        lineTo(13.73f, 14.44f)
+        quadToRelative(-1.78f, 1.55f, -4.22f, 1.55f)
+        quadTo(6.8f, 15.98f, 4.9f, 14.11f)
+        reflectiveQuadTo(3f, 9.52f)
+        reflectiveQuadTo(4.9f, 4.9f)
+        reflectiveQuadTo(9.52f, 3f)
+        reflectiveQuadToRelative(4.59f, 1.9f)
+        reflectiveQuadToRelative(1.88f, 4.62f)
+        quadToRelative(0f, 0.98f, -0.47f, 2.23f)
+        reflectiveQuadToRelative(-1.08f, 1.99f)
+        lineToRelative(0.28f, 0.28f)
+        horizontalLineToRelative(0.8f)
+        close()
+    } }
+
+    val Place: ImageVector by lazy(LazyThreadSafetyMode.NONE) { materialIcon(name = "place") {
+        moveTo(12f, 11.48f)
+        quadToRelative(1.03f, 0f, 1.76f, -0.73f)
+        reflectiveQuadTo(14.48f, 9f)
+        reflectiveQuadTo(13.76f, 7.24f)
+        reflectiveQuadTo(12f, 6.52f)
+        reflectiveQuadTo(10.24f, 7.24f)
+        reflectiveQuadTo(9.52f, 9f)
+        reflectiveQuadToRelative(0.73f, 1.76f)
+        reflectiveQuadTo(12f, 11.48f)
+        close()
+        moveTo(12f, 2.02f)
+        quadToRelative(2.91f, 0f, 4.95f, 2.04f)
+        reflectiveQuadTo(18.98f, 9f)
+        quadToRelative(0f, 1.45f, -0.73f, 3.33f)
+        reflectiveQuadTo(16.5f, 15.84f)
+        reflectiveQuadToRelative(-2.04f, 3.07f)
+        reflectiveQuadToRelative(-1.71f, 2.27f)
+        lineTo(12f, 21.98f)
+        quadTo(11.72f, 21.66f, 11.25f, 21.12f)
+        reflectiveQuadTo(9.56f, 18.96f)
+        reflectiveQuadTo(7.43f, 15.82f)
+        reflectiveQuadTo(5.77f, 12.38f)
+        reflectiveQuadTo(5.02f, 9f)
+        quadToRelative(0f, -2.91f, 2.04f, -4.95f)
+        reflectiveQuadTo(12f, 2.02f)
+        close()
+    } }
+
+    val Menu: ImageVector by lazy(LazyThreadSafetyMode.NONE) { materialIcon(name = "menu") {
+        moveTo(3f, 6f)
+        horizontalLineTo(21f)
+        verticalLineTo(8.02f)
+        horizontalLineTo(3f)
+        verticalLineTo(6f)
+        close()
+        moveToRelative(0f, 6.98f)
+        verticalLineTo(11.02f)
+        horizontalLineTo(21f)
+        verticalLineToRelative(1.97f)
+        horizontalLineTo(3f)
+        close()
+        moveTo(3f, 18f)
+        verticalLineTo(15.98f)
+        horizontalLineTo(21f)
+        verticalLineTo(18f)
+        horizontalLineTo(3f)
+        close()
+    } }
+
+    val ArrowBack: ImageVector by lazy(LazyThreadSafetyMode.NONE) { materialIcon(name = "arrow_back", autoMirror = true) {
+        moveTo(20.02f, 11.02f)
+        verticalLineToRelative(1.97f)
+        horizontalLineTo(7.83f)
+        lineToRelative(5.58f, 5.63f)
+        lineTo(12f, 20.02f)
+        lineTo(3.98f, 12f)
+        lineTo(12f, 3.98f)
+        lineToRelative(1.41f, 1.41f)
+        lineTo(7.83f, 11.02f)
+        horizontalLineTo(20.02f)
+        close()
+    } }
+
+    val ArrowForward: ImageVector by lazy(LazyThreadSafetyMode.NONE) { materialIcon(name = "arrow_forward", autoMirror = true) {
+        moveTo(12f, 3.98f)
+        lineTo(20.02f, 12f)
+        lineTo(12f, 20.02f)
+        lineTo(10.59f, 18.61f)
+        lineToRelative(5.58f, -5.63f)
+        horizontalLineTo(3.98f)
+        verticalLineTo(11.02f)
+        horizontalLineTo(16.17f)
+        lineTo(10.59f, 5.39f)
+        lineTo(12f, 3.98f)
+        close()
+    } }
+}
+
+private inline fun materialIcon(
+    name: String,
+    autoMirror: Boolean = false,
+    pathBody: PathBuilder.() -> Unit,
+): ImageVector =
+    ImageVector.Builder(
+        name = name,
+        defaultWidth = 24.dp,
+        defaultHeight = 24.dp,
+        viewportWidth = 24f,
+        viewportHeight = 24f,
+        autoMirror = autoMirror,
+    ).apply {
+        path(fill = SolidColor(Color.Black), pathFillType = PathFillType.NonZero, pathBuilder = pathBody)
+    }.build()

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/mylists/MyTabsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/mylists/MyTabsScreen.kt
@@ -23,8 +23,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
@@ -46,6 +44,7 @@ import androidx.compose.ui.res.stringResource
 import kotlinx.coroutines.launch
 import org.onebusaway.android.R
 import org.onebusaway.android.ui.compose.components.ObaTopAppBar
+import org.onebusaway.android.ui.icons.AppIcons
 
 /** A labelled overflow action (the per-tab "Clear" item) for [MyTab]. */
 data class TabAction(@param:StringRes val labelRes: Int, val onClick: () -> Unit)
@@ -140,7 +139,7 @@ private fun ClearOverflow(clear: TabAction) {
     var expanded by remember { mutableStateOf(false) }
     Box {
         IconButton(onClick = { expanded = true }) {
-            Icon(Icons.Default.MoreVert, contentDescription = null)
+            Icon(AppIcons.MoreVert, contentDescription = null)
         }
         DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
             DropdownMenuItem(

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/nightlight/NightLightDestination.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/nightlight/NightLightDestination.kt
@@ -27,8 +27,6 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
@@ -59,6 +57,7 @@ import org.onebusaway.android.R
 import org.onebusaway.android.ui.common.Shortcuts
 import org.onebusaway.android.ui.compose.components.ObaTopAppBar
 import org.onebusaway.android.ui.compose.findActivity
+import org.onebusaway.android.ui.icons.AppIcons
 import org.onebusaway.android.ui.nav.NavRoutes
 import org.onebusaway.android.util.PreferenceUtils
 
@@ -186,7 +185,7 @@ private fun NightLightScreen(onBack: () -> Unit, onCreateShortcut: () -> Unit) {
                 Box {
                     IconButton(onClick = { expanded = true }) {
                         Icon(
-                            imageVector = Icons.Default.MoreVert,
+                            imageVector = AppIcons.MoreVert,
                             contentDescription = null,
                             tint = MaterialTheme.colorScheme.onSurface
                         )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/routeinfo/RouteInfoScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/routeinfo/RouteInfoScreen.kt
@@ -29,10 +29,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.KeyboardArrowDown
-import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
@@ -63,6 +59,7 @@ import org.onebusaway.android.ui.compose.components.LoadingContent
 import org.onebusaway.android.ui.compose.components.MenuHeader
 import org.onebusaway.android.ui.compose.components.StopRowContent
 import org.onebusaway.android.ui.compose.theme.ObaTheme
+import org.onebusaway.android.ui.icons.AppIcons
 
 /** Stateful entry point: collects the ViewModel's state and wires UI events to the host. */
 @Composable
@@ -100,7 +97,7 @@ fun RouteInfoScreen(
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            imageVector = AppIcons.ArrowBack,
                             contentDescription = stringResource(R.string.navigate_up)
                         )
                     }
@@ -232,9 +229,9 @@ private fun DirectionHeader(name: String, expanded: Boolean, onClick: () -> Unit
         )
         Icon(
             imageVector = if (expanded) {
-                Icons.Filled.KeyboardArrowUp
+                AppIcons.KeyboardArrowUp
             } else {
-                Icons.Filled.KeyboardArrowDown
+                AppIcons.KeyboardArrowDown
             },
             contentDescription = null
         )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/search/SearchScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/search/SearchScreen.kt
@@ -22,8 +22,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -37,6 +35,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import org.onebusaway.android.R
 import org.onebusaway.android.ui.compose.components.LoadingContent
+import org.onebusaway.android.ui.icons.AppIcons
 
 /**
  * Shared incremental-search screen: a search box above a state-driven body. Embedded inside
@@ -65,7 +64,7 @@ fun <T> SearchScreen(
                 {
                     IconButton(onClick = { onQueryChange("") }) {
                         Icon(
-                            imageVector = Icons.Filled.Clear,
+                            imageVector = AppIcons.Clear,
                             contentDescription = stringResource(R.string.stop_info_clear)
                         )
                     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/survey/SurveyOverlay.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/survey/SurveyOverlay.kt
@@ -26,8 +26,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.Checkbox
@@ -59,6 +57,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.repeatOnLifecycle
 import org.onebusaway.android.R
 import org.onebusaway.android.models.SurveyQuestion
+import org.onebusaway.android.ui.icons.AppIcons
 import org.onebusaway.android.ui.survey.utils.SurveyUtils
 
 /**
@@ -179,7 +178,7 @@ private fun SurveyHeroCard(
                     )
                     IconButton(onClick = callbacks.onRequestDismiss) {
                         Icon(
-                            Icons.Filled.Close,
+                            AppIcons.Close,
                             contentDescription = stringResource(R.string.dismiss_survey),
                         )
                     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripdetails/TripDetailsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripdetails/TripDetailsScreen.kt
@@ -38,8 +38,6 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Info
 import androidx.compose.material3.Icon
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.IconButton
@@ -78,6 +76,7 @@ import org.onebusaway.android.ui.compose.components.LoadingContent
 import org.onebusaway.android.ui.compose.components.ObaTopAppBar
 import org.onebusaway.android.ui.compose.theme.ObaTheme
 import org.onebusaway.android.time.WallTime
+import org.onebusaway.android.ui.icons.AppIcons
 
 /** Refresh interval matching the legacy TripDetailsListFragment (fixed 60s). */
 private const val REFRESH_PERIOD_MS = 60_000L
@@ -155,7 +154,7 @@ fun TripDetailsScreen(
                     // Speed-estimation trajectory graph (debug).
                     IconButton(onClick = onShowTrajectory) {
                         Icon(
-                            imageVector = Icons.Filled.Info,
+                            imageVector = AppIcons.Info,
                             contentDescription = "Trajectory",
                             tint = MaterialTheme.colorScheme.onSurface
                         )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripinfo/TripInfoScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripinfo/TripInfoScreen.kt
@@ -27,9 +27,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -63,6 +60,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import org.onebusaway.android.R
 import org.onebusaway.android.ui.compose.components.LoadingContent
 import org.onebusaway.android.ui.compose.theme.ObaTheme
+import org.onebusaway.android.ui.icons.AppIcons
 
 /** Stateful entry point: collects the ViewModel state and wires the form callbacks. */
 @Composable
@@ -111,7 +109,7 @@ fun TripInfoScreen(
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            imageVector = AppIcons.ArrowBack,
                             contentDescription = stringResource(R.string.navigate_up)
                         )
                     }
@@ -163,7 +161,7 @@ private fun OverflowMenu(onShowRoute: () -> Unit, onShowStop: () -> Unit) {
     Box {
         IconButton(onClick = { expanded = true }) {
             Icon(
-                imageVector = Icons.Default.MoreVert,
+                imageVector = AppIcons.MoreVert,
                 contentDescription = null,
                 tint = MaterialTheme.colorScheme.onSurface
             )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanForm.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanForm.kt
@@ -22,9 +22,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.BasicTextField
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
@@ -54,6 +51,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.onebusaway.android.R
 import org.onebusaway.android.ui.compose.theme.ObaTheme
+import org.onebusaway.android.ui.icons.AppIcons
 
 /**
  * The trip-plan form: two autocomplete address fields (each with current-location + contacts
@@ -142,7 +140,7 @@ fun TripPlanForm(
                 }
                 IconButton(onClick = onAdvancedSettings) {
                     Icon(
-                        imageVector = Icons.Default.Settings,
+                        imageVector = AppIcons.Settings,
                         contentDescription = stringResource(R.string.trip_plan_advanced_settings),
                     )
                 }
@@ -310,7 +308,7 @@ private fun EndpointPillField(
                     },
                     trailingIcon = {
                         Icon(
-                            imageVector = Icons.Filled.Close,
+                            imageVector = AppIcons.Close,
                             contentDescription = stringResource(R.string.trip_plan_clear_endpoint)
                         )
                     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
@@ -33,9 +33,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.KeyboardArrowDown
-import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -77,6 +74,7 @@ import org.onebusaway.android.ui.compose.components.EtaPartsText
 import org.onebusaway.android.ui.compose.components.LoadingContent
 import org.onebusaway.android.ui.compose.components.RouteBadgeChip
 import org.onebusaway.android.ui.compose.findActivity
+import org.onebusaway.android.ui.icons.AppIcons
 import org.onebusaway.android.util.DisplayFormat
 import org.onebusaway.android.util.GeoPoint
 import org.onebusaway.android.ui.compose.theme.ObaTheme
@@ -385,7 +383,7 @@ private fun DirectionRow(item: DirectionItem, onFocusPoint: (GeoPoint) -> Unit) 
             }
             if (hasSubItems) {
                 Icon(
-                    imageVector = if (expanded) Icons.Filled.KeyboardArrowUp else Icons.Filled.KeyboardArrowDown,
+                    imageVector = if (expanded) AppIcons.KeyboardArrowUp else AppIcons.KeyboardArrowDown,
                     contentDescription = null,
                     tint = MaterialTheme.colorScheme.onSurfaceVariant
                 )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tutorial/SpotlightTutorial.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tutorial/SpotlightTutorial.kt
@@ -41,8 +41,6 @@ import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -80,6 +78,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.lerp
 import kotlin.math.hypot
 import org.onebusaway.android.R
+import org.onebusaway.android.ui.icons.AppIcons
 
 /**
  * One step of a spotlight tutorial: a caption (title + body, optional trailing [bodyIcon]) anchored to
@@ -403,7 +402,7 @@ private fun TutorialCaption(
                 )
                 IconButton(onClick = onClose) {
                     Icon(
-                        Icons.Default.Close,
+                        AppIcons.Close,
                         contentDescription = stringResource(R.string.tutorial_button_close),
                     )
                 }


### PR DESCRIPTION
## Summary

`androidx.compose.material:material-icons-core` is **deprecated** and frozen at 1.7.8 (the build already carried a comment noting this). The app uses only **12 distinct glyphs**, so this vendors them as plain Compose `ImageVector`s and removes the dependency.

## What changed

- **New `org.onebusaway.android.ui.icons.AppIcons`** — the 12 icons (`Close`, `Clear`, `Info`, `KeyboardArrowDown`/`Up`, `MoreVert`, `Settings`, `Search`, `Place`, `Menu`, and AutoMirrored `ArrowBack`/`ArrowForward`) as `ImageVector`s built via a small local `materialIcon()` helper. Depends only on `androidx.compose.ui.graphics` — already on the classpath.
- **17 call sites swapped** — `Icons.{Filled,Default}.X` / `Icons.AutoMirrored.Filled.X` → `AppIcons.X`, dropping every `androidx.compose.material.icons` import.
- **Dependency removed** — `compose-material-icons-core` and its `materialIcons` version pin are gone from `build.gradle.kts` and `libs.versions.toml`.

## Preserving the current look

Per the request, this keeps today's appearance — it does **not** switch to Material Symbols:

- Path data is the classic **Material Icons** family (the same design `Icons.Filled.*` rendered), taken **verbatim** from Google's official Compose icon export at `fonts.google.com` (generated `.kt` → `ImageVector`, Apache-2.0).
- The black `SolidColor` fill is tinted by the `Icon` composable at each call site, exactly as the library icons were.
- The two directional arrows keep **`autoMirror = true`** so RTL mirroring is unchanged.
- Coordinates differ from the frozen 1.7.8 artifact only at the **sub-pixel** level (e.g. `close` starts at `18.98` vs `19.0` on the 24px grid) — visually indistinguishable at any real size.

The About-screen attribution to Google's material-design-icons (Apache-2.0) is intentionally kept — we still use their designs.

## Testing

- `./gradlew :onebusaway-android:compileObaGoogleDebugKotlin -PwarningsAsErrors=true` passes clean (validates `AppIcons`, all 17 swaps, and no orphaned imports under the CI warnings gate).
- Compose UI + lint run in CI.

Follows the dependency-cleanup series (#1963, #1965).

🤖 Generated with [Claude Code](https://claude.com/claude-code)