### PR TITLE
Offer a leg's interchangeable routes in the trip planner (#2010)

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/compose/components/RouteBadgeChipRenderTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/compose/components/RouteBadgeChipRenderTest.kt
@@ -18,13 +18,17 @@ package org.onebusaway.android.ui.compose.components
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.PixelMap
+import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.toPixelMap
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.captureToImage
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -38,7 +42,7 @@ import org.onebusaway.android.ui.compose.theme.ObaTheme
  * several routes rather than as separate badges, or as one long name:
  *  - its route colors meet **directly**, with none of the surface behind showing through as a gap;
  *  - they meet along a **slash-like diagonal**, not a vertical edge;
- *  - that meeting line, and the badge's outline, are drawn in black.
+ *  - that meeting line is much darker than the routes it separates, and the badge's outline is black.
  *
  * Rendering assertions, so they live on-device: the badge is drawn over a garish background that must
  * not appear anywhere inside it, and the color boundary is located on a high and a low scan line to
@@ -60,9 +64,16 @@ class RouteBadgeChipRenderTest {
 
     private fun renderJoinedBadge(routes: List<RouteBadge> = listOf(link1, link2)) {
         composeRule.setContent {
-            ObaTheme {
-                Box(Modifier.background(backdrop).padding(8.dp)) {
-                    RouteBadgeChip(routes, Modifier.testTag(BADGE))
+            // Pinned density, so what these assertions see doesn't depend on the screen they run on.
+            // Deliberately a low one: it is the hostile case for a hairline — the badge is only a few
+            // dozen pixels across and the diagonal line between its routes is barely two pixels wide,
+            // fully antialiased. (An earlier version of this test read single pixels and passed on a
+            // dense phone while failing on CI's emulator.)
+            CompositionLocalProvider(LocalDensity provides Density(LOW_DENSITY)) {
+                ObaTheme {
+                    Box(Modifier.background(backdrop).padding(8.dp)) {
+                        RouteBadgeChip(routes, Modifier.testTag(BADGE))
+                    }
                 }
             }
         }
@@ -111,17 +122,18 @@ class RouteBadgeChipRenderTest {
         )
     }
 
-    /** A single-route badge is still one flat color inside its outline — no diagonal, no second color. */
+    /**
+     * A single-route badge is one flat color inside its outline — no diagonal, no second color. Compares
+     * the *dominant* color of the leftmost and rightmost interior columns rather than one pixel of each:
+     * a route name can reach into either end of a narrow badge, but it never fills a whole column.
+     */
     @Test
     fun singleRouteBadgeIsOneSolidColor() {
         renderJoinedBadge(routes = listOf(link1))
 
         val pixels = badgePixels()
-        val middle = pixels.height / 2
-        val leftEdge = pixels[EDGE_INSET, middle]
-        val rightEdge = pixels[pixels.width - 1 - EDGE_INSET, middle]
 
-        assertEquals(leftEdge, rightEdge)
+        assertEquals(columnColor(pixels, EDGE_INSET), columnColor(pixels, pixels.width - 1 - EDGE_INSET))
     }
 
     /** The badge is bounded by a black outline, so it reads as one object against any background. */
@@ -140,20 +152,42 @@ class RouteBadgeChipRenderTest {
     }
 
     /**
-     * The routes are separated by a black line inside the badge — the thing that keeps two routes
-     * sharing a color (or having none) from reading as a single name.
+     * Where the two routes meet there is a black line — the thing that keeps routes sharing a color (or
+     * having none) from reading as one long name. Asserted as "much darker than either route color" at
+     * the meeting point rather than "exactly black" anywhere: the line is a diagonal hairline, so at a
+     * low screen density every pixel of it is antialiased with the bands it separates and none comes out
+     * pure black. The line is drawn regardless of the routes' colors, so two distinct colors — which
+     * make the meeting point findable — exercise the same drawing the same-color case relies on.
      */
     @Test
     fun routesAreSeparatedByABlackLine() {
-        renderJoinedBadge(routes = listOf(link1, link1.copy(shortName = "2 Line")))
+        renderJoinedBadge()
 
         val pixels = badgePixels()
-        val interior = interiorRows(pixels).flatMap { y ->
-            (EDGE_INSET until pixels.width - EDGE_INSET).map { x -> pixels[x, y] }
-        }
+        val rows = interiorRows(pixels)
+        val bands = listOf(
+            columnColor(pixels, EDGE_INSET),
+            columnColor(pixels, pixels.width - 1 - EDGE_INSET)
+        )
+        val row = rows[rows.size / 2]
+        val meeting = boundaryX(pixels, row)
+        val darkest = ((meeting - 1)..(meeting + 2))
+            .filter { it in 0 until pixels.width }
+            .minOf { pixels[it, row].luminance() }
 
-        assertTrue("no black separating line found inside the badge", interior.any { it == Color.Black })
+        assertTrue(
+            "expected a dark line where the routes meet (x=$meeting): darkest luminance there was " +
+                "$darkest, against route colors ${bands.map { it.luminance() }}",
+            darkest < bands.minOf { it.luminance() } / 2f
+        )
     }
+
+    /** The most common color down one interior column — the band behind whatever glyphs cross it. */
+    private fun columnColor(pixels: PixelMap, x: Int): Color = interiorRows(pixels)
+        .groupingBy { y -> pixels[x, y] }
+        .eachCount()
+        .maxBy { it.value }
+        .key
 
     /** The rows to scan: the badge's middle band, clear of its rounded corners. */
     private fun interiorRows(pixels: PixelMap): List<Int> = (pixels.height / 4 until pixels.height * 3 / 4).toList()
@@ -177,5 +211,8 @@ class RouteBadgeChipRenderTest {
 
         /** Scans start this far inside the badge, clear of its outline (1dp, so a few px at any density). */
         const val EDGE_INSET = 6
+
+        /** The density every case renders at — low, so hairlines and glyphs get the least room. */
+        const val LOW_DENSITY = 2f
     }
 }

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/compose/components/RouteBadgeChipRenderTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/compose/components/RouteBadgeChipRenderTest.kt
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.compose.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PixelMap
+import androidx.compose.ui.graphics.toPixelMap
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.captureToImage
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.unit.dp
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.onebusaway.android.ui.compose.createUnconfinedComposeRule
+import org.onebusaway.android.ui.compose.theme.ObaTheme
+
+/**
+ * Pixel-level checks on the joined route badge (#2010) — the two things that make it read as one chip
+ * of several routes rather than as separate badges:
+ *  - its route colors meet **directly**, with none of the surface behind showing through as a seam;
+ *  - they meet along a **slash-like diagonal**, not a vertical edge.
+ *
+ * Rendering assertions, so they live on-device: the badge is drawn over a garish background that must
+ * not appear anywhere inside it, and the color boundary is located on a high and a low scan line to
+ * confirm which way it leans. Reading a run of one color (rather than the first pixel that differs)
+ * keeps the glyphs drawn on top of that color from being mistaken for the boundary.
+ */
+class RouteBadgeChipRenderTest {
+
+    // See createUnconfinedComposeRule for why Unconfined composition is used here (issue #1792).
+    @get:Rule
+    val composeRule = createUnconfinedComposeRule()
+
+    /** Nothing else in the badge is this color, so any pixel of it inside the chip is a gap. */
+    private val backdrop = Color.Magenta
+
+    private val link1 = RouteBadge("1 Line", 0xFF00A651.toInt())
+    private val link2 = RouteBadge("2 Line", 0xFF0075C4.toInt())
+
+    private fun renderJoinedBadge(routes: List<RouteBadge> = listOf(link1, link2)) {
+        composeRule.setContent {
+            ObaTheme {
+                Box(Modifier.background(backdrop).padding(8.dp)) {
+                    RouteBadgeChip(routes, Modifier.testTag(BADGE))
+                }
+            }
+        }
+        // Let the composition attach and draw before any pixel is read: captureToImage needs a live
+        // hierarchy, and these tests share an instrumentation process with the other Compose suites.
+        composeRule.waitForIdle()
+        composeRule.onNodeWithTag(BADGE).assertExists()
+    }
+
+    private fun badgePixels(): PixelMap = composeRule.onNodeWithTag(BADGE).captureToImage().toPixelMap()
+
+    /**
+     * The two route colors abut with no sliver of the surface behind them. Scanned across the badge's
+     * middle band only: the chip's corners are rounded, so its very top and bottom rows legitimately
+     * show the backdrop outside that rounding.
+     */
+    @Test
+    fun joinedBadgeHasNoGapBetweenItsRouteColors() {
+        renderJoinedBadge()
+
+        val pixels = badgePixels()
+        val leaked = interiorRows(pixels).flatMap { y ->
+            (1 until pixels.width - 1).filter { x -> pixels[x, y] == backdrop }.map { x -> x to y }
+        }
+
+        assertEquals("backdrop visible inside the badge at $leaked", emptyList<Pair<Int, Int>>(), leaked)
+    }
+
+    /**
+     * The boundary between the colors leans like a "/": it sits further right near the top of the badge
+     * than near the bottom.
+     */
+    @Test
+    fun joinedBadgeColorsMeetAlongASlashDiagonal() {
+        renderJoinedBadge()
+
+        val pixels = badgePixels()
+        val rows = interiorRows(pixels)
+        val nearTop = boundaryX(pixels, rows.first())
+        val nearBottom = boundaryX(pixels, rows.last())
+
+        assertTrue(
+            "expected the boundary to lean right going up, but it was at x=$nearTop near the top " +
+                "and x=$nearBottom near the bottom",
+            nearTop > nearBottom + MIN_LEAN_PX
+        )
+    }
+
+    /** A single-route badge is still one flat color — the diagonal is only for a joined one. */
+    @Test
+    fun singleRouteBadgeIsOneSolidColor() {
+        renderJoinedBadge(routes = listOf(link1))
+
+        val pixels = badgePixels()
+        val leftEdge = pixels[1, pixels.height / 2]
+        val rightEdge = pixels[pixels.width - 2, pixels.height / 2]
+
+        assertEquals(leftEdge, rightEdge)
+    }
+
+    /** The rows to scan: the badge's middle band, clear of its rounded corners. */
+    private fun interiorRows(pixels: PixelMap): List<Int> = (pixels.height / 4 until pixels.height * 3 / 4).toList()
+
+    /**
+     * Where the first route's color gives way to the second on this row: the last pixel still matching
+     * the row's leftmost color. Taking the *last* match rather than the first mismatch steps over the
+     * route name drawn on top of that color.
+     */
+    private fun boundaryX(pixels: PixelMap, y: Int): Int {
+        val first = pixels[1, y]
+        return (1 until pixels.width - 1).last { x -> pixels[x, y] == first }
+    }
+
+    private companion object {
+        const val BADGE = "joined-route-badge"
+
+        /** The lean has to be visible, not a rounding artifact — a couple of pixels at minimum. */
+        const val MIN_LEAN_PX = 2
+    }
+}

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/compose/components/RouteBadgeChipRenderTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/compose/components/RouteBadgeChipRenderTest.kt
@@ -34,15 +34,17 @@ import org.onebusaway.android.ui.compose.createUnconfinedComposeRule
 import org.onebusaway.android.ui.compose.theme.ObaTheme
 
 /**
- * Pixel-level checks on the joined route badge (#2010) — the two things that make it read as one chip
- * of several routes rather than as separate badges:
- *  - its route colors meet **directly**, with none of the surface behind showing through as a seam;
- *  - they meet along a **slash-like diagonal**, not a vertical edge.
+ * Pixel-level checks on the joined route badge (#2010) — what makes it read as one bounded chip of
+ * several routes rather than as separate badges, or as one long name:
+ *  - its route colors meet **directly**, with none of the surface behind showing through as a gap;
+ *  - they meet along a **slash-like diagonal**, not a vertical edge;
+ *  - that meeting line, and the badge's outline, are drawn in black.
  *
  * Rendering assertions, so they live on-device: the badge is drawn over a garish background that must
  * not appear anywhere inside it, and the color boundary is located on a high and a low scan line to
- * confirm which way it leans. Reading a run of one color (rather than the first pixel that differs)
- * keeps the glyphs drawn on top of that color from being mistaken for the boundary.
+ * confirm which way it leans. Scans start inside the outline ([EDGE_INSET]) and read a *run* of one
+ * color rather than the first pixel that differs, so neither the outline nor the glyphs drawn on a
+ * band are mistaken for the boundary.
  */
 class RouteBadgeChipRenderTest {
 
@@ -83,7 +85,7 @@ class RouteBadgeChipRenderTest {
 
         val pixels = badgePixels()
         val leaked = interiorRows(pixels).flatMap { y ->
-            (1 until pixels.width - 1).filter { x -> pixels[x, y] == backdrop }.map { x -> x to y }
+            (EDGE_INSET until pixels.width - EDGE_INSET).filter { x -> pixels[x, y] == backdrop }.map { x -> x to y }
         }
 
         assertEquals("backdrop visible inside the badge at $leaked", emptyList<Pair<Int, Int>>(), leaked)
@@ -109,16 +111,48 @@ class RouteBadgeChipRenderTest {
         )
     }
 
-    /** A single-route badge is still one flat color — the diagonal is only for a joined one. */
+    /** A single-route badge is still one flat color inside its outline — no diagonal, no second color. */
     @Test
     fun singleRouteBadgeIsOneSolidColor() {
         renderJoinedBadge(routes = listOf(link1))
 
         val pixels = badgePixels()
-        val leftEdge = pixels[1, pixels.height / 2]
-        val rightEdge = pixels[pixels.width - 2, pixels.height / 2]
+        val middle = pixels.height / 2
+        val leftEdge = pixels[EDGE_INSET, middle]
+        val rightEdge = pixels[pixels.width - 1 - EDGE_INSET, middle]
 
         assertEquals(leftEdge, rightEdge)
+    }
+
+    /** The badge is bounded by a black outline, so it reads as one object against any background. */
+    @Test
+    fun badgeIsOutlinedInBlack() {
+        renderJoinedBadge()
+
+        val pixels = badgePixels()
+        val middleRow = pixels.height / 2
+        val middleColumn = pixels.width / 2
+
+        assertEquals("left edge", Color.Black, pixels[0, middleRow])
+        assertEquals("right edge", Color.Black, pixels[pixels.width - 1, middleRow])
+        assertEquals("top edge", Color.Black, pixels[middleColumn, 0])
+        assertEquals("bottom edge", Color.Black, pixels[middleColumn, pixels.height - 1])
+    }
+
+    /**
+     * The routes are separated by a black line inside the badge — the thing that keeps two routes
+     * sharing a color (or having none) from reading as a single name.
+     */
+    @Test
+    fun routesAreSeparatedByABlackLine() {
+        renderJoinedBadge(routes = listOf(link1, link1.copy(shortName = "2 Line")))
+
+        val pixels = badgePixels()
+        val interior = interiorRows(pixels).flatMap { y ->
+            (EDGE_INSET until pixels.width - EDGE_INSET).map { x -> pixels[x, y] }
+        }
+
+        assertTrue("no black separating line found inside the badge", interior.any { it == Color.Black })
     }
 
     /** The rows to scan: the badge's middle band, clear of its rounded corners. */
@@ -130,8 +164,9 @@ class RouteBadgeChipRenderTest {
      * route name drawn on top of that color.
      */
     private fun boundaryX(pixels: PixelMap, y: Int): Int {
-        val first = pixels[1, y]
-        return (1 until pixels.width - 1).last { x -> pixels[x, y] == first }
+        val scan = EDGE_INSET until pixels.width - EDGE_INSET
+        val first = pixels[scan.first, y]
+        return scan.last { x -> pixels[x, y] == first }
     }
 
     private companion object {
@@ -139,5 +174,8 @@ class RouteBadgeChipRenderTest {
 
         /** The lean has to be visible, not a rounding artifact — a couple of pixels at minimum. */
         const val MIN_LEAN_PX = 2
+
+        /** Scans start this far inside the badge, clear of its outline (1dp, so a few px at any density). */
+        const val EDGE_INSET = 6
     }
 }

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/DirectionRowAlternativeRoutesTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/DirectionRowAlternativeRoutesTest.kt
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.tripresults
+
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.onebusaway.android.R
+import org.onebusaway.android.directions.model.TripLeg
+import org.onebusaway.android.directions.model.TripMode
+import org.onebusaway.android.time.ServerTime
+import org.onebusaway.android.ui.compose.components.RouteBadge
+import org.onebusaway.android.ui.compose.createUnconfinedComposeRule
+import org.onebusaway.android.util.GeoPoint
+
+/**
+ * Verifies that a ride's interchangeable routes (#2010) reach the rider in both places they're drawn:
+ * the itinerary option card's joined roundel at the top, and the ride's own joined badge in the trip
+ * log (with its "whichever comes first" caption). A ride with a single route badges only that route and
+ * says nothing about alternatives.
+ *
+ * The on-device counterpart to [org.onebusaway.android.directions.model.InterchangeableRoutesTest]
+ * (which decides *which* routes qualify) and `RouteBadgesTest` (which builds the badge).
+ */
+class DirectionRowAlternativeRoutesTest {
+
+    // See createUnconfinedComposeRule for why Unconfined composition is used here (issue #1792).
+    @get:Rule
+    val composeRule = createUnconfinedComposeRule()
+
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext
+
+    private val boardPoint = GeoPoint(47.8158, -122.2942)
+    private val alightPoint = GeoPoint(47.6114, -122.3376)
+
+    /** The issue's own case: two lines sharing the track from Lynnwood into downtown Seattle. */
+    private val interlinedLegRef = RouteLegRef(
+        routeId = "40_2LINE",
+        headsign = "Downtown Redmond",
+        board = RouteStopRef("40_N23-T2", "N23", "Lynnwood City Center", boardPoint),
+        alight = RouteStopRef("40_1108", "1108", "Westlake", alightPoint),
+        alternatives = listOf(
+            AlternativeRouteRef(
+                routeId = "40_100479",
+                headsign = "Federal Way Downtown",
+                shortName = "1 Line",
+                routeColor = 0xFF00A651.toInt()
+            )
+        ),
+        badge = LegBadge(
+            listOf(
+                RouteBadge("1 Line", 0xFF00A651.toInt()),
+                RouteBadge("2 Line", 0xFF0075C4.toInt())
+            )
+        )
+    )
+
+    private val ride = TripLogEntry.Transit(
+        routeShortName = "2 Line",
+        routeDisplayName = "2 Line",
+        routeColorHex = "0075C4",
+        headsign = "Downtown Redmond",
+        boardTime = ServerTime(2 * 60_000L),
+        exitTime = ServerTime(32 * 60_000L),
+        durationMinutes = 30,
+        realtime = RealtimeState.Unknown,
+        rideEvents = emptyList(),
+        routeLeg = interlinedLegRef,
+        legPoints = listOf(boardPoint, alightPoint)
+    )
+
+    private fun state(routeLeg: RouteLegRef) = TripResultsUiState.Success(
+        options = listOf(
+            ItineraryOption(
+                mode = ModeSummary.Routes(listOf(routeLeg.badge)),
+                durationMinutes = 32L,
+                startTime = ServerTime(0L),
+                endTime = ServerTime(32 * 60_000L)
+            )
+        ),
+        selectedIndex = 0,
+        directions = listOf(ride.copy(routeLeg = routeLeg))
+    )
+
+    /** Both roundels — the option card's and the ride's — name each interchangeable route. */
+    @Test
+    fun interchangeableRoutesAreBadgedInThePickerAndTheLog() {
+        composeRule.setContent { TripResultsList(state = state(interlinedLegRef)) }
+
+        // One node per route in each of the two badges: the option card's and the ride's.
+        composeRule.onAllNodesWithText("1 Line").assertCountEquals(2)
+        composeRule.onAllNodesWithText("2 Line").assertCountEquals(2)
+    }
+
+    /** The ride carries the caption that makes the badge an instruction, not just a label. */
+    @Test
+    fun interchangeableRideSaysToTakeWhicheverComesFirst() {
+        composeRule.setContent { TripResultsList(state = state(interlinedLegRef)) }
+
+        composeRule
+            .onNodeWithText(context.getString(R.string.directions_whichever_comes_first))
+            .assertExists()
+    }
+
+    /** A ride the rider can't substitute anything for badges its own route and adds no caption. */
+    @Test
+    fun rideWithoutInterchangeableRoutesBadgesOnlyItsOwnRoute() {
+        val soloRef = interlinedLegRef.copy(
+            alternatives = emptyList(),
+            badge = LegBadge(listOf(RouteBadge("2 Line", 0xFF0075C4.toInt())))
+        )
+        composeRule.setContent { TripResultsList(state = state(soloRef)) }
+
+        composeRule.onAllNodesWithText("1 Line").assertCountEquals(0)
+        composeRule
+            .onAllNodesWithText(context.getString(R.string.directions_whichever_comes_first))
+            .assertCountEquals(0)
+    }
+
+    /**
+     * The badge's color comes from the route's GTFS color, tolerating the '#' some feeds prefix. Lives
+     * on-device because parsing it goes through `android.graphics.Color`, which the JVM tests
+     * (`RouteBadgesTest`, which covers the naming and ordering) can't call.
+     */
+    @Test
+    fun badgeTakesItsColorFromTheRoutesGtfsColor() {
+        val badge = TripLeg(
+            mode = TripMode.TRAM,
+            routeId = "40:2LINE",
+            routeShortName = "2 Line",
+            routeColor = "#0075C4"
+        ).plannedBadge()
+
+        assertEquals("2 Line", badge.shortName)
+        assertEquals(0xFF0075C4.toInt(), badge.routeColor)
+    }
+}

--- a/onebusaway-android/src/main/graphql/otp2/Plan.graphql
+++ b/onebusaway-android/src/main/graphql/otp2/Plan.graphql
@@ -16,6 +16,25 @@ fragment PlaceFields on Place {
     vehicleRentalStation { stationId name }
 }
 
+# RouteFields is the planned leg's route. AlternativeRouteFields is the deliberately smaller set an
+# alternative leg needs (below): a plan asks for alternatives on every transit leg of every itinerary,
+# so each field there is paid for many times over — it carries only what names the route on a badge
+# and what resolves it onto an OBA id, with no long name or agency timezone.
+fragment RouteFields on Route {
+    gtfsId
+    shortName
+    longName
+    color
+    agency { gtfsId name timezone }
+}
+
+fragment AlternativeRouteFields on Route {
+    gtfsId
+    shortName
+    color
+    agency { gtfsId name }
+}
+
 query Plan(
     $origin: PlanLabeledLocationInput!
     $destination: PlanLabeledLocationInput!
@@ -23,6 +42,7 @@ query Plan(
     $modes: PlanModesInput
     $preferences: PlanPreferencesInput
     $numItineraries: Int!
+    $alternativeLegs: Int!
 ) {
     planConnection(
         origin: $origin
@@ -65,15 +85,33 @@ query Plan(
                         ...PlaceFields
                     }
                     route {
-                        gtfsId
-                        shortName
-                        longName
-                        color
-                        agency { gtfsId name timezone }
+                        ...RouteFields
                     }
                     trip {
                         gtfsId
                         tripHeadsign
+                    }
+                    # Interleaved/interchangeable routes (#2010): OTP's own alternative-leg search,
+                    # which returns the next departures that serve this leg's *exact* board and alight
+                    # stops on ANY route (the GTFS GraphQL API runs it with
+                    # AlternativeLegsFilter.NO_FILTER — verified in OTP's LegImpl.alternativeLegs), so
+                    # a corridor's other lines come back alongside later trips of this leg's own route.
+                    # The parent-station arguments are deliberately omitted: their default keeps the
+                    # search on the exact stops, so an alternative is boardable at the very stop the
+                    # drawer tells the rider to wait at — never a sibling platform across the station.
+                    # Null for a non-transit leg (OTP returns no alternatives rather than an error).
+                    # Which of these are actually interchangeable is decided by InterchangeableRoutes.kt,
+                    # not here; this is the raw candidate set.
+                    nextLegs(numberOfLegs: $alternativeLegs) {
+                        duration
+                        route {
+                            ...AlternativeRouteFields
+                        }
+                        trip {
+                            tripHeadsign
+                        }
+                        from { stop { gtfsId } }
+                        to { stop { gtfsId } }
                     }
                     legGeometry {
                         points

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/adapters/Otp2PlanAdapters.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/adapters/Otp2PlanAdapters.kt
@@ -24,6 +24,7 @@ import org.onebusaway.android.api.graphql.fragment.PlaceFields
 import org.onebusaway.android.directions.model.TripAbsoluteDirection
 import org.onebusaway.android.directions.model.TripItinerary
 import org.onebusaway.android.directions.model.TripLeg
+import org.onebusaway.android.directions.model.TripLegAlternative
 import org.onebusaway.android.directions.model.TripLegGeometry
 import org.onebusaway.android.directions.model.TripMode
 import org.onebusaway.android.directions.model.TripPlace
@@ -57,12 +58,12 @@ private fun PlanQuery.Node.toTripItinerary(): TripItinerary = TripItinerary(
 private fun PlanQuery.Leg.toTripLeg(): TripLeg = TripLeg(
     mode = mode?.rawValue.toEnum<TripMode>(),
     route = null, // No OTP2 equivalent of OTP1's flat display-string `route` field.
-    routeId = route?.gtfsId,
-    routeShortName = route?.shortName,
-    routeLongName = route?.longName,
-    routeColor = route?.color,
-    agencyId = route?.agency?.gtfsId,
-    agencyName = route?.agency?.name,
+    routeId = route?.routeFields?.gtfsId,
+    routeShortName = route?.routeFields?.shortName,
+    routeLongName = route?.routeFields?.longName,
+    routeColor = route?.routeFields?.color,
+    agencyId = route?.routeFields?.agency?.gtfsId,
+    agencyName = route?.routeFields?.agency?.name,
     headsign = trip?.tripHeadsign,
     tripId = trip?.gtfsId,
     realTime = realTime ?: false,
@@ -83,7 +84,25 @@ private fun PlanQuery.Leg.toTripLeg(): TripLeg = TripLeg(
     intermediateStops = null,
     stop = null,
     steps = steps.orEmpty().filterNotNull().map { it.toTripStep() },
-    legGeometry = legGeometry?.let { TripLegGeometry(points = it.points, length = it.length ?: 0) }
+    legGeometry = legGeometry?.let { TripLegGeometry(points = it.points, length = it.length ?: 0) },
+    // OTP's own alternative-leg search for this leg (#2010) — null on a non-transit leg, and carried
+    // over unjudged: interchangeability is decided by `interchangeableRoutes()`, which needs the whole
+    // itinerary (the next leg's departure) and so can't be answered leg-at-a-time here.
+    alternatives = nextLegs.orEmpty().map { it.toTripLegAlternative() }
+)
+
+private fun PlanQuery.NextLeg.toTripLegAlternative(): TripLegAlternative = TripLegAlternative(
+    routeId = route?.alternativeRouteFields?.gtfsId,
+    routeShortName = route?.alternativeRouteFields?.shortName,
+    routeColor = route?.alternativeRouteFields?.color,
+    agencyId = route?.alternativeRouteFields?.agency?.gtfsId,
+    agencyName = route?.alternativeRouteFields?.agency?.name,
+    headsign = trip?.tripHeadsign,
+    // The alternative trip's own board→alight ride time, the quantity the interchangeability rule
+    // compares against the planned leg's.
+    duration = (duration ?: 0.0).seconds,
+    fromStopId = from.stop?.gtfsId,
+    toStopId = to.stop?.gtfsId
 )
 
 // PlaceFields backs both Leg.from and Leg.to (see the Plan.graphql fragment) — one mapping instead

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/model/InterchangeableRoutes.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/model/InterchangeableRoutes.kt
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.directions.model
+
+import kotlin.time.Duration
+import org.onebusaway.android.util.ROUTE_NAME_ORDER
+
+/**
+ * Decides which *other* routes a rider may board in place of a transit leg's planned one — the
+ * "interleaved lines" case from #2010: between Lynnwood and downtown the 1 Line and the 2 Line run
+ * the same track to the same platforms, so the directions should say "take whichever comes first"
+ * rather than naming one of them.
+ *
+ * The candidate set comes from OTP ([TripLeg.alternatives], `Leg.nextLegs`), which returns upcoming
+ * departures between this leg's exact board and alight stops on *any* route. This file supplies the
+ * policy on top of it, and the policy is deliberately about **ride time**, never about which vehicle
+ * happens to show up first: a local that turns up early must not be offered in place of the express
+ * the plan is built around.
+ *
+ * A candidate route qualifies when
+ *
+ *     candidate ride time  ≤  planned ride time + [transferSlack]
+ *
+ * where the slack is the wait the itinerary itself already budgets before the next transit leg
+ * departs — the exact amount by which the rider can arrive late at the alight stop and still make the
+ * transfer as planned. There is no invented constant anywhere in that rule: every term is read off
+ * the itinerary. On the last transit leg there is no transfer left to protect, so the slack is zero
+ * and only routes that are no slower than the planned one qualify.
+ *
+ * Two further conservatisms, both because the drawer's claim is "any of these will do" — a promise
+ * that has to hold for whichever vehicle actually arrives, not just the next one:
+ *  - a route is represented by its **slowest** candidate trip, so a route with one fast run and one
+ *    slow one is judged on the slow one;
+ *  - a candidate whose own board/alight stops don't match the leg's is dropped rather than trusted.
+ *
+ * Pure and `Context`-free, so `InterchangeableRoutesTest` can exercise the rule directly.
+ */
+
+/**
+ * A route the rider may board instead of a leg's planned route — one that passed the rule above.
+ * [headsign] is the candidate trip's, for matching the route's direction group in the live arrivals
+ * at the board stop.
+ */
+data class InterchangeableRoute(
+    val routeId: String,
+    val shortName: String?,
+    val routeColor: String?,
+    val agencyId: String?,
+    val agencyName: String?,
+    val headsign: String?
+) {
+    /** The name to show for this route, falling back to the OTP id when it has no short name. */
+    val displayName: String get() = shortName?.takeIf { it.isNotBlank() } ?: routeId
+}
+
+/**
+ * The interchangeable routes for each of [TripItinerary.legs], **index-aligned to that list** so a
+ * caller can walk legs and alternatives together. Non-transit legs and legs with no qualifying
+ * alternative get an empty list, so an OTP1 plan (no candidates at all) yields all-empty and every
+ * caller keeps its existing behaviour.
+ */
+fun TripItinerary.interchangeableRoutes(): List<List<InterchangeableRoute>> = legs.indices.map { index -> interchangeableRoutesForLeg(index) }
+
+private fun TripItinerary.interchangeableRoutesForLeg(index: Int): List<InterchangeableRoute> {
+    val leg = legs[index]
+    if (leg.mode?.isTransit != true) return emptyList()
+    val budget = leg.duration + transferSlack(index)
+    return leg.alternatives
+        .asSequence()
+        // A candidate that isn't a different route, or that doesn't run between this leg's own two
+        // stops, is not an alternative to it.
+        .filter { it.routeId != null && it.routeId != leg.routeId }
+        .filter { it.fromStopId == leg.from.stopId && it.toStopId == leg.to.stopId }
+        .groupBy { requireNotNull(it.routeId) }
+        // Judge each route on its slowest run: the rider boards whichever of them turns up.
+        .mapValues { (_, trips) -> trips.maxBy { it.duration } }
+        .values
+        .filter { it.duration <= budget }
+        .map { candidate ->
+            InterchangeableRoute(
+                routeId = requireNotNull(candidate.routeId),
+                shortName = candidate.routeShortName,
+                routeColor = candidate.routeColor,
+                agencyId = candidate.agencyId,
+                agencyName = candidate.agencyName,
+                headsign = candidate.headsign
+            )
+        }
+        .sortedWith(compareBy(ROUTE_NAME_ORDER) { it.displayName })
+}
+
+/**
+ * How late the rider may reach leg [index]'s alight stop and still make the itinerary's next transit
+ * leg: that leg's departure, minus this leg's planned arrival, minus everything the plan has the
+ * rider doing in between (the transfer walk, or a stay-put transfer's zero). In other words the wait
+ * already built into the plan at the transfer point.
+ *
+ * [Duration.ZERO] when no transit leg follows — the last ride has no connection left to protect, so
+ * an alternative has to be no slower than the planned vehicle to qualify. Also zero (never negative)
+ * if the plan leaves no wait at all, e.g. a timed transfer boarded the moment it arrives.
+ */
+private fun TripItinerary.transferSlack(index: Int): Duration {
+    val nextTransit = (index + 1..legs.lastIndex).firstOrNull { legs[it].mode?.isTransit == true }
+        ?: return Duration.ZERO
+    val betweenLegs = (index + 1 until nextTransit).fold(Duration.ZERO) { total, i -> total + legs[i].duration }
+    val gap = legs[nextTransit].startTime - legs[index].endTime
+    return (gap - betweenLegs).coerceAtLeast(Duration.ZERO)
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/model/TripItinerary.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/model/TripItinerary.kt
@@ -98,7 +98,36 @@ data class TripLeg(
     val intermediateStops: List<TripPlace>? = null,
     val stop: List<TripPlace>? = null,
     val steps: List<TripStep> = emptyList(),
-    val legGeometry: TripLegGeometry? = null
+    val legGeometry: TripLegGeometry? = null,
+    // Other departures OTP found between this leg's own board and alight stops, on any route
+    // (#2010) — the raw candidate set, straight off the wire. Includes later trips of this leg's own
+    // route. Which of them the drawer may present as interchangeable is decided by
+    // [interchangeableRoutes], not here. Always empty on the OTP1 path, which has no equivalent.
+    val alternatives: List<TripLegAlternative> = emptyList()
+)
+
+/**
+ * One departure from OTP's alternative-leg search for a [TripLeg] (OTP2 `Leg.nextLegs`, #2010): a
+ * single trip that runs between the same two stops as the leg it hangs off.
+ *
+ * [duration] is that trip's board→alight ride time — the field the interchangeability rule compares
+ * against the planned leg's, so a local can't be offered in place of an express. [fromStopId] and
+ * [toStopId] are OTP's GTFS stop ids for this trip's own boarding and alighting stops; the query asks
+ * OTP for exact-stop alternatives, and [interchangeableRoutes] re-checks them against the leg rather
+ * than trusting that, so a candidate can never send the rider to a different platform than the one
+ * the drawer names.
+ */
+@Serializable
+data class TripLegAlternative(
+    val routeId: String? = null,
+    val routeShortName: String? = null,
+    val routeColor: String? = null,
+    val agencyId: String? = null,
+    val agencyName: String? = null,
+    val headsign: String? = null,
+    @Serializable(with = DurationSerializer::class) val duration: Duration = Duration.ZERO,
+    val fromStopId: String? = null,
+    val toStopId: String? = null
 )
 
 @Serializable

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/Otp2PlanRequestBuilder.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/Otp2PlanRequestBuilder.kt
@@ -57,6 +57,21 @@ object Otp2PlanRequestBuilder {
      */
     private const val NUM_ITINERARIES = 5
 
+    /**
+     * How many upcoming departures OTP's alternative-leg search returns per transit leg
+     * (`Leg.nextLegs(numberOfLegs:)`, #2010). A response page size, not a tuning threshold on the
+     * data: OTP walks the same patterns and timetables either way and applies this as the final
+     * `.limit(…)` (see `AlternativeLegs.getAlternativeLegs`), so raising it costs response bytes
+     * rather than server work.
+     *
+     * It is still a **cap on what the rider is told**, and worth naming as such: the page is shared by
+     * every route serving the leg, so on a frequent corridor an infrequent-but-equivalent route can
+     * fall past it and simply not be offered. The failure is silent and one-directional — the badge
+     * under-reports, never over-reports — and which routes make the page varies with how often the
+     * planned one runs.
+     */
+    private const val ALTERNATIVE_LEGS = 12
+
     private val DATE_TIME_FORMATTER: DateTimeFormatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME
 
     /**
@@ -100,7 +115,8 @@ object Otp2PlanRequestBuilder {
                 buildPreferences(builder.getWheelchairAccessible(), builder.getOptimizeTransfers())
             ),
             modes = buildModes(builder.getModeSetId(), BikeshareAvailability.isEnabled(context)),
-            numItineraries = NUM_ITINERARIES
+            numItineraries = NUM_ITINERARIES,
+            alternativeLegs = ALTERNATIVE_LEGS
         )
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/RouteBadgeChip.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/RouteBadgeChip.kt
@@ -15,6 +15,7 @@
  */
 package org.onebusaway.android.ui.compose.components
 
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -29,6 +30,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.CacheDrawScope
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawWithCache
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -45,6 +48,17 @@ private val BADGE_SHAPE = RoundedCornerShape(1.dp)
  * rather than as a vertical seam.
  */
 private const val SLASH_SLANT_RATIO = 0.5f
+
+/** The width of the badge's outline and of the line where two routes meet inside it. */
+private val BADGE_LINE_WIDTH = 1.dp
+
+/**
+ * The badge's outline, and the line where two of its routes meet: black in either theme. The chips
+ * themselves are pale in light mode and deep in dark mode ([rememberRouteBadgeColors]) but always
+ * colored, so a black line reads against any of them — and keeps two routes that happen to share a
+ * color (or have none) from running together into one name.
+ */
+private val BADGE_LINE_COLOR = Color.Black
 
 /**
  * A small route roundel — the route's short name on a chip tinted from its GTFS color (via
@@ -88,18 +102,23 @@ fun RouteBadgeChip(shortName: String, routeColor: Int?, modifier: Modifier = Mod
  * the badge reads as one choice of several routes rather than as a sequence of separate legs.
  *
  * Each segment paints its own band, overhanging its neighbours by half the lean; siblings paint left to
- * right, so each band's left edge cleanly overwrites the previous band's overhang and the two colors
- * meet along the diagonal with nothing between them. The whole chip is clipped to [BADGE_SHAPE], which
+ * right, so each band's left edge cleanly overwrites the previous band's overhang and the colors meet
+ * exactly on the diagonal. A [BADGE_LINE_COLOR] hairline is then drawn along that meeting line, and the
+ * whole chip is outlined in the same color — so the badge reads as one bounded object holding two
+ * names, even when its routes share a color or have none. The chip is clipped to [BADGE_SHAPE], which
  * trims the outermost bands' overhang back to the badge's own edges.
  *
- * A single-route list is exactly the plain chip above. [scale] enlarges everything proportionally, as
- * on the plain chip.
+ * A single-route list is the plain chip above, outlined to match: these badges sit side by side in the
+ * trip planner (`[2] [1 Line/2 Line]`), so they have to be bounded the same way. The plain chip's other
+ * callers keep their un-outlined roundel. [scale] enlarges everything proportionally, as on the plain
+ * chip.
  */
 @Composable
 fun RouteBadgeChip(routes: List<RouteBadge>, modifier: Modifier = Modifier, scale: Float = 1f) {
+    val outlined = modifier.border(BADGE_LINE_WIDTH, BADGE_LINE_COLOR, BADGE_SHAPE)
     if (routes.size == 1) {
         val route = routes.first()
-        RouteBadgeChip(route.shortName, route.routeColor, modifier, scale)
+        RouteBadgeChip(route.shortName, route.routeColor, outlined, scale)
         return
     }
     val base = MaterialTheme.typography.labelMedium
@@ -108,7 +127,7 @@ fun RouteBadgeChip(routes: List<RouteBadge>, modifier: Modifier = Modifier, scal
         lineHeight = base.lineHeight * scale,
         letterSpacing = base.letterSpacing * scale
     )
-    Row(modifier.clip(BADGE_SHAPE).height(IntrinsicSize.Min)) {
+    Row(outlined.clip(BADGE_SHAPE).height(IntrinsicSize.Min)) {
         routes.forEachIndexed { index, route ->
             val (container, content) = rememberRouteBadgeColors(route.routeColor)
             Text(
@@ -117,18 +136,33 @@ fun RouteBadgeChip(routes: List<RouteBadge>, modifier: Modifier = Modifier, scal
                 fontWeight = FontWeight.Bold,
                 maxLines = 1,
                 color = content,
-                // Wider than the plain chip's padding: the divider leans through the segment edges, so
-                // the extra breathing room keeps a name clear of the neighbouring color.
+                // Wider than the plain chip's padding: the meeting line leans through the segment edges,
+                // so the extra breathing room keeps a name clear of it and of the neighbouring color.
                 modifier = Modifier
                     .fillMaxHeight()
-                    // drawWithCache, not drawBehind: the band's Path depends only on the segment's
-                    // size, so it's built once per size change instead of on every draw pass.
+                    // drawWithCache, not drawBehind: the band's Path and the line's geometry depend only
+                    // on the segment's size, so they're built once per size change, not per draw pass.
                     .drawWithCache {
                         val band = slantedBandPath(
                             extendStart = index == 0,
                             extendEnd = index == routes.lastIndex
                         )
-                        onDrawBehind { drawPath(band, container) }
+                        val lean = leanPx()
+                        val lineWidth = BADGE_LINE_WIDTH.toPx()
+                        onDrawBehind {
+                            drawPath(band, container)
+                            // Only the leading edge, and never on the first segment: each segment draws
+                            // its line after its band, so it lands on top of the neighbouring band this
+                            // one just overwrote.
+                            if (index > 0) {
+                                drawLine(
+                                    color = BADGE_LINE_COLOR,
+                                    start = Offset(lean, 0f),
+                                    end = Offset(-lean, size.height),
+                                    strokeWidth = lineWidth
+                                )
+                            }
+                        }
                     }
                     .padding(horizontal = 5.dp * scale, vertical = 1.dp * scale)
             )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/RouteBadgeChip.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/RouteBadgeChip.kt
@@ -15,6 +15,10 @@
  */
 package org.onebusaway.android.ui.compose.components
 
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
@@ -22,8 +26,25 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.CacheDrawScope
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawWithCache
+import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+
+/** One route on a badge: its short name and (nullable) GTFS color as an ARGB int. */
+data class RouteBadge(val shortName: String, val routeColor: Int?)
+
+/** The badge's corner rounding — barely rounded, matching the roundels elsewhere in the app. */
+private val BADGE_SHAPE = RoundedCornerShape(1.dp)
+
+/**
+ * How far the divider between two routes leans, as a fraction of the badge's height: it sits at the
+ * segment edge at mid-height and shifts by half this either way, so it reads as a "/" between the names
+ * rather than as a vertical seam.
+ */
+private const val SLASH_SLANT_RATIO = 0.5f
 
 /**
  * A small route roundel — the route's short name on a chip tinted from its GTFS color (via
@@ -48,7 +69,7 @@ fun RouteBadgeChip(shortName: String, routeColor: Int?, modifier: Modifier = Mod
         modifier = modifier,
         color = container,
         contentColor = content,
-        shape = RoundedCornerShape(1.dp)
+        shape = BADGE_SHAPE
     ) {
         Text(
             text = shortName,
@@ -59,3 +80,80 @@ fun RouteBadgeChip(shortName: String, routeColor: Int?, modifier: Modifier = Mod
         )
     }
 }
+
+/**
+ * The same roundel for a set of routes that are ridden interchangeably (#2010) — "1 Line/2 Line" for a
+ * pair of lines sharing the same track between two stops. One chip, not several: the names sit side by
+ * side on a single background divided by a slash-like diagonal, each half in its own route color, so
+ * the badge reads as one choice of several routes rather than as a sequence of separate legs.
+ *
+ * Each segment paints its own band, overhanging its neighbours by half the lean; siblings paint left to
+ * right, so each band's left edge cleanly overwrites the previous band's overhang and the two colors
+ * meet along the diagonal with nothing between them. The whole chip is clipped to [BADGE_SHAPE], which
+ * trims the outermost bands' overhang back to the badge's own edges.
+ *
+ * A single-route list is exactly the plain chip above. [scale] enlarges everything proportionally, as
+ * on the plain chip.
+ */
+@Composable
+fun RouteBadgeChip(routes: List<RouteBadge>, modifier: Modifier = Modifier, scale: Float = 1f) {
+    if (routes.size == 1) {
+        val route = routes.first()
+        RouteBadgeChip(route.shortName, route.routeColor, modifier, scale)
+        return
+    }
+    val base = MaterialTheme.typography.labelMedium
+    val style = base.copy(
+        fontSize = base.fontSize * scale,
+        lineHeight = base.lineHeight * scale,
+        letterSpacing = base.letterSpacing * scale
+    )
+    Row(modifier.clip(BADGE_SHAPE).height(IntrinsicSize.Min)) {
+        routes.forEachIndexed { index, route ->
+            val (container, content) = rememberRouteBadgeColors(route.routeColor)
+            Text(
+                text = route.shortName,
+                style = style,
+                fontWeight = FontWeight.Bold,
+                maxLines = 1,
+                color = content,
+                // Wider than the plain chip's padding: the divider leans through the segment edges, so
+                // the extra breathing room keeps a name clear of the neighbouring color.
+                modifier = Modifier
+                    .fillMaxHeight()
+                    // drawWithCache, not drawBehind: the band's Path depends only on the segment's
+                    // size, so it's built once per size change instead of on every draw pass.
+                    .drawWithCache {
+                        val band = slantedBandPath(
+                            extendStart = index == 0,
+                            extendEnd = index == routes.lastIndex
+                        )
+                        onDrawBehind { drawPath(band, container) }
+                    }
+                    .padding(horizontal = 5.dp * scale, vertical = 1.dp * scale)
+            )
+        }
+    }
+}
+
+/**
+ * This segment's background as a parallelogram: vertical at the badge's outer edges
+ * ([extendStart]/[extendEnd] push those past the clip so no sliver of background shows through), and
+ * leaning by [SLASH_SLANT_RATIO] of the height where it meets a neighbour. The lean is symmetric about
+ * mid-height, so the divider crosses the segment edge exactly where the layout puts it.
+ */
+private fun CacheDrawScope.slantedBandPath(extendStart: Boolean, extendEnd: Boolean): Path {
+    val lean = leanPx()
+    // Overhang the neighbouring segment far enough that an outer edge is always covered after clipping.
+    val outer = size.height
+    return Path().apply {
+        moveTo(if (extendStart) -outer else lean, 0f)
+        lineTo(if (extendEnd) size.width + outer else size.width + lean, 0f)
+        lineTo(if (extendEnd) size.width + outer else size.width - lean, size.height)
+        lineTo(if (extendStart) -outer else -lean, size.height)
+        close()
+    }
+}
+
+/** Half the lean, in px: how far the meeting line shifts either side of the segment edge. */
+private fun CacheDrawScope.leanPx(): Float = size.height * SLASH_SLANT_RATIO / 2f

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
@@ -96,6 +96,7 @@ import org.onebusaway.android.ui.arrivals.rememberArrivalRowCallbacks
 import org.onebusaway.android.ui.compose.components.DRAG_HANDLE_HEIGHT
 import org.onebusaway.android.ui.compose.components.DRAG_HANDLE_VERTICAL_PADDING
 import org.onebusaway.android.ui.compose.components.DragHandleBar
+import org.onebusaway.android.ui.compose.components.RouteBadgeChip
 import org.onebusaway.android.ui.compose.components.SwitchRow
 import org.onebusaway.android.ui.compose.findActivity
 import org.onebusaway.android.ui.compose.navigationBarBottomPadding
@@ -347,6 +348,13 @@ private fun DirectionsSheetHandle(collapsed: Boolean, onSetCollapsed: (Boolean) 
  * a pill to focus its vehicle, long-press for the trip menu — wired through [rememberArrivalRowCallbacks]).
  * Spins up a per-stop arrivals session keyed to [stop] — so it polls only while shown — and picks the
  * route group matching the leg (by route id, then headsign). Ids on [routeLeg]/[stop] are OBA-format.
+ *
+ * A leg with interchangeable routes ([RouteLegRef.alternatives], #2010) gets one further strip per such
+ * route below the planned one, each behind its own route badge so the pills can't be mistaken for the
+ * planned route's — that badge is the only thing distinguishing them, since a pill shows an ETA and no
+ * route. All of them read the one arrivals poll this stop already runs, so the extra routes cost no
+ * extra request. An alternative with no OBA id, or with nothing upcoming at this stop, is simply left
+ * out — its name still appears on the card's "or …" line.
  */
 @Composable
 fun DirectionStopEtaStrip(
@@ -383,23 +391,49 @@ fun DirectionStopEtaStrip(
     val callbacks = rememberArrivalRowCallbacks(session.handler, session.viewModel)
 
     val content = state as? ArrivalsUiState.Content ?: return // nothing until the first load lands
-    val group = content.routeGroups.pickForLeg(routeLeg)
-    if (group == null) {
+    val plannedGroup = content.routeGroups.pickRoute(routeLeg.routeId, routeLeg.headsign)
+    val alternativeGroups = routeLeg.alternatives.mapNotNull { alternative ->
+        content.routeGroups.pickRoute(alternative.routeId, alternative.headsign)
+            ?.let { alternative to it }
+    }
+    if (plannedGroup == null && alternativeGroups.isEmpty()) {
         NoEtasText(rowPadding)
         return
     }
-    EtaStrip(
-        trips = group.trips,
-        actionsFor = { content.actions[it.tripId] },
-        callbacks = callbacks,
-        modifier = modifier.then(rowPadding)
-    )
+    Column(modifier) {
+        if (plannedGroup == null) {
+            NoEtasText(rowPadding)
+        } else {
+            EtaStrip(
+                trips = plannedGroup.trips,
+                actionsFor = { content.actions[it.tripId] },
+                callbacks = callbacks,
+                modifier = rowPadding
+            )
+        }
+        alternativeGroups.forEach { (alternative, group) ->
+            Row(
+                modifier = rowPadding,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                RouteBadgeChip(alternative.shortName, alternative.routeColor)
+                Spacer(Modifier.width(8.dp))
+                EtaStrip(
+                    trips = group.trips,
+                    actionsFor = { content.actions[it.tripId] },
+                    callbacks = callbacks,
+                    modifier = Modifier.weight(1f)
+                )
+            }
+        }
+    }
 }
 
-/** The leg's route group at this stop: matched by OBA route id, preferring the leg's headsign. */
-private fun List<RouteRowGroup>.pickForLeg(routeLeg: RouteLegRef): RouteRowGroup? {
-    val forRoute = filter { it.routeId == routeLeg.routeId }
-    val headsign = routeLeg.headsign
+/** The group for [routeId] at this stop: matched by OBA route id, preferring [headsign]'s direction.
+ *  Null when the route has no OBA id (unresolved) or nothing upcoming at the stop. */
+private fun List<RouteRowGroup>.pickRoute(routeId: String?, headsign: String?): RouteRowGroup? {
+    if (routeId == null) return null
+    val forRoute = filter { it.routeId == routeId }
     return forRoute.firstOrNull { headsign != null && it.headsign.equals(headsign, ignoreCase = true) }
         ?: forRoute.firstOrNull()
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/Interlines.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/Interlines.kt
@@ -15,9 +15,11 @@
  */
 package org.onebusaway.android.ui.tripresults
 
+import org.onebusaway.android.directions.model.InterchangeableRoute
+import org.onebusaway.android.directions.model.TripItinerary
 import org.onebusaway.android.directions.model.TripLeg
+import org.onebusaway.android.directions.model.interchangeableRoutes
 import org.onebusaway.android.directions.model.routeDisplayShortName
-import org.onebusaway.android.util.parseObaHexColor
 
 /**
  * Pure interline analysis over a trip's legs (#2000) — no `Context` / OBA-id resolution, so it's
@@ -76,24 +78,38 @@ internal object Interlines {
     }
 
     /**
-     * One [RouteBadge] per distinct vehicle-and-route the transit legs use, in order: a self-interline
-     * folds to a single badge, a cross-route interline keeps both routes' badges.
+     * One [LegBadge] per distinct vehicle-and-route the transit legs use, in order: a self-interline
+     * folds to a single badge, a cross-route interline keeps both routes' badges. Each badge names
+     * every route that ride can be taken on — its own, joined by whatever [substitutable] (index-
+     * aligned to [legs]) says is interchangeable with it (#2010).
      */
-    fun routeBadges(legs: List<TripLeg>): List<RouteBadge> {
-        val badges = ArrayList<RouteBadge>()
+    fun routeBadges(legs: List<TripLeg>, substitutable: List<List<InterchangeableRoute>>): List<LegBadge> {
+        val badges = ArrayList<LegBadge>()
         legs.forEachIndexed { i, leg ->
             if (leg.mode?.isTransit != true) return@forEachIndexed
             val selfInterline = leg.interlineWithPreviousLeg && i > 0 && leg.routeId == legs[i - 1].routeId
             if (selfInterline) return@forEachIndexed
-            badges += RouteBadge(
-                shortName = badgeShortName(leg),
-                // routeColor is a bare wire hex; tolerate a leading '#' just in case.
-                routeColor = parseObaHexColor(leg.routeColor?.removePrefix("#"))
-            )
+            badges += legBadge(leg, substitutable[i])
         }
         return badges
     }
 
     /** The route's display short name, or empty — see [routeDisplayShortName]. */
     fun badgeShortName(leg: TripLeg): String = leg.routeDisplayShortName().orEmpty()
+}
+
+/**
+ * The interchangeable routes ([interchangeableRoutes]) the rider may actually be offered, index-aligned
+ * to the itinerary's legs — that set, emptied for any leg belonging to a stay-aboard interline chain of
+ * more than one leg (#2000 × #2010).
+ *
+ * The interchangeability rule reasons about one leg: another route between *this* leg's board and
+ * alight stops, arriving in time for what the plan does next. On an interlined ride the plan's next act
+ * is to stay seated past that alight stop, so a different vehicle over the same two stops is not a
+ * substitute at all — it would put the rider off at the seam with no instruction. Rather than teach the
+ * rule about chains, drop the offer for those legs: the ride is still shown, just without alternatives.
+ */
+internal fun TripItinerary.substitutableRoutes(): List<List<InterchangeableRoute>> {
+    val ridesAlone = Interlines.chains(legs).filter { it.leaderIndex == it.alightIndex }.map { it.leaderIndex }.toSet()
+    return interchangeableRoutes().mapIndexed { index, routes -> if (index in ridesAlone) routes else emptyList() }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/RouteBadges.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/RouteBadges.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.tripresults
+
+import org.onebusaway.android.directions.model.InterchangeableRoute
+import org.onebusaway.android.directions.model.TripLeg
+import org.onebusaway.android.directions.model.routeDisplayShortName
+import org.onebusaway.android.ui.compose.components.RouteBadge
+import org.onebusaway.android.util.ROUTE_NAME_ORDER
+import org.onebusaway.android.util.parseObaHexColor
+
+/**
+ * Builds the [LegBadge] a transit leg draws — the planned route plus whatever else the rider may ride
+ * for that leg (#2010). Both places a leg's routes appear (the itinerary option cards and the
+ * directions drawer) are fed from here by [TripResultsRepository], so the two can't name or order a
+ * corridor's routes differently.
+ *
+ * Pure (no `Context`), so `RouteBadgesTest` covers the naming, ordering and color parsing directly.
+ */
+
+/** The badge for one transit leg: its planned route joined by the routes ruled interchangeable with
+ *  it ([org.onebusaway.android.directions.model.interchangeableRoutes]). */
+internal fun legBadge(leg: TripLeg, alternatives: List<InterchangeableRoute>): LegBadge = legBadge(leg.plannedBadge(), alternatives.map { it.badge() })
+
+/**
+ * The leg's badge: [planned] joined by [alternatives], in natural name order. The plan's own choice
+ * isn't given pride of place, deliberately — the routes are interchangeable, so "1 Line/2 Line" should
+ * read the same whichever one the planner picked; which one it did pick is still on the card's header
+ * line and its ETA strip.
+ */
+internal fun legBadge(planned: RouteBadge, alternatives: List<RouteBadge>): LegBadge = LegBadge(
+    (listOf(planned) + alternatives)
+        .distinctBy { it.shortName }
+        .sortedWith(compareBy(ROUTE_NAME_ORDER) { it.shortName })
+)
+
+/** The transit leg's own roundel: its display short name and parsed GTFS color. */
+internal fun TripLeg.plannedBadge(): RouteBadge = RouteBadge(routeDisplayShortName().orEmpty(), badgeColor(routeColor))
+
+/** An interchangeable route's roundel, alongside [plannedBadge] in the same leg's badge. */
+internal fun InterchangeableRoute.badge(): RouteBadge = RouteBadge(displayName, badgeColor(routeColor))
+
+/** A wire route color as a badge color: OTP hands over a bare hex, but tolerate a leading '#'. */
+private fun badgeColor(wireHex: String?): Int? = parseObaHexColor(wireHex?.removePrefix("#"))

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsRepository.kt
@@ -21,10 +21,12 @@ import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.onebusaway.android.directions.OtpObaIdResolver
+import org.onebusaway.android.directions.model.InterchangeableRoute
 import org.onebusaway.android.directions.model.TripItinerary
 import org.onebusaway.android.directions.model.TripLeg
 import org.onebusaway.android.directions.model.TripMode
 import org.onebusaway.android.directions.model.TripPlace
+import org.onebusaway.android.directions.model.interchangeableRoutes
 import org.onebusaway.android.directions.util.DirectionsGenerator
 import org.onebusaway.android.map.RiddenSegment
 import org.onebusaway.android.util.geoPointOrNull
@@ -60,7 +62,10 @@ class DefaultTripResultsRepository @Inject constructor(
 
     /** Projects one [TripItinerary] into the structured [ItineraryOption] the card renders. */
     private fun summarize(itinerary: TripItinerary): ItineraryOption {
-        val badges = Interlines.routeBadges(itinerary.legs)
+        // A badge per distinct vehicle-and-route (#2000), each naming every route that ride can be
+        // taken on, so an interchangeable pair reads as one joined "1 Line/2 Line" roundel rather than
+        // picking a winner (#2010).
+        val badges = Interlines.routeBadges(itinerary.legs, itinerary.substitutableRoutes())
         // A transit trip shows route badges; a walk-only trip shows the walk glyph; anything else
         // (bike/car) keeps the legacy mode-label title.
         val mode = when {
@@ -93,7 +98,7 @@ class DefaultTripResultsRepository @Inject constructor(
             // One RouteLegRef per transit chain (a stay-aboard interline folds its continuation legs into
             // the chain leader, #2000); the builder folds the same continuation legs into the leader's
             // Transit entry so the two agree.
-            val routeLegRefs = resolveRouteLegRefs(itinerary.legs)
+            val routeLegRefs = resolveRouteLegRefs(itinerary.legs, itinerary.substitutableRoutes())
             TripLogBuilder.build(itinerary.legs, flat, routeLegRefs)
         }
     }
@@ -105,8 +110,14 @@ class DefaultTripResultsRepository @Inject constructor(
      * lists each cross-route change ([RouteLegRef.interlineTransitions]) so the rider is told to stay
      * aboard rather than get off and reboard. A self-interline (same route) leaves no transition, hiding
      * the seam entirely.
+     *
+     * [substitutable] is index-aligned to [legs] and supplies the chain leader's interchangeable routes
+     * (#2010) — already empty for an interlined chain, see [TripItinerary.substitutableRoutes].
      */
-    private suspend fun resolveRouteLegRefs(legs: List<TripLeg>): List<RouteLegRef?> {
+    private suspend fun resolveRouteLegRefs(
+        legs: List<TripLeg>,
+        substitutable: List<List<InterchangeableRoute>>
+    ): List<RouteLegRef?> {
         val refs = MutableList<RouteLegRef?>(legs.size) { null }
         for (chain in Interlines.chains(legs)) {
             val leader = legs[chain.leaderIndex]
@@ -129,16 +140,32 @@ class DefaultTripResultsRepository @Inject constructor(
                     anchorStopId = otpObaIdResolver.obaStopId(legs[j].from.stopId, legs[j].agencyId, legs[j].agencyName)
                 )
             }
+            val alternatives = substitutable[chain.leaderIndex]
             refs[chain.leaderIndex] = RouteLegRef(
                 routeId = otpObaIdResolver.obaRouteId(leader.routeId, leader.agencyId, leader.agencyName),
                 headsign = leader.headsign,
                 board = leader.from.resolveStop(leader),
                 alight = legs[chain.alightIndex].to.resolveStop(legs[chain.alightIndex]),
                 interlineTransitions = transitions,
-                extraSegments = extraSegments
+                extraSegments = extraSegments,
+                alternatives = alternatives.map { it.resolve() },
+                // Built here, alongside the option cards' badges, so the drawer renders one rather than
+                // deriving it per row (#2010).
+                badge = legBadge(leader, alternatives)
             )
         }
         return refs
+    }
+
+    /** The same OTP-route-id → OBA-route-id resolution the planned route gets, for an alternative. */
+    private suspend fun InterchangeableRoute.resolve(): AlternativeRouteRef {
+        val badge = badge()
+        return AlternativeRouteRef(
+            routeId = otpObaIdResolver.obaRouteId(routeId, agencyId, agencyName),
+            headsign = headsign,
+            shortName = badge.shortName,
+            routeColor = badge.routeColor
+        )
     }
 
     private suspend fun TripPlace.resolveStop(leg: TripLeg) = RouteStopRef(

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
@@ -93,6 +93,7 @@ import org.onebusaway.android.time.ServerTime
 import org.onebusaway.android.ui.compose.components.EtaDurationText
 import org.onebusaway.android.ui.compose.components.EtaPartsText
 import org.onebusaway.android.ui.compose.components.LoadingContent
+import org.onebusaway.android.ui.compose.components.RouteBadge
 import org.onebusaway.android.ui.compose.components.RouteBadgeChip
 import org.onebusaway.android.ui.compose.components.RouteLineColors
 import org.onebusaway.android.ui.compose.components.ScrollChevronGutter
@@ -197,8 +198,11 @@ private fun OptionCard(
             // The modes: transit route badges (no comma between), a walk glyph for a walk-only trip, or
             // a mode label for other non-transit trips.
             when (val mode = option.mode) {
-                is ModeSummary.Routes -> Row(horizontalArrangement = Arrangement.spacedBy(3.dp)) {
-                    mode.badges.forEach { RouteBadgeChip(it.shortName, it.routeColor) }
+                // One roundel per leg. The gap between legs is deliberately wide, so "two legs" and
+                // "one leg, two interchangeable routes" (which is one seamless chip) can't read as the
+                // same thing (#2010).
+                is ModeSummary.Routes -> Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                    mode.badges.forEach { RouteBadgeChip(it.routes) }
                 }
                 ModeSummary.Walk -> Icon(
                     painterResource(R.drawable.ic_directions_walk),
@@ -956,8 +960,15 @@ private fun ColumnScope.BoardContent(
             .defaultMinSize(minHeight = ROW_MIN_TOUCH_HEIGHT)
             .clickable(onClickLabel = expandLabel(model), onClick = onToggle)
     ) {
+        // A ride the rider may take on more than one route (#2010) badges them all as one joined
+        // roundel; an ordinary ride badges its own route exactly as before.
+        val badge = entry.routeLeg.badge
         Row(verticalAlignment = Alignment.CenterVertically) {
-            RouteBadgeChip(entry.routeShortName, routeColorInt(entry.routeColorHex), scale = 1.5f)
+            if (badge.isInterchangeable) {
+                RouteBadgeChip(badge.routes, scale = 1.5f)
+            } else {
+                RouteBadgeChip(entry.routeShortName, routeColorInt(entry.routeColorHex), scale = 1.5f)
+            }
             if (entry.routeDisplayName.isNotEmpty() && entry.routeDisplayName != entry.routeShortName) {
                 Spacer(Modifier.width(8.dp))
                 Text(
@@ -975,6 +986,15 @@ private fun ColumnScope.BoardContent(
         entry.headsign?.let {
             Text(
                 text = it,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        // What the joined badge means: any of those routes will do, so board the first to arrive. Each
+        // one's own ETA strip sits under the board stop below (#2010).
+        if (badge.isInterchangeable) {
+            Text(
+                text = stringResource(R.string.directions_whichever_comes_first),
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
@@ -1153,14 +1173,27 @@ private fun TripResultsPreview() {
         val state = TripResultsUiState.Success(
             options = listOf(
                 ItineraryOption(
-                    mode = ModeSummary.Routes(listOf(RouteBadge("8", 0xFF1B6EF3.toInt()))),
+                    // A bus leg, then an interchangeable rail pair drawn as one joined badge (#2010).
+                    mode = ModeSummary.Routes(
+                        listOf(
+                            LegBadge(listOf(RouteBadge("8", 0xFF1B6EF3.toInt()))),
+                            LegBadge(
+                                listOf(
+                                    RouteBadge("1 Line", 0xFF00A651.toInt()),
+                                    RouteBadge("2 Line", 0xFF0075C4.toInt())
+                                )
+                            )
+                        )
+                    ),
                     durationMinutes = 32,
                     startTime = ServerTime(0L),
                     endTime = ServerTime(32 * 60_000L),
                     walkDistanceMeters = 800.0
                 ),
                 ItineraryOption(
-                    mode = ModeSummary.Routes(listOf(RouteBadge("48", null), RouteBadge("11", null))),
+                    mode = ModeSummary.Routes(
+                        listOf(LegBadge(listOf(RouteBadge("48", null))), LegBadge(listOf(RouteBadge("11", null))))
+                    ),
                     durationMinutes = 41,
                     startTime = ServerTime(0L),
                     endTime = ServerTime(41 * 60_000L),

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
@@ -17,6 +17,7 @@ package org.onebusaway.android.ui.tripresults
 
 import org.onebusaway.android.map.RiddenSegment
 import org.onebusaway.android.time.ServerTime
+import org.onebusaway.android.ui.compose.components.RouteBadge
 import org.onebusaway.android.util.GeoPoint
 
 /**
@@ -39,8 +40,9 @@ data class ItineraryOption(
 
 /** What an option card's first line shows for the trip's modes (mutually exclusive by construction). */
 sealed interface ModeSummary {
-    /** A transit trip: its legs' route roundels, in order. */
-    data class Routes(val badges: List<RouteBadge>) : ModeSummary
+    /** A transit trip: one roundel per leg, in order (a leg's roundel names every route that leg can
+     *  be ridden on — see [LegBadge]). */
+    data class Routes(val badges: List<LegBadge>) : ModeSummary
 
     /** A walk-only trip — shown as a walk glyph. */
     data object Walk : ModeSummary
@@ -49,8 +51,19 @@ sealed interface ModeSummary {
     data class Label(val text: String) : ModeSummary
 }
 
-/** A transit leg's route roundel data: its short name and (nullable) GTFS color as an ARGB int. */
-data class RouteBadge(val shortName: String, val routeColor: Int?)
+/**
+ * One transit leg's roundel: every route the leg can be ridden on — the planned route plus any
+ * interchangeable ones (#2010) — as a single joined chip, each route in its own color ("1 Line/2 Line"
+ * for the Lynnwood–downtown pair). An ordinary leg holds exactly one route and draws as the plain
+ * one-color chip it always did.
+ *
+ * [routes] is in natural route-name order rather than plan order, so a corridor reads the same way
+ * whichever of its lines the planner happened to pick.
+ */
+data class LegBadge(val routes: List<RouteBadge>) {
+    /** Whether this leg has more than one route to ride, i.e. the chip is a joined/multicolor one. */
+    val isInterchangeable: Boolean get() = routes.size > 1
+}
 
 /**
  * One entry in the trip **log** — the directions rendered as a single transit timeline the user reads
@@ -182,6 +195,11 @@ sealed interface RealtimeState {
  * **OBA-format** — resolved from OTP's GTFS ids at build time (see [org.onebusaway.android.directions
  * .OtpObaIdResolver]); [routeId]/[RouteStopRef.stopId] are null when they couldn't be resolved (an
  * unknown agency, or the OTP1 path). [headsign] disambiguates which direction group's ETAs to show.
+ *
+ * [alternatives] are the interchangeable routes for this leg (#2010) — the board stop shows each
+ * one's live ETA strip under the planned route's, so the rider can see which of them comes first.
+ * [badge] is the leg's finished roundel (planned route joined by those alternatives), built once by
+ * the repository rather than re-derived per row while composing.
  */
 data class RouteLegRef(
     val routeId: String?,
@@ -199,7 +217,9 @@ data class RouteLegRef(
     // stay-aboard interline (#2000): each names the route continued onto and the seam stop boarded
     // there. The map focus draws each segment's shape + stops and the shared vehicle across them.
     // Empty for an ordinary leg. Carried straight onto [org.onebusaway.android.map.ShowRouteRequest].
-    val extraSegments: List<RiddenSegment> = emptyList()
+    val extraSegments: List<RiddenSegment> = emptyList(),
+    val alternatives: List<AlternativeRouteRef> = emptyList(),
+    val badge: LegBadge = LegBadge(emptyList())
 )
 
 /**
@@ -213,6 +233,20 @@ data class InterlineTransition(
     val routeShortName: String?,
     val headsign: String?,
     val stop: RouteStopRef
+)
+
+/**
+ * An interchangeable route on a transit leg: its display name and color for the badge beside its ETA
+ * strip, plus the same OBA-id/headsign pair [RouteLegRef] carries for the planned route, used to pick
+ * that route's direction group out of the board stop's arrivals. [routeId] is null when the OTP route
+ * couldn't be resolved onto an OBA id — the route still names itself on the leg's badge, but has no
+ * ETA strip to show.
+ */
+data class AlternativeRouteRef(
+    val routeId: String?,
+    val headsign: String?,
+    val shortName: String,
+    val routeColor: Int?
 )
 
 /** A transit stop reached on a leg — its OBA id (for arrivals), display name, code, and location. */

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/RouteDisplay.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/RouteDisplay.kt
@@ -24,6 +24,14 @@ import org.onebusaway.util.comparators.AlphanumComparator
 data class RouteDisplayNames(val shortName: String, val longName: String?)
 
 /**
+ * The app's one route-name order: numeric-aware ("natural"), so "8" sorts before "40" before "550"
+ * rather than lexicographically. Everywhere a list of route names is shown in name order — the
+ * arrivals rows, [formatRouteDisplayNames], a trip leg's interchangeable routes (#2010) — sorts with
+ * this, so the same set of routes reads the same way wherever it appears.
+ */
+val ROUTE_NAME_ORDER: Comparator<String> = AlphanumComparator()
+
+/**
  * Resolves a route's display names with the same short→long→description fallbacks the legacy
  * UIUtils.setRouteView applied: the short name falls back to the long name, and the secondary
  * line is the long name (or the description when the long name is missing or equals the short
@@ -90,7 +98,7 @@ fun getRouteDescription(shortName: String?, longName: String?, description: Stri
 fun formatRouteDisplayNames(
     routeDisplayNames: List<String>,
     nextArrivalRouteShortNames: List<String>
-): String = routeDisplayNames.sortedWith(AlphanumComparator()).joinToString(", ") { name ->
+): String = routeDisplayNames.sortedWith(ROUTE_NAME_ORDER).joinToString(", ") { name ->
     // Highlight (with "*") names that match one of the next X identical arrivals.
     if (nextArrivalRouteShortNames.any { it.equals(name, ignoreCase = true) }) "$name*" else name
 }

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -917,6 +917,9 @@
     <string name="directions_to_here">Directions to here</string>
     <!-- Shown under a transit leg's Board/Alight row when that stop has no upcoming arrivals for the route -->
     <string name="directions_stop_no_arrivals">No upcoming arrivals</string>
+    <!-- Caption beside a transit leg's joined route badge, when several routes go between the same two
+         stops without making the rider late for the rest of the trip (badge reads e.g. "1 Line/2 Line"). -->
+    <string name="directions_whichever_comes_first">whichever comes first</string>
     <string name="trip_plan_clear_endpoint">Clear</string>
     <!-- Content descriptions for the chevrons that hint the itinerary-option picker can scroll sideways -->
     <string name="trip_plan_options_scroll_previous">Show previous options</string>

--- a/onebusaway-android/src/test/java/org/onebusaway/android/api/Otp2PlanDecodeTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/api/Otp2PlanDecodeTest.kt
@@ -25,7 +25,9 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.onebusaway.android.api.adapters.toTripItineraries
 import org.onebusaway.android.api.graphql.PlanQuery
+import org.onebusaway.android.api.graphql.fragment.AlternativeRouteFields
 import org.onebusaway.android.api.graphql.fragment.PlaceFields
+import org.onebusaway.android.api.graphql.fragment.RouteFields
 import org.onebusaway.android.api.graphql.type.AbsoluteDirection
 import org.onebusaway.android.api.graphql.type.Mode
 import org.onebusaway.android.api.graphql.type.RelativeDirection
@@ -77,7 +79,9 @@ class Otp2PlanDecodeTest {
                     lat = 47.6,
                     lon = -122.3
                 )
-            )
+            ),
+            // A non-transit leg has no alternatives — OTP returns null rather than erroring.
+            nextLegs = null
         )
         val busLeg = PlanQuery.Leg(
             mode = Mode.BUS,
@@ -99,16 +103,28 @@ class Otp2PlanDecodeTest {
                 )
             ),
             to = to(place(name = "Stop B", lat = 47.62, lon = -122.32)),
-            route = PlanQuery.Route(
-                gtfsId = "1_5",
-                shortName = "5",
-                longName = "Fifth Ave",
-                color = "0000FF",
-                agency = PlanQuery.Agency(gtfsId = "1_1", name = "Metro", timezone = "America/Los_Angeles")
-            ),
+            route = PlanQuery.Route(__typename = "Route", routeFields = routeFields()),
             trip = PlanQuery.Trip(gtfsId = "1_trip_5", tripHeadsign = "Downtown"),
             legGeometry = null,
-            steps = null
+            steps = null,
+            // One alternative departure on another route between the same two stops (#2010).
+            nextLegs = listOf(
+                PlanQuery.NextLeg(
+                    duration = 540.0,
+                    route = PlanQuery.Route1(
+                        __typename = "Route",
+                        alternativeRouteFields = AlternativeRouteFields(
+                            gtfsId = "1_7",
+                            shortName = "7",
+                            color = "FF0000",
+                            agency = AlternativeRouteFields.Agency(gtfsId = "1_1", name = "Metro")
+                        )
+                    ),
+                    trip = PlanQuery.Trip1(tripHeadsign = "Downtown via 7th"),
+                    from = PlanQuery.From1(stop = PlanQuery.Stop(gtfsId = "1_1001")),
+                    to = PlanQuery.To1(stop = PlanQuery.Stop1(gtfsId = "1_1002"))
+                )
+            )
         )
         val node = PlanQuery.Node(
             start = "2026-07-11T10:00:00-07:00",
@@ -168,6 +184,22 @@ class Otp2PlanDecodeTest {
         assertEquals(30.seconds, bus.departureDelay)
         assertEquals(TripVertexType.BIKESHARE, bus.from.vertexType)
         assertEquals("bs_9", bus.from.bikeShareId)
+
+        // The leg's alternative departures (`nextLegs`) come across unjudged — route identity, the
+        // ride time the interchangeability rule compares, and both stop ids to check it against.
+        assertEquals(1, bus.alternatives.size)
+        val alternative = bus.alternatives[0]
+        assertEquals("1_7", alternative.routeId)
+        assertEquals("7", alternative.routeShortName)
+        assertEquals("FF0000", alternative.routeColor)
+        assertEquals("1_1", alternative.agencyId)
+        assertEquals("Metro", alternative.agencyName)
+        assertEquals("Downtown via 7th", alternative.headsign)
+        assertEquals(540.seconds, alternative.duration)
+        assertEquals("1_1001", alternative.fromStopId)
+        assertEquals("1_1002", alternative.toStopId)
+        // A walk leg's `nextLegs` is null on the wire, not an error — it maps to no alternatives.
+        assertTrue(walk.alternatives.isEmpty())
     }
 
     /** An unrecognized wire `Mode` (Apollo's `UNKNOWN__` sentinel) must degrade to null, not throw. */
@@ -205,7 +237,8 @@ class Otp2PlanDecodeTest {
             route = null,
             trip = null,
             legGeometry = null,
-            steps = null
+            steps = null,
+            nextLegs = null
         )
         val node = PlanQuery.Node(
             start = itineraryStart,
@@ -235,6 +268,21 @@ class Otp2PlanDecodeTest {
         vehicleParking: PlaceFields.VehicleParking? = null,
         vehicleRentalStation: PlaceFields.VehicleRentalStation? = null
     ): PlaceFields = PlaceFields(name, lat, lon, stop, rentalVehicle, vehicleParking, vehicleRentalStation)
+
+    /** Builds a [RouteFields] fixture (the fragment shared by the planned leg's route and each
+     *  alternative leg's — see Plan.graphql). */
+    private fun routeFields(
+        gtfsId: String = "1_5",
+        shortName: String? = "5",
+        longName: String? = "Fifth Ave",
+        color: String? = "0000FF"
+    ): RouteFields = RouteFields(
+        gtfsId = gtfsId,
+        shortName = shortName,
+        longName = longName,
+        color = color,
+        agency = RouteFields.Agency(gtfsId = "1_1", name = "Metro", timezone = "America/Los_Angeles")
+    )
 
     private fun from(fields: PlaceFields) = PlanQuery.From(__typename = "Place", placeFields = fields)
 

--- a/onebusaway-android/src/test/java/org/onebusaway/android/directions/model/InterchangeableRoutesTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/directions/model/InterchangeableRoutesTest.kt
@@ -1,0 +1,244 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.directions.model
+
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.onebusaway.android.time.ServerTime
+
+/**
+ * JVM tests for [interchangeableRoutes] — which of OTP's alternative departures the drawer may tell a
+ * rider to board instead of the planned one (#2010).
+ *
+ * The rule under test: a candidate route qualifies when its ride time fits inside the planned leg's
+ * ride time plus the wait the itinerary already budgets before the next transit leg. So a leg
+ * followed by a slack transfer can offer a somewhat slower route, the last leg of a trip can't offer
+ * any slower route at all, and a local never stands in for the express a plan is built around.
+ */
+class InterchangeableRoutesTest {
+
+    private val t0 = ServerTime(0L)
+
+    /** The motivating case: two lines sharing track between the same two platforms, same ride time. */
+    @Test
+    fun offersAnotherRouteOverTheSameStopsAtTheSameRideTime() {
+        val leg = transitLeg(
+            routeId = "40:1LINE",
+            rideTime = 30.minutes,
+            alternatives = listOf(alternative(routeId = "40:2LINE", shortName = "2 Line", rideTime = 30.minutes))
+        )
+        val routes = itinerary(leg).interchangeableRoutes()[0]
+
+        assertEquals(listOf("2 Line"), routes.map { it.displayName })
+    }
+
+    /** Later trips of the leg's *own* route are alternatives to that departure, not to the route. */
+    @Test
+    fun ignoresLaterTripsOfTheLegsOwnRoute() {
+        val leg = transitLeg(
+            routeId = "40:1LINE",
+            rideTime = 30.minutes,
+            alternatives = listOf(alternative(routeId = "40:1LINE", shortName = "1 Line", rideTime = 30.minutes))
+        )
+        assertEquals(emptyList<String>(), itinerary(leg).interchangeableRoutes()[0].map { it.displayName })
+    }
+
+    /**
+     * On the trip's last transit leg there is no transfer left to protect, so the slack is zero: a
+     * route that rides even slightly longer than the planned one is not offered. (The 3rd Ave case
+     * from #2010 — the 13 rides 254s where the planned D Line rides 244s.)
+     */
+    @Test
+    fun lastTransitLegOffersOnlyRoutesNoSlowerThanThePlannedOne() {
+        val leg = transitLeg(
+            routeId = "1_DLINE",
+            rideTime = 244.seconds,
+            alternatives = listOf(
+                alternative(routeId = "1_1", shortName = "1", rideTime = 238.seconds),
+                alternative(routeId = "1_13", shortName = "13", rideTime = 254.seconds),
+                alternative(routeId = "1_ELINE", shortName = "E Line", rideTime = 107.seconds)
+            )
+        )
+        // A trailing walk leg doesn't make this any less the last *transit* leg.
+        val plan = itinerary(leg, walkLeg(duration = 6.minutes))
+
+        assertEquals(listOf("1", "E Line"), plan.interchangeableRoutes()[0].map { it.displayName })
+    }
+
+    /**
+     * With a transfer downstream, the slack is the wait the plan budgets at the transfer point: the
+     * next transit leg's departure, less this leg's arrival, less the transfer walk. Here the leg
+     * arrives at 10:20, the rider walks 5 minutes, and the connection leaves at 10:33 — 8 minutes of
+     * slack, so a route riding up to 8 minutes longer still makes it.
+     */
+    @Test
+    fun transferSlackLetsASlowerRouteQualifyOnlyUpToTheConnection() {
+        val leg = transitLeg(
+            routeId = "1_100",
+            startTime = ServerTime(minutesMs(0)),
+            rideTime = 20.minutes,
+            alternatives = listOf(
+                alternative(routeId = "1_101", shortName = "101", rideTime = 28.minutes),
+                alternative(routeId = "1_102", shortName = "102", rideTime = 29.minutes)
+            )
+        )
+        val plan = itinerary(
+            leg,
+            walkLeg(duration = 5.minutes),
+            transitLeg(routeId = "1_200", startTime = ServerTime(minutesMs(33)), rideTime = 10.minutes)
+        )
+
+        // 101 rides 8 minutes longer and still catches the connection; 102's 9 minutes misses it.
+        assertEquals(listOf("101"), plan.interchangeableRoutes()[0].map { it.displayName })
+    }
+
+    /** A plan that leaves no wait at the transfer behaves like the last leg: no slower route. */
+    @Test
+    fun timedTransferWithNoWaitAllowsNoSlowerRoute() {
+        val leg = transitLeg(
+            routeId = "1_100",
+            startTime = ServerTime(minutesMs(0)),
+            rideTime = 20.minutes,
+            alternatives = listOf(
+                alternative(routeId = "1_101", shortName = "101", rideTime = 20.minutes),
+                alternative(routeId = "1_102", shortName = "102", rideTime = 21.minutes)
+            )
+        )
+        val plan = itinerary(
+            leg,
+            transitLeg(routeId = "1_200", startTime = ServerTime(minutesMs(20)), rideTime = 10.minutes)
+        )
+
+        assertEquals(listOf("101"), plan.interchangeableRoutes()[0].map { it.displayName })
+    }
+
+    /**
+     * A route runs some fast trips and some slow ones; the rider boards whichever turns up, so the
+     * route is judged — and described — by its slowest run.
+     */
+    @Test
+    fun judgesARouteByItsSlowestCandidateTrip() {
+        val leg = transitLeg(
+            routeId = "1_100",
+            rideTime = 20.minutes,
+            alternatives = listOf(
+                alternative(routeId = "1_101", shortName = "101", rideTime = 18.minutes),
+                alternative(routeId = "1_101", shortName = "101", rideTime = 25.minutes)
+            )
+        )
+        assertEquals(emptyList<String>(), itinerary(leg).interchangeableRoutes()[0].map { it.displayName })
+    }
+
+    /** A candidate that doesn't run between this leg's own two stops is dropped, not trusted. */
+    @Test
+    fun dropsCandidatesThatDontServeTheLegsStops() {
+        val leg = transitLeg(
+            routeId = "1_100",
+            rideTime = 20.minutes,
+            alternatives = listOf(
+                alternative(routeId = "1_101", shortName = "101", rideTime = 15.minutes, toStopId = "1_999"),
+                alternative(routeId = "1_102", shortName = "102", rideTime = 15.minutes, fromStopId = "1_888")
+            )
+        )
+        assertEquals(emptyList<String>(), itinerary(leg).interchangeableRoutes()[0].map { it.displayName })
+    }
+
+    /** Names sort naturally ("8" before "40" before "550"), like the arrivals list's route rows. */
+    @Test
+    fun sortsQualifyingRoutesByNaturalRouteName() {
+        val leg = transitLeg(
+            routeId = "1_100",
+            rideTime = 20.minutes,
+            alternatives = listOf(
+                alternative(routeId = "1_550", shortName = "550", rideTime = 15.minutes),
+                alternative(routeId = "1_8", shortName = "8", rideTime = 15.minutes),
+                alternative(routeId = "1_40", shortName = "40", rideTime = 15.minutes)
+            )
+        )
+        assertEquals(listOf("8", "40", "550"), itinerary(leg).interchangeableRoutes()[0].map { it.displayName })
+    }
+
+    /** The result is index-aligned to the itinerary's legs, so walk legs hold their (empty) place. */
+    @Test
+    fun resultIsAlignedToTheLegList() {
+        val plan = itinerary(
+            walkLeg(duration = 2.minutes),
+            transitLeg(
+                routeId = "1_100",
+                rideTime = 20.minutes,
+                alternatives = listOf(alternative(routeId = "1_101", shortName = "101", rideTime = 20.minutes))
+            ),
+            walkLeg(duration = 2.minutes)
+        )
+        val routes = plan.interchangeableRoutes()
+
+        assertEquals(3, routes.size)
+        assertEquals(emptyList<String>(), routes[0].map { it.displayName })
+        assertEquals(listOf("101"), routes[1].map { it.displayName })
+        assertEquals(emptyList<String>(), routes[2].map { it.displayName })
+    }
+
+    /** An OTP1 plan carries no candidates at all — every leg comes back empty rather than erroring. */
+    @Test
+    fun legWithoutCandidatesHasNoAlternatives() {
+        val leg = transitLeg(routeId = "1_100", rideTime = 20.minutes)
+        assertEquals(emptyList<String>(), itinerary(leg).interchangeableRoutes()[0].map { it.displayName })
+    }
+
+    private fun itinerary(vararg legs: TripLeg) = TripItinerary(startTime = t0, legs = legs.toList())
+
+    private fun transitLeg(
+        routeId: String,
+        rideTime: Duration,
+        startTime: ServerTime = t0,
+        alternatives: List<TripLegAlternative> = emptyList()
+    ) = TripLeg(
+        mode = TripMode.BUS,
+        routeId = routeId,
+        duration = rideTime,
+        startTime = startTime,
+        endTime = startTime + rideTime,
+        from = TripPlace(name = "Board", stopId = BOARD_STOP),
+        to = TripPlace(name = "Alight", stopId = ALIGHT_STOP),
+        alternatives = alternatives
+    )
+
+    private fun walkLeg(duration: Duration) = TripLeg(mode = TripMode.WALK, duration = duration)
+
+    private fun alternative(
+        routeId: String,
+        shortName: String,
+        rideTime: Duration,
+        fromStopId: String = BOARD_STOP,
+        toStopId: String = ALIGHT_STOP
+    ) = TripLegAlternative(
+        routeId = routeId,
+        routeShortName = shortName,
+        duration = rideTime,
+        fromStopId = fromStopId,
+        toStopId = toStopId
+    )
+
+    private fun minutesMs(minutes: Long) = minutes * 60_000L
+
+    private companion object {
+        const val BOARD_STOP = "1_500"
+        const val ALIGHT_STOP = "1_501"
+    }
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/Otp2PlanResolveTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/Otp2PlanResolveTest.kt
@@ -122,7 +122,8 @@ class Otp2PlanResolveTest {
             route = null,
             trip = null,
             legGeometry = null,
-            steps = null
+            steps = null,
+            nextLegs = null
         )
         val node = PlanQuery.Node(
             start = "2026-07-11T10:00:00-07:00",

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/InterlinesTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/InterlinesTest.kt
@@ -17,12 +17,17 @@ package org.onebusaway.android.ui.tripresults
 
 import org.junit.Assert.assertEquals
 import org.junit.Test
+import org.onebusaway.android.directions.model.InterchangeableRoute
+import org.onebusaway.android.directions.model.TripItinerary
 import org.onebusaway.android.directions.model.TripLeg
+import org.onebusaway.android.directions.model.TripLegAlternative
 import org.onebusaway.android.directions.model.TripMode
+import org.onebusaway.android.directions.model.TripPlace
 
 /**
  * JVM tests for [Interlines]: the pure analysis that folds a self-interline seam away and keeps a
- * cross-route stay-aboard interline as one chain with a route-change transition (#2000).
+ * cross-route stay-aboard interline as one chain with a route-change transition (#2000) — and, on top
+ * of it, which rides may be offered an interchangeable route ([substitutableRoutes], #2010).
  */
 class InterlinesTest {
 
@@ -93,17 +98,60 @@ class InterlinesTest {
 
     @Test
     fun routeBadges_foldSelfInterlineButKeepCrossRoute() {
-        assertEquals(
-            listOf("12"),
-            Interlines.routeBadges(listOf(transit("12"), transit("12", interline = true))).map { it.shortName }
+        assertEquals(listOf("12"), badgeNames(listOf(transit("12"), transit("12", interline = true))))
+        assertEquals(listOf("10", "12"), badgeNames(listOf(transit("10"), transit("12", interline = true))))
+        assertEquals(listOf("8", "48"), badgeNames(listOf(transit("8"), walk, transit("48"))))
+    }
+
+    /** A ride's badge names the routes it can be taken on, not just the planned one (#2010). */
+    @Test
+    fun routeBadges_nameTheLegsInterchangeableRoutes() {
+        val legs = listOf(transit("1 Line"))
+        val badges = Interlines.routeBadges(legs, listOf(listOf(interchangeable("2 Line"))))
+
+        assertEquals(listOf(listOf("1 Line", "2 Line")), badges.map { badge -> badge.routes.map { it.shortName } })
+    }
+
+    /**
+     * A stay-aboard interline rides past its own alight stop (#2000), so another route between that
+     * leg's two stops isn't a substitute for the ride — the offer is dropped for those legs (#2010).
+     */
+    @Test
+    fun substitutableRoutes_dropsTheOfferOnAnInterlinedRide() {
+        val interlined = TripItinerary(legs = listOf(withAlternative("10"), withAlternative("12", interline = true)))
+        val standalone = TripItinerary(legs = listOf(withAlternative("10")))
+
+        assertEquals(listOf(emptyList<String>(), emptyList()), interlined.substitutableRoutes().map { routes -> routes.map { it.displayName } })
+        assertEquals(listOf(listOf("99")), standalone.substitutableRoutes().map { routes -> routes.map { it.displayName } })
+    }
+
+    private fun badgeNames(legs: List<TripLeg>): List<String> = Interlines.routeBadges(legs, legs.map { emptyList() }).map { it.routes.single().shortName }
+
+    private fun interchangeable(shortName: String) = InterchangeableRoute(
+        routeId = "route_$shortName",
+        shortName = shortName,
+        routeColor = null,
+        agencyId = null,
+        agencyName = null,
+        headsign = null
+    )
+
+    /** A transit leg between two stops, with one same-stops, same-ride-time alternative on route 99. */
+    private fun withAlternative(route: String, interline: Boolean = false) = transit(route, interline).copy(
+        from = TripPlace(stopId = BOARD_STOP),
+        to = TripPlace(stopId = ALIGHT_STOP),
+        alternatives = listOf(
+            TripLegAlternative(
+                routeId = "99",
+                routeShortName = "99",
+                fromStopId = BOARD_STOP,
+                toStopId = ALIGHT_STOP
+            )
         )
-        assertEquals(
-            listOf("10", "12"),
-            Interlines.routeBadges(listOf(transit("10"), transit("12", interline = true))).map { it.shortName }
-        )
-        assertEquals(
-            listOf("8", "48"),
-            Interlines.routeBadges(listOf(transit("8"), walk, transit("48"))).map { it.shortName }
-        )
+    )
+
+    private companion object {
+        const val BOARD_STOP = "1_500"
+        const val ALIGHT_STOP = "1_501"
     }
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/RouteBadgesTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/RouteBadgesTest.kt
@@ -1,0 +1,131 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.tripresults
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.onebusaway.android.directions.model.InterchangeableRoute
+import org.onebusaway.android.directions.model.TripLeg
+import org.onebusaway.android.directions.model.TripMode
+import org.onebusaway.android.ui.compose.components.RouteBadge
+
+/**
+ * JVM tests for the joined route badge a transit leg draws (#2010) — the planned route plus whatever
+ * else the leg can be ridden on, shared by the itinerary option cards and the directions drawer.
+ */
+class RouteBadgesTest {
+
+    /** The badge reads in natural route order, not plan order, so a corridor looks the same either way. */
+    @Test
+    fun joinsPlannedAndAlternativeRoutesInNaturalOrder() {
+        val badge = legBadge(
+            planned = RouteBadge("2 Line", null),
+            alternatives = listOf(RouteBadge("1 Line", null))
+        )
+
+        assertEquals(listOf("1 Line", "2 Line"), badge.routes.map { it.shortName })
+        assertTrue(badge.isInterchangeable)
+    }
+
+    /** …and the mirror-image plan produces the identical badge. */
+    @Test
+    fun badgeIsTheSameWhicheverRouteThePlanPicked() {
+        val plannedTwo = legBadge(RouteBadge("2 Line", null), listOf(RouteBadge("1 Line", null)))
+        val plannedOne = legBadge(RouteBadge("1 Line", null), listOf(RouteBadge("2 Line", null)))
+
+        assertEquals(plannedTwo, plannedOne)
+    }
+
+    @Test
+    fun naturalOrderSortsRouteNumbersNumerically() {
+        val badge = legBadge(
+            planned = RouteBadge("40", null),
+            alternatives = listOf(RouteBadge("550", null), RouteBadge("8", null))
+        )
+
+        assertEquals(listOf("8", "40", "550"), badge.routes.map { it.shortName })
+    }
+
+    /** A leg with nothing interchangeable is a plain one-route badge. */
+    @Test
+    fun singleRouteLegIsNotInterchangeable() {
+        val badge = legBadge(planned = RouteBadge("8", null), alternatives = emptyList())
+
+        assertEquals(listOf("8"), badge.routes.map { it.shortName })
+        assertFalse(badge.isInterchangeable)
+    }
+
+    /** A route can't appear twice in one badge, however it reached the list. */
+    @Test
+    fun dropsADuplicateOfThePlannedRoute() {
+        val badge = legBadge(RouteBadge("8", null), listOf(RouteBadge("8", null), RouteBadge("7", null)))
+
+        assertEquals(listOf("7", "8"), badge.routes.map { it.shortName })
+    }
+
+    /** A leg badges its route's short name. (Parsing the GTFS color needs the Android graphics stack,
+     *  so that half is asserted on-device — see `DirectionRowAlternativeRoutesTest`.) */
+    @Test
+    fun legBadgeUsesTheRouteShortName() {
+        val badge = TripLeg(
+            mode = TripMode.BUS,
+            routeId = "1_100",
+            routeShortName = "8",
+            routeLongName = "Rainier Ave"
+        ).plannedBadge()
+
+        assertEquals("8", badge.shortName)
+    }
+
+    /** No short name (some feeds only name a route long-form): fall back to the route/id, no color. */
+    @Test
+    fun legBadgeFallsBackToTheRouteIdWhenUnnamed() {
+        val badge = TripLeg(mode = TripMode.BUS, routeId = "1_100").plannedBadge()
+
+        assertEquals("1_100", badge.shortName)
+        assertNull(badge.routeColor)
+    }
+
+    /** A leg's badge is its planned route joined by the routes ruled interchangeable with it. */
+    @Test
+    fun legBadgeJoinsTheLegsRouteWithItsInterchangeableOnes() {
+        val leg = TripLeg(mode = TripMode.BUS, routeId = "1_100", routeShortName = "8")
+
+        val badge = legBadge(leg, listOf(interchangeableRoute(shortName = "7")))
+
+        assertEquals(listOf("7", "8"), badge.routes.map { it.shortName })
+    }
+
+    /** An interchangeable route badges the same way the planned one does; an unnamed one falls back
+     *  to its route id, so a badge segment is never blank. */
+    @Test
+    fun interchangeableRouteBadgesItsDisplayName() {
+        assertEquals("1 Line", interchangeableRoute(shortName = "1 Line").badge().shortName)
+        assertEquals("40:100479", interchangeableRoute(shortName = null).badge().shortName)
+    }
+
+    private fun interchangeableRoute(shortName: String?) = InterchangeableRoute(
+        routeId = "40:100479",
+        shortName = shortName,
+        routeColor = null,
+        agencyId = "40:1",
+        agencyName = "Sound Transit",
+        headsign = "Federal Way Downtown"
+    )
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/TripResultsViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/TripResultsViewModelTest.kt
@@ -28,6 +28,7 @@ import org.junit.Test
 import org.onebusaway.android.directions.model.TripItinerary
 import org.onebusaway.android.testing.MainDispatcherRule
 import org.onebusaway.android.time.ServerTime
+import org.onebusaway.android.ui.compose.components.RouteBadge
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class TripResultsViewModelTest {
@@ -41,7 +42,7 @@ class TripResultsViewModelTest {
     )
 
     private fun option(shortName: String) = ItineraryOption(
-        mode = ModeSummary.Routes(listOf(RouteBadge(shortName, routeColor = null))),
+        mode = ModeSummary.Routes(listOf(LegBadge(listOf(RouteBadge(shortName, routeColor = null))))),
         durationMinutes = 30,
         startTime = ServerTime(0L),
         endTime = ServerTime(30 * 60_000L)


### PR DESCRIPTION
Fixes #2010.

Between Lynnwood and downtown the 1 Line and the 2 Line run the same track to the same platforms, so a plan that names one of them is telling the rider less than it knows: either will do, and the right advice is "take whichever comes first".

## Where the answer comes from

OTP2's `Leg.nextLegs` returns upcoming departures between a leg's **exact** board and alight stops on *any* route — the GTFS GraphQL API runs it with `AlternativeLegsFilter.NO_FILTER` (verified in OTP's `LegImpl.alternativeLegs`), so a corridor's other lines come back alongside later trips of the leg's own route. The parent-station arguments are deliberately omitted: their default keeps the search on the exact stops, so an alternative is always boardable at the very stop the drawer names, never a sibling platform.

Candidates cross the wire boundary unjudged; interchangeability is decided in one pure place (`InterchangeableRoutes.kt`).

## The rule

It is about **ride time**, never about which vehicle happens to turn up first — a local running early must not stand in for the express a plan is built around. A candidate route qualifies when

```
candidate ride time  ≤  planned ride time + transfer slack
```

where the slack is the wait the itinerary already budgets before the next transit leg departs — exactly how late the rider may reach the alight stop and still make the connection as planned. **No invented constant:** every term is read off the itinerary. The last transit leg has no connection left to protect, so its slack is zero and only routes no slower than the planned one qualify.

Two conservatisms, because the claim is "any of these will do" and that has to hold for whichever vehicle actually arrives:
- a route is judged by its **slowest** returned trip;
- a candidate whose own board/alight stops don't match the leg's is dropped rather than trusted.

## What the rider sees

One joined roundel per ride, in both places a leg's routes appear — the itinerary option cards and the directions drawer. `RouteBadgeChip` now takes a list of routes and draws them as a single chip split by a slash-like diagonal, each route in its own color, with a black line along that diagonal and a black outline around the chip — so it reads as one bounded object holding two names even when its routes share a color (or have none). The leg card adds a "whichever comes first" caption, and the board stop shows each route's live ETA strip under the planned route's (from the poll that stop already runs — no extra request), so the rider can see which is genuinely first.

## Interaction with #2000 (stay-aboard interlines) — worth a look

The two features meet in a way neither issue anticipated. An interlined ride continues *past* its own alight stop, so another route between that leg's two stops is **not** a substitute — it would put the rider off at the seam with no instruction. Rather than teach the rule about chains, `substitutableRoutes()` drops the offer for legs in a multi-leg chain; the ride still renders, just without alternatives. Badges compose the other way round: one badge per distinct vehicle-and-route (#2000), each naming every route that ride can be taken on (#2010).

## Please sign off on one bound

`ALTERNATIVE_LEGS = 12` (`Otp2PlanRequestBuilder`) is the `nextLegs` page size. It costs response bytes rather than server work (OTP walks the same patterns either way and applies it as a final `.limit(…)`), **but it is a cap on what the rider is told**: the page is shared by every route serving the leg, so on a frequent corridor an infrequent-but-equivalent route can fall past it and simply not be offered. The failure is silent and one-directional — the badge under-reports, never over-reports — and which routes make the page varies with how often the planned route runs. Flagging it explicitly per the "no unsanctioned heuristics" rule in CLAUDE.md; the doc comment says the same at the call site.

## Compatibility

- **OTP1 REST** has no equivalent, so that path yields no alternatives and is unchanged.
- **OTP2 servers must be ≥ 2.5.0**, where `nextLegs` was added (checked against the v2.4.0/v2.5.0 schemas; the signature hasn't changed since). A custom-URL user pointing at an older OTP2 would have the whole plan query rejected at GraphQL validation, not just lose this feature. `@include(if:)` can't help — validation happens first — so a fallback would mean a second query document. Happy to add one if you'd rather not carry that.

## Verification

Against the live Puget Sound OTP2 server, replaying Apollo's exact generated document:
- Lynnwood City Center → Westlake: planned 2 Line → offers **1 Line** (and the mirror-image itinerary offers the 2 Line). Same stop pair, identical 30m30s rides. This is the issue's own case.
- 3rd Ave & Pike → 3rd Ave & Bell: planned route 2 (254s) → offers **1, 13, D Line, E Line**; drops the 4 (307s). Planned 28 (368s) → drops the 5 (482s): the local doesn't stand in for the express.

Tests: 1170 unit (new `InterchangeableRoutesTest` covers the rule — transfer slack, zero-slack last leg, own-route trips ignored, slowest-trip judging, stop mismatch, ordering, index alignment; `RouteBadgesTest` covers the badge; `InterlinesTest` gains the #2000 × #2010 case). 16 instrumented tests on a physical Pixel 7 Pro, including pixel-level checks that the joined badge shows no background through its colors, that its divider leans like a slash, that the badge is outlined in black, and that two same-colored routes are still separated by a black line. All four were falsified — made to fail by flattening the divider, opening a 1dp gap, and dropping the outline/line — so they aren't vacuous.

`spotlessApply` and a strict `-PwarningsAsErrors=true` compile are clean; lint left to CI per CLAUDE.md.

---

- [x] Format your changes with `./gradlew spotlessApply`.
- [x] Run the unit tests with `gradlew connectedObaGoogleDebugAndroidTest` to make sure you didn't break anything

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for interchangeable route options in trip planning and trip results.
  * Trip results now render joined multi-route badge chips plus “whichever comes first” guidance when applicable.
  * ETAs now include qualifying alternative-route rows.
* **Bug Fixes**
  * Improved joined route badge rendering (natural sorting, no internal gaps, clear dividers/outlines, and correct color/label handling with fallbacks).
* **Tests**
  * Added/expanded unit and instrumentation tests covering alternative-leg planning, badge composition, ETA behavior, interlined cases, and rendering pixel checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->