### PR TITLE
Reverse-geocode the trip origin so the directions name a real place (#2006)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/GeocodeRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/GeocodeRepository.kt
@@ -19,6 +19,7 @@ import android.content.Context
 import android.location.Geocoder
 import dagger.hilt.android.qualifiers.ApplicationContext
 import edu.usf.cutr.pelias.AutocompleteRequest
+import edu.usf.cutr.pelias.PeliasRequest
 import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -33,9 +34,21 @@ import org.onebusaway.android.util.RegionUtils
 import org.onebusaway.android.util.locationOf
 import org.onebusaway.android.util.runCatchingCancellable
 
-/** Address-autocomplete suggestions for the trip-plan endpoints. */
+/** Address geocoding for the trip-plan endpoints: autocomplete forward, coordinates back. */
 interface GeocodeRepository {
     suspend fun suggest(query: String): Result<List<TripEndpoint.Geocoded>>
+
+    /**
+     * The short name of the place at [lat]/[lon] ("Pike Place Market", "1717 Cascade Way"), or null
+     * when the geocoder knows of nothing there. Used to label an endpoint the user chose as a bare
+     * point — their current location or a map pick — which otherwise reaches the directions as OTP's
+     * "Origin" placeholder (#2006).
+     *
+     * A plain `String?` rather than the [CustomAddress] the geocoders produce: the caller wants a
+     * label, and keeping `android.location.Address` out of this interface keeps the ViewModel that
+     * consumes it JVM-testable (as [suggest]'s [TripEndpoint.Geocoded] projection already does).
+     */
+    suspend fun reverse(lat: Double, lon: Double): Result<String?>
 }
 
 /**
@@ -67,6 +80,58 @@ class DefaultGeocodeRepository @Inject constructor(
             }
             addresses.withinRegion(region).map { it.toGeocoded() }
         }
+    }
+
+    /**
+     * Reverse lookup, same backend split as [suggest]. Unlike a text query there is nothing to bias —
+     * a reverse lookup has one answer, at a point the user has already chosen as an endpoint — so the
+     * region's bounding box isn't applied here; filtering by it could only ever discard a correct name.
+     */
+    override suspend fun reverse(lat: Double, lon: Double): Result<String?> = withContext(Dispatchers.IO) {
+        runCatchingCancellable {
+            if (BuildFlavorUtils.isPeliasApiKeyDefined()) {
+                peliasReverse(lat, lon)
+            } else {
+                platformReverse(lat, lon)
+            }?.takeIf { it.isNotBlank() }
+        }
+    }
+
+    /** Pelias `/reverse`: the nearest feature to the point. Throws IOException on failure. */
+    private fun peliasReverse(lat: Double, lon: Double): String? {
+        val url = peliasReverseUrl(
+            endpoint = context.getString(R.string.pelias_reverse_api_url),
+            apiKey = BuildConfig.PELIAS_API_KEY,
+            lat = lat,
+            lon = lon
+        )
+        val feature = PeliasReverseRequest(url).call().features.firstOrNull() ?: return null
+        // Pelias carries the structured short `name` ("Pike Place Market", "1717 Cascade Way") beside the
+        // fully-qualified `label` ("1717 Cascade Way, Springfield, MA, USA"); the request pins the layers
+        // (see [peliasReverseUrl]) so this is a place's name and never a county's or a country's.
+        return feature.properties[PELIAS_NAME_PROPERTY] as? String
+    }
+
+    /** On-device [Geocoder] fallback (no Pelias key). */
+    private fun platformReverse(lat: Double, lon: Double): String? {
+        // Sync getFromLocation is deprecated in API 33 — same reasoning (and same degraded, key-free
+        // path) as platformSuggestions above: its replacement requires API 33 while minSdk is 23.
+        @Suppress("DEPRECATION")
+        val address = Geocoder(context).getFromLocation(lat, lon, REVERSE_MAX_RESULTS)?.firstOrNull()
+            ?: return null
+        // The street address — house number ([Address.getSubThoroughfare]) and street
+        // ([Address.getThoroughfare]) — which is this geocoder's answer to Pelias's short `name` above.
+        // Deliberately not CustomAddress.toString(), which tails off into the county and city a timeline
+        // node doesn't want ("1717 Cascade Way", not "1717 Cascade Way, Snohomish County, Everett").
+        //
+        // Built from the two fields that *are* the street address rather than from `featureName`, which
+        // the platform fills with the house number for a street address but with the place's name for a
+        // named feature — telling those apart would mean comparing the strings. So `featureName` is used
+        // only where there is no street for it to duplicate, and a named venue reads as its address
+        // ("85 Pike Pl") rather than its name: unambiguous, at the cost of some colour.
+        return address.thoroughfare?.let { street ->
+            listOfNotNull(address.subThoroughfare, street).joinToString(" ")
+        } ?: address.featureName ?: address.getAddressLine(0)
     }
 
     /** Pelias autocomplete, biased to the region's bounding box. Throws IOException on failure. */
@@ -104,6 +169,43 @@ class DefaultGeocodeRepository @Inject constructor(
         const val GEOCODER_MAX_RESULTS = 5
     }
 }
