### PR TITLE
Serialize per-entity favorite writes so the last tap wins (#2001)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/database/oba/RouteFavoritesRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/database/oba/RouteFavoritesRepository.kt
@@ -31,6 +31,7 @@ import org.onebusaway.android.analytics.PlausibleAnalytics
 import org.onebusaway.android.api.data.RouteDataSource
 import org.onebusaway.android.app.di.AppScope
 import org.onebusaway.android.region.RegionRepository
+import org.onebusaway.android.util.KeyedMutex
 import org.onebusaway.android.util.routeDisplayNames
 
 /**
@@ -72,6 +73,11 @@ class RouteFavoritesRepository @Inject constructor(
     @param:ApplicationContext private val context: Context
 ) : RouteFavorites {
 
+    // Serializes writes per route id so two rapid taps on the same star (star then unstar) can't reach
+    // the store out of order and leave it disagreeing with the last tap (#2001). Every route-star
+    // surface funnels through [setFavorite], so guarding here covers them uniformly.
+    private val writeGuard = KeyedMutex<String>()
+
     /** The starred route ids, live: import-gated, and deduped so an unrelated `routes` write (a route
      *  recorded on an arrivals load) doesn't re-emit an identical set. */
     override fun favoriteRouteIds(): Flow<Set<String>> = routeDao.favoriteRouteIds()
@@ -93,7 +99,7 @@ class RouteFavoritesRepository @Inject constructor(
         longName: String?,
         url: String?,
         favorite: Boolean
-    ) {
+    ) = writeGuard.withLock(routeId) {
         importGate.awaitReady()
         val regionId = regionRepository.region.value?.id
         // Ensure the row for the folder JOIN without counting a "use" — a favorite toggle must not bump

--- a/onebusaway-android/src/main/java/org/onebusaway/android/database/oba/StopFavoritesRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/database/oba/StopFavoritesRepository.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 import org.onebusaway.android.region.RegionRepository
+import org.onebusaway.android.util.KeyedMutex
 
 /**
  * Stop starring for the shared focus banner, mirroring [RouteFavoritesRepository]. Exists so the
@@ -36,6 +37,11 @@ class StopFavoritesRepository @Inject constructor(
     private val regionRepository: RegionRepository,
     private val importGate: ImportGate
 ) {
+
+    // Serializes writes per stop id so two rapid taps on the same star (star then unstar) can't reach
+    // the store out of order and leave it disagreeing with the last tap (#2001). Both stop-star
+    // surfaces funnel through [setFavorite], so guarding here covers them uniformly.
+    private val writeGuard = KeyedMutex<String>()
 
     /** The starred stop ids, live and import-gated (so legacy favorites are visible on first read). */
     fun favoriteStopIds(): Flow<Set<String>> = stopDao.favoriteStopIds()
@@ -56,7 +62,7 @@ class StopFavoritesRepository @Inject constructor(
         latitude: Double,
         longitude: Double,
         favorite: Boolean
-    ) {
+    ) = writeGuard.withLock(id) {
         importGate.awaitReady()
         stopDao.setFavoriteEnsuringRow(
             identity = StopRecord(

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/FocusBannerViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/FocusBannerViewModel.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import org.onebusaway.android.database.oba.RouteFavoritesRepository
+import org.onebusaway.android.database.oba.RouteFavorites
 import org.onebusaway.android.database.oba.StopFavoritesRepository
 import org.onebusaway.android.map.RouteHeader
 import org.onebusaway.android.ui.home.FocusedStop
@@ -36,7 +36,9 @@ import org.onebusaway.android.util.runCatchingCancellable
 /** Route- and stop-favorite state for the shared focus banner. */
 @HiltViewModel
 class FocusBannerViewModel @Inject constructor(
-    private val routeFavorites: RouteFavoritesRepository,
+    // The narrow route-star seam (not the concrete repository) so the banner's overlay reconcile is
+    // JVM-unit-testable with a fake (#2001); Hilt binds it to RouteFavoritesRepository.
+    private val routeFavorites: RouteFavorites,
     private val stopFavorites: StopFavoritesRepository
 ) : ViewModel() {
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/KeyedMutex.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/KeyedMutex.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.util
+
+import java.util.concurrent.ConcurrentHashMap
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * A mutex partitioned by key: [withLock] serializes only the actions that share a [key] and lets
+ * unrelated keys run concurrently — one lightweight [Mutex] per distinct key, kept in a
+ * [ConcurrentHashMap] so [withLock] is safe to call from any context (mirrors [SingleFlight]).
+ *
+ * The favorite stars (#2001) use it to serialize writes per entity id. Each tap on a star launches
+ * an independent write coroutine; without this, two rapid taps on the same id (star then unstar)
+ * could reach the store out of order and leave the DB — and the optimistic overlay that reconciles
+ * against it — persistently disagreeing with the last tap. Because [Mutex] is fair (FIFO among
+ * waiters) and acquiring the lock is the write's first act (nothing suspends before it), the writes
+ * for one id run strictly in the order their [withLock] calls are reached; the callers launch on the
+ * main dispatcher, which processes taps one at a time, so that order is tap order — and the store
+ * always converges to the last tap. Different ids never contend.
+ *
+ * Keys are retained for the process lifetime (a favorited entity is a bounded set), so no removal
+ * race with a concurrent locker is possible.
+ */
+class KeyedMutex<K : Any> {
+
+    private val locks = ConcurrentHashMap<K, Mutex>()
+
+    /** Runs [action] holding the lock for [key], excluding only other [withLock] calls for that key. */
+    suspend fun <T> withLock(key: K, action: suspend () -> T): T = locks
+        .getOrPut(key) { Mutex() }
+        .withLock { action() }
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/map/FocusBannerViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/map/FocusBannerViewModelTest.kt
@@ -59,12 +59,12 @@ class FocusBannerViewModelTest {
             longName: String?,
             url: String?,
             favorite: Boolean
-        ) {}
+        ) = Unit
     }
 
     private object NoopImportGate : ImportGate {
-        override suspend fun awaitReady() {}
-        override fun start() {}
+        override suspend fun awaitReady() = Unit
+        override fun start() = Unit
     }
 
     /**
@@ -127,12 +127,12 @@ class FocusBannerViewModelTest {
  */
 private abstract class FakeStopDaoBase : StopDao {
     override suspend fun userInfo(stopId: String): StopUserInfoRow? = null
-    override suspend fun setFavorite(stopId: String, favorite: Int) {}
+    override suspend fun setFavorite(stopId: String, favorite: Int) = Unit
     override suspend fun userInfoMap(): List<StopUserInfoMapRow> = emptyList()
     override suspend fun location(stopId: String): StopLocationRow? = null
     override suspend fun nameForStop(stopId: String): String? = null
     override suspend fun getStop(stopId: String): StopRecord? = null
-    override suspend fun upsert(stop: StopRecord) {}
+    override suspend fun upsert(stop: StopRecord) = Unit
     override suspend fun markStopUsed(
         id: String,
         code: String,
@@ -142,13 +142,13 @@ private abstract class FakeStopDaoBase : StopDao {
         longitude: Double,
         regionId: Long?,
         now: Long
-    ) {}
+    ) = Unit
     override fun recents(cutoff: Long, regionId: Long?): Flow<List<StopListRow>> = flowOf(emptyList())
     override fun recentsForSearch(cutoff: Long, regionId: Long?): Flow<List<StopRecentRow>> = flowOf(emptyList())
     override fun starredByName(regionId: Long?): Flow<List<StopListRow>> = flowOf(emptyList())
     override fun starredByFrequency(regionId: Long?): Flow<List<StopListRow>> = flowOf(emptyList())
     override fun favoriteStopIds(): Flow<List<String>> = flowOf(emptyList())
-    override suspend fun markUnused(stopId: String) {}
-    override suspend fun markAllUnused() {}
-    override suspend fun clearAllFavorites() {}
+    override suspend fun markUnused(stopId: String) = Unit
+    override suspend fun markAllUnused() = Unit
+    override suspend fun clearAllFavorites() = Unit
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/map/FocusBannerViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/map/FocusBannerViewModelTest.kt
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.home.map
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.onebusaway.android.database.oba.ImportGate
+import org.onebusaway.android.database.oba.RouteFavorites
+import org.onebusaway.android.database.oba.StopDao
+import org.onebusaway.android.database.oba.StopFavoritesRepository
+import org.onebusaway.android.database.oba.StopListRow
+import org.onebusaway.android.database.oba.StopLocationRow
+import org.onebusaway.android.database.oba.StopRecentRow
+import org.onebusaway.android.database.oba.StopRecord
+import org.onebusaway.android.database.oba.StopUserInfoMapRow
+import org.onebusaway.android.database.oba.StopUserInfoRow
+import org.onebusaway.android.region.FakeRegionRepository
+import org.onebusaway.android.testing.MainDispatcherRule
+import org.onebusaway.android.ui.home.FocusedStop
+import org.onebusaway.android.util.GeoPoint
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class FocusBannerViewModelTest {
+
+    // Unconfined so the derived StateFlows (favoriteStopIds, stopFavoritesReady) recompute eagerly.
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule(UnconfinedTestDispatcher())
+
+    private class FakeRouteFavorites : RouteFavorites {
+        override fun favoriteRouteIds(): Flow<Set<String>> = flowOf(emptySet())
+        override suspend fun setFavorite(
+            routeId: String,
+            shortName: String?,
+            longName: String?,
+            url: String?,
+            favorite: Boolean
+        ) {}
+    }
+
+    private object NoopImportGate : ImportGate {
+        override suspend fun awaitReady() {}
+        override fun start() {}
+    }
+
+    /**
+     * A [StopDao] backing the favorite flag in-memory, whose FIRST write can be parked mid-flight
+     * (via [firstWriteGate]) to force the out-of-order completion the #2001 race needs: a slow star
+     * write that would otherwise land after a later, faster unstar.
+     */
+    private class FakeStopDao : FakeStopDaoBase() {
+        val stored = MutableStateFlow<Set<String>>(emptySet())
+        var firstWriteGate: CompletableDeferred<Unit>? = null
+        val firstWriteEntered = CompletableDeferred<Unit>()
+        private var writes = 0
+
+        override suspend fun setFavoriteEnsuringRow(identity: StopRecord, favorite: Int) {
+            if (writes++ == 0) {
+                firstWriteEntered.complete(Unit)
+                firstWriteGate?.await()
+            }
+            stored.update { if (favorite == 1) it + identity.id else it - identity.id }
+        }
+
+        override fun favoriteStopIds(): Flow<List<String>> = stored.map { it.toList() }
+    }
+
+    @Test
+    fun `a fast star then unstar leaves both the store and the overlay unstarred`() = runTest(UnconfinedTestDispatcher()) {
+        val dao = FakeStopDao().apply { firstWriteGate = CompletableDeferred() }
+        val stopFavorites = StopFavoritesRepository(dao, FakeRegionRepository(), NoopImportGate)
+        val viewModel = FocusBannerViewModel(FakeRouteFavorites(), stopFavorites)
+        advanceUntilIdle()
+        // The banner ignores taps until the persisted set is known.
+        assertTrue(viewModel.stopFavoritesReady.value)
+
+        val stop = FocusedStop("1_100", "Pine St & 3rd Ave", "577", GeoPoint(47.6, -122.3))
+
+        // Tap 1: star. Its write parks mid-flight (a slow write).
+        viewModel.toggleStopFavorite(stop)
+        dao.firstWriteEntered.await()
+        // Tap 2: unstar, while the star write is still parked. Without per-id serialization this write
+        // would complete first and the parked star would land last, leaving the store starred.
+        viewModel.toggleStopFavorite(stop)
+
+        // The optimistic overlay already reflects the last tap.
+        assertEquals(emptySet<String>(), viewModel.favoriteStopIds.value)
+
+        // Release the parked star write.
+        dao.firstWriteGate!!.complete(Unit)
+        advanceUntilIdle()
+
+        // The persisted store converged to the last tap — the writes did not reorder.
+        assertEquals(emptySet<String>(), dao.stored.value)
+        // And the overlay reconciled against it (no override left stuck contradicting the store).
+        assertEquals(emptySet<String>(), viewModel.favoriteStopIds.value)
+    }
+}
+
+/**
+ * The unused half of the [StopDao] surface, kept out of the way so [FocusBannerViewModelTest.FakeStopDao]
+ * shows only the two methods the favorite path touches.
+ */
+private abstract class FakeStopDaoBase : StopDao {
+    override suspend fun userInfo(stopId: String): StopUserInfoRow? = null
+    override suspend fun setFavorite(stopId: String, favorite: Int) {}
+    override suspend fun userInfoMap(): List<StopUserInfoMapRow> = emptyList()
+    override suspend fun location(stopId: String): StopLocationRow? = null
+    override suspend fun nameForStop(stopId: String): String? = null
+    override suspend fun getStop(stopId: String): StopRecord? = null
+    override suspend fun upsert(stop: StopRecord) {}
+    override suspend fun markStopUsed(
+        id: String,
+        code: String,
+        name: String,
+        direction: String,
+        latitude: Double,
+        longitude: Double,
+        regionId: Long?,
+        now: Long
+    ) {}
+    override fun recents(cutoff: Long, regionId: Long?): Flow<List<StopListRow>> = flowOf(emptyList())
+    override fun recentsForSearch(cutoff: Long, regionId: Long?): Flow<List<StopRecentRow>> = flowOf(emptyList())
+    override fun starredByName(regionId: Long?): Flow<List<StopListRow>> = flowOf(emptyList())
+    override fun starredByFrequency(regionId: Long?): Flow<List<StopListRow>> = flowOf(emptyList())
+    override fun favoriteStopIds(): Flow<List<String>> = flowOf(emptyList())
+    override suspend fun markUnused(stopId: String) {}
+    override suspend fun markAllUnused() {}
+    override suspend fun clearAllFavorites() {}
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/util/KeyedMutexTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/util/KeyedMutexTest.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.util
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class KeyedMutexTest {
+
+    @Test
+    fun `actions on the same key run one at a time, in the order they acquired`() = runTest(UnconfinedTestDispatcher()) {
+        val mutex = KeyedMutex<String>()
+        val order = mutableListOf<String>()
+        val gate = CompletableDeferred<Unit>()
+
+        // First action acquires the key and parks mid-flight.
+        launch {
+            mutex.withLock("k") {
+                order.add("a-start")
+                gate.await()
+                order.add("a-end")
+            }
+        }
+        // Second action for the same key must wait behind the first — it can't start yet.
+        launch { mutex.withLock("k") { order.add("b") } }
+        advanceUntilIdle()
+        assertEquals(listOf("a-start"), order)
+
+        // Releasing the first lets the second run — and only then.
+        gate.complete(Unit)
+        advanceUntilIdle()
+        assertEquals(listOf("a-start", "a-end", "b"), order)
+    }
+
+    @Test
+    fun `actions on different keys do not block each other`() = runTest(UnconfinedTestDispatcher()) {
+        val mutex = KeyedMutex<String>()
+        val order = mutableListOf<String>()
+        val gate = CompletableDeferred<Unit>()
+
+        // k1 parks holding its own lock...
+        launch {
+            mutex.withLock("k1") {
+                gate.await()
+                order.add("k1")
+            }
+        }
+        // ...but k2 is a different key, so it runs immediately regardless.
+        launch { mutex.withLock("k2") { order.add("k2") } }
+        advanceUntilIdle()
+        assertEquals(listOf("k2"), order)
+
+        gate.complete(Unit)
+        advanceUntilIdle()
+        assertEquals(listOf("k2", "k1"), order)
+    }
+
+    @Test
+    fun `withLock returns the action's result`() = runTest(UnconfinedTestDispatcher()) {
+        val mutex = KeyedMutex<String>()
+
+        val result = mutex.withLock("k") { 42 }
+
+        assertEquals(42, result)
+    }
+}


### PR DESCRIPTION
Closes #2001.

## Problem

Both favorite-toggle surfaces apply an optimistic overlay on tap, then launch an **independent** coroutine that writes through the repository; the overlay is dropped once the store re-emits a value matching it. Rapid taps on the same entity (star → unstar) launch two writes that can complete **out of order**. If the earlier star write lands after the later unstar write, the DB ends in the wrong final state — and because the store then keeps re-emitting a value contradicting the overlay, the reconcile predicate (`(id in stored) == favorite`) never matches, so the override sticks, leaving the UI and DB persistently disagreeing.

Narrow (requires out-of-order write completion) but an implicit invariant rather than an enforced one. Raised by CodeRabbit on #1997; pre-existing pattern from #1994 and the route-favorite path.

## Fix

Serialize favorite writes **per entity id** at the repository layer — the natural home, since every star surface now funnels through `StopFavoritesRepository` / `RouteFavoritesRepository`.

- **`KeyedMutex`** — a mutex partitioned by key (one `Mutex` per key in a `ConcurrentHashMap`), mirroring the existing `SingleFlight` util. `withLock(key) { … }` serializes only actions sharing a key; unrelated ids never contend. Because `Mutex` is fair and acquiring the lock is the write's first act (nothing suspends before it), writes for one id run strictly in acquisition order — which is tap order, as the callers launch on the main dispatcher (taps processed one at a time). The store always converges to the last tap.
- **`StopFavoritesRepository.setFavorite`** / **`RouteFavoritesRepository.setFavorite`** now run their write body inside `writeGuard.withLock(id) { … }`. Both stop-star surfaces (map banner + full-screen arrivals) and every route-star surface already funnel through these singletons, so guarding here covers them uniformly.
- **`FocusBannerViewModel`** now depends on the existing `RouteFavorites` interface (Hilt already `@Binds` it to `RouteFavoritesRepository`) instead of the concrete class — a small testability win so the banner's overlay reconcile is JVM-unit-testable with a fake.

## Tests

- **`KeyedMutexTest`** — same-key actions serialize in acquisition order; different keys don't block; the result propagates.
- **`FocusBannerViewModelTest`** — the regression test the issue asks for: fast-taps star → unstar with the star write parked mid-flight (a `CompletableDeferred` gate in the fake DAO forces the out-of-order completion), then asserts **both** the persisted store and the optimistic overlay end unstarred.

Verified the regression test **fails** when the guard is bypassed (assertion at the persisted-store check), so it genuinely catches the race rather than being a tautology. Local build is clean under `-PwarningsAsErrors=true` and `spotlessCheck`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevent rapid star/unstar taps from causing out-of-order favorite state changes for the same route or stop.
  * Ensures the stored favorite status always reflects the user’s latest action.
  * Keeps the responsive favorite overlay behavior consistent during fast interactions.
* **New Features**
  * Added a coroutine-safe keyed locking utility to serialize write operations per item id.
* **Tests**
  * Added unit tests covering rapid star-then-unstar race handling.
  * Added tests verifying keyed locking behavior for same vs. different keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->