### PR TITLE
Long-tap route badge → "Show route on map" (#1993)

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/arrivals/RouteArrivalRowLongPressTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/arrivals/RouteArrivalRowLongPressTest.kt
@@ -33,6 +33,7 @@ import org.onebusaway.android.R
 import org.onebusaway.android.ui.arrivals.components.ArrivalRowCallbacks
 import org.onebusaway.android.ui.arrivals.components.RouteArrivalRow
 import org.onebusaway.android.ui.arrivals.components.previewArrival
+import org.onebusaway.android.ui.arrivals.components.previewRowCallbacks
 import org.onebusaway.android.ui.compose.createUnconfinedComposeRule
 
 class RouteArrivalRowLongPressTest {
@@ -48,7 +49,7 @@ class RouteArrivalRowLongPressTest {
         val scheduleUrl = "https://example.com/routes/40"
         setRow(
             scheduleUrl = scheduleUrl,
-            callbacks = testCallbacks(
+            callbacks = previewRowCallbacks(
                 onShowRouteOnMap = { routeOnMapId = it.routeId },
                 onShowRouteSchedule = { openedScheduleUrl = it }
             )
@@ -63,12 +64,10 @@ class RouteArrivalRowLongPressTest {
 
         openRouteMenu(context)
 
-        // The schedule item is present because the route has a schedule URL.
-        val scheduleLabel = context.getString(R.string.bus_options_menu_show_route_schedule)
-        composeRule.waitUntil(timeoutMillis = 5_000) {
-            composeRule.onAllNodesWithText(scheduleLabel).fetchSemanticsNodes().isNotEmpty()
-        }
-        composeRule.onNodeWithText(scheduleLabel).performClick()
+        // The schedule item is present (the click fails if not) because the route has a schedule URL.
+        composeRule.onNodeWithText(
+            context.getString(R.string.bus_options_menu_show_route_schedule)
+        ).performClick()
 
         assertEquals(scheduleUrl, openedScheduleUrl)
         assertEquals(null, routeOnMapId)
@@ -82,7 +81,7 @@ class RouteArrivalRowLongPressTest {
         // "Show route schedule" is not shown.
         val trip = setRow(
             scheduleUrl = null,
-            callbacks = testCallbacks(
+            callbacks = previewRowCallbacks(
                 onShowRouteOnMap = { routeOnMapId = it.routeId },
                 onShowRouteSchedule = { openedScheduleUrl = it }
             )
@@ -91,35 +90,17 @@ class RouteArrivalRowLongPressTest {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
         openRouteMenu(context)
 
-        val showOnMapLabel = context.getString(R.string.bus_options_menu_show_route_on_map)
-        composeRule.waitUntil(timeoutMillis = 5_000) {
-            composeRule.onAllNodesWithText(showOnMapLabel).fetchSemanticsNodes().isNotEmpty()
-        }
         // With no schedule URL, the schedule item is absent.
         composeRule.onAllNodesWithText(
             context.getString(R.string.bus_options_menu_show_route_schedule)
         ).assertCountEquals(0)
-        composeRule.onNodeWithText(showOnMapLabel).performClick()
+        composeRule.onNodeWithText(
+            context.getString(R.string.bus_options_menu_show_route_on_map)
+        ).performClick()
 
         assertEquals(trip.routeId, routeOnMapId)
         assertEquals(null, openedScheduleUrl)
     }
-
-    /** Callbacks with every action a no-op except the two the menu tests assert on. */
-    private fun testCallbacks(
-        onShowRouteOnMap: (ArrivalInfo) -> Unit = {},
-        onShowRouteSchedule: (String) -> Unit = {}
-    ) = ArrivalRowCallbacks(
-        onRouteFavorite = {},
-        onShowVehiclesOnMap = {},
-        onShowRouteOnMap = onShowRouteOnMap,
-        onEtaClick = {},
-        onShowTripStatus = {},
-        onSetReminder = {},
-        onShowRouteSchedule = onShowRouteSchedule,
-        onReportArrivalProblem = {},
-        onShowAlert = {}
-    )
 
     /** Renders a single route arrivals row (route "40") with the given [scheduleUrl], returning its trip. */
     private fun setRow(scheduleUrl: String?, callbacks: ArrivalRowCallbacks): ArrivalInfo {
@@ -146,13 +127,14 @@ class RouteArrivalRowLongPressTest {
     }
 
     /**
-     * Drive the long press through the row's OnLongClick *semantics action* rather than an injected
-     * longClick() gesture. combinedClickable registers the same lambda as both the gesture and the
-     * accessibility action, so invoking the action exercises the real wiring — but deterministically,
-     * without depending on the long-press timeout elapsing against the test's virtual frame clock
-     * (that timing was racy on the CI emulator: the hold sometimes registered as a plain tap, so the
-     * menu never opened). onLongClickLabel (the always-present "Show route on map" item) disambiguates
-     * the row's long press from the ETA pill's own trip-actions long press.
+     * Long-press the row and wait for its menu to be open. The long press is driven through the row's
+     * OnLongClick *semantics action* rather than an injected longClick() gesture. combinedClickable
+     * registers the same lambda as both the gesture and the accessibility action, so invoking the action
+     * exercises the real wiring — but deterministically, without depending on the long-press timeout
+     * elapsing against the test's virtual frame clock (that timing was racy on the CI emulator: the hold
+     * sometimes registered as a plain tap, so the menu never opened). onLongClickLabel (the
+     * always-present "Show route on map" item) disambiguates the row's long press from the ETA pill's
+     * own trip-actions long press.
      */
     private fun openRouteMenu(context: Context) {
         val menuLabel = context.getString(R.string.bus_options_menu_show_route_on_map)
@@ -161,5 +143,11 @@ class RouteArrivalRowLongPressTest {
                 node.config.getOrNull(SemanticsActions.OnLongClick)?.label == menuLabel
             }
         ).performSemanticsAction(SemanticsActions.OnLongClick)
+        // The centered menu opens in a Dialog (a separate window); on slower devices (e.g. the CI
+        // emulator) the main composition can report idle a frame before that window is laid out, so
+        // wait for the menu's always-present item to appear before returning.
+        composeRule.waitUntil(timeoutMillis = 5_000) {
+            composeRule.onAllNodesWithText(menuLabel).fetchSemanticsNodes().isNotEmpty()
+        }
     }
 }

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/arrivals/RouteArrivalRowLongPressTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/arrivals/RouteArrivalRowLongPressTest.kt
@@ -15,6 +15,7 @@
  */
 package org.onebusaway.android.ui.arrivals
 
+import android.content.Context
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.SemanticsMatcher
@@ -42,19 +43,87 @@ class RouteArrivalRowLongPressTest {
 
     @Test
     fun longPressOpensScheduleWithoutOverflowButton() {
-        val trip = previewArrival("40", "Northgate", etaMinutes = 3)
-        val scheduleUrl = "https://example.com/routes/40"
         var openedScheduleUrl: String? = null
-        val callbacks = ArrivalRowCallbacks(
-            onRouteFavorite = {},
-            onShowVehiclesOnMap = {},
-            onEtaClick = {},
-            onShowTripStatus = {},
-            onSetReminder = {},
-            onShowRouteSchedule = { openedScheduleUrl = it },
-            onReportArrivalProblem = {},
-            onShowAlert = {}
+        var routeOnMapId: String? = null
+        val scheduleUrl = "https://example.com/routes/40"
+        setRow(
+            scheduleUrl = scheduleUrl,
+            callbacks = testCallbacks(
+                onShowRouteOnMap = { routeOnMapId = it.routeId },
+                onShowRouteSchedule = { openedScheduleUrl = it }
+            )
         )
+
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        // The route-level action moved off a dedicated overflow button and onto the row's long press,
+        // so the overflow affordance must be gone.
+        composeRule.onAllNodesWithContentDescription(
+            context.getString(R.string.stop_info_item_options_title)
+        ).assertCountEquals(0)
+
+        openRouteMenu(context)
+
+        // The schedule item is present because the route has a schedule URL.
+        val scheduleLabel = context.getString(R.string.bus_options_menu_show_route_schedule)
+        composeRule.waitUntil(timeoutMillis = 5_000) {
+            composeRule.onAllNodesWithText(scheduleLabel).fetchSemanticsNodes().isNotEmpty()
+        }
+        composeRule.onNodeWithText(scheduleLabel).performClick()
+
+        assertEquals(scheduleUrl, openedScheduleUrl)
+        assertEquals(null, routeOnMapId)
+    }
+
+    @Test
+    fun longPressShowsRouteOnMapEvenWithoutSchedule() {
+        var routeOnMapId: String? = null
+        var openedScheduleUrl: String? = null
+        // No schedule URL: "Show route on map" is still available (it's the always-present item), while
+        // "Show route schedule" is not shown.
+        val trip = setRow(
+            scheduleUrl = null,
+            callbacks = testCallbacks(
+                onShowRouteOnMap = { routeOnMapId = it.routeId },
+                onShowRouteSchedule = { openedScheduleUrl = it }
+            )
+        )
+
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        openRouteMenu(context)
+
+        val showOnMapLabel = context.getString(R.string.bus_options_menu_show_route_on_map)
+        composeRule.waitUntil(timeoutMillis = 5_000) {
+            composeRule.onAllNodesWithText(showOnMapLabel).fetchSemanticsNodes().isNotEmpty()
+        }
+        // With no schedule URL, the schedule item is absent.
+        composeRule.onAllNodesWithText(
+            context.getString(R.string.bus_options_menu_show_route_schedule)
+        ).assertCountEquals(0)
+        composeRule.onNodeWithText(showOnMapLabel).performClick()
+
+        assertEquals(trip.routeId, routeOnMapId)
+        assertEquals(null, openedScheduleUrl)
+    }
+
+    /** Callbacks with every action a no-op except the two the menu tests assert on. */
+    private fun testCallbacks(
+        onShowRouteOnMap: (ArrivalInfo) -> Unit = {},
+        onShowRouteSchedule: (String) -> Unit = {}
+    ) = ArrivalRowCallbacks(
+        onRouteFavorite = {},
+        onShowVehiclesOnMap = {},
+        onShowRouteOnMap = onShowRouteOnMap,
+        onEtaClick = {},
+        onShowTripStatus = {},
+        onSetReminder = {},
+        onShowRouteSchedule = onShowRouteSchedule,
+        onReportArrivalProblem = {},
+        onShowAlert = {}
+    )
+
+    /** Renders a single route arrivals row (route "40") with the given [scheduleUrl], returning its trip. */
+    private fun setRow(scheduleUrl: String?, callbacks: ArrivalRowCallbacks): ArrivalInfo {
+        val trip = previewArrival("40", "Northgate", etaMinutes = 3)
         val actions = ArrivalActions(
             tripId = trip.tripId,
             routeId = trip.routeId,
@@ -65,7 +134,6 @@ class RouteArrivalRowLongPressTest {
             agencyName = null,
             blockId = null
         )
-
         composeRule.setContent {
             RouteArrivalRow(
                 group = RouteRowGroup(listOf(trip)),
@@ -74,36 +142,24 @@ class RouteArrivalRowLongPressTest {
                 callbacks = callbacks
             )
         }
+        return trip
+    }
 
-        val context = InstrumentationRegistry.getInstrumentation().targetContext
-        // The route-level action moved off a dedicated overflow button and onto the row's long press,
-        // so the overflow affordance must be gone.
-        composeRule.onAllNodesWithContentDescription(
-            context.getString(R.string.stop_info_item_options_title)
-        ).assertCountEquals(0)
-
-        // Drive the long press through the row's OnLongClick *semantics action* rather than an injected
-        // longClick() gesture. combinedClickable registers the same lambda as both the gesture and the
-        // accessibility action, so invoking the action exercises the real wiring — but deterministically,
-        // without depending on the long-press timeout elapsing against the test's virtual frame clock
-        // (that timing was racy on the CI emulator: the hold sometimes registered as a plain tap, so the
-        // menu never opened). onLongClickLabel disambiguates the row's schedule action from the ETA
-        // pill's own trip-actions long press.
-        val scheduleLabel = context.getString(R.string.bus_options_menu_show_route_schedule)
+    /**
+     * Drive the long press through the row's OnLongClick *semantics action* rather than an injected
+     * longClick() gesture. combinedClickable registers the same lambda as both the gesture and the
+     * accessibility action, so invoking the action exercises the real wiring — but deterministically,
+     * without depending on the long-press timeout elapsing against the test's virtual frame clock
+     * (that timing was racy on the CI emulator: the hold sometimes registered as a plain tap, so the
+     * menu never opened). onLongClickLabel (the always-present "Show route on map" item) disambiguates
+     * the row's long press from the ETA pill's own trip-actions long press.
+     */
+    private fun openRouteMenu(context: Context) {
+        val menuLabel = context.getString(R.string.bus_options_menu_show_route_on_map)
         composeRule.onNode(
-            SemanticsMatcher("has long-press action labeled \"$scheduleLabel\"") { node ->
-                node.config.getOrNull(SemanticsActions.OnLongClick)?.label == scheduleLabel
+            SemanticsMatcher("has long-press action labeled \"$menuLabel\"") { node ->
+                node.config.getOrNull(SemanticsActions.OnLongClick)?.label == menuLabel
             }
         ).performSemanticsAction(SemanticsActions.OnLongClick)
-
-        // The centered menu opens in a Dialog (a separate window); on slower devices (e.g. the CI
-        // emulator) the main composition can report idle a frame before that window is laid out, so
-        // wait for the schedule item to appear before acting on it rather than asserting immediately.
-        composeRule.waitUntil(timeoutMillis = 5_000) {
-            composeRule.onAllNodesWithText(scheduleLabel).fetchSemanticsNodes().isNotEmpty()
-        }
-        composeRule.onNodeWithText(scheduleLabel).performClick()
-
-        assertEquals(scheduleUrl, openedScheduleUrl)
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalActionHandlers.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalActionHandlers.kt
@@ -32,7 +32,7 @@ import org.onebusaway.android.util.PreferenceUtils
 
 /**
  * Builds the [ArrivalActionHandler] shared by the standalone arrivals activity and the map panel.
- * The only behavioral difference is [onShowRouteOnMap]: the standalone launches HomeActivity in
+ * The only behavioral difference is [revealRoute]: the standalone launches HomeActivity in
  * route mode, while the panel drives the existing map. Everything else (favorite/alert dialogs,
  * navigation, report flow) is identical, so it lives here once.
  */
@@ -40,8 +40,9 @@ fun createArrivalActionHandler(
     activity: AppCompatActivity,
     viewModel: ArrivalsViewModel,
     currentContent: () -> ArrivalsUiState.Content?,
-    // Carries the arrival's stop in the request, so route mode can narrow to the stop-relevant direction.
-    onShowRouteOnMap: (ArrivalInfo, ShowRouteRequest) -> Unit,
+    // Shows a route on the map for the given request — stop/direction-scoped or not, per the caller.
+    // The standalone launches HomeActivity in route mode; the panel drives the existing map.
+    revealRoute: (ArrivalInfo, ShowRouteRequest) -> Unit,
     // How to show the alert hide/undo snackbar — supplied by the host so the dialog isn't tied to a
     // specific View (the standalone activity anchors to its root; Compose hosts use a SnackbarHost).
     showUndoSnackbar: (messageRes: Int, actionRes: Int?, onAction: (() -> Unit)?) -> Unit,
@@ -69,10 +70,10 @@ fun createArrivalActionHandler(
 
     override fun onShowVehiclesOnMap(arrival: ArrivalInfo) {
         recordRoute(arrival)
-        // A row (or menu) tap always frames the whole route: pass the arrival's stop so route mode shows
+        // A row-body tap frames the route scoped to this stop: pass the arrival's stop so route mode shows
         // only the direction (stops + vehicles) serving it, but no focusTripId — the vehicle+stop zoom is
         // the ETA pill's job ([onFocusVehicleOnMap]).
-        onShowRouteOnMap(
+        revealRoute(
             arrival,
             ShowRouteRequest(
                 arrival.routeId,
@@ -80,6 +81,13 @@ fun createArrivalActionHandler(
                 initialDirectionId = arrival.directionId
             )
         )
+    }
+
+    override fun onShowRouteOnMap(arrival: ArrivalInfo) {
+        recordRoute(arrival)
+        // Bare request — no stop/direction scoping and no focusTripId (those make the row/pill variants
+        // stop-scoped) — so it mirrors NavController.revealRouteOnMap(routeId), the search-bar path.
+        revealRoute(arrival, ShowRouteRequest(arrival.routeId))
     }
 
     override fun onFocusVehicleOnMap(arrival: ArrivalInfo) {
@@ -97,7 +105,7 @@ fun createArrivalActionHandler(
         if (tripId == null) {
             Toast.makeText(activity, R.string.stop_info_vehicle_not_on_map, Toast.LENGTH_SHORT).show()
         }
-        onShowRouteOnMap(
+        revealRoute(
             arrival,
             ShowRouteRequest(
                 arrival.routeId,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsDestinations.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsDestinations.kt
@@ -112,7 +112,7 @@ fun NavGraphBuilder.arrivalsGraph(navController: NavHostController) {
                 activity = activity,
                 viewModel = arrivalsVm,
                 currentContent = { arrivalsVm.state.value as? ArrivalsUiState.Content },
-                onShowRouteOnMap = { _, request -> navController.revealRouteOnMap(request) },
+                revealRoute = { _, request -> navController.revealRouteOnMap(request) },
                 showUndoSnackbar = { messageRes, actionRes, onAction ->
                     scope.launch {
                         val result = snackbarHostState.showSnackbar(

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsScreen.kt
@@ -125,6 +125,7 @@ internal fun rememberArrivalRowCallbacks(
     ArrivalRowCallbacks(
         onRouteFavorite = handler::onRouteFavorite,
         onShowVehiclesOnMap = handler::onShowVehiclesOnMap,
+        onShowRouteOnMap = handler::onShowRouteOnMap,
         onEtaClick = handler::onFocusVehicleOnMap,
         onShowTripStatus = handler::onShowTripStatus,
         onSetReminder = handler::onSetReminder,
@@ -142,6 +143,10 @@ internal fun rememberArrivalRowCallbacks(
 interface ArrivalActionHandler {
     fun onRouteFavorite(actions: ArrivalActions)
     fun onShowVehiclesOnMap(arrival: ArrivalInfo)
+
+    /** The badge long-press "Show route on map": frame the whole route as if searched from the search
+     *  bar — no stop/direction scoping, unlike the stop-scoped [onShowVehiclesOnMap] row-body tap. */
+    fun onShowRouteOnMap(arrival: ArrivalInfo)
 
     /** The ETA-pill tap: frame the arrival's live vehicle with its stop, or toast if none is tracked. */
     fun onFocusVehicleOnMap(arrival: ArrivalInfo)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
@@ -53,6 +53,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
@@ -88,6 +89,8 @@ import org.onebusaway.android.util.DisplayFormat
 class ArrivalRowCallbacks(
     val onRouteFavorite: (ArrivalActions) -> Unit,
     val onShowVehiclesOnMap: (ArrivalInfo) -> Unit,
+    /** Badge long-press "Show route on map" — the whole-route (unscoped) reveal; cf. [onShowVehiclesOnMap]. */
+    val onShowRouteOnMap: (ArrivalInfo) -> Unit,
     /** The ETA pill was tapped: focus that arrival's live vehicle + its stop (whole-route tap is the row body). */
     val onEtaClick: (ArrivalInfo) -> Unit,
     val onShowTripStatus: (ArrivalInfo) -> Unit,
@@ -248,7 +251,9 @@ internal fun ArrivalRowContent(
  * - The top-left corner star toggles the route favorite ([ArrivalRowCallbacks.onRouteFavorite]).
  * - The badge section's top-right corner (by the divider) shows a service-alert warning glyph when
  *   any trip in the group is affected by an active alert; tapping it opens that alert ([ArrivalRowCallbacks.onShowAlert]).
- * - Long-pressing the row body opens the route-level menu (schedule) when the route has a schedule URL.
+ * - Long-pressing the row body (badge included) opens the route-level menu: "Show route on map"
+ *   (always, framing the whole route as if searched — [ArrivalRowCallbacks.onShowRouteOnMap]) plus
+ *   "Show route schedule" when the route has a schedule URL.
  *
  * [actionsFor] resolves each trip's [ArrivalActions] (keyed by trip id upstream); the representative
  * trip's actions drive the badge color and the route menu. [etaAnchor] is attached to the first pill
@@ -275,11 +280,9 @@ fun RouteArrivalRow(
     val onAlertClick = alertClick(group, actionsFor, callbacks)
     val selectionColor = mapRouteColor ?: routeActions?.routeColor
     val scheduleUrl = routeActions?.scheduleUrl?.takeIf { it.isNotBlank() }
-    val scheduleActionLabel = if (scheduleUrl != null) {
-        stringResource(R.string.bus_options_menu_show_route_schedule)
-    } else {
-        null
-    }
+    // The menu's always-present item ("Show route on map") labels the long-press for accessibility, and
+    // disambiguates the row's long press from the ETA pill's own trip-actions long press.
+    val routeMenuLabel = stringResource(R.string.bus_options_menu_show_route_on_map)
     val displayedRouteNames = selectedRouteNames.takeIf { selected }.orEmpty()
     val compoundBadge = displayedRouteNames.size > 1
     val selectionBorder = selectionColor
@@ -292,12 +295,13 @@ fun RouteArrivalRow(
                     .fillMaxWidth()
                     // Give the row a definite height (its tallest child) so the divider can fill it.
                     .height(IntrinsicSize.Min)
-                    // Tap frames the whole route; long press opens its schedule menu. The ETA pills
-                    // remain independent children with their own trip-specific tap/long-press actions.
+                    // Tap frames the route scoped to this stop; long press opens the route menu (show on
+                    // map / schedule). The ETA pills remain independent children with their own
+                    // trip-specific tap/long-press actions.
                     .combinedClickable(
                         onClick = { callbacks.onShowVehiclesOnMap(representative) },
-                        onLongClickLabel = scheduleActionLabel,
-                        onLongClick = if (scheduleUrl != null) ({ menuExpanded = true }) else null
+                        onLongClickLabel = routeMenuLabel,
+                        onLongClick = { menuExpanded = true }
                     )
                     .padding(
                         start = 10.dp,
@@ -376,14 +380,12 @@ fun RouteArrivalRow(
                     )
                 }
             }
-            if (scheduleUrl != null) {
-                RouteActionsMenu(
-                    expanded = menuExpanded,
-                    onDismiss = { menuExpanded = false },
-                    scheduleUrl = scheduleUrl,
-                    callbacks = callbacks
-                )
-            }
+            RouteActionsMenu(
+                expanded = menuExpanded,
+                onDismiss = { menuExpanded = false },
+                onShowRouteOnMap = { callbacks.onShowRouteOnMap(representative) },
+                onShowSchedule = scheduleUrl?.let { url -> { callbacks.onShowRouteSchedule(url) } }
+            )
         }
     }
 }
@@ -407,20 +409,30 @@ internal fun alertClick(
  *  keep the two in sync via this single value rather than a bare literal on each side. */
 private val ROW_VERTICAL_PADDING = 8.dp
 
-/** The route-level long-press menu: open the route's schedule. The route's star lives as the row's own
- *  corner toggle ([FavoriteStarButton]); per-trip actions live on each pill's long-press menu
- *  ([TripActionsMenu]). Shown only when the route has a [scheduleUrl]. */
+/** The route-level long-press menu: show the whole route on the map (always), and — when [onShowSchedule]
+ *  is non-null (the route has a schedule) — open its schedule. A dumb view: both actions arrive pre-bound.
+ *  The route's star lives as the row's own corner toggle ([FavoriteStarButton]); per-trip actions live on
+ *  each pill's long-press menu ([TripActionsMenu]). */
 @Composable
 internal fun RouteActionsMenu(
     expanded: Boolean,
     onDismiss: () -> Unit,
-    scheduleUrl: String,
-    callbacks: ArrivalRowCallbacks
+    onShowRouteOnMap: () -> Unit,
+    onShowSchedule: (() -> Unit)?
 ) {
     CenteredLongPressMenu(expanded = expanded, onDismissRequest = onDismiss) {
-        MenuRow(R.string.bus_options_menu_show_route_schedule, MaterialSymbols.Schedule) {
+        MenuRow(
+            R.string.bus_options_menu_show_route_on_map,
+            ImageVector.vectorResource(R.drawable.ic_action_location_map)
+        ) {
             onDismiss()
-            callbacks.onShowRouteSchedule(scheduleUrl)
+            onShowRouteOnMap()
+        }
+        if (onShowSchedule != null) {
+            MenuRow(R.string.bus_options_menu_show_route_schedule, MaterialSymbols.Schedule) {
+                onDismiss()
+                onShowSchedule()
+            }
         }
     }
 }
@@ -633,6 +645,7 @@ internal fun previewArrival(
 internal fun previewRowCallbacks() = ArrivalRowCallbacks(
     onRouteFavorite = {},
     onShowVehiclesOnMap = {},
+    onShowRouteOnMap = {},
     onEtaClick = {},
     onShowTripStatus = {},
     onSetReminder = {},

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
@@ -641,15 +641,19 @@ internal fun previewArrival(
     )
 }
 
-/** No-op [ArrivalRowCallbacks] for previews (nothing is interactive in a static preview). */
-internal fun previewRowCallbacks() = ArrivalRowCallbacks(
+/** All-no-op [ArrivalRowCallbacks] for previews (nothing is interactive in a static preview) and for
+ *  tests, which override just the slots they observe — the one place to grow when a slot is added. */
+internal fun previewRowCallbacks(
+    onShowRouteOnMap: (ArrivalInfo) -> Unit = {},
+    onShowRouteSchedule: (String) -> Unit = {}
+) = ArrivalRowCallbacks(
     onRouteFavorite = {},
     onShowVehiclesOnMap = {},
-    onShowRouteOnMap = {},
+    onShowRouteOnMap = onShowRouteOnMap,
     onEtaClick = {},
     onShowTripStatus = {},
     onSetReminder = {},
-    onShowRouteSchedule = {},
+    onShowRouteSchedule = onShowRouteSchedule,
     onReportArrivalProblem = {},
     onShowAlert = {}
 )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -358,7 +358,7 @@ fun HomeScreen(
                     arrivalsViewModelFactory = arrivalsViewModelFactory,
                     tutorialState = tutorialState,
                     onArrivalsLoaded = onArrivalsLoaded,
-                    onShowRouteOnMap = { arrival, request ->
+                    revealRoute = { arrival, request ->
                         homeViewModel.selectArrivalRoute(
                             request = request,
                             shortName = arrival.shortName.orEmpty().ifBlank { arrival.routeId },

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
@@ -396,13 +396,22 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-    /** Select a drawer route and dispatch its map command as one atomic focus transition. */
+    /**
+     * Dispatch a route reveal from the arrivals drawer as one atomic focus transition. A stop-scoped
+     * [request] (it carries a `directionStopId`) becomes a route selection subordinate to the focused
+     * stop; an unscoped one enters standalone route focus (where [shortName]/[headsign] are unused —
+     * the standalone banner resolves the route itself).
+     */
     fun selectArrivalRoute(
         request: ShowRouteRequest,
         shortName: String,
         headsign: String?,
         undoViewport: MapViewport? = null
     ) {
+        if (request.directionStopId == null) {
+            focusStandaloneRoute(request, undoViewport)
+            return
+        }
         val stopFocus = _currentFocus.value as? CurrentFocus.Stop ?: return
         selectStopRoute(
             stopFocus = stopFocus,
@@ -413,7 +422,8 @@ class HomeViewModel @Inject constructor(
         )
     }
 
-    /** Enter route focus from a route-oriented surface (search, recents, deep link, route info). */
+    /** Enter route focus from a route-oriented surface (search, recents, deep link, route info) or an
+     *  unscoped drawer reveal (the row menu's "Show route on map", via [selectArrivalRoute]). */
     fun focusStandaloneRoute(request: ShowRouteRequest, undoViewport: MapViewport? = null) {
         pushFocus(CurrentFocus.Route(request.toRouteTarget()), undoViewport)
         emitMapDirective(MapDirective.ShowRoute(request, stopScoped = false))

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/arrivals/ArrivalsSheetHost.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/arrivals/ArrivalsSheetHost.kt
@@ -83,7 +83,9 @@ internal fun rememberArrivalsSession(
     arrivalsViewModelFactory: ArrivalsViewModel.Factory,
     tutorialState: TutorialState?,
     onArrivalsLoaded: (ArrivalsLoaded) -> Unit,
-    onShowRouteOnMap: (ArrivalInfo, ShowRouteRequest) -> Unit,
+    // The transport for every "show a route on the map" variant (row tap, ETA pill, menu item) — the
+    // request's own fields carry the stop/direction scoping, or its absence.
+    revealRoute: (ArrivalInfo, ShowRouteRequest) -> Unit,
     onShowTrip: (tripId: String, stopId: String) -> Unit,
     onEditReminder: (args: ReminderEditorArgs) -> Unit,
     showUndoSnackbar: (messageRes: Int, actionRes: Int?, onAction: (() -> Unit)?) -> Unit
@@ -104,7 +106,7 @@ internal fun rememberArrivalsSession(
             }
         )
         val activity = context.findActivity()
-        val showRouteState = rememberUpdatedState(onShowRouteOnMap)
+        val showRouteState = rememberUpdatedState(revealRoute)
         val showTripState = rememberUpdatedState(onShowTrip)
         val editReminderState = rememberUpdatedState(onEditReminder)
         val undoSnackbarState = rememberUpdatedState(showUndoSnackbar)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/arrivals/ArrivalsSheetHost.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/arrivals/ArrivalsSheetHost.kt
@@ -113,7 +113,7 @@ internal fun rememberArrivalsSession(
                 activity = activity,
                 viewModel = viewModel,
                 currentContent = { viewModel.state.value as? ArrivalsUiState.Content },
-                onShowRouteOnMap = { arrival, request -> showRouteState.value(arrival, request) },
+                revealRoute = { arrival, request -> showRouteState.value(arrival, request) },
                 showUndoSnackbar = { messageRes, actionRes, onAction ->
                     undoSnackbarState.value(messageRes, actionRes, onAction)
                 },

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
@@ -373,7 +373,7 @@ fun DirectionStopEtaStrip(
         onArrivalsLoaded = {},
         // A pill tap (via the shared handler's onFocusVehicleOnMap) lands here with a focusTripId
         // request — hand it to the host to focus/animate/ping that vehicle, reusing the arrivals path.
-        onShowRouteOnMap = { _, request -> onFocusVehicle(request) },
+        revealRoute = { _, request -> onFocusVehicle(request) },
         onShowTrip = onShowTrip,
         onEditReminder = onEditReminder,
         showUndoSnackbar = { _, _, _ -> }

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -133,6 +133,7 @@
     <string name="stop_info_vehicle_not_on_map">This trip&#8217;s vehicle isn&#8217;t on the map right now</string>
     <string name="bus_options_menu_show_trip_details">Show trip status</string>
     <string name="bus_options_menu_set_reminder">Set a reminder</string>
+    <string name="bus_options_menu_show_route_on_map">Show route on map</string>
     <string name="bus_options_menu_show_route_schedule">Show route schedule</string>
     <string name="bus_options_menu_report_trip_problem">Report arrival time problem</string>
 

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
@@ -372,6 +372,31 @@ class HomeViewModelTest {
     }
 
     @Test
+    fun `an unscoped drawer route request enters standalone route focus`() = runTest {
+        val vm = viewModel()
+        val map = MapDirectiveRecorder(vm)
+        val mapJob = launch { map.collect() }
+        advanceUntilIdle()
+        vm.onStopFocused(FocusedStop("stop", "Main St", "100", GeoPoint(47.6, -122.3)))
+        advanceUntilIdle()
+        map.sent.clear()
+
+        // The row menu's "Show route on map": a bare request with no stop scoping must behave like a
+        // searched route — standalone route focus, not a selection under the focused stop.
+        vm.selectArrivalRoute(
+            request = ShowRouteRequest("65"),
+            shortName = "65",
+            headsign = "Downtown"
+        )
+        advanceUntilIdle()
+
+        assertEquals(ShowRouteRequest("65"), map.routeRequests.single())
+        assertEquals(false, map.routeCommands.single().stopScoped)
+        assertEquals(CurrentFocus.Route(RouteTarget("65")), vm.currentFocus.value)
+        mapJob.cancel()
+    }
+
+    @Test
     fun `clearing a subordinate route retains stop focus`() = runTest {
         val vm = viewModel()
         val map = MapDirectiveRecorder(vm)


### PR DESCRIPTION
Closes #1993.

Adds an always-available **"Show route on map"** item to the arrivals row's long-press menu. It frames the whole route on the map exactly as a search-bar result would — a plain `ShowRouteRequest(routeId)` with no stop/direction scoping — distinct from the row-body tap, which stays scoped to the tapped stop's direction (`onShowVehiclesOnMap`).

## Behavior

- **Long-pressing a route row** (badge included) now always opens the route menu. Previously the long press only did anything when the route had a schedule URL.
- The menu shows **"Show route on map"** first (always), then **"Show route schedule"** when the route has a schedule URL.
- "Show route on map" reuses the same `revealRouteOnMap(routeId)` path a searched route takes, landing in the shared `MapDirective.ShowRoute` focus flow.

## Implementation

- Wires a new `onShowRouteOnMap` callback through `ArrivalRowCallbacks` → `rememberArrivalRowCallbacks` → `ArrivalActionHandler` → `createArrivalActionHandler`, mirroring the sibling map actions. The builder's internal transport lambda was renamed `onShowRouteOnMap` → `revealRoute` to free the name for the new handler method (it already fed three callers, so it now names the primitive rather than one caller).
- `RouteActionsMenu` is now a dumb view: both actions arrive pre-bound (`onShowRouteOnMap: () -> Unit` + nullable `onShowSchedule: (() -> Unit)?`, where null omits the schedule item).
- The menu icon reuses the existing `ic_action_location_map` drawable via `ImageVector.vectorResource(...)`.
- Adds a `bus_options_menu_show_route_on_map` string.

## Tests

`RouteArrivalRowLongPressTest` updated + a new `longPressShowsRouteOnMapEvenWithoutSchedule` verifying the item fires `onShowRouteOnMap` and is present even with no schedule URL (while the schedule item is absent). Shared setup extracted into `testCallbacks(...)`/`setRow(...)` helpers.

## Verification

- `compileObaGoogleDebugKotlin` + `compileObaGoogleDebugAndroidTestKotlin` clean under `-PwarningsAsErrors=true` (reproduces the CI Kotlin-warnings gate).
- `spotlessApply` reports no drift.
- Instrumented tests not run locally (require a device/emulator); left for CI. Lint left for CI per repo guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **“Show route on map”** option to the route arrival long-press menu, with updated labeling and consistent menu accessibility.
  * Route map viewing can now reveal the full route without stop/direction restrictions (when applicable).
  * The **schedule** option remains available only when schedule info exists.

* **Bug Fixes**
  * Improved long-press menu behavior so the correct actions appear and trigger the expected map/schedule outcomes.

* **Tests**
  * Added unit/integration coverage for unscoped route reveals and menu action availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->