### PR TITLE
Consolidate the two stop-star write paths onto StopFavoritesRepository (#1996)

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/database/oba/StopDaoMergeTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/database/oba/StopDaoMergeTest.kt
@@ -68,6 +68,91 @@ class StopDaoMergeTest {
     }
 
     @Test
+    fun setFavoriteEnsuringRow_insertsIdentityRowWhenAbsent() = runBlocking {
+        // A stop focused on the map (only in cached_stops) has no user-state row yet — starring it
+        // must create the row with the flag already set (#684).
+        assertEquals(null, dao.getStop("s1"))
+
+        dao.setFavoriteEnsuringRow(
+            StopRecord(
+                id = "s1",
+                code = "100",
+                name = "Main St",
+                direction = "",
+                useCount = 0,
+                latitude = 47.0,
+                longitude = -122.0,
+                regionId = 1L
+            ),
+            favorite = 1
+        )
+
+        val s = dao.getStop("s1")!!
+        assertEquals(1, s.favorite)
+        assertEquals("Main St", s.name)
+        assertEquals("100", s.code)
+        assertEquals(1L, s.regionId)
+    }
+
+    @Test
+    fun setFavoriteEnsuringRow_onlyFlipsFlagWhenRowExists() = runBlocking {
+        // Existing row carries user state that a re-star must not clobber.
+        dao.markStopUsed("s1", "100", "Main St", "N", 47.0, -122.0, regionId = 1L, now = 100)
+        dao.upsert(dao.getStop("s1")!!.copy(userName = "Home"))
+
+        // Ensure-row is handed the focused-stop identity (blank direction, no user state), but the row
+        // exists, so only the flag flips — user_name / use_count / access_time survive.
+        dao.setFavoriteEnsuringRow(
+            StopRecord(
+                id = "s1",
+                code = "100",
+                name = "Main St",
+                direction = "",
+                useCount = 0,
+                latitude = 47.0,
+                longitude = -122.0,
+                regionId = 1L
+            ),
+            favorite = 1
+        )
+
+        val s = dao.getStop("s1")!!
+        assertEquals(1, s.favorite)
+        assertEquals("Home", s.userName)
+        assertEquals("N", s.direction)
+        assertEquals(1, s.useCount)
+        assertEquals(100L, s.accessTime)
+    }
+
+    @Test
+    fun setFavoriteEnsuringRow_earlyStarSurvivesLaterArrivalsLoad() = runBlocking {
+        // Star before arrivals load (row inserted), then the arrivals load merges onto the row — the
+        // early star must stick and the identity/coords fill in (#684).
+        dao.setFavoriteEnsuringRow(
+            StopRecord(
+                id = "s1",
+                code = "",
+                name = "",
+                direction = "",
+                useCount = 0,
+                latitude = 47.0,
+                longitude = -122.0,
+                regionId = 1L
+            ),
+            favorite = 1
+        )
+
+        dao.markStopUsed("s1", "100", "Main Street", "N", 47.0, -122.0, regionId = 1L, now = 200)
+
+        val s = dao.getStop("s1")!!
+        assertEquals(1, s.favorite) // early star preserved by the merge
+        assertEquals("Main Street", s.name) // identity backfilled by the arrivals load
+        assertEquals("100", s.code)
+        assertEquals(1, s.useCount)
+        assertEquals(200L, s.accessTime)
+    }
+
+    @Test
     fun starredByName_scopesToRegion_andProjectsUiName() = runBlocking {
         // region 1, with a custom name (UI_NAME should be the user name)
         dao.markStopUsed("s1", "1", "Alpha", "N", 1.0, 1.0, regionId = 1L, now = 1)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/database/oba/StopDao.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/database/oba/StopDao.kt
@@ -61,6 +61,23 @@ interface StopDao {
     @Query("UPDATE stops SET favorite = :favorite WHERE _id = :stopId")
     suspend fun setFavorite(stopId: String, favorite: Int)
 
+    /**
+     * Sets the favorite flag, first ensuring the stop row exists so a stop focused on the map before
+     * its arrivals have loaded can still be starred (#684). When the row is absent the [identity] row
+     * (id/name/coords/region from the focused stop) is inserted with the flag already set; when it
+     * already exists only the flag is flipped, so an existing row's user_name / use_count / access_time
+     * are never clobbered. A later arrivals load merges onto this row via [markStopUsed] and preserves
+     * the favorite.
+     */
+    @Transaction
+    suspend fun setFavoriteEnsuringRow(identity: StopRecord, favorite: Int) {
+        if (getStop(identity.id) == null) {
+            upsert(identity.copy(favorite = favorite))
+        } else {
+            setFavorite(identity.id, favorite)
+        }
+    }
+
     @Query("SELECT favorite, user_name FROM stops WHERE _id = :stopId LIMIT 1")
     suspend fun userInfo(stopId: String): StopUserInfoRow?
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/database/oba/StopFavoritesRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/database/oba/StopFavoritesRepository.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.database.oba
+
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onStart
+import org.onebusaway.android.region.RegionRepository
+
+/**
+ * Stop starring for the shared focus banner, mirroring [RouteFavoritesRepository]. Exists so the
+ * banner's stop star works the moment a stop is focused, rather than only after its arrivals have
+ * loaded (#684): [setFavorite] ensures the `stops` row exists before flipping the flag, so a stop
+ * that isn't yet in the user-state table (it lives only in the map's `cached_stops` cache until an
+ * arrivals load records it) can still be starred.
+ */
+@Singleton
+class StopFavoritesRepository @Inject constructor(
+    private val stopDao: StopDao,
+    private val regionRepository: RegionRepository,
+    private val importGate: ImportGate
+) {
+
+    /** The starred stop ids, live and import-gated (so legacy favorites are visible on first read). */
+    fun favoriteStopIds(): Flow<Set<String>> = stopDao.favoriteStopIds()
+        .onStart { importGate.awaitReady() }
+        .map { it.toSet() }
+        .distinctUntilChanged()
+
+    /**
+     * Stars (or unstars) a stop. Ensures the `stops` row exists first — inserting the identity
+     * (id/name/code/coords + current region) only when absent, so an existing row's user name and
+     * use-count are never clobbered — then sets the flag. Gated on the one-time legacy import so the
+     * write can't be undone by a later import merge.
+     */
+    suspend fun setFavorite(
+        id: String,
+        code: String?,
+        name: String?,
+        latitude: Double,
+        longitude: Double,
+        favorite: Boolean
+    ) {
+        importGate.awaitReady()
+        stopDao.setFavoriteEnsuringRow(
+            identity = StopRecord(
+                id = id,
+                code = code.orEmpty(),
+                name = name.orEmpty(),
+                direction = "",
+                useCount = 0,
+                latitude = latitude,
+                longitude = longitude,
+                regionId = regionRepository.region.value?.id
+            ),
+            favorite = if (favorite) 1 else 0
+        )
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsRepository.kt
@@ -33,6 +33,7 @@ import org.onebusaway.android.database.oba.ImportGate
 import org.onebusaway.android.database.oba.RouteFavorites
 import org.onebusaway.android.database.oba.ServiceAlertDao
 import org.onebusaway.android.database.oba.StopDao
+import org.onebusaway.android.database.oba.StopFavoritesRepository
 import org.onebusaway.android.database.oba.markStopUsed
 import org.onebusaway.android.models.FocusedTrip
 import org.onebusaway.android.models.ObaRoute
@@ -139,8 +140,20 @@ interface ArrivalsRepository {
         minutesAfter: Int
     ): Result<ArrivalsData>
 
-    /** Marks (or unmarks) the stop as a favorite in the provider. */
-    suspend fun setStopFavorite(stopId: String, favorite: Boolean)
+    /**
+     * Stars (or unstars) the stop. Funnels through [StopFavoritesRepository] — the single owner of
+     * stop-favorite membership — so this surface gets the same ensure-the-row-exists guarantee as the
+     * map focus banner (#1996). The caller passes the loaded stop identity (code/name/coords) so the
+     * ensure-row insert has something to write when the row is somehow absent.
+     */
+    suspend fun setStopFavorite(
+        stopId: String,
+        code: String?,
+        name: String?,
+        latitude: Double,
+        longitude: Double,
+        favorite: Boolean
+    )
 
     /**
      * Stars (or unstars) a route wholesale (#1751), then backfills the route's full details
@@ -232,6 +245,7 @@ class DefaultArrivalsRepository @Inject constructor(
     private val stopArrivals: StopArrivalsDataSource,
     private val serviceAlertDao: ServiceAlertDao,
     private val stopDao: StopDao,
+    private val stopFavorites: StopFavoritesRepository,
     private val routeFavorites: RouteFavorites,
     private val importGate: ImportGate,
     private val preferences: PreferencesRepository,
@@ -424,9 +438,27 @@ class DefaultArrivalsRepository @Inject constructor(
             .map { getRouteDisplayName(it) }
     }
 
-    override suspend fun setStopFavorite(stopId: String, favorite: Boolean) {
-        importGate.awaitReady()
-        stopDao.setFavorite(stopId, if (favorite) 1 else 0)
+    override suspend fun setStopFavorite(
+        stopId: String,
+        code: String?,
+        name: String?,
+        latitude: Double,
+        longitude: Double,
+        favorite: Boolean
+    ) {
+        // Delegate to the shared owner (#1996): it gates on the import and ensures the `stops` row
+        // exists before flipping the flag — the same guarantee the map focus banner's star gets. On
+        // this path the on-load recordStop has already created the row, so the ensure is a no-op flag
+        // flip; the point is that the write no longer bypasses StopFavoritesRepository with a bare
+        // stopDao.setFavorite that silently no-ops when the row is missing.
+        stopFavorites.setFavorite(
+            id = stopId,
+            code = code,
+            name = name,
+            latitude = latitude,
+            longitude = longitude,
+            favorite = favorite
+        )
     }
 
     override suspend fun favoriteRoute(

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsViewModel.kt
@@ -176,7 +176,16 @@ class ArrivalsViewModel @AssistedInject constructor(
         val content = state.value as? ArrivalsUiState.Content ?: return
         val newValue = !content.header.isFavorite
         loaded.value?.let { loaded.value = it.copy(header = content.header.copy(isFavorite = newValue)) }
-        viewModelScope.launch { repository.setStopFavorite(content.header.stopId, newValue) }
+        viewModelScope.launch {
+            repository.setStopFavorite(
+                stopId = content.header.stopId,
+                code = content.stopCode,
+                name = content.header.name,
+                latitude = content.stopLat,
+                longitude = content.stopLon,
+                favorite = newValue
+            )
+        }
     }
 
     /** Opens the stop-details dialog (the overflow "show stop details" action). */

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -230,6 +230,8 @@ fun HomeScreen(
                 val mapRouteColors by mapViewModel.focusedRouteColors.collectAsStateWithLifecycle()
                 val focusBannerViewModel = hiltViewModel<FocusBannerViewModel>()
                 val favoriteRouteIds by focusBannerViewModel.favoriteRouteIds.collectAsStateWithLifecycle()
+                val favoriteStopIds by focusBannerViewModel.favoriteStopIds.collectAsStateWithLifecycle()
+                val stopFavoritesReady by focusBannerViewModel.stopFavoritesReady.collectAsStateWithLifecycle()
                 val scope = rememberCoroutineScope()
                 val density = LocalDensity.current
                 val resources = LocalResources.current
@@ -390,8 +392,13 @@ fun HomeScreen(
                             ?: currentFocus.stop.name.orEmpty(),
                         direction = arrivalsContent?.header?.direction,
                         stopCode = arrivalsContent?.stopCode ?: currentFocus.stop.code,
-                        isFavorite = arrivalsContent?.header?.isFavorite == true,
-                        favoriteEnabled = arrivalsContent != null,
+                        // Star state + toggle come from the favorites store keyed by stop id, so the star
+                        // works the instant a stop is focused rather than only after its arrivals load (#684).
+                        // It's gated on the favorites store being ready (its one-time legacy import done),
+                        // not on arrivals, so a legacy-starred stop is never shown unstarred (and thus
+                        // un-unstarrable) during that window.
+                        isFavorite = currentFocus.stop.id in favoriteStopIds,
+                        favoriteEnabled = stopFavoritesReady,
                         hasAlerts = arrivalsContent?.hasAlerts == true,
                         subordinateRoutes = currentFocus.selectedRoute?.legs?.map { leg ->
                             FocusBannerState.SubordinateRoute(
@@ -639,7 +646,9 @@ fun HomeScreen(
                                             onToggleFavorite = {
                                                 when (focusBannerState) {
                                                     is FocusBannerState.Stop ->
-                                                        arrivalsSession?.viewModel?.toggleFavorite()
+                                                        currentFocus.focusedStop?.let {
+                                                            focusBannerViewModel.toggleStopFavorite(it)
+                                                        }
                                                     is FocusBannerState.Route ->
                                                         focusBannerViewModel.toggleRouteFavorite(
                                                             focusBannerState.header

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/FocusBannerViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/FocusBannerViewModel.kt
@@ -23,27 +23,54 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import org.onebusaway.android.database.oba.RouteFavoritesRepository
+import org.onebusaway.android.database.oba.StopFavoritesRepository
 import org.onebusaway.android.map.RouteHeader
+import org.onebusaway.android.ui.home.FocusedStop
+import org.onebusaway.android.util.runCatchingCancellable
 
-/** Route-favorite state for the shared focus banner. Stop favorites remain stop-session state. */
+/** Route- and stop-favorite state for the shared focus banner. */
 @HiltViewModel
 class FocusBannerViewModel @Inject constructor(
-    private val routeFavorites: RouteFavoritesRepository
+    private val routeFavorites: RouteFavoritesRepository,
+    private val stopFavorites: StopFavoritesRepository
 ) : ViewModel() {
 
     // Optimistic overrides applied synchronously on tap so back-to-back toggles each build on the last
     // intent instead of the store's (still-lagging) snapshot. Each entry is dropped once the store's
-    // flow catches up to it, so a favorite changed on another surface is never masked.
+    // flow catches up to it, so a favorite changed on another surface is never masked. Routes and stops
+    // keep separate overlays (ids can collide across the two namespaces).
     private val optimisticFavorites = MutableStateFlow<Map<String, Boolean>>(emptyMap())
+    private val optimisticStopFavorites = MutableStateFlow<Map<String, Boolean>>(emptyMap())
 
     val favoriteRouteIds: StateFlow<Set<String>> =
         combine(routeFavorites.favoriteRouteIds(), optimisticFavorites) { stored, overrides ->
             stored.toMutableSet().apply {
                 overrides.forEach { (routeId, favorite) -> if (favorite) add(routeId) else remove(routeId) }
+            }
+        }.stateIn(viewModelScope, SharingStarted.Eagerly, emptySet())
+
+    // Latest persisted stop-favorite set, or null until the import-gated store's first emission. Kept
+    // distinct from "loaded but empty" so a legacy-starred stop is never shown unstarred (and thus
+    // un-unstarrable) during the one-time legacy import window.
+    private val storedStopFavorites: StateFlow<Set<String>?> =
+        stopFavorites.favoriteStopIds()
+            .stateIn(viewModelScope, SharingStarted.Eagerly, null)
+
+    /** True once the persisted stop-favorite set is known; the banner star stays disabled until then. */
+    val stopFavoritesReady: StateFlow<Boolean> =
+        storedStopFavorites
+            .map { it != null }
+            .stateIn(viewModelScope, SharingStarted.Eagerly, false)
+
+    val favoriteStopIds: StateFlow<Set<String>> =
+        combine(storedStopFavorites, optimisticStopFavorites) { stored, overrides ->
+            stored.orEmpty().toMutableSet().apply {
+                overrides.forEach { (stopId, favorite) -> if (favorite) add(stopId) else remove(stopId) }
             }
         }.stateIn(viewModelScope, SharingStarted.Eagerly, emptySet())
 
@@ -53,6 +80,14 @@ class FocusBannerViewModel @Inject constructor(
             routeFavorites.favoriteRouteIds().collect { stored ->
                 optimisticFavorites.update { overrides ->
                     overrides.filterNot { (routeId, favorite) -> (routeId in stored) == favorite }
+                }
+            }
+        }
+        viewModelScope.launch {
+            storedStopFavorites.collect { stored ->
+                if (stored == null) return@collect
+                optimisticStopFavorites.update { overrides ->
+                    overrides.filterNot { (stopId, favorite) -> (stopId in stored) == favorite }
                 }
             }
         }
@@ -70,6 +105,37 @@ class FocusBannerViewModel @Inject constructor(
                 url = null,
                 favorite = favorite
             )
+        }
+    }
+
+    /**
+     * Stars/unstars the focused [stop] straight from the banner — independent of whether its arrivals
+     * have loaded (#684). Ensures the stop row exists via [StopFavoritesRepository.setFavorite].
+     */
+    fun toggleStopFavorite(stop: FocusedStop) {
+        // Ignore taps until the persisted set is known — otherwise a legacy-starred stop looks unstarred
+        // and this would compute favorite = true, re-starring what's already starred.
+        if (!stopFavoritesReady.value) return
+        val favorite = stop.id !in favoriteStopIds.value
+        optimisticStopFavorites.update { it + (stop.id to favorite) }
+        viewModelScope.launch {
+            val result = runCatchingCancellable {
+                stopFavorites.setFavorite(
+                    id = stop.id,
+                    code = stop.code,
+                    name = stop.name,
+                    latitude = stop.point.latitude,
+                    longitude = stop.point.longitude,
+                    favorite = favorite
+                )
+            }
+            // On a persistence failure the store can never reconcile this override, so roll it back —
+            // but only if it still matches this request, so a newer tap isn't clobbered.
+            if (result.isFailure) {
+                optimisticStopFavorites.update { overrides ->
+                    if (overrides[stop.id] == favorite) overrides - stop.id else overrides
+                }
+            }
         }
     }
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/ArrivalsViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/ArrivalsViewModelTest.kt
@@ -84,7 +84,14 @@ private class FakeArrivalsRepository(
         return callResults.getOrNull(call) ?: result
     }
 
-    override suspend fun setStopFavorite(stopId: String, favorite: Boolean) {
+    override suspend fun setStopFavorite(
+        stopId: String,
+        code: String?,
+        name: String?,
+        latitude: Double,
+        longitude: Double,
+        favorite: Boolean
+    ) {
         lastFavoriteSet = stopId to favorite
     }
 

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/DefaultArrivalsRepositoryTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/DefaultArrivalsRepositoryTest.kt
@@ -44,6 +44,7 @@ import org.onebusaway.android.database.oba.RouteFavorites
 import org.onebusaway.android.database.oba.ServiceAlertDao
 import org.onebusaway.android.database.oba.ServiceAlertRecord
 import org.onebusaway.android.database.oba.StopDao
+import org.onebusaway.android.database.oba.StopFavoritesRepository
 import org.onebusaway.android.database.oba.StopListRow
 import org.onebusaway.android.database.oba.StopLocationRow
 import org.onebusaway.android.database.oba.StopRecentRow
@@ -100,6 +101,10 @@ class DefaultArrivalsRepositoryTest {
     private class FakeStopDao : StopDao {
         val markStopUsedCalls = mutableListOf<String>()
 
+        /** Rows inserted via [upsert] — the branch [StopDao.setFavoriteEnsuringRow] takes when the
+         *  stop row is absent (this fake's [getStop] always returns null). */
+        val upsertedStops = mutableListOf<StopRecord>()
+
         @Volatile
         var userInfoGate: CompletableDeferred<Unit>? = null
         val userInfoEntered = CompletableDeferred<Unit>()
@@ -132,7 +137,9 @@ class DefaultArrivalsRepositoryTest {
         override suspend fun location(stopId: String): StopLocationRow? = null
         override suspend fun nameForStop(stopId: String): String? = null
         override suspend fun getStop(stopId: String): StopRecord? = null
-        override suspend fun upsert(stop: StopRecord) {}
+        override suspend fun upsert(stop: StopRecord) {
+            upsertedStops.add(stop)
+        }
         override fun recents(cutoff: Long, regionId: Long?): Flow<List<StopListRow>> = flowOf(emptyList())
         override fun recentsForSearch(cutoff: Long, regionId: Long?): Flow<List<StopRecentRow>> = flowOf(emptyList())
         override fun starredByName(regionId: Long?): Flow<List<StopListRow>> = flowOf(emptyList())
@@ -203,6 +210,9 @@ class DefaultArrivalsRepositoryTest {
         stopArrivals = dataSource,
         serviceAlertDao = FakeServiceAlertDao(),
         stopDao = stopDao,
+        // The real shared owner over the same fake StopDao, so setStopFavorite exercises the actual
+        // ensure-row delegation (#1996) rather than a stub.
+        stopFavorites = StopFavoritesRepository(stopDao, FakeRegionRepository(), NoopImportGate),
         routeFavorites = FakeRouteFavorites(),
         importGate = NoopImportGate,
         preferences = FakePreferencesRepository(),
@@ -306,6 +316,32 @@ class DefaultArrivalsRepositoryTest {
         repository.getArrivals(STOP_ID, 65).getOrThrow()
 
         assertEquals(listOf(STOP_ID), stopDao.markStopUsedCalls)
+    }
+
+    // --- Stop favoriting --------------------------------------------------------------------------
+
+    @Test
+    fun `setStopFavorite ensures the stop row exists instead of a bare no-op update`() = runTest {
+        // The row is absent (this fake's getStop always returns null) — the pre-#1996 bare
+        // stopDao.setFavorite UPDATE would have silently no-op'd. Delegating to StopFavoritesRepository
+        // instead inserts the identity row with the flag already set, matching the map focus banner.
+        val stopDao = FakeStopDao()
+        val repository = repository(FakeStopArrivalsDataSource(), stopDao = stopDao)
+
+        repository.setStopFavorite(
+            stopId = STOP_ID,
+            code = "577",
+            name = "Pine St & 3rd Ave",
+            latitude = 47.6,
+            longitude = -122.3,
+            favorite = true
+        )
+
+        val inserted = stopDao.upsertedStops.single()
+        assertEquals(STOP_ID, inserted.id)
+        assertEquals("577", inserted.code)
+        assertEquals("Pine St & 3rd Ave", inserted.name)
+        assertEquals(1, inserted.favorite)
     }
 
     // --- The stale-fallback path ------------------------------------------------------------------


### PR DESCRIPTION
Closes #1996.

## Depends on #1994

This is a follow-up cleanup from the #1994 review and **builds on that PR's `StopFavoritesRepository`**, so it is based on the `fix/684-star-stop-before-arrivals-load` branch rather than `main`. Please merge #1994 first (then this can be retargeted to `main`, or squash-merged after).

## What & why

PR #1994 (#684) added `StopFavoritesRepository.setFavorite`, which stars a stop by *ensuring the `stops` row exists* before flipping the `favorite` flag. The full-screen arrivals star, however, still wrote through a **separate** path — `ArrivalsRepository.setStopFavorite` did a bare `stopDao.setFavorite(...)` with **no** ensure-row step. So there were two implementations of "star a stop" hitting the same `stops.favorite` column with different row-existence guarantees.

This makes `StopFavoritesRepository` the single owner of stop-favorite membership and has `ArrivalsRepository.setStopFavorite` delegate to it — mirroring how every route-star surface funnels through `RouteFavoritesRepository.setFavorite`.

## Changes

- `DefaultArrivalsRepository.setStopFavorite` now delegates to `stopFavorites.setFavorite(...)`, dropping the bare `stopDao.setFavorite`. Both surfaces get the ensure-row guarantee.
- The `setStopFavorite` interface now carries the loaded stop identity (code/name/coords) so the ensure-row insert has something to write; the arrivals ViewModel supplies it from the loaded `Content` state — the same way `FocusBannerViewModel` supplies identity to the same repository call.
- Dropped the now-redundant `importGate.awaitReady()` from that method (the delegate gates internally).
- On the arrivals path the row already exists (the on-load `recordStop` created it), so the ensure is a no-op flag flip today — but the write no longer relies on that implicit invariant.

## Out of scope

Bookmark analytics (`REPORT_BOOKMARK_EVENT_URL`) is left out — neither stop path emitted it before, matching the issue's note.

## Tests

- Updated both `ArrivalsRepository` interface fakes for the new signature.
- `DefaultArrivalsRepositoryTest` now constructs the *real* `StopFavoritesRepository` over the fake DAO, so the delegation is exercised for real, plus a new test proving an absent row is now **inserted** with the flag set (the guarantee the old bare update lacked).
- Verified: `compileObaGoogleDebugKotlin -PwarningsAsErrors=true` clean; `DefaultArrivalsRepositoryTest` + `ArrivalsViewModelTest` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved stop favorites so starring a stop is saved even before arrivals finish loading.
  * Stop identity and location details are preserved when saving favorites.
  * Home screen favorite status now updates immediately and remains consistent across views.
  * Favorite actions are temporarily disabled until saved favorites are ready.

* **Bug Fixes**
  * Prevented later arrivals updates from overwriting an early favorite selection.
  * Added rollback when saving a favorite fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->