### PR TITLE
Mark on-map ETA pills with a pin; drop the trip-focus refusal toast (#1992)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/adapters/ArrivalAdapters.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/adapters/ArrivalAdapters.kt
@@ -66,4 +66,14 @@ private class DtoArrivalData(
     override val scheduleDeviation get() = d.tripStatus?.scheduleDeviation ?: 0L
     override val lastKnownLat get() = d.tripStatus?.lastKnownLocation?.lat
     override val lastKnownLon get() = d.tripStatus?.lastKnownLocation?.lon
+
+    // Drawable only when the vehicle is actively on THIS trip (activeTripId == this arrival's tripId) and
+    // has a location — the same source (lastKnownLocation ?: position) the map turns into a marker keyed
+    // by activeTripId (see TripExtrapolationBuilder.extrapolatedVehicles). If the block's vehicle is still
+    // upstream on an earlier trip, its activeTripId differs, the map draws no marker for this trip, and a
+    // pill tap wouldn't reframe — so this is correctly false there (#1992).
+    override val hasPlottableVehicle
+        get() = d.tripStatus?.let { ts ->
+            ts.activeTripId == d.tripId && (ts.lastKnownLocation != null || ts.position != null)
+        } ?: false
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapEffect.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapEffect.kt
@@ -44,16 +44,6 @@ sealed interface MapEffect {
     object WaitingForLocation : MapEffect
 
     /**
-     * An arrivals ETA-pill tap asked to frame that trip's live vehicle with its stop, but no vehicle is
-     * running that trip right now (a future block trip, or one the server isn't tracking) — show the
-     * "vehicle isn't on the map" toast. Raised by [RouteMapController] when a pending focus resolves to
-     * [FocusResolution.DROP]; the route itself is still shown, just not zoomed to a vehicle. The arrivals
-     * handler emits the same `R.string.stop_info_vehicle_not_on_map` toast directly for the degenerate
-     * blank-tripId case (see `ArrivalActionHandlers.onFocusVehicleOnMap`); keep the wording in sync.
-     */
-    object VehicleNotOnMap : MapEffect
-
-    /**
      * A viewport/route load failed — show the map error toast for OBA status [code] (an HTTP status or
      * an `ObaApi.OBA_*` sentinel). Rendered by the UI layer, so the cold controllers don't reach for a
      * `Context` just to present the toast.

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
@@ -190,17 +190,14 @@ class RouteMapController(
     // by collectLatest either way. Cancelled with the route session in [stop].
     private var selectionJob: Job? = null
 
-    // A pending arrivals ETA-pill focus: fit trip [tripId]'s live vehicle together with the originating
-    // stop once the vehicle appears. Held until the first vehicle set arrives, then resolved once by
-    // [tryFocusVehicle]: if a marker for the trip is on the map the camera fits the vehicle↔stop box,
-    // otherwise it's dropped (the vehicle isn't running that trip right now) — we raise the
-    // [MapEffect.VehicleNotOnMap] toast so the tap isn't silently ignored, and, if [frameFallback], frame
-    // the whole route instead (the initial framing the launch deferred pending this decision). A pending
-    // focus only ever comes from the ETA-pill tap ([ShowRouteRequest.focusTripId]), so a DROP always maps
-    // to that toast. Held as one value (like [DirectionState]) so the id and the fallback flag can't drift.
-    private data class PendingFocus(val tripId: String, val frameFallback: Boolean)
-
-    private var pendingFocus: PendingFocus? = null
+    // A pending arrivals ETA-pill focus: the trip id whose live vehicle should be fit together with the
+    // originating stop once it appears. Held until the first vehicle set arrives, then resolved once by
+    // [tryFocusVehicle]: if a marker for the trip is on the map the camera fits the vehicle↔stop box;
+    // otherwise it's dropped silently — the vehicle isn't running that trip right now, so we neither move
+    // the camera nor toast (#1992: a miss must not yank the map out to the whole-route extent, and the
+    // arrivals ETA strip's "on the map" pin already tells the user which pills reframe on tap). Only ever
+    // set from an ETA-pill tap ([ShowRouteRequest.focusTripId]).
+    private var pendingFocus: String? = null
 
     /**
      * Show route [routeId]: load the route + header and start the vehicle poll. [zoomToRoute] frames
@@ -225,7 +222,7 @@ class RouteMapController(
         this.directionStopId = directionStopId
         this.highlightedSegment = highlightedSegment
         this.initialDirectionOverride = initialDirectionId
-        this.pendingFocus = focusTripId?.let { PendingFocus(it, frameFallback = zoomToRoute) }
+        this.pendingFocus = focusTripId
         // A whole-route launch has no direction to wait for, so its vehicles show as soon as they poll;
         // a direction-anchored launch (an anchor stop or a restored direction) stays Pending until the
         // route load resolves the filter (below).
@@ -267,13 +264,13 @@ class RouteMapController(
     /**
      * Ask to fit trip [tripId]'s live vehicle + the originating stop on the already-shown route (the ETA
      * pill tapped for an arrival whose route the map is already parked on). Resolves immediately against
-     * the current vehicle set: when the vehicle isn't there, [tryFocusVehicle] raises the "vehicle isn't on
-     * the map" toast; a vehicle that only appears on a later poll still frames then, via [publishVehicleSet].
-     * The map already shows the route here, so there's no fallback frame ([PendingFocus.frameFallback] is
-     * false) — we don't yank the camera to the whole-route extent just because a specific vehicle is missing.
+     * the current vehicle set: when the vehicle isn't there, [tryFocusVehicle] drops the focus silently (no
+     * camera move, no toast); a vehicle that only appears on a later poll still frames then, via
+     * [publishVehicleSet]. We never yank the camera to the whole-route extent just because a specific
+     * vehicle is missing (#1992).
      */
     fun requestFocus(tripId: String) {
-        pendingFocus = PendingFocus(tripId, frameFallback = false)
+        pendingFocus = tripId
         tryFocusVehicle(currentVehicleLayer())
     }
 
@@ -305,13 +302,12 @@ class RouteMapController(
     // Resolve a pending focus against [layer] (the just-built vehicle set, threaded in so the poll path
     // doesn't re-run the extrapolation), once we actually have vehicles to check. With a marker for the
     // trip present, fit the vehicle together with the originating stop; absent, the pending focus is
-    // dropped — we raise the "vehicle isn't on the map" toast (the pill tap must not be silently ignored)
-    // and, when [PendingFocus.frameFallback], frame the route as the deferred fallback. A no-op until
-    // there's a resolved direction and a landed poll, so the decision waits for real data rather than
-    // firing on the empty pre-poll set.
+    // dropped silently — no live vehicle runs this trip right now, so we neither move the camera nor toast
+    // (#1992). A no-op until there's a resolved direction and a landed poll, so the decision waits for real
+    // data rather than firing on the empty pre-poll set.
     private fun tryFocusVehicle(layer: MapVehicles?) {
         val focus = pendingFocus ?: return
-        val marker = layer?.markers?.firstOrNull { it.activeTripId == focus.tripId }
+        val marker = layer?.markers?.firstOrNull { it.activeTripId == focus }
         when (resolveVehicleFocus(directionState is DirectionState.Resolved, latestPoll != null, marker != null)) {
             FocusResolution.WAIT -> Unit
             FocusResolution.FIT -> {
@@ -321,13 +317,12 @@ class RouteMapController(
                 host.frame(FramingIntent.Points(listOfNotNull(marker?.point, originatingStopPoint())))
                 // Radiate a ping from the vehicle so it's clear which one this arrival is querying (#1764);
                 // keyed by trip id so the ripple follows the marker as it settles onto its projected spot.
-                renderState.emitPing(focus.tripId)
+                renderState.emitPing(focus)
             }
-            FocusResolution.DROP -> {
-                pendingFocus = null
-                if (focus.frameFallback) host.frameRoute()
-                host.emitEffect(MapEffect.VehicleNotOnMap)
-            }
+            // No live vehicle runs this trip right now: drop the focus silently. We deliberately neither
+            // frame the whole route (#1992: a pill tap must not yank the camera out to the route extent) nor
+            // toast — the arrivals ETA strip's "on the map" pin already signals which pills reframe on tap.
+            FocusResolution.DROP -> pendingFocus = null
         }
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/models/ArrivalData.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/models/ArrivalData.kt
@@ -59,6 +59,17 @@ interface ArrivalData {
     val scheduleDeviation: Long
     val lastKnownLat: Double?
     val lastKnownLon: Double?
+
+    /**
+     * True when a live vehicle is **actively serving this exact trip** right now and has reported a
+     * plottable position — i.e. the trip status's active trip is this arrival's trip and it carries a
+     * last-known-location/position. That is precisely the condition under which the map can draw a marker
+     * for the trip (keyed by its active trip id), so tapping the arrival's ETA pill would reframe the map
+     * to that vehicle (#1992). Distinct from [predicted], which is the bare real-time flag with no
+     * location requirement (a schedule-deviation-only prediction is [predicted] but not this). Defaults
+     * false for arrival sources that carry no trip-status detail.
+     */
+    val hasPlottableVehicle: Boolean get() = false
 }
 
 /** Headway-based (exact_times=0) service window; server-clock bounds, [headway] in seconds. */

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalActionHandlers.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalActionHandlers.kt
@@ -85,18 +85,11 @@ fun createArrivalActionHandler(
     override fun onFocusVehicleOnMap(arrival: ArrivalInfo) {
         recordRoute(arrival)
         // The ETA-pill tap: same route + direction as the row, plus the trip so the map fits that
-        // arrival's live vehicle together with this stop. When no live vehicle is running the trip, the map
-        // toasts "vehicle isn't on the map" and shows the route instead — that fallback lives in
-        // RouteMapController, keyed off focusTripId being set.
+        // arrival's live vehicle together with this stop. When no live vehicle is running the trip (or a
+        // partial response carries no tripId to key on), RouteMapController drops the focus silently — no
+        // camera move, no toast (#1992). The ETA strip's "on the map" pin already tells the user which
+        // pills reframe on tap, so a miss is expected rather than an error to announce.
         val tripId = arrival.tripId.ifBlank { null }
-        // A partial response with no tripId can't be focused at all, so the map has nothing to key on;
-        // toast up front (the pill must never be silently ignored) and still show the route for context.
-        // The other emitter of this same toast is RouteMapController's DROP path (via MapEffect.
-        // VehicleNotOnMap), for the case where a tripId exists but no live vehicle is running it — keep the
-        // two in sync via the shared R.string.stop_info_vehicle_not_on_map.
-        if (tripId == null) {
-            Toast.makeText(activity, R.string.stop_info_vehicle_not_on_map, Toast.LENGTH_SHORT).show()
-        }
         onShowRouteOnMap(
             arrival,
             ShowRouteRequest(

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalInfo.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalInfo.kt
@@ -93,6 +93,16 @@ class ArrivalInfo(
     val shortName: String? get() = data.shortName
     val routeLongName: String? get() = data.routeLongName
 
+    /**
+     * True when a live vehicle is actively serving this trip and has a plottable position right now
+     * (#1992): the ETA pill shows the "on the map" pin instead of the rss glyph, since tapping it would
+     * reframe the map to that vehicle. Implies [predicted] (a pin is always real-time), so the pin is a
+     * strict refinement of the rss "AVL-tracked" cue rather than a separate state. Derived from the
+     * arrival's own trip status, so it holds before the route is ever shown on the map — the row doesn't
+     * need to be selected first.
+     */
+    val vehicleOnMap: Boolean get() = predicted && data.hasPlottableVehicle
+
     /** The route-row sort/display name (#1822): short name falling back to the long name (the same
      *  [getRouteDisplayName] fallback used elsewhere for this route), then the route id — never
      *  blank, so it's always a valid [RouteRowGroup] sort key. */

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
@@ -523,6 +523,23 @@ internal fun RealtimeIndicator(color: Color, modifier: Modifier = Modifier) {
     )
 }
 
+/**
+ * The "on the map right now" indicator: a filled map pin that replaces the [RealtimeIndicator] rss glyph
+ * on an ETA pill whose live vehicle is currently drawn on the map (#1992). Both mean the arrival is
+ * real-time; the pin additionally says "tapping this pill reframes the map to that vehicle", where the
+ * rss glyph marks an AVL-tracked trip whose vehicle isn't drawn (so a tap does nothing). Shown only on
+ * the interactive ETA-strip pills, since only those drive a map reframe.
+ */
+@Composable
+internal fun OnMapIndicator(color: Color, modifier: Modifier = Modifier) {
+    Icon(
+        painter = painterResource(R.drawable.ic_map_pin),
+        contentDescription = null,
+        modifier = modifier,
+        tint = color
+    )
+}
+
 private fun strikeThroughIf(canceled: Boolean): TextDecoration = if (canceled) TextDecoration.LineThrough else TextDecoration.None
 
 /**
@@ -578,7 +595,8 @@ private data class PreviewArrivalData(
     override val hasTripStatus: Boolean = false,
     override val scheduleDeviation: Long = 0L,
     override val lastKnownLat: Double? = null,
-    override val lastKnownLon: Double? = null
+    override val lastKnownLon: Double? = null,
+    override val hasPlottableVehicle: Boolean = false
 ) : ArrivalData {
     override val scheduledDepartureTime: ServerTime get() = scheduledArrivalTime
     override val predictedDepartureTime: ServerTime? get() = predictedArrivalTime
@@ -602,6 +620,9 @@ internal fun previewArrival(
     routeId: String = "route_$shortName",
     routeLongName: String? = null,
     directionId: Int? = null,
+    // When true (and [predicted]), the arrival's live vehicle is drawn on the map for this trip, so its
+    // pill shows the "on the map" pin instead of the rss glyph (#1992).
+    hasPlottableVehicle: Boolean = false,
     // Trip-instance identity for the strip's LazyRow key (see EtaStrip). Callers that build a
     // multi-pill strip must pass a distinct id per pill — the default alone collides, and a duplicate
     // key throws. Not derived from etaMinutes on purpose: two pills legitimately share an ETA (a loop
@@ -622,7 +643,8 @@ internal fun previewArrival(
             predicted = predicted,
             status = status,
             routeLongName = routeLongName,
-            tripId = tripId
+            tripId = tripId,
+            hasPlottableVehicle = hasPlottableVehicle
         ),
         now = ServerTime(0L),
         includeArrivalDepartureInStatusLabel = false

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStrip.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStrip.kt
@@ -283,6 +283,7 @@ private fun EtaPillWithMenu(
             eta = trip.liveEta(liveNow),
             color = colorResource(trip.color),
             predicted = trip.predicted,
+            onMap = trip.vehicleOnMap,
             canceled = trip.status == Status.CANCELED,
             clockTime = clockTime,
             onClick = { callbacks.onEtaClick(trip) },
@@ -339,6 +340,10 @@ internal fun EtaPill(
     color: Color,
     predicted: Boolean,
     modifier: Modifier = Modifier,
+    // The trip's live vehicle is drawn on the map right now (#1992): show the "on the map" pin instead of
+    // the rss glyph, cueing that a tap on this pill reframes the map to that vehicle. Implies [predicted]
+    // (a drawn vehicle is always real-time), so it wins when both would apply.
+    onMap: Boolean = false,
     canceled: Boolean = false,
     clockTime: String? = null,
     onClick: (() -> Unit)? = null,
@@ -353,7 +358,7 @@ internal fun EtaPill(
     // it back to their height via fillMaxHeight (see EtaStrip), and the label is centered within it.
     val nowSize = 26.sp
     val labelSize = 14.sp
-    val indicatorSize = 12.dp // 1.5× the base accent; overlaid, so the extra size overlaps, not widens
+    val indicatorSize = 13.8.dp // 1.5× the base accent, then +15%; overlaid, so the extra size overlaps, not widens
     val clockTimeSize = 10.sp
     val topPadding = 3.dp
     val bottomPadding = 3.5.dp
@@ -439,15 +444,17 @@ internal fun EtaPill(
                 }
             }
             // The live indicator, overlaid on the top-trailing corner so its 1.5× size overlaps the
-            // ETA text a little instead of widening the pill (drawn last = on top).
-            if (predicted) {
-                RealtimeIndicator(
-                    color = Color.White,
-                    modifier = Modifier
-                        .align(Alignment.TopEnd)
-                        .padding(top = 1.dp, end = 1.dp)
-                        .size(indicatorSize)
-                )
+            // ETA text a little instead of widening the pill (drawn last = on top). A vehicle that's drawn
+            // on the map now shows the "on the map" pin (a tap reframes to it); an AVL-tracked trip whose
+            // vehicle isn't drawn shows the rss glyph (#1992).
+            val indicatorModifier = Modifier
+                .align(Alignment.TopEnd)
+                .padding(top = 1.dp, end = 1.dp)
+                .size(indicatorSize)
+            if (onMap) {
+                OnMapIndicator(color = Color.White, modifier = indicatorModifier)
+            } else if (predicted) {
+                RealtimeIndicator(color = Color.White, modifier = indicatorModifier)
             }
         }
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
@@ -317,11 +317,6 @@ fun MapFeature(
                     R.string.main_waiting_for_location,
                     Toast.LENGTH_SHORT
                 ).show()
-                MapEffect.VehicleNotOnMap -> Toast.makeText(
-                    context,
-                    R.string.stop_info_vehicle_not_on_map,
-                    Toast.LENGTH_SHORT
-                ).show()
                 is MapEffect.ShowError -> Toast.makeText(
                     context,
                     ObaRequestErrors.getMapErrorString(context, effect.code),

--- a/onebusaway-android/src/main/res/drawable/ic_map_pin.xml
+++ b/onebusaway-android/src/main/res/drawable/ic_map_pin.xml
@@ -1,0 +1,13 @@
+<!-- Material Symbols "location_on" (24dp). The "on the map right now" indicator on an ETA pill: a
+     filled map pin marking a trip whose live vehicle is currently drawn on the map, distinct from the
+     rss_feed glyph that marks any AVL-tracked arrival (#1992). Tinted at the call site via
+     Icon(tint = ...). -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M12,2c-3.87,0 -7,3.13 -7,7c0,5.25 7,13 7,13s7,-7.75 7,-13C19,5.13 15.87,2 12,2zM12,11.5c-1.38,0 -2.5,-1.12 -2.5,-2.5s1.12,-2.5 2.5,-2.5s2.5,1.12 2.5,2.5S13.38,11.5 12,11.5z" />
+</vector>

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -130,7 +130,6 @@
 
     <string name="bus_options_menu_add_star">Add star to route</string>
     <string name="bus_options_menu_remove_star">Remove star from route</string>
-    <string name="stop_info_vehicle_not_on_map">This trip&#8217;s vehicle isn&#8217;t on the map right now</string>
     <string name="bus_options_menu_show_trip_details">Show trip status</string>
     <string name="bus_options_menu_set_reminder">Set a reminder</string>
     <string name="bus_options_menu_show_route_schedule">Show route schedule</string>

--- a/onebusaway-android/src/test/java/org/onebusaway/android/api/adapters/ArrivalAdaptersTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/api/adapters/ArrivalAdaptersTest.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.api.adapters
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.onebusaway.android.api.contract.ArrivalDeparture
+import org.onebusaway.android.api.contract.Position
+import org.onebusaway.android.api.contract.TripStatus
+
+/**
+ * [DtoArrivalData.hasPlottableVehicle] — the "the map can draw a vehicle for THIS trip right now" predicate
+ * behind the ETA pill's "on the map" pin (#1992). It must mirror the map's own draw condition: the trip
+ * status's active trip is this arrival's trip AND it carries a location (last-known or current position).
+ */
+class ArrivalAdaptersTest {
+
+    private fun arrival(tripId: String = "trip", tripStatus: TripStatus? = null) =
+        ArrivalDeparture(routeId = "route", tripId = tripId, stopId = "stop", tripStatus = tripStatus)
+            .asArrivalData(directionId = null)
+
+    @Test
+    fun `no trip status is not plottable`() {
+        assertFalse(arrival(tripStatus = null).hasPlottableVehicle)
+    }
+
+    @Test
+    fun `active on this trip with a last-known location is plottable`() {
+        val status = TripStatus(activeTripId = "trip", lastKnownLocation = Position(47.6, -122.3))
+        assertTrue(arrival(tripId = "trip", tripStatus = status).hasPlottableVehicle)
+    }
+
+    @Test
+    fun `active on this trip with only a current position is plottable`() {
+        val status = TripStatus(activeTripId = "trip", position = Position(47.6, -122.3))
+        assertTrue(arrival(tripId = "trip", tripStatus = status).hasPlottableVehicle)
+    }
+
+    @Test
+    fun `vehicle upstream on an earlier block trip is not plottable for this trip`() {
+        // The block's vehicle is still serving an earlier trip, so the map would draw a marker keyed to
+        // that trip, not this one — tapping this pill wouldn't reframe, so it must be false here.
+        val status = TripStatus(activeTripId = "earlier_trip", lastKnownLocation = Position(47.6, -122.3))
+        assertFalse(arrival(tripId = "trip", tripStatus = status).hasPlottableVehicle)
+    }
+
+    @Test
+    fun `active on this trip but with no location is not plottable`() {
+        // A schedule-deviation-only status (no GPS) is real-time but has nothing to draw.
+        val status = TripStatus(activeTripId = "trip", scheduleDeviation = 120L)
+        assertFalse(arrival(tripId = "trip", tripStatus = status).hasPlottableVehicle)
+    }
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/api/adapters/ArrivalAdaptersTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/api/adapters/ArrivalAdaptersTest.kt
@@ -29,9 +29,8 @@ import org.onebusaway.android.api.contract.TripStatus
  */
 class ArrivalAdaptersTest {
 
-    private fun arrival(tripId: String = "trip", tripStatus: TripStatus? = null) =
-        ArrivalDeparture(routeId = "route", tripId = tripId, stopId = "stop", tripStatus = tripStatus)
-            .asArrivalData(directionId = null)
+    private fun arrival(tripId: String = "trip", tripStatus: TripStatus? = null) = ArrivalDeparture(routeId = "route", tripId = tripId, stopId = "stop", tripStatus = tripStatus)
+        .asArrivalData(directionId = null)
 
     @Test
     fun `no trip status is not plottable`() {

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/FocusResolutionTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/FocusResolutionTest.kt
@@ -55,7 +55,7 @@ class FocusResolutionTest {
     @Test
     fun drops_when_no_vehicle_runs_the_trip() {
         // A real poll landed and the trip has no live vehicle (e.g. it's a future block trip): drop the
-        // focus so the caller can fall back to framing the whole route.
+        // focus so the caller leaves the camera put (no reframe, no toast — #1992).
         assertEquals(
             FocusResolution.DROP,
             resolveVehicleFocus(directionResolved = true, pollLanded = true, markerPresent = false)

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/ArrivalInfoTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/ArrivalInfoTest.kt
@@ -47,12 +47,14 @@ class ArrivalInfoTest {
     private fun arrival(
         predicted: Boolean,
         predictedArrivalTime: Long,
-        scheduledArrivalTime: Long = scheduledArrival
+        scheduledArrivalTime: Long = scheduledArrival,
+        hasPlottableVehicle: Boolean = false
     ): ArrivalData = FakeArrivalData(
         predicted = predicted,
         // Mirror the adapter's wire→domain mint: a non-positive predicted instant decodes to null.
         predictedArrivalTime = predictedArrivalTime.takeIf { it > 0L }?.let { ServerTime(it) },
-        scheduledArrivalTime = ServerTime(scheduledArrivalTime)
+        scheduledArrivalTime = ServerTime(scheduledArrivalTime),
+        hasPlottableVehicle = hasPlottableVehicle
     )
 
     private fun infoFor(data: ArrivalData) = ArrivalInfo(
@@ -125,6 +127,30 @@ class ArrivalInfoTest {
     }
 
     @Test
+    fun `vehicleOnMap is true only when a genuine prediction has a plottable vehicle (#1992)`() {
+        // The pin is a strict refinement of the rss cue: a drawable vehicle AND a real prediction.
+        assertTrue(
+            "genuine prediction + plottable vehicle shows the pin",
+            infoFor(arrival(predicted = true, predictedArrivalTime = 1_783_119_500_000L, hasPlottableVehicle = true))
+                .vehicleOnMap
+        )
+        assertFalse(
+            "no plottable vehicle stays on the rss glyph",
+            infoFor(arrival(predicted = true, predictedArrivalTime = 1_783_119_500_000L, hasPlottableVehicle = false))
+                .vehicleOnMap
+        )
+    }
+
+    @Test
+    fun `vehicleOnMap is false when the prediction is suppressed even with a plottable vehicle (#1992)`() {
+        // A closed-stop -1 sentinel normalizes predicted to false, so the pin can't outlive the rss cue
+        // it refines — no indicator at all here, not a pin.
+        assertFalse(
+            infoFor(arrival(predicted = true, predictedArrivalTime = -1L, hasPlottableVehicle = true)).vehicleOnMap
+        )
+    }
+
+    @Test
     fun `liveEta matches eta at the constructor's own now (issue #1781)`() {
         val info = genuinePrediction
 
@@ -170,5 +196,6 @@ private data class FakeArrivalData(
     override val hasTripStatus: Boolean = false,
     override val scheduleDeviation: Long = 0L,
     override val lastKnownLat: Double? = null,
-    override val lastKnownLon: Double? = null
+    override val lastKnownLon: Double? = null,
+    override val hasPlottableVehicle: Boolean = false
 ) : ArrivalData


### PR DESCRIPTION
Closes #1992.

## Problem
Tapping an ETA pill whose vehicle isn't on the map did two unwanted things:
1. **(bug)** it framed the entire route instead of doing nothing, and
2. it popped a refusal toast — a kludge, since the RSS icon (which means "AVL-tracked") led people to reasonably expect a reframe and then get a toast.

## What changed
**No more yank, no more toast.** A pill tap that finds no live vehicle for the trip now drops silently — no camera move, no toast. (`RouteMapController`'s focus DROP branch no longer frames the route or emits an effect; `MapEffect.VehicleNotOnMap`, its handler, the blank-tripId toast, and the `stop_info_vehicle_not_on_map` string are removed.)

**A second icon tells you which pills reframe.** A pill whose trip has a *plottable* live vehicle shows a **map-pin** instead of the RSS glyph:
- **RSS** = AVL-tracked (a real-time prediction exists; may be schedule-deviation only).
- **Pin** = a vehicle is actively serving *this* trip and has a GPS position — exactly the condition under which the map can draw a marker for it, so tapping reframes.

The pin is derived from the arrival's **own trip status** (`tripStatus.activeTripId == this trip && has location`), mirroring the map's draw predicate (`TripExtrapolationBuilder`). So it shows on the rows **before any route is selected**, and the arrivals UI needs no map-render-state dependency. A vehicle still upstream on an earlier block trip correctly gets **no** pin (tapping wouldn't reframe it).

## Key pieces
- `ArrivalData.hasPlottableVehicle` (computed in `DtoArrivalData`) → `ArrivalInfo.vehicleOnMap` (= `predicted && hasPlottableVehicle`, so pin ⊂ real-time).
- New `ic_map_pin` drawable; pin and RSS share one indicator slot on the pill (both white), bumped ~15% to 13.8dp.

## Tests
- `ArrivalAdaptersTest` — the `hasPlottableVehicle` predicate, including the upstream-block and no-location cases.
- `ArrivalInfoTest` — a `vehicleOnMap` case (needs a genuine prediction + a plottable vehicle; a suppressed closed-stop prediction stays off).
- `FocusResolutionTest` — still green (DROP now drops silently).
- All variants compile clean under `-PwarningsAsErrors=true`; installed and exercised on a device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “on the map” indicator (map-pin) to ETA pills when a live vehicle for the matching trip has a plottable location.
* **Bug Fixes**
  * Improved focus behavior for missing vehicles: the app now avoids reframe/camera side effects and suppresses the “vehicle isn’t on the map” toast, while keeping waiting-for-location and error toasts working.
* **Tests**
  * Added/updated tests covering plottable-vehicle eligibility, the new indicator visibility rules, and updated focus-resolution expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->