### PR TITLE
Modernize the trip-plan-change monitor; fix the OTP1→OTP2 "better plan" misfire

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/OtpGtfsIds.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/OtpGtfsIds.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.directions
+
+/**
+ * The **entity part** of an OTP GTFS id — the single, sanctioned normalization for OTP entity ids
+ * across the OTP1/OTP2 planner split. Both [OtpObaIdResolver] (mapping OTP ids onto OBA ids) and the
+ * trip-plan-change monitor's itinerary identity ([org.onebusaway.android.directions.model.ItineraryDescription])
+ * consume this one rule, so there is a single definition rather than two.
+ *
+ * The contract (per the pinned OTP2 GTFS schema, `graphql/otp2/schema.graphqls`): an OTP2 entity id is
+ * `{feedId}:{entityId}` (e.g. `kcm:102574`, `1:trip_5`); an OTP1 id is the bare `{entityId}` (e.g.
+ * `trip_5`). The **entity id is identical across both schemes** — only the feed/agency prefix differs —
+ * so stripping the feed prefix yields the same underlying GTFS entity id whichever planner produced it.
+ * That makes it the stable key for comparing a trip planned under one scheme against a re-plan under the
+ * other. (Verified against live Puget Sound OTP2 deployments; see [OtpObaIdResolver] for the OBA-id
+ * mapping that rests on the same premise.)
+ *
+ * **Colon-only, deliberately.** The delimiter is `:`. Underscore is *not* a delimiter here: OBA ids are
+ * `{agency}_{entity}`, and a GTFS entity id legitimately contains underscores (`agency_trip_5`), so
+ * splitting on `_` would corrupt real ids. An unprefixed id (no colon) passes through unchanged.
+ *
+ * @return the substring after the first `:`, the whole value when there is no `:`, or null for a
+ *   null/blank input.
+ */
+fun gtfsEntitySuffix(id: String?): String? {
+    val s = id ?: return null
+    return s.substringAfter(':', missingDelimiterValue = s).takeIf { it.isNotEmpty() }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/OtpObaIdResolver.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/OtpObaIdResolver.kt
@@ -54,7 +54,7 @@ class OtpObaIdResolver @Inject constructor(
     suspend fun obaStopId(stopGtfsId: String?, agencyGtfsId: String?, agencyName: String?): String? = obaId(stopGtfsId, agencyGtfsId, agencyName)
 
     private suspend fun obaId(entityGtfsId: String?, agencyGtfsId: String?, agencyName: String?): String? {
-        val entity = entityGtfsId.entitySuffix() ?: return null
+        val entity = gtfsEntitySuffix(entityGtfsId) ?: return null
         val agency = resolveAgency(agencyGtfsId, agencyName) ?: return null
         return "${agency}_$entity"
     }
@@ -66,7 +66,7 @@ class OtpObaIdResolver @Inject constructor(
      * already equals OBA's (the common case).
      */
     private suspend fun resolveAgency(agencyGtfsId: String?, agencyName: String?): String? {
-        val derived = agencyGtfsId.entitySuffix()
+        val derived = gtfsEntitySuffix(agencyGtfsId)
         val agencies = agencies() ?: return derived
         if (derived != null && agencies.any { it.id == derived }) return derived
         return agencyName
@@ -76,11 +76,5 @@ class OtpObaIdResolver @Inject constructor(
 
     private suspend fun agencies(): List<AgencyContact>? = mutex.withLock {
         cachedAgencies ?: agenciesDataSource.getAgencies().getOrNull()?.also { cachedAgencies = it }
-    }
-
-    /** The entity part after the feed prefix (`kcm:102574` → `102574`); the whole value when unprefixed. */
-    private fun String?.entitySuffix(): String? {
-        val s = this ?: return null
-        return s.substringAfter(':', missingDelimiterValue = s).takeIf { it.isNotEmpty() }
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/model/ItineraryDescription.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/model/ItineraryDescription.kt
@@ -1,5 +1,6 @@
-/**
+/*
  * Copyright (C) 2016 Cambridge Systematics, Inc.
+ * Copyright (C) 2026 Open Transit Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,15 +18,29 @@ package org.onebusaway.android.directions.model
 
 import java.time.Duration
 import java.time.Instant
+import org.onebusaway.android.directions.gtfsEntitySuffix
 
 /**
- * Itinerary desciption is a list of trips and a rank. This is for the Realtime service.
+ * The identity of a monitored itinerary: the ordered trip ids of its transit legs plus its end time.
+ * The trip-plan-change monitor compares the itinerary the user is watching against a fresh re-plan by
+ * matching these (see [org.onebusaway.android.directions.realtime.TripMonitorDecider]).
+ *
+ * **Identity is compared on the normalized entity suffix of each trip id, not the raw id.** OTP1 and
+ * OTP2 label the same GTFS trip differently — OTP2 prefixes a feed id (`1:trip_5`), OTP1 does not
+ * (`trip_5`) — so raw-string equality would report an unchanged trip as "changed" after the OTP1→OTP2
+ * migration. [gtfsEntitySuffix] strips the feed prefix (the one sanctioned normalization), collapsing
+ * both to the same underlying id so a monitor armed under either planner compares correctly. The raw
+ * [tripIds] are retained as-is (that is what the monitor persists across process death); normalization
+ * happens only at comparison time via [normalizedTripIds].
  */
 class ItineraryDescription {
 
     val tripIds: List<String>
 
     val endDate: Instant?
+
+    /** The [tripIds] with each feed prefix stripped — the scheme-independent match key. */
+    val normalizedTripIds: List<String> by lazy { tripIds.map { gtfsEntitySuffix(it) ?: it } }
 
     constructor(itinerary: TripItinerary) {
         tripIds = itinerary.legs
@@ -41,13 +56,11 @@ class ItineraryDescription {
     }
 
     /**
-     * Check if this itinerary matches the itinerary of another ItineraryDescription
-     *
-     * @param other object to compare to
-     * @return true if matches, false otherwise
+     * Whether this itinerary is the same one described by [other], comparing the normalized
+     * ([normalizedTripIds]) trip ids as an ordered structural equality — so the same trips in the same
+     * order match regardless of which planner (OTP1/OTP2) labeled them.
      */
-    fun itineraryMatches(other: ItineraryDescription): Boolean = // Ordered structural equality: same trip IDs in the same order.
-        tripIds == other.tripIds
+    fun itineraryMatches(other: ItineraryDescription): Boolean = normalizedTripIds == other.normalizedTripIds
 
     /**
      * Check the delay on this itinerary relative to a newer one.
@@ -62,16 +75,6 @@ class ItineraryDescription {
         // Both are server-provided instants; measure the span with java.time rather than raw epoch millis.
         return Duration.between(thisEnd, otherEnd).toMillis() / 1000
     }
-
-    /**
-     * An ID for this ItineraryDescription.
-     * The notification requires an ID so it does not create duplicates. Right now, sending a
-     * notification cancels out the trip-plan monitor, so we do not send multiple notifications,
-     * but we may in future.
-     * Use the hash code of the trips array. Not guaranteed to be unique.
-     */
-    val id: Int
-        get() = if (tripIds.isEmpty()) -1 else tripIds.hashCode()
 
     /**
      * @param now the current time, supplied by the caller (keep the clock out of this helper).

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/model/ItineraryDescription.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/model/ItineraryDescription.kt
@@ -33,27 +33,17 @@ import org.onebusaway.android.directions.gtfsEntitySuffix
  * [tripIds] are retained as-is (that is what the monitor persists across process death); normalization
  * happens only at comparison time via [normalizedTripIds].
  */
-class ItineraryDescription {
-
-    val tripIds: List<String>
-
-    val endDate: Instant?
+class ItineraryDescription(val tripIds: List<String>, val endDate: Instant?) {
 
     /** The [tripIds] with each feed prefix stripped — the scheme-independent match key. */
-    val normalizedTripIds: List<String> by lazy { tripIds.map { gtfsEntitySuffix(it) ?: it } }
+    val normalizedTripIds: List<String> = tripIds.map { gtfsEntitySuffix(it) ?: it }
 
-    constructor(itinerary: TripItinerary) {
+    constructor(itinerary: TripItinerary) : this(
         tripIds = itinerary.legs
             .filter { it.mode?.isTransit == true }
-            .mapNotNull { it.tripId }
-
+            .mapNotNull { it.tripId },
         endDate = itinerary.legs.lastOrNull()?.endTime?.let { Instant.ofEpochMilli(it.epochMs) }
-    }
-
-    constructor(tripIds: List<String>, endDate: Instant?) {
-        this.tripIds = tripIds
-        this.endDate = endDate
-    }
+    )
 
     /**
      * Whether this itinerary is the same one described by [other], comparing the normalized

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/realtime/MonitorStateParse.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/realtime/MonitorStateParse.kt
@@ -20,23 +20,19 @@ import org.onebusaway.android.directions.model.ItineraryDescription
 import org.onebusaway.android.time.ServerTime
 
 /**
- * The validated state one [TripPlanMonitorService] tick needs: the itinerary being watched
- * ([description]) and its server-clock [departure] (null = unknown, i.e. fall back to the trip-end
- * guard).
- */
-data class TripMonitorState(
-    val description: ItineraryDescription,
-    val departure: ServerTime?
-)
-
-/**
  * The outcome of validating a persisted monitor bundle before (re)starting the loop. A pure sealed type
  * (no Android/`Bundle` dependency) so the version/validity gate is JVM-unit-testable — see
  * [parseMonitorState].
  */
 sealed interface MonitorStateParse {
-    /** The bundle is usable — monitor [state]. */
-    data class Valid(val state: TripMonitorState) : MonitorStateParse
+    /**
+     * The bundle is usable: monitor the itinerary described by [description] (its server-clock
+     * [departure] is null when unknown, i.e. fall back to the trip-end guard).
+     */
+    data class Valid(
+        val description: ItineraryDescription,
+        val departure: ServerTime?
+    ) : MonitorStateParse
 
     /** Required state is absent/empty — there is nothing to monitor. Stop without notifying. */
     data object Missing : MonitorStateParse
@@ -73,5 +69,5 @@ fun parseMonitorState(
     }
     val description = ItineraryDescription(tripIds, Instant.ofEpochMilli(endDateMillis))
     val departure = if (startDateMillis != 0L) ServerTime(startDateMillis) else null
-    return MonitorStateParse.Valid(TripMonitorState(description, departure))
+    return MonitorStateParse.Valid(description, departure)
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/realtime/TripMonitorState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/realtime/TripMonitorState.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.directions.realtime
+
+import java.time.Instant
+import org.onebusaway.android.directions.model.ItineraryDescription
+import org.onebusaway.android.time.ServerTime
+
+/**
+ * The validated state one [TripPlanMonitorService] tick needs: the itinerary being watched
+ * ([description]) and its server-clock [departure] (null = unknown, i.e. fall back to the trip-end
+ * guard).
+ */
+data class TripMonitorState(
+    val description: ItineraryDescription,
+    val departure: ServerTime?
+)
+
+/**
+ * The outcome of validating a persisted monitor bundle before (re)starting the loop. A pure sealed type
+ * (no Android/`Bundle` dependency) so the version/validity gate is JVM-unit-testable — see
+ * [parseMonitorState].
+ */
+sealed interface MonitorStateParse {
+    /** The bundle is usable — monitor [state]. */
+    data class Valid(val state: TripMonitorState) : MonitorStateParse
+
+    /** Required state is absent/empty — there is nothing to monitor. Stop without notifying. */
+    data object Missing : MonitorStateParse
+
+    /**
+     * The bundle was written by a newer, incompatible monitor format — a pending alarm or redelivered
+     * `START_REDELIVER_INTENT` surviving an app update. We can't trust it, so stop **without** notifying
+     * rather than risk a spurious "your trip changed" alert on state we can no longer interpret.
+     */
+    data object Incompatible : MonitorStateParse
+}
+
+/**
+ * Validate the raw primitives read from a monitor bundle. Pure (no Android types) so it is unit-testable.
+ *
+ * @param version the persisted [TripPlanMonitor.MONITOR_STATE_VERSION]; null when the key is absent — a
+ *   bundle written before versioning, treated as the compatible legacy v0 (its raw ids still normalize
+ *   and compare correctly, so it is safe to honor).
+ * @param tripIds the raw (un-normalized) transit-leg trip ids of the watched itinerary.
+ * @param startDateMillis the itinerary's server-clock departure epoch millis; 0 = unknown.
+ * @param endDateMillis the itinerary's server-clock end epoch millis; 0 = absent (unusable).
+ */
+fun parseMonitorState(
+    version: Int?,
+    tripIds: List<String>?,
+    startDateMillis: Long,
+    endDateMillis: Long
+): MonitorStateParse {
+    if (version != null && version > TripPlanMonitor.MONITOR_STATE_VERSION) {
+        return MonitorStateParse.Incompatible
+    }
+    if (tripIds.isNullOrEmpty() || endDateMillis == 0L) {
+        return MonitorStateParse.Missing
+    }
+    val description = ItineraryDescription(tripIds, Instant.ofEpochMilli(endDateMillis))
+    val departure = if (startDateMillis != 0L) ServerTime(startDateMillis) else null
+    return MonitorStateParse.Valid(TripMonitorState(description, departure))
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/realtime/TripPlanMonitor.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/realtime/TripPlanMonitor.kt
@@ -32,7 +32,6 @@ import org.onebusaway.android.time.ServerTime
 import org.onebusaway.android.time.WallTime
 import org.onebusaway.android.ui.tripplan.TripPlanParams
 import org.onebusaway.android.ui.tripplan.toRequestBuilder
-import org.onebusaway.android.util.PreferenceUtils
 
 /**
  * Entry point + scheduler for the trip-plan-change monitor. Replaces the WorkManager/AlarmManager poll
@@ -62,6 +61,18 @@ object TripPlanMonitor {
     /** The watched itinerary's end time, epoch millis (long). */
     const val EXTRA_ITINERARY_END_DATE = "org.onebusaway.android.tripmonitor.ITINERARY_END_DATE"
 
+    /** The [MONITOR_STATE_VERSION] the bundle was written with (int; absent = legacy v0). */
+    const val EXTRA_MONITOR_VERSION = "org.onebusaway.android.tripmonitor.MONITOR_VERSION"
+
+    /**
+     * Version of the persisted monitor-state format. A pending alarm / redelivered service intent can
+     * survive an app update, so bump this whenever the bundle's shape or meaning changes incompatibly;
+     * a service reading a **newer** version than it understands stops silently rather than misfiring
+     * (see [parseMonitorState]). Bare trip-id normalization already bridges the OTP1↔OTP2 id-vocabulary
+     * difference, so v1 stays compatible with pre-versioning (v0) bundles.
+     */
+    const val MONITOR_STATE_VERSION = 1
+
     internal const val ACTION_START_MONITORING =
         "org.onebusaway.android.tripmonitor.action.START_MONITORING"
 
@@ -84,7 +95,9 @@ object TripPlanMonitor {
     ) {
         val app = context.applicationContext
 
-        if (!PreferenceUtils.getBoolean(OTPConstants.PREFERENCE_KEY_LIVE_UPDATES, true)) {
+        // Single enable-gate (in-app toggle AND OS-side allowed) — see TripPlanNotifications. Also
+        // re-checked at the call site; belt-and-suspenders since arming can be deferred by an alarm.
+        if (!TripPlanNotifications.isEnabled(app)) {
             return
         }
 
@@ -116,6 +129,7 @@ object TripPlanMonitor {
         val builder = params.toRequestBuilder(app)
         val bundle = Bundle().apply {
             builder.copyIntoBundleSimple(this)
+            putInt(EXTRA_MONITOR_VERSION, MONITOR_STATE_VERSION)
             putStringArray(EXTRA_ITINERARY_DESC, tripIds.toTypedArray())
             putLong(EXTRA_ITINERARY_START_DATE, itineraryDeparture.epochMs)
             putLong(EXTRA_ITINERARY_END_DATE, endDate.toEpochMilli())

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/realtime/TripPlanMonitorService.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/realtime/TripPlanMonitorService.kt
@@ -81,7 +81,7 @@ class TripPlanMonitorService : Service() {
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         val extras = intent?.extras
         val target = extras?.let { readNotificationTarget(it) }
-        val parse = extras?.let { parseMonitorState(it) }
+        val parse = extras?.let { readMonitorState(it) }
         if (extras == null || target == null || parse !is MonitorStateParse.Valid) {
             // Stop without notifying on any unusable state. Incompatible = a pending alarm / redelivered
             // intent written by a newer monitor format that survived an app update; we can't interpret it,
@@ -94,7 +94,6 @@ class TripPlanMonitorService : Service() {
             stopSelf()
             return Service.START_NOT_STICKY
         }
-        val state = parse.state
 
         // Must promote to the foreground promptly after startForegroundService(); do it synchronously.
         startForegroundMonitoring(target)
@@ -102,7 +101,7 @@ class TripPlanMonitorService : Service() {
         // A fresh start supersedes any in-flight loop (re-selected option / redelivered intent).
         monitorJob?.cancel()
         monitorJob = serviceScope.launch {
-            runMonitorLoop(extras, state.description, target, state.departure)
+            runMonitorLoop(extras, parse.description, target, parse.departure)
         }
 
         // Redeliver the monitoring state if the service is killed and restarted mid-window.
@@ -288,7 +287,7 @@ class TripPlanMonitorService : Service() {
     // -- Monitoring state (read back from the intent extras) ------------------------------------
 
     /** Pull the persisted primitives out of the [Bundle] and validate them (see [parseMonitorState]). */
-    private fun parseMonitorState(extras: Bundle): MonitorStateParse = parseMonitorState(
+    private fun readMonitorState(extras: Bundle): MonitorStateParse = parseMonitorState(
         version = if (extras.containsKey(TripPlanMonitor.EXTRA_MONITOR_VERSION)) {
             extras.getInt(TripPlanMonitor.EXTRA_MONITOR_VERSION)
         } else {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/realtime/TripPlanMonitorService.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/realtime/TripPlanMonitorService.kt
@@ -81,23 +81,29 @@ class TripPlanMonitorService : Service() {
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         val extras = intent?.extras
         val target = extras?.let { readNotificationTarget(it) }
-        val desc = extras?.let { readItineraryDescription(it) }
-        if (extras == null || target == null || desc == null) {
-            Log.w(TAG, "Missing monitoring state - stopping")
+        val parse = extras?.let { parseMonitorState(it) }
+        if (extras == null || target == null || parse !is MonitorStateParse.Valid) {
+            // Stop without notifying on any unusable state. Incompatible = a pending alarm / redelivered
+            // intent written by a newer monitor format that survived an app update; we can't interpret it,
+            // so we never risk a spurious "your trip changed" alert on it.
+            when (parse) {
+                MonitorStateParse.Incompatible ->
+                    Log.w(TAG, "Monitor bundle is a newer, incompatible format - stopping")
+                else -> Log.w(TAG, "Missing monitoring state - stopping")
+            }
             stopSelf()
             return Service.START_NOT_STICKY
         }
+        val state = parse.state
 
         // Must promote to the foreground promptly after startForegroundService(); do it synchronously.
         startForegroundMonitoring(target)
 
-        // The stored departure is a server-provided instant (0 = unknown); mint it back into ServerTime.
-        val departureMs = extras.getLong(TripPlanMonitor.EXTRA_ITINERARY_START_DATE)
-        val itineraryDeparture: ServerTime? = if (departureMs != 0L) ServerTime(departureMs) else null
-
         // A fresh start supersedes any in-flight loop (re-selected option / redelivered intent).
         monitorJob?.cancel()
-        monitorJob = serviceScope.launch { runMonitorLoop(extras, desc, target, itineraryDeparture) }
+        monitorJob = serviceScope.launch {
+            runMonitorLoop(extras, state.description, target, state.departure)
+        }
 
         // Redeliver the monitoring state if the service is killed and restarted mid-window.
         return Service.START_REDELIVER_INTENT
@@ -142,7 +148,6 @@ class TripPlanMonitorService : Service() {
                     when (result) {
                         is MonitorResult.Deviation -> {
                             notifyChange(
-                                desc,
                                 target,
                                 builder,
                                 itineraries,
@@ -151,19 +156,20 @@ class TripPlanMonitorService : Service() {
                                 } else {
                                     R.string.trip_plan_early
                                 },
-                                messageRes = R.string.trip_plan_notification_new_plan_text
+                                messageRes = R.string.trip_plan_notification_deviation_text
                             )
                             break
                         }
 
                         MonitorResult.ItineraryChanged -> {
+                            // The monitored itinerary is no longer among the recommended results — the
+                            // plan "changed", which is not the same as "a better plan was found".
                             notifyChange(
-                                desc,
                                 target,
                                 builder,
                                 itineraries,
-                                titleRes = R.string.trip_plan_notification_new_plan_title,
-                                messageRes = R.string.trip_plan_notification_new_plan_text
+                                titleRes = R.string.trip_plan_notification_changed_title,
+                                messageRes = R.string.trip_plan_notification_changed_text
                             )
                             break
                         }
@@ -229,7 +235,6 @@ class TripPlanMonitorService : Service() {
 
     /** Fires the user-facing "your trip changed" alert (a distinct, dismissable notification). */
     private fun notifyChange(
-        desc: ItineraryDescription,
         target: Class<*>,
         builder: TripRequestBuilder,
         itineraries: List<TripItinerary>,
@@ -238,18 +243,16 @@ class TripPlanMonitorService : Service() {
     ) {
         val messageText = getString(messageRes)
 
-        // Reopen the trip-plan screen with enough state to rehydrate the form + fresh results
-        // (matches TripPlanScreen.maybeRestoreFromIntent, which reads the simplified request bundle).
-        // The itinerary list is JSON-encoded (kotlinx.serialization), not passed via
-        // Intent.putExtra(String, Serializable) — TripItinerary has no reason to implement
-        // java.io.Serializable itself, unlike the OTP1 POJOs this domain model replaced.
+        // Reopen HOME with enough state to rehydrate the directions form + these fresh results. The
+        // simplified request bundle + JSON itineraries are consumed by HomeActivity.maybeRestoreDirections-
+        // FromIntent (#1939), which re-enters the on-map directions focus. The itinerary list is
+        // JSON-encoded (kotlinx.serialization), not Intent.putExtra(String, Serializable) — TripItinerary
+        // has no reason to implement java.io.Serializable, unlike the OTP1 POJOs this model replaced.
         val requestExtras = Bundle().also { builder.copyIntoBundleSimple(it) }
         val openIntent = Intent(applicationContext, target).apply {
             putExtras(requestExtras)
             putExtra(OTPConstants.ITINERARIES, itineraries.toJson())
             putExtra(OTPConstants.INTENT_SOURCE, OTPConstants.Source.NOTIFICATION)
-            // The request/itinerary bundle rides along for a future restore-into-directions (#1939); the
-            // intent opens HOME (no EXTRA_NAV_ROUTE) rather than the retired standalone trip-plan screen.
             flags = Intent.FLAG_ACTIVITY_SINGLE_TOP
         }
 
@@ -266,7 +269,7 @@ class TripPlanMonitorService : Service() {
             .build()
 
         val manager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-        manager.notify(desc.id, notification)
+        manager.notify(TRIP_CHANGE_NOTIFICATION_ID, notification)
     }
 
     private fun activityPendingIntent(intent: Intent): PendingIntent {
@@ -284,14 +287,17 @@ class TripPlanMonitorService : Service() {
 
     // -- Monitoring state (read back from the intent extras) ------------------------------------
 
-    private fun readItineraryDescription(extras: Bundle): ItineraryDescription? {
-        val tripIds = extras.getStringArray(TripPlanMonitor.EXTRA_ITINERARY_DESC)?.toList()
-        val endDateMillis = extras.getLong(TripPlanMonitor.EXTRA_ITINERARY_END_DATE)
-        if (tripIds.isNullOrEmpty() || endDateMillis == 0L) {
-            return null
-        }
-        return ItineraryDescription(tripIds, Instant.ofEpochMilli(endDateMillis))
-    }
+    /** Pull the persisted primitives out of the [Bundle] and validate them (see [parseMonitorState]). */
+    private fun parseMonitorState(extras: Bundle): MonitorStateParse = parseMonitorState(
+        version = if (extras.containsKey(TripPlanMonitor.EXTRA_MONITOR_VERSION)) {
+            extras.getInt(TripPlanMonitor.EXTRA_MONITOR_VERSION)
+        } else {
+            null
+        },
+        tripIds = extras.getStringArray(TripPlanMonitor.EXTRA_ITINERARY_DESC)?.toList(),
+        startDateMillis = extras.getLong(TripPlanMonitor.EXTRA_ITINERARY_START_DATE),
+        endDateMillis = extras.getLong(TripPlanMonitor.EXTRA_ITINERARY_END_DATE)
+    )
 
     private fun readNotificationTarget(extras: Bundle): Class<*>? {
         val name = extras.getString(OTPConstants.NOTIFICATION_TARGET) ?: return null
@@ -306,7 +312,13 @@ class TripPlanMonitorService : Service() {
     private companion object {
         const val TAG = "TripPlanMonitorSvc"
 
-        /** Stable id for the ongoing foreground notification (distinct from the per-trip alert id). */
+        /** Stable id for the ongoing foreground notification (distinct from the change-alert id). */
         const val ONGOING_NOTIFICATION_ID = 0x7C1D
+
+        /**
+         * Stable id for the "your trip changed / is delayed" alert. Fixed (not per-trip) because only one
+         * trip is monitored at a time, so a later alert correctly replaces an earlier one.
+         */
+        const val TRIP_CHANGE_NOTIFICATION_ID = 0x7C1E
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/realtime/TripPlanNotifications.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/realtime/TripPlanNotifications.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.directions.realtime
+
+import android.app.NotificationManager
+import android.content.Context
+import android.os.Build
+import androidx.core.app.NotificationManagerCompat
+import org.onebusaway.android.R
+import org.onebusaway.android.app.di.PreferencesEntryPoint
+import org.onebusaway.android.notifications.NotificationChannels
+
+/**
+ * The single gate for whether the trip-plan-change monitor should arm. Replaces the two overlapping,
+ * SDK-inconsistent checks that preceded it: a hidden `live_updates` preference with no settings UI, and
+ * an arm-time check that consulted the in-app toggle only pre-O (on O+ it read channel importance and
+ * ignored the toggle, so the Settings switch did nothing on modern devices).
+ *
+ * Both sides must allow notifications: the **in-app** toggle
+ * ([R.string.preference_key_trip_plan_notifications], the Settings switch, default on) gates arming on
+ * every SDK level, and the **OS** stays the source of truth for delivery — app-level notifications
+ * enabled (which also covers the `POST_NOTIFICATIONS` runtime grant on Android 13+) and the
+ * [NotificationChannels.TRIP_PLAN_UPDATES_ID] channel not set to "None" (O+).
+ */
+object TripPlanNotifications {
+
+    fun isEnabled(context: Context): Boolean {
+        val app = context.applicationContext
+
+        val appPrefEnabled = PreferencesEntryPoint.get(app)
+            .getBoolean(R.string.preference_key_trip_plan_notifications, true)
+        if (!appPrefEnabled) return false
+
+        val manager = NotificationManagerCompat.from(app)
+        if (!manager.areNotificationsEnabled()) return false
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = manager.getNotificationChannel(NotificationChannels.TRIP_PLAN_UPDATES_ID)
+            if (channel != null && channel.importance == NotificationManager.IMPORTANCE_NONE) {
+                return false
+            }
+        }
+        return true
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/OTPConstants.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/OTPConstants.kt
@@ -21,8 +21,6 @@ import java.util.concurrent.TimeUnit
 
 object OTPConstants {
 
-    const val PREFERENCE_KEY_LIVE_UPDATES = "live_updates"
-
     @JvmField
     val DEFAULT_UPDATE_INTERVAL_TRIP_TIME = TimeUnit.SECONDS.toMillis(60)
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
@@ -16,9 +16,6 @@
 package org.onebusaway.android.ui.tripresults
 
 import android.app.Activity
-import android.app.NotificationManager
-import android.content.Context
-import android.os.Build
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
@@ -69,11 +66,10 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.coroutines.launch
 import org.onebusaway.android.R
-import org.onebusaway.android.app.di.PreferencesEntryPoint
 import org.onebusaway.android.directions.model.TripItinerary
 import org.onebusaway.android.directions.realtime.TripPlanMonitor
+import org.onebusaway.android.directions.realtime.TripPlanNotifications
 import org.onebusaway.android.directions.util.ConversionUtils
-import org.onebusaway.android.notifications.NotificationChannels
 import org.onebusaway.android.time.ServerTime
 import org.onebusaway.android.ui.compose.components.EtaDurationText
 import org.onebusaway.android.ui.compose.components.EtaPartsText
@@ -373,17 +369,7 @@ private fun maybeStartTripUpdates(
 ) {
     val itinerary = itineraries.getOrNull(index) ?: return
     if (params == null) return
-
-    val context = activity.applicationContext
-    val notificationsEnabled = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-        val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-        val channel = manager.getNotificationChannel(NotificationChannels.TRIP_PLAN_UPDATES_ID)
-        channel != null && channel.importance != NotificationManager.IMPORTANCE_NONE
-    } else {
-        PreferencesEntryPoint.get(context)
-            .getBoolean(R.string.preference_key_trip_plan_notifications, true)
-    }
-    if (!notificationsEnabled) return
+    if (!TripPlanNotifications.isEnabled(activity)) return
 
     // The notification re-opens the activity that launched monitoring (HomeActivity, which hosts the
     // trip-plan destination) tagged with the TRIP_PLAN route — see TripPlanMonitorService.notifyChange.

--- a/onebusaway-android/src/main/res/values-es/strings.xml
+++ b/onebusaway-android/src/main/res/values-es/strings.xml
@@ -1021,8 +1021,6 @@
 
     <!-- Real time -->
 
-    <string name="trip_plan_notification_new_plan_title">Encontramos un mejor plan de viaje</string>
-    <string name="trip_plan_notification_new_plan_text">Toca para ver los nuevos resultados de tu último origen/destino.</string>
     <string name="trip_plan_delay">Tú viaje esta atrasado.</string>
     <string name="trip_plan_early">Tú viaje esta adelantado.</string>
 

--- a/onebusaway-android/src/main/res/values-fi/strings.xml
+++ b/onebusaway-android/src/main/res/values-fi/strings.xml
@@ -803,8 +803,6 @@
     <string name="trip_plan_advanced_settings">Lisäasetukset</string>
     <string name="trip_plan_delay">Matkasi on myöhässä.</string>
     <string name="trip_plan_early">Matkasi on etuajassa.</string>
-    <string name="trip_plan_notification_new_plan_title">Löysimme paremman matkasuunnitelman</string>
-    <string name="trip_plan_notification_new_plan_text">Napauta nähdäksesi uudet tulokset viimeisimmälle lähtöpaikka/määränpää-parille.</string>
     <string name="minimize_transfers">Minimoi vaihdot</string>
     <string name="maximum_walk_distance">Enimmäiskävelymatka:</string>
     <string name="wheelchair_accessible">Vältä portaita</string>

--- a/onebusaway-android/src/main/res/values-it/strings.xml
+++ b/onebusaway-android/src/main/res/values-it/strings.xml
@@ -864,8 +864,6 @@
 
     <!-- Real time -->
 
-    <string name="trip_plan_notification_new_plan_title">Piano di viaggio migliore trovato</string>
-    <string name="trip_plan_notification_new_plan_text">Tocca per vedere i nuovi risultati per i tuoi ultimi luoghi di partenza/arrivo.</string>
     <string name="trip_plan_delay">Il tuo viaggio è in ritardo.</string>
     <string name="trip_plan_early">Il tuo viaggio è in anticipo.</string>
 

--- a/onebusaway-android/src/main/res/values-pl/strings.xml
+++ b/onebusaway-android/src/main/res/values-pl/strings.xml
@@ -980,8 +980,6 @@
     <string name="connector_before_route">Linia</string>
 
     <!-- Trip plan notifications -->
-    <string name="trip_plan_notification_new_plan_title">Znaleźliśmy lepszy plan podróży</string>
-    <string name="trip_plan_notification_new_plan_text">Dotknij, aby zobaczyć nowe wyniki dla Twojego ostatniego miejsca początkowego/docelowego.</string>
     <string name="trip_plan_delay">Twoja podróż jest opóźniona.</string>
     <string name="trip_plan_early">Twoja podróż jest wcześniej.</string>
 

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -1107,8 +1107,9 @@
 
     <!-- Real time -->
 
-    <string name="trip_plan_notification_new_plan_title">We found a better trip plan</string>
-    <string name="trip_plan_notification_new_plan_text">Tap to see new results for your last origin/destination.</string>
+    <string name="trip_plan_notification_changed_title">Your planned trip changed</string>
+    <string name="trip_plan_notification_changed_text">Your trip is no longer among the recommended options. Tap to see new results for your origin and destination.</string>
+    <string name="trip_plan_notification_deviation_text">Tap to see updated results for your origin and destination.</string>
     <string name="trip_plan_delay">Your trip is delayed.</string>
     <string name="trip_plan_early">Your trip is early.</string>
     <string name="trip_plan_monitoring_notification_title">Watching your trip</string>

--- a/onebusaway-android/src/test/java/org/onebusaway/android/directions/OtpGtfsIdsTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/directions/OtpGtfsIdsTest.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.directions
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/** JVM unit tests for [gtfsEntitySuffix], the sanctioned OTP entity-id normalization (colon-only). */
+class OtpGtfsIdsTest {
+
+    @Test
+    fun stripsTheFeedPrefixAfterTheColon() {
+        assertEquals("102574", gtfsEntitySuffix("kcm:102574"))
+        assertEquals("2LINE", gtfsEntitySuffix("40:2LINE"))
+        assertEquals("trip_5", gtfsEntitySuffix("1:trip_5"))
+    }
+
+    @Test
+    fun passesAnUnprefixedIdThrough() {
+        // An OTP1 bare id has no feed prefix and must survive unchanged, so it compares equal to the
+        // normalized OTP2 form of the same trip.
+        assertEquals("trip_5", gtfsEntitySuffix("trip_5"))
+    }
+
+    @Test
+    fun doesNotSplitOnUnderscore() {
+        // Underscore is NOT a delimiter here (OBA ids are agency_entity, and GTFS ids contain
+        // underscores). Only the colon feed-prefix is stripped.
+        assertEquals("agency_trip_5", gtfsEntitySuffix("agency_trip_5"))
+        assertEquals("agency_trip_5", gtfsEntitySuffix("1:agency_trip_5"))
+    }
+
+    @Test
+    fun onlyTheFirstColonDelimitsTheFeed() {
+        assertEquals("route:42", gtfsEntitySuffix("feed:route:42"))
+    }
+
+    @Test
+    fun nullAndBlankReturnNull() {
+        assertNull(gtfsEntitySuffix(null))
+        assertNull(gtfsEntitySuffix(""))
+    }
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/directions/model/ItineraryDescriptionTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/directions/model/ItineraryDescriptionTest.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.directions.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * JVM unit tests for [ItineraryDescription.itineraryMatches] — identity compares the normalized
+ * (feed-prefix-stripped) trip ids, so the same trip matches across the OTP1/OTP2 id vocabularies.
+ */
+class ItineraryDescriptionTest {
+
+    private fun desc(vararg tripIds: String) = ItineraryDescription(tripIds.toList(), endDate = null)
+
+    @Test
+    fun sameTripAcrossSchemesMatches() {
+        // OTP1 bare id vs OTP2 feed-prefixed id for the same GTFS trip.
+        assertTrue(desc("trip_5").itineraryMatches(desc("1:trip_5")))
+        assertTrue(desc("1:trip_5").itineraryMatches(desc("trip_5")))
+    }
+
+    @Test
+    fun underscoreIsPreservedInTheEntityId() {
+        assertTrue(desc("agency_trip_5").itineraryMatches(desc("1:agency_trip_5")))
+    }
+
+    @Test
+    fun multiLegOrderIsSignificant() {
+        assertTrue(desc("a", "b").itineraryMatches(desc("1:a", "2:b")))
+        assertFalse(desc("a", "b").itineraryMatches(desc("b", "a")))
+    }
+
+    @Test
+    fun distinctTripsDoNotMatch() {
+        assertFalse(desc("trip_5").itineraryMatches(desc("trip_6")))
+        // Different entities that merely share a feed prefix must not collapse together.
+        assertFalse(desc("1:trip_5").itineraryMatches(desc("1:trip_6")))
+    }
+
+    @Test
+    fun normalizedTripIdsStripTheFeedPrefixButKeepRawIds() {
+        val d = desc("1:trip_5", "kcm:102574")
+        assertEquals(listOf("trip_5", "102574"), d.normalizedTripIds)
+        // Raw ids are retained as stored (that is what the monitor persists).
+        assertEquals(listOf("1:trip_5", "kcm:102574"), d.tripIds)
+    }
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/directions/realtime/TripMonitorDeciderTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/directions/realtime/TripMonitorDeciderTest.kt
@@ -93,4 +93,67 @@ class TripMonitorDeciderTest {
         )
         assertEquals(MonitorResult.ItineraryChanged, result)
     }
+
+    /**
+     * Regression for the OTP1→OTP2 misfire: a trip armed under OTP1 (bare id `trip_5`) re-planned under
+     * OTP2 (feed-prefixed `1:trip_5`) is the *same* trip and must NOT report `ItineraryChanged`. Before
+     * the entity-suffix normalization this compared raw strings and fired the false "better plan" alert.
+     */
+    @Test
+    fun crossScheme_sameTrip_matchesInsteadOfReportingChanged() {
+        val end = 1_000_000L
+        val result = TripMonitorDecider.decide(
+            monitoring("trip_5", end), // armed under OTP1
+            listOf(itinerary("1:trip_5", end + TimeUnit.SECONDS.toMillis(30))), // re-planned under OTP2
+            thresholdSeconds
+        )
+        assertEquals(MonitorResult.KeepMonitoring, result)
+    }
+
+    @Test
+    fun crossScheme_sameTripDelayed_reportsDeviationNotChanged() {
+        val end = 1_000_000L
+        val result = TripMonitorDecider.decide(
+            monitoring("trip_5", end),
+            listOf(itinerary("1:trip_5", end + TimeUnit.MINUTES.toMillis(5))),
+            thresholdSeconds
+        )
+        assertEquals(MonitorResult.Deviation(TimeUnit.MINUTES.toSeconds(5)), result)
+    }
+
+    @Test
+    fun matchingItinerary_exactlyAtThreshold_keepsMonitoring() {
+        val end = 1_000_000L
+        val result = TripMonitorDecider.decide(
+            monitoring("t1", end),
+            listOf(itinerary("t1", end + TimeUnit.SECONDS.toMillis(thresholdSeconds))), // == threshold
+            thresholdSeconds
+        )
+        // abs(delay) > threshold is strict, so exactly-at-threshold is not yet a deviation.
+        assertEquals(MonitorResult.KeepMonitoring, result)
+    }
+
+    @Test
+    fun matchingItinerary_oneSecondPastThreshold_reportsDeviation() {
+        val end = 1_000_000L
+        val result = TripMonitorDecider.decide(
+            monitoring("t1", end),
+            listOf(itinerary("t1", end + TimeUnit.SECONDS.toMillis(thresholdSeconds + 1))),
+            thresholdSeconds
+        )
+        assertEquals(MonitorResult.Deviation(thresholdSeconds + 1), result)
+    }
+
+    @Test
+    fun matchingItinerary_unparseableEndDate_keepsMonitoring() {
+        // The monitored description has no end date (couldn't be parsed): getDelay is null, so a match
+        // with no measurable delay keeps polling rather than crying "changed" or "delayed".
+        val current = ItineraryDescription(listOf("t1"), endDate = null)
+        val result = TripMonitorDecider.decide(
+            current,
+            listOf(itinerary("t1", 1_000_000L)),
+            thresholdSeconds
+        )
+        assertEquals(MonitorResult.KeepMonitoring, result)
+    }
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/directions/realtime/TripMonitorStateTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/directions/realtime/TripMonitorStateTest.kt
@@ -27,13 +27,15 @@ class TripMonitorStateTest {
     private val start = 1_700_000_000_000L
     private val end = 1_700_000_600_000L
 
+    private val version = TripPlanMonitor.MONITOR_STATE_VERSION
+
     @Test
     fun validBundleParsesToState() {
-        val parse = parseMonitorState(TripPlanMonitor.MONITOR_STATE_VERSION, tripIds, start, end)
+        val parse = parseMonitorState(version, tripIds, start, end)
         assertTrue(parse is MonitorStateParse.Valid)
-        val state = (parse as MonitorStateParse.Valid).state
-        assertEquals(tripIds, state.description.tripIds)
-        assertEquals(start, state.departure?.epochMs)
+        val valid = parse as MonitorStateParse.Valid
+        assertEquals(tripIds, valid.description.tripIds)
+        assertEquals(start, valid.departure?.epochMs)
     }
 
     @Test
@@ -45,16 +47,16 @@ class TripMonitorStateTest {
 
     @Test
     fun unknownStartDateBecomesNullDeparture() {
-        val parse = parseMonitorState(TripPlanMonitor.MONITOR_STATE_VERSION, tripIds, startDateMillis = 0L, endDateMillis = end)
+        val parse = parseMonitorState(version, tripIds, startDateMillis = 0L, endDateMillis = end)
         assertTrue(parse is MonitorStateParse.Valid)
-        assertNull((parse as MonitorStateParse.Valid).state.departure)
+        assertNull((parse as MonitorStateParse.Valid).departure)
     }
 
     @Test
     fun emptyTripIdsIsMissing() {
         assertEquals(
             MonitorStateParse.Missing,
-            parseMonitorState(TripPlanMonitor.MONITOR_STATE_VERSION, tripIds = emptyList(), startDateMillis = start, endDateMillis = end)
+            parseMonitorState(version, tripIds = emptyList(), startDateMillis = start, endDateMillis = end)
         )
     }
 
@@ -62,7 +64,7 @@ class TripMonitorStateTest {
     fun nullTripIdsIsMissing() {
         assertEquals(
             MonitorStateParse.Missing,
-            parseMonitorState(TripPlanMonitor.MONITOR_STATE_VERSION, tripIds = null, startDateMillis = start, endDateMillis = end)
+            parseMonitorState(version, tripIds = null, startDateMillis = start, endDateMillis = end)
         )
     }
 
@@ -70,7 +72,7 @@ class TripMonitorStateTest {
     fun absentEndDateIsMissing() {
         assertEquals(
             MonitorStateParse.Missing,
-            parseMonitorState(TripPlanMonitor.MONITOR_STATE_VERSION, tripIds, startDateMillis = start, endDateMillis = 0L)
+            parseMonitorState(version, tripIds, startDateMillis = start, endDateMillis = 0L)
         )
     }
 
@@ -79,7 +81,7 @@ class TripMonitorStateTest {
         // A bundle from a future build we can't interpret: stop silently rather than misfire.
         assertEquals(
             MonitorStateParse.Incompatible,
-            parseMonitorState(TripPlanMonitor.MONITOR_STATE_VERSION + 1, tripIds, start, end)
+            parseMonitorState(version + 1, tripIds, start, end)
         )
     }
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/directions/realtime/TripMonitorStateTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/directions/realtime/TripMonitorStateTest.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.directions.realtime
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** JVM unit tests for [parseMonitorState] — the version/validity gate on a persisted monitor bundle. */
+class TripMonitorStateTest {
+
+    private val tripIds = listOf("1:trip_5")
+    private val start = 1_700_000_000_000L
+    private val end = 1_700_000_600_000L
+
+    @Test
+    fun validBundleParsesToState() {
+        val parse = parseMonitorState(TripPlanMonitor.MONITOR_STATE_VERSION, tripIds, start, end)
+        assertTrue(parse is MonitorStateParse.Valid)
+        val state = (parse as MonitorStateParse.Valid).state
+        assertEquals(tripIds, state.description.tripIds)
+        assertEquals(start, state.departure?.epochMs)
+    }
+
+    @Test
+    fun absentVersionIsTreatedAsCompatibleLegacyState() {
+        // A bundle written before versioning (v0) — its raw ids still normalize and compare correctly.
+        val parse = parseMonitorState(version = null, tripIds = tripIds, startDateMillis = start, endDateMillis = end)
+        assertTrue(parse is MonitorStateParse.Valid)
+    }
+
+    @Test
+    fun unknownStartDateBecomesNullDeparture() {
+        val parse = parseMonitorState(TripPlanMonitor.MONITOR_STATE_VERSION, tripIds, startDateMillis = 0L, endDateMillis = end)
+        assertTrue(parse is MonitorStateParse.Valid)
+        assertNull((parse as MonitorStateParse.Valid).state.departure)
+    }
+
+    @Test
+    fun emptyTripIdsIsMissing() {
+        assertEquals(
+            MonitorStateParse.Missing,
+            parseMonitorState(TripPlanMonitor.MONITOR_STATE_VERSION, tripIds = emptyList(), startDateMillis = start, endDateMillis = end)
+        )
+    }
+
+    @Test
+    fun nullTripIdsIsMissing() {
+        assertEquals(
+            MonitorStateParse.Missing,
+            parseMonitorState(TripPlanMonitor.MONITOR_STATE_VERSION, tripIds = null, startDateMillis = start, endDateMillis = end)
+        )
+    }
+
+    @Test
+    fun absentEndDateIsMissing() {
+        assertEquals(
+            MonitorStateParse.Missing,
+            parseMonitorState(TripPlanMonitor.MONITOR_STATE_VERSION, tripIds, startDateMillis = start, endDateMillis = 0L)
+        )
+    }
+
+    @Test
+    fun newerVersionIsIncompatible() {
+        // A bundle from a future build we can't interpret: stop silently rather than misfire.
+        assertEquals(
+            MonitorStateParse.Incompatible,
+            parseMonitorState(TripPlanMonitor.MONITOR_STATE_VERSION + 1, tripIds, start, end)
+        )
+    }
+}


### PR DESCRIPTION
## Problem

The trip-plan-change monitor could fire a surprise **"We found a better trip plan"** notification for a trip the user didn't recently plan — the feature that prompted this.

**Root cause:** itinerary identity was exact ordered-string equality over transit-leg `tripId` (`ItineraryDescription.itineraryMatches`), and `tripId` is the OTP `gtfsId` verbatim from both adapters. The pinned OTP2 schema documents `Trip.gtfsId` as colon-delimited `FeedId:TripId` (`graphql/otp2/schema.graphqls`); OTP1 emits bare ids (`trip_5`). A monitor armed under one id vocabulary can never string-match a re-plan under the other, so `TripMonitorDecider.decide` fell through to `ItineraryChanged` and fired the "better plan" alert for a trip that never changed. `START_REDELIVER_INTENT` + a persisted AlarmManager PendingIntent means a stale pre-OTP2 monitor can redeliver after an app update and re-plan under OTP2, reproducing it.

The identity logic is the last piece untouched since the 2016 original; this modernizes it and folds in the adjacent debt found along the way.

## Changes

**1. Normalized itinerary identity (the fix).** Compare on the *entity suffix* of each trip id, not the raw string. The `FeedId:` prefix is stripped via a shared `gtfsEntitySuffix()` extracted from `OtpObaIdResolver` — the **documented** OTP2 id contract ("the entity id is identical on both sides, only the feed prefix differs"), reused by both the resolver and `ItineraryDescription`. So `trip_5` (OTP1) and `1:trip_5` (OTP2) compare equal. Colon-only, deliberately (OBA ids are `agency_entity` and GTFS ids contain underscores). Raw ids stay in the persisted bundle, so the currently-pending pre-OTP2 alarm also compares correctly when it fires.

> ⚠️ **No-heuristics sign-off:** per `CLAUDE.md`, reusing this sanctioned colon transform re-opens the human sign-off gate. It is grounded in the pinned schema + the resolver's existing (unit-tested) rule, not invented. Note: the `Otp2PlanDecodeTest` fixtures use underscore ids (`1_trip_5`), which contradict the schema's colon form — those fixtures are wrong; normalization intentionally does **not** follow them. (Fixing that fixture is out of scope here.)

**2. Version-stamped monitor state.** New `EXTRA_MONITOR_VERSION` / `MONITOR_STATE_VERSION` behind a pure, unit-tested `parseMonitorState()`. A bundle from a newer/incompatible build (redelivered across an app update) stops the service **silently** instead of misfiring; an absent version = compatible legacy v0.

**3. Honest notification.** `ItineraryChanged` → "Your planned trip changed" (not "better"); the deviation body gets its own string. Retires the old "better plan" strings **and their translations** (which literally said "better plan" in it/es/pl/fi). The change alert uses a fixed id (single monitored trip) rather than the not-guaranteed-unique `tripIds.hashCode()`.

**4. One enable-gate.** `TripPlanNotifications.isEnabled()` = the in-app toggle **AND** the OS (app-level notifications incl. `POST_NOTIFICATIONS`, and channel importance). Previously the app pref was ignored on O+, so the Settings switch did nothing on modern devices. Retires the hidden, UI-less `live_updates` preference. *(User-visible: the toggle now gates arming on all SDK levels.)*

**5. Cleanup.** Refreshes stale `#1939` comments (restore-into-directions is merged and live).

**Non-goals:** no multi-trip monitoring, no service/alarm re-architecture (#1732/#1733 stays), no OTP1 removal (fix works for both), no "actually better" ranking, no persisted-bundle/`TripItinerary` JSON schema change.

## Tests (JVM, pure)

- `OtpGtfsIdsTest` — colon split, unprefixed passthrough, underscore preserved, null.
- `ItineraryDescriptionTest` — cross-scheme matching, order-sensitivity, non-collision.
- `TripMonitorDeciderTest` — the load-bearing **regression** (OTP1 armed vs OTP2 re-plan ⇒ `KeepMonitoring`/`Deviation`, never `ItineraryChanged`) + the previously-untested null-delay and threshold-boundary branches.
- `TripMonitorStateTest` — the version/validity gate (valid / legacy-v0 / missing / incompatible).
- `OtpObaIdResolverTest` and `TripItineraryJsonTest` stay green (no persisted-format change).

Both flavors + test sources compile under `-PwarningsAsErrors=true`; `spotlessCheck` passes; installed and running on a device.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved trip monitoring across different trip ID formats.
  * Added validation for restored trip-monitoring state to handle missing or unsupported data safely.
  * Trip-plan notifications now respect both in-app and device notification settings.
  * Updated trip-change and service-deviation notification messages.
  * Repeated trip-change alerts now replace older alerts instead of accumulating.

* **Bug Fixes**
  * Prevented unnecessary monitoring when notifications are disabled.
  * Improved handling of itinerary matching, delays, and incomplete trip data.

* **Tests**
  * Added coverage for ID normalization, itinerary matching, notification decisions, delay thresholds, and monitor-state validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->