+
+/** A reverse lookup wants the one place at the point, not a list. */
+private const val REVERSE_MAX_RESULTS = 1
+
+/** The Pelias feature property holding a place's own short name, beside the qualified `label`. */
+private const val PELIAS_NAME_PROPERTY = "name"
+
+/**
+ * The kinds of Pelias result worth labelling a trip endpoint with, nearest first: the building, else the
+ * venue standing on it, else the street.
+ *
+ * Pelias otherwise answers a reverse lookup with whatever is nearest across *every* layer, which in a
+ * thinly-mapped area is a `county` or `region` — so the origin node would read "Snohomish County". Asking
+ * for the place-like layers means an answer is either a real place or absent, and absent degrades to
+ * OTP's own name rather than to something worse than it.
+ */
+private const val PELIAS_PLACE_LAYERS = "address,venue,street"
+
+/**
+ * The Pelias `/reverse` query for a point. Top-level and `internal` so the query shape is unit-testable
+ * without a `Context` (as [otpPlanUrl][org.onebusaway.android.ui.tripplan.otpPlanUrl] is on the OTP side).
+ *
+ * The coordinates are interpolated through `Double.toString`, which is locale-independent — so the
+ * decimal separator is always the `.` the API expects, whatever the device locale.
+ */
+internal fun peliasReverseUrl(endpoint: String, apiKey: String, lat: Double, lon: Double): String = "$endpoint?point.lat=$lat&point.lon=$lon&api_key=$apiKey" +
+    "&size=$REVERSE_MAX_RESULTS&layers=$PELIAS_PLACE_LAYERS"
+
+/**
+ * A Pelias `/reverse` request: coordinates in, the place at them out.
+ *
+ * The vendored client library only models the text-query endpoints — every `PeliasRequest.Builder`
+ * hard-codes `?text=` — so the reverse query string is assembled by the caller. The response is the
+ * same GeoJSON feature collection, so the request itself rides the library's own [PeliasRequest.call]
+ * (URL fetch + parse) rather than a second HTTP/JSON path.
+ */
+private class PeliasReverseRequest(url: String) : PeliasRequest(url)
 
 /** Mints the domain [TripEndpoint.Geocoded] from a geocoder [CustomAddress] result (the wire boundary). */
 internal fun CustomAddress.toGeocoded(): TripEndpoint.Geocoded = TripEndpoint.Geocoded(

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanViewModel.kt
@@ -23,9 +23,12 @@ import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 import javax.inject.Inject
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -35,6 +38,7 @@ import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.withTimeoutOrNull
 import org.onebusaway.android.directions.model.TripItinerary
 import org.onebusaway.android.location.SearchCenter
 import org.onebusaway.android.region.RegionRepository
@@ -95,6 +99,13 @@ class TripPlanViewModel @Inject constructor(
     private val fromQueries = MutableStateFlow("")
     private val toQueries = MutableStateFlow("")
 
+    // Reverse-geocoded names, keyed by the coordinate that produced them. Re-planning re-submits the same
+    // points — a date or arrive-by change, an advanced-settings apply, or editing *the other* endpoint all
+    // re-plan — and what a point is called doesn't change between them, so the lookup is worth exactly
+    // once. Only successes are remembered, so a failed lookup is retried rather than cached as "unnamed".
+    // Read and written only from the plan collector, which runs on the main dispatcher.
+    private val reverseNames = mutableMapOf<Pair<Double, Double>, String>()
+
     // Plan submissions, driven reactively. Each user action that can change the plan sends its params
     // (or null when the form isn't submittable) here; the collector below [mapLatest]-cancels the plan
     // in flight as soon as the next input arrives, so a slow plan that outlives its edit can't publish a
@@ -122,18 +133,55 @@ class TripPlanViewModel @Inject constructor(
                     if (_planState.value !is PlanResult.Idle) _planState.value = PlanResult.Idle
                 } else {
                     _planState.value = PlanResult.Loading
-                    planRepository.plan(params).fold(
-                        // Carry the request that produced the results so the host can arm the
-                        // trip-plan-change monitor to re-plan it (see PlanResult.Success.params).
-                        onSuccess = { _planState.value = PlanResult.Success(it, params) },
-                        onFailure = { _planState.value = PlanResult.Error(it.toTripPlanError()) }
-                    )
+                    coroutineScope {
+                        // Naming the endpoints is an independent network call, so it runs alongside the
+                        // plan rather than before it: it costs no wall clock beyond the plan itself
+                        // unless the geocoder is slower, and [REVERSE_GEOCODE_TIMEOUT] caps even that.
+                        val origin = async { placeNameOf(params.from) }
+                        val destination = async { placeNameOf(params.to) }
+                        planRepository.plan(params).fold(
+                            // Carry the request that produced the results so the host can arm the
+                            // trip-plan-change monitor to re-plan it (see PlanResult.Success.params).
+                            onSuccess = { itineraries ->
+                                _planState.value = PlanResult.Success(
+                                    itineraries.withTerminalPlaceNames(origin.await(), destination.await()),
+                                    params
+                                )
+                            },
+                            onFailure = {
+                                // Nothing left to name — don't hold the error behind a lookup whose answer
+                                // is about to be discarded ("outside the transit network" is a routine
+                                // failure for exactly the map-picked endpoints that need one).
+                                origin.cancel()
+                                destination.cancel()
+                                _planState.value = PlanResult.Error(it.toTripPlanError())
+                            }
+                        )
+                    }
                 }
             }
             .launchIn(viewModelScope)
     }
 
     private suspend fun suggestionsFor(query: String): List<TripEndpoint.Geocoded> = if (query.isBlank()) emptyList() else geocode.suggest(query).getOrDefault(emptyList())
+
+    /**
+     * What to call a plan endpoint: an endpoint the user picked by name already answers for itself, but
+     * "my location" or a point on the map is only a coordinate — and OTP, sent bare coordinates, echoes
+     * them back as its own "Origin" placeholder, which is what the directions used to be left labelling
+     * their first node with (#2006). Reverse-geocodes that case.
+     *
+     * Best-effort: a failed, timed-out, or empty lookup returns null and the timeline keeps OTP's name,
+     * so a plan is never blocked or failed by geocoding.
+     */
+    private suspend fun placeNameOf(endpoint: TripEndpoint): String? {
+        endpoint.displayText?.takeIf { it.isNotBlank() }?.let { return it }
+        val lat = endpoint.lat ?: return null
+        val lon = endpoint.lon ?: return null
+        reverseNames[lat to lon]?.let { return it }
+        val name = withTimeoutOrNull(REVERSE_GEOCODE_TIMEOUT) { geocode.reverse(lat, lon).getOrNull() }
+        return name?.also { reverseNames[lat to lon] = it }
+    }
 
     fun onFromQueryChange(query: String) {
         _formState.update { it.copy(from = TripEndpoint.FreeText(query)) }
@@ -257,8 +305,49 @@ class TripPlanViewModel @Inject constructor(
     private companion object {
         const val SUGGEST_DEBOUNCE_MS = 350L
 
+        /**
+         * How long a plan will wait on the endpoint-naming lookups it runs alongside the OTP call.
+         * Naming is a cosmetic upgrade of the directions' first/last node, so a slow geocoder must not
+         * hold the route back — past this the plan publishes with OTP's own names.
+         */
+        val REVERSE_GEOCODE_TIMEOUT = 4.seconds
+
         // Mirror OTPConstants.TRIP_PLAN_DATE/TIME_STRING_FORMAT (inlined to keep this JVM-pure).
         const val DATE_PATTERN = "MMMM dd"
         const val TIME_PATTERN = "hh:mm a"
+    }
+}
+
+/**
+ * Names the trip's two ends on the itineraries themselves — the first leg's origin and the last leg's
+ * destination — leaving OTP's own name wherever we have nothing better (#2006).
+ *
+ * OTP is sent bare coordinates for *every* endpoint (`TripRequestBuilder.getAddressString`), so what it
+ * echoes back for the two terminals is its "Origin"/"Destination" placeholder, never a real place. The
+ * requester is the only party that knows what the user actually picked, so it stamps that in here, once,
+ * where the request and its results meet — rather than handing every downstream reader a second channel
+ * to consult. Everything that reads an itinerary afterwards (the trip log, the map focus, the trip-update
+ * notification, which serializes these very objects and restores them on re-entry) then sees one
+ * self-describing trip.
+ *
+ * Top-level and `internal` so this stays JVM-unit-testable, like the OTP-side [otpPlanUrl].
+ */
+internal fun List<TripItinerary>.withTerminalPlaceNames(origin: String?, destination: String?): List<TripItinerary> {
+    val originName = origin?.takeIf { it.isNotBlank() }
+    val destinationName = destination?.takeIf { it.isNotBlank() }
+    if (originName == null && destinationName == null) return this
+    return map { itinerary ->
+        if (itinerary.legs.isEmpty()) {
+            itinerary
+        } else {
+            val legs = itinerary.legs.toMutableList()
+            // A single-leg trip is both terminals, so these apply in order to the same leg.
+            originName?.let { legs[0] = legs[0].let { leg -> leg.copy(from = leg.from.copy(name = it)) } }
+            destinationName?.let {
+                val last = legs.lastIndex
+                legs[last] = legs[last].let { leg -> leg.copy(to = leg.to.copy(name = it)) }
+            }
+            itinerary.copy(legs = legs)
+        }
     }
 }

--- a/onebusaway-android/src/main/res/values/donottranslate.xml
+++ b/onebusaway-android/src/main/res/values/donottranslate.xml
@@ -100,6 +100,9 @@
     <!-- Pelias API URL for geocoding -->
     <string name="pelias_api_url">https://api.geocode.earth/v1/autocomplete</string>
 
+    <!-- Pelias API URL for reverse geocoding (coordinates to a place name) -->
+    <string name="pelias_reverse_api_url">https://api.geocode.earth/v1/reverse</string>
+
     <!-- Oba Analytics Messages -->
     <string name="analytics_problem">report_problem</string>
     <string name="analytics_accessibility">accessibility</string>

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/PeliasReverseUrlTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/PeliasReverseUrlTest.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.tripplan
+
+import java.util.Locale
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * JVM tests for the Pelias `/reverse` query the geocode repository builds by hand — the vendored client
+ * library models only the text-query endpoints, whose builders hard-code `?text=`, so this query shape
+ * has no library to keep it honest.
+ */
+class PeliasReverseUrlTest {
+
+    private val defaultLocale = Locale.getDefault()
+
+    @After
+    fun restoreLocale() {
+        Locale.setDefault(defaultLocale)
+    }
+
+    @Test
+    fun `builds the reverse query for a point`() {
+        assertEquals(
+            "https://api.geocode.earth/v1/reverse?point.lat=47.6&point.lon=-122.3&api_key=abc123&size=1&layers=address,venue,street",
+            peliasReverseUrl("https://api.geocode.earth/v1/reverse", "abc123", 47.6, -122.3)
+        )
+    }
+
+    @Test
+    fun `coordinates keep a dot decimal separator in a comma-decimal locale`() {
+        // A locale-formatted "47,6" would silently split the query parameter.
+        Locale.setDefault(Locale.GERMANY)
+        assertEquals(
+            "https://pelias.example/v1/reverse?point.lat=47.6&point.lon=-122.3&api_key=k&size=1&layers=address,venue,street",
+            peliasReverseUrl("https://pelias.example/v1/reverse", "k", 47.6, -122.3)
+        )
+    }
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TerminalPlaceNamesTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TerminalPlaceNamesTest.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.tripplan
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Test
+import org.onebusaway.android.directions.model.TripItinerary
+import org.onebusaway.android.directions.model.TripLeg
+import org.onebusaway.android.directions.model.TripPlace
+
+/**
+ * JVM tests for [withTerminalPlaceNames] — the plan boundary stamping what the user actually picked onto
+ * the trip's two ends, in place of the "Origin"/"Destination" placeholders OTP returns for a trip routed
+ * between bare coordinates (#2006).
+ */
+class TerminalPlaceNamesTest {
+
+    private fun leg(from: String?, to: String?) = TripLeg(from = TripPlace(name = from), to = TripPlace(name = to))
+
+    private val twoLegs = TripItinerary(
+        legs = listOf(leg("Origin", "Pine St & 3rd Ave"), leg("Pine St & 3rd Ave", "Destination"))
+    )
+
+    @Test
+    fun `names the first leg's origin and the last leg's destination`() {
+        val named = listOf(twoLegs).withTerminalPlaceNames("Pike Place Market", "Sea-Tac Airport")
+
+        val legs = named.single().legs
+        assertEquals("Pike Place Market", legs.first().from.name)
+        assertEquals("Sea-Tac Airport", legs.last().to.name)
+        // The interior of the trip is the transit network's own names — untouched.
+        assertEquals("Pine St & 3rd Ave", legs.first().to.name)
+        assertEquals("Pine St & 3rd Ave", legs.last().from.name)
+    }
+
+    @Test
+    fun `every itinerary is named, since they all share the trip's two ends`() {
+        val named = listOf(twoLegs, twoLegs, twoLegs).withTerminalPlaceNames("Pike Place Market", "Sea-Tac Airport")
+
+        assertEquals(3, named.size)
+        named.forEach { assertEquals("Pike Place Market", it.legs.first().from.name) }
+    }
+
+    @Test
+    fun `a single-leg trip is both of its own terminals`() {
+        val walkOnly = listOf(TripItinerary(legs = listOf(leg("Origin", "Destination"))))
+
+        val leg = walkOnly.withTerminalPlaceNames("Pike Place Market", "Sea-Tac Airport").single().legs.single()
+        assertEquals("Pike Place Market", leg.from.name)
+        assertEquals("Sea-Tac Airport", leg.to.name)
+    }
+
+    @Test
+    fun `a name we do not have leaves OTP's own name alone`() {
+        val named = listOf(twoLegs).withTerminalPlaceNames(null, "  ")
+
+        val legs = named.single().legs
+        assertEquals("Origin", legs.first().from.name)
+        assertEquals("Destination", legs.last().to.name)
+    }
+
+    @Test
+    fun `nothing to name returns the itineraries untouched`() {
+        val planned = listOf(twoLegs)
+        assertSame(planned, planned.withTerminalPlaceNames(null, null))
+    }
+
+    @Test
+    fun `a legless itinerary has no terminals to name`() {
+        val empty = listOf(TripItinerary())
+        assertEquals(empty, empty.withTerminalPlaceNames("Pike Place Market", "Sea-Tac Airport"))
+    }
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripPlanViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripPlanViewModelTest.kt
@@ -19,6 +19,7 @@ import java.io.IOException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -27,6 +28,8 @@ import org.junit.Rule
 import org.junit.Test
 import org.onebusaway.android.R
 import org.onebusaway.android.directions.model.TripItinerary
+import org.onebusaway.android.directions.model.TripLeg
+import org.onebusaway.android.directions.model.TripPlace
 import org.onebusaway.android.directions.util.TripRequestBuilder
 import org.onebusaway.android.location.FakeLocationRepository
 import org.onebusaway.android.location.SearchCenter
@@ -35,6 +38,9 @@ import org.onebusaway.android.region.RegionRepository
 import org.onebusaway.android.region.region
 import org.onebusaway.android.testing.MainDispatcherRule
 import org.onebusaway.android.util.TimeProvider
+
+/** What OTP calls a trip's origin when it was asked to route from a bare coordinate. */
+private const val OTP_PLACEHOLDER_ORIGIN = "Origin"
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class TripPlanViewModelTest {
@@ -46,12 +52,38 @@ class TripPlanViewModelTest {
     private val origin = TripEndpoint.Geocoded("Origin", lat = 47.6, lon = -122.3)
     private val destination = TripEndpoint.Geocoded("Destination", lat = 47.7, lon = -122.2)
 
-    private class FakeGeocodeRepository(var result: Result<List<TripEndpoint.Geocoded>>) : GeocodeRepository {
+    /** A two-leg itinerary named the way OTP names one planned between bare coordinates. */
+    private val plannedTrip = listOf(
+        TripItinerary(
+            legs = listOf(
+                TripLeg(from = TripPlace(name = OTP_PLACEHOLDER_ORIGIN), to = TripPlace(name = "Pine St & 3rd Ave")),
+                TripLeg(from = TripPlace(name = "Pine St & 3rd Ave"), to = TripPlace(name = "Destination"))
+            )
+        )
+    )
+
+    private class FakeGeocodeRepository(
+        var result: Result<List<TripEndpoint.Geocoded>>,
+        var reverseResult: Result<String?> = Result.success(null)
+    ) : GeocodeRepository {
         var lastQuery: String? = null
+        val reverseCalls = mutableListOf<Pair<Double, Double>>()
+
         override suspend fun suggest(query: String): Result<List<TripEndpoint.Geocoded>> {
             lastQuery = query
             return result
         }
+
+        override suspend fun reverse(lat: Double, lon: Double): Result<String?> {
+            reverseCalls.add(lat to lon)
+            return reverseResult
+        }
+    }
+
+    /** A geocoder whose reverse lookup never answers, to exercise the plan's naming timeout. */
+    private class StalledGeocodeRepository : GeocodeRepository {
+        override suspend fun suggest(query: String) = Result.success(emptyList<TripEndpoint.Geocoded>())
+        override suspend fun reverse(lat: Double, lon: Double): Result<String?> = CompletableDeferred<Result<String?>>().await()
     }
 
     private class FakeTripPlanRepository(var result: Result<List<TripItinerary>>) : TripPlanRepository {
@@ -285,6 +317,110 @@ class TripPlanViewModelTest {
         val vm = viewModel(plan = FakeTripPlanRepository(Result.failure(IOException("boom"))))
         setBothEndpoints(vm)
         advanceUntilIdle()
+        assertEquals(PlanResult.Error(TripPlanError.Unknown), vm.planState.value)
+    }
+
+    /** The name the surfaced result gives the trip's origin — the first leg's origin. */
+    private fun plannedOriginName(vm: TripPlanViewModel): String? = (vm.planState.value as PlanResult.Success).itineraries.first().legs.first().from.name
+
+    @Test
+    fun `a coordinate-only endpoint is reverse-geocoded onto the itineraries`() = runTest {
+        val geocode = FakeGeocodeRepository(
+            Result.success(emptyList()),
+            reverseResult = Result.success("Pike Place Market")
+        )
+        val vm = viewModel(geocode = geocode, plan = FakeTripPlanRepository(Result.success(plannedTrip)))
+
+        vm.setFrom(TripEndpoint.CurrentLocation(lat = 47.6, lon = -122.3))
+        vm.setTo(TripEndpoint.MapPoint(lat = 47.7, lon = -122.2))
+        advanceUntilIdle()
+
+        val legs = (vm.planState.value as PlanResult.Success).itineraries.first().legs
+        assertEquals("Pike Place Market", legs.first().from.name)
+        assertEquals("Pike Place Market", legs.last().to.name)
+        assertEquals(listOf(47.6 to -122.3, 47.7 to -122.2), geocode.reverseCalls.sortedBy { it.first })
+        // The form's own pill keeps its fixed "My Location" label.
+        assertEquals(null, vm.formState.value.from.displayText)
+    }
+
+    @Test
+    fun `an endpoint the user named labels the trip without a lookup`() = runTest {
+        val geocode = FakeGeocodeRepository(
+            Result.success(emptyList()),
+            reverseResult = Result.success("Somewhere Else")
+        )
+        val vm = viewModel(geocode = geocode, plan = FakeTripPlanRepository(Result.success(plannedTrip)))
+        setBothEndpoints(vm)
+        advanceUntilIdle()
+
+        assertEquals("Origin", plannedOriginName(vm))
+        assertTrue(geocode.reverseCalls.isEmpty())
+    }
+
+    @Test
+    fun `a failed reverse lookup keeps OTP's own name and still plans`() = runTest {
+        val geocode = FakeGeocodeRepository(
+            Result.success(emptyList()),
+            reverseResult = Result.failure(IOException("boom"))
+        )
+        val vm = viewModel(geocode = geocode, plan = FakeTripPlanRepository(Result.success(plannedTrip)))
+
+        vm.setFrom(TripEndpoint.CurrentLocation(lat = 47.6, lon = -122.3))
+        vm.setTo(destination)
+        advanceUntilIdle()
+
+        assertEquals(OTP_PLACEHOLDER_ORIGIN, plannedOriginName(vm))
+    }
+
+    @Test
+    fun `a stalled reverse lookup does not hold the route back`() = runTest {
+        val vm = viewModel(
+            geocode = StalledGeocodeRepository(),
+            plan = FakeTripPlanRepository(Result.success(plannedTrip))
+        )
+
+        vm.setFrom(TripEndpoint.CurrentLocation(lat = 47.6, lon = -122.3))
+        vm.setTo(destination)
+        advanceUntilIdle()
+
+        assertTrue(vm.planState.value is PlanResult.Success)
+        assertEquals(OTP_PLACEHOLDER_ORIGIN, plannedOriginName(vm))
+    }
+
+    @Test
+    fun `a re-plan reuses the name already looked up for the same point`() = runTest {
+        val geocode = FakeGeocodeRepository(
+            Result.success(emptyList()),
+            reverseResult = Result.success("Pike Place Market")
+        )
+        val vm = viewModel(geocode = geocode, plan = FakeTripPlanRepository(Result.success(plannedTrip)))
+        vm.setFrom(TripEndpoint.CurrentLocation(lat = 47.6, lon = -122.3))
+        vm.setTo(destination)
+        advanceUntilIdle()
+        assertEquals(1, geocode.reverseCalls.size)
+
+        // Nudging the time re-plans the same two points; the geocoder must not be asked again.
+        vm.setDateTime(90_000L)
+        vm.setArriving(true)
+        advanceUntilIdle()
+
+        assertEquals(1, geocode.reverseCalls.size)
+        assertEquals("Pike Place Market", plannedOriginName(vm))
+    }
+
+    @Test
+    fun `a plan failure surfaces without waiting on the naming lookup`() = runTest {
+        val vm = viewModel(
+            geocode = StalledGeocodeRepository(),
+            plan = FakeTripPlanRepository(Result.failure(IOException("boom")))
+        )
+
+        vm.setFrom(TripEndpoint.CurrentLocation(lat = 47.6, lon = -122.3))
+        vm.setTo(destination)
+        // No advanceUntilIdle: only the plan is allowed to complete. A naming lookup still in flight must
+        // not hold the error behind its timeout.
+        runCurrent()
+
         assertEquals(PlanResult.Error(TripPlanError.Unknown), vm.planState.value)
     }
 


### PR DESCRIPTION
Fixes #2006.

## The problem

The trip-log timeline opened with **"Start · Origin"**. `TripRequestBuilder.getAddressString` formats `"%g,%g"` whenever an endpoint has coordinates — which is *every* endpoint, including a Pelias pick — so what OTP echoes back as the first leg's `from.name` is always its own placeholder, never a real place.

## The fix

The requester is the only party that knows what the user picked, so it names the trip's two ends itself.

- **`GeocodeRepository.reverse(lat, lon)`** — the mirror of `suggest()`. Pelias `/reverse`, with the on-device `Geocoder` as the key-free fallback, off the main thread.
- **The plan pipeline** resolves both endpoint names *alongside* the OTP call and stamps them onto the itineraries (`withTerminalPlaceNames`). One self-describing trip then flows to every reader — the log, the map focus, and the trip-update notification, which serializes these very objects and restores them on re-entry (so the notification path gets real names too, rather than falling back to "Origin" as a side channel keyed off the request would have).

Best-effort throughout: an endpoint the user named needs no lookup at all; results are memoized per coordinate so a date nudge or arrive-by toggle doesn't re-ask; a stalled geocoder is capped at 4s; a failed or empty lookup simply keeps OTP's name. A plan *failure* cancels the naming jobs rather than making the error wait behind them.

## Notes for review

- **No string matching to pick the name.** Each geocoder's own structured fields decide it: Pelias's `name` (distinct from its fully-qualified `label`), and house number + street from the platform `Address`. Notably *not* `CustomAddress.toString()`, which tails off into the county and city ("1717 Cascade Way, Snohomish County, Everett").
- **`layers=address,venue,street` is pinned on the Pelias query.** Without it a reverse lookup answers from any layer, so a thinly-mapped point comes back as a county. With it, the answer is either a real place or absent — and absent degrades to OTP's name.
- **A named venue reads as its address on the platform fallback** ("85 Pike Pl", not "Pike Place Market"). The platform fills `featureName` with the house number for a street address but with the place's name for a named feature, and telling those apart means comparing strings. Unambiguous over colourful. The Pelias path keeps venue names, since there `name` is its own field.
- **The vendored Pelias client has no reverse type** — every `PeliasRequest.Builder` hard-codes `?text=` — so the query is assembled here and rides the library's own fetch/parse via a one-line subclass (its constructor is `protected`).
- No new heuristics: no magnitude guesses, no unit inference, no fuzzy matching.

## Possible follow-up

OTP2's `PlanLabeledLocationInput` has a `label` field, documented in the vendored schema as *"This label is then returned with the location in the itineraries."* Sending it (plus `name::lat,lon` on the OTP1 REST path) would make `from.name` correct at the source and delete `withTerminalPlaceNames` entirely. I left it out of this PR: it changes the wire contract for two OTP protocols, and if a server ignores the label the feature regresses to "Origin" with no client-side fallback. Worth its own issue if it can be verified against the deployed servers.

## Testing

`./gradlew :onebusaway-android:testObaGoogleDebugUnitTest spotlessCheck` and a `-PwarningsAsErrors=true` compile all pass. New JVM tests cover the reverse-geocoded name reaching the itineraries, named endpoints skipping the lookup, failure/stall degrading to OTP's name, the per-coordinate memo, the fast error path, the Pelias query shape (including a comma-decimal locale), and `withTerminalPlaceNames` (multi-itinerary, single-leg, blank/absent names, legless).

Installed and launched on a device; the app runs clean. **The Pelias `/reverse` path itself is unexercised** — this checkout has no `Pelias_oba` key, so only the platform fallback was reachable locally. Worth a look on a keyed build before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Trip plans now display human-readable names for coordinate-based origin and destination points.
  * Endpoint names are retrieved automatically when available, with device-based fallback support.
  * Existing user-provided endpoint labels remain unchanged.
* **Bug Fixes**
  * Trip planning no longer waits unnecessarily when location naming is unavailable or slow.
  * Previously retrieved location names are reused for faster repeat searches.
* **Tests**
  * Added coverage for endpoint naming, fallback behavior, caching, and timeout handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->