### PR TITLE
Handle stay-aboard interlines in directions and on the map (#2000)

### DIFF
--- a/onebusaway-android/src/main/graphql/otp2/Plan.graphql
+++ b/onebusaway-android/src/main/graphql/otp2/Plan.graphql
@@ -49,6 +49,7 @@ query Plan(
                     duration
                     distance
                     realTime
+                    interlineWithPreviousLeg
                     start {
                         scheduledTime
                         estimated { time delay }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/adapters/Otp2PlanAdapters.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/adapters/Otp2PlanAdapters.kt
@@ -66,6 +66,7 @@ private fun PlanQuery.Leg.toTripLeg(): TripLeg = TripLeg(
     headsign = trip?.tripHeadsign,
     tripId = trip?.gtfsId,
     realTime = realTime ?: false,
+    interlineWithPreviousLeg = interlineWithPreviousLeg ?: false,
     distance = distance ?: 0.0,
     duration = (duration ?: 0.0).seconds,
     departureDelay = start.estimated?.delay.toDelayDuration(),

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/model/TripItinerary.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/model/TripItinerary.kt
@@ -81,6 +81,12 @@ data class TripLeg(
     val headsign: String? = null,
     val tripId: String? = null,
     val realTime: Boolean = false,
+    // OTP2 `Leg.interlineWithPreviousLeg`: true when the same vehicle continues from the previous leg
+    // and the passenger stays aboard (a self-interline where a route reverses onto itself, or a
+    // stay-aboard interline onto a different route). The directions layer folds such a leg into the
+    // previous leg's card instead of emitting a spurious get-off/get-on pair (#2000). Always false on
+    // the OTP1 path.
+    val interlineWithPreviousLeg: Boolean = false,
     val distance: Double = 0.0,
     @Serializable(with = DurationSerializer::class) val duration: Duration = Duration.ZERO,
     @Serializable(with = DurationSerializer::class) val departureDelay: Duration = Duration.ZERO,
@@ -120,6 +126,14 @@ data class TripStep(
     val lat: Double = 0.0,
     val lon: Double = 0.0
 )
+
+/**
+ * The leg's display short name: its route short name, else the OTP1 flat route string, else the route
+ * id; null when the leg carries none. As a #662 work-around this deliberately never uses the trip short
+ * name. Shared by the directions generator's itinerary title and the interline badge/label logic so the
+ * fallback lives in one place.
+ */
+fun TripLeg.routeDisplayShortName(): String? = listOf(routeShortName, route, routeId).firstOrNull { !it.isNullOrEmpty() }
 
 @Serializable
 data class TripLegGeometry(val points: String? = null, val length: Int = 0)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/DirectionsGenerator.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/DirectionsGenerator.kt
@@ -28,6 +28,7 @@ import org.onebusaway.android.directions.model.TripLeg
 import org.onebusaway.android.directions.model.TripMode
 import org.onebusaway.android.directions.model.TripPlace
 import org.onebusaway.android.directions.model.TripRelativeDirection
+import org.onebusaway.android.directions.model.routeDisplayShortName
 import org.onebusaway.android.time.ServerTime
 
 /**
@@ -362,11 +363,6 @@ class DirectionsGenerator(
 
     /* Added for Trip Plan titles */
 
-    private fun getTransitTitle(leg: TripLeg): String? {
-        // As a work-around for #662, we don't use leg.tripShortName
-        return arrayOf(leg.routeShortName, leg.route, leg.routeId).firstOrNull { !it.isNullOrEmpty() }
-    }
-
     val itineraryTitle: String
         get() {
             if (legs.size == 1) {
@@ -384,7 +380,7 @@ class DirectionsGenerator(
             for (leg in legs) {
                 val mode = leg.mode
                 if (mode?.isTransit == true) {
-                    tokens.add(getTransitTitle(leg))
+                    tokens.add(leg.routeDisplayShortName())
                 } else {
                     if (mode == TripMode.BICYCLE) {
                         tokens.add(applicationContext.getString(R.string.transit_directions_bikeshare_label))

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
@@ -301,7 +301,8 @@ class MapViewModel @Inject constructor(
         initialDirectionId: Int? = null,
         focusTripId: String? = null,
         preserveStopFocus: Boolean = false,
-        highlightedSegment: List<GeoPoint> = emptyList()
+        highlightedSegment: List<GeoPoint> = emptyList(),
+        extraSegments: List<RiddenSegment> = emptyList()
     ) {
         leaveCurrentView(clearStopFocus = !preserveStopFocus)
         persistRoute(routeId, directionStopId, initialDirectionId)
@@ -311,7 +312,8 @@ class MapViewModel @Inject constructor(
             directionStopId,
             initialDirectionId,
             focusTripId,
-            highlightedSegment
+            highlightedSegment,
+            extraSegments
         )
         bikeController.start(directions = false, selectedBikeStationIds = null)
     }
@@ -456,7 +458,8 @@ class MapViewModel @Inject constructor(
                 initialDirectionId = request.initialDirectionId,
                 focusTripId = request.focusTripId,
                 preserveStopFocus = stopScoped,
-                highlightedSegment = request.highlightedSegment
+                highlightedSegment = request.highlightedSegment,
+                extraSegments = request.extraSegments
             )
         }
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RiddenSegment.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RiddenSegment.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.map
+
+/**
+ * One leg of a stay-aboard interline ride, beyond the first (#2000): the passenger stays on one vehicle
+ * as it runs consecutive trips in a block, so the ride crosses [routeId]/direction seams the rider never
+ * acts on. Each extra segment names the route it continues onto and the stop it boards there ([anchorStopId],
+ * the seam) — enough for the route focus to load that route (or reuse the leader's when [routeId] matches),
+ * resolve the ridden direction from the anchor, and draw that segment's shape + stops + shared vehicle.
+ *
+ * A **self-interline** (12→12) yields extra segments whose [routeId] equals the leader's — a second
+ * *direction* of one route; a **cross-route interline** (45→75) yields a different [routeId] — a second
+ * route to load. Both are handled uniformly by the leader-plus-extra-segments model in [RouteMapController].
+ */
+data class RiddenSegment(
+    val routeId: String,
+    val anchorStopId: String?
+)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
@@ -110,6 +110,26 @@ class RouteMapController(
     // publishMapPresentation so it survives re-publishes (vehicle polls, direction changes).
     private var highlightedSegment: List<GeoPoint> = emptyList()
 
+    // The additional ridden legs of a stay-aboard interline (#2000) drilled into route focus, beyond the
+    // leader route/direction: each names a route continued onto (the same route in another direction for
+    // a self-interline, or a different route to load for a cross-route interline) and its seam stop. The
+    // focus draws each segment's shape + stops and shows the shared block vehicle across them. Empty for
+    // every ordinary route launch. Set in start(); the maps/polls below are (re)built as the routes load.
+    private var extraSegments: List<RiddenSegment> = emptyList()
+
+    // Loaded route maps for the extra segments' *other* routes, keyed by routeId (a self-interline
+    // segment reuses the leader's [routeShape], so only distinct cross-route ids land here). (Re)built by
+    // onRouteLoaded; read by the extra-segment shape/stop helpers.
+    private var extraRouteMaps: Map<String, RouteMap> = emptyMap()
+
+    // The latest vehicle poll per extra route id — a cross-route interline polls each route so the one
+    // shared block vehicle shows through every phase. Merged with [latestPoll] in sampleVehicles; empty
+    // otherwise.
+    private var extraPolls: Map<String, VehiclePoll> = emptyMap()
+
+    // The per-extra-route vehicle poll jobs, cancelled alongside [vehicleJob].
+    private var extraVehicleJobs: List<Job> = emptyList()
+
     // A restore/deep-link override for the initial direction (the user-selected direction persisted
     // across process death); when set and still valid it wins over the anchor stop's direction.
     private var initialDirectionOverride: Int? = null
@@ -152,6 +172,18 @@ class RouteMapController(
     // resolved (it reads null during the Pending window, which no caller relies on).
     private val currentDirectionId: Int?
         get() = (directionState as? DirectionState.Resolved)?.directionId
+
+    /** True while a stay-aboard interline is drilled in — the ride spans more than the leader leg (#2000);
+     *  the focus then draws each extra segment's route/direction and shows the shared vehicle across all. */
+    private val isInterlineComposite: Boolean
+        get() = extraSegments.isNotEmpty()
+
+    /** The loaded [RouteMap] backing an extra segment: the leader's own route when the ids match (a
+     *  self-interline's other direction), else its separately-loaded route (null until it loads). */
+    private fun RiddenSegment.routeMap(): RouteMap? = if (routeId == this@RouteMapController.routeId) routeShape else extraRouteMaps[routeId]
+
+    /** The direction an extra segment rides, resolved from its seam anchor against its route's stops. */
+    private fun RiddenSegment.directionId(): Int? = routeMap()?.stops?.anchorDirectionId(anchorStopId)
 
     private val presentationDirectionId: Int?
         get() = when (val state = directionState) {
@@ -216,11 +248,17 @@ class RouteMapController(
         directionStopId: String? = null,
         initialDirectionId: Int? = null,
         focusTripId: String? = null,
-        highlightedSegment: List<GeoPoint> = emptyList()
+        highlightedSegment: List<GeoPoint> = emptyList(),
+        extraSegments: List<RiddenSegment> = emptyList()
     ) {
         this.routeId = routeId
         this.directionStopId = directionStopId
         this.highlightedSegment = highlightedSegment
+        this.extraSegments = extraSegments
+        // (Re)built as the extra routes load / poll in onRouteLoaded + startVehiclePolling; cleared here
+        // so a prior focus's routes/polls can't leak into this one during the load window.
+        this.extraRouteMaps = emptyMap()
+        this.extraPolls = emptyMap()
         this.initialDirectionOverride = initialDirectionId
         this.pendingFocus = focusTripId
         // A whole-route launch has no direction to wait for, so its vehicles show as soon as they poll;
@@ -292,8 +330,13 @@ class RouteMapController(
         // republish when it actually changes.
         if (highlightedSegment != request.highlightedSegment) {
             highlightedSegment = request.highlightedSegment
+            // No reload here (reframe contract), so extra-interline routes aren't re-fetched — this
+            // reframe path is only hit for a same-route+direction re-tap, where the extras are unchanged.
+            extraSegments = request.extraSegments
+            // Re-draw against the already-loaded routes so a stale segment doesn't linger; each show*
+            // call publishes.
             showDirectionStops()
-            publishMapPresentation()
+            showDirectionPolylines()
         }
         request.initialDirectionId?.let { selectDirection(it) }
         request.focusTripId?.let { requestFocus(it) } ?: if (frameRoute) frameRouteOrSegment() else Unit
@@ -342,15 +385,38 @@ class RouteMapController(
         val id = routeId ?: return null
         val resolved = directionState as? DirectionState.Resolved ?: return null
         val poll = latestPoll ?: return null
+        // A stay-aboard interline is one shared block vehicle running consecutive trips across the ridden
+        // routes/directions, so don't direction-filter and merge each extra route's poll — the vehicle
+        // must show through every phase, not vanish when it flips direction/route at a seam (#2000).
+        val directionFilter = if (isInterlineComposite) null else resolved.directionId
+        val leaderVehicles = extrapolatedVehicles(
+            poll.response,
+            setOf(id),
+            now,
+            directionFilter,
+            includeDataFixPoint,
+            tripObservationRepository::lookupTripState
+        )
+        val extraVehicles = if (isInterlineComposite) {
+            extraPolls.flatMap { (extraRouteId, extraPoll) ->
+                extrapolatedVehicles(
+                    extraPoll.response,
+                    setOf(extraRouteId),
+                    now,
+                    null,
+                    includeDataFixPoint,
+                    tripObservationRepository::lookupTripState
+                )
+            }
+        } else {
+            emptyList()
+        }
+        val merged = leaderVehicles + extraVehicles
+        // Dedup only in the composite case (the one shared vehicle can briefly surface in two routes'
+        // polls at a seam); the plain path stays byte-identical to before.
+        val vehicles = if (isInterlineComposite) merged.distinctBy { it.status.activeTripId } else merged
         return MapVehicles(
-            markers = extrapolatedVehicles(
-                poll.response,
-                setOf(id),
-                now,
-                resolved.directionId,
-                includeDataFixPoint,
-                tripObservationRepository::lookupTripState
-            ).map { it.toMarker() },
+            markers = vehicles.map { it.toMarker() },
             response = poll.response
         )
     }
@@ -474,13 +540,18 @@ class RouteMapController(
     fun stop() {
         routeJob?.cancel()
         vehicleJob?.cancel()
+        extraVehicleJobs.forEach { it.cancel() }
         selectionJob?.cancel()
         routeJob = null
         vehicleJob = null
+        extraVehicleJobs = emptyList()
         selectionJob = null
         routeId = null
         directionStopId = null
         highlightedSegment = emptyList()
+        extraSegments = emptyList()
+        extraRouteMaps = emptyMap()
+        extraPolls = emptyMap()
         initialDirectionOverride = null
         routeStops = emptyList()
         routeStopRoutes = emptyList()
@@ -710,15 +781,21 @@ class RouteMapController(
             // The repository narrows the stops (and the vehicle direction id) to directionStopId's
             // direction when set; a whole-route launch passes null and gets the full route back.
             val result = routeRepository.getRoute(id, directionStopId)
+            // Load each *other* route a stay-aboard interline continues onto (a self-interline segment
+            // reuses the leader's map, so it's excluded here), so their shapes/stops/vehicles can be drawn
+            // alongside (#2000). A failed extra load is dropped — the leg still frames its geometry.
+            val extras = extraSegments.map { it.routeId }.distinct().filter { it != id }
+                .mapNotNull { extraRouteId -> routeRepository.getRoute(extraRouteId).getOrNull()?.let { extraRouteId to it } }
+                .toMap()
             // Clear the spinner once the load resolves — before dispatching, so it's cleared on the
             // error path too (mirrors StopsMapController). A cancelled load never reaches here; the
             // view transition that cancelled it clears progress via leaveCurrentView().
             host.setProgress(false)
-            onRouteLoaded(result, zoomToRoute)
+            onRouteLoaded(result, extras, zoomToRoute)
         }
     }
 
-    private fun onRouteLoaded(result: Result<RouteMap?>, zoomToRoute: Boolean) {
+    private fun onRouteLoaded(result: Result<RouteMap?>, extraRoutes: Map<String, RouteMap>, zoomToRoute: Boolean) {
         // The route load has resolved (success or failure), so release the vehicle layer the sampler held
         // back in direction mode: fall back to Resolved(null) — vehicles unfiltered — and publish the set
         // so the renderer reconciles them, rather than leaving them hidden until the next poll. The
@@ -739,6 +816,9 @@ class RouteMapController(
         // Retain the full route so a later direction switch re-filters locally (no reload). The shown
         // direction prefers a valid restore override (a persisted user switch), else the anchor stop's.
         routeStops = routeMap.stops
+        // Retain the interline's other loaded routes so the extra-segment shape/stop/vehicle helpers can
+        // read them (a self-interline segment reads the leader's routeShape instead) (#2000).
+        extraRouteMaps = extraRoutes
         routeStopRoutes = routeMap.routes
         directions = routeMap.directions
         routeShape = routeMap
@@ -770,17 +850,49 @@ class RouteMapController(
         if (segment.isDrawableSegment()) host.frameItineraryLeg(segment) else host.frameRoute()
     }
 
-    /** Retain the route's stops narrowed to [currentDirectionId] as the base route presentation. */
+    /**
+     * Retain the ride's stops as the base route presentation: the leader route's stops narrowed to
+     * [currentDirectionId], plus — for a stay-aboard interline (#2000) — each extra segment's route/
+     * direction stops, all clipped to the ridden [highlightedSegment]. Each stop keeps its own
+     * route+direction key so cross-route stops colour correctly.
+     */
     private fun showDirectionStops() {
-        val route = routeId ?: return
-        val stops = routeStops.stopsForDirection(currentDirectionId).onSegment(highlightedSegment)
+        val leaderRoute = routeId ?: return
+        val stopsById = LinkedHashMap<String, ObaStop>()
+        val keysById = HashMap<String, MutableSet<RouteDirectionKey>>()
+        fun collect(stops: List<ObaStop>, key: RouteDirectionKey) {
+            for (stop in stops) {
+                stopsById.putIfAbsent(stop.id, stop)
+                keysById.getOrPut(stop.id) { mutableSetOf() }.add(key)
+            }
+        }
+        collect(
+            routeStops.stopsForDirection(currentDirectionId).onSegment(highlightedSegment),
+            RouteDirectionKey(leaderRoute, currentDirectionId)
+        )
+        // Extra interline legs contribute their own route/direction's stops on the ridden segment; a
+        // self-interline segment reads the leader's route (its other direction), a cross-route one its
+        // separately-loaded route.
+        for (segment in extraSegments) {
+            val route = segment.routeMap() ?: continue
+            val directionId = segment.directionId()
+            collect(
+                route.stops.stopsForDirection(directionId).onSegment(highlightedSegment),
+                RouteDirectionKey(segment.routeId, directionId)
+            )
+        }
+        val stops = stopsById.values.toList()
         baseStopPresentation = RouteStopPresentation(
             stops = stops,
-            routes = routeStopRoutes,
-            routeDirectionsByStopId = stops.associate {
-                it.id to setOf(RouteDirectionKey(route, currentDirectionId))
-            },
-            projectedPoints = projectStopsOntoShape(stops)
+            routes = (routeStopRoutes + extraRouteMaps.values.flatMap { it.routes }).distinctBy { it.id },
+            routeDirectionsByStopId = keysById.mapValues { it.value.toSet() },
+            // An interline ride spans multiple direction shapes, so project onto the ridden segment (the
+            // emphasized line every leg's stops sit on); a plain leg keeps projecting onto its own shape.
+            projectedPoints = if (isInterlineComposite) {
+                projectStopsOntoPolylines(stops, listOf(highlightedSegment))
+            } else {
+                projectStopsOntoShape(stops)
+            }
         )
         publishMapPresentation()
     }
@@ -804,8 +916,10 @@ class RouteMapController(
      * arrows are stamped only when the direction's own travel-ordered shape is used — never on the
      * whole-route merged fallback (a direction that carried no shape on the wire).
      */
-    private fun directionPolylines(directionId: Int?): List<RoutePolyline> {
-        val route = routeShape ?: return emptyList()
+    private fun directionPolylines(directionId: Int?): List<RoutePolyline> = routeShape?.let { directionPolylines(it, directionId) }.orEmpty()
+
+    /** [directionPolylines] against an explicit [route] map — used to draw an interline's extra routes. */
+    private fun directionPolylines(route: RouteMap, directionId: Int?): List<RoutePolyline> {
         val shape = route.shapeForDirection(directionId)
         return shape.polylines.map { points ->
             focusedRoutePolyline(
@@ -819,7 +933,13 @@ class RouteMapController(
     /** Re-draw the base route for [currentDirectionId]. Called on load and on every direction switch. */
     private fun showDirectionPolylines() {
         if (routeShape == null) return
-        basePolylines = directionPolylines(currentDirectionId)
+        // A stay-aboard interline (#2000) draws each extra segment's own route/direction shape alongside
+        // the leader's, as faint context, so the routes/directions the rider stays aboard through are all
+        // visible. An ordinary leg draws only its single direction.
+        basePolylines = directionPolylines(currentDirectionId) +
+            extraSegments.flatMap { segment ->
+                segment.routeMap()?.let { directionPolylines(it, segment.directionId()) }.orEmpty()
+            }
         publishMapPresentation()
     }
 
@@ -856,6 +976,7 @@ class RouteMapController(
      */
     private fun startVehiclePolling(initialDelayMs: Long) {
         vehicleJob?.cancel()
+        extraVehicleJobs.forEach { it.cancel() }
         val id = routeId ?: return
         vehicleJob = scope.launch {
             if (initialDelayMs > 0L) {
@@ -870,6 +991,20 @@ class RouteMapController(
             tripObservationRepository.routeVehiclesStream(id, VEHICLE_REFRESH_PERIOD_MS).collect { response ->
                 latestPoll = VehiclePoll(response, SystemClock.elapsedRealtimeNanos())
                 publishVehicleSet()
+            }
+        }
+        // A cross-route interline (#2000) polls each other route too, so the one shared block vehicle
+        // shows through every phase; sampleVehicles merges these polls. (A self-interline segment shares
+        // the leader's route, so it's excluded — the leader poll already covers it.)
+        extraVehicleJobs = extraSegments.map { it.routeId }.distinct().filter { it != id }.map { extraRouteId ->
+            scope.launch {
+                if (initialDelayMs > 0L) {
+                    delay(initialDelayMs)
+                }
+                tripObservationRepository.routeVehiclesStream(extraRouteId, VEHICLE_REFRESH_PERIOD_MS).collect { response ->
+                    extraPolls = extraPolls + (extraRouteId to VehiclePoll(response, SystemClock.elapsedRealtimeNanos()))
+                    publishVehicleSet()
+                }
             }
         }
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
@@ -21,6 +21,8 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -116,6 +118,13 @@ class RouteMapController(
     // focus draws each segment's shape + stops and shows the shared block vehicle across them. Empty for
     // every ordinary route launch. Set in start(); the maps/polls below are (re)built as the routes load.
     private var extraSegments: List<RiddenSegment> = emptyList()
+
+    // The distinct *other* routes an interline's [extraSegments] continue onto — the cross-route ids to
+    // load and poll alongside the leader. A self-interline segment reuses the leader's [routeId], so it's
+    // excluded here (its shape/stops/vehicles already come from the leader). Read by both the route load
+    // and the vehicle poll so the two can't silently diverge.
+    private val extraRouteIds: List<String>
+        get() = extraSegments.map { it.routeId }.distinct().filterNot { it == routeId }
 
     // Loaded route maps for the extra segments' *other* routes, keyed by routeId (a self-interline
     // segment reuses the leader's [routeShape], so only distinct cross-route ids land here). (Re)built by
@@ -328,10 +337,13 @@ class RouteMapController(
         // e.g. tapping a different leg of the same route. Re-emphasize the polyline and re-filter the
         // shown stops so a stale segment doesn't linger. start() sets this unconditionally; here we only
         // republish when it actually changes.
-        if (highlightedSegment != request.highlightedSegment) {
+        if (highlightedSegment != request.highlightedSegment || extraSegments != request.extraSegments) {
             highlightedSegment = request.highlightedSegment
-            // No reload here (reframe contract), so extra-interline routes aren't re-fetched — this
-            // reframe path is only hit for a same-route+direction re-tap, where the extras are unchanged.
+            // Move both segment fields together so a redraw can't key off a fresh highlightedSegment while
+            // extraSegments stays stale (or vice versa). No reload here (reframe contract), so extra-interline
+            // routes aren't re-fetched — in practice this path is only hit for a same-route+direction re-tap,
+            // where any changed extras continue onto already-loaded routes (a genuinely new cross-route id
+            // would need a full re-enter, per the reframe/re-enter split in MapViewModel.toRoute).
             extraSegments = request.extraSegments
             // Re-draw against the already-loaded routes so a stale segment doesn't linger; each show*
             // call publishes.
@@ -778,15 +790,19 @@ class RouteMapController(
         val id = routeId ?: return
         routeJob?.cancel()
         routeJob = scope.launch {
-            // The repository narrows the stops (and the vehicle direction id) to directionStopId's
-            // direction when set; a whole-route launch passes null and gets the full route back.
-            val result = routeRepository.getRoute(id, directionStopId)
-            // Load each *other* route a stay-aboard interline continues onto (a self-interline segment
-            // reuses the leader's map, so it's excluded here), so their shapes/stops/vehicles can be drawn
-            // alongside (#2000). A failed extra load is dropped — the leg still frames its geometry.
-            val extras = extraSegments.map { it.routeId }.distinct().filter { it != id }
-                .mapNotNull { extraRouteId -> routeRepository.getRoute(extraRouteId).getOrNull()?.let { extraRouteId to it } }
-                .toMap()
+            // Fetch the leader and every *other* interline route (a self-interline segment reuses the
+            // leader's map, so [extraRouteIds] excludes it) concurrently, so an N-route interline is one
+            // round trip's wait rather than N+1 sequential ones (#2000). The repository narrows the leader's
+            // stops (and the vehicle direction id) to directionStopId's direction when set; a whole-route
+            // launch passes null and gets the full route back. A failed extra load is dropped — the leg
+            // still frames its geometry.
+            val (result, extras) = coroutineScope {
+                val leader = async { routeRepository.getRoute(id, directionStopId) }
+                val extraLoads = extraRouteIds.map { extraRouteId ->
+                    async { routeRepository.getRoute(extraRouteId).getOrNull()?.let { extraRouteId to it } }
+                }
+                leader.await() to extraLoads.awaitAll().filterNotNull().toMap()
+            }
             // Clear the spinner once the load resolves — before dispatching, so it's cleared on the
             // error path too (mirrors StopsMapController). A cancelled load never reaches here; the
             // view transition that cancelled it clears progress via leaveCurrentView().
@@ -996,7 +1012,7 @@ class RouteMapController(
         // A cross-route interline (#2000) polls each other route too, so the one shared block vehicle
         // shows through every phase; sampleVehicles merges these polls. (A self-interline segment shares
         // the leader's route, so it's excluded — the leader poll already covers it.)
-        extraVehicleJobs = extraSegments.map { it.routeId }.distinct().filter { it != id }.map { extraRouteId ->
+        extraVehicleJobs = extraRouteIds.map { extraRouteId ->
             scope.launch {
                 if (initialDelayMs > 0L) {
                     delay(initialDelayMs)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/ShowRouteRequest.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/ShowRouteRequest.kt
@@ -39,11 +39,17 @@ import org.onebusaway.android.util.GeoPoint
  * @property highlightedSegment when non-empty (a trip-plan transit leg drilled into route focus), the
  *   polyline of the board→alight portion the user rides — drawn as a thick line over the full route so
  *   the traveled segment stands out. Empty for every non-directions "show route" caller.
+ * @property extraSegments the *additional* ridden legs of a stay-aboard interline (#2000), beyond the
+ *   leader ([routeId] + [directionStopId]). Non-empty only for a folded interline card: a self-interline
+ *   (12→12) carries a segment with the same [routeId] (its other direction); a cross-route interline
+ *   (45→75) carries a different route to load and draw alongside. The route focus draws each segment's
+ *   shape + stops and shows the shared block vehicle across them all. Empty for every ordinary caller.
  */
 data class ShowRouteRequest(
     val routeId: String,
     val directionStopId: String? = null,
     val focusTripId: String? = null,
     val initialDirectionId: Int? = null,
-    val highlightedSegment: List<GeoPoint> = emptyList()
+    val highlightedSegment: List<GeoPoint> = emptyList(),
+    val extraSegments: List<RiddenSegment> = emptyList()
 )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
@@ -33,6 +33,7 @@ import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 import org.onebusaway.android.directions.model.TripItinerary
 import org.onebusaway.android.location.LocationRepository
+import org.onebusaway.android.map.RiddenSegment
 import org.onebusaway.android.map.ShowRouteRequest
 import org.onebusaway.android.map.render.MapViewport
 import org.onebusaway.android.models.FocusedTrip
@@ -608,11 +609,14 @@ class HomeViewModel @Inject constructor(
             focusItineraryLegOnMap(fallbackLegPoints)
             return
         }
-        // Anchor to the boarding stop so the route shows only the ridden direction.
+        // Anchor to the boarding stop so the route shows only the ridden direction. A folded interline
+        // (#2000) carries its extra ridden legs so the map draws each continued-onto route/direction and
+        // the shared vehicle across them; empty for an ordinary leg (plain single-route focus).
         focusItineraryRouteLegOnMap(
             routeId,
             segment = fallbackLegPoints,
-            directionStopId = routeLeg.board?.stopId
+            directionStopId = routeLeg.board?.stopId,
+            extraSegments = routeLeg.extraSegments
         )
     }
 
@@ -636,6 +640,7 @@ class HomeViewModel @Inject constructor(
         segment: List<GeoPoint> = emptyList(),
         directionStopId: String? = null,
         directionId: Int? = null,
+        extraSegments: List<RiddenSegment> = emptyList(),
         undoViewport: MapViewport? = null
     ) {
         enterDirectionsRouteFocus(
@@ -643,7 +648,8 @@ class HomeViewModel @Inject constructor(
                 routeId = routeId,
                 directionStopId = directionStopId,
                 initialDirectionId = directionId,
-                highlightedSegment = segment
+                highlightedSegment = segment,
+                extraSegments = extraSegments
             ),
             undoViewport
         )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/DirectionCardGrouping.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/DirectionCardGrouping.kt
@@ -56,18 +56,30 @@ object DirectionCardGrouping {
     ): List<DirectionItem> {
         val cards = ArrayList<DirectionItem>(legs.size)
         var cursor = 0
+        // Card numbers count *emitted* cards, not legs — an interlined leg is folded into the previous
+        // card rather than getting its own number (#2000), so numbering stays gap-free.
+        var cardNumber = 0
         legs.forEachIndexed { legIndex, leg ->
-            val cardNumber = legIndex + 1
             val legPoints = leg.decodedPoints()
             if (leg.mode?.isOnStreetNonTransit == true) {
                 val walk = flatDirections.getOrNull(cursor++) ?: return@forEachIndexed
-                cards += walkCard(cardNumber, walk, legPoints)
+                cards += walkCard(++cardNumber, walk, legPoints)
             } else {
                 val board = flatDirections.getOrNull(cursor++) ?: return@forEachIndexed
                 // Consume the generator's "get off" direction to keep the cursor aligned; the Board and
                 // Alight stops ride on the pre-resolved routeLeg and are rendered as the card's sub-items.
                 flatDirections.getOrNull(cursor++)
-                cards += transitCard(cardNumber, board, legPoints, routeLegRefs.getOrNull(legIndex))
+                if (leg.interlineWithPreviousLeg && cards.isNotEmpty()) {
+                    // A stay-aboard interline: the rider never leaves the vehicle. Fold this leg into the
+                    // previous (chain-leading) card — its polyline extends the card's frame; the chain's
+                    // final alight and any route-change rows already ride on that card's routeLeg (built
+                    // span-aware in TripResultsRepository). The generator's board/off directions here are
+                    // consumed only to keep the cursor aligned.
+                    val last = cards[cards.lastIndex]
+                    cards[cards.lastIndex] = last.copy(legPoints = last.legPoints + legPoints)
+                } else {
+                    cards += transitCard(++cardNumber, board, legPoints, routeLegRefs.getOrNull(legIndex))
+                }
             }
         }
         return cards

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/DirectionCardGrouping.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/DirectionCardGrouping.kt
@@ -56,6 +56,15 @@ object DirectionCardGrouping {
     ): List<DirectionItem> {
         val cards = ArrayList<DirectionItem>(legs.size)
         var cursor = 0
+        // Which legs fold into their chain leader — derived from Interlines.chains() (the same source of
+        // truth resolveRouteLegRefs uses) rather than the raw interlineWithPreviousLeg flag, so the two
+        // agree on exactly which legs merge. chains() defensively drops a leading/malformed continuation
+        // flag that has no valid transit predecessor; keying off it here means such a leg gets its own
+        // transit card (with its own route/board/alight info) instead of being silently folded into an
+        // unrelated preceding card (e.g. a walk) (#2000).
+        val foldedLegIndices = Interlines.chains(legs)
+            .flatMap { chain -> (chain.leaderIndex + 1)..chain.alightIndex }
+            .toSet()
         // Card numbers count *emitted* cards, not legs — an interlined leg is folded into the previous
         // card rather than getting its own number (#2000), so numbering stays gap-free.
         var cardNumber = 0
@@ -69,7 +78,7 @@ object DirectionCardGrouping {
                 // Consume the generator's "get off" direction to keep the cursor aligned; the Board and
                 // Alight stops ride on the pre-resolved routeLeg and are rendered as the card's sub-items.
                 flatDirections.getOrNull(cursor++)
-                if (leg.interlineWithPreviousLeg && cards.isNotEmpty()) {
+                if (legIndex in foldedLegIndices && cards.isNotEmpty()) {
                     // A stay-aboard interline: the rider never leaves the vehicle. Fold this leg into the
                     // previous (chain-leading) card — its polyline extends the card's frame; the chain's
                     // final alight and any route-change rows already ride on that card's routeLeg (built

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/Interlines.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/Interlines.kt
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.tripresults
+
+import org.onebusaway.android.directions.model.TripLeg
+import org.onebusaway.android.directions.model.routeDisplayShortName
+import org.onebusaway.android.util.parseObaHexColor
+
+/**
+ * Pure interline analysis over a trip's legs (#2000) — no `Context` / OBA-id resolution, so it's
+ * JVM-unit-testable. OTP2 splits one continuous vehicle ride into consecutive legs, flagging every leg
+ * after the first [TripLeg.interlineWithPreviousLeg] (same vehicle, passenger stays aboard). Two shapes
+ * matter:
+ *  - a **self-interline** — the same route reversing onto itself (identical `routeId` across the seam),
+ *    e.g. an inbound 12 that becomes an outbound 12; the rider never acts, so the seam is hidden;
+ *  - a **cross-route interline** — the vehicle changes to a *different* route while the rider stays
+ *    seated; surfaced as a "stay on board" transition rather than a get-off/get-on pair.
+ *
+ * Comparing `routeId` across a seam is an exact match on the canonical GTFS route id (not a heuristic):
+ * the [TripLeg.interlineWithPreviousLeg] flag is the sanctioned "same vehicle, stay aboard" signal, and
+ * equal ids mean it is literally the same route.
+ */
+internal object Interlines {
+
+    /**
+     * One continuous vehicle ride rendered as a single directions card: board at [leaderIndex]'s
+     * origin, alight at [alightIndex]'s destination. [transitionLegIndices] are the continuation legs
+     * whose route differs from the leg they continue from — the cross-route changes the rider is told
+     * to stay aboard through; a self-interline contributes none.
+     */
+    data class Chain(
+        val leaderIndex: Int,
+        val alightIndex: Int,
+        val transitionLegIndices: List<Int>
+    )
+
+    /**
+     * The transit chains in leg order. A chain leader is a transit leg that is not itself an interlined
+     * continuation; it absorbs the following [TripLeg.interlineWithPreviousLeg] transit legs. Non-transit
+     * legs (walk/bike/car) are not chains and don't appear here.
+     */
+    fun chains(legs: List<TripLeg>): List<Chain> {
+        val chains = ArrayList<Chain>()
+        var i = 0
+        while (i < legs.size) {
+            val leg = legs[i]
+            if (leg.mode?.isTransit != true || leg.interlineWithPreviousLeg) {
+                // Non-transit legs have no chain; an interlined continuation is absorbed by its leader
+                // (or, if it has none — malformed / leading — is skipped so it never leads a chain).
+                i++
+                continue
+            }
+            var end = i
+            val transitions = ArrayList<Int>()
+            while (end + 1 < legs.size && legs[end + 1].interlineWithPreviousLeg && legs[end + 1].mode?.isTransit == true) {
+                end++
+                if (legs[end].routeId != legs[end - 1].routeId) transitions += end
+            }
+            chains += Chain(leaderIndex = i, alightIndex = end, transitionLegIndices = transitions)
+            i = end + 1
+        }
+        return chains
+    }
+
+    /**
+     * One [RouteBadge] per distinct vehicle-and-route the transit legs use, in order: a self-interline
+     * folds to a single badge, a cross-route interline keeps both routes' badges.
+     */
+    fun routeBadges(legs: List<TripLeg>): List<RouteBadge> {
+        val badges = ArrayList<RouteBadge>()
+        legs.forEachIndexed { i, leg ->
+            if (leg.mode?.isTransit != true) return@forEachIndexed
+            val selfInterline = leg.interlineWithPreviousLeg && i > 0 && leg.routeId == legs[i - 1].routeId
+            if (selfInterline) return@forEachIndexed
+            badges += RouteBadge(
+                shortName = badgeShortName(leg),
+                // routeColor is a bare wire hex; tolerate a leading '#' just in case.
+                routeColor = parseObaHexColor(leg.routeColor?.removePrefix("#"))
+            )
+        }
+        return badges
+    }
+
+    /** The route's display short name, or empty — see [routeDisplayShortName]. */
+    fun badgeShortName(leg: TripLeg): String = leg.routeDisplayShortName().orEmpty()
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsRepository.kt
@@ -26,8 +26,8 @@ import org.onebusaway.android.directions.model.TripLeg
 import org.onebusaway.android.directions.model.TripMode
 import org.onebusaway.android.directions.model.TripPlace
 import org.onebusaway.android.directions.util.DirectionsGenerator
+import org.onebusaway.android.map.RiddenSegment
 import org.onebusaway.android.util.geoPointOrNull
-import org.onebusaway.android.util.parseObaHexColor
 import org.onebusaway.android.util.runCatchingCancellable
 
 /**
@@ -60,19 +60,11 @@ class DefaultTripResultsRepository @Inject constructor(
 
     /** Projects one [TripItinerary] into the structured [ItineraryOption] the card renders. */
     private fun summarize(itinerary: TripItinerary): ItineraryOption {
-        val transitLegs = itinerary.legs.filter { it.mode?.isTransit == true }
+        val badges = Interlines.routeBadges(itinerary.legs)
         // A transit trip shows route badges; a walk-only trip shows the walk glyph; anything else
         // (bike/car) keeps the legacy mode-label title.
         val mode = when {
-            transitLegs.isNotEmpty() -> ModeSummary.Routes(
-                transitLegs.map { leg ->
-                    RouteBadge(
-                        shortName = leg.badgeShortName(),
-                        // routeColor is a bare wire hex; tolerate a leading '#' just in case.
-                        routeColor = parseObaHexColor(leg.routeColor?.removePrefix("#"))
-                    )
-                }
-            )
+            badges.isNotEmpty() -> ModeSummary.Routes(badges)
             itinerary.legs.all { it.mode == TripMode.WALK } -> ModeSummary.Walk
             else -> ModeSummary.Label(DirectionsGenerator(itinerary.legs, context).itineraryTitle)
         }
@@ -88,9 +80,6 @@ class DefaultTripResultsRepository @Inject constructor(
         )
     }
 
-    /** The route's display short name (short name, else the route, else the id). */
-    private fun TripLeg.badgeShortName(): String = listOf(routeShortName, route, routeId).firstOrNull { !it.isNullOrEmpty() }.orEmpty()
-
     override suspend fun directionsFor(
         itinerary: TripItinerary
     ): Result<List<DirectionItem>> = withContext(Dispatchers.IO) {
@@ -100,20 +89,53 @@ class DefaultTripResultsRepository @Inject constructor(
             // transit leg's OTP route/stop ids are resolved to OBA ids here (a suspend, network-backed
             // step) so the drawer can highlight the route and show each stop's live ETAs.
             val flat = DirectionsGenerator(itinerary.legs, context).directions
-            val routeLegRefs = itinerary.legs.map { leg ->
-                if (leg.mode?.isOnStreetNonTransit == true) null else resolveRouteLeg(leg)
-            }
+            val routeLegRefs = resolveRouteLegRefs(itinerary.legs)
             DirectionCardGrouping.groupByLeg(itinerary.legs, flat, routeLegRefs)
         }
     }
 
-    /** Resolve a transit leg's OTP route/stop ids onto the OBA ids the drawer's map + ETA strips need. */
-    private suspend fun resolveRouteLeg(leg: TripLeg): RouteLegRef = RouteLegRef(
-        routeId = otpObaIdResolver.obaRouteId(leg.routeId, leg.agencyId, leg.agencyName),
-        headsign = leg.headsign,
-        board = leg.from.resolveStop(leg),
-        alight = leg.to.resolveStop(leg)
-    )
+    /**
+     * Resolves one [RouteLegRef] per transit chain ([Interlines.chains]), aligned to [legs] (non-transit
+     * legs and interlined continuations are null). A stay-aboard interline (#2000) collapses into the
+     * chain leader's ref: it boards at the leader's origin, alights at the *last* leg's destination, and
+     * lists each cross-route change ([RouteLegRef.interlineTransitions]) so the rider is told to stay
+     * aboard rather than get off and reboard. A self-interline (same route) leaves no transition, hiding
+     * the seam entirely.
+     */
+    private suspend fun resolveRouteLegRefs(legs: List<TripLeg>): List<RouteLegRef?> {
+        val refs = MutableList<RouteLegRef?>(legs.size) { null }
+        for (chain in Interlines.chains(legs)) {
+            val leader = legs[chain.leaderIndex]
+            val transitions = chain.transitionLegIndices.map { j ->
+                InterlineTransition(
+                    routeShortName = Interlines.badgeShortName(legs[j]),
+                    headsign = legs[j].headsign,
+                    stop = legs[j].from.resolveStop(legs[j])
+                )
+            }
+            // The ride's legs beyond the leader — each continued onto on the same vehicle, boarding at
+            // its own seam stop. The map focus loads/draws each (reusing the leader's route when the id
+            // matches — a self-interline) and shows the shared vehicle across them (#2000). A leg whose
+            // route can't be resolved to an OBA id is dropped (it can't be loaded), same as the leader.
+            val extraSegments = ((chain.leaderIndex + 1)..chain.alightIndex).mapNotNull { j ->
+                val routeId = otpObaIdResolver.obaRouteId(legs[j].routeId, legs[j].agencyId, legs[j].agencyName)
+                    ?: return@mapNotNull null
+                RiddenSegment(
+                    routeId = routeId,
+                    anchorStopId = otpObaIdResolver.obaStopId(legs[j].from.stopId, legs[j].agencyId, legs[j].agencyName)
+                )
+            }
+            refs[chain.leaderIndex] = RouteLegRef(
+                routeId = otpObaIdResolver.obaRouteId(leader.routeId, leader.agencyId, leader.agencyName),
+                headsign = leader.headsign,
+                board = leader.from.resolveStop(leader),
+                alight = legs[chain.alightIndex].to.resolveStop(legs[chain.alightIndex]),
+                interlineTransitions = transitions,
+                extraSegments = extraSegments
+            )
+        }
+        return refs
+    }
 
     private suspend fun TripPlace.resolveStop(leg: TripLeg) = RouteStopRef(
         stopId = otpObaIdResolver.obaStopId(stopId, leg.agencyId, leg.agencyName),

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
@@ -481,6 +481,11 @@ private fun DirectionRow(
                     )
                     stopEtaStrip(routeLeg, stop, item.legPoints)
                 }
+                // Stay-aboard interlines onto a different route (#2000): the rider stays seated while
+                // the vehicle changes route, so this reads "Stay on board…" rather than get-off/get-on.
+                routeLeg.interlineTransitions.forEach { transition ->
+                    InterlineRow(transition, onFocusPoint)
+                }
                 routeLeg.alight?.let { stop ->
                     RouteStopLabel(
                         R.string.step_by_step_transit_get_off,
@@ -548,6 +553,50 @@ private fun RouteStopLabel(actionRes: Int, stopName: String?, onClick: () -> Uni
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier.weight(1f)
         )
+    }
+}
+
+/**
+ * A stay-aboard interline row (#2000): the vehicle keeps going but its route changes, so the rider is
+ * told to stay on board — never to get off and reboard. Shows the new route label (short name + "to
+ * headsign") and the seam stop where the change happens; tapping zooms the map to that stop.
+ */
+@Composable
+private fun InterlineRow(transition: InterlineTransition, onFocusPoint: (GeoPoint) -> Unit) {
+    val routeLabel = buildString {
+        append(transition.routeShortName.orEmpty())
+        if (!transition.headsign.isNullOrEmpty()) {
+            append(" ")
+            append(stringResource(R.string.step_by_step_transit_connector_headsign))
+            append(" ")
+            append(transition.headsign)
+        }
+    }.trim()
+    val stop = transition.stop
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { stop.point?.let(onFocusPoint) }
+            .padding(start = 36.dp, end = 12.dp, top = 8.dp, bottom = 4.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        DirectionIcon(R.drawable.ic_continue)
+        Spacer(Modifier.width(12.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = stringResource(R.string.step_by_step_transit_interline, routeLabel),
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            stop.name?.let { name ->
+                Text(
+                    text = "${stringResource(R.string.step_by_step_transit_connector_stop_name)} $name",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
     }
 }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
@@ -15,6 +15,7 @@
  */
 package org.onebusaway.android.ui.tripresults
 
+import org.onebusaway.android.map.RiddenSegment
 import org.onebusaway.android.time.ServerTime
 import org.onebusaway.android.util.GeoPoint
 
@@ -94,7 +95,29 @@ data class RouteLegRef(
     val routeId: String?,
     val headsign: String?,
     val board: RouteStopRef?,
-    val alight: RouteStopRef?
+    val alight: RouteStopRef?,
+    // Mid-ride route changes on one continuous vehicle (stay-aboard interlines onto a *different*
+    // route, #2000), in order between [board] and [alight]. Empty for an ordinary transit leg and for
+    // a self-interline (a route reversing onto itself) — whose seam is folded away silently.
+    val interlineTransitions: List<InterlineTransition> = emptyList(),
+    // The *additional* ridden legs beyond the leader ([routeId] + [board]) when this card folds a
+    // stay-aboard interline (#2000): each names the route continued onto and the seam stop boarded
+    // there. The map focus draws each segment's shape + stops and the shared vehicle across them.
+    // Empty for an ordinary leg. Carried straight onto [org.onebusaway.android.map.ShowRouteRequest].
+    val extraSegments: List<RiddenSegment> = emptyList()
+)
+
+/**
+ * A stay-aboard interline onto a **different** route within one continuous vehicle ride (#2000): at
+ * [stop] the vehicle changes to route [routeShortName] (heading to [headsign]) and the passenger stays
+ * seated. Rendered as a distinct row between Board and Alight so the directions never tell the rider to
+ * get off and reboard. Self-interlines (same route reversing onto itself) produce no transition — the
+ * seam vanishes entirely.
+ */
+data class InterlineTransition(
+    val routeShortName: String?,
+    val headsign: String?,
+    val stop: RouteStopRef
 )
 
 /** A transit stop reached on a leg — its OBA id (for arrivals), display name, code, and location. */

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -974,6 +974,9 @@
     <!-- Transit instruction start -->
     <string name="step_by_step_transit_get_on">Get on</string>
     <string name="step_by_step_transit_get_off">Get off</string>
+    <!-- Shown when the trip stays aboard the same vehicle but its route changes (a stay-aboard
+         interline, #2000); %1$s is the new route label, e.g. "12 to Downtown". -->
+    <string name="step_by_step_transit_interline">Stay on board — the vehicle becomes %1$s</string>
     <!--                This is exactly the formula that should be used, because the app won't include
                     the destination stop under this text, so would be best to avoid expressions like
                      "stops to destination". For example in the trip Barcelona/Paris/London/New York,

--- a/onebusaway-android/src/test/java/org/onebusaway/android/api/Otp2PlanDecodeTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/api/Otp2PlanDecodeTest.kt
@@ -18,6 +18,7 @@ package org.onebusaway.android.api
 import java.time.OffsetDateTime
 import kotlin.time.Duration.Companion.seconds
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
@@ -50,6 +51,7 @@ class Otp2PlanDecodeTest {
             duration = 120.0,
             distance = 123.4,
             realTime = null,
+            interlineWithPreviousLeg = null,
             start = PlanQuery.Start(scheduledTime = "2026-07-11T10:00:00-07:00", estimated = null),
             end = PlanQuery.End(scheduledTime = "2026-07-11T10:02:00-07:00", estimated = null),
             from = from(place(name = "Origin", lat = 47.6, lon = -122.3)),
@@ -82,6 +84,7 @@ class Otp2PlanDecodeTest {
             duration = 600.0,
             distance = null,
             realTime = true,
+            interlineWithPreviousLeg = true,
             start = PlanQuery.Start(
                 scheduledTime = "2026-07-11T10:02:00-07:00",
                 estimated = PlanQuery.Estimated(time = "2026-07-11T10:02:30-07:00", delay = "PT30S")
@@ -136,6 +139,8 @@ class Otp2PlanDecodeTest {
         assertEquals(iso("2026-07-11T10:00:00-07:00"), walk.startTime)
         assertEquals(iso("2026-07-11T10:02:00-07:00"), walk.endTime)
         assertEquals("Origin", walk.from.name)
+        // A null wire `interlineWithPreviousLeg` maps to false (an ordinary leg, no stay-aboard seam).
+        assertFalse(walk.interlineWithPreviousLeg)
         assertEquals(47.6, walk.from.lat!!, 1e-6)
         // No stop/rentalVehicle/vehicleParking/vehicleRentalStation on the origin place -> NORMAL.
         assertEquals(TripVertexType.NORMAL, walk.from.vertexType)
@@ -157,6 +162,7 @@ class Otp2PlanDecodeTest {
         assertEquals("Metro", bus.agencyName)
         assertEquals("Downtown", bus.headsign)
         assertEquals("1_trip_5", bus.tripId)
+        assertTrue("interlineWithPreviousLeg maps through from the wire", bus.interlineWithPreviousLeg)
         // start.estimated is present (real-time delay) — endTime/startTime prefer estimated.time.
         assertEquals(iso("2026-07-11T10:02:30-07:00"), bus.startTime)
         assertEquals(30.seconds, bus.departureDelay)
@@ -191,6 +197,7 @@ class Otp2PlanDecodeTest {
             duration = 60.0,
             distance = 10.0,
             realTime = false,
+            interlineWithPreviousLeg = null,
             start = PlanQuery.Start(scheduledTime = "2026-07-11T10:00:00-07:00", estimated = null),
             end = PlanQuery.End(scheduledTime = "2026-07-11T10:01:00-07:00", estimated = null),
             from = from(place(name = "X", lat = 1.0, lon = 2.0)),

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/Otp2PlanResolveTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/Otp2PlanResolveTest.kt
@@ -114,6 +114,7 @@ class Otp2PlanResolveTest {
             duration = 2400.0,
             distance = 3200.0,
             realTime = null,
+            interlineWithPreviousLeg = null,
             start = PlanQuery.Start(scheduledTime = "2026-07-11T10:00:00-07:00", estimated = null),
             end = PlanQuery.End(scheduledTime = "2026-07-11T10:40:00-07:00", estimated = null),
             from = from("Origin", 47.60, -122.30),

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/DirectionCardGroupingTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/DirectionCardGroupingTest.kt
@@ -166,4 +166,37 @@ class DirectionCardGroupingTest {
             .groupByLeg(listOf(transitLeg), listOf(boardDir, alightDir), listOf(transitRef)).single()
         assertEquals(transitRef, transit.routeLeg)
     }
+
+    // A stay-aboard continuation of [transitLeg] onto a second leg — the interlined leg the repository
+    // would fold away. Its own routeLegRef is null (the chain leader's ref spans the whole ride).
+    private val interlinedLeg = transitLeg.copy(interlineWithPreviousLeg = true)
+
+    @Test
+    fun interlinedLeg_isFoldedIntoTheLeaderCard_notItsOwn() {
+        // Two transit legs sharing a vehicle (a self-interline) render as ONE card, so the directions
+        // never say "get off … get on" at the seam (#2000).
+        val cards = DirectionCardGrouping.groupByLeg(
+            legs = listOf(transitLeg, interlinedLeg),
+            flatDirections = listOf(boardDir, alightDir, boardDir, alightDir),
+            routeLegRefs = listOf(transitRef, null)
+        )
+        assertEquals(1, cards.size)
+        assertTrue(cards.single().isTransit)
+        assertEquals(transitRef, cards.single().routeLeg)
+    }
+
+    @Test
+    fun foldedCard_concatenatesTheChainPolyline_andNumbersSequentially() {
+        val cards = DirectionCardGrouping.groupByLeg(
+            legs = listOf(walkLeg, transitLeg, interlinedLeg),
+            flatDirections = listOf(walkDir, boardDir, alightDir, boardDir, alightDir),
+            routeLegRefs = listOf(null, transitRef, null)
+        )
+        assertEquals(2, cards.size)
+        // Walk card is "1.", the folded transit chain is "2." — numbering counts emitted cards, not legs.
+        assertTrue(cards[0].text.startsWith("1. "))
+        assertTrue(cards[1].text.startsWith("2. "))
+        // The chain card frames both legs' geometry (3 + 3 decoded points).
+        assertEquals(6, cards[1].legPoints.size)
+    }
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/InterlinesTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/InterlinesTest.kt
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.tripresults
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.onebusaway.android.directions.model.TripLeg
+import org.onebusaway.android.directions.model.TripMode
+
+/**
+ * JVM tests for [Interlines]: the pure analysis that folds a self-interline seam away and keeps a
+ * cross-route stay-aboard interline as one chain with a route-change transition (#2000).
+ */
+class InterlinesTest {
+
+    private fun transit(route: String, interline: Boolean = false) = TripLeg(
+        mode = TripMode.BUS,
+        routeId = route,
+        routeShortName = route,
+        interlineWithPreviousLeg = interline
+    )
+
+    private val walk = TripLeg(mode = TripMode.WALK)
+
+    @Test
+    fun selfInterline_foldsToOneChainWithNoTransition() {
+        // Inbound 12 becomes outbound 12 on the same vehicle: one continuous ride, seam hidden.
+        val chains = Interlines.chains(listOf(transit("12"), transit("12", interline = true)))
+        assertEquals(1, chains.size)
+        assertEquals(Interlines.Chain(leaderIndex = 0, alightIndex = 1, transitionLegIndices = emptyList()), chains.single())
+    }
+
+    @Test
+    fun crossRouteInterline_isOneChainWithATransitionAtTheSeam() {
+        // Board the 10, the vehicle becomes the 12 mid-ride: one chain, one route-change transition.
+        val chains = Interlines.chains(listOf(transit("10"), transit("12", interline = true)))
+        assertEquals(
+            Interlines.Chain(leaderIndex = 0, alightIndex = 1, transitionLegIndices = listOf(1)),
+            chains.single()
+        )
+    }
+
+    @Test
+    fun chainAlightsAtTheLastLeg_mixedSelfAndCrossRoute() {
+        // 10 -> 12 (change) -> 12 (self): one chain, alighting at leg 2, a single transition at leg 1.
+        val chains = Interlines.chains(
+            listOf(transit("10"), transit("12", interline = true), transit("12", interline = true))
+        )
+        assertEquals(
+            Interlines.Chain(leaderIndex = 0, alightIndex = 2, transitionLegIndices = listOf(1)),
+            chains.single()
+        )
+    }
+
+    @Test
+    fun nonInterlinedLegs_areSeparateChains() {
+        val chains = Interlines.chains(listOf(transit("8"), walk, transit("48")))
+        assertEquals(
+            listOf(
+                Interlines.Chain(0, 0, emptyList()),
+                Interlines.Chain(2, 2, emptyList())
+            ),
+            chains
+        )
+    }
+
+    @Test
+    fun aChainNestedBetweenWalkLegs_isFoundWithCorrectSpan() {
+        val chains = Interlines.chains(
+            listOf(walk, transit("12"), transit("12", interline = true), walk)
+        )
+        assertEquals(Interlines.Chain(1, 2, emptyList()), chains.single())
+    }
+
+    @Test
+    fun aLeadingInterlineFlagWithNoPredecessor_leadsNoChain() {
+        // Malformed input (nothing precedes it to stay aboard from): it must not become a chain leader.
+        assertEquals(emptyList<Interlines.Chain>(), Interlines.chains(listOf(transit("12", interline = true))))
+    }
+
+    @Test
+    fun routeBadges_foldSelfInterlineButKeepCrossRoute() {
+        assertEquals(
+            listOf("12"),
+            Interlines.routeBadges(listOf(transit("12"), transit("12", interline = true))).map { it.shortName }
+        )
+        assertEquals(
+            listOf("10", "12"),
+            Interlines.routeBadges(listOf(transit("10"), transit("12", interline = true))).map { it.shortName }
+        )
+        assertEquals(
+            listOf("8", "48"),
+            Interlines.routeBadges(listOf(transit("8"), walk, transit("48"))).map { it.shortName }
+        )
+    }
+}


### PR DESCRIPTION
Fixes #2000.

An OTP2 trip plan splits a **stay-aboard interline** — the rider stays on one vehicle as it runs consecutive trips in a block — into multiple legs, flagging each continuation `interlineWithPreviousLeg`. The app ignored that flag, so a **self-interline** (a route reversing onto itself — e.g. the 12 inbound → 12 outbound) told the rider to *get off at Pine & 9th and reboard the same 12*, and drilling into the leg only ever drew the leader route.

## What this does

**Wire + model.** Requests `interlineWithPreviousLeg` in `Plan.graphql`, carries it on `TripLeg` (default false on the OTP1 path).

**Directions drawer.** `Interlines` groups a leg's interline chain; the folded card:
- hides a **self-interline** seam entirely (no get-off/reboard), and
- renders a **cross-route** stay-aboard change as a distinct *"Stay on board — the vehicle becomes …"* row rather than an exit/board pair.

One route badge per distinct vehicle-and-route.

**Map focus.** A drilled-in leg carries its ridden `RiddenSegment`s beyond the leader route. `RouteMapController` now, for each segment:
- draws that route/direction's shape (reusing the leader's loaded route for a self-interline's other direction; **loading the other route** for a cross-route interline),
- shows that route/direction's stops on the ridden segment, each keyed to its own route+direction so cross-route stops colour correctly, and
- merges each route's vehicle poll (unfiltered, de-duped by trip) so the one **shared block vehicle** shows through every phase.

The ordinary single-route focus is byte-identical — everything keys off an empty extra-segment list.

Also collapses the duplicated route-short-name fallback into a shared `TripLeg.routeDisplayShortName()`.

## Testing
- `./gradlew :onebusaway-android:compileObaGoogleDebugKotlin -PwarningsAsErrors=true` clean; Spotless clean.
- Unit tests: `InterlinesTest` (chain grouping + badge folding), `DirectionCardGroupingTest` (fold into leader card, polyline concat, gap-free numbering), `Otp2PlanDecodeTest` (flag parses), `RouteDirectionFocusTest`.
- Installed on a device; **not yet verified on-screen against a live interlined itinerary** — reviewers with a region that returns one should sanity-check the render.

## Known rough edges (deliberately left)
- The thick *highlight* line is drawn in the leader route's colour across all portions (the faint per-route shapes underneath are correctly coloured).
- `reframe` does not re-fetch extra routes (only reachable via a same-leader-stop re-tap, which effectively never happens).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for stay-on-board interlined trips in directions and trip planning.
  * Interlined legs are grouped into clearer, consolidated direction cards with route badges.
  * Added in-step messaging for route changes, including tap-to-focus seam stops.
  * Maps now display connected interline segments, vehicles, stops, and polylines together.

* **Bug Fixes**
  * Improved route-name fallback handling and direction card numbering for interlined journeys.

* **Tests**
  * Added coverage for interline decoding, grouping, route badges, transitions, and map-related trip behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->