### PR TITLE
Fix destination reminder alerts not vibrating on API 26+ (#985)

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/notifications/NotificationChannelsTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/notifications/NotificationChannelsTest.kt
@@ -20,9 +20,9 @@ import android.os.Build
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.SdkSuppress
 import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -46,10 +46,13 @@ class NotificationChannelsTest {
 
     @Before
     fun setUp() {
-        // A channel's importance/vibration are locked to its first registration, so clear any left by
-        // a prior run/install to assert the code's intended configuration from a clean slate.
-        manager.deleteNotificationChannel(NotificationChannels.DESTINATION_ARRIVAL_ID)
-        manager.deleteNotificationChannel(NotificationChannels.DESTINATION_ALERT_ID)
+        // Registering an already-registered channel cannot lower its importance or change its
+        // vibration — those are the user's to change once the channel exists — so what's asserted
+        // below is the configuration of a *first* registration. That holds on a fresh install (CI),
+        // which is the contract under test. Deleting first does not buy a clean slate: Android
+        // deliberately resurrects a deleted channel's previous settings when the same id is
+        // recreated, so on a device where these channels were already tweaked the assertions can
+        // fail. Reinstall the app in that case rather than treating it as a regression.
         NotificationChannels.registerAll(context)
     }
 
@@ -60,9 +63,9 @@ class NotificationChannelsTest {
         ) { "Destination arrival channel should be registered" }
         assertEquals(NotificationManager.IMPORTANCE_HIGH, channel.importance)
         assertTrue("Arrival channel must vibrate (#985)", channel.shouldVibrate())
-        assertNotNull(channel.vibrationPattern)
-        assertTrue(
-            NotificationChannels.DESTINATION_VIBRATION_PATTERN.contentEquals(channel.vibrationPattern)
+        assertArrayEquals(
+            NotificationChannels.DESTINATION_VIBRATION_PATTERN,
+            channel.vibrationPattern
         )
     }
 

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/notifications/NotificationChannelsTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/notifications/NotificationChannelsTest.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.notifications
+
+import android.app.NotificationManager
+import android.os.Build
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Verifies the destination-reminder notification channels are configured so the arrival alerts
+ * actually vibrate on API 26+ (#985): the builder's `setVibrate` is ignored once channels own
+ * vibration, so the fix lives in the channel definitions.
+ */
+@RunWith(AndroidJUnit4::class)
+class NotificationChannelsTest {
+
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext
+    private val manager = context.getSystemService(NotificationManager::class.java)
+
+    @Before
+    fun setUp() {
+        // Channels only exist on API 26+; below that registerAll is a no-op and there's nothing to assert.
+        assumeTrue(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
+        // A channel's importance/vibration are locked to its first registration, so clear any left by
+        // a prior run/install to assert the code's intended configuration from a clean slate.
+        manager.deleteNotificationChannel(NotificationChannels.DESTINATION_ARRIVAL_ID)
+        manager.deleteNotificationChannel(NotificationChannels.DESTINATION_ALERT_ID)
+        NotificationChannels.registerAll(context)
+    }
+
+    @Test
+    fun arrivalChannel_isHighImportance_andVibrates() {
+        val channel = manager.getNotificationChannel(NotificationChannels.DESTINATION_ARRIVAL_ID)
+        assertNotNull("Destination arrival channel should be registered", channel)
+        assertEquals(NotificationManager.IMPORTANCE_HIGH, channel.importance)
+        assertTrue("Arrival channel must vibrate (#985)", channel.shouldVibrate())
+        assertNotNull(channel.vibrationPattern)
+        assertTrue(
+            NotificationChannels.DESTINATION_VIBRATION_PATTERN.contentEquals(channel.vibrationPattern)
+        )
+    }
+
+    @Test
+    fun progressChannel_staysQuiet() {
+        // The distance/progress notification re-posts continuously, so its channel must not buzz.
+        val channel = manager.getNotificationChannel(NotificationChannels.DESTINATION_ALERT_ID)
+        assertNotNull("Destination alert channel should be registered", channel)
+        assertEquals(NotificationManager.IMPORTANCE_LOW, channel.importance)
+        assertFalse("Progress channel must not vibrate", channel.shouldVibrate())
+    }
+}

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/notifications/NotificationChannelsTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/notifications/NotificationChannelsTest.kt
@@ -18,12 +18,12 @@ package org.onebusaway.android.notifications
 import android.app.NotificationManager
 import android.os.Build
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.SdkSuppress
 import androidx.test.platform.app.InstrumentationRegistry
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
-import org.junit.Assume.assumeTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -32,8 +32,13 @@ import org.junit.runner.RunWith
  * Verifies the destination-reminder notification channels are configured so the arrival alerts
  * actually vibrate on API 26+ (#985): the builder's `setVibrate` is ignored once channels own
  * vibration, so the fix lives in the channel definitions.
+ *
+ * Notification channels only exist on API 26+; below that [NotificationChannels.registerAll] is a
+ * no-op and there's nothing to assert. [SdkSuppress] statically gates the whole class to API 26+ so
+ * the test runner skips it — and the channel API calls below it — on lower floors.
  */
 @RunWith(AndroidJUnit4::class)
+@SdkSuppress(minSdkVersion = Build.VERSION_CODES.O)
 class NotificationChannelsTest {
 
     private val context = InstrumentationRegistry.getInstrumentation().targetContext
@@ -41,8 +46,6 @@ class NotificationChannelsTest {
 
     @Before
     fun setUp() {
-        // Channels only exist on API 26+; below that registerAll is a no-op and there's nothing to assert.
-        assumeTrue(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
         // A channel's importance/vibration are locked to its first registration, so clear any left by
         // a prior run/install to assert the code's intended configuration from a clean slate.
         manager.deleteNotificationChannel(NotificationChannels.DESTINATION_ARRIVAL_ID)
@@ -52,8 +55,9 @@ class NotificationChannelsTest {
 
     @Test
     fun arrivalChannel_isHighImportance_andVibrates() {
-        val channel = manager.getNotificationChannel(NotificationChannels.DESTINATION_ARRIVAL_ID)
-        assertNotNull("Destination arrival channel should be registered", channel)
+        val channel = requireNotNull(
+            manager.getNotificationChannel(NotificationChannels.DESTINATION_ARRIVAL_ID)
+        ) { "Destination arrival channel should be registered" }
         assertEquals(NotificationManager.IMPORTANCE_HIGH, channel.importance)
         assertTrue("Arrival channel must vibrate (#985)", channel.shouldVibrate())
         assertNotNull(channel.vibrationPattern)
@@ -65,8 +69,9 @@ class NotificationChannelsTest {
     @Test
     fun progressChannel_staysQuiet() {
         // The distance/progress notification re-posts continuously, so its channel must not buzz.
-        val channel = manager.getNotificationChannel(NotificationChannels.DESTINATION_ALERT_ID)
-        assertNotNull("Destination alert channel should be registered", channel)
+        val channel = requireNotNull(
+            manager.getNotificationChannel(NotificationChannels.DESTINATION_ALERT_ID)
+        ) { "Destination alert channel should be registered" }
         assertEquals(NotificationManager.IMPORTANCE_LOW, channel.importance)
         assertFalse("Progress channel must not vibrate", channel.shouldVibrate())
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/nav/NavigationServiceProvider.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/nav/NavigationServiceProvider.java
@@ -57,8 +57,6 @@ public class NavigationServiceProvider implements TextToSpeech.OnInitListener {
   private static final int ALERT_STATE_ENDING_PATH_LINK = 1;
 
   public static final int NOTIFICATION_ID = 33620;
-  private static final long[] VIBRATION_PATTERN =
-      new long[] {2000, 1000, 2000, 1000, 2000, 1000, 2000, 1000, 2000, 1000};
   public static final int DISTANCE_THRESHOLD = 200;
 
   // Number of times to repeat voice commands
@@ -709,14 +707,22 @@ public class NavigationServiceProvider implements TextToSpeech.OnInitListener {
         }
       }
 
-      mBuilder.setContentText(message);
-      mBuilder.setVibrate(VIBRATION_PATTERN);
-      mBuilder.setDeleteIntent(pDelIntent);
+      // Fire the "get ready" alert on the high-importance arrival channel so it vibrates (#985);
+      // the shared progress notification stays on the quiet DESTINATION_ALERT_ID channel.
+      NotificationCompat.Builder alertBuilder =
+          new NotificationCompat.Builder(mContext, NotificationChannels.DESTINATION_ARRIVAL_ID)
+              .setSmallIcon(R.drawable.ic_content_flag)
+              .setContentTitle(
+                  mContext.getResources().getString(R.string.destination_reminder_title))
+              .setContentIntent(pIntent)
+              .setContentText(message)
+              .setVibrate(NotificationChannels.DESTINATION_VIBRATION_PATTERN)
+              .setDeleteIntent(pDelIntent);
 
       NotificationManager mNotificationManager =
           (NotificationManager) mContext.getSystemService(Context.NOTIFICATION_SERVICE);
 
-      mNotificationManager.notify(NOTIFICATION_ID + 1, mBuilder.build());
+      mNotificationManager.notify(NOTIFICATION_ID + 1, alertBuilder.build());
 
     } else if (eventType == EVENT_TYPE_PULL_CORD) { // Pull the cord
       mFinished = true;
@@ -733,15 +739,23 @@ public class NavigationServiceProvider implements TextToSpeech.OnInitListener {
           silence(500, TextToSpeech.QUEUE_ADD);
         }
       }
-      mBuilder.setContentText(message);
-      mBuilder.setVibrate(VIBRATION_PATTERN);
-      mBuilder.setDeleteIntent(pDelIntent);
+      // Fire the "pull the cord" arrival alert on the high-importance arrival channel so it
+      // vibrates (#985); the shared progress notification stays on the quiet channel.
+      NotificationCompat.Builder alertBuilder =
+          new NotificationCompat.Builder(mContext, NotificationChannels.DESTINATION_ARRIVAL_ID)
+              .setSmallIcon(R.drawable.ic_content_flag)
+              .setContentTitle(
+                  mContext.getResources().getString(R.string.destination_reminder_title))
+              .setContentIntent(pIntent)
+              .setContentText(message)
+              .setVibrate(NotificationChannels.DESTINATION_VIBRATION_PATTERN)
+              .setDeleteIntent(pDelIntent);
 
       NotificationManager mNotificationManager =
           (NotificationManager) mContext.getSystemService(Context.NOTIFICATION_SERVICE);
 
       mNotificationManager.cancel(NOTIFICATION_ID + 1);
-      mNotificationManager.notify(NOTIFICATION_ID + 2, mBuilder.build());
+      mNotificationManager.notify(NOTIFICATION_ID + 2, alertBuilder.build());
 
       mBuilder =
           new NotificationCompat.Builder(mContext, NotificationChannels.DESTINATION_ALERT_ID)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/nav/NavigationServiceProvider.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/nav/NavigationServiceProvider.java
@@ -707,22 +707,11 @@ public class NavigationServiceProvider implements TextToSpeech.OnInitListener {
         }
       }
 
-      // Fire the "get ready" alert on the high-importance arrival channel so it vibrates (#985);
-      // the shared progress notification stays on the quiet DESTINATION_ALERT_ID channel.
-      NotificationCompat.Builder alertBuilder =
-          new NotificationCompat.Builder(mContext, NotificationChannels.DESTINATION_ARRIVAL_ID)
-              .setSmallIcon(R.drawable.ic_content_flag)
-              .setContentTitle(
-                  mContext.getResources().getString(R.string.destination_reminder_title))
-              .setContentIntent(pIntent)
-              .setContentText(message)
-              .setVibrate(NotificationChannels.DESTINATION_VIBRATION_PATTERN)
-              .setDeleteIntent(pDelIntent);
-
       NotificationManager mNotificationManager =
           (NotificationManager) mContext.getSystemService(Context.NOTIFICATION_SERVICE);
 
-      mNotificationManager.notify(NOTIFICATION_ID + 1, alertBuilder.build());
+      mNotificationManager.notify(
+          NOTIFICATION_ID + 1, buildArrivalAlert(message, pIntent, pDelIntent));
 
     } else if (eventType == EVENT_TYPE_PULL_CORD) { // Pull the cord
       mFinished = true;
@@ -739,23 +728,12 @@ public class NavigationServiceProvider implements TextToSpeech.OnInitListener {
           silence(500, TextToSpeech.QUEUE_ADD);
         }
       }
-      // Fire the "pull the cord" arrival alert on the high-importance arrival channel so it
-      // vibrates (#985); the shared progress notification stays on the quiet channel.
-      NotificationCompat.Builder alertBuilder =
-          new NotificationCompat.Builder(mContext, NotificationChannels.DESTINATION_ARRIVAL_ID)
-              .setSmallIcon(R.drawable.ic_content_flag)
-              .setContentTitle(
-                  mContext.getResources().getString(R.string.destination_reminder_title))
-              .setContentIntent(pIntent)
-              .setContentText(message)
-              .setVibrate(NotificationChannels.DESTINATION_VIBRATION_PATTERN)
-              .setDeleteIntent(pDelIntent);
-
       NotificationManager mNotificationManager =
           (NotificationManager) mContext.getSystemService(Context.NOTIFICATION_SERVICE);
 
       mNotificationManager.cancel(NOTIFICATION_ID + 1);
-      mNotificationManager.notify(NOTIFICATION_ID + 2, alertBuilder.build());
+      mNotificationManager.notify(
+          NOTIFICATION_ID + 2, buildArrivalAlert(message, pIntent, pDelIntent));
 
       mBuilder =
           new NotificationCompat.Builder(mContext, NotificationChannels.DESTINATION_ALERT_ID)
@@ -771,6 +749,37 @@ public class NavigationServiceProvider implements TextToSpeech.OnInitListener {
     }
     // If we reach this point then the event_type isn't initial startup
     return null;
+  }
+
+  /**
+   * Builds one of the two one-shot destination arrival alerts ("get ready" / "pull the cord").
+   *
+   * <p>Posted on the high-importance {@link NotificationChannels#DESTINATION_ARRIVAL_ID} channel
+   * rather than the shared DESTINATION_ALERT_ID one: on API 26+ the channel owns vibration and
+   * prominence, so an alert on the deliberately-quiet progress channel never buzzed (#985), and
+   * raising that channel instead would make the continuously re-posted distance notification buzz
+   * on every location update.
+   *
+   * <p>{@code setPriority} and {@code setVibrate} are the pre-26 equivalents of the channel's
+   * importance and vibration pattern — ignored on 26+, still required on the API 23-25 floor — so
+   * the alert is equally prominent across the supported range.
+   *
+   * @param message text shown in the notification body (also the spoken message)
+   * @param contentIntent fired when the rider taps the alert
+   * @param deleteIntent fired when the alert is dismissed, to stop the repeated voice commands
+   */
+  private Notification buildArrivalAlert(
+      String message, PendingIntent contentIntent, PendingIntent deleteIntent) {
+    return new NotificationCompat.Builder(mContext, NotificationChannels.DESTINATION_ARRIVAL_ID)
+        .setSmallIcon(R.drawable.ic_content_flag)
+        .setContentTitle(mContext.getResources().getString(R.string.destination_reminder_title))
+        .setContentIntent(contentIntent)
+        .setContentText(message)
+        .setPriority(NotificationCompat.PRIORITY_HIGH)
+        .setDefaults(NotificationCompat.DEFAULT_SOUND)
+        .setVibrate(NotificationChannels.DESTINATION_VIBRATION_PATTERN)
+        .setDeleteIntent(deleteIntent)
+        .build();
   }
 
   /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/notifications/NotificationChannels.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/notifications/NotificationChannels.kt
@@ -33,7 +33,32 @@ object NotificationChannels {
 
     const val TRIP_PLAN_UPDATES_ID = "trip_plan_updates"
     const val ARRIVAL_REMINDERS_ID = "arrival_reminders"
+
+    /**
+     * Ongoing destination-reminder progress (the foreground-service distance notification) and the
+     * trip-feedback follow-ups. Deliberately quiet ([NotificationManager.IMPORTANCE_LOW], no
+     * vibration): the distance notification re-posts on every location update, so alerting on it
+     * would buzz continuously. The "act now" arrival alerts use [DESTINATION_ARRIVAL_ID] instead.
+     */
     const val DESTINATION_ALERT_ID = "destination_alerts"
+
+    /**
+     * The one-shot "get ready" / "pull the cord" alerts fired as the rider nears the destination
+     * stop. Distinct from [DESTINATION_ALERT_ID] so it can be high-importance and vibrate without
+     * making the continuously-updating progress notification buzz (#985). Vibration is owned by the
+     * channel on API 26+, so [DESTINATION_VIBRATION_PATTERN] is set here; the notification builders
+     * also call `setVibrate` for the pre-26 path.
+     */
+    const val DESTINATION_ARRIVAL_ID = "destination_arrival"
+
+    /**
+     * Vibration pattern for the destination arrival alerts, shared by the [DESTINATION_ARRIVAL_ID]
+     * channel (API 26+) and the notification builders' `setVibrate` (pre-26). Exposed as a
+     * `@JvmField` so the Java notification code (`NavigationServiceProvider`) reads the same source.
+     */
+    @JvmField
+    val DESTINATION_VIBRATION_PATTERN =
+        longArrayOf(2000, 1000, 2000, 1000, 2000, 1000, 2000, 1000, 2000, 1000)
 
     /**
      * Registers the app's notification channels. A no-op below API 26 (channels didn't exist);
@@ -78,6 +103,17 @@ object NotificationChannels {
                 NotificationManager.IMPORTANCE_LOW
             ).apply {
                 description = "All notifications relating to Destination alerts"
+            }
+        )
+        manager.createNotificationChannel(
+            NotificationChannel(
+                DESTINATION_ARRIVAL_ID,
+                "Destination arrival alerts",
+                NotificationManager.IMPORTANCE_HIGH
+            ).apply {
+                description = "Vibrates and alerts you when you are approaching your destination stop."
+                enableVibration(true)
+                vibrationPattern = DESTINATION_VIBRATION_PATTERN
             }
         )
     }


### PR DESCRIPTION
Closes #985.

## The bug
The destination-reminder "get ready" and "pull the cord" alerts requested vibration via `mBuilder.setVibrate(VIBRATION_PATTERN)` (`NavigationServiceProvider.java`), but posted on the `DESTINATION_ALERT_ID` channel, which is created `IMPORTANCE_LOW` with no channel-level vibration (`NotificationChannels.kt`). On **API 26+ vibration is owned by the channel**, so the builder-level request is silently ignored and the alerts never vibrate. minSdk is 23, so only pre-26 devices ever buzzed.

## Why not just bump the channel
`DESTINATION_ALERT_ID` is shared: it also carries the **ongoing foreground/distance progress notification** (re-posted on every location update — bumping the channel would make it buzz continuously) and the quiet trip-feedback follow-ups. So the fix needs to separate the "act now" alerts from the background progress.

## The fix
- Add a dedicated **`DESTINATION_ARRIVAL_ID`** channel — `IMPORTANCE_HIGH` with channel vibration enabled — for the one-shot "get ready" / "pull the cord" alerts.
- Post those two alerts on the new channel; the progress + feedback notifications stay on the quiet `DESTINATION_ALERT_ID`.
- Move the vibration pattern into `NotificationChannels` as the single source, shared by the channel (API 26+) and the builders' `setVibrate` (pre-26 path).

### Design note (behavior change worth a look)
Raising importance to `HIGH` means these alerts now also **make a sound and show as heads-up**, not just vibrate. For a time-critical "you're arriving, pull the cord" alert this is appropriate and restores the pre-notification-channels behavior (where `setVibrate` on a default-priority notification also sounded). Happy to dial it to `DEFAULT` (sound + vibrate, no heads-up) if you'd prefer less prominence.

## Testing
- Compiles clean under `-PwarningsAsErrors=true` (Kotlin + Java + androidTest).
- Spotless-clean.
- Adds `NotificationChannelsTest` (instrumented): asserts the arrival channel is `IMPORTANCE_HIGH` and `shouldVibrate()`, and the progress channel stays `IMPORTANCE_LOW` / non-vibrating. Not run on-device locally (no emulator here); CI's API-33 run will exercise it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a high-priority destination arrival notification channel with vibration support.
  * Destination arrival alerts now use dedicated notification handling and vibration patterns.
  * Progress alerts remain quiet with low importance and no vibration.

* **Tests**
  * Added coverage verifying notification-channel importance, vibration behavior, and vibration patterns on Android 8.0 and later.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->