### PR TITLE
Fix nightly Android Lint errors (16) surfaced on main

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
@@ -65,8 +65,10 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalResources
+import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -149,7 +151,11 @@ fun DirectionsFormCard(
     val activity = context.findActivity()
     var showAdvanced by remember { mutableStateOf(false) }
 
-    val maxHeight = (LocalConfiguration.current.screenHeightDp * 0.6f).dp
+    // containerSize (px) reflects the actual available window; Configuration.screenHeightDp is lint-flagged
+    // as unreliable across insets/multi-window. Match the HomeScreen peek-cap pattern.
+    val maxHeight = with(LocalDensity.current) {
+        (LocalWindowInfo.current.containerSize.height * 0.6f).toDp()
+    }
     Surface(
         modifier = modifier.fillMaxWidth(),
         shape = RoundedCornerShape(16.dp),
@@ -271,7 +277,10 @@ fun DirectionsResultsSheet(
     // content is padded above the nav chrome so the collapsed handle (and the last list row) aren't
     // stranded under the gesture pill / 3-button bar. Collapsed height includes it so the handle fits.
     val navBottom = navigationBarBottomPadding()
-    val fullHeight = (LocalConfiguration.current.screenHeightDp * 0.4f).dp
+    // containerSize (px), not Configuration.screenHeightDp (lint-flagged as unreliable across insets).
+    val fullHeight = with(LocalDensity.current) {
+        (LocalWindowInfo.current.containerSize.height * 0.4f).toDp()
+    }
     var collapsed by rememberSaveable { mutableStateOf(false) }
     val sheetHeight by animateDpAsState(
         targetValue = if (collapsed) DIRECTIONS_SHEET_PEEK + navBottom else fullHeight,
@@ -547,11 +556,12 @@ private fun DirectionsAdvancedSettingsDialog(
     onDismiss: () -> Unit
 ) {
     val context = LocalContext.current
+    val resources = LocalResources.current
     val imperial = remember { !PreferenceUtils.getUnitsAreMetricFromPreferences(context) }
     // (display label, trip-mode code) for each option, dropping bikeshare modes when unavailable.
-    val options = remember {
-        val typed = context.resources.obtainTypedArray(R.array.transit_mode_array)
-        val labels = context.resources.getStringArray(R.array.transit_mode_array)
+    val options = remember(resources) {
+        val typed = resources.obtainTypedArray(R.array.transit_mode_array)
+        val labels = resources.getStringArray(R.array.transit_mode_array)
         val all = (0 until typed.length()).map { i ->
             labels[i] to TripModes.getTripModeCodeFromSelection(typed.getResourceId(i, 0))
         }
@@ -578,6 +588,13 @@ private fun DirectionsAdvancedSettingsDialog(
         )
     }
     var expanded by remember { mutableStateOf(false) }
+
+    // Preference keys resolved in composition (stringResource) so the confirm handler doesn't read
+    // resource values off LocalContext.current (lint: LocalContextGetResourceValueCall).
+    val prefKeyTravelBy = stringResource(R.string.preference_key_trip_plan_travel_by)
+    val prefKeyMaxWalk = stringResource(R.string.preference_key_trip_plan_maximum_walking_distance)
+    val prefKeyMinimizeTransfers = stringResource(R.string.preference_key_trip_plan_minimize_transfers)
+    val prefKeyAvoidStairs = stringResource(R.string.preference_key_trip_plan_avoid_stairs)
 
     AlertDialog(
         onDismissRequest = onDismiss,
@@ -643,22 +660,10 @@ private fun DirectionsAdvancedSettingsDialog(
                 viewModel.applyAdvancedSettings(
                     AdvancedSettings(selectedMode, maxWalkMeters, minimizeTransfers, wheelchair)
                 )
-                PreferenceUtils.saveInt(
-                    context.getString(R.string.preference_key_trip_plan_travel_by),
-                    selectedMode
-                )
-                PreferenceUtils.saveDouble(
-                    context.getString(R.string.preference_key_trip_plan_maximum_walking_distance),
-                    maxWalkMeters ?: Double.MAX_VALUE
-                )
-                PreferenceUtils.saveBoolean(
-                    context.getString(R.string.preference_key_trip_plan_minimize_transfers),
-                    minimizeTransfers
-                )
-                PreferenceUtils.saveBoolean(
-                    context.getString(R.string.preference_key_trip_plan_avoid_stairs),
-                    wheelchair
-                )
+                PreferenceUtils.saveInt(prefKeyTravelBy, selectedMode)
+                PreferenceUtils.saveDouble(prefKeyMaxWalk, maxWalkMeters ?: Double.MAX_VALUE)
+                PreferenceUtils.saveBoolean(prefKeyMinimizeTransfers, minimizeTransfers)
+                PreferenceUtils.saveBoolean(prefKeyAvoidStairs, wheelchair)
                 onDismiss()
             }) { Text(stringResource(R.string.ok)) }
         }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
@@ -125,9 +125,9 @@ fun MapFeature(
     // The sheet-driven FAB lift, computed by HomeScreen from its live SheetState (the map composes only
     // when HOME is the destination, so this lives with the sheet rather than round-tripping the VM).
     fabBottomInset: Dp,
+    modifier: Modifier = Modifier,
     // A long-press on the map surfaces the "directions from/to here" menu; HomeScreen owns that state.
-    onMapLongPress: (GeoPoint) -> Unit = {},
-    modifier: Modifier = Modifier
+    onMapLongPress: (GeoPoint) -> Unit = {}
 ) {
     val context = LocalContext.current
     val resources = LocalResources.current

--- a/onebusaway-android/src/main/res/values-es/strings.xml
+++ b/onebusaway-android/src/main/res/values-es/strings.xml
@@ -450,7 +450,6 @@
     <!-- TODO: Modes -->
     <string name="report_problem_onvehicle_bus">¿Estas en este bus?</string>
     <string name="report_problem_uservehicle_hint">Número del bus (opcional)</string>
-    <string name="report_problem_report">Reportar</string>
 
     <!-- Region list -->
     <plurals name="distance_miles">
@@ -853,7 +852,6 @@
 
 
     <string name="tripplanner_no_server_selected_error">No hay ninguna región seleccionada</string>
-    <string name="tripplanner_error_dialog_title">No fue posible realizar la Planeación</string>
     <!-- Errors -->
     <string name="tripplanner_error_not_defined">Lo sentimos, algo salió mal. Por favor, inténtalo de nuevo.</string>
     <string name="tripplanner_error_request_timeout">Por favor verifica tu conexión a Internet e intentalo
@@ -877,11 +875,8 @@
     <!-- When routing from my location -->
     <string name="tripplanner_current_location">Ubicación actual</string>
 
-    <string name="tripplanner_no_contact">No existe un contacto del planeador de viajes para esta región.
-    </string>
 
     <string name="tripplanner_reverse">Invertir</string>
-    <string name="tripplanner_report_trip_problem">Reportar un Problema al Planear el Viaje</string>
 
     <!-- Instructions generation -->
 

--- a/onebusaway-android/src/main/res/values-fi/strings.xml
+++ b/onebusaway-android/src/main/res/values-fi/strings.xml
@@ -760,7 +760,6 @@
 
     <!-- Report issue -->
     <string name="report_dialog_stop_header">Napauta pysäkkiä kartalla</string>
-    <string name="report_problem_report">Ilmoita</string>
     <string name="ri_others">Muut</string>
     <string name="ri_desc_hint">Ongelman kuvaus</string>
     <string name="ri_button_camera">Kamera</string>
@@ -808,7 +807,6 @@
     <string name="wheelchair_accessible">Vältä portaita</string>
     <string name="travel_by_label">Matkustustapa: </string>
     <string name="tripplanner_no_server_selected_error">Aluetta ei ole valittu</string>
-    <string name="tripplanner_error_dialog_title">Suunnittelu ei mahdollista</string>
     <string name="tripplanner_error_not_defined">Pahoittelut, jokin meni pieleen. Yritä uudelleen.</string>
     <string name="tripplanner_error_request_timeout">Tarkista internetyhteys ja yritä uudelleen.</string>
     <string name="tripplanner_error_system">Tarkista internetyhteys ja yritä uudelleen.</string>
@@ -826,9 +824,7 @@
     <string name="tripplanner_error_geocode_from_to_ambiguous">Lähtöpaikka ja määränpää ovat epäselviä</string>
     <string name="tripplanner_error_triangle">Jokin meni pieleen. Muuta pyöräilyasetuksia ja yritä uudelleen</string>
     <string name="tripplanner_current_location">Nykyinen sijainti</string>
-    <string name="tripplanner_no_contact">Tälle alueelle ei ole matkasuunnittelun yhteystietoa.</string>
     <string name="tripplanner_reverse">Käännä</string>
-    <string name="tripplanner_report_trip_problem">Ilmoita matkasuunnitelman ongelmasta</string>
     <string name="connector_before_route">Linja</string>
     <string name="time_connector_next_day">huomenna</string>
     <string name="time_connector_before_time">klo</string>

--- a/onebusaway-android/src/main/res/values-it/strings.xml
+++ b/onebusaway-android/src/main/res/values-it/strings.xml
@@ -375,7 +375,6 @@
     <!-- TODO: Modes -->
     <string name="report_problem_onvehicle_bus">Sei su questo autobus?</string>
     <string name="report_problem_uservehicle_hint">Numero autobus (facoltativo)</string>
-    <string name="report_problem_report">Segnala</string>
 
     <!-- Region list -->
     <plurals name="distance_miles">
@@ -699,7 +698,6 @@
 
 
     <string name="tripplanner_no_server_selected_error">Nessuna area selezionata</string>
-    <string name="tripplanner_error_dialog_title">Impossibile pianificare</string>
     <!-- Errors -->
     <string name="tripplanner_error_not_defined">Spiacenti, qualcosa è andato storto. Riprova.</string>
     <string name="tripplanner_error_request_timeout">Controlla la tua connessione Internet e riprova.</string>
@@ -720,10 +718,8 @@
     <!-- When routing from my location -->
     <string name="tripplanner_current_location">Posizione attuale</string>
 
-    <string name="tripplanner_no_contact">Non c’è un contatto per la pianificazione del viaggio in ques’area.</string>
 
     <string name="tripplanner_reverse">Inverti</string>
-    <string name="tripplanner_report_trip_problem">Segnala problema con piano di viaggio</string>
 
 
     <!-- Instructions generation -->

--- a/onebusaway-android/src/main/res/values-pl/strings.xml
+++ b/onebusaway-android/src/main/res/values-pl/strings.xml
@@ -417,7 +417,6 @@
     <!-- TODO: Modes -->
     <string name="report_problem_onvehicle_bus">Jesteś w autobusie?</string>
     <string name="report_problem_uservehicle_hint">opcjonalnie</string>
-    <string name="report_problem_report">Zgłoś</string>
 
     <!-- Region list -->
     <plurals name="distance_miles" tools:ignore="MissingQuantity">
@@ -851,7 +850,6 @@
     <string name="trip_plan_time">Czas</string>
 
     <string name="tripplanner_no_server_selected_error">Nie wybrano regionu</string>
-    <string name="tripplanner_error_dialog_title">Planowanie niemożliwe</string>
     <!-- Errors -->
     <string name="tripplanner_error_not_defined">Przepraszamy, coś poszło nie tak. Spróbuj ponownie.</string>
     <string name="tripplanner_error_request_timeout">Sprawdź połączenie internetowe i spróbuj ponownie.
@@ -873,10 +871,7 @@
     <string name="tripplanner_error_triangle">Coś poszło nie tak. Zmień opcje roweru i spróbuj ponownie</string>
     <!-- When routing from my location -->
     <string name="tripplanner_current_location">Aktualna lokalizacja</string>
-    <string name="tripplanner_no_contact">Brak kontaktu do planowania podróży dla tego regionu.
-    </string>
     <string name="tripplanner_reverse">Odwróć</string>
-    <string name="tripplanner_report_trip_problem">Zgłoś problem z planowaniem podróży</string>
 
 
     <!-- Step-by-step screen -->

--- a/onebusaway-android/src/main/res/values/donottranslate.xml
+++ b/onebusaway-android/src/main/res/values/donottranslate.xml
@@ -108,7 +108,6 @@
 
     <!-- The below region name value needs to match existing iOS Firebase User Property -->
     <string name="analytics_label_region_name">RegionName</string>
-    <string name="analytics_label_trip_plan">Planned a Trip</string>
     <string name="analytics_label_button_press_star">starred_stops</string>
     <string name="analytics_label_button_press_reminders">my_reminders</string>
     <string name="analytics_label_button_press_trip_plan">trip_plan</string>
@@ -136,7 +135,6 @@
     <string name="analytics_label_stop_problem">feedback_stop_problem</string>
     <string name="analytics_label_trip_problem">feedback_trip_problem</string>
     <string name="analytics_label_app_feedback">feedback_app_feedback_email</string>
-    <string name="analytics_label_app_feedback_otp">Reported OTP problem</string>
     <string name="analytics_label_app_feedback_without_location">feedback_app_feedback_email_no_location</string>
     <string name="analytics_label_customer_service">feedback_customer_service</string>
     <string name="analytics_label_customer_service_web">Open web page</string>

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -476,7 +476,6 @@
     <!-- TODO: Modes -->
     <string name="report_problem_onvehicle_bus">Are you on this bus?</string>
     <string name="report_problem_uservehicle_hint">Bus number (optional)</string>
-    <string name="report_problem_report">Report</string>
 
     <!-- Region list -->
     <plurals name="distance_miles">
@@ -902,7 +901,6 @@
 
     <!-- Trip Planner strings -->
 
-    <string name="trip_plan_title">Plan a trip</string>
     <string name="trip_plan_from">From: </string>
     <string name="trip_plan_to">To: </string>
     <string name="trip_plan_leaving">Leaving</string>
@@ -926,7 +924,6 @@
 
 
     <string name="tripplanner_no_server_selected_error">No region selected</string>
-    <string name="tripplanner_error_dialog_title">Planning not possible</string>
     <!-- Errors -->
     <!-- Trip-plan error category headers (the consistent heading on the error snackbar; the specific
          wire message is shown as the reason line beneath). One header per category, so e.g. every
@@ -961,11 +958,8 @@
     <!-- When routing from my location -->
     <string name="tripplanner_current_location">Current Location</string>
 
-    <string name="tripplanner_no_contact">There is no trip planning contact for this region.
-    </string>
 
     <string name="tripplanner_reverse">Reverse</string>
-    <string name="tripplanner_report_trip_problem">Report Trip Plan Problem</string>
 
     <!-- Note: %1$s is replaced with app_name for white-label support -->
 


### PR DESCRIPTION
## Summary

The nightly [`lint` job](https://github.com/OneBusAway/onebusaway-android/actions/runs/29901642780) failed with **16 Android Lint errors** on `main`. Lint runs *only* in the nightly workflow (`android.yml` runs `check` with `-x lint` because it's ~7–15 min), so these accumulated from merged PRs (#1961 directions drawer, #1988 ETA strip) and only surfaced now.

## Fixes

| Check | Count | Fix |
|---|---|---|
| `ConfigurationScreenWidthHeight` | 2 | `DirectionsFeature.kt` — replace `Configuration.screenHeightDp` with `LocalWindowInfo.current.containerSize.height` + `LocalDensity`, matching the existing `HomeScreen.kt` peek-cap pattern |
| `LocalContextResourcesRead` | 2 | Read the transit-mode arrays via `LocalResources.current` instead of `context.resources` |
| `LocalContextGetResourceValueCall` | 4 | Hoist the trip-plan preference keys to `stringResource()` in composition; the confirm handler uses the resolved vals |
| `ModifierParameter` | 1 | `MapFeature.kt` — make `modifier` the first optional parameter (caller uses named args, so safe) |
| `UnusedResources` | 7 | Remove dead trip-planner/report strings + their `es`/`fi`/`it`/`pl` translations (else `ExtraTranslation` would fire next nightly) |

Each removed string was verified unreferenced across all `.kt`/`.java`/`.xml` (including flavors) before deletion.

## Verification

`./gradlew :onebusaway-android:compileObaGoogleDebugKotlin -PwarningsAsErrors=true` passes clean. Full lint will run on the nightly / can be re-run to confirm zero errors.