### PR TITLE
Directions legs: always-expand transit, board-only ETA, block-level walk-leg zoom

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,9 +72,12 @@ spotless {
         // this move away from hand-formatting removes. Disabled so formatting stays fully automatic.
         "ktlint_standard_max-line-length" to "disabled"
     )
+    // `.claude/**` holds Claude Code's gitignored scratch — notably nested git worktrees whose (possibly
+    // pre-reformat) sources would otherwise be globbed in and fail the format gate. It never ships and
+    // doesn't exist on CI, so exclude it everywhere alongside generated `build/` output.
     kotlin {
         target("**/*.kt")
-        targetExclude("**/build/**")
+        targetExclude("**/build/**", "**/.claude/**")
         ktlint(ktlintVersion).editorConfigOverride(ktlintConfig)
     }
     kotlinGradle {
@@ -82,11 +85,12 @@ spotless {
         // brand-flavor files under onebusaway-android/flavors/*.gradle are *.gradle, not *.gradle.kts,
         // so they're intentionally not matched here.
         target("**/*.gradle.kts")
+        targetExclude("**/.claude/**")
         ktlint(ktlintVersion).editorConfigOverride(ktlintConfig)
     }
     java {
         target("**/*.java")
-        targetExclude("**/build/**")
+        targetExclude("**/build/**", "**/.claude/**")
         googleJavaFormat()
     }
 }

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/DirectionRowFocusTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/DirectionRowFocusTest.kt
@@ -30,11 +30,11 @@ import org.onebusaway.android.ui.compose.createUnconfinedComposeRule
 import org.onebusaway.android.util.GeoPoint
 
 /**
- * Verifies the leg-card tap split in [TripResultsList]: tapping a card **body** frames the whole leg
- * (`onFocusLeg` with its polyline), falling back to the leg's point when it has no polyline; the
- * separate **expand button** only reveals the sub-steps (never moves the map); and a revealed sub-step
- * focuses its own point. Drives the real click wiring by node text / content description, not
- * coordinates.
+ * Verifies the leg-card tap wiring in [TripResultsList]: tapping a card **body** frames the whole leg
+ * (`onFocusLeg` with its polyline), falling back to the leg's point when it has no polyline. A walk/other
+ * leg's turn-by-turn steps collapse behind an **expand button** (which only reveals them, never moves the
+ * map) and tapping a revealed sub-step focuses its own point; a transit leg's Board/Alight ETA strips are
+ * always shown. Drives the real click wiring by node text / content description, not coordinates.
  */
 class DirectionRowFocusTest {
 
@@ -98,7 +98,7 @@ class DirectionRowFocusTest {
     }
 
     @Test
-    fun expandButtonRevealsSubSteps_withoutMovingTheMap_thenSubStepFocuses() {
+    fun walkLegExpandButtonRevealsSubSteps_withoutMovingTheMap_thenSubStepFocuses() {
         var framed: List<GeoPoint>? = null
         var focused: GeoPoint? = null
         composeRule.setContent {
@@ -109,7 +109,7 @@ class DirectionRowFocusTest {
             )
         }
 
-        // Sub-steps are collapsed to start.
+        // A walk/other leg's turn-by-turn steps are collapsed to start.
         composeRule.onNodeWithText(stopA.text).assertDoesNotExist()
 
         // The expand button reveals the sub-steps — and moves neither the leg frame nor a point.
@@ -201,7 +201,7 @@ class DirectionRowFocusTest {
     }
 
     @Test
-    fun expandingTransitLeg_showsBothStopEtaStrips() {
+    fun transitLeg_showsOnlyTheBoardStopEtaStrip() {
         composeRule.setContent {
             TripResultsList(
                 state = routeState,
@@ -211,14 +211,9 @@ class DirectionRowFocusTest {
 
         val boardName = boardStop.name!!
         val alightName = alightStop.name!!
-        // The strips are hidden until the leg is expanded.
-        composeRule.onNodeWithText(stripMarker(boardName)).assertDoesNotExist()
-        composeRule.onNodeWithContentDescription(context.getString(R.string.trip_plan_expand_leg))
-            .performClick()
-
-        // Expanding shows both the Board and Alight strips at once (no per-stop toggle).
+        // The Board strip is shown (no expand toggle); the Alight stop has no ETA strip.
         composeRule.onNodeWithText(stripMarker(boardName)).assertExists()
-        composeRule.onNodeWithText(stripMarker(alightName)).assertExists()
+        composeRule.onNodeWithText(stripMarker(alightName)).assertDoesNotExist()
     }
 
     @Test
@@ -227,9 +222,6 @@ class DirectionRowFocusTest {
         composeRule.setContent {
             TripResultsList(state = routeState, onFocusPoint = { focused = it })
         }
-
-        composeRule.onNodeWithContentDescription(context.getString(R.string.trip_plan_expand_leg))
-            .performClick()
 
         composeRule.onNodeWithText(boardStop.name!!).performClick()
         assertEquals(boardStop.point, focused)

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleCameraCommands.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleCameraCommands.kt
@@ -154,7 +154,7 @@ fun applyFramingIntent(
         )
 
         is FramingIntent.Points -> {
-            val (sw, ne) = framingCorners(intent.points) ?: return
+            val (sw, ne) = framingCorners(intent.points, intent.minSpanDeg) ?: return
             val bounds = LatLngBounds(LatLng(sw.latitude, sw.longitude), LatLng(ne.latitude, ne.longitude))
             // An ETA tap emits the padding update and this framing together with no ordering guarantee, so
             // fold the current insets in here (see animateBounds) or the vehicle+stop pair lands under the

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapHost.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapHost.kt
@@ -39,6 +39,7 @@ import org.onebusaway.android.location.isLocationEnabled
 import org.onebusaway.android.map.render.CameraCommand
 import org.onebusaway.android.map.render.CameraSnapshot
 import org.onebusaway.android.map.render.FramingIntent
+import org.onebusaway.android.map.render.MIN_FRAMING_SPAN_DEG
 import org.onebusaway.android.map.render.MapPadding
 import org.onebusaway.android.map.render.MapRenderState
 import org.onebusaway.android.map.render.MapViewport
@@ -285,9 +286,10 @@ class MapHost(
 
     /**
      * Frame a single itinerary leg by fitting its polyline [points] within the map's content padding
-     * (so the leg lands in the band above the results sheet). Retained like [frameItinerary].
+     * (so the leg lands in the band above the results sheet). Retained like [frameItinerary]. A short
+     * leg is fit to at least [minSpanDeg] so it doesn't over-zoom (see [framingCorners]).
      */
-    fun frameItineraryLeg(points: List<GeoPoint>) = frame(FramingIntent.Points(points))
+    fun frameItineraryLeg(points: List<GeoPoint>, minSpanDeg: Double = MIN_FRAMING_SPAN_DEG) = frame(FramingIntent.Points(points, minSpanDeg))
 
     /**
      * Frame a degenerate directions itinerary (no route shape — start == end): center on [lat], [lon] at

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
@@ -39,6 +39,7 @@ import org.onebusaway.android.map.render.CameraCommand
 import org.onebusaway.android.map.render.CameraSnapshot
 import org.onebusaway.android.map.render.MapRenderState
 import org.onebusaway.android.map.render.MapViewport
+import org.onebusaway.android.map.render.WALK_LEG_MIN_FRAMING_SPAN_DEG
 import org.onebusaway.android.map.render.viewport
 import org.onebusaway.android.models.FocusedTrip
 import org.onebusaway.android.models.ObaRoute
@@ -505,7 +506,9 @@ class MapViewModel @Inject constructor(
      */
     fun focusItineraryLeg(points: List<GeoPoint>) {
         if (!directionsActive || points.isEmpty()) return
-        mapHost.frameItineraryLeg(points)
+        // A short walking leg (crossing a street) frames to a block-level floor rather than the default
+        // minimum, so the user doesn't have to zoom in further to read it.
+        mapHost.frameItineraryLeg(points, WALK_LEG_MIN_FRAMING_SPAN_DEG)
     }
 
     /** Clear the drawn itinerary while staying in directions mode (e.g. the plan became unsubmittable). */

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/FramingIntent.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/FramingIntent.kt
@@ -49,11 +49,15 @@ sealed interface FramingIntent {
      * Fit the bounds enclosing an explicit set of [points] with the default padding — the arrivals-row
      * tap fitting a route's live vehicle together with its originating stop, so the map frames the
      * relationship between the two. Self-contained (unlike [Route]/[Region], it carries its own points),
-     * so a replay to a re-created adapter just re-fits the same box. The adapter expands a degenerate box
-     * (a vehicle sitting on its stop) to a minimum span so it doesn't zoom to the rooftops
-     * (see [framingCorners]).
+     * so a replay to a re-created adapter just re-fits the same box. The adapter expands a box smaller
+     * than [minSpanDeg] up to that span so a tiny/degenerate box (a vehicle sitting on its stop) doesn't
+     * zoom to the rooftops (see [framingCorners]); a tapped walking leg passes a tighter block-level
+     * floor ([WALK_LEG_MIN_FRAMING_SPAN_DEG]) so a short hop frames closer in.
      */
-    data class Points(val points: List<GeoPoint>) : FramingIntent
+    data class Points(
+        val points: List<GeoPoint>,
+        val minSpanDeg: Double = MIN_FRAMING_SPAN_DEG
+    ) : FramingIntent
 }
 
 /** Default breathing room between route/itinerary bounds and the unobstructed map viewport. */
@@ -61,6 +65,14 @@ const val DEFAULT_FRAMING_PADDING_DP: Float = 20.0f
 
 /** The smallest lat/lon span a [FramingIntent.Points] box is fit to, so near-coincident points don't over-zoom. */
 const val MIN_FRAMING_SPAN_DEG: Double = 0.004
+
+/**
+ * The block-level minimum span used when framing a tapped walking leg — so a short hop (e.g. crossing a
+ * street) frames closer in than the default [MIN_FRAMING_SPAN_DEG] rather than making the user zoom in
+ * further. ~0.0014° of latitude ≈ 500 ft; longitude degrees run shorter at these latitudes, so the box
+ * is a touch narrower than tall, matching the existing degree-uniform convention (see [framingCorners]).
+ */
+const val WALK_LEG_MIN_FRAMING_SPAN_DEG: Double = 0.0014
 
 /**
  * Padding (dp) between a [FramingIntent.Points] box and the map edges — breathing room around the fit

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
@@ -393,13 +393,12 @@ private fun maybeStartTripUpdates(
 /**
  * One itinerary leg, as a card. Tapping the card **body**:
  *  - a transit leg highlights its route on the map (the whole route + the traveled segment thick); its
- *    two sub-items are **Board** and **Alight**, and tapping one reveals that stop's live ETA strip
- *    inline ([stopEtaStrip]) — pills wired like the arrivals drawer.
+ *    two sub-items are **Board** and **Alight**; the Board stop shows its live ETA strip inline
+ *    ([stopEtaStrip]) — pills wired like the arrivals drawer. These are **always shown**.
  *  - a walk/other leg frames the leg (falling back to its representative point when it has no polyline);
- *    its sub-items are the turn-by-turn steps, each recentring the map on its own point.
- *
- * A distinct **expand button** reveals the sub-items. So the body moves the map while the button only
- * toggles the drawer — two separate targets.
+ *    its sub-items are the turn-by-turn steps, each recentring the map on its own point. These would be
+ *    mostly noise, so they stay **collapsed** behind a chevron **expand button** — tapping it only
+ *    toggles the drawer (never moves the map).
  */
 @Composable
 private fun DirectionRow(
@@ -409,17 +408,17 @@ private fun DirectionRow(
     onFocusPoint: (GeoPoint) -> Unit,
     stopEtaStrip: @Composable (RouteLegRef, RouteStopRef, List<GeoPoint>) -> Unit
 ) {
-    // Rows are keyed by index in the LazyColumn, so switching itineraries reuses this slot for a
-    // different DirectionItem. Key the expansion state on the item so it resets on that swap instead of
-    // leaking into the new itinerary's card.
-    var expanded by remember(item) { mutableStateOf(false) }
-    // A transit leg with a resolvable route id highlights its route (and expands to Board/Alight);
+    // A transit leg with a resolvable route id highlights its route (and its Board/Alight sub-items);
     // otherwise the body frames the leg polyline, or (no geometry) recenters on the representative point.
     val routeLeg = item.routeLeg?.takeIf { it.routeId != null }
     val canFrame = item.legPoints.isNotEmpty()
     val point = item.focusPoint
-    val expandable = routeLeg != null || item.subItems.isNotEmpty()
     val bodyClickable = routeLeg != null || canFrame || point != null
+    // Only walk/other legs collapse their turn-by-turn steps behind a chevron — a transit leg's
+    // Board/Alight strips are always shown. Rows are keyed by index in the LazyColumn, so key the
+    // expansion state on the item to reset it when this slot is reused for a different itinerary's leg.
+    val collapsibleSteps = routeLeg == null && item.subItems.isNotEmpty()
+    var expanded by remember(item) { mutableStateOf(false) }
     Surface(
         shape = RoundedCornerShape(12.dp),
         color = MaterialTheme.colorScheme.surface,
@@ -439,7 +438,12 @@ private fun DirectionRow(
                             else -> point?.let(onFocusPoint)
                         }
                     }
-                    .padding(start = 12.dp, top = 10.dp, bottom = 10.dp, end = 4.dp)
+                    .padding(
+                        start = 12.dp,
+                        top = 10.dp,
+                        bottom = 10.dp,
+                        end = if (collapsibleSteps) 4.dp else 12.dp
+                    )
             ) {
                 DirectionIcon(item.iconRes)
                 Spacer(Modifier.width(12.dp))
@@ -465,7 +469,7 @@ private fun DirectionRow(
                         )
                     }
                 }
-                if (expandable) {
+                if (collapsibleSteps) {
                     // ~1.75x the default chevron so the expand/collapse control reads clearly.
                     IconButton(onClick = { expanded = !expanded }, modifier = Modifier.size(56.dp)) {
                         Icon(
@@ -480,29 +484,28 @@ private fun DirectionRow(
                     }
                 }
             }
-            if (expanded) {
-                if (routeLeg != null) {
-                    // Board and Alight, each a tap target that zooms to its stop, followed by that stop's
-                    // live ETA strip.
-                    routeLeg.board?.let { stop ->
-                        RouteStopLabel(
-                            R.string.step_by_step_transit_get_on,
-                            stop.name,
-                            onClick = { stop.point?.let(onFocusPoint) }
-                        )
-                        stopEtaStrip(routeLeg, stop, item.legPoints)
-                    }
-                    routeLeg.alight?.let { stop ->
-                        RouteStopLabel(
-                            R.string.step_by_step_transit_get_off,
-                            stop.name,
-                            onClick = { stop.point?.let(onFocusPoint) }
-                        )
-                        stopEtaStrip(routeLeg, stop, item.legPoints)
-                    }
-                } else {
-                    item.subItems.forEach { sub -> SubDirectionRow(sub, onFocusPoint) }
+            if (routeLeg != null) {
+                // A transit leg's Board and Alight are always shown — each a tap target that zooms to
+                // its stop. Only the Board stop carries a live ETA strip.
+                routeLeg.board?.let { stop ->
+                    RouteStopLabel(
+                        R.string.step_by_step_transit_get_on,
+                        stop.name,
+                        onClick = { stop.point?.let(onFocusPoint) }
+                    )
+                    stopEtaStrip(routeLeg, stop, item.legPoints)
                 }
+                routeLeg.alight?.let { stop ->
+                    RouteStopLabel(
+                        R.string.step_by_step_transit_get_off,
+                        stop.name,
+                        onClick = { stop.point?.let(onFocusPoint) }
+                    )
+                }
+                Spacer(Modifier.height(4.dp))
+            } else if (expanded) {
+                // A walk/other leg's turn-by-turn steps, revealed only when the user expands them.
+                item.subItems.forEach { sub -> SubDirectionRow(sub, onFocusPoint) }
                 Spacer(Modifier.height(4.dp))
             }
         }
@@ -534,8 +537,8 @@ private fun SubDirectionRow(item: DirectionItem, onFocusPoint: (GeoPoint) -> Uni
 
 /**
  * A transit leg's Board / Alight label: the boarding action ([actionRes] — "Get on" / "Get off") and
- * its [stopName], shown above that stop's inline ETA strip (which is always visible while the leg is
- * expanded). Its own tap target — tapping zooms the map to that stop ([onClick]).
+ * its [stopName]. The Board label is shown above that stop's inline ETA strip; the Alight label stands
+ * alone. Its own tap target — tapping zooms the map to that stop ([onClick]).
  */
 @Composable
 private fun RouteStopLabel(actionRes: Int, stopName: String?, onClick: () -> Unit) {

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -920,7 +920,7 @@
     <!-- Content descriptions for the chevrons that hint the itinerary-option picker can scroll sideways -->
     <string name="trip_plan_options_scroll_previous">Show previous options</string>
     <string name="trip_plan_options_scroll_more">Show more options</string>
-    <!-- Content descriptions for the button that expands/collapses a leg's steps in the directions list -->
+    <!-- Content descriptions for the button that expands/collapses a walking leg's turn-by-turn steps in the directions list -->
     <string name="trip_plan_expand_leg">Show steps</string>
     <string name="trip_plan_collapse_leg">Hide steps</string>
 

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreCameraCommands.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreCameraCommands.kt
@@ -137,7 +137,7 @@ fun applyFramingIntent(intent: FramingIntent, map: MapLibreMap, renderState: Map
         )
 
         is FramingIntent.Points -> {
-            val (sw, ne) = framingCorners(intent.points) ?: return
+            val (sw, ne) = framingCorners(intent.points, intent.minSpanDeg) ?: return
             val bounds = LatLngBounds.Builder()
                 .include(LatLng(sw.latitude, sw.longitude))
                 .include(LatLng(ne.latitude, ne.longitude))

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/FramingCornersTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/FramingCornersTest.kt
@@ -1,0 +1,63 @@
+/* Copyright (C) 2026 Open Transit Software Foundation */
+package org.onebusaway.android.map
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.onebusaway.android.map.render.MIN_FRAMING_SPAN_DEG
+import org.onebusaway.android.map.render.WALK_LEG_MIN_FRAMING_SPAN_DEG
+import org.onebusaway.android.map.render.framingCorners
+import org.onebusaway.android.util.GeoPoint
+
+class FramingCornersTest {
+
+    private fun span(corners: Pair<GeoPoint, GeoPoint>): Pair<Double, Double> {
+        val (sw, ne) = corners
+        return (ne.latitude - sw.latitude) to (ne.longitude - sw.longitude)
+    }
+
+    @Test
+    fun `empty points return null`() {
+        assertNull(framingCorners(emptyList()))
+    }
+
+    @Test
+    fun `a degenerate box is inflated to the minimum span, centered on the point`() {
+        val p = GeoPoint(47.6, -122.3)
+        val corners = framingCorners(listOf(p))!!
+        val (latSpan, lonSpan) = span(corners)
+
+        assertEquals(MIN_FRAMING_SPAN_DEG, latSpan, 1e-9)
+        assertEquals(MIN_FRAMING_SPAN_DEG, lonSpan, 1e-9)
+        // Centered on the original point.
+        assertEquals(p.latitude, (corners.first.latitude + corners.second.latitude) / 2, 1e-9)
+        assertEquals(p.longitude, (corners.first.longitude + corners.second.longitude) / 2, 1e-9)
+    }
+
+    @Test
+    fun `the walk-leg floor frames a short hop tighter than the default`() {
+        // A ~street-crossing hop: two points a few meters apart.
+        val hop = listOf(GeoPoint(47.6000, -122.3000), GeoPoint(47.6001, -122.3001))
+
+        val walkCorners = framingCorners(hop, WALK_LEG_MIN_FRAMING_SPAN_DEG)!!
+        val defaultCorners = framingCorners(hop)!!
+
+        val (walkLat, _) = span(walkCorners)
+        val (defaultLat, _) = span(defaultCorners)
+
+        assertEquals(WALK_LEG_MIN_FRAMING_SPAN_DEG, walkLat, 1e-9)
+        assertEquals(MIN_FRAMING_SPAN_DEG, defaultLat, 1e-9)
+        assertTrue("walk-leg floor should be tighter", walkLat < defaultLat)
+    }
+
+    @Test
+    fun `a box already larger than the floor is left as-is`() {
+        val far = listOf(GeoPoint(47.60, -122.30), GeoPoint(47.70, -122.20))
+        val corners = framingCorners(far, WALK_LEG_MIN_FRAMING_SPAN_DEG)!!
+        val (latSpan, lonSpan) = span(corners)
+
+        assertEquals(0.10, latSpan, 1e-9)
+        assertEquals(0.10, lonSpan, 1e-9)
+    }
+}


### PR DESCRIPTION
## Summary

Reworks the trip-results direction leg cards and the walk-leg map framing.

### Leg cards (`TripResultsScreen`)
- **Transit legs** now always show their **Board / Alight** sub-items — the chevron expand toggle is gone for them, since the user can just scroll the list.
- **Walk / other legs** keep the chevron expand button for their turn-by-turn steps (collapsed by default); expanded, they'd mostly be noise.
- The **Alight ("Get off")** stop no longer shows an ETA strip — only the **Board ("Get on")** stop carries a live ETA strip.

### Walk-leg framing (`FramingIntent` / `MapHost` / `MapViewModel` + both map adapters)
- Tapping a walking leg now frames it to a **block-level floor** (`WALK_LEG_MIN_FRAMING_SPAN_DEG` ≈ 500 ft) instead of the shared default (`MIN_FRAMING_SPAN_DEG` ≈ 1460 ft), so a short hop like crossing a street auto-zooms much closer — no manual zoom-in.
- The floor is threaded only through the walk-leg path via a new `minSpanDeg` field on `FramingIntent.Points`. The vehicle+stop ETA-tap pair and route-segment framing keep the original default, so their "don't zoom to the rooftops" behavior is unchanged.
- Longer legs are unaffected — the floor only applies when the leg's own bounds are smaller than it.

### Tooling
- Separate commit: exclude `.claude/` (Claude Code's gitignored scratch, incl. nested worktrees) from the Spotless targets so `spotlessCheck` doesn't trip over stale worktree sources locally. No effect on CI (that dir never exists there).

## Testing
- New `FramingCornersTest` (JVM unit) covering the min-span inflation, the tighter walk-leg floor, and large-box passthrough.
- Updated `DirectionRowFocusTest` for the always-expanded transit sub-items, board-only ETA strip, and walk-leg collapse/expand.
- Both flavors (`obaGoogle`, `obaMaplibre`) + androidTest compile clean under `-PwarningsAsErrors=true`; `spotlessCheck` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved map framing for short walking segments, keeping nearby locations visible without excessive zoom.
  - Applied consistent minimum map spacing when displaying itinerary legs.
  - Transit legs now always show Board and Alight information, with Board ETA details visible by default.
  - Walking legs now provide a clear expand control for turn-by-turn directions without moving the map.
- **Accessibility**
  - Clarified accessibility text for the walking directions expand control.
- **Tests**
  - Added coverage for map framing and updated trip results behavior checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->