### PR TITLE
Seed RegionState.Resolving so a transient null region is distinguishable from "no region" (#1969)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/region/RegionRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/region/RegionRepository.kt
@@ -162,14 +162,11 @@ class DefaultRegionRepository @Inject constructor(
     init {
         appScope.launch {
             val seeded = loadPersistedRegion()
-            // Settle the initial Resolving state now that the persisted region (if any) has loaded — to the
-            // persisted region, or to a deliberate Active(null) when a custom OBA API URL is configured
-            // (the rider set a custom endpoint, so there genuinely is no region). With neither, leave
-            // Resolving for refresh() to settle. settleIfResolving is a no-op once the state has settled,
-            // and its check-and-write is atomic with the other holder writers, so a concurrent refresh()
-            // that has resolved to Active/NeedsManualChoice/Failed is never clobbered (refresh's own
-            // transient Resolving is deliberately settled over — it publishes its result regardless).
-            // `seeded` is null in the custom-URL branch, so the single call covers both cases.
+            // Settle the initial Resolving state now that the persisted region (if any) has loaded — to
+            // the persisted region, or to a deliberate Active(null) when a custom OBA API URL is configured
+            // (the rider set a custom endpoint, so there genuinely is no region). With neither, leave it
+            // Resolving for refresh() to settle. `seeded` is null in the custom-URL branch, so the single
+            // call covers both cases; settleIfResolving handles the concurrent-refresh race (see its doc).
             if (seeded != null || hasCustomObaApiUrl()) holder.settleIfResolving(seeded)
         }
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/region/RegionRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/region/RegionRepository.kt
@@ -154,14 +154,25 @@ class DefaultRegionRepository @Inject constructor(
     // Seeded null and then asynchronously from the region cache once the one-time import has run — the
     // Room cache read is suspend and must wait on the importer, so the @Singleton constructor can't read
     // it synchronously anymore. region.value is briefly null at cold start until the seed resolves; the
-    // region-derived subsystems collect the flow and re-init on emit, so they pick it up.
-    private val holder = RegionStateHolder(null)
+    // region-derived subsystems collect the flow and re-init on emit, so they pick it up. [state] starts
+    // Resolving (not Active(null)) so a one-shot consumer can tell "not resolved yet" from "no region" —
+    // the init block below settles it (#1969).
+    private val holder = RegionStateHolder()
 
     init {
         appScope.launch {
             val seeded = loadPersistedRegion()
-            // Don't clobber a region a concurrent refresh() may have already set.
-            if (seeded != null && holder.region.value == null) holder.activated(seeded)
+            // Settle the initial Resolving state now that the persisted region (if any) has loaded — to the
+            // persisted region, or to a deliberate Active(null) when a custom OBA API URL is configured
+            // (the rider set a custom endpoint, so there genuinely is no region). With neither, leave
+            // Resolving for refresh() to settle. Only while the state is still that untouched Resolving
+            // seed: a concurrent refresh() that has already resolved to Active/NeedsManualChoice/Failed owns
+            // the state and must not be clobbered (refresh's own transient Resolving is fine to override —
+            // it settles the state again itself). `seeded` is null in the custom-URL branch, so the single
+            // activated(seeded) covers both cases.
+            if (holder.state.value == RegionState.Resolving && (seeded != null || hasCustomObaApiUrl())) {
+                holder.activated(seeded)
+            }
         }
     }
 
@@ -184,6 +195,9 @@ class DefaultRegionRepository @Inject constructor(
         return regionCache.cachedRegion(id)
     }
 
+    /** Whether a custom OBA API URL is configured — the "deliberately no region" case (used by init + [refresh]). */
+    private fun hasCustomObaApiUrl(): Boolean = prefs.getString(R.string.preference_key_oba_api_url, null)?.isNotEmpty() == true
+
     override fun applyRegion(region: Region?, regionChanged: Boolean) {
         // The canonical region write: this holder is the single source of truth for the current region
         // (every reader observes [region] or reads its value), plus the persisted region-id pref and the
@@ -204,7 +218,7 @@ class DefaultRegionRepository @Inject constructor(
         holder.resolving()
 
         // A custom API URL means we don't use the Regions API at all (region stays null).
-        if (prefs.getString(R.string.preference_key_oba_api_url, null)?.isNotEmpty() == true) {
+        if (hasCustomObaApiUrl()) {
             holder.activated(null)
             return@withContext RegionStatus.Skipped
         }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/region/RegionRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/region/RegionRepository.kt
@@ -165,14 +165,12 @@ class DefaultRegionRepository @Inject constructor(
             // Settle the initial Resolving state now that the persisted region (if any) has loaded — to the
             // persisted region, or to a deliberate Active(null) when a custom OBA API URL is configured
             // (the rider set a custom endpoint, so there genuinely is no region). With neither, leave
-            // Resolving for refresh() to settle. Only while the state is still that untouched Resolving
-            // seed: a concurrent refresh() that has already resolved to Active/NeedsManualChoice/Failed owns
-            // the state and must not be clobbered (refresh's own transient Resolving is fine to override —
-            // it settles the state again itself). `seeded` is null in the custom-URL branch, so the single
-            // activated(seeded) covers both cases.
-            if (holder.state.value == RegionState.Resolving && (seeded != null || hasCustomObaApiUrl())) {
-                holder.activated(seeded)
-            }
+            // Resolving for refresh() to settle. settleIfResolving is a no-op once the state has settled,
+            // and its check-and-write is atomic with the other holder writers, so a concurrent refresh()
+            // that has resolved to Active/NeedsManualChoice/Failed is never clobbered (refresh's own
+            // transient Resolving is deliberately settled over — it publishes its result regardless).
+            // `seeded` is null in the custom-URL branch, so the single call covers both cases.
+            if (seeded != null || hasCustomObaApiUrl()) holder.settleIfResolving(seeded)
         }
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/region/RegionStateHolder.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/region/RegionStateHolder.kt
@@ -26,17 +26,24 @@ import org.onebusaway.android.region.Region
  * repository's resolution is `Context`-coupled (it calls `RegionUtils.getRegions` etc.), but the
  * holder is pure. The repository's `refresh`/`choose`/`applyRegion` writers feed it.
  *
- * [region] holds the last-set region (null when a custom API URL is configured); [state] adds the
- * transient [RegionState.Resolving] / [RegionState.NeedsManualChoice] / [RegionState.Failed] nuance.
- * [region] is left untouched by [resolving]/[needsChoice]/[failed] (the last region still applies while
- * a refresh is in flight or after a failure); only [activated] moves it.
+ * Both flows start empty — a null [region] and a [RegionState.Resolving] [state] — and [activated] is the
+ * only writer that installs a region; [region] is left untouched by [resolving]/[needsChoice]/[failed] (the
+ * last region still applies while a refresh is in flight or after a failure). [state] adds the transient
+ * [RegionState.Resolving] / [RegionState.NeedsManualChoice] / [RegionState.Failed] nuance ([region] is null
+ * whenever a custom API URL is configured).
+ *
+ * [state] starts [RegionState.Resolving], **not** [RegionState.Active]: at construction no resolution has
+ * completed, so a consumer that takes a one-shot action on the first state it sees can tell "not resolved
+ * yet" (transient — a value is coming) apart from a deliberate `Active(null)` (a custom API URL is
+ * configured, so there is no region). [DefaultRegionRepository]'s `init` settles this once the persisted
+ * region has loaded — see its `init` block (#1969).
  */
-class RegionStateHolder(seed: Region?) {
+class RegionStateHolder {
 
-    private val _region = MutableStateFlow(seed)
+    private val _region = MutableStateFlow<Region?>(null)
     val region: StateFlow<Region?> = _region.asStateFlow()
 
-    private val _state = MutableStateFlow<RegionState>(RegionState.Active(seed))
+    private val _state = MutableStateFlow<RegionState>(RegionState.Resolving)
     val state: StateFlow<RegionState> = _state.asStateFlow()
 
     /** A region (or null for a custom API URL) became active: moves both [region] and [state]. */

--- a/onebusaway-android/src/main/java/org/onebusaway/android/region/RegionStateHolder.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/region/RegionStateHolder.kt
@@ -37,6 +37,12 @@ import org.onebusaway.android.region.Region
  * yet" (transient — a value is coming) apart from a deliberate `Active(null)` (a custom API URL is
  * configured, so there is no region). [DefaultRegionRepository]'s `init` settles this once the persisted
  * region has loaded — see its `init` block (#1969).
+ *
+ * The writers are `@Synchronized` so a compound transition (the [settleIfResolving] check-and-write) is
+ * atomic with respect to the others. That serializes *writers* only: [region] and [state] are separate
+ * flows, so a reader collecting one can still momentarily observe it against the other's prior value.
+ * Readers that need both consistent should derive from [state] alone (its [RegionState.Active] carries the
+ * region), not pair [region] with [state].
  */
 class RegionStateHolder {
 
@@ -64,9 +70,7 @@ class RegionStateHolder {
      */
     @Synchronized
     fun settleIfResolving(region: Region?) {
-        if (_state.value != RegionState.Resolving) return
-        _region.value = region
-        _state.value = RegionState.Active(region)
+        if (_state.value == RegionState.Resolving) activated(region)
     }
 
     /** A resolution is in flight; [region] keeps its last value. */

--- a/onebusaway-android/src/main/java/org/onebusaway/android/region/RegionStateHolder.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/region/RegionStateHolder.kt
@@ -47,22 +47,42 @@ class RegionStateHolder {
     val state: StateFlow<RegionState> = _state.asStateFlow()
 
     /** A region (or null for a custom API URL) became active: moves both [region] and [state]. */
+    @Synchronized
     fun activated(region: Region?) {
         _region.value = region
         _state.value = RegionState.Active(region)
     }
 
+    /**
+     * Settles the initial [RegionState.Resolving] seed to [RegionState.Active] — the repository init's
+     * persisted-region write. A no-op unless [state] is still [RegionState.Resolving], so a concurrent
+     * refresh that has already settled to Active/NeedsManualChoice/Failed is never clobbered — and unlike
+     * a bare check at the call site, the check and the write are atomic with the other writers (all
+     * `@Synchronized`), closing the interleaving where a refresh settles between them (#1969). A refresh's
+     * own transient [resolving] *is* settled over deliberately: it publishes its result regardless, so
+     * the early seed only fills the wait.
+     */
+    @Synchronized
+    fun settleIfResolving(region: Region?) {
+        if (_state.value != RegionState.Resolving) return
+        _region.value = region
+        _state.value = RegionState.Active(region)
+    }
+
     /** A resolution is in flight; [region] keeps its last value. */
+    @Synchronized
     fun resolving() {
         _state.value = RegionState.Resolving
     }
 
     /** No region could be auto-selected; the user must pick from [regions]. [region] keeps its value. */
+    @Synchronized
     fun needsChoice(regions: List<Region>) {
         _state.value = RegionState.NeedsManualChoice(regions)
     }
 
     /** Region info could not be loaded; [region] keeps its last value. */
+    @Synchronized
     fun failed() {
         _state.value = RegionState.Failed
     }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/region/RegionStateHolderTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/region/RegionStateHolderTest.kt
@@ -23,23 +23,17 @@ import org.junit.Test
 class RegionStateHolderTest {
 
     @Test
-    fun `the seed region is the initial value and Active`() {
-        // Region equality is id-based, so region(1) matches the seeded region(1).
-        val holder = RegionStateHolder(region(1))
-        assertEquals(region(1), holder.region.value)
-        assertEquals(RegionState.Active(region(1)), holder.state.value)
-    }
-
-    @Test
-    fun `a null seed yields a null Active`() {
-        val holder = RegionStateHolder(null)
+    fun `starts with a null region and a Resolving state`() {
+        // The state starts Resolving (not Active) so cold-start consumers can tell "not resolved yet" from
+        // a real Active (#1969); the repository's init settles it via activated().
+        val holder = RegionStateHolder()
         assertNull(holder.region.value)
-        assertEquals(RegionState.Active(null), holder.state.value)
+        assertEquals(RegionState.Resolving, holder.state.value)
     }
 
     @Test
     fun `activated updates region and state, including back to null`() {
-        val holder = RegionStateHolder(region(1))
+        val holder = RegionStateHolder()
         holder.activated(region(2))
         assertEquals(region(2), holder.region.value)
         assertEquals(RegionState.Active(region(2)), holder.state.value)
@@ -50,7 +44,8 @@ class RegionStateHolderTest {
 
     @Test
     fun `resolving and failed change state but keep the last region`() {
-        val holder = RegionStateHolder(region(1))
+        // Region equality is id-based, so region(1) matches the activated region(1).
+        val holder = RegionStateHolder().apply { activated(region(1)) }
         holder.resolving()
         assertEquals(region(1), holder.region.value)
         assertEquals(RegionState.Resolving, holder.state.value)
@@ -61,7 +56,7 @@ class RegionStateHolderTest {
 
     @Test
     fun `needsChoice carries the regions and keeps the last region`() {
-        val holder = RegionStateHolder(null)
+        val holder = RegionStateHolder()
         val regions = listOf(region(1), region(2))
         holder.needsChoice(regions)
         assertNull(holder.region.value)

--- a/onebusaway-android/src/test/java/org/onebusaway/android/region/RegionStateHolderTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/region/RegionStateHolderTest.kt
@@ -25,10 +25,57 @@ class RegionStateHolderTest {
     @Test
     fun `starts with a null region and a Resolving state`() {
         // The state starts Resolving (not Active) so cold-start consumers can tell "not resolved yet" from
-        // a real Active (#1969); the repository's init settles it via activated().
+        // a real Active (#1969); the repository's init settles it via settleIfResolving().
         val holder = RegionStateHolder()
         assertNull(holder.region.value)
         assertEquals(RegionState.Resolving, holder.state.value)
+    }
+
+    @Test
+    fun `settleIfResolving activates while the state is still Resolving`() {
+        val holder = RegionStateHolder()
+        holder.settleIfResolving(region(1))
+        assertEquals(region(1), holder.region.value)
+        assertEquals(RegionState.Active(region(1)), holder.state.value)
+    }
+
+    @Test
+    fun `settleIfResolving with null is the deliberate custom-URL Active(null)`() {
+        val holder = RegionStateHolder()
+        holder.settleIfResolving(null)
+        assertNull(holder.region.value)
+        assertEquals(RegionState.Active(null), holder.state.value)
+    }
+
+    @Test
+    fun `settleIfResolving settles over a refresh's transient resolving`() {
+        // A refresh marks Resolving before its IO; the init seed may land mid-flight and is allowed to
+        // publish early — the refresh's terminal write then supersedes it (#1969).
+        val holder = RegionStateHolder().apply { resolving() }
+        holder.settleIfResolving(region(1))
+        assertEquals(region(1), holder.region.value)
+        assertEquals(RegionState.Active(region(1)), holder.state.value)
+    }
+
+    @Test
+    fun `settleIfResolving is a no-op once the state has settled`() {
+        // Regression guard for the #1969 review note: a refresh that has already resolved — to Active,
+        // NeedsManualChoice, or Failed — owns the state; the late init seed must not clobber it.
+        val active = RegionStateHolder().apply { activated(region(1)) }
+        active.settleIfResolving(region(2))
+        assertEquals(region(1), active.region.value)
+        assertEquals(RegionState.Active(region(1)), active.state.value)
+
+        val regions = listOf(region(1), region(2))
+        val choosing = RegionStateHolder().apply { needsChoice(regions) }
+        choosing.settleIfResolving(region(3))
+        assertNull(choosing.region.value)
+        assertEquals(RegionState.NeedsManualChoice(regions), choosing.state.value)
+
+        val failed = RegionStateHolder().apply { failed() }
+        failed.settleIfResolving(region(3))
+        assertNull(failed.region.value)
+        assertEquals(RegionState.Failed, failed.state.value)
     }
 
     @Test

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/settings/RegionOtpResetTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/settings/RegionOtpResetTest.kt
@@ -83,6 +83,29 @@ class RegionOtpResetTest {
     }
 
     @Test
+    fun `a Resolving state does not prematurely satisfy the await`() = runTest {
+        // Regression guard for #1969: the region flow now seeds RegionState.Resolving (not Active(null)),
+        // so a one-shot await for a terminal resolution must treat Resolving as "not resolved yet" and keep
+        // waiting — the old Active(null) seed would have resolved the await against a region that had not
+        // actually resolved.
+        val regions = listOf(region(1), region(2))
+        val state = MutableStateFlow<RegionState>(RegionState.Resolving)
+        var reset = false
+
+        val job = launch {
+            resetOtpVersionOnRegionChange(RegionStatus.NeedsManualSelection(regions), state) { reset = true }
+        }
+        advanceUntilIdle()
+        assertFalse("Resolving is not a terminal resolution; the await must keep waiting", reset)
+        assertFalse("the await must still be suspended on Resolving", job.isCompleted)
+
+        state.value = RegionState.Active(regions[0]) // a region finally resolves
+        advanceUntilIdle()
+        assertTrue("resets once the region actually becomes Active", reset)
+        job.cancel()
+    }
+
+    @Test
     fun `a forced manual selection that fails resolves without resetting`() = runTest {
         val regions = listOf(region(1), region(2))
         val state = MutableStateFlow<RegionState>(RegionState.NeedsManualChoice(regions))


### PR DESCRIPTION
Fixes #1969.

## Problem

`RegionRepository` seeds its region flow to `null` and fills it asynchronously, and `RegionStateHolder` seeded `RegionState` to **`Active(null)`**. During the cold-start window there was no way for a consumer to tell these two apart:

- *"the region hasn't resolved yet"* (transient — a value is coming), and
- *"there deliberately is no region"* (a custom OBA API URL is configured).

`Active` means "resolved" everywhere else it's read; the initial seed quietly violated that. The concrete fallout the issue calls out: `AdvancedSettingsViewModel`'s one-shot `state.first { it is Active || it is Failed }` could resolve against the `Active(null)` seed — a region that hadn't actually resolved.

## Fix

Seed `RegionState.Resolving` (already on the sealed interface, just never used as the initial value) instead of `Active(null)`, and let `DefaultRegionRepository.init` settle it once `loadPersistedRegion()` completes:

- persisted region → `Active(region)`
- no region but a custom OBA API URL configured → `Active(null)` (the deliberate no-region case)
- neither → stay `Resolving` for `refresh()` to settle

The settle only fires while the state is still the untouched `Resolving` seed, so a concurrent `refresh()` that has already resolved to `Active`/`NeedsManualChoice`/`Failed` is never clobbered.

Now `Active` is honest: a one-shot await treats `Resolving` as "not resolved yet" and keeps waiting.

## Scope

The **core seed fix only**, per the issue's blast-radius caution. The `SurveyViewModel`/`HelpViewModel` readiness mirrors are left untouched — they snapshot `region.value` (not `state`) to turn the cold `regionPresent` flow into a synchronously-readable `StateFlow`, so they're orthogonal to this change and wouldn't have been removed by it. Removing that triplicated mirror is a separate hot-`StateFlow` refactor.

## Cleanups folded in (from `/simplify`)

- `refresh()` now calls the extracted `hasCustomObaApiUrl()` helper instead of re-inlining the same pref check.
- Dropped the now-vestigial `seed: Region?` param from `RegionStateHolder`: `state` no longer uses it and production always passed `null`, so it only permitted an incoherent `(region=X, state=Resolving)` construction. The holder starts empty and `activated()` is the sole region writer.

## Testing

- Clean compile under `-PwarningsAsErrors=true` (the CI gate).
- `RegionStateHolderTest` updated for the `Resolving` initial state.
- `RegionOtpResetTest` gains a regression guard that a `Resolving` state does not prematurely satisfy the terminal-await.
- `RegionStateHolderTest`, `RegionOtpResetTest`, `AdvancedSettingsViewModelTest`, `RegionPickerViewModelTest`, `RegionStatusTest` all pass.
- `spotlessApply` clean.

This is a pure JVM/logic change — no on-device behavior change beyond the cold-start state semantics, which the region-derived subsystems already handle reactively (they observe `region`, whose cold-start value is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved region startup behavior: the app now defaults to a “resolving” state, then settles correctly using the saved region or intentionally handles “no region” when a custom API endpoint is set.
  * Refined settlement logic so actions don’t proceed until region resolution is fully settled, including safe handling of an initial transient resolving state.
* **Tests**
  * Updated and added unit tests for the new default region initialization contract, `settleIfResolving` behavior, and a regression test ensuring OTP reset doesn’t trigger while region state is still resolving.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->