### PR TITLE
Show stop number and direction under the stop name in the focus banner

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/home/map/FocusBannerTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/home/map/FocusBannerTest.kt
@@ -47,6 +47,7 @@ class FocusBannerTest {
                 state = FocusBannerState.Stop(
                     title = "Pine St & 3rd Ave",
                     direction = "N",
+                    stopCode = "12345",
                     isFavorite = false,
                     favoriteEnabled = true,
                     hasAlerts = hasAlerts,
@@ -124,7 +125,10 @@ class FocusBannerTest {
     @Test
     fun stopBannerShowsIdentityAndFullSubordinateRouteChain() {
         setStopBanner()
-        composeRule.onNodeWithText("Pine St & 3rd Ave (N)").assertIsDisplayed()
+        composeRule.onNodeWithText("Pine St & 3rd Ave").assertIsDisplayed()
+        val expectedSubtitle = "${context.getString(R.string.stop_details_code, "12345")} · " +
+            context.getString(R.string.direction_n)
+        composeRule.onNodeWithText(expectedSubtitle).assertIsDisplayed()
         listOf("65", "75", "40", "Downtown").forEach {
             composeRule.onNodeWithText(it).assertIsDisplayed()
         }
@@ -152,6 +156,7 @@ class FocusBannerTest {
                 state = FocusBannerState.Stop(
                     title = "Pine St & 3rd Ave",
                     direction = null,
+                    stopCode = null,
                     isFavorite = false,
                     favoriteEnabled = false,
                     hasAlerts = false

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -389,6 +389,7 @@ fun HomeScreen(
                         title = arrivalsContent?.header?.name?.takeIf { it.isNotBlank() }
                             ?: currentFocus.stop.name.orEmpty(),
                         direction = arrivalsContent?.header?.direction,
+                        stopCode = arrivalsContent?.stopCode ?: currentFocus.stop.code,
                         isFavorite = arrivalsContent?.header?.isFavorite == true,
                         favoriteEnabled = arrivalsContent != null,
                         hasAlerts = arrivalsContent?.hasAlerts == true,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/FocusBanner.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/FocusBanner.kt
@@ -83,6 +83,9 @@ private val HEADER_ICON_SIZE = 36.dp
 private val HEADER_ICON_BUTTON_SIZE = 40.dp
 private val FOCUS_RAIL_ICON_SIZE = 26.4.dp
 
+// The stop name shrinks to fit within this many lines before ellipsizing; see ShrinkToFitStopTitle.
+private const val MAX_TITLE_LINES = 2
+
 /**
  * Presentation state for the map's shared focus banner.
  */
@@ -297,12 +300,24 @@ private fun StopFocusBanner(
 
 /**
  * The stop name at [MaterialTheme.typography.titleLarge], shrinking down to [MaterialTheme.typography.titleMedium]'s
- * size (in 1sp steps) to stay on one line before falling back to wrapping — uncapped and untruncated, rather than
- * an ellipsis — at that floor size.
+ * size (in 1sp steps) so the name fits within [MAX_TITLE_LINES] lines before it has to ellipsize, and capped at
+ * [MAX_TITLE_LINES] lines.
  *
  * Measures via [TextMeasurer] rather than `BoxWithConstraints`: this sits inside [FocusBanner]'s
  * `Modifier.height(IntrinsicSize.Min)` row, and `BoxWithConstraints` is a `SubcomposeLayout`, which throws when
  * asked for intrinsic measurements. `fillMaxWidth` + `onSizeChanged` reports the available width without one.
+ *
+ * [LineBadge] hand-rolls the same shrink-to-fit idea, but against a fixed known width so it can measure
+ * synchronously during composition; this variant fits an unknown fill-available width, hence the `onSizeChanged`
+ * round-trip below. Kept file-private for its single call site — if a second fill-width shrink consumer appears,
+ * that's the trigger to promote a shared `ShrinkToFitText` into the components package.
+ *
+ * `maxWidthPx` is reported through `onSizeChanged`, so it lags the actual available width by a layout→recompose
+ * round-trip: when the width shrinks (e.g. the alert icon arrives asynchronously after the arrivals load and
+ * narrows this column) the font resolved for the previous, wider width is momentarily a touch too large for the new
+ * width. The two-line budget absorbs that — the transient is at worst a brief extra line or ellipsis that the next
+ * recomposition resolves as the font steps down — rather than the hard one-line edge-truncation an earlier revision
+ * showed.
  */
 @Composable
 private fun ShrinkToFitStopTitle(title: String) {
@@ -311,16 +326,16 @@ private fun ShrinkToFitStopTitle(title: String) {
     val textMeasurer = rememberTextMeasurer()
     var maxWidthPx by remember { mutableIntStateOf(0) }
 
-    fun fitsOneLine(fontSize: TextUnit) = maxWidthPx <= 0 || !textMeasurer.measure(
-        text = title,
-        style = fullStyle.copy(fontSize = fontSize),
-        maxLines = 1,
-        constraints = Constraints(maxWidth = maxWidthPx)
-    ).didOverflowWidth
+    fun fitsWithinLineCap(fontSize: TextUnit) = maxWidthPx <= 0 ||
+        textMeasurer.measure(
+            text = title,
+            style = fullStyle.copy(fontSize = fontSize),
+            constraints = Constraints(maxWidth = maxWidthPx)
+        ).lineCount <= MAX_TITLE_LINES
 
     val resolvedSize = remember(title, maxWidthPx) {
         var candidate = fullStyle.fontSize
-        while (candidate > floorSize && !fitsOneLine(candidate)) {
+        while (candidate > floorSize && !fitsWithinLineCap(candidate)) {
             candidate = (candidate.value - 1).sp
         }
         candidate
@@ -328,7 +343,8 @@ private fun ShrinkToFitStopTitle(title: String) {
     Text(
         text = title,
         style = fullStyle.copy(fontSize = resolvedSize),
-        maxLines = if (fitsOneLine(resolvedSize)) 1 else Int.MAX_VALUE,
+        maxLines = MAX_TITLE_LINES,
+        overflow = TextOverflow.Ellipsis,
         modifier = Modifier.fillMaxWidth().onSizeChanged { maxWidthPx = it.width }
     )
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/FocusBanner.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/FocusBanner.kt
@@ -45,19 +45,24 @@ import androidx.compose.material3.VerticalDivider
 import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.onebusaway.android.R
@@ -69,6 +74,7 @@ import org.onebusaway.android.ui.compose.components.RadioOptionList
 import org.onebusaway.android.ui.compose.components.RouteBadgeChip
 import org.onebusaway.android.ui.compose.components.rememberRouteBadgeColors
 import org.onebusaway.android.ui.compose.theme.ObaTheme
+import org.onebusaway.android.util.DisplayFormat
 
 // The banner's route action icons (switch-direction / cancel) share one size + tint so they read as
 // one control group: a larger-than-default 36dp icon in a deliberately tightened 40dp touch box
@@ -96,6 +102,7 @@ sealed interface FocusBannerState {
     data class Stop(
         val title: String,
         val direction: String?,
+        val stopCode: String?,
         override val isFavorite: Boolean,
         override val favoriteEnabled: Boolean,
         val hasAlerts: Boolean,
@@ -224,22 +231,26 @@ private fun StopFocusBanner(
                 .padding(start = 8.dp, top = 4.dp, end = 4.dp, bottom = 4.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            val name = if (!state.direction.isNullOrBlank()) {
-                "${state.title} (${state.direction.trim()})"
-            } else {
-                state.title
-            }
-            Text(
-                text = name,
-                style = MaterialTheme.typography.titleMedium,
-                maxLines = 2,
-                overflow = TextOverflow.Ellipsis,
+            val subtitle = stopSubtitleText(state.stopCode, state.direction)
+            Column(
                 modifier = Modifier.weight(1f).clickable(
                     onClickLabel = stringResource(R.string.stop_info_recenter),
                     role = Role.Button,
                     onClick = onRecenter
                 )
-            )
+            ) {
+                ShrinkToFitStopTitle(state.title)
+                if (subtitle != null) {
+                    Text(
+                        text = subtitle,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.padding(top = 4.dp)
+                    )
+                }
+            }
             if (state.hasAlerts) {
                 BannerAlertAction(onClick = onShowAlerts)
             }
@@ -282,6 +293,53 @@ private fun StopFocusBanner(
             }
         }
     }
+}
+
+/**
+ * The stop name at [MaterialTheme.typography.titleLarge], shrinking down to [MaterialTheme.typography.titleMedium]'s
+ * size (in 1sp steps) to stay on one line before falling back to wrapping — uncapped and untruncated, rather than
+ * an ellipsis — at that floor size.
+ *
+ * Measures via [TextMeasurer] rather than `BoxWithConstraints`: this sits inside [FocusBanner]'s
+ * `Modifier.height(IntrinsicSize.Min)` row, and `BoxWithConstraints` is a `SubcomposeLayout`, which throws when
+ * asked for intrinsic measurements. `fillMaxWidth` + `onSizeChanged` reports the available width without one.
+ */
+@Composable
+private fun ShrinkToFitStopTitle(title: String) {
+    val fullStyle = MaterialTheme.typography.titleLarge
+    val floorSize = MaterialTheme.typography.titleMedium.fontSize
+    val textMeasurer = rememberTextMeasurer()
+    var maxWidthPx by remember { mutableIntStateOf(0) }
+
+    fun fitsOneLine(fontSize: TextUnit) = maxWidthPx <= 0 || !textMeasurer.measure(
+        text = title,
+        style = fullStyle.copy(fontSize = fontSize),
+        maxLines = 1,
+        constraints = Constraints(maxWidth = maxWidthPx)
+    ).didOverflowWidth
+
+    val resolvedSize = remember(title, maxWidthPx) {
+        var candidate = fullStyle.fontSize
+        while (candidate > floorSize && !fitsOneLine(candidate)) {
+            candidate = (candidate.value - 1).sp
+        }
+        candidate
+    }
+    Text(
+        text = title,
+        style = fullStyle.copy(fontSize = resolvedSize),
+        maxLines = if (fitsOneLine(resolvedSize)) 1 else Int.MAX_VALUE,
+        modifier = Modifier.fillMaxWidth().onSizeChanged { maxWidthPx = it.width }
+    )
+}
+
+/** The stop's identity line: passenger-facing stop number and formatted direction, joined when both are known. */
+@Composable
+private fun stopSubtitleText(stopCode: String?, direction: String?): String? {
+    val codeText = stopCode?.takeIf { it.isNotBlank() }
+        ?.let { stringResource(R.string.stop_details_code, it) }
+    val directionText = DisplayFormat.stopDirectionText(LocalContext.current, direction)
+    return listOfNotNull(codeText, directionText).takeIf { it.isNotEmpty() }?.joinToString(" · ")
 }
 
 /** A deliberately tiny route chip: only enough padding to distinguish the route from its headsign. */
@@ -504,6 +562,7 @@ private fun FocusBannerPreview() {
                 state = FocusBannerState.Stop(
                     title = "Pine St & 3rd Ave",
                     direction = "N",
+                    stopCode = "12345",
                     isFavorite = true,
                     favoriteEnabled = true,
                     hasAlerts = true,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/mylists/MyListRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/mylists/MyListRepository.kt
@@ -88,9 +88,7 @@ private val RECENT_WINDOW_MS = 7 * DateUtils.DAY_IN_MILLIS
 internal fun recentCutoff(): Long = System.currentTimeMillis() - RECENT_WINDOW_MS
 
 private fun StopListRow.toStopItem(context: Context): StopListItem {
-    val directionText = direction?.takeIf { it.isNotEmpty() }
-        ?.let { context.getString(DisplayFormat.getStopDirectionText(it)) }
-        ?.takeIf { it.isNotEmpty() }
+    val directionText = DisplayFormat.stopDirectionText(context, direction)
     return StopListItem(
         id = id,
         name = uiName.orEmpty(),

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/DisplayFormat.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/DisplayFormat.kt
@@ -180,6 +180,12 @@ object DisplayFormat {
         }
     }
 
+    /** [direction] resolved to a localized display string ("Northbound"), or null when absent/blank. */
+    @JvmStatic
+    fun stopDirectionText(context: Context, direction: String?): String? = direction?.takeIf { it.isNotBlank() }
+        ?.let { context.getString(getStopDirectionText(it)) }
+        ?.takeIf { it.isNotEmpty() }
+
     @JvmStatic
     @StringRes
     fun getStopDirectionText(direction: String): Int = when (direction) {


### PR DESCRIPTION
## Summary
- Closes #437 — adds a secondary line under the stop name in the map's stop-focus banner showing the passenger-facing stop number and formatted direction (e.g. "Stop # 12345 · Northbound"), reusing the existing `stop_details_code` string and `DisplayFormat` direction formatter already used elsewhere (stop list rows, the stop details dialog).
- The stop name now **shrinks to fit within two lines** — from `titleLarge` down to a `titleMedium` floor, in 1sp steps — before it has to ellipsize, since the added subtitle line and the alert/close icons make width tighter to work with. Capped at `maxLines = 2`.

## Resolved: async alert-icon truncation (was the draft blocker)
**Root cause.** The title's fit decision (font size and line cap) was derived from the available width reported through `onSizeChanged`, which lags the *actual* width by a layout→recompose round-trip. When a stop's alerts flag arrived asynchronously after the initial arrivals load, the alert icon appearing narrowed the title column, and for that frame the title was laid out into the new, narrower width using a `maxLines = 1` chosen for the previous, wider width — so with the default `TextOverflow.Clip` it truncated at the edge instead of re-wrapping.

**Fix.** Shrink the font to fit the name within **two lines** and cap at `maxLines = 2` (`MAX_TITLE_LINES`) with an ellipsis fallback. A stale *font size* is harmless (briefly a hair large/small, no lost text); the destructive part was the one-line clip. The two-line budget absorbs the stale-width transient — at worst a brief extra line the next recomposition resolves — rather than a hard edge truncation.

## Test plan
- [x] `./gradlew :onebusaway-android:compileObaGoogleDebugKotlin -PwarningsAsErrors=true`
- [x] Manually installed on a physical device and exercised the stop-focus banner (verified the earlier `BoxWithConstraints`/`SubcomposeLayout`-under-`IntrinsicSize.Min` crash stays fixed, and the async-alert case now re-wraps instead of truncating)
- [ ] `FocusBannerTest` instrumented tests updated for the new subtitle; not yet run on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Stop banners can show a subtitle derived from the stop code plus localized direction.
  * Stop banner titles now automatically shrink-to-fit and truncate cleanly.
  * Stop direction text is now handled consistently via a shared localized formatting helper.
* **Bug Fixes**
  * Improved stop banner subtitle/details when arrival data includes stop codes, and corrected loading-state handling.
* **Tests**
  * Updated focus banner tests to reflect the new stop-code subtitle behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->