### PR TITLE
Show a wheelchair-accessibility indicator on the map focus banner (#1029)

### DIFF
--- a/onebusaway-android/schemas/org.onebusaway.android.database.AppDatabase/8.json
+++ b/onebusaway-android/schemas/org.onebusaway.android.database.AppDatabase/8.json
@@ -1,0 +1,874 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 8,
+    "identityHash": "cad8ddca75505989070335e414d7d045",
+    "entities": [
+      {
+        "tableName": "studies",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`study_id` INTEGER NOT NULL, `name` TEXT NOT NULL, `description` TEXT NOT NULL, `is_subscribed` INTEGER NOT NULL, PRIMARY KEY(`study_id`))",
+        "fields": [
+          {
+            "fieldPath": "study_id",
+            "columnName": "study_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "is_subscribed",
+            "columnName": "is_subscribed",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "study_id"
+          ]
+        }
+      },
+      {
+        "tableName": "surveys",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`survey_id` INTEGER NOT NULL, `study_id` INTEGER NOT NULL, `name` TEXT NOT NULL, `state` INTEGER NOT NULL, PRIMARY KEY(`survey_id`), FOREIGN KEY(`study_id`) REFERENCES `studies`(`study_id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "survey_id",
+            "columnName": "survey_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "study_id",
+            "columnName": "study_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "survey_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_surveys_study_id",
+            "unique": false,
+            "columnNames": [
+              "study_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_surveys_study_id` ON `${TABLE_NAME}` (`study_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "studies",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "study_id"
+            ],
+            "referencedColumns": [
+              "study_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "alerts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "stops",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` TEXT NOT NULL, `code` TEXT NOT NULL, `name` TEXT NOT NULL, `direction` TEXT NOT NULL, `use_count` INTEGER NOT NULL, `latitude` REAL NOT NULL, `longitude` REAL NOT NULL, `user_name` TEXT, `access_time` INTEGER, `favorite` INTEGER, `region_id` INTEGER, PRIMARY KEY(`_id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "code",
+            "columnName": "code",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "direction",
+            "columnName": "direction",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "useCount",
+            "columnName": "use_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userName",
+            "columnName": "user_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "accessTime",
+            "columnName": "access_time",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "favorite",
+            "columnName": "favorite",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "regionId",
+            "columnName": "region_id",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "_id"
+          ]
+        }
+      },
+      {
+        "tableName": "routes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` TEXT NOT NULL, `short_name` TEXT NOT NULL, `long_name` TEXT, `use_count` INTEGER NOT NULL, `user_name` TEXT, `access_time` INTEGER, `favorite` INTEGER, `url` TEXT, `region_id` INTEGER, PRIMARY KEY(`_id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shortName",
+            "columnName": "short_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longName",
+            "columnName": "long_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "useCount",
+            "columnName": "use_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userName",
+            "columnName": "user_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "accessTime",
+            "columnName": "access_time",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "favorite",
+            "columnName": "favorite",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "regionId",
+            "columnName": "region_id",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "_id"
+          ]
+        }
+      },
+      {
+        "tableName": "trips",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` TEXT NOT NULL, `stop_id` TEXT NOT NULL, `route_id` TEXT, `departure` INTEGER NOT NULL, `headsign` TEXT, `name` TEXT NOT NULL, `reminder` INTEGER NOT NULL, `alarm_delete_path` TEXT NOT NULL, `service_date` INTEGER NOT NULL, `stop_sequence` INTEGER NOT NULL, `trip_id` TEXT NOT NULL, `vehicle_id` TEXT, PRIMARY KEY(`_id`, `stop_id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stopId",
+            "columnName": "stop_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "routeId",
+            "columnName": "route_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "departure",
+            "columnName": "departure",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "headsign",
+            "columnName": "headsign",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reminder",
+            "columnName": "reminder",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "alarmDeletePath",
+            "columnName": "alarm_delete_path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serviceDate",
+            "columnName": "service_date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stopSequence",
+            "columnName": "stop_sequence",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tripId",
+            "columnName": "trip_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vehicleId",
+            "columnName": "vehicle_id",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "_id",
+            "stop_id"
+          ]
+        }
+      },
+      {
+        "tableName": "trip_alerts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `trip_id` TEXT NOT NULL, `stop_id` TEXT NOT NULL, `start_time` INTEGER NOT NULL, `state` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tripId",
+            "columnName": "trip_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stopId",
+            "columnName": "stop_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startTime",
+            "columnName": "start_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "_id"
+          ]
+        }
+      },
+      {
+        "tableName": "service_alerts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` TEXT NOT NULL, `marked_read_time` INTEGER, `hidden` INTEGER, PRIMARY KEY(`_id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "markedReadTime",
+            "columnName": "marked_read_time",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "hidden",
+            "columnName": "hidden",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "_id"
+          ]
+        }
+      },
+      {
+        "tableName": "regions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER NOT NULL, `name` TEXT NOT NULL, `oba_base_url` TEXT NOT NULL, `siri_base_url` TEXT NOT NULL, `lang` TEXT NOT NULL, `contact_email` TEXT NOT NULL, `supports_api_discovery` INTEGER NOT NULL, `supports_api_realtime` INTEGER NOT NULL, `supports_siri_realtime` INTEGER NOT NULL, `twitter_url` TEXT, `experimental` INTEGER, `stop_info_url` TEXT, `otp_base_url` TEXT, `otp_contact_email` TEXT, `supports_otp_bikeshare` INTEGER, `otp_base_graphql_url` TEXT, `supports_embedded_social` INTEGER, `payment_android_app_id` TEXT, `payment_warning_title` TEXT, `payment_warning_body` TEXT, `sidecar_base_url` TEXT DEFAULT 'https://onebusaway.co', `plausible_analytics_server_url` TEXT, `umami_analytics_url` TEXT, `umami_analytics_id` TEXT, PRIMARY KEY(`_id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "obaBaseUrl",
+            "columnName": "oba_base_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "siriBaseUrl",
+            "columnName": "siri_base_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "lang",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contactEmail",
+            "columnName": "contact_email",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "supportsObaDiscovery",
+            "columnName": "supports_api_discovery",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "supportsObaRealtime",
+            "columnName": "supports_api_realtime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "supportsSiriRealtime",
+            "columnName": "supports_siri_realtime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "twitterUrl",
+            "columnName": "twitter_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "experimental",
+            "columnName": "experimental",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "stopInfoUrl",
+            "columnName": "stop_info_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "otpBaseUrl",
+            "columnName": "otp_base_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "otpContactEmail",
+            "columnName": "otp_contact_email",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "supportsOtpBikeshare",
+            "columnName": "supports_otp_bikeshare",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "otpBaseGraphqlUrl",
+            "columnName": "otp_base_graphql_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "supportsEmbeddedSocial",
+            "columnName": "supports_embedded_social",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "paymentAndroidAppId",
+            "columnName": "payment_android_app_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "paymentWarningTitle",
+            "columnName": "payment_warning_title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "paymentWarningBody",
+            "columnName": "payment_warning_body",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sidecarBaseUrl",
+            "columnName": "sidecar_base_url",
+            "affinity": "TEXT",
+            "defaultValue": "'https://onebusaway.co'"
+          },
+          {
+            "fieldPath": "plausibleAnalyticsServerUrl",
+            "columnName": "plausible_analytics_server_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "umamiAnalyticsUrl",
+            "columnName": "umami_analytics_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "umamiAnalyticsId",
+            "columnName": "umami_analytics_id",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "_id"
+          ]
+        }
+      },
+      {
+        "tableName": "region_bounds",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `region_id` INTEGER NOT NULL, `lat` REAL NOT NULL, `lon` REAL NOT NULL, `lat_span` REAL NOT NULL, `lon_span` REAL NOT NULL, FOREIGN KEY(`region_id`) REFERENCES `regions`(`_id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "regionId",
+            "columnName": "region_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "lat",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "lon",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "latSpan",
+            "columnName": "lat_span",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lonSpan",
+            "columnName": "lon_span",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_region_bounds_region_id",
+            "unique": false,
+            "columnNames": [
+              "region_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_region_bounds_region_id` ON `${TABLE_NAME}` (`region_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "regions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "region_id"
+            ],
+            "referencedColumns": [
+              "_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "open311_servers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `region_id` INTEGER NOT NULL, `jurisdiction` TEXT, `api_key` TEXT NOT NULL, `open311_base_url` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "regionId",
+            "columnName": "region_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "jurisdiction",
+            "columnName": "jurisdiction",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "apiKey",
+            "columnName": "api_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "baseUrl",
+            "columnName": "open311_base_url",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "_id"
+          ]
+        }
+      },
+      {
+        "tableName": "nav_stops",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `nav_id` TEXT NOT NULL, `start_time` INTEGER NOT NULL, `trip_id` TEXT NOT NULL, `destination_id` TEXT NOT NULL, `before_id` TEXT NOT NULL, `seq_num` INTEGER NOT NULL, `is_active` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "navId",
+            "columnName": "nav_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startTime",
+            "columnName": "start_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tripId",
+            "columnName": "trip_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "destinationId",
+            "columnName": "destination_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "beforeId",
+            "columnName": "before_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sequence",
+            "columnName": "seq_num",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "active",
+            "columnName": "is_active",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "_id"
+          ]
+        }
+      },
+      {
+        "tableName": "cached_stops",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` TEXT NOT NULL, `code` TEXT, `name` TEXT, `direction` TEXT, `latitude` REAL NOT NULL, `longitude` REAL NOT NULL, `location_type` INTEGER NOT NULL, `route_ids` TEXT NOT NULL, `wheelchair_boarding` TEXT, `region_id` INTEGER NOT NULL, `last_seen` INTEGER NOT NULL, PRIMARY KEY(`_id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "code",
+            "columnName": "code",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "direction",
+            "columnName": "direction",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "locationType",
+            "columnName": "location_type",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "routeIds",
+            "columnName": "route_ids",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wheelchairBoarding",
+            "columnName": "wheelchair_boarding",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "regionId",
+            "columnName": "region_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSeen",
+            "columnName": "last_seen",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cached_stops_region_id_latitude_longitude",
+            "unique": false,
+            "columnNames": [
+              "region_id",
+              "latitude",
+              "longitude"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_stops_region_id_latitude_longitude` ON `${TABLE_NAME}` (`region_id`, `latitude`, `longitude`)"
+          },
+          {
+            "name": "index_cached_stops_region_id_last_seen",
+            "unique": false,
+            "columnNames": [
+              "region_id",
+              "last_seen"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_stops_region_id_last_seen` ON `${TABLE_NAME}` (`region_id`, `last_seen`)"
+          }
+        ]
+      },
+      {
+        "tableName": "cached_route_types",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` TEXT NOT NULL, `type` INTEGER NOT NULL, `region_id` INTEGER NOT NULL, `last_seen` INTEGER NOT NULL, PRIMARY KEY(`_id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "regionId",
+            "columnName": "region_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSeen",
+            "columnName": "last_seen",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cached_route_types_region_id_last_seen",
+            "unique": false,
+            "columnNames": [
+              "region_id",
+              "last_seen"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_route_types_region_id_last_seen` ON `${TABLE_NAME}` (`region_id`, `last_seen`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'cad8ddca75505989070335e414d7d045')"
+    ]
+  }
+}

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/database/AppDatabaseMigrationTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/database/AppDatabaseMigrationTest.kt
@@ -31,8 +31,9 @@ import org.onebusaway.android.SmokeTest
  * empty — the data import from the legacy ContentProvider DB is a separate slice); and that
  * [MIGRATION_3_4] reconciles `routes.favorite` from the authoritative `route_headsign_favorites` table
  * before dropping it (#1751) and adds the `surveys.study_id` foreign-key child index (#1739); and that
- * [MIGRATION_5_6] adds `regions.otp_base_graphql_url` defaulting existing rows to OTP1 (#1780); and
- * that [MIGRATION_6_7] drops the retired `stop_routes_filter` table.
+ * [MIGRATION_5_6] adds `regions.otp_base_graphql_url` defaulting existing rows to OTP1 (#1780); that
+ * [MIGRATION_6_7] drops the retired `stop_routes_filter` table; and that [MIGRATION_7_8] adds
+ * `cached_stops.wheelchair_boarding` as NULL for existing rows (#1029).
  */
 @SmokeTest // API-23 floor smoke subset (#1818): exercises Room migrations + java.time desugaring
 @RunWith(AndroidJUnit4::class)
@@ -180,6 +181,27 @@ class AppDatabaseMigrationTest {
         db.query(
             "SELECT name FROM sqlite_master WHERE type='table' AND name='stop_routes_filter'"
         ).use { c -> assertEquals("stop_routes_filter should be dropped", 0, c.count) }
+        db.close()
+    }
+
+    @Test
+    fun migrate7To8_addsWheelchairBoardingColumnNullForExistingStops() {
+        helper.createDatabase(TEST_DB, 7).use { db ->
+            // A pre-existing cached stop with no wheelchair column yet.
+            db.execSQL(
+                "INSERT INTO cached_stops " +
+                    "(_id, code, name, direction, latitude, longitude, location_type, route_ids, region_id, last_seen) " +
+                    "VALUES ('1_100', '100', 'Pine St', 'N', 47.6, -122.3, 0, '', 1, 0)"
+            )
+        }
+
+        // runMigrationsAndValidate asserts the resulting schema matches the exported 8.json.
+        val db = helper.runMigrationsAndValidate(TEST_DB, 8, true, MIGRATION_7_8)
+
+        db.query("SELECT wheelchair_boarding FROM cached_stops WHERE _id = '1_100'").use { c ->
+            c.moveToFirst()
+            assertTrue("pre-existing cached stop should have NULL wheelchair_boarding (UNKNOWN)", c.isNull(0))
+        }
         db.close()
     }
 

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/database/oba/MapStopCacheDaoTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/database/oba/MapStopCacheDaoTest.kt
@@ -190,6 +190,6 @@ class MapStopCacheDaoTest {
     ) = CachedStopRecord(
         id = id, code = "code", name = "name", direction = "N",
         latitude = lat, longitude = lon, locationType = 0,
-        routeIds = routeIds, regionId = regionId, lastSeen = lastSeen
+        routeIds = routeIds, wheelchairBoarding = null, regionId = regionId, lastSeen = lastSeen
     )
 }

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/mock/MockObaStop.java
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/mock/MockObaStop.java
@@ -20,6 +20,7 @@ import android.location.Location;
 import java.util.HashMap;
 import org.onebusaway.android.models.ObaRoute;
 import org.onebusaway.android.models.ObaStop;
+import org.onebusaway.android.models.WheelchairBoarding;
 import org.onebusaway.android.util.Locations;
 
 /** Provides a mock ObaStop to use in testing */
@@ -90,6 +91,11 @@ public class MockObaStop {
     @Override
     public String getId() {
       return "Hillsborough Area Regional Transit_26";
+    }
+
+    @Override
+    public WheelchairBoarding getWheelchairBoarding() {
+      return WheelchairBoarding.UNKNOWN;
     }
   }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/adapters/StopAdapters.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/adapters/StopAdapters.kt
@@ -19,6 +19,7 @@ package org.onebusaway.android.api.adapters
 import android.location.Location
 import org.onebusaway.android.api.contract.StopReference
 import org.onebusaway.android.models.ObaStop
+import org.onebusaway.android.models.WheelchairBoarding
 import org.onebusaway.android.util.locationOf
 
 /**
@@ -37,6 +38,8 @@ internal class DtoStop(private val ref: StopReference) : ObaStop {
     override val direction: String? get() = ref.direction
     override val locationType: Int get() = ref.locationType
     override val routeIds: Array<String> get() = ref.routeIds.toTypedArray()
+    override val wheelchairBoarding: WheelchairBoarding
+        get() = WheelchairBoarding.fromString(ref.wheelchairBoarding)
 }
 
 /**
@@ -50,7 +53,8 @@ class ObaStopElement @JvmOverloads constructor(
     private val code: String = "",
     override val direction: String = "",
     override val locationType: Int = ObaStop.LOCATION_STOP,
-    override val routeIds: Array<String> = EMPTY_ROUTES
+    override val routeIds: Array<String> = EMPTY_ROUTES,
+    override val wheelchairBoarding: WheelchairBoarding = WheelchairBoarding.UNKNOWN
 ) : ObaStop {
 
     override val stopCode: String get() = code

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/contract/ObaApiModels.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/contract/ObaApiModels.kt
@@ -153,7 +153,11 @@ data class StopReference(
     val lat: Double = 0.0,
     val lon: Double = 0.0,
     val locationType: Int = 0,
-    val routeIds: List<String> = emptyList()
+    val routeIds: List<String> = emptyList(),
+    // The GTFS wheelchair-boarding accessibility state as a wire string ("ACCESSIBLE" /
+    // "NOT_ACCESSIBLE" / "UNKNOWN"); null on servers/feeds that omit it. Minted to the
+    // WheelchairBoarding domain enum by the adapter.
+    val wheelchairBoarding: String? = null
 )
 
 /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/app/di/DatabaseModule.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/app/di/DatabaseModule.kt
@@ -30,6 +30,7 @@ import org.onebusaway.android.database.MIGRATION_3_4
 import org.onebusaway.android.database.MIGRATION_4_5
 import org.onebusaway.android.database.MIGRATION_5_6
 import org.onebusaway.android.database.MIGRATION_6_7
+import org.onebusaway.android.database.MIGRATION_7_8
 import org.onebusaway.android.database.oba.DefaultImportGate
 import org.onebusaway.android.database.oba.ImportGate
 import org.onebusaway.android.database.oba.LegacyDataImporter
@@ -69,7 +70,8 @@ object DatabaseModule {
         MIGRATION_3_4,
         MIGRATION_4_5,
         MIGRATION_5_6,
-        MIGRATION_6_7
+        MIGRATION_6_7,
+        MIGRATION_7_8
     ).build()
 
     @Provides

--- a/onebusaway-android/src/main/java/org/onebusaway/android/database/AppDatabase.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/database/AppDatabase.kt
@@ -50,6 +50,10 @@ import org.onebusaway.android.database.widealerts.entity.AlertEntity
  *
  * v7 retires the per-stop route filter (#1807-era arrivals cleanup): the `stop_routes_filter` table is
  * dropped now that arrivals are grouped by route and the "show only this route" filter is gone.
+ *
+ * v8 adds `cached_stops.wheelchair_boarding` (#1029): the stop's GTFS wheelchair-boarding accessibility
+ * (a WheelchairBoarding enum name), so the map focus banner can show an accessibility indicator for
+ * cached stops too. NULL (every existing cached row) reads back as UNKNOWN.
  */
 @Database(
     entities = [
@@ -68,7 +72,7 @@ import org.onebusaway.android.database.widealerts.entity.AlertEntity
         CachedStopRecord::class,
         CachedRouteTypeRecord::class
     ],
-    version = 7,
+    version = 8,
     exportSchema = true
 )
 abstract class AppDatabase : RoomDatabase() {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/database/Migrations.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/database/Migrations.kt
@@ -180,3 +180,16 @@ val MIGRATION_6_7 = object : Migration(6, 7) {
         db.execSQL("DROP TABLE IF EXISTS `stop_routes_filter`")
     }
 }
+
+/**
+ * Adds `cached_stops.wheelchair_boarding` (#1029): the stop's GTFS wheelchair-boarding accessibility as
+ * a WheelchairBoarding enum name. NULL (every existing cached row) reads back as UNKNOWN. Purely
+ * additive, no other v7 table/column changes. Verified by AppDatabaseMigrationTest.
+ */
+val MIGRATION_7_8 = object : Migration(7, 8) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            "ALTER TABLE `cached_stops` ADD COLUMN `wheelchair_boarding` TEXT"
+        )
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/database/oba/MapStopCacheEntities.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/database/oba/MapStopCacheEntities.kt
@@ -51,6 +51,9 @@ data class CachedStopRecord(
     @ColumnInfo(name = "longitude") val longitude: Double,
     @ColumnInfo(name = "location_type") val locationType: Int,
     @ColumnInfo(name = "route_ids") val routeIds: String,
+    // The GTFS wheelchair-boarding state as a WheelchairBoarding enum name, or NULL for rows cached
+    // before this column existed / stops whose feed omits it (both read back as UNKNOWN).
+    @ColumnInfo(name = "wheelchair_boarding") val wheelchairBoarding: String?,
     @ColumnInfo(name = "region_id") val regionId: Long,
     @ColumnInfo(name = "last_seen") val lastSeen: Long
 )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/database/oba/MapStopCacheMappers.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/database/oba/MapStopCacheMappers.kt
@@ -19,6 +19,7 @@ import android.location.Location
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.days
 import org.onebusaway.android.models.ObaStop
+import org.onebusaway.android.models.WheelchairBoarding
 import org.onebusaway.android.time.WallTime
 import org.onebusaway.android.util.locationOf
 
@@ -85,6 +86,8 @@ private class CachedObaStop(private val record: CachedStopRecord) : ObaStop {
     override val direction: String? get() = record.direction
     override val locationType: Int get() = record.locationType
     override val routeIds: Array<String> get() = splitRouteIds(record.routeIds)
+    override val wheelchairBoarding: WheelchairBoarding
+        get() = WheelchairBoarding.fromString(record.wheelchairBoarding)
 }
 
 /** Presents this cached row as an [ObaStop] for the map overlay. */
@@ -100,6 +103,9 @@ fun ObaStop.toCachedRecord(regionId: Long, now: Long): CachedStopRecord = Cached
     longitude = longitude,
     locationType = locationType,
     routeIds = joinRouteIds(routeIds),
+    // Persist the wire representation (WheelchairBoarding.toString()), the exact string
+    // WheelchairBoarding.fromString reads back — so write and read can't drift apart.
+    wheelchairBoarding = wheelchairBoarding.toString(),
     regionId = regionId,
     lastSeen = now
 )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/database/oba/MapStopCacheMappers.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/database/oba/MapStopCacheMappers.kt
@@ -103,9 +103,7 @@ fun ObaStop.toCachedRecord(regionId: Long, now: Long): CachedStopRecord = Cached
     longitude = longitude,
     locationType = locationType,
     routeIds = joinRouteIds(routeIds),
-    // Persist the wire representation (WheelchairBoarding.toString()), the exact string
-    // WheelchairBoarding.fromString reads back — so write and read can't drift apart.
-    wheelchairBoarding = wheelchairBoarding.toString(),
+    wheelchairBoarding = wheelchairBoarding.name,
     regionId = regionId,
     lastSeen = now
 )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/models/ObaStop.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/models/ObaStop.kt
@@ -46,6 +46,9 @@ interface ObaStop : ObaElement {
     /** The list of route IDs serving this stop. */
     val routeIds: Array<String>
 
+    /** The wheelchair-boarding accessibility of the stop; [WheelchairBoarding.UNKNOWN] when unstated. */
+    val wheelchairBoarding: WheelchairBoarding
+
     companion object {
         const val LOCATION_STOP = 0
         const val LOCATION_STATION = 1

--- a/onebusaway-android/src/main/java/org/onebusaway/android/models/WheelchairBoarding.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/models/WheelchairBoarding.kt
@@ -23,20 +23,24 @@ package org.onebusaway.android.models
  * A stop with no `wheelchairBoarding` on the wire (an older server, or a feed that omits the field)
  * decodes to [UNKNOWN] — the GTFS default of "no accessibility information", not a guess.
  */
-enum class WheelchairBoarding(private val value: String) {
-    ACCESSIBLE("ACCESSIBLE"),
-    NOT_ACCESSIBLE("NOT_ACCESSIBLE"),
-    UNKNOWN("UNKNOWN");
-
-    override fun toString(): String = value
+enum class WheelchairBoarding {
+    ACCESSIBLE,
+    NOT_ACCESSIBLE,
+    UNKNOWN;
 
     companion object {
         /**
          * Maps the wire string to the enum. A null (field absent) or unrecognized value is treated as
          * [UNKNOWN] — the GTFS default when accessibility is unstated — so callers get a total,
          * non-null domain to switch on.
+         *
+         * The wire strings are exactly the constant names, so [name] round-trips a value back onto the
+         * wire (and into storage) without a second spelling of each constant to keep in sync.
          */
-        @JvmStatic
-        fun fromString(value: String?): WheelchairBoarding = entries.firstOrNull { it.value == value } ?: UNKNOWN
+        fun fromString(value: String?): WheelchairBoarding = when (value) {
+            ACCESSIBLE.name -> ACCESSIBLE
+            NOT_ACCESSIBLE.name -> NOT_ACCESSIBLE
+            else -> UNKNOWN
+        }
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/models/WheelchairBoarding.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/models/WheelchairBoarding.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.models
+
+/**
+ * A stop's wheelchair-boarding accessibility, from the GTFS `wheelchair_boarding` field as surfaced
+ * by the OBA REST `stop` element (issue #1029). The OBA server maps the numeric GTFS values to these
+ * three string states on the wire; [fromString] mints the wire string back into the domain.
+ *
+ * A stop with no `wheelchairBoarding` on the wire (an older server, or a feed that omits the field)
+ * decodes to [UNKNOWN] — the GTFS default of "no accessibility information", not a guess.
+ */
+enum class WheelchairBoarding(private val value: String) {
+    ACCESSIBLE("ACCESSIBLE"),
+    NOT_ACCESSIBLE("NOT_ACCESSIBLE"),
+    UNKNOWN("UNKNOWN");
+
+    override fun toString(): String = value
+
+    companion object {
+        /**
+         * Maps the wire string to the enum. A null (field absent) or unrecognized value is treated as
+         * [UNKNOWN] — the GTFS default when accessibility is unstated — so callers get a total,
+         * non-null domain to switch on.
+         */
+        @JvmStatic
+        fun fromString(value: String?): WheelchairBoarding = entries.firstOrNull { it.value == value } ?: UNKNOWN
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsRepository.kt
@@ -39,6 +39,7 @@ import org.onebusaway.android.models.FocusedTrip
 import org.onebusaway.android.models.ObaRoute
 import org.onebusaway.android.models.ObaSituation
 import org.onebusaway.android.models.ObaStop
+import org.onebusaway.android.models.WheelchairBoarding
 import org.onebusaway.android.models.contentKey
 import org.onebusaway.android.preferences.PreferencesRepository
 import org.onebusaway.android.region.RegionRepository
@@ -362,7 +363,8 @@ class DefaultArrivalsRepository @Inject constructor(
             stopId = snapshot.stopId,
             name = MyTextUtils.formatDisplayText(stop?.name).orEmpty(),
             direction = stop?.direction,
-            isFavorite = userInfo?.favorite == 1
+            isFavorite = userInfo?.favorite == 1,
+            wheelchairBoarding = stop?.wheelchairBoarding ?: WheelchairBoarding.UNKNOWN
         )
         val routeDisplayNames = buildRouteDisplayNames(snapshot, stop)
         // Pure grouping; no store write. Hidden state is derived in the ViewModel from [alertHideState]

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsUiState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsUiState.kt
@@ -15,6 +15,7 @@
  */
 package org.onebusaway.android.ui.arrivals
 
+import org.onebusaway.android.models.WheelchairBoarding
 import org.onebusaway.android.time.ServerTime
 
 /** The stop being viewed, for the arrivals screen header. */
@@ -22,7 +23,8 @@ data class StopHeader(
     val stopId: String,
     val name: String,
     val direction: String?,
-    val isFavorite: Boolean
+    val isFavorite: Boolean,
+    val wheelchairBoarding: WheelchairBoarding = WheelchairBoarding.UNKNOWN
 )
 
 /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/CurrentFocusPersistence.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/CurrentFocusPersistence.kt
@@ -75,8 +75,7 @@ internal object CurrentFocusPersistence {
         state[KEY_STOP_CODE] = stop?.code
         state[KEY_STOP_LAT] = stop?.point?.latitude
         state[KEY_STOP_LON] = stop?.point?.longitude
-        // The wire representation (toString()) — the exact string WheelchairBoarding.fromString reads back.
-        state[KEY_STOP_WHEELCHAIR] = stop?.wheelchairBoarding?.toString()
+        state[KEY_STOP_WHEELCHAIR] = stop?.wheelchairBoarding?.name
         state[KEY_BIKE_STATION] = (focus as? CurrentFocus.BikeStation)?.id
 
         val target = (focus as? CurrentFocus.Route)?.target

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/CurrentFocusPersistence.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/CurrentFocusPersistence.kt
@@ -17,6 +17,7 @@ package org.onebusaway.android.ui.home
 
 import androidx.lifecycle.SavedStateHandle
 import org.onebusaway.android.map.MapParams
+import org.onebusaway.android.models.WheelchairBoarding
 import org.onebusaway.android.util.GeoPoint
 
 /** Mechanical SavedStateHandle encoding for [CurrentFocus], kept out of focus transition logic. */
@@ -27,6 +28,7 @@ internal object CurrentFocusPersistence {
     private const val KEY_STOP_CODE = "home.focusedStop.code"
     private const val KEY_STOP_LAT = "home.focusedStop.lat"
     private const val KEY_STOP_LON = "home.focusedStop.lon"
+    private const val KEY_STOP_WHEELCHAIR = "home.focusedStop.wheelchairBoarding"
     private const val KEY_BIKE_STATION = "home.focusedBikeStation.id"
     private const val KEY_ROUTE_ID = "home.currentFocus.route.id"
     private const val KEY_ROUTE_STOP_ID = "home.currentFocus.route.stopId"
@@ -73,6 +75,8 @@ internal object CurrentFocusPersistence {
         state[KEY_STOP_CODE] = stop?.code
         state[KEY_STOP_LAT] = stop?.point?.latitude
         state[KEY_STOP_LON] = stop?.point?.longitude
+        // The wire representation (toString()) — the exact string WheelchairBoarding.fromString reads back.
+        state[KEY_STOP_WHEELCHAIR] = stop?.wheelchairBoarding?.toString()
         state[KEY_BIKE_STATION] = (focus as? CurrentFocus.BikeStation)?.id
 
         val target = (focus as? CurrentFocus.Route)?.target
@@ -145,7 +149,8 @@ internal object CurrentFocusPersistence {
             point = GeoPoint(
                 state.get<Double>(KEY_STOP_LAT) ?: 0.0,
                 state.get<Double>(KEY_STOP_LON) ?: 0.0
-            )
+            ),
+            wheelchairBoarding = WheelchairBoarding.fromString(state[KEY_STOP_WHEELCHAIR])
         )
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/FocusedStop.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/FocusedStop.kt
@@ -15,6 +15,7 @@
  */
 package org.onebusaway.android.ui.home
 
+import org.onebusaway.android.models.WheelchairBoarding
 import org.onebusaway.android.util.GeoPoint
 
 /**
@@ -26,7 +27,10 @@ data class FocusedStop(
     val id: String,
     val name: String?,
     val code: String?,
-    val point: GeoPoint
+    val point: GeoPoint,
+    // The tapped stop's accessibility, carried through so the focus banner can show it (#1029);
+    // [WheelchairBoarding.UNKNOWN] for focuses minted without an ObaStop (intent extras, restore).
+    val wheelchairBoarding: WheelchairBoarding = WheelchairBoarding.UNKNOWN
 ) {
     // Empty companion so intent/extras parsing can hang off it as a `FocusedStop.fromIntent(...)`
     // extension where that contract lives (HomeActivity), without this model knowing about intents.

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -400,6 +400,7 @@ fun HomeScreen(
                         isFavorite = currentFocus.stop.id in favoriteStopIds,
                         favoriteEnabled = stopFavoritesReady,
                         hasAlerts = arrivalsContent?.hasAlerts == true,
+                        wheelchairBoarding = currentFocus.stop.wheelchairBoarding,
                         subordinateRoutes = currentFocus.selectedRoute?.legs?.map { leg ->
                             FocusBannerState.SubordinateRoute(
                                 shortName = leg.shortName,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -70,6 +70,7 @@ import kotlinx.coroutines.launch
 import org.onebusaway.android.R
 import org.onebusaway.android.map.MapViewModel
 import org.onebusaway.android.map.RouteHeader
+import org.onebusaway.android.models.WheelchairBoarding
 import org.onebusaway.android.ui.arrivals.ArrivalsLoaded
 import org.onebusaway.android.ui.arrivals.ArrivalsUiState
 import org.onebusaway.android.ui.arrivals.ArrivalsViewModel
@@ -400,7 +401,13 @@ fun HomeScreen(
                         isFavorite = currentFocus.stop.id in favoriteStopIds,
                         favoriteEnabled = stopFavoritesReady,
                         hasAlerts = arrivalsContent?.hasAlerts == true,
-                        wheelchairBoarding = currentFocus.stop.wheelchairBoarding,
+                        // Like the stop code and direction above: the loaded arrivals are the source, with
+                        // the focus as the pre-load fallback. Only a map tap mints a focus from a full
+                        // ObaStop — a search result, deep link or directions stop carries just an id — so
+                        // without the arrivals source the glyph would be missing on most entry points.
+                        wheelchairBoarding = arrivalsContent?.header?.wheelchairBoarding
+                            ?.takeIf { it != WheelchairBoarding.UNKNOWN }
+                            ?: currentFocus.stop.wheelchairBoarding,
                         subordinateRoutes = currentFocus.selectedRoute?.legs?.map { leg ->
                             FocusBannerState.SubordinateRoute(
                                 shortName = leg.shortName,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/FocusBanner.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/FocusBanner.kt
@@ -28,6 +28,7 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -83,6 +84,10 @@ import org.onebusaway.android.util.DisplayFormat
 private val HEADER_ICON_SIZE = 36.dp
 private val HEADER_ICON_BUTTON_SIZE = 40.dp
 private val FOCUS_RAIL_ICON_SIZE = 26.4.dp
+
+// Sized to sit on the stop's subtitle line without outgrowing its bodySmall text.
+private val SUBTITLE_ICON_SIZE = 16.dp
+private val SUBTITLE_ICON_OPTICAL_LIFT = 1.dp
 
 // The stop name shrinks to fit within this many lines before ellipsizing; see ShrinkToFitStopTitle.
 private const val MAX_TITLE_LINES = 2
@@ -245,19 +250,28 @@ private fun StopFocusBanner(
                 )
             ) {
                 ShrinkToFitStopTitle(state.title)
-                if (subtitle != null) {
-                    Text(
-                        text = subtitle,
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                        modifier = Modifier.padding(top = 4.dp)
-                    )
+                val wheelchairGlyph = wheelchairGlyph(state.wheelchairBoarding)
+                if (subtitle != null || wheelchairGlyph != null) {
+                    Row(
+                        modifier = Modifier.padding(top = 4.dp),
+                        horizontalArrangement = Arrangement.spacedBy(4.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        if (subtitle != null) {
+                            Text(
+                                text = subtitle,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                                modifier = Modifier.weight(1f, fill = false)
+                            )
+                        }
+                        if (wheelchairGlyph != null) {
+                            WheelchairBoardingIndicator(wheelchairGlyph)
+                        }
+                    }
                 }
-            }
-            if (state.wheelchairBoarding == WheelchairBoarding.ACCESSIBLE) {
-                WheelchairAccessibleIndicator()
             }
             if (state.hasAlerts) {
                 BannerAlertAction(onClick = onShowAlerts)
@@ -490,20 +504,37 @@ private fun BannerFavoriteAction(
 }
 
 /**
- * A non-interactive badge marking the focused stop as wheelchair accessible (#1029). Shown only for
- * [WheelchairBoarding.ACCESSIBLE]; the "not accessible"/"unknown" states render nothing, since most
- * feeds leave the GTFS field unset and a stream of "unknown" badges would be noise.
+ * The icon and its description for a stop's GTFS wheelchair boarding (#1029), or null when there is
+ * nothing to show: [WheelchairBoarding.UNKNOWN] draws no glyph, since most feeds leave the field unset
+ * and a stream of "unknown" glyphs would be noise. Resolving it once — rather than at both the layout
+ * guard and the glyph — keeps the "what's worth showing" rule in a single exhaustive `when`.
+ */
+private fun wheelchairGlyph(boarding: WheelchairBoarding): Pair<Int, Int>? = when (boarding) {
+    WheelchairBoarding.ACCESSIBLE ->
+        R.drawable.ic_wheelchair_accessible to R.string.stop_wheelchair_accessible
+    WheelchairBoarding.NOT_ACCESSIBLE ->
+        R.drawable.not_accessible_24 to R.string.stop_wheelchair_not_accessible
+    WheelchairBoarding.UNKNOWN -> null
+}
+
+/**
+ * A non-interactive [wheelchairGlyph] on the stop's subtitle line, sized and tinted to read as part of
+ * the subtitle rather than as an action.
+ *
+ * Nudged up by [SUBTITLE_ICON_OPTICAL_LIFT]: the row centers the icon against the subtitle's *layout*
+ * box, which reserves descender space the stop code and direction never use, so a box-centered glyph
+ * reads slightly low against the text beside it.
  */
 @Composable
-private fun WheelchairAccessibleIndicator() {
+private fun WheelchairBoardingIndicator(glyph: Pair<Int, Int>) {
+    val (iconRes, descriptionRes) = glyph
     Icon(
-        painter = painterResource(R.drawable.ic_wheelchair_accessible),
-        contentDescription = stringResource(R.string.stop_wheelchair_accessible),
-        tint = MaterialTheme.colorScheme.primary,
-        // 12dp padding + 24dp icon = a 48dp footprint, matching the alert/close actions it sits beside.
+        painter = painterResource(iconRes),
+        contentDescription = stringResource(descriptionRes),
+        tint = MaterialTheme.colorScheme.onSurfaceVariant,
         modifier = Modifier
-            .padding(12.dp)
-            .size(24.dp)
+            .offset(y = -SUBTITLE_ICON_OPTICAL_LIFT)
+            .size(SUBTITLE_ICON_SIZE)
     )
 }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/FocusBanner.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/FocusBanner.kt
@@ -68,6 +68,7 @@ import androidx.compose.ui.unit.sp
 import org.onebusaway.android.R
 import org.onebusaway.android.map.RouteHeader
 import org.onebusaway.android.models.RouteMapDirection
+import org.onebusaway.android.models.WheelchairBoarding
 import org.onebusaway.android.ui.compose.components.DirectionHeadsign
 import org.onebusaway.android.ui.compose.components.LineBadge
 import org.onebusaway.android.ui.compose.components.RadioOptionList
@@ -109,6 +110,7 @@ sealed interface FocusBannerState {
         override val isFavorite: Boolean,
         override val favoriteEnabled: Boolean,
         val hasAlerts: Boolean,
+        val wheelchairBoarding: WheelchairBoarding = WheelchairBoarding.UNKNOWN,
         val subordinateRoutes: List<SubordinateRoute> = emptyList(),
         val subordinateHeadsign: String? = null
     ) : FocusBannerState {
@@ -253,6 +255,9 @@ private fun StopFocusBanner(
                         modifier = Modifier.padding(top = 4.dp)
                     )
                 }
+            }
+            if (state.wheelchairBoarding == WheelchairBoarding.ACCESSIBLE) {
+                WheelchairAccessibleIndicator()
             }
             if (state.hasAlerts) {
                 BannerAlertAction(onClick = onShowAlerts)
@@ -484,6 +489,24 @@ private fun BannerFavoriteAction(
     )
 }
 
+/**
+ * A non-interactive badge marking the focused stop as wheelchair accessible (#1029). Shown only for
+ * [WheelchairBoarding.ACCESSIBLE]; the "not accessible"/"unknown" states render nothing, since most
+ * feeds leave the GTFS field unset and a stream of "unknown" badges would be noise.
+ */
+@Composable
+private fun WheelchairAccessibleIndicator() {
+    Icon(
+        painter = painterResource(R.drawable.ic_wheelchair_accessible),
+        contentDescription = stringResource(R.string.stop_wheelchair_accessible),
+        tint = MaterialTheme.colorScheme.primary,
+        // 12dp padding + 24dp icon = a 48dp footprint, matching the alert/close actions it sits beside.
+        modifier = Modifier
+            .padding(12.dp)
+            .size(24.dp)
+    )
+}
+
 @Composable
 private fun BannerAlertAction(onClick: () -> Unit) {
     Icon(
@@ -582,6 +605,7 @@ private fun FocusBannerPreview() {
                     isFavorite = true,
                     favoriteEnabled = true,
                     hasAlerts = true,
+                    wheelchairBoarding = WheelchairBoarding.ACCESSIBLE,
                     subordinateRoutes = listOf(
                         FocusBannerState.SubordinateRoute("65", 0xFF26823B.toInt()),
                         FocusBannerState.SubordinateRoute("75", 0xFF125BA8.toInt())

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
@@ -150,7 +150,7 @@ fun MapFeature(
             override fun onStopClick(marker: StopMarker) {
                 val stop = marker.stop
                 val transition = homeViewModel.onStopFocused(
-                    FocusedStop(stop.id, stop.name, stop.stopCode, marker.point),
+                    FocusedStop(stop.id, stop.name, stop.stopCode, marker.point, stop.wheelchairBoarding),
                     continuingRoutes = marker.presentedRoutes
                 )
                 if (transition == StopFocusTransition.ReplacePresentation) {

--- a/onebusaway-android/src/main/res/drawable/ic_wheelchair_accessible.xml
+++ b/onebusaway-android/src/main/res/drawable/ic_wheelchair_accessible.xml
@@ -1,0 +1,25 @@
+<!--
+  ~ Copyright (C) 2026 Open Transit Software Foundation
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<!-- Material Symbols "accessible" (the international symbol of access). -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M480,240Q447,240 423.5,216.5Q400,193 400,160Q400,127 423.5,103.5Q447,80 480,80Q513,80 536.5,103.5Q560,127 560,160Q560,193 536.5,216.5Q513,240 480,240ZM680,880L680,680Q680,680 680,680Q680,680 680,680L480,680Q447,680 423.5,656.5Q400,633 400,600L400,360Q400,327 423.5,303.5Q447,280 480,280Q504,280 521.5,290.5Q539,301 559,324Q614,390 658.5,414.5Q703,439 760,440L760,520Q707,520 653,497Q599,474 560,442L560,580L680,580Q713,580 736.5,603.5Q760,627 760,660L760,880L680,880ZM400,880Q317,880 258.5,821.5Q200,763 200,680Q200,608 245.5,553Q291,498 360,484L360,566Q325,580 302.5,610.5Q280,641 280,680Q280,730 315,765Q350,800 400,800Q439,800 469.5,777.5Q500,755 514,720L596,720Q582,789 527,834.5Q472,880 400,880Z"/>
+</vector>

--- a/onebusaway-android/src/main/res/drawable/not_accessible_24.xml
+++ b/onebusaway-android/src/main/res/drawable/not_accessible_24.xml
@@ -1,0 +1,25 @@
+<!--
+  ~ Copyright (C) 2026 Open Transit Software Foundation
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<!-- Material Symbols "not_accessible" (the symbol of access, struck through). -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M791,904L567,680L480,680Q447,680 423.5,656.5Q400,633 400,600L400,513L56,169L112,112L848,848L791,904ZM400,880Q317,880 258.5,821.5Q200,763 200,680Q200,607 245.5,552.5Q291,498 360,484L360,567Q325,580 302.5,610.5Q280,641 280,680Q280,730 315,765Q350,800 400,800Q439,800 470,777.5Q501,755 513,720L596,720Q582,789 527.5,834.5Q473,880 400,880ZM480,240Q447,240 423.5,216.5Q400,193 400,160Q400,127 423.5,103.5Q447,80 480,80Q513,80 536.5,103.5Q560,127 560,160Q560,193 536.5,216.5Q513,240 480,240ZM760,520Q707,520 653,497Q599,474 560,442L560,442L560,442L423,305Q433,294 446,287.5Q459,281 480,281Q495,281 513,288Q531,295 546,310L597,367Q626,399 669.5,420Q713,441 760,440L760,520Z"/>
+</vector>

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -330,6 +330,7 @@
 
     <!-- Stop Details -->
     <string name="stop_details_code">Stop # %1$s</string>
+    <string name="stop_wheelchair_accessible">Wheelchair accessible</string>
 
     <!-- Arrival Time Style B -->
 

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -331,6 +331,7 @@
     <!-- Stop Details -->
     <string name="stop_details_code">Stop # %1$s</string>
     <string name="stop_wheelchair_accessible">Wheelchair accessible</string>
+    <string name="stop_wheelchair_not_accessible">Not wheelchair accessible</string>
 
     <!-- Arrival Time Style B -->
 

--- a/onebusaway-android/src/test/java/org/onebusaway/android/api/StopDetailsDecodeTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/api/StopDetailsDecodeTest.kt
@@ -22,6 +22,7 @@ import org.junit.Test
 import org.onebusaway.android.api.contract.EntryWithReferences
 import org.onebusaway.android.api.contract.ObaEnvelope
 import org.onebusaway.android.api.contract.StopReference
+import org.onebusaway.android.models.WheelchairBoarding
 
 /**
  * Ports the legacy StopRequestTest onto the modernized `stop` endpoint: decodes a real Puget Sound
@@ -36,8 +37,9 @@ class StopDetailsDecodeTest {
         coerceInputValues = true
     }
 
-    // Captured from api.pugetsound.onebusaway.org/api/where/stop/1_29261.json (trimmed; extra
-    // entry fields parent/staticRouteIds/wheelchairBoarding and ref kinds are ignored by the model).
+    // Captured from api.pugetsound.onebusaway.org/api/where/stop/1_29261.json (trimmed; extra entry
+    // fields parent/staticRouteIds and unmodeled ref kinds are ignored by the model, but
+    // wheelchairBoarding is now decoded — see the assertion below).
     private val body = """
         {
           "version": 2, "code": 200, "currentTime": 1782347930000, "text": "OK",
@@ -73,6 +75,8 @@ class StopDetailsDecodeTest {
         // locationType 0 == a stop (vs. a station).
         assertEquals(0, stop.locationType)
         assertEquals(listOf("1_100275", "1_100009", "1_100223", "1_102650"), stop.routeIds)
+        assertEquals("ACCESSIBLE", stop.wheelchairBoarding)
+        assertEquals(WheelchairBoarding.ACCESSIBLE, WheelchairBoarding.fromString(stop.wheelchairBoarding))
 
         // Every routeId resolves to a route in the references (legacy asserted routes.size == routeIds).
         val routes = stop.routeIds.map { data.references.route(it) }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/database/oba/MapStopCacheMappersTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/database/oba/MapStopCacheMappersTest.kt
@@ -20,6 +20,7 @@ import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.onebusaway.android.models.ObaStop
+import org.onebusaway.android.models.WheelchairBoarding
 import org.onebusaway.android.time.WallTime
 
 /** JVM unit tests for the pure map-stop-cache mappers ([MapStopCacheMappers]). */
@@ -75,7 +76,8 @@ class MapStopCacheMappersTest {
             locationType = ObaStop.LOCATION_STOP,
             lat = 47.61,
             lon = -122.34,
-            routeIds = arrayOf("1_100", "1_101")
+            routeIds = arrayOf("1_100", "1_101"),
+            wheelchairBoarding = WheelchairBoarding.ACCESSIBLE
         )
 
         val record = stop.toCachedRecord(regionId = 3L, now = 500L)
@@ -91,6 +93,7 @@ class MapStopCacheMappersTest {
         assertEquals(47.61, back.latitude, 1e-9)
         assertEquals(-122.34, back.longitude, 1e-9)
         assertArrayEquals(arrayOf("1_100", "1_101"), back.routeIds)
+        assertEquals(WheelchairBoarding.ACCESSIBLE, back.wheelchairBoarding)
     }
 
     @Test
@@ -113,6 +116,8 @@ class MapStopCacheMappersTest {
         assertEquals(null, back.name)
         assertEquals(ObaStop.LOCATION_STATION, back.locationType)
         assertArrayEquals(emptyArray<String>(), back.routeIds)
+        // No accessibility given → the default UNKNOWN round-trips (not null).
+        assertEquals(WheelchairBoarding.UNKNOWN, back.wheelchairBoarding)
     }
 
     private fun fakeStop(
@@ -123,7 +128,8 @@ class MapStopCacheMappersTest {
         locationType: Int,
         lat: Double,
         lon: Double,
-        routeIds: Array<String>
+        routeIds: Array<String>,
+        wheelchairBoarding: WheelchairBoarding = WheelchairBoarding.UNKNOWN
     ): ObaStop = object : ObaStop {
         override val id = id
         override val stopCode = code
@@ -133,6 +139,7 @@ class MapStopCacheMappersTest {
         override val latitude = lat
         override val longitude = lon
         override val routeIds = routeIds
+        override val wheelchairBoarding = wheelchairBoarding
 
         // Never touched by the mappers (would need Android); guard so a regression is loud.
         override val location: Location get() = throw UnsupportedOperationException()


### PR DESCRIPTION
Closes #1029.

Google-Maps-style accessibility: when a stop reports GTFS `wheelchair_boarding` as accessible, the map focus banner shows a wheelchair badge. The OBA REST stop element already carries `wheelchairBoarding` (`ACCESSIBLE` / `NOT_ACCESSIBLE` / `UNKNOWN`) — the client was decoding the rest of the stop and silently discarding this field — so this is a purely client-side change.

## What changed

- **New domain type** `WheelchairBoarding` — a 3-state enum with `fromString(...)` that mints the wire string into the domain and treats an absent/unrecognized value as `UNKNOWN` (the GTFS default of "unstated", not a guess). Follows the existing `Occupancy` pattern.
- **Parse + model** — `StopReference` DTO now decodes the field; `ObaStop` gained `wheelchairBoarding`, implemented in all three impls (`DtoStop`, `ObaStopElement`, `CachedObaStop`). Minting happens at the adapter boundary, consistent with `TripAdapters`.
- **Banner** — threaded `ObaStop → FocusedStop → FocusBannerState.Stop`, persisted across process death in `CurrentFocusPersistence`, and rendered in `FocusBanner`. The badge shows **only for `ACCESSIBLE`**; `NOT_ACCESSIBLE`/`UNKNOWN` render nothing, since most feeds leave the field unset and a stream of "unknown" icons would be noise. New `ic_wheelchair_accessible.xml` (Material "accessible" symbol) + a `stop_wheelchair_accessible` string with a `contentDescription`.
- **Map cache** — the map's stops come through a Room cache, so without persisting the field a stop would show the badge right after a fresh fetch but not after a cache reload. Added a nullable `cached_stops.wheelchair_boarding` column: schema **v7 → v8** with additive `MIGRATION_7_8` (`ALTER TABLE … ADD COLUMN`), regenerated `8.json`. Existing rows read back as `UNKNOWN`.

## Tests

- `StopDetailsDecodeTest` asserts the field decodes (its fixture already contained `"wheelchairBoarding": "ACCESSIBLE"`).
- `MapStopCacheMappersTest` asserts the value round-trips through the cache and that the default is `UNKNOWN` (not null).
- `AppDatabaseMigrationTest.migrate7To8_…` asserts the column is added NULL for pre-existing rows.

## Verification

Clean `-PwarningsAsErrors=true` compile (main + unit + androidTest, Kotlin & Java), `spotlessCheck`, and the affected unit suites pass. The instrumented tests (`migrate7To8`, DAO test) were not run — no device was available in this environment; CI will exercise them.

## Scope note

Indicator is on the **map focus banner** only, as requested. The model plumbing is in place if we later want it on the arrivals header or stop-details dialog too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added wheelchair accessibility boarding status to stop data (accessible, not accessible, or unknown).
  * Persisted and surfaced wheelchair status across stop details, arrivals headers, and cached stop records.
  * Display wheelchair accessibility indicator in the map focus banner for non-unknown values.
* **Bug Fixes**
  * Preserved wheelchair accessibility status when restoring focused stops.
  * Migrated existing cached stop entries to safely support the new wheelchair boarding field (existing rows read as unknown).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->