### PR TITLE
Surface the route schedule on the map's route focus banner (#40)

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/home/map/FocusBannerTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/home/map/FocusBannerTest.kt
@@ -15,15 +15,21 @@
  */
 package org.onebusaway.android.ui.home.map
 
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.longClick
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
 import androidx.test.platform.app.InstrumentationRegistry
 import kotlin.math.abs
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -65,6 +71,7 @@ class FocusBannerTest {
                 onRecenterStop = {},
                 onSelectDirection = {},
                 onFrameRoute = {},
+                onShowSchedule = {},
                 onHeight = {}
             )
         }
@@ -89,17 +96,21 @@ class FocusBannerTest {
         assertTrue((alertBounds.bottom - alertBounds.top).value >= 47.5f)
     }
 
-    @Test
-    fun routeBannerUsesRouteOrientationIcon() {
+    private fun setRouteBanner(
+        scheduleUrl: String? = null,
+        onShowSchedule: (String) -> Unit = {},
+        onFrameRoute: () -> Unit = {}
+    ) {
         composeRule.setContent {
             FocusBanner(
                 state = FocusBannerState.Route(
                     header = org.onebusaway.android.map.RouteHeader(
                         loading = false,
                         shortName = "40",
-                        longName = "Downtown - Northgate",
+                        longName = ROUTE_LONG_NAME,
                         agency = "Metro",
-                        routeId = "1_40"
+                        routeId = "1_40",
+                        scheduleUrl = scheduleUrl
                     ),
                     isFavorite = false
                 ),
@@ -109,10 +120,16 @@ class FocusBannerTest {
                 onClearSubordinateRoute = {},
                 onRecenterStop = {},
                 onSelectDirection = {},
-                onFrameRoute = {},
+                onFrameRoute = onFrameRoute,
+                onShowSchedule = onShowSchedule,
                 onHeight = {}
             )
         }
+    }
+
+    @Test
+    fun routeBannerUsesRouteOrientationIcon() {
+        setRouteBanner()
 
         composeRule.onNodeWithContentDescription(
             context.getString(R.string.route_shortcut)
@@ -120,6 +137,32 @@ class FocusBannerTest {
         composeRule.onNodeWithContentDescription(
             context.getString(R.string.bus_options_menu_add_star)
         ).assertIsDisplayed().assertHasClickAction()
+    }
+
+    @Test
+    fun longPressingRouteBannerOpensTheSchedule() {
+        var opened: String? = null
+        setRouteBanner(scheduleUrl = SCHEDULE_URL, onShowSchedule = { opened = it })
+
+        composeRule.onNodeWithText(ROUTE_LONG_NAME).performTouchInput { longClick() }
+
+        composeRule.onNodeWithText(
+            context.getString(R.string.bus_options_menu_show_route_schedule)
+        ).performClick()
+
+        assertEquals(SCHEDULE_URL, opened)
+    }
+
+    /** Tapping still frames the route, but with no schedule page there is nothing to long-press for. */
+    @Test
+    fun routeBannerHasNoLongPressWithoutASchedule() {
+        var framed = false
+        setRouteBanner(onFrameRoute = { framed = true })
+
+        val row = composeRule.onNodeWithText(ROUTE_LONG_NAME)
+        row.assert(SemanticsMatcher.keyNotDefined(SemanticsActions.OnLongClick))
+        row.performClick()
+        assertTrue(framed)
     }
 
     @Test
@@ -168,6 +211,7 @@ class FocusBannerTest {
                 onRecenterStop = {},
                 onSelectDirection = {},
                 onFrameRoute = {},
+                onShowSchedule = {},
                 onHeight = {}
             )
         }
@@ -186,5 +230,10 @@ class FocusBannerTest {
         val stopNameCenter = (stopName.top.value + stopName.bottom.value) / 2f
         val railCenter = (typeIconCenter + starCenter) / 2f
         assertTrue(abs(stopNameCenter - railCenter) < 1f)
+    }
+
+    private companion object {
+        const val ROUTE_LONG_NAME = "Downtown - Northgate"
+        const val SCHEDULE_URL = "https://example.org/route/40/schedule"
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
@@ -71,6 +71,9 @@ data class RouteHeader(
     /** The route's GTFS color (ARGB), or null when the agency didn't set one — the header's route
      *  badge chip takes its hue, matching the arrival rows. */
     val routeColor: Int? = null,
+    /** The route's schedule page ([ObaRoute.url]), or null when the agency publishes none — the
+     *  banner's long-press menu offers it when present. */
+    val scheduleUrl: String? = null,
     val directions: List<RouteMapDirection> = emptyList(),
     val currentDirectionId: Int? = null
 ) {
@@ -267,6 +270,7 @@ class MapViewModel @Inject constructor(
             agency = agencyName ?: "",
             routeId = route.id,
             routeColor = route.color,
+            scheduleUrl = route.url?.takeIf { it.isNotBlank() },
             directions = directions,
             currentDirectionId = currentDirectionId
         )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsScreen.kt
@@ -81,10 +81,10 @@ import org.onebusaway.android.models.RouteDirectionKey
 import org.onebusaway.android.time.ServerTime
 import org.onebusaway.android.time.WallTime
 import org.onebusaway.android.ui.arrivals.components.ArrivalRowCallbacks
-import org.onebusaway.android.ui.arrivals.components.MenuRow
 import org.onebusaway.android.ui.arrivals.components.RouteArrivalRow
 import org.onebusaway.android.ui.arrivals.dialogs.StopDetailsHost
 import org.onebusaway.android.ui.compose.components.LoadingContent
+import org.onebusaway.android.ui.compose.components.MenuRow
 import org.onebusaway.android.ui.icons.AppIcons
 import org.onebusaway.android.ui.nightlight.NightLightLauncher
 import org.onebusaway.android.util.DisplayFormat

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
@@ -78,6 +78,7 @@ import org.onebusaway.android.ui.compose.components.DirectionHeadsign
 import org.onebusaway.android.ui.compose.components.FavoriteStarButton
 import org.onebusaway.android.ui.compose.components.LineBadge
 import org.onebusaway.android.ui.compose.components.MaterialSymbols
+import org.onebusaway.android.ui.compose.components.MenuRow
 import org.onebusaway.android.ui.compose.components.rememberRouteBadgeColors
 import org.onebusaway.android.ui.compose.theme.ObaTheme
 import org.onebusaway.android.util.DisplayFormat
@@ -435,16 +436,6 @@ internal fun RouteActionsMenu(
             }
         }
     }
-}
-
-/** A labelled menu item with an optional decorative leading [icon]. */
-@Composable
-internal fun MenuRow(textRes: Int, icon: ImageVector? = null, onClick: () -> Unit) {
-    DropdownMenuItem(
-        text = { Text(stringResource(textRes)) },
-        onClick = onClick,
-        leadingIcon = icon?.let { { Icon(imageVector = it, contentDescription = null) } }
-    )
 }
 
 private val PillShape = RoundedCornerShape(6.dp)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStrip.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStrip.kt
@@ -73,6 +73,7 @@ import org.onebusaway.android.ui.arrivals.ArrivalActions
 import org.onebusaway.android.ui.arrivals.ArrivalInfo
 import org.onebusaway.android.ui.compose.components.CenteredLongPressMenu
 import org.onebusaway.android.ui.compose.components.MaterialSymbols
+import org.onebusaway.android.ui.compose.components.MenuRow
 import org.onebusaway.android.ui.compose.components.ScrollChevronGutter
 import org.onebusaway.android.ui.compose.components.tightLineStyle
 import org.onebusaway.android.ui.compose.theme.ObaTheme

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/CenteredLongPressMenu.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/CenteredLongPressMenu.kt
@@ -20,10 +20,15 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 
@@ -51,4 +56,14 @@ internal fun CenteredLongPressMenu(
             Column(Modifier.padding(vertical = 8.dp), content = content)
         }
     }
+}
+
+/** A labelled menu item with an optional decorative leading [icon]. */
+@Composable
+internal fun MenuRow(textRes: Int, icon: ImageVector? = null, onClick: () -> Unit) {
+    DropdownMenuItem(
+        text = { Text(stringResource(textRes)) },
+        onClick = onClick,
+        leadingIcon = icon?.let { { Icon(imageVector = it, contentDescription = null) } }
+    )
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -128,6 +128,7 @@ import org.onebusaway.android.ui.tutorial.TutorialOverlay
 import org.onebusaway.android.ui.tutorial.WelcomeTutorial
 import org.onebusaway.android.ui.tutorial.rememberTutorialState
 import org.onebusaway.android.ui.tutorial.tutorialAnchor
+import org.onebusaway.android.util.ExternalIntents
 import org.onebusaway.android.util.GeoPoint
 import org.onebusaway.android.util.geoPointOrNull
 
@@ -987,6 +988,7 @@ private fun BoxScope.HomeMapOverlays(
     // clearance, but the map's top-padding derivation needs the card's bottom edge in map coordinates,
     // so add both the status-bar inset and chrome clearance back onto its reported height.
     if (focusBannerState != null) {
+        val context = LocalContext.current
         FocusBanner(
             state = focusBannerState,
             onClose = onCloseFocus,
@@ -996,6 +998,9 @@ private fun BoxScope.HomeMapOverlays(
             onRecenterStop = onRecenterStop,
             onSelectDirection = onSelectRouteDirection,
             onFrameRoute = onFrameRoute,
+            // Same destination as the arrivals drawer's route menu, wired locally rather than through
+            // HomeActivityActions — the browser hand-off needs nothing but a Context.
+            onShowSchedule = { url -> ExternalIntents.goToUrl(context, url) },
             onHeight = { h -> onFocusBannerBottom(h + focusBannerTopPx) },
             modifier = Modifier
                 .align(Alignment.TopCenter)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/FocusBanner.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/FocusBanner.kt
@@ -17,7 +17,9 @@ package org.onebusaway.android.ui.home.map
 
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -35,6 +37,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -70,8 +73,11 @@ import org.onebusaway.android.R
 import org.onebusaway.android.map.RouteHeader
 import org.onebusaway.android.models.RouteMapDirection
 import org.onebusaway.android.models.WheelchairBoarding
+import org.onebusaway.android.ui.compose.components.CenteredLongPressMenu
 import org.onebusaway.android.ui.compose.components.DirectionHeadsign
 import org.onebusaway.android.ui.compose.components.LineBadge
+import org.onebusaway.android.ui.compose.components.MaterialSymbols
+import org.onebusaway.android.ui.compose.components.MenuRow
 import org.onebusaway.android.ui.compose.components.RadioOptionList
 import org.onebusaway.android.ui.compose.components.RouteBadgeChip
 import org.onebusaway.android.ui.compose.components.rememberRouteBadgeColors
@@ -148,6 +154,7 @@ fun FocusBanner(
     onRecenterStop: () -> Unit,
     onSelectDirection: (Int) -> Unit,
     onFrameRoute: () -> Unit,
+    onShowSchedule: (String) -> Unit,
     onHeight: (Int) -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -183,6 +190,7 @@ fun FocusBanner(
                         state = state,
                         onSelectDirection = onSelectDirection,
                         onFrameRoute = onFrameRoute,
+                        onShowSchedule = onShowSchedule,
                         onClose = onClose
                     )
                 }
@@ -396,14 +404,19 @@ private fun CompactRouteDismissAction(onClick: () -> Unit) {
     )
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun RouteFocusBanner(
     state: FocusBannerState.Route,
     onSelectDirection: (Int) -> Unit,
     onFrameRoute: () -> Unit,
+    onShowSchedule: (String) -> Unit,
     onClose: () -> Unit
 ) {
     val header = state.header
+    val scheduleUrl = header.scheduleUrl
+    var menuExpanded by remember { mutableStateOf(false) }
+    val scheduleLabel = stringResource(R.string.bus_options_menu_show_route_schedule)
     Row(
         Modifier.fillMaxWidth().padding(if (header.loading) 8.dp else 4.dp),
         verticalAlignment = Alignment.CenterVertically
@@ -419,9 +432,14 @@ private fun RouteFocusBanner(
             Row(
                 Modifier
                     .weight(1f)
-                    .clickable(
+                    // Tap frames the route; long press opens the route menu — the same gesture
+                    // pairing the arrivals drawer's route rows use. A route with no schedule page
+                    // has nothing to put in the menu, so it stays tap-only.
+                    .combinedClickable(
                         onClickLabel = stringResource(R.string.route_header_frame_route),
                         role = Role.Button,
+                        onLongClickLabel = if (scheduleUrl != null) scheduleLabel else null,
+                        onLongClick = if (scheduleUrl != null) ({ menuExpanded = true }) else null,
                         onClick = onFrameRoute
                     ),
                 verticalAlignment = Alignment.CenterVertically
@@ -474,6 +492,17 @@ private fun RouteFocusBanner(
             contentDescription = stringResource(android.R.string.cancel),
             onClick = onClose
         )
+    }
+    if (scheduleUrl != null) {
+        CenteredLongPressMenu(
+            expanded = menuExpanded,
+            onDismissRequest = { menuExpanded = false }
+        ) {
+            MenuRow(R.string.bus_options_menu_show_route_schedule, MaterialSymbols.Schedule) {
+                menuExpanded = false
+                onShowSchedule(scheduleUrl)
+            }
+        }
     }
 }
 
@@ -650,6 +679,7 @@ private fun FocusBannerPreview() {
                 onRecenterStop = {},
                 onSelectDirection = {},
                 onFrameRoute = {},
+                onShowSchedule = {},
                 onHeight = {}
             )
             Spacer(Modifier.size(12.dp))
@@ -660,6 +690,7 @@ private fun FocusBannerPreview() {
                         shortName = "40",
                         longName = "Downtown Seattle - Northgate",
                         agency = "King County Metro",
+                        scheduleUrl = "https://example.org/route/40/schedule",
                         directions = listOf(
                             RouteMapDirection(0, "to Downtown Seattle"),
                             RouteMapDirection(1, "to Northgate")
@@ -675,6 +706,7 @@ private fun FocusBannerPreview() {
                 onRecenterStop = {},
                 onSelectDirection = {},
                 onFrameRoute = {},
+                onShowSchedule = {},
                 onHeight = {}
             )
         }


### PR DESCRIPTION
Closes #40.

The route's schedule-page URL reached the app but no map surface offered it. The focus banner's route header was tap-only (frame the route), and `RouteHeader` didn't carry the URL at all — so a user looking at a route on the map had no way to reach its schedule.

## What this does

Long-pressing the route focus banner's badge/name row opens a `CenteredLongPressMenu` with **"Show route schedule"**, opening the page via the existing `ExternalIntents.goToUrl`. This is the same gesture pairing and menu style the arrivals drawer's route rows already use (#1993/#1998), and it reuses the legacy `bus_options_menu_show_route_schedule` string — no new user-facing strings.

- **Tap still frames the route.** Long press is purely additive, which is why this uses `combinedClickable` on the existing modifier chain rather than a new gesture layer.
- **A route whose feed publishes no schedule page stays tap-only** — `onLongClick`/`onLongClickLabel` are null, so no long-press action is exposed to touch or to accessibility services, and no empty menu can open.

## How

- `RouteHeader` gains `scheduleUrl`, populated in `MapViewModel.toRouteHeader()` from `ObaRoute.url`, which was already sitting on `LoadedRoute.Loaded` — no new fetch, and it follows the same pattern as the neighbouring `routeColor`.
- The browser hand-off is wired at the `HomeScreen` call site via `LocalContext`, as `DonationCard` and `AgenciesScreen` do, rather than through `HomeActivityActions` — it needs nothing but a `Context`.
- `MenuRow` moves from `ui/arrivals/components/ArrivalRows.kt` to `ui/compose/components/CenteredLongPressMenu.kt`, next to the menu and `MenuHeader` it fills, now that a third feature builds one of these menus. Pure move; no behavior change.

## Testing

`FocusBannerTest` covers both paths: the long press opening the menu and handing the URL to the callback, and the absence of any long-press action when the route has no schedule (with tap still framing). Verified on a physical device — 9 instrumented tests pass across `FocusBannerTest` and `RouteArrivalRowLongPressTest` (the latter to confirm the `MenuRow` move left the arrivals menus alone). Compiles clean under `-PwarningsAsErrors=true`.

## Follow-up (not in this PR)

Whether a blank `ObaRoute.url` counts as "no schedule page" is currently decided independently in three places: this change and `ArrivalRows` both apply `takeIf { it.isNotBlank() }`, while `ArrivalsRepository` passes `route?.url` through unfiltered. Normalizing once at the wire→domain boundary would retire the repetition; that touches files outside this change, so it's left as a follow-up.
