### PR TITLE
Make the report-success dialog message translatable (#986)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/InfrastructureIssueScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/report/ui/InfrastructureIssueScreen.kt
@@ -64,7 +64,6 @@ import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import androidx.navigation.NavController
 import edu.usf.cutr.open311client.Open311
-import edu.usf.cutr.open311client.constants.Open311Constants
 import edu.usf.cutr.open311client.models.Service
 import java.io.File
 import java.io.FileOutputStream
@@ -321,9 +320,9 @@ fun InfrastructureIssueDestination(
         AlertDialog(
             onDismissRequest = leaveReportFlow,
             properties = DialogProperties(dismissOnClickOutside = false),
-            text = { Text(Open311Constants.M_REPORT_SUCCESS) },
+            text = { Text(stringResource(R.string.ri_successful_submit)) },
             confirmButton = {
-                TextButton(onClick = leaveReportFlow) { Text("OK") }
+                TextButton(onClick = leaveReportFlow) { Text(stringResource(R.string.ok)) }
             }
         )
     }

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -736,6 +736,7 @@
     <string name="ri_no_trip">No arrival times, please check back later.</string>
     <string name="ri_anonymous_checkbox">Keep it anonymous</string>
     <string name="ri_unsuccessful_submit">An error occurred during submission, please try again later.</string>
+    <string name="ri_successful_submit">Your issue has been successfully reported</string>
 
     <!-- report issue types screen-->
     <!-- Remove rt_infrastructure_problem and use rt_stop_problem -->


### PR DESCRIPTION
Closes #986.

## Problem

The "Report a Problem" success dialog rendered its message and button label from non-translatable sources:

- The message was `Open311Constants.M_REPORT_SUCCESS` — a hardcoded English constant from the `edu.usf.cutr.open311client` library ("Your issue has been successfully reported").
- The confirm button was a literal `"OK"`.

Neither routed through the app's string resources, so translators/editors couldn't change them — exactly what #986 reported.

## Fix

`onebusaway-android/src/main/java/org/onebusaway/android/report/ui/InfrastructureIssueScreen.kt`

- Message → `stringResource(R.string.ri_successful_submit)` (new resource, preserving the current English wording).
- Button → the existing `stringResource(R.string.ok)`.
- Dropped the now-unused `Open311Constants` import.

`onebusaway-android/src/main/res/values/strings.xml`

- Added `ri_successful_submit` next to its sibling `ri_unsuccessful_submit`.

This is the single shared success dialog for both the stop/trip problem and Open311 report flows (driven by `InfrastructureIssueEvent.ReportSent`), so it covers both report types.

## Notes

- English-only string addition is CI-safe: `MissingTranslation` is disabled in the `lint {}` block and the locale files are intentionally partial, so other locales fall back to English until translated via the normal workflow.
- Verified locally: `./gradlew :onebusaway-android:compileObaGoogleDebugKotlin -PwarningsAsErrors=true` → BUILD SUCCESSFUL (the strict CI gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the infrastructure issue reporting success dialog with localized messaging.
  * Updated the confirmation button label to use the app’s standard “OK” text.
  * Added a clear confirmation message when an issue is successfully reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->