### PR TITLE
Distinguish stop-focus from route-focus on the map (#1985)

### DIFF
--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
@@ -262,6 +262,7 @@ class GoogleMapRenderer(
             snapshot.stops,
             snapshot.focusedStopId,
             snapshot.routeStopsScaleWithZoom,
+            snapshot.stopFocusRecedesAdjacent,
             map.cameraPosition.zoom
         )
 

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleRouteStopBitmapLayer.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleRouteStopBitmapLayer.kt
@@ -24,8 +24,11 @@ import com.google.android.gms.maps.model.BitmapDescriptor
 import com.google.android.gms.maps.model.BitmapDescriptorFactory
 import com.google.android.gms.maps.model.Marker
 import com.google.android.gms.maps.model.MarkerOptions
+import kotlin.math.ceil
 import kotlin.math.roundToInt
 import org.onebusaway.android.map.render.RouteStopCircles
+import org.onebusaway.android.map.render.StopBitmaps
+import org.onebusaway.android.map.render.StopDirection
 import org.onebusaway.android.map.render.StopMarker
 import org.onebusaway.android.map.render.focusedRouteStopScale
 import org.onebusaway.android.map.render.stopZIndex
@@ -53,7 +56,10 @@ internal class GoogleRouteStopBitmapLayer(
 
     private data class IconKey(
         val diameterPx: Int,
-        val selected: Boolean
+        val selected: Boolean,
+        // The focused stop's service-direction arrow angle (clockwise degrees from north); null draws no
+        // arrow. Part of the key so two focused stops facing different ways cache distinct bitmaps.
+        val arrowAngleDeg: Float?
     )
 
     private val stopsById = HashMap<String, RenderedStop>()
@@ -61,19 +67,25 @@ internal class GoogleRouteStopBitmapLayer(
     private var renderedStops: List<StopMarker> = emptyList()
     private var renderedFocusedStopId: String? = null
     private var renderedScaleWithZoom = false
+    private var renderedRecedeAdjacent = false
     private var renderedSizes: StampSizes? = null
+
+    // The focused stop's arrow angle, resolved in render() and reused when re-stamping on zoom settle.
+    private var renderedArrowAngle: Float? = null
 
     override fun render(
         stops: List<StopMarker>,
         focusedStopId: String?,
         scaleWithZoom: Boolean,
+        recedeAdjacent: Boolean,
         zoom: Float
     ) {
         val routeStops = stops.filter(StopMarker::routeStop)
         if (
             routeStops == renderedStops &&
             focusedStopId == renderedFocusedStopId &&
-            scaleWithZoom == renderedScaleWithZoom
+            scaleWithZoom == renderedScaleWithZoom &&
+            recedeAdjacent == renderedRecedeAdjacent
         ) {
             return
         }
@@ -82,8 +94,10 @@ internal class GoogleRouteStopBitmapLayer(
         renderedStops = routeStops
         renderedFocusedStopId = focusedStopId
         renderedScaleWithZoom = scaleWithZoom
+        renderedRecedeAdjacent = recedeAdjacent
+        renderedArrowAngle = routeStops.firstOrNull { it.id == focusedStopId }?.let(::arrowAngle)
 
-        val sizes = stampSizes(zoom, scaleWithZoom)
+        val sizes = stampSizes(zoom, scaleWithZoom, recedeAdjacent)
         val liveIds = routeStops.mapTo(HashSet(), StopMarker::id)
         val gone = stopsById.iterator()
         while (gone.hasNext()) {
@@ -127,7 +141,7 @@ internal class GoogleRouteStopBitmapLayer(
     }
 
     override fun onCameraSettled(zoom: Float) {
-        val sizes = stampSizes(zoom, renderedScaleWithZoom)
+        val sizes = stampSizes(zoom, renderedScaleWithZoom, renderedRecedeAdjacent)
         if (sizes == renderedSizes) return
         renderedSizes = sizes
         stamp(sizes)
@@ -142,7 +156,9 @@ internal class GoogleRouteStopBitmapLayer(
         renderedStops = emptyList()
         renderedFocusedStopId = null
         renderedScaleWithZoom = false
+        renderedRecedeAdjacent = false
         renderedSizes = null
+        renderedArrowAngle = null
     }
 
     private fun stamp(sizes: StampSizes) {
@@ -162,24 +178,34 @@ internal class GoogleRouteStopBitmapLayer(
         rendered.marker.zIndex = zIndex(selected)
     }
 
-    private fun icon(diameterPx: Int, selected: Boolean): BitmapDescriptor = icons.getOrPut(IconKey(diameterPx, selected)) {
-        BitmapDescriptorFactory.fromBitmap(
-            drawRouteStopBitmap(
-                diameterPx,
-                selected,
-                if (selected) selectedFillColor else fillColor,
-                outlineColor
+    // Only the focused stop carries a direction arrow, in the selected fill; adjacent circles pass null.
+    private fun icon(diameterPx: Int, selected: Boolean): BitmapDescriptor {
+        val arrowAngleDeg = if (selected) renderedArrowAngle else null
+        return icons.getOrPut(IconKey(diameterPx, selected, arrowAngleDeg)) {
+            BitmapDescriptorFactory.fromBitmap(
+                drawRouteStopBitmap(
+                    diameterPx,
+                    selected,
+                    if (selected) selectedFillColor else fillColor,
+                    outlineColor,
+                    arrowAngleDeg,
+                    RouteStopCircles.FOCUS_ARROW_GAP_DP * density
+                )
             )
-        )
+        }
     }
+
+    /** The stop's service-direction arrow angle (clockwise degrees from north), or null when it has none. */
+    private fun arrowAngle(stop: StopMarker): Float? = StopDirection.fromKey(stop.direction).takeIf { it != StopDirection.NONE }?.compassAngle
 
     private fun zIndex(selected: Boolean): Float = stopZIndex(routeStop = true, favorite = false) + if (selected) 0.01f else 0f
 
     private fun StampSizes.forSelection(selected: Boolean): Int = if (selected) this.selected else normal
 
-    private fun stampSizes(zoom: Float, scaleWithZoom: Boolean): StampSizes = StampSizes(
-        normal = routeStopDiameterPx(zoom, scaleWithZoom, selected = false, density),
-        selected = routeStopDiameterPx(zoom, scaleWithZoom, selected = true, density)
+    private fun stampSizes(zoom: Float, scaleWithZoom: Boolean, recedeAdjacent: Boolean): StampSizes = StampSizes(
+        normal = routeStopDiameterPx(zoom, scaleWithZoom, selected = false, recedeAdjacent, density),
+        // The focused stop never recedes — it's the one being emphasized.
+        selected = routeStopDiameterPx(zoom, scaleWithZoom, selected = true, recedeAdjacent = false, density)
     )
 }
 
@@ -187,11 +213,16 @@ internal fun routeStopDiameterPx(
     zoom: Float,
     scaleWithZoom: Boolean,
     selected: Boolean,
+    recedeAdjacent: Boolean,
     density: Float
 ): Int {
     val focusScale = if (scaleWithZoom) focusedRouteStopScale(zoom) else 1f
-    val selectedScale = if (selected) RouteStopCircles.FOCUSED_SCALE else 1f
-    return (2f * RouteStopCircles.RADIUS_PX * focusScale * selectedScale * density)
+    val emphasisScale = when {
+        selected -> RouteStopCircles.FOCUSED_SCALE
+        recedeAdjacent -> RouteStopCircles.ADJACENT_SCALE
+        else -> 1f
+    }
+    return (2f * RouteStopCircles.RADIUS_PX * focusScale * emphasisScale * density)
         .roundToInt()
         .coerceAtLeast(1)
 }
@@ -200,17 +231,32 @@ private fun drawRouteStopBitmap(
     diameterPx: Int,
     selected: Boolean,
     fillColor: Int,
-    outlineColor: Int
+    outlineColor: Int,
+    arrowAngleDeg: Float?,
+    arrowGapPx: Float
 ): Bitmap {
-    val bitmap = createBitmap(diameterPx, diameterPx)
-    val canvas = Canvas(bitmap)
-    val center = diameterPx / 2f
     val scale = diameterPx / (2f * RouteStopCircles.RADIUS_PX)
     // The selected circle is drawn at FOCUSED_SCALE, but its ring keeps the same on-screen weight as
     // every other stop — divide the selection scale back out of the stroke (not the diameter).
     val selectedScale = if (selected) RouteStopCircles.FOCUSED_SCALE else 1f
     val strokeWidth = RouteStopCircles.STROKE_WIDTH_PX * scale / selectedScale
-    val radius = center - strokeWidth / 2f
+    val radius = diameterPx / 2f - strokeWidth / 2f
+
+    // The arrow's outline is a fraction of the marker's ring width — finer on the smaller arrow shape.
+    val arrowOutlineWidth = strokeWidth * RouteStopCircles.FOCUS_ARROW_OUTLINE_SCALE
+
+    // With an arrow the bitmap grows to fit its overhang at any rotation (plus half the stroke, which
+    // straddles the tip); the circle stays centered so the marker's (0.5, 0.5) anchor keeps the circle
+    // center on the stop point either way.
+    val size = if (arrowAngleDeg != null) {
+        val reach = StopBitmaps.directionArrowReach(radius, RouteStopCircles.FOCUS_ARROW_SCALE, arrowGapPx)
+        ceil(2f * (reach + arrowOutlineWidth / 2f)).toInt() + 2
+    } else {
+        diameterPx
+    }
+    val bitmap = createBitmap(size, size)
+    val canvas = Canvas(bitmap)
+    val center = size / 2f
     val paint = Paint(Paint.ANTI_ALIAS_FLAG)
 
     paint.color = fillColor
@@ -225,6 +271,24 @@ private fun drawRouteStopBitmap(
     if (selected) {
         paint.style = Paint.Style.FILL
         canvas.drawCircle(center, center, radius * RouteStopCircles.INNER_RADIUS_SCALE, paint)
+    }
+
+    if (arrowAngleDeg != null) {
+        // A solid arrow in the circle's own (selected) fill — same colour twice — enlarged and pushed out
+        // past the circle, ringed in the marker's own outline colour and width.
+        StopBitmaps.drawDirectionArrow(
+            canvas,
+            center,
+            center,
+            radius,
+            fillColor,
+            fillColor,
+            arrowAngleDeg,
+            RouteStopCircles.FOCUS_ARROW_SCALE,
+            arrowGapPx,
+            outlineColor,
+            arrowOutlineWidth
+        )
     }
     return bitmap
 }

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleRouteStopLayer.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleRouteStopLayer.kt
@@ -20,7 +20,13 @@ import org.onebusaway.android.map.render.StopMarker
 
 /** Renderer-independent boundary for interchangeable Google route-stop drawing strategies. */
 internal interface GoogleRouteStopLayer {
-    fun render(stops: List<StopMarker>, focusedStopId: String?, scaleWithZoom: Boolean, zoom: Float)
+    fun render(
+        stops: List<StopMarker>,
+        focusedStopId: String?,
+        scaleWithZoom: Boolean,
+        recedeAdjacent: Boolean,
+        zoom: Float
+    )
 
     fun onCameraMoveStarted() = Unit
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteViewGeometry.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteViewGeometry.kt
@@ -8,10 +8,10 @@ package org.onebusaway.android.map
 import org.onebusaway.android.map.layout.RouteBadgeLayoutInput
 import org.onebusaway.android.map.layout.RouteBadgePath
 import org.onebusaway.android.map.layout.layoutRouteBadges
+import org.onebusaway.android.map.render.ADJACENT_ROUTE_LINE_WIDTH_PROFILE
 import org.onebusaway.android.map.render.DEEMPHASIZED_ROUTE_LINE_WIDTH_PROFILE
 import org.onebusaway.android.map.render.DEFAULT_ROUTE_LINE_COLOR
 import org.onebusaway.android.map.render.FOCUSED_ROUTE_LINE_WIDTH_PROFILE
-import org.onebusaway.android.map.render.ROUTE_LINE_WIDTH_PROFILE
 import org.onebusaway.android.map.render.RouteBadge
 import org.onebusaway.android.map.render.RoutePolyline
 import org.onebusaway.android.map.render.RoutePolylineTransform
@@ -48,9 +48,10 @@ internal fun List<RoutePolyline>.asDeemphasizedRouteUnderlay(): List<RoutePolyli
 }
 
 /**
- * Convert exact trip shapes into uniform-width directional route lines. When [emphasizedRoute] is
- * set, that route-direction uses a 1.5x stroke while siblings use a thin, plain stroke and render
- * first, keeping the emphasized variant visually on top at shared segments.
+ * Convert exact trip shapes into route lines. When [emphasizedRoute] is null (stop focus, no route
+ * selected) every shape is a thin, plain adjacency line with no direction chevrons. When it's set,
+ * that route-direction uses a 1.5x directional stroke while siblings use a thin, plain stroke and
+ * render first, keeping the emphasized variant visually on top at shared segments.
  */
 internal fun FocusedTripGeometry.toRoutePolylines(
     emphasizedRoute: RouteDirectionKey? = null,
@@ -72,7 +73,7 @@ internal fun FocusedTripGeometry.toRoutePolylines(
             )
         } else {
             val widthProfile = if (emphasizedRoute == null) {
-                ROUTE_LINE_WIDTH_PROFILE
+                ADJACENT_ROUTE_LINE_WIDTH_PROFILE
             } else {
                 DEEMPHASIZED_ROUTE_LINE_WIDTH_PROFILE
             }
@@ -80,7 +81,9 @@ internal fun FocusedTripGeometry.toRoutePolylines(
                 routeColors[shape.routeDirection] ?: shape.routeColor,
                 shape.points,
                 widthProfile,
-                directional = emphasizedRoute == null,
+                // Adjacent routes in stop focus are plain thin lines — no direction chevrons — so the
+                // mode reads as "these routes pass here", reserving chevrons for a selected route (#1985).
+                directional = false,
                 transforms = ROUTE_VIEW_TRANSFORMS
             )
         }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/DetailZoomRamp.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/DetailZoomRamp.kt
@@ -51,6 +51,15 @@ data class RouteLineWidthProfile(
 /** Ordinary route presentation, before a route is selected from a focused stop. */
 val ROUTE_LINE_WIDTH_PROFILE = RouteLineWidthProfile(ROUTE_LINE_WIDTH_DP)
 
+/**
+ * Adjacent routes shown in stop focus, before any route is selected. They recede to half the ordinary
+ * stroke so stop focus reads distinctly from the selected-route state, where one route is thickened
+ * instead (#1985).
+ */
+val ADJACENT_ROUTE_LINE_WIDTH_PROFILE = ROUTE_LINE_WIDTH_PROFILE.copy(
+    thicknessDp = ROUTE_LINE_WIDTH_DP * 0.5f
+)
+
 /** Shared by single-route view and a route selected from focused-stop mode. */
 val FOCUSED_ROUTE_LINE_WIDTH_PROFILE = ROUTE_LINE_WIDTH_PROFILE.copy(
     thicknessDp = ROUTE_LINE_WIDTH_DP * 1.5f

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
@@ -230,6 +230,18 @@ data class MapRenderSnapshot(
     /** Focused-stop adjacency and route focus use the same route-stop zoom scale. */
     val routeStopsScaleWithZoom: Boolean
         get() = routeModeScalesStopsWithZoom || focusedStopId != null
+
+    /**
+     * Stop focus with no route selected yet: a stop is focused but route mode isn't active, so the
+     * adjacent route-stop circles recede (half size) to set this mode apart from selected-route focus,
+     * where one route is thickened instead (#1985).
+     *
+     * Like [routeStopsScaleWithZoom] above, this reads [routeModeScalesStopsWithZoom] as the "route mode
+     * active" signal — the three presentation states (plain / stop-focus / route-focus) are decoded from
+     * two booleans. If a fourth state ever appears, that's the seam to promote to an explicit mode enum.
+     */
+    val stopFocusRecedesAdjacent: Boolean
+        get() = focusedStopId != null && !routeModeScalesStopsWithZoom
 }
 
 /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/RouteStopCircles.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/RouteStopCircles.kt
@@ -22,6 +22,31 @@ object RouteStopCircles {
     const val FOCUSED_SCALE = 1.8f
     const val INNER_RADIUS_SCALE = 0.36f
 
+    /**
+     * Adjacent (non-focused) route-stop circles shrink to half size in stop focus, before any route
+     * is selected, so the focused stop stands out and the mode reads distinctly from selected-route
+     * focus (#1985). Their stroke rides the smaller radius, thinning in proportion.
+     */
+    const val ADJACENT_SCALE = 0.5f
+
+    /**
+     * The focused stop's service-direction arrow (#1985) is drawn this much larger than the plain
+     * directional stop marker's arrow, so it reads clearly against the enlarged selected circle.
+     */
+    const val FOCUS_ARROW_SCALE = 1.5f
+
+    /**
+     * ...and pushed this many dp farther out from the marker center than the plain arrow's tuck, so it
+     * clears the selected circle's ring and its inner dot. Multiplied by display density for pixels.
+     */
+    const val FOCUS_ARROW_GAP_DP = 4f
+
+    /**
+     * The focused stop's arrow takes the marker's ring colour, but drawn at this fraction of the ring's
+     * width — a slightly finer outline reads better on the arrow's smaller shape than a full-weight ring.
+     */
+    const val FOCUS_ARROW_OUTLINE_SCALE = 0.65f
+
     // All three route-stop circle colors are theme-aware resources resolved by the flavor layers (this
     // pure styling layer has no Context): the unselected fill `R.color.route_stop_fill`, the outline
     // `R.color.route_stop_outline`, and the selected fill `R.color.map_stop_focus` (the shared

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/StopBitmaps.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/StopBitmaps.kt
@@ -194,19 +194,11 @@ object StopBitmaps {
         starOutlineWidthPx: Float
     ): Bitmap {
         val circleRadius = basePx / 2f
-        val arrowWidth = basePx / 2f
-        val arrowHeight = basePx / 3f
-        val cutout = basePx / 12f
-        val tuck = basePx / 10f
-        // Radial distances from the marker center to the arrow's tip and base, matching the plain
-        // marker's arrow-vs-circle geometry (the arrow base tucks slightly under the circle edge).
-        val tipDistance = circleRadius + arrowHeight - tuck
-        val baseDistance = circleRadius - tuck
         val starRadius = starDiameterPx / 2f
 
         // Square canvas big enough for whichever reaches further from center — the inflated star or the
         // arrow tip — so the arrow fits at any rotation. +2 leaves room for the anti-aliased outline.
-        val reach = max(starRadius, if (hasArrow) tipDistance else 0f)
+        val reach = max(starRadius, if (hasArrow) directionArrowReach(circleRadius) else 0f)
         val size = ceil(2 * reach).toInt() + 2
         val bm = createBitmap(size, size)
         val canvas = Canvas(bm)
@@ -223,41 +215,95 @@ object StopBitmaps {
         )
 
         if (hasArrow) {
-            // A north-pointing arrow about the center; rotating the whole canvas turns both the path and
-            // its gradient to the compass direction in one step.
-            val path = Path().apply {
-                fillType = Path.FillType.EVEN_ODD
-                moveTo(center, center - tipDistance) // tip
-                lineTo(center - arrowWidth / 2, center - baseDistance) // lower left
-                lineTo(center, center - baseDistance - cutout) // cutout notch
-                lineTo(center + arrowWidth / 2, center - baseDistance) // lower right
-                lineTo(center, center - tipDistance)
-                close()
-            }
-            canvas.withRotation(directionAngleDeg, center, center) {
-                val fill = Paint(Paint.ANTI_ALIAS_FLAG).apply {
-                    style = Paint.Style.FILL
-                    // Darkest at the tip, matching the plain markers' arrow shading.
-                    shader = LinearGradient(
-                        center,
-                        center - tipDistance,
-                        center,
-                        center - tipDistance + arrowHeight,
-                        arrowTipColor,
-                        arrowBaseColor,
-                        Shader.TileMode.MIRROR
-                    )
-                }
-                drawPath(path, fill)
-                val stroke = Paint(Paint.ANTI_ALIAS_FLAG).apply {
-                    style = Paint.Style.STROKE
-                    strokeWidth = 1f
-                    color = Color.WHITE
-                }
-                drawPath(path, stroke)
-            }
+            drawDirectionArrow(canvas, center, center, circleRadius, arrowTipColor, arrowBaseColor, directionAngleDeg)
         }
         return bm
+    }
+
+    /**
+     * How far the tip of a [drawDirectionArrow] reaches from the circle center, for a circle of
+     * [circleRadiusPx] with the arrow scaled by [arrowScale] and pushed out by [radialOffsetPx]. Callers
+     * use it to size a bitmap that fits the arrow at any rotation (it overhangs the circle on one side).
+     */
+    @JvmStatic
+    @JvmOverloads
+    fun directionArrowReach(circleRadiusPx: Float, arrowScale: Float = 1f, radialOffsetPx: Float = 0f): Float {
+        val baseDistance = circleRadiusPx - circleRadiusPx / 5f + radialOffsetPx
+        val arrowHeight = circleRadiusPx * 2f / 3f * arrowScale
+        return baseDistance + arrowHeight
+    }
+
+    /**
+     * Draws the shared stop direction arrow — a north-pointing arrowhead tucked at the edge of a circle
+     * of [circleRadiusPx] centered at ([cx], [cy]), rotated [angleDeg] clockwise, filled with the
+     * [arrowTipColor]→[arrowBaseColor] gradient (darkest at the tip; pass the same colour twice for a
+     * solid fill). It matches the arrowhead the plain directional stop markers ([directionalStopMarker])
+     * draw, and is the shared builder the starred marker ([favoriteMarker]) and the focused route-stop
+     * (#1985) render through. [arrowScale] enlarges the arrowhead and [radialOffsetPx] pushes it farther
+     * from center — the focused route-stop passes both so its arrow reads bigger and clears the enlarged
+     * selected circle. Its outer stroke is [outlineColor] at [outlineWidthPx] (default a thin white edge;
+     * the focused route-stop passes the marker's own ring colour and width so the arrow matches it). The
+     * caller centers the circle and sizes the canvas from [directionArrowReach] so the arrow fits at any
+     * [angleDeg].
+     */
+    @JvmStatic
+    @JvmOverloads
+    fun drawDirectionArrow(
+        canvas: Canvas,
+        cx: Float,
+        cy: Float,
+        circleRadiusPx: Float,
+        arrowTipColor: Int,
+        arrowBaseColor: Int,
+        angleDeg: Float,
+        arrowScale: Float = 1f,
+        radialOffsetPx: Float = 0f,
+        outlineColor: Int = Color.WHITE,
+        outlineWidthPx: Float = 1f
+    ) {
+        val arrowWidth = circleRadiusPx * arrowScale
+        val arrowHeight = circleRadiusPx * 2f / 3f * arrowScale
+        val cutout = circleRadiusPx / 6f * arrowScale
+        // Radial distances to the arrow's base and tip; the base tucks under the circle edge (a fifth of
+        // the radius), then [radialOffsetPx] pushes the whole arrow outward. The tip distance is the
+        // reach the caller sizes the canvas from — single-sourced so drawing and sizing can't diverge.
+        val baseDistance = circleRadiusPx - circleRadiusPx / 5f + radialOffsetPx
+        val tipDistance = directionArrowReach(circleRadiusPx, arrowScale, radialOffsetPx)
+        // A north-pointing arrow about the center; rotating the whole canvas turns both the path and its
+        // gradient to the compass direction in one step.
+        val path = Path().apply {
+            fillType = Path.FillType.EVEN_ODD
+            moveTo(cx, cy - tipDistance) // tip
+            lineTo(cx - arrowWidth / 2, cy - baseDistance) // lower left
+            lineTo(cx, cy - baseDistance - cutout) // cutout notch
+            lineTo(cx + arrowWidth / 2, cy - baseDistance) // lower right
+            lineTo(cx, cy - tipDistance)
+            close()
+        }
+        canvas.withRotation(angleDeg, cx, cy) {
+            val fill = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+                style = Paint.Style.FILL
+                // Darkest at the tip, matching the plain markers' arrow shading.
+                shader = LinearGradient(
+                    cx,
+                    cy - tipDistance,
+                    cx,
+                    cy - tipDistance + arrowHeight,
+                    arrowTipColor,
+                    arrowBaseColor,
+                    Shader.TileMode.MIRROR
+                )
+            }
+            drawPath(path, fill)
+            val stroke = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+                style = Paint.Style.STROKE
+                strokeWidth = outlineWidthPx
+                // Rounded joins so a thicker stroke doesn't spike out at the arrow's sharp tip.
+                strokeJoin = Paint.Join.ROUND
+                color = outlineColor
+            }
+            drawPath(path, stroke)
+        }
     }
 
     /** Builds the 10-vertex path of a five-pointed star centered at ([cx], [cy]), tip up. */

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
@@ -197,7 +197,8 @@ class MapLibreRenderer(
         routeStopCircleLayer.render(
             snapshot.stops,
             snapshot.focusedStopId,
-            snapshot.routeStopsScaleWithZoom
+            snapshot.routeStopsScaleWithZoom,
+            snapshot.stopFocusRecedesAdjacent
         )
 
         if (snapshot.bikeshareVisible) {

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRouteStopCircleLayer.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRouteStopCircleLayer.kt
@@ -67,6 +67,7 @@ internal class MapLibreRouteStopCircleLayer(
     private var renderedStops: List<StopMarker> = emptyList()
     private var renderedFocusedStopId: String? = null
     private var renderedScaleWithZoom = false
+    private var renderedRecedeAdjacent = false
 
     init {
         style.addSource(source)
@@ -104,37 +105,56 @@ internal class MapLibreRouteStopCircleLayer(
         )
     }
 
-    fun render(stops: List<StopMarker>, focusedStopId: String?, scaleWithZoom: Boolean) {
+    fun render(
+        stops: List<StopMarker>,
+        focusedStopId: String?,
+        scaleWithZoom: Boolean,
+        recedeAdjacent: Boolean
+    ) {
         val routeStops = stops.filter(StopMarker::routeStop)
         if (
             routeStops == renderedStops &&
             focusedStopId == renderedFocusedStopId &&
-            scaleWithZoom == renderedScaleWithZoom
+            scaleWithZoom == renderedScaleWithZoom &&
+            recedeAdjacent == renderedRecedeAdjacent
         ) {
             return
         }
         renderedStops = routeStops
         renderedFocusedStopId = focusedStopId
         renderedScaleWithZoom = scaleWithZoom
+        renderedRecedeAdjacent = recedeAdjacent
         stopById = routeStops.associateBy(StopMarker::id)
 
         val stopFocusMinScale = if (scaleWithZoom) STOP_FOCUS_ROUTE_MIN_SCALE else 1f
         val features = routeStops.map { stop ->
-            val selectedScale = if (stop.id == focusedStopId) RouteStopCircles.FOCUSED_SCALE else 1f
+            val focused = stop.id == focusedStopId
+            // The focused stop grows; adjacent stops recede in stop focus. The stroke rides the
+            // selection-free radius so the focused ring keeps constant weight, but adjacent circles
+            // thin in proportion with their smaller radius.
+            val selectionScale = if (focused) RouteStopCircles.FOCUSED_SCALE else 1f
+            val adjacentScale = if (recedeAdjacent && !focused) RouteStopCircles.ADJACENT_SCALE else 1f
             Feature.fromGeometry(Point.fromLngLat(stop.point.longitude, stop.point.latitude)).apply {
                 addStringProperty(STOP_ID_PROPERTY, stop.id)
-                addBooleanProperty(SELECTED_PROPERTY, stop.id == focusedStopId)
+                addBooleanProperty(SELECTED_PROPERTY, focused)
                 addNumberProperty(
                     MIN_RADIUS_PROPERTY,
-                    RouteStopCircles.RADIUS_PX * stopFocusMinScale * selectedScale
+                    RouteStopCircles.RADIUS_PX * stopFocusMinScale * selectionScale * adjacentScale
                 )
-                addNumberProperty(MAX_RADIUS_PROPERTY, RouteStopCircles.RADIUS_PX * selectedScale)
-                // Base radii without the selection scale, so the stroke-width ramp stays constant weight.
+                addNumberProperty(
+                    MAX_RADIUS_PROPERTY,
+                    RouteStopCircles.RADIUS_PX * selectionScale * adjacentScale
+                )
+                // Base radii without the selection scale, so the stroke-width ramp stays constant weight
+                // for the focused stop; the adjacent scale rides along so receded circles thin to match.
                 addNumberProperty(
                     STROKE_MIN_RADIUS_PROPERTY,
-                    RouteStopCircles.RADIUS_PX * stopFocusMinScale
+                    RouteStopCircles.RADIUS_PX * stopFocusMinScale * adjacentScale
                 )
-                addNumberProperty(STROKE_MAX_RADIUS_PROPERTY, RouteStopCircles.RADIUS_PX)
+                addNumberProperty(
+                    STROKE_MAX_RADIUS_PROPERTY,
+                    RouteStopCircles.RADIUS_PX * adjacentScale
+                )
             }
         }
         source.setGeoJson(FeatureCollection.fromFeatures(features))
@@ -161,6 +181,7 @@ internal class MapLibreRouteStopCircleLayer(
         renderedStops = emptyList()
         renderedFocusedStopId = null
         renderedScaleWithZoom = false
+        renderedRecedeAdjacent = false
     }
 
     /**

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteViewGeometryTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteViewGeometryTest.kt
@@ -5,6 +5,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.onebusaway.android.map.render.ADJACENT_ROUTE_LINE_WIDTH_PROFILE
 import org.onebusaway.android.map.render.DEEMPHASIZED_ROUTE_LINE_WIDTH_PROFILE
 import org.onebusaway.android.map.render.FOCUSED_ROUTE_LINE_WIDTH_PROFILE
 import org.onebusaway.android.map.render.ROUTE_LINE_WIDTH_PROFILE
@@ -30,7 +31,7 @@ class RouteViewGeometryTest {
     }
 
     @Test
-    fun `focused trip shape uses one uniform directional line`() {
+    fun `focused trip shape uses one thin plain adjacency line without chevrons`() {
         val geometry = FocusedTripGeometry(
             listOf(
                 FocusedTripShape(
@@ -44,12 +45,12 @@ class RouteViewGeometryTest {
 
         val lines = geometry.toRoutePolylines()
 
-        assertEquals(listOf(ROUTE_LINE_WIDTH_PROFILE), lines.map { it.widthProfile })
+        assertEquals(listOf(ADJACENT_ROUTE_LINE_WIDTH_PROFILE), lines.map { it.widthProfile })
         assertEquals(
             listOf(GeoPoint(0.0, 0.0), GeoPoint(0.0, 1.0), GeoPoint(0.0, 2.0)),
             lines.single().points
         )
-        assertTrue(lines.all { it.directional })
+        assertTrue(lines.none { it.directional })
         lines.forEach {
             assertEquals(
                 setOf(RoutePolylineTransform.VIEWPORT_CLIP, RoutePolylineTransform.ZOOM_SIMPLIFY),

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/render/MapRenderStateRouteStopScaleTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/render/MapRenderStateRouteStopScaleTest.kt
@@ -39,4 +39,25 @@ class MapRenderStateRouteStopScaleTest {
         state.setFocusedStopId("stop")
         assertTrue(state.snapshot.value.routeStopsScaleWithZoom)
     }
+
+    @Test
+    fun `adjacent stops recede only in stop focus, not route mode or plain map`() {
+        val state = MapRenderState()
+        val route = RoutePolyline(
+            color = 1,
+            points = listOf(GeoPoint(0.0, 0.0), GeoPoint(1.0, 1.0))
+        )
+
+        // Plain map: no focused stop, no route mode.
+        state.setRoutePolylines(listOf(route))
+        assertFalse(state.snapshot.value.stopFocusRecedesAdjacent)
+
+        // Stop focus with no route selected: adjacent circles recede.
+        state.setFocusedStopId("stop")
+        assertTrue(state.snapshot.value.stopFocusRecedesAdjacent)
+
+        // Route mode (with a focused stop): adjacency no longer recedes — one route is emphasized instead.
+        state.setRoutePolylines(listOf(route), routeModeScalesStopsWithZoom = true)
+        assertFalse(state.snapshot.value.stopFocusRecedesAdjacent)
+    }
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/render/RouteLineWidthProfileTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/render/RouteLineWidthProfileTest.kt
@@ -41,4 +41,14 @@ class RouteLineWidthProfileTest {
         assertEquals(11.25f, FOCUSED_ROUTE_LINE_WIDTH_PROFILE.thicknessAt(13.5f), 0f)
         assertEquals(15f, FOCUSED_ROUTE_LINE_WIDTH_PROFILE.thicknessAt(16f), 0f)
     }
+
+    @Test
+    fun `adjacent route profile is half the ordinary stroke, sharing its zoom ramp`() {
+        assertEquals(5f, ADJACENT_ROUTE_LINE_WIDTH_PROFILE.thicknessDp, 0f)
+        assertEquals(ROUTE_LINE_WIDTH_PROFILE.thicknessDp / 2f, ADJACENT_ROUTE_LINE_WIDTH_PROFILE.thicknessDp, 0f)
+        assertEquals(11f, ADJACENT_ROUTE_LINE_WIDTH_PROFILE.rampStartZoom, 0f)
+        assertEquals(16f, ADJACENT_ROUTE_LINE_WIDTH_PROFILE.fullThicknessZoom, 0f)
+        assertEquals(2.5f, ADJACENT_ROUTE_LINE_WIDTH_PROFILE.thicknessAt(10f), 0f)
+        assertEquals(5f, ADJACENT_ROUTE_LINE_WIDTH_PROFILE.thicknessAt(16f), 0f)
+    }
 }

--- a/onebusaway-android/src/testGoogle/java/org/onebusaway/android/map/googlemapsv2/GoogleRouteStopBitmapLayerTest.kt
+++ b/onebusaway-android/src/testGoogle/java/org/onebusaway/android/map/googlemapsv2/GoogleRouteStopBitmapLayerTest.kt
@@ -35,5 +35,19 @@ class GoogleRouteStopBitmapLayerTest {
         assertEquals(108, diameter(zoom = 18f, stopFocused = true, selected = true))
     }
 
-    private fun diameter(zoom: Float, stopFocused: Boolean, selected: Boolean): Int = routeStopDiameterPx(zoom, stopFocused, selected, density = 3f)
+    @Test
+    fun `receding halves adjacent stops but never the focused stop`() {
+        // Adjacent (non-selected) stops recede to half the size they'd otherwise have.
+        assertEquals(30, diameter(zoom = 16f, stopFocused = true, selected = false, recedeAdjacent = true))
+        assertEquals(9, diameter(zoom = 10f, stopFocused = true, selected = false, recedeAdjacent = true))
+        // The focused stop keeps its emphasized size — it's the one being highlighted.
+        assertEquals(108, diameter(zoom = 18f, stopFocused = true, selected = true, recedeAdjacent = true))
+    }
+
+    private fun diameter(
+        zoom: Float,
+        stopFocused: Boolean,
+        selected: Boolean,
+        recedeAdjacent: Boolean = false
+    ): Int = routeStopDiameterPx(zoom, stopFocused, selected, recedeAdjacent, density = 3f)
 }


### PR DESCRIPTION
Fixes #1985 — the switch between **stop focus** (all adjacent routes/stops shown) and **stop→route focus** (one route emphasized) was too subtle. This sharpens the visual hierarchy so the two modes read distinctly.

## Changes

- **Adjacent route lines** in stop focus (no route selected) recede to **half width** and **drop their direction chevrons** — they now read as "these routes pass here" instead of competing with a selected route (which keeps its thick, chevroned line).
- **Adjacent (non-focused) route-stop circles** shrink to **half size** in stop focus; the focused stop keeps its emphasis, so it clearly stands out.
- **The focused stop gains a service-direction arrow** pointing in its service direction (like the plain stop icons), reusing the plain markers' arrowhead geometry: solid selected fill, 1.5× size, pushed out past the ring, outlined in the marker's own ring colour at 0.65× width. Stops with no direction keep the plain selected circle.

## Design notes

- The mode is derived on the render snapshot as `stopFocusRecedesAdjacent` (`focusedStopId != null && !routeModeScalesStopsWithZoom`) and threaded into both flavor layers, mirroring the sibling `routeStopsScaleWithZoom` derivation.
- Arrow geometry is extracted into a shared, flavor-neutral `StopBitmaps.drawDirectionArrow` (de-duplicated out of the starred-marker builder), so a future MapLibre port can reuse it.
- **MapLibre arrow parity is deferred**: its route-stops render as GPU `CircleLayer`s (no bitmap), so the arrow needs a separate symbol/layer — a follow-up. The thinner/smaller adjacent styling *is* applied to both flavors; only the focused-stop arrow is Google-only for now. (This mirrors the existing Google-only vehicle continuation arrow.)

## Testing

- New/updated JVM unit tests: adjacent line-width profile, `stopFocusRecedesAdjacent` mode derivation, and `routeStopDiameterPx` receding.
- Both flavors compile clean under `-PwarningsAsErrors=true`; affected unit tests pass.
- Verified on-device (Pixel 7 Pro, Google flavor) across the sizing/arrow iterations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved focused-stop map visuals with directional arrows on the selected stop.
  * Adjacent stops now recede and route lines appear thinner during stop focus.
  * Selected routes remain emphasized with directional indicators.

* **Bug Fixes**
  * Focused stops retain their prominent size while surrounding stops scale down consistently across map providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->