### PR TITLE
Make regionPresent a hot StateFlow; drop the triplicated readiness mirrors (#1969)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/region/RegionRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/region/RegionRepository.kt
@@ -24,10 +24,11 @@ import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.onebusaway.android.BuildConfig
@@ -59,11 +60,12 @@ interface RegionRepository {
     fun currentRegion(): Region? = region.value
 
     /**
-     * Whether a region is currently resolved — the deduped `region != null` projection. Derived once
-     * here so feature view models (survey, what's-new gate) consume one canonical predicate instead of
-     * each re-deriving it from [region].
+     * Whether a region is currently resolved — the deduped `region != null` projection, as a **hot**
+     * [StateFlow] with a synchronous `.value`. Owned here so feature view models (survey, what's-new gate)
+     * consume one canonical predicate they can collect *and* read synchronously, instead of each snapshotting
+     * [region] and re-collecting it into a private mirror (#1969).
      */
-    val regionPresent: Flow<Boolean> get() = region.map { it != null }.distinctUntilChanged()
+    val regionPresent: StateFlow<Boolean>
 
     /**
      * The richer resolution state — what the UI can render directly: a refresh in flight,
@@ -166,6 +168,14 @@ class DefaultRegionRepository @Inject constructor(
     override val region: StateFlow<Region?> get() = holder.region
 
     override val state: StateFlow<RegionState> get() = holder.state
+
+    // The canonical "is a region resolved?" predicate, kept hot on the app scope so consumers get a
+    // synchronous .value and one shared collector instead of each mirroring [region] themselves (#1969).
+    // Eagerly (not WhileSubscribed): it's a trivial derived boolean on a process-lifetime singleton, and
+    // keeping .value always current matters more than shedding a no-op collector when nobody's subscribed.
+    override val regionPresent: StateFlow<Boolean> =
+        holder.region.map { it != null }.distinctUntilChanged()
+            .stateIn(appScope, SharingStarted.Eagerly, holder.region.value != null)
 
     /** Loads the persisted current region (by the saved region-id) from the cache, or null if none. */
     private suspend fun loadPersistedRegion(): Region? {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/help/HelpViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/help/HelpViewModel.kt
@@ -16,14 +16,12 @@
 package org.onebusaway.android.ui.home.help
 
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
 import org.onebusaway.android.BuildConfig
 import org.onebusaway.android.R
 import org.onebusaway.android.preferences.PreferencesRepository
@@ -58,18 +56,10 @@ class HelpViewModel @Inject constructor(
     private val _state = MutableStateFlow(HelpUiState())
     val state: StateFlow<HelpUiState> = _state.asStateFlow()
 
-    // Whether a region has resolved — gates the auto-show of "What's New". Reads the shared
-    // [RegionRepository.regionPresent] predicate; [HelpFeature] reads it. Mirrors the manual
-    // collect-into-MutableStateFlow idiom used by the other feature VMs (WeatherViewModel) rather than a
-    // SharingStarted.Eagerly stateIn, whose never-completing collector leaks across JVM unit tests.
-    private val _regionReady = MutableStateFlow(regionRepository.region.value != null)
-    val regionReady: StateFlow<Boolean> = _regionReady.asStateFlow()
-
-    init {
-        viewModelScope.launch {
-            regionRepository.regionPresent.collect { _regionReady.value = it }
-        }
-    }
+    // Whether a region has resolved — gates the auto-show of "What's New". The repository owns this hot
+    // predicate ([RegionRepository.regionPresent]); [HelpFeature] reads it. Re-exposed verbatim (no local
+    // mirror needed).
+    val regionReady: StateFlow<Boolean> get() = regionRepository.regionPresent
 
     /**
      * The Twitter/X URL to open from the help menu: the current region's own Twitter URL when it has

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/survey/SurveyViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/survey/SurveyViewModel.kt
@@ -97,19 +97,10 @@ class SurveyViewModel @Inject constructor(
     private val _state = MutableStateFlow(SurveyUiState())
     val state: StateFlow<SurveyUiState> = _state.asStateFlow()
 
-    // Whether a region has resolved — the survey needs one to build its study URL. Reads the shared
-    // [RegionRepository.regionPresent] predicate; [SurveyFeature] uses it to re-trigger [maybeRequestSurvey]
-    // once a region is present. Mirrors the manual collect-into-MutableStateFlow idiom used by the other
-    // feature VMs (WeatherViewModel) rather than a SharingStarted.Eagerly stateIn, whose never-completing
-    // collector leaks across JVM unit tests.
-    private val _regionReady = MutableStateFlow(regionRepository.region.value != null)
-    val regionReady: StateFlow<Boolean> = _regionReady.asStateFlow()
-
-    init {
-        viewModelScope.launch {
-            regionRepository.regionPresent.collect { _regionReady.value = it }
-        }
-    }
+    // Whether a region has resolved — the survey needs one to build its study URL. The repository owns this
+    // hot predicate ([RegionRepository.regionPresent]); [SurveyFeature] collects it to re-trigger
+    // [maybeRequestSurvey] once a region is present. Re-exposed verbatim (no local mirror needed).
+    val regionReady: StateFlow<Boolean> get() = regionRepository.regionPresent
 
     private val _effects = MutableSharedFlow<SurveyEffect>(extraBufferCapacity = 1)
     val effects: SharedFlow<SurveyEffect> = _effects.asSharedFlow()

--- a/onebusaway-android/src/test/java/org/onebusaway/android/region/RegionTestFixtures.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/region/RegionTestFixtures.kt
@@ -28,6 +28,8 @@ import org.onebusaway.android.region.Region
 internal class FakeRegionRepository(initial: Region? = null) : RegionRepository {
     private val _region = MutableStateFlow(initial)
     override val region: StateFlow<Region?> = _region
+    private val _regionPresent = MutableStateFlow(initial != null)
+    override val regionPresent: StateFlow<Boolean> = _regionPresent
     private val _state = MutableStateFlow<RegionState>(RegionState.Active(initial))
     override val state: StateFlow<RegionState> = _state
 
@@ -56,6 +58,7 @@ internal class FakeRegionRepository(initial: Region? = null) : RegionRepository 
 
     fun emit(region: Region?) {
         _region.value = region
+        _regionPresent.value = region != null
         _state.value = RegionState.Active(region)
     }
 

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HelpViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HelpViewModelTest.kt
@@ -18,13 +18,11 @@ package org.onebusaway.android.ui.home
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
-import org.junit.Rule
 import org.junit.Test
 import org.onebusaway.android.R
 import org.onebusaway.android.region.FakeRegionRepository
 import org.onebusaway.android.region.region
 import org.onebusaway.android.testing.FakePreferencesRepository
-import org.onebusaway.android.testing.MainDispatcherRule
 import org.onebusaway.android.ui.home.help.HelpDialog
 import org.onebusaway.android.ui.home.help.HelpViewModel
 
@@ -34,11 +32,6 @@ import org.onebusaway.android.ui.home.help.HelpViewModel
  * package info from Application, so it's verified by equivalence rather than here.
  */
 class HelpViewModelTest {
-
-    // HelpViewModel launches a region collector in its init (the regionReady gate), so viewModelScope
-    // needs the test Main dispatcher even though these dialog tests don't advance it.
-    @get:Rule
-    val mainDispatcherRule = MainDispatcherRule()
 
     private fun viewModel(
         prefs: FakePreferencesRepository = FakePreferencesRepository(),


### PR DESCRIPTION
Follow-up to #1983 / part of #1969 — the "3 consumers carrying hand-rolled workarounds" cleanup, kept as its own PR.

## Problem

`RegionRepository.regionPresent` was a **cold** `Flow<Boolean>`:

```kotlin
val regionPresent: Flow<Boolean> get() = region.map { it != null }.distinctUntilChanged()
```

With no synchronous `.value`, `SurveyViewModel` and `HelpViewModel` each snapshot `region.value` at construction and then separately collect the flow into a private `MutableStateFlow` to expose a `regionReady` gate — the same workaround written twice, each carrying a comment explaining they hand-roll it to avoid `SharingStarted.Eagerly` `stateIn` (whose never-completing collector leaks across JVM unit tests):

```kotlin
private val _regionReady = MutableStateFlow(regionRepository.region.value != null)  // snapshot
val regionReady: StateFlow<Boolean> = _regionReady.asStateFlow()
init { viewModelScope.launch { regionRepository.regionPresent.collect { _regionReady.value = it } } }  // correct
```

## Fix

Own the predicate **hot** in the repository:

```kotlin
override val regionPresent: StateFlow<Boolean> =
    holder.region.map { it != null }.distinctUntilChanged()
        .stateIn(appScope, SharingStarted.Eagerly, holder.region.value != null)
```

The `Eagerly` collector lives on the process-lifetime **app scope** of the `@Singleton`, so the JVM-test leak the view models were dodging never arises — tests substitute `FakeRegionRepository`, which stays a plain `MutableStateFlow`. Both VMs now re-expose `regionRepository.regionPresent` verbatim and delete their mirror + `init` collector:

```kotlin
val regionReady: StateFlow<Boolean> get() = regionRepository.regionPresent
```

## Why separate from the seed fix

This is orthogonal to the `RegionState.Resolving` seed change in #1983: the mirrors read `region.value` (not `state`), so the seed change didn't enable this — a hot `regionPresent` does. Keeping it apart leaves each change reviewable on its own. `AnalyticsProvider` is deliberately **not** touched: it collects `region` directly to rebuild its emitters, which is the ordinary reactive-rebuild pattern, not a readiness mirror.

## Changes

- Interface: `regionPresent` `Flow<Boolean>` → abstract `StateFlow<Boolean>`.
- `DefaultRegionRepository` implements it via `stateIn` on `appScope`.
- `FakeRegionRepository` implements it as a `MutableStateFlow` updated in `emit()`.
- `SurveyViewModel` / `HelpViewModel` drop `_regionReady` + the init collector; `regionReady` is now a passthrough.
- `HelpViewModel` loses its only init coroutine → removed the now-dead `viewModelScope`/`launch` imports and the stale `MainDispatcherRule` in `HelpViewModelTest` that existed only for that collector.

Net −13 lines.

## Testing

- Clean compile under `-PwarningsAsErrors=true` (the CI gate).
- The **full** `obaGoogleDebug` unit-test suite passes (the `FakeRegionRepository` change touches many VM tests).
- `spotlessApply` clean.

No on-device behavior change: `regionPresent`/`regionReady` emit the same boolean sequence; only the flow is now hot with a synchronous `.value`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved region availability state tracking so the app reflects region readiness immediately and consistently.
  * Help and survey screens now receive up-to-date region readiness information directly.

* **Tests**
  * Updated test fixtures to support region presence state.
  * Simplified view model test setup while preserving existing coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->