### PR TITLE
Directions ETA strip: justify to first upcoming pill on first display (#1973)

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/arrivals/EtaStripJustifyTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/arrivals/EtaStripJustifyTest.kt
@@ -31,8 +31,10 @@ import org.onebusaway.android.ui.compose.createUnconfinedComposeRule
 
 /**
  * On-device regression test for the strip justifying to its first non-negative ETA (recent-past
- * pills overflowing off the left, see EtaStrip's `start` parameter). Renders the real composable —
- * not a fake — and asserts the scroll actually happened, since a broken justify silently leaves
+ * pills overflowing off the left). The strip derives this first-upcoming justify internally from
+ * `trips`, so this also guards against the #1973 regression where forgetting to justify let the pin
+ * start at 0 and glide-animate the recent-past pills off on entry. Renders the real composable — not
+ * a fake — and asserts the scroll actually happened, since a broken justify silently leaves
  * scrollState at 0. Covers both a strip that overflows its host and one whose pills fit (where the
  * justify only works because SlideBox floors the content width — see EtaStrip's `minReachablePx`).
  */
@@ -77,8 +79,8 @@ class EtaStripJustifyTest {
     }
 
     /**
-     * Renders the real [EtaStrip] in a [hostWidth]-wide host, justified to its first upcoming ETA,
-     * and asserts the strip actually scrolls the recent-past pills off the leading edge.
+     * Renders the real [EtaStrip] in a [hostWidth]-wide host and asserts the strip actually scrolls
+     * the recent-past pills off the leading edge, justifying to its first upcoming ETA.
      *
      * The measure -> onGloballyPositioned -> pinnedOffsetPx write -> LaunchedEffect -> scrollTo chain
      * spans a recomposition, so a single waitForIdle() can return before scrollTo has run. Poll
@@ -86,7 +88,6 @@ class EtaStripJustifyTest {
      * broken justify silently leaves scrollState at 0.
      */
     private fun assertJustifiesLeadingEdge(hostWidth: Dp, trips: List<ArrivalInfo>) {
-        val firstUpcomingIndex = trips.indexOfFirst { it.eta >= 0 }
         lateinit var scrollState: ScrollState
 
         composeRule.setContent {
@@ -96,7 +97,6 @@ class EtaStripJustifyTest {
                     trips = trips,
                     actionsFor = { null },
                     callbacks = previewRowCallbacks(),
-                    start = firstUpcomingIndex,
                     scrollState = scrollState
                 )
             }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/RouteRowGroup.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/RouteRowGroup.kt
@@ -73,11 +73,6 @@ data class RouteRowGroup(val trips: List<ArrivalInfo>) {
     /** The soonest trip; source of the row's route badge, headsign, and route-level actions/color. */
     val representative: ArrivalInfo get() = trips.first()
 
-    /** Index of the soonest *upcoming* (first non-negative ETA) trip within [trips], or null when every
-     *  trip is recent-past. Lets a row justify that pill to the leading edge so the recent-past pills
-     *  overflow before it. */
-    val firstUpcomingIndex: Int? get() = trips.indexOfFirst { it.eta >= 0 }.takeIf { it >= 0 }
-
     val routeId: String get() = representative.routeId
     val directionId: Int? get() = representative.directionId
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
@@ -356,9 +356,6 @@ fun RouteArrivalRow(
                         trips = group.trips,
                         actionsFor = actionsFor,
                         callbacks = callbacks,
-                        // Justify the soonest upcoming pill to the leading edge (the ETA the row is
-                        // sorted by), so recent-past pills overflow left.
-                        start = group.firstUpcomingIndex,
                         firstPillModifier = etaAnchor
                     )
                 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStrip.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStrip.kt
@@ -86,8 +86,7 @@ import org.onebusaway.android.util.DisplayFormat
  * [now]), or -1 when every trip is recent-past. The single source of the "which pill leads" rule,
  * shared by the strip's first-display pin and its live-departure BOOKKEEPER so the two can't disagree.
  */
-private fun List<ArrivalInfo>.firstUpcomingIndex(now: ServerTime): Int =
-    indexOfFirst { it.liveEta(now) >= 0 }
+private fun List<ArrivalInfo>.firstUpcomingIndex(now: ServerTime): Int = indexOfFirst { it.liveEta(now) >= 0 }
 
 /**
  * The horizontally-scrollable strip of per-trip ETA pills below the direction name. When the pills

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStrip.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStrip.kt
@@ -82,6 +82,14 @@ import org.onebusaway.android.util.DisplayFormat
 // not a gesture on this strip.
 
 /**
+ * Index of the soonest *upcoming* pill (first trip whose live ETA hasn't gone negative against
+ * [now]), or -1 when every trip is recent-past. The single source of the "which pill leads" rule,
+ * shared by the strip's first-display pin and its live-departure BOOKKEEPER so the two can't disagree.
+ */
+private fun List<ArrivalInfo>.firstUpcomingIndex(now: ServerTime): Int =
+    indexOfFirst { it.liveEta(now) >= 0 }
+
+/**
  * The horizontally-scrollable strip of per-trip ETA pills below the direction name. When the pills
  * overflow the row, a chevron appears at that edge to signal there's more to scroll to; tapping it
  * moves the strip one strip-width further that direction (or to the end, whichever is closer). The
@@ -121,13 +129,12 @@ internal fun EtaStrip(
     // The pill currently pinned to the strip's leading edge — earlier (recent-past) pills overflow off
     // the left, reachable via the left chevron. Initialized to the first-upcoming index so the strip
     // justifies there on first display (0 — already the strip's start — when the first pill is itself
-    // upcoming, or when none is). Derived from `trips` with the SAME predicate the BOOKKEEPER effect
-    // uses below, so first-display and steady-state agree and no caller can desync them by forgetting
-    // to pass it (#1973). Thereafter only ever advances forward, from the BOOKKEEPER — never yanked
-    // backward by an ordinary poll data reshuffle.
+    // upcoming, or when none is; `firstUpcomingIndex` returns -1 there, floored to 0). Uses the SAME
+    // `firstUpcomingIndex` helper the BOOKKEEPER effect uses below, so first-display and steady-state
+    // agree and no caller can desync them by forgetting to pass it (#1973). Thereafter only ever
+    // advances forward, from the BOOKKEEPER — never yanked backward by an ordinary poll data reshuffle.
     var pinnedIndex by remember {
-        val firstUpcoming = trips.indexOfFirst { it.liveEta(liveNow) >= 0 }
-        mutableIntStateOf(firstUpcoming.takeIf { it in 1..trips.lastIndex } ?: 0)
+        mutableIntStateOf(trips.firstUpcomingIndex(liveNow).coerceAtLeast(0))
     }
 
     // A one-shot scroll target (absolute, same units as pinnedOffsetPx) set by tapping an overflow
@@ -153,7 +160,7 @@ internal fun EtaStrip(
     // exactly once as a level change, not by polling a recomposition-derived key. Never backward, so
     // an ordinary poll data reshuffle can't yank the pin; only a live departure moves it.
     LaunchedEffect(Unit) {
-        snapshotFlow { tripsState.value.indexOfFirst { it.liveEta(liveNowState.value) >= 0 } }
+        snapshotFlow { tripsState.value.firstUpcomingIndex(liveNowState.value) }
             .collect { current ->
                 if (current > pinnedIndex) {
                     pinnedIndex = current

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStrip.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStrip.kt
@@ -89,9 +89,9 @@ import org.onebusaway.android.util.DisplayFormat
  * strip's own drag-to-scroll.
  *
  * The strip also keeps its soonest *upcoming* pill pinned to the leading edge over time: it snaps
- * there instantly on first display (using [start]), then as the shared live clock ticks a trip's ETA
- * past zero between polls, glides the strip left so the just-departed pill visibly slides into the
- * left overflow instead of sitting there stale until the next poll.
+ * there instantly on first display, then as the shared live clock ticks a trip's ETA past zero
+ * between polls, glides the strip left so the just-departed pill visibly slides into the left
+ * overflow instead of sitting there stale until the next poll.
  */
 @Composable
 internal fun EtaStrip(
@@ -99,10 +99,6 @@ internal fun EtaStrip(
     actionsFor: (ArrivalInfo) -> ArrivalActions?,
     callbacks: ArrivalRowCallbacks,
     modifier: Modifier = Modifier,
-    // The trip index to justify to the strip's leading (left) edge on first display; earlier trips
-    // (e.g. the recent-past, negative-ETA pills) then overflow off the left, reachable via the left
-    // chevron. Null (or index 0) leaves the strip at its start.
-    start: Int? = null,
     firstPillModifier: Modifier = Modifier,
     // Hoisted so callers (and previews) can control/observe the scroll — e.g. a preview starts it
     // mid-scroll to show both edge chevrons.
@@ -123,10 +119,16 @@ internal fun EtaStrip(
     var pinnedOffsetPx by remember { mutableIntStateOf(-1) }
 
     // The pill currently pinned to the strip's leading edge — earlier (recent-past) pills overflow off
-    // the left, reachable via the left chevron. Starts at the poll-time first-upcoming index (or 0,
-    // already the strip's start, when every trip is upcoming); only ever advances forward, from the
-    // BOOKKEEPER effect below — never yanked backward by an ordinary poll data reshuffle.
-    var pinnedIndex by remember { mutableIntStateOf(start?.takeIf { it in 1..trips.lastIndex } ?: 0) }
+    // the left, reachable via the left chevron. Initialized to the first-upcoming index so the strip
+    // justifies there on first display (0 — already the strip's start — when the first pill is itself
+    // upcoming, or when none is). Derived from `trips` with the SAME predicate the BOOKKEEPER effect
+    // uses below, so first-display and steady-state agree and no caller can desync them by forgetting
+    // to pass it (#1973). Thereafter only ever advances forward, from the BOOKKEEPER — never yanked
+    // backward by an ordinary poll data reshuffle.
+    var pinnedIndex by remember {
+        val firstUpcoming = trips.indexOfFirst { it.liveEta(liveNow) >= 0 }
+        mutableIntStateOf(firstUpcoming.takeIf { it in 1..trips.lastIndex } ?: 0)
+    }
 
     // A one-shot scroll target (absolute, same units as pinnedOffsetPx) set by tapping an overflow
     // chevron; takes priority over the pinned-pill anchor below. Left in place once reached — like an


### PR DESCRIPTION
Fixes #1973.

## Problem
In the directions drawer, a transit leg's inline ETA strip visibly *animated* its recent-past (negative-ETA) pills off into the left gutter whenever the strip came into view. The arrivals drawer's strips don't do this — they appear already justified to the first upcoming pill.

## Root cause
`EtaStrip` had an optional `start` parameter naming the trip index to justify to on first display. `DirectionStopEtaStrip` omitted it, so `pinnedIndex` initialized to 0, the first alignment snapped to offset 0 (a no-op that still consumed the snap phase), and then the BOOKKEEPER effect advanced the pin to the first upcoming trip — via the **glide** path, producing the entry animation. This replayed on every fresh composition.

## Fix
Rather than patch the one call site, this removes the trap. `start` was fully derivable from `trips` — both call sites just computed `indexOfFirst { eta >= 0 }` on the same list the strip already has. So `EtaStrip` now derives its initial pin **internally**, using the *same* predicate the BOOKKEEPER effect uses, so first-display and steady-state agree and no caller can desync them by forgetting to pass it.

Removed:
- the `start` parameter and its two call-site arguments (`ArrivalRows`, `DirectionsFeature`),
- the now-unused `RouteRowGroup.firstUpcomingIndex`.

`EtaStripJustifyTest` now exercises the default path (no explicit `start`), so it directly guards this regression on-device.

## Acceptance
A directions leg strip with recent-past arrivals appears already justified to the first upcoming pill — no entry animation — including when re-entering view. Negative pills remain reachable via the left chevron.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved arrival-time displays so the first upcoming ETA remains correctly positioned while earlier arrivals pass.
  * Fixed ETA strip scrolling behavior to prevent recent-past arrival pills from starting at the wrong position or gliding out of view.
  * Improved consistency in identifying and tracking the next upcoming arrival as live ETAs update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->