### PR TITLE
Fold report/ into ui/report/ and wire its ViewModels through Hilt

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/util/test/ReportUtilTest.java
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/util/test/ReportUtilTest.java
@@ -19,7 +19,7 @@ import android.test.AndroidTestCase;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.onebusaway.android.report.ui.util.ServiceUtils;
+import org.onebusaway.android.ui.report.ServiceUtils;
 
 /** Tests to evaluate issue reporting utilities */
 @RunWith(AndroidJUnit4.class)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/app/di/NetworkEntryPoint.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/app/di/NetworkEntryPoint.kt
@@ -23,7 +23,6 @@ import dagger.hilt.components.SingletonComponent
 import org.onebusaway.android.api.contract.RegionsWebService
 import org.onebusaway.android.api.contract.ReminderWebService
 import org.onebusaway.android.api.data.LocationSearchDataSource
-import org.onebusaway.android.api.data.ProblemReportDataSource
 import org.onebusaway.android.api.data.StopArrivalsDataSource
 
 /**
@@ -53,8 +52,6 @@ interface NetworkEntryPoint {
 
     fun stopArrivalsDataSource(): StopArrivalsDataSource
 
-    fun problemReportDataSource(): ProblemReportDataSource
-
     companion object {
         /** Resolves the shared [RegionsWebService] from any [context] (its application is used). */
         @JvmStatic
@@ -75,10 +72,5 @@ interface NetworkEntryPoint {
         @JvmStatic
         fun getStopArrivals(context: Context): StopArrivalsDataSource = EntryPointAccessors.fromApplication(context, NetworkEntryPoint::class.java)
             .stopArrivalsDataSource()
-
-        /** Resolves the shared [ProblemReportDataSource] from any [context] (its application is used). */
-        @JvmStatic
-        fun getProblemReport(context: Context): ProblemReportDataSource = EntryPointAccessors.fromApplication(context, NetworkEntryPoint::class.java)
-            .problemReportDataSource()
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/app/di/RepositoryModule.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/app/di/RepositoryModule.kt
@@ -73,6 +73,12 @@ import org.onebusaway.android.ui.home.widealert.DefaultWideAlertsRepository
 import org.onebusaway.android.ui.home.widealert.WideAlertsRepository
 import org.onebusaway.android.ui.regions.DefaultRegionsRepository
 import org.onebusaway.android.ui.regions.RegionsRepository
+import org.onebusaway.android.ui.report.infrastructure.DefaultGeocodeAddressRepository
+import org.onebusaway.android.ui.report.infrastructure.DefaultServiceListRepository
+import org.onebusaway.android.ui.report.infrastructure.GeocodeAddressRepository
+import org.onebusaway.android.ui.report.infrastructure.ServiceListRepository
+import org.onebusaway.android.ui.report.problem.DefaultProblemReportRepository
+import org.onebusaway.android.ui.report.problem.ProblemReportRepository
 import org.onebusaway.android.ui.report.types.DefaultReportTypeRepository
 import org.onebusaway.android.ui.report.types.ReportTypeRepository
 import org.onebusaway.android.ui.routeinfo.DefaultRouteInfoRepository
@@ -146,6 +152,22 @@ abstract class RepositoryModule {
 
     @Binds
     abstract fun bindReportTypeRepository(impl: DefaultReportTypeRepository): ReportTypeRepository
+
+    // The report flow's graph-constructible collaborators. The Open311 *category* repository stays
+    // factory-built (see the class KDoc above) — it takes opaque library values off the issue VM's
+    // runtime state — but these three take only a Context or an already-bound data source.
+    @Binds
+    abstract fun bindServiceListRepository(impl: DefaultServiceListRepository): ServiceListRepository
+
+    @Binds
+    abstract fun bindGeocodeAddressRepository(
+        impl: DefaultGeocodeAddressRepository
+    ): GeocodeAddressRepository
+
+    @Binds
+    abstract fun bindProblemReportRepository(
+        impl: DefaultProblemReportRepository
+    ): ProblemReportRepository
 
     @Binds
     abstract fun bindTripResultsRepository(impl: DefaultTripResultsRepository): TripResultsRepository

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.kt
@@ -41,7 +41,6 @@ import org.onebusaway.android.directions.util.TripRequestBuilder
 import org.onebusaway.android.map.MapParams
 import org.onebusaway.android.map.MapViewModel
 import org.onebusaway.android.region.RegionRepository
-import org.onebusaway.android.report.ui.ReportLauncher
 import org.onebusaway.android.ui.arrivals.ArrivalsLoaded
 import org.onebusaway.android.ui.arrivals.ArrivalsViewModel
 import org.onebusaway.android.ui.home.AccessibilityAnalyticsEffect
@@ -65,6 +64,7 @@ import org.onebusaway.android.ui.home.weather.WeatherViewModel
 import org.onebusaway.android.ui.nav.IntentRouteMapper
 import org.onebusaway.android.ui.nav.NavHelp
 import org.onebusaway.android.ui.nav.NavRoutes
+import org.onebusaway.android.ui.report.ReportLauncher
 import org.onebusaway.android.ui.survey.SurveyViewModel
 import org.onebusaway.android.ui.tripplan.TripPlanViewModel
 import org.onebusaway.android.ui.tripplan.toGeocoded

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalActionHandlers.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalActionHandlers.kt
@@ -21,10 +21,10 @@ import org.onebusaway.android.R
 import org.onebusaway.android.app.di.DatabaseEntryPoint
 import org.onebusaway.android.app.di.FirebaseMessagingEntryPoint
 import org.onebusaway.android.map.ShowRouteRequest
-import org.onebusaway.android.report.ui.InfrastructureIssueLauncher
 import org.onebusaway.android.ui.arrivals.dialogs.StopDetailsHost
 import org.onebusaway.android.ui.arrivals.dialogs.showSituationDialog
 import org.onebusaway.android.ui.nav.ReminderEditorArgs
+import org.onebusaway.android.ui.report.infrastructure.InfrastructureIssueLauncher
 import org.onebusaway.android.ui.tripdetails.TripDetailsLauncher
 import org.onebusaway.android.ui.tripinfo.TripInfoLauncher
 import org.onebusaway.android.util.ExternalIntents

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalActionHandlers.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalActionHandlers.kt
@@ -24,6 +24,7 @@ import org.onebusaway.android.map.ShowRouteRequest
 import org.onebusaway.android.ui.arrivals.dialogs.StopDetailsHost
 import org.onebusaway.android.ui.arrivals.dialogs.showSituationDialog
 import org.onebusaway.android.ui.nav.ReminderEditorArgs
+import org.onebusaway.android.ui.report.infrastructure.DefaultIssueType
 import org.onebusaway.android.ui.report.infrastructure.InfrastructureIssueLauncher
 import org.onebusaway.android.ui.tripdetails.TripDetailsLauncher
 import org.onebusaway.android.ui.tripinfo.TripInfoLauncher
@@ -157,7 +158,7 @@ fun createArrivalActionHandler(
         val arrival = content.arrivals.firstOrNull { it.tripId == actions.tripId } ?: return
         InfrastructureIssueLauncher.startWithService(
             activity,
-            activity.getString(R.string.ri_selected_service_trip),
+            DefaultIssueType.TRIP,
             content.header.stopId,
             content.header.name,
             content.stopCode,
@@ -202,7 +203,7 @@ fun createArrivalActionHandler(
         val content = currentContent() ?: return
         InfrastructureIssueLauncher.startWithService(
             activity,
-            activity.getString(R.string.ri_selected_service_stop),
+            DefaultIssueType.STOP,
             content.header.stopId,
             content.header.name,
             content.stopCode,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalInfo.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalInfo.kt
@@ -23,8 +23,8 @@ import org.onebusaway.android.R
 import org.onebusaway.android.models.ArrivalData
 import org.onebusaway.android.models.Occupancy
 import org.onebusaway.android.models.Status
-import org.onebusaway.android.report.TripReportContext
 import org.onebusaway.android.time.ServerTime
+import org.onebusaway.android.ui.report.TripReportContext
 import org.onebusaway.android.util.ArrivalInfoUtils
 import org.onebusaway.android.util.DisplayFormat
 import org.onebusaway.android.util.getRouteDisplayName

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeNavHost.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeNavHost.kt
@@ -54,7 +54,6 @@ import org.onebusaway.android.app.di.AnalyticsEntryPoint
 import org.onebusaway.android.app.di.PreferencesEntryPoint
 import org.onebusaway.android.map.MapViewModel
 import org.onebusaway.android.region.Region
-import org.onebusaway.android.report.ui.reportGraph
 import org.onebusaway.android.ui.HomeActivity
 import org.onebusaway.android.ui.arrivals.ArrivalsViewModel
 import org.onebusaway.android.ui.arrivals.arrivalsGraph
@@ -77,6 +76,7 @@ import org.onebusaway.android.ui.nav.consumeStopReveal
 import org.onebusaway.android.ui.nav.navigateFromHome
 import org.onebusaway.android.ui.nav.revealRouteOnMap
 import org.onebusaway.android.ui.nav.revealStopOnMap
+import org.onebusaway.android.ui.report.reportGraph
 import org.onebusaway.android.ui.settings.settingsGraph
 import org.onebusaway.android.ui.survey.SurveyViewModel
 import org.onebusaway.android.ui.tripdetails.TripDetailsLauncher

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/nav/NavRoutes.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/nav/NavRoutes.kt
@@ -93,7 +93,7 @@ object NavRoutes {
     // --- Report / problem-reporting flow (former ReportActivity /
     // CustomerServiceActivity / InfrastructureIssueActivity). The whole flow's stop/location/trip
     // context rides one nav-arg ([ARG_REPORT_CONTEXT] = an encoded
-    // [org.onebusaway.android.report.ReportContext]), so each destination reads its own back-stack args
+    // [org.onebusaway.android.ui.report.ReportContext]), so each destination reads its own back-stack args
     // (process-death safe) instead of the host activity intent. ---
 
     /** The encoded report context (stop/location/trip), carried by every report destination. */

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/nav/NavRoutes.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/nav/NavRoutes.kt
@@ -111,17 +111,19 @@ object NavRoutes {
     /** Builds a navigable [CUSTOMER_SERVICE] route, optionally carrying the encoded [reportContext]. */
     fun customerService(reportContext: String? = null): String = "customerService" + reportContextQuery(reportContext)
 
-    // The infrastructure-issue (stop/trip problem) hybrid map+form screen: the selected-service keyword
-    // ("stop"/"trip") plus the encoded report context, both as nav-args.
-    const val ARG_SELECTED_SERVICE = "selectedService"
+    // The infrastructure-issue (stop/trip problem) hybrid map+form screen: which problem the report was
+    // started for, plus the encoded report context, both as nav-args. The issue type rides as a
+    // DefaultIssueType name ("STOP"/"TRIP"); absent means no category is pre-selected. Parsed by
+    // DefaultIssueType.fromNavArg — nav keeps it a plain String so it needn't know the report feature.
+    const val ARG_ISSUE_TYPE = "issueType"
     const val INFRASTRUCTURE_ISSUE =
-        "infrastructureIssue?$ARG_SELECTED_SERVICE={$ARG_SELECTED_SERVICE}" +
+        "infrastructureIssue?$ARG_ISSUE_TYPE={$ARG_ISSUE_TYPE}" +
             "&$ARG_REPORT_CONTEXT={$ARG_REPORT_CONTEXT}"
 
-    /** Builds a navigable [INFRASTRUCTURE_ISSUE] route, optionally carrying [selectedService] + context. */
-    fun infrastructureIssue(selectedService: String? = null, reportContext: String? = null): String = "infrastructureIssue" +
+    /** Builds a navigable [INFRASTRUCTURE_ISSUE] route, optionally carrying [issueType] + context. */
+    fun infrastructureIssue(issueType: String? = null, reportContext: String? = null): String = "infrastructureIssue" +
         buildList {
-            if (selectedService != null) add("$ARG_SELECTED_SERVICE=${Uri.encode(selectedService)}")
+            if (issueType != null) add("$ARG_ISSUE_TYPE=${Uri.encode(issueType)}")
             if (reportContext != null) add("$ARG_REPORT_CONTEXT=${Uri.encode(reportContext)}")
         }.let { if (it.isEmpty()) "" else "?" + it.joinToString("&") }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/report/ReportConstants.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/report/ReportConstants.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.onebusaway.android.report.constants;
+package org.onebusaway.android.ui.report;
 
 /**
  * Constants used in report implementation

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/report/ReportContext.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/report/ReportContext.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.onebusaway.android.report
+package org.onebusaway.android.ui.report
 
 /**
  * The trip context a "report a problem" launch carries, as plain scalars — every field the report

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/report/ReportDestinations.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/report/ReportDestinations.kt
@@ -73,7 +73,7 @@ fun NavGraphBuilder.reportGraph(navController: NavHostController) {
     composable(
         NavRoutes.INFRASTRUCTURE_ISSUE,
         arguments = listOf(
-            navArgument(NavRoutes.ARG_SELECTED_SERVICE) {
+            navArgument(NavRoutes.ARG_ISSUE_TYPE) {
                 type = NavType.StringType
                 nullable = true
                 defaultValue = null
@@ -82,7 +82,7 @@ fun NavGraphBuilder.reportGraph(navController: NavHostController) {
         )
     ) { _ ->
         // No args read here: the destination's ViewModel takes both this route's args
-        // (ARG_SELECTED_SERVICE + the encoded ReportContext) off its own SavedStateHandle.
+        // (ARG_ISSUE_TYPE + the encoded ReportContext) off its own SavedStateHandle.
         ObaTheme {
             InfrastructureIssueDestination(navController = navController)
         }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/report/ReportDestinations.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/report/ReportDestinations.kt
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.onebusaway.android.report.ui
+package org.onebusaway.android.ui.report
 
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
@@ -26,12 +26,13 @@ import androidx.navigation.NavType
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
 import org.onebusaway.android.app.di.PreferencesEntryPoint
-import org.onebusaway.android.report.ReportContext
 import org.onebusaway.android.ui.compose.theme.ObaTheme
 import org.onebusaway.android.ui.feedback.FeedbackLauncher
 import org.onebusaway.android.ui.feedback.FeedbackScreen
 import org.onebusaway.android.ui.feedback.FeedbackSubmitter
 import org.onebusaway.android.ui.nav.NavRoutes
+import org.onebusaway.android.ui.report.customerservice.CustomerServiceDestination
+import org.onebusaway.android.ui.report.infrastructure.InfrastructureIssueDestination
 
 /**
  * The report / feedback navigation cluster: the report chooser ([NavRoutes.REPORT]) and its customer

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/report/ReportDestinations.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/report/ReportDestinations.kt
@@ -80,15 +80,11 @@ fun NavGraphBuilder.reportGraph(navController: NavHostController) {
             },
             reportContextArg()
         )
-    ) { backStackEntry ->
-        val selectedService =
-            backStackEntry.arguments?.getString(NavRoutes.ARG_SELECTED_SERVICE)
+    ) { _ ->
+        // No args read here: the destination's ViewModel takes both this route's args
+        // (ARG_SELECTED_SERVICE + the encoded ReportContext) off its own SavedStateHandle.
         ObaTheme {
-            InfrastructureIssueDestination(
-                navController = navController,
-                selectedService = selectedService,
-                reportContext = backStackEntry.decodeReportContext()
-            )
+            InfrastructureIssueDestination(navController = navController)
         }
     }
     // Feedback destination: the post-trip destination-reminder feedback screen.

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/report/ReportLauncher.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/report/ReportLauncher.kt
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.onebusaway.android.report.ui
+package org.onebusaway.android.ui.report
 
 import android.content.Context
 import android.content.Intent
@@ -40,8 +40,6 @@ import org.onebusaway.android.app.di.AnalyticsEntryPoint
 import org.onebusaway.android.app.di.LocationEntryPoint
 import org.onebusaway.android.app.di.RegionEntryPoint
 import org.onebusaway.android.region.Region
-import org.onebusaway.android.report.ReportContext
-import org.onebusaway.android.report.constants.ReportConstants
 import org.onebusaway.android.time.ElapsedTime
 import org.onebusaway.android.ui.HomeActivity
 import org.onebusaway.android.ui.compose.findActivity

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/report/ReportLauncher.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/report/ReportLauncher.kt
@@ -44,6 +44,7 @@ import org.onebusaway.android.time.ElapsedTime
 import org.onebusaway.android.ui.HomeActivity
 import org.onebusaway.android.ui.compose.findActivity
 import org.onebusaway.android.ui.nav.NavRoutes
+import org.onebusaway.android.ui.report.infrastructure.DefaultIssueType
 import org.onebusaway.android.ui.report.types.ReportAction
 import org.onebusaway.android.ui.report.types.ReportTypeListRoute
 import org.onebusaway.android.util.BuildFlavorUtils
@@ -183,10 +184,7 @@ private fun onReportActionSelected(
 
         ReportAction.STOP_PROBLEM -> {
             navController.navigate(
-                NavRoutes.infrastructureIssue(
-                    activity.getString(R.string.ri_selected_service_stop),
-                    encodedContext
-                )
+                NavRoutes.infrastructureIssue(DefaultIssueType.STOP.name, encodedContext)
             )
             reportEvent(
                 activity,
@@ -197,10 +195,7 @@ private fun onReportActionSelected(
 
         ReportAction.ARRIVAL_PROBLEM -> {
             navController.navigate(
-                NavRoutes.infrastructureIssue(
-                    activity.getString(R.string.ri_selected_service_trip),
-                    encodedContext
-                )
+                NavRoutes.infrastructureIssue(DefaultIssueType.TRIP.name, encodedContext)
             )
             reportEvent(
                 activity,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/report/ServiceUtils.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/report/ServiceUtils.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.onebusaway.android.report.ui.util;
+package org.onebusaway.android.ui.report;
 
 import android.content.Context;
 import androidx.annotation.NonNull;
@@ -22,7 +22,6 @@ import edu.usf.cutr.open311client.models.Service;
 import java.util.List;
 import java.util.Locale;
 import org.onebusaway.android.R;
-import org.onebusaway.android.report.constants.ReportConstants;
 
 public class ServiceUtils {
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/report/customerservice/CustomerServiceDestination.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/report/customerservice/CustomerServiceDestination.kt
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.onebusaway.android.report.ui
+package org.onebusaway.android.ui.report.customerservice
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -24,9 +24,8 @@ import androidx.navigation.NavController
 import org.onebusaway.android.R
 import org.onebusaway.android.analytics.PlausibleAnalytics
 import org.onebusaway.android.app.di.AnalyticsEntryPoint
-import org.onebusaway.android.report.ReportContext
 import org.onebusaway.android.ui.compose.findActivity
-import org.onebusaway.android.ui.report.customerservice.CustomerServiceRoute
+import org.onebusaway.android.ui.report.ReportContext
 import org.onebusaway.android.util.ExternalIntents
 
 /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/report/infrastructure/GeocodeAddressRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/report/infrastructure/GeocodeAddressRepository.kt
@@ -18,8 +18,10 @@ package org.onebusaway.android.ui.report.infrastructure
 
 import android.content.Context
 import android.location.Geocoder
+import dagger.hilt.android.qualifiers.ApplicationContext
 import java.io.IOException
 import java.util.Locale
+import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.onebusaway.android.util.GeoPoint
@@ -37,7 +39,9 @@ interface GeocodeAddressRepository {
     suspend fun forwardGeocode(query: String): Result<GeoPoint>
 }
 
-class DefaultGeocodeAddressRepository(private val context: Context) : GeocodeAddressRepository {
+class DefaultGeocodeAddressRepository @Inject constructor(
+    @ApplicationContext private val context: Context
+) : GeocodeAddressRepository {
 
     @Suppress("DEPRECATION") // Synchronous Geocoder API, run off the main thread.
     override suspend fun reverseGeocode(

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/report/infrastructure/InfrastructureIssueLauncher.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/report/infrastructure/InfrastructureIssueLauncher.kt
@@ -32,11 +32,15 @@ import org.onebusaway.android.ui.report.TripReportContext
  */
 object InfrastructureIssueLauncher {
 
+    /**
+     * @param issueType which problem the report was started for; rides the route as its enum name so
+     *   the destination's ViewModel can resolve it from nav-args without touching resources.
+     */
     @JvmStatic
     @JvmOverloads
     fun startWithService(
         activity: Activity,
-        serviceKeyword: String,
+        issueType: DefaultIssueType,
         stopId: String?,
         stopName: String?,
         stopCode: String?,
@@ -59,7 +63,7 @@ object InfrastructureIssueLauncher {
         activity.startActivity(
             HomeActivity.navIntent(
                 activity,
-                NavRoutes.infrastructureIssue(serviceKeyword, context.encode())
+                NavRoutes.infrastructureIssue(issueType.name, context.encode())
             )
         )
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/report/infrastructure/InfrastructureIssueLauncher.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/report/infrastructure/InfrastructureIssueLauncher.kt
@@ -36,8 +36,10 @@ object InfrastructureIssueLauncher {
      * @param issueType which problem the report was started for; rides the route as its enum name so
      *   the destination's ViewModel can resolve it from nav-args without touching resources.
      */
+    // @JvmStatic to match the other launcher facades, which legacy Java callers still reach. No
+    // @JvmOverloads: the trailing defaults are only used from Kotlin, and generating Java overloads
+    // of a method taking a Kotlin enum earns nothing.
     @JvmStatic
-    @JvmOverloads
     fun startWithService(
         activity: Activity,
         issueType: DefaultIssueType,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/report/infrastructure/InfrastructureIssueLauncher.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/report/infrastructure/InfrastructureIssueLauncher.kt
@@ -14,13 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.onebusaway.android.report.ui
+package org.onebusaway.android.ui.report.infrastructure
 
 import android.app.Activity
-import org.onebusaway.android.report.ReportContext
-import org.onebusaway.android.report.TripReportContext
 import org.onebusaway.android.ui.HomeActivity
 import org.onebusaway.android.ui.nav.NavRoutes
+import org.onebusaway.android.ui.report.ReportContext
+import org.onebusaway.android.ui.report.TripReportContext
 
 /**
  * Launcher facade for the infrastructure-issue (stop/trip problem) screen (former

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/report/infrastructure/InfrastructureIssueModels.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/report/infrastructure/InfrastructureIssueModels.kt
@@ -16,6 +16,7 @@
 package org.onebusaway.android.ui.report.infrastructure
 
 import org.onebusaway.android.models.ObaStop
+import org.onebusaway.android.ui.nav.NavRoutes
 import org.onebusaway.android.ui.report.TripReportContext
 import org.onebusaway.android.util.GeoPoint
 
@@ -52,7 +53,29 @@ sealed interface ReportTarget {
 }
 
 /** The category to auto-select when the screen opens, from the report type list. */
-enum class DefaultIssueType { NONE, STOP, TRIP }
+enum class DefaultIssueType {
+    NONE,
+    STOP,
+    TRIP;
+
+    companion object {
+
+        /**
+         * Resolves the [NavRoutes.ARG_ISSUE_TYPE] nav-arg. The two non-matching cases are
+         * deliberately distinct: an **absent** arg is the ordinary "started without a category"
+         * launch ([NONE]), while a **present-but-unrecognized** one can only be a bug, since every
+         * producer of this route writes an enum [name] — so it throws rather than degrading to
+         * [NONE], where it would be indistinguishable from a launch that never asked for a category
+         * and would surface only as a category that mysteriously stopped pre-selecting.
+         */
+        fun fromNavArg(name: String?): DefaultIssueType {
+            if (name == null) return NONE
+            return requireNotNull(entries.firstOrNull { it.name == name }) {
+                "Unrecognized ${NavRoutes.ARG_ISSUE_TYPE} nav-arg \"$name\"; expected one of $entries"
+            }
+        }
+    }
+}
 
 /** Complete UI state for the infrastructure-issue container. */
 data class InfrastructureIssueUiState(

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/report/infrastructure/InfrastructureIssueModels.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/report/infrastructure/InfrastructureIssueModels.kt
@@ -16,7 +16,7 @@
 package org.onebusaway.android.ui.report.infrastructure
 
 import org.onebusaway.android.models.ObaStop
-import org.onebusaway.android.report.TripReportContext
+import org.onebusaway.android.ui.report.TripReportContext
 import org.onebusaway.android.util.GeoPoint
 
 /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/report/infrastructure/InfrastructureIssueScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/report/infrastructure/InfrastructureIssueScreen.kt
@@ -53,6 +53,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringArrayResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.DialogProperties
@@ -75,11 +76,9 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.onebusaway.android.R
 import org.onebusaway.android.analytics.PlausibleAnalytics
-import org.onebusaway.android.api.adapters.ObaStopElement
 import org.onebusaway.android.app.di.AnalyticsEntryPoint
 import org.onebusaway.android.app.di.ArrivalsViewModelFactoryEntryPoint
 import org.onebusaway.android.app.di.LocationEntryPoint
-import org.onebusaway.android.app.di.NetworkEntryPoint
 import org.onebusaway.android.map.MapParams
 import org.onebusaway.android.map.StopsMapViewModel
 import org.onebusaway.android.map.compose.ObaMap
@@ -97,7 +96,6 @@ import org.onebusaway.android.ui.report.open311.Open311ProblemViewModel
 import org.onebusaway.android.ui.report.open311.Open311Route
 import org.onebusaway.android.ui.report.open311.Open311SubmitState
 import org.onebusaway.android.ui.report.open311.Open311TripContext
-import org.onebusaway.android.ui.report.problem.DefaultProblemReportRepository
 import org.onebusaway.android.ui.report.problem.ProblemCodes
 import org.onebusaway.android.ui.report.problem.ProblemKind
 import org.onebusaway.android.ui.report.problem.ProblemParams
@@ -115,16 +113,12 @@ import org.onebusaway.android.util.MyTextUtils
  * [InfrastructureControls], and the inline stop/trip form, arrivals picker, and Open311 dynamic form
  * (Tier 1) — the whole report flow is pure Compose now, with no fragments.
  *
- * The [InfrastructureIssueViewModel] is built once (back-stack-entry-scoped) from the nav-args
- * `selectedService` and the decoded [ReportContext] (lat/lon, stop id/name/code, the scalar trip
- * context, agency name, block id), reproducing the former Activity's hand-built factory.
+ * The [InfrastructureIssueViewModel] is back-stack-entry-scoped and reads its own launch args
+ * (`selectedService` plus the encoded [ReportContext] — lat/lon, stop id/name/code, the scalar trip
+ * context, agency name, block id) from this entry's nav-args via SavedStateHandle.
  */
 @Composable
-fun InfrastructureIssueDestination(
-    navController: NavController,
-    selectedService: String?,
-    reportContext: ReportContext
-) {
+fun InfrastructureIssueDestination(navController: NavController) {
     val activity = LocalContext.current.findActivity()
 
     // Entry-scoped map view model (distinct from HomeActivity's own; this is a separate back-stack
@@ -132,14 +126,10 @@ fun InfrastructureIssueDestination(
     // machinery), starting in stop mode so nearby stops load + are tappable.
     val mapViewModel = hiltViewModel<StopsMapViewModel>()
 
-    // Build the InfrastructureIssueViewModel once, scoped to this back-stack entry (so its
-    // viewModelScope is cancelled when the destination leaves). Reads selectedService and the rest of
-    // the context from the decoded nav-args — the former Activity's createViewModel.
-    val viewModel: InfrastructureIssueViewModel = viewModel(
-        factory = viewModelFactory {
-            initializer { createInfrastructureIssueViewModel(activity, selectedService, reportContext) }
-        }
-    )
+    // Scoped to this back-stack entry (so its viewModelScope is cancelled when the destination
+    // leaves). It reads selectedService and the encoded ReportContext straight off the entry's
+    // nav-args via SavedStateHandle, so there's nothing to hand it here.
+    val viewModel: InfrastructureIssueViewModel = hiltViewModel()
 
     // The "report submitted" dialog (Tier 1: was ReportSuccessDialog, a DialogFragment).
     var showSuccess by remember { mutableStateOf(false) }
@@ -326,41 +316,6 @@ fun InfrastructureIssueDestination(
 // The former map FrameLayout was 200dp tall (infrastructure_issue.xml).
 private const val MAP_HEIGHT = 200
 
-/**
- * Builds the [InfrastructureIssueViewModel] from the nav-arg [selectedService] and the decoded
- * [reportContext] (port of InfrastructureIssueActivity.createViewModel). The stop/location context,
- * the scalar trip context, and the agency/block ids all ride on the nav-arg now.
- */
-private fun createInfrastructureIssueViewModel(
-    activity: AppCompatActivity,
-    selectedService: String?,
-    reportContext: ReportContext
-): InfrastructureIssueViewModel {
-    val latitude = reportContext.lat
-    val longitude = reportContext.lon
-
-    val initialStop: ObaStop? = reportContext.stopId?.let { stopId ->
-        ObaStopElement(stopId, latitude, longitude, reportContext.stopName.orEmpty(), reportContext.stopCode.orEmpty())
-    }
-
-    val defaultIssueType = when (selectedService) {
-        activity.getString(R.string.ri_selected_service_stop) -> DefaultIssueType.STOP
-        activity.getString(R.string.ri_selected_service_trip) -> DefaultIssueType.TRIP
-        else -> DefaultIssueType.NONE
-    }
-
-    return InfrastructureIssueViewModel(
-        serviceListRepository = DefaultServiceListRepository(activity.applicationContext),
-        geocodeRepository = DefaultGeocodeAddressRepository(activity.applicationContext),
-        initialLocation = GeoPoint(latitude, longitude),
-        initialStop = initialStop,
-        defaultIssueType = defaultIssueType,
-        arrivalInfo = reportContext.trip,
-        agencyName = reportContext.agencyName,
-        blockId = reportContext.blockId
-    )
-}
-
 // --- Inline report forms (Tier 1, P3a: were ProblemReportFragment / SimpleArrivalsPickerFragment) -----
 
 /**
@@ -377,12 +332,33 @@ private fun StopTripProblemForm(
     onSubmit: ((() -> Unit)?) -> Unit
 ) {
     val context = LocalContext.current
-    val vm: ProblemReportViewModel = viewModel(
-        key = "problem:${arrival?.tripId ?: stop.id}",
-        factory = viewModelFactory {
-            initializer { createProblemReportViewModel(context, stop, arrival) }
+    // The codes are a resource array, so they're read in composition and handed to the assisted
+    // factory; the repository comes from the graph.
+    val stopCodes = stringArrayResource(R.array.report_stop_problem_code).toList()
+    val tripCodes = stringArrayResource(R.array.report_trip_problem_code_bus).toList()
+    val vm: ProblemReportViewModel =
+        hiltViewModel<ProblemReportViewModel, ProblemReportViewModel.Factory>(
+            key = "problem:${arrival?.tripId ?: stop.id}"
+        ) { factory ->
+            if (arrival != null) {
+                factory.create(
+                    params = ProblemParams.Trip(
+                        tripId = arrival.tripId,
+                        stopId = arrival.stopId,
+                        vehicleId = arrival.vehicleId,
+                        serviceDate = arrival.serviceDate
+                    ),
+                    codes = ProblemCodes.trip(tripCodes),
+                    headsign = MyTextUtils.formatDisplayText(arrival.headsign)
+                )
+            } else {
+                factory.create(
+                    params = ProblemParams.Stop(stop.id),
+                    codes = ProblemCodes.stop(stopCodes),
+                    headsign = null
+                )
+            }
         }
-    )
 
     LaunchedEffect(vm) {
         vm.submitState.collect { state ->
@@ -430,6 +406,10 @@ private fun ArrivalsPickerInline(
     activity: AppCompatActivity,
     issueViewModel: InfrastructureIssueViewModel
 ) {
+    // Not hiltViewModel(): ArrivalsViewModel is deliberately plain @AssistedInject rather than
+    // @HiltViewModel, because the home sheet builds it against a non-Hilt-aware per-stop
+    // ViewModelStoreOwner — see ArrivalsViewModelFactoryEntryPoint. Nothing is hand-constructed here;
+    // the factory (and its repository) still come from the graph.
     val arrivalsViewModel: ArrivalsViewModel = viewModel(
         key = "picker:${stop.id}",
         factory = viewModelFactory {
@@ -440,40 +420,6 @@ private fun ArrivalsPickerInline(
     )
     SimpleArrivalsPicker(arrivalsViewModel) { arrival ->
         issueViewModel.onArrivalSelected(arrival.toTripReportContext())
-    }
-}
-
-/** Port of ProblemReportFragment.createViewModel — stop or trip params + codes + repository. */
-private fun createProblemReportViewModel(
-    context: Context,
-    stop: ObaStop,
-    arrival: TripReportContext?
-): ProblemReportViewModel {
-    val repository =
-        DefaultProblemReportRepository(NetworkEntryPoint.getProblemReport(context.applicationContext))
-    return if (arrival != null) {
-        ProblemReportViewModel(
-            params = ProblemParams.Trip(
-                tripId = arrival.tripId,
-                stopId = arrival.stopId,
-                vehicleId = arrival.vehicleId,
-                serviceDate = arrival.serviceDate
-            ),
-            codes = ProblemCodes.trip(
-                context.resources.getStringArray(R.array.report_trip_problem_code_bus).toList()
-            ),
-            headsign = MyTextUtils.formatDisplayText(arrival.headsign),
-            repository = repository
-        )
-    } else {
-        ProblemReportViewModel(
-            params = ProblemParams.Stop(stop.id),
-            codes = ProblemCodes.stop(
-                context.resources.getStringArray(R.array.report_stop_problem_code).toList()
-            ),
-            headsign = null,
-            repository = repository
-        )
     }
 }
 
@@ -521,6 +467,11 @@ private fun Open311FormInline(
     // Read the analytics label in composition (stringResource) rather than context.getString() inside
     // the submit callback below, which lint flags (LocalContextGetResourceValueCall, #1692).
     val analyticsProblem = stringResource(R.string.analytics_problem)
+    // The one report ViewModel still built by hand, and deliberately so: its DefaultOpen311Repository
+    // takes the chosen category's opaque library `Service` and the issue VM's `Open311` endpoint —
+    // runtime values off a sibling ViewModel's state — plus a closure reading that VM's live location.
+    // Nothing in it comes from the graph, so binding it would be ceremony (see RepositoryModule's
+    // KDoc: "Repos with runtime-arg constructors (e.g. Open311) are not here").
     val vm: Open311ProblemViewModel = viewModel(
         key = "open311:${target.category.code ?: target.category.name}",
         factory = viewModelFactory {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/report/infrastructure/InfrastructureIssueScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/report/infrastructure/InfrastructureIssueScreen.kt
@@ -332,32 +332,31 @@ private fun StopTripProblemForm(
     onSubmit: ((() -> Unit)?) -> Unit
 ) {
     val context = LocalContext.current
-    // The codes are a resource array, so they're read in composition and handed to the assisted
-    // factory; the repository comes from the graph.
-    val stopCodes = stringArrayResource(R.array.report_stop_problem_code).toList()
-    val tripCodes = stringArrayResource(R.array.report_trip_problem_code_bus).toList()
+    // The code labels are a resource array, so they have to be read in composition rather than in the
+    // creation callback below — but only the array for the kind actually being reported.
+    val codes = if (arrival != null) {
+        ProblemCodes.trip(stringArrayResource(R.array.report_trip_problem_code_bus).toList())
+    } else {
+        ProblemCodes.stop(stringArrayResource(R.array.report_stop_problem_code).toList())
+    }
     val vm: ProblemReportViewModel =
         hiltViewModel<ProblemReportViewModel, ProblemReportViewModel.Factory>(
             key = "problem:${arrival?.tripId ?: stop.id}"
         ) { factory ->
-            if (arrival != null) {
-                factory.create(
-                    params = ProblemParams.Trip(
+            factory.create(
+                params = if (arrival != null) {
+                    ProblemParams.Trip(
                         tripId = arrival.tripId,
                         stopId = arrival.stopId,
                         vehicleId = arrival.vehicleId,
                         serviceDate = arrival.serviceDate
-                    ),
-                    codes = ProblemCodes.trip(tripCodes),
-                    headsign = MyTextUtils.formatDisplayText(arrival.headsign)
-                )
-            } else {
-                factory.create(
-                    params = ProblemParams.Stop(stop.id),
-                    codes = ProblemCodes.stop(stopCodes),
-                    headsign = null
-                )
-            }
+                    )
+                } else {
+                    ProblemParams.Stop(stop.id)
+                },
+                codes = codes,
+                headsign = arrival?.let { MyTextUtils.formatDisplayText(it.headsign) }
+            )
         }
 
     LaunchedEffect(vm) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/report/infrastructure/InfrastructureIssueScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/report/infrastructure/InfrastructureIssueScreen.kt
@@ -113,8 +113,8 @@ import org.onebusaway.android.util.MyTextUtils
  * [InfrastructureControls], and the inline stop/trip form, arrivals picker, and Open311 dynamic form
  * (Tier 1) — the whole report flow is pure Compose now, with no fragments.
  *
- * The [InfrastructureIssueViewModel] is back-stack-entry-scoped and reads its own launch args
- * (`selectedService` plus the encoded [ReportContext] — lat/lon, stop id/name/code, the scalar trip
+ * The [InfrastructureIssueViewModel] is back-stack-entry-scoped and reads its own launch args (the
+ * [DefaultIssueType] plus the encoded [ReportContext] — lat/lon, stop id/name/code, the scalar trip
  * context, agency name, block id) from this entry's nav-args via SavedStateHandle.
  */
 @Composable
@@ -127,7 +127,7 @@ fun InfrastructureIssueDestination(navController: NavController) {
     val mapViewModel = hiltViewModel<StopsMapViewModel>()
 
     // Scoped to this back-stack entry (so its viewModelScope is cancelled when the destination
-    // leaves). It reads selectedService and the encoded ReportContext straight off the entry's
+    // leaves). It reads the issue type and the encoded ReportContext straight off the entry's
     // nav-args via SavedStateHandle, so there's nothing to hand it here.
     val viewModel: InfrastructureIssueViewModel = hiltViewModel()
 
@@ -333,11 +333,15 @@ private fun StopTripProblemForm(
 ) {
     val context = LocalContext.current
     // The code labels are a resource array, so they have to be read in composition rather than in the
-    // creation callback below — but only the array for the kind actually being reported.
-    val codes = if (arrival != null) {
-        ProblemCodes.trip(stringArrayResource(R.array.report_trip_problem_code_bus).toList())
-    } else {
-        ProblemCodes.stop(stringArrayResource(R.array.report_stop_problem_code).toList())
+    // creation callback below — but only the array for the kind actually being reported. Remembered
+    // because the form recomposes on every keystroke while the list is only read once, when the
+    // ViewModel is created; the labels re-resolve (and the codes rebuild) if the locale changes.
+    val isTrip = arrival != null
+    val codeLabels = stringArrayResource(
+        if (isTrip) R.array.report_trip_problem_code_bus else R.array.report_stop_problem_code
+    ).toList()
+    val codes = remember(isTrip, codeLabels) {
+        if (isTrip) ProblemCodes.trip(codeLabels) else ProblemCodes.stop(codeLabels)
     }
     val vm: ProblemReportViewModel =
         hiltViewModel<ProblemReportViewModel, ProblemReportViewModel.Factory>(

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/report/infrastructure/InfrastructureIssueScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/report/infrastructure/InfrastructureIssueScreen.kt
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.onebusaway.android.report.ui
+package org.onebusaway.android.ui.report.infrastructure
 
 import android.content.Context
 import android.net.Uri
@@ -85,19 +85,12 @@ import org.onebusaway.android.map.StopsMapViewModel
 import org.onebusaway.android.map.compose.ObaMap
 import org.onebusaway.android.map.compose.ObaMapCallbacks
 import org.onebusaway.android.models.ObaStop
-import org.onebusaway.android.report.ReportContext
-import org.onebusaway.android.report.TripReportContext
 import org.onebusaway.android.ui.arrivals.ArrivalsViewModel
 import org.onebusaway.android.ui.compose.components.ObaTopAppBar
 import org.onebusaway.android.ui.compose.findActivity
 import org.onebusaway.android.ui.nav.NavRoutes
-import org.onebusaway.android.ui.report.infrastructure.DefaultGeocodeAddressRepository
-import org.onebusaway.android.ui.report.infrastructure.DefaultIssueType
-import org.onebusaway.android.ui.report.infrastructure.DefaultServiceListRepository
-import org.onebusaway.android.ui.report.infrastructure.InfrastructureControls
-import org.onebusaway.android.ui.report.infrastructure.InfrastructureIssueEvent
-import org.onebusaway.android.ui.report.infrastructure.InfrastructureIssueViewModel
-import org.onebusaway.android.ui.report.infrastructure.ReportTarget
+import org.onebusaway.android.ui.report.ReportContext
+import org.onebusaway.android.ui.report.TripReportContext
 import org.onebusaway.android.ui.report.open311.DefaultOpen311Repository
 import org.onebusaway.android.ui.report.open311.Open311IssueContext
 import org.onebusaway.android.ui.report.open311.Open311ProblemViewModel

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/report/infrastructure/InfrastructureIssueViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/report/infrastructure/InfrastructureIssueViewModel.kt
@@ -28,8 +28,8 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import org.onebusaway.android.models.ObaStop
-import org.onebusaway.android.report.TripReportContext
-import org.onebusaway.android.report.constants.ReportConstants
+import org.onebusaway.android.ui.report.ReportConstants
+import org.onebusaway.android.ui.report.TripReportContext
 import org.onebusaway.android.util.GeoPoint
 
 /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/report/infrastructure/InfrastructureIssueViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/report/infrastructure/InfrastructureIssueViewModel.kt
@@ -16,8 +16,11 @@
  */
 package org.onebusaway.android.ui.report.infrastructure
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -27,10 +30,12 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import org.onebusaway.android.api.adapters.ObaStopElement
 import org.onebusaway.android.models.ObaStop
+import org.onebusaway.android.ui.nav.NavRoutes
 import org.onebusaway.android.ui.report.ReportConstants
+import org.onebusaway.android.ui.report.ReportContext
 import org.onebusaway.android.ui.report.TripReportContext
-import org.onebusaway.android.util.GeoPoint
 
 /**
  * Orchestrates the infrastructure-issue container: tracks the [IssueLocation], loads Open311
@@ -42,23 +47,38 @@ import org.onebusaway.android.util.GeoPoint
  * as opaque values ([open311], [ServiceListItem.Category.raw]) that the host casts when launching
  * the Open311 form, so this ViewModel never imports edu.usf.cutr.
  */
-class InfrastructureIssueViewModel(
+@HiltViewModel
+class InfrastructureIssueViewModel @Inject constructor(
+    savedState: SavedStateHandle,
     private val serviceListRepository: ServiceListRepository,
-    private val geocodeRepository: GeocodeAddressRepository,
-    initialLocation: GeoPoint,
-    initialStop: ObaStop?,
-    private val defaultIssueType: DefaultIssueType,
-    private var arrivalInfo: TripReportContext?,
-    private val agencyName: String?,
-    private val blockId: String?
+    private val geocodeRepository: GeocodeAddressRepository
 ) : ViewModel() {
 
+    // Launch args arrive via SavedStateHandle from the INFRASTRUCTURE_ISSUE destination's nav-args:
+    // the whole stop/location/trip context rides one encoded [ReportContext], and the issue type the
+    // report was started for rides [NavRoutes.ARG_SELECTED_SERVICE] as a [DefaultIssueType] name.
+    // Decoding here (rather than in the destination) keeps the args process-death-safe and lets the
+    // screen be a plain hiltViewModel() call — same shape as TripInfoViewModel / RouteInfoViewModel.
+    private val reportContext =
+        ReportContext.decode(savedState.get<String>(NavRoutes.ARG_REPORT_CONTEXT))
+
+    private val defaultIssueType = savedState.get<String>(NavRoutes.ARG_SELECTED_SERVICE)
+        ?.let { name -> DefaultIssueType.entries.firstOrNull { it.name == name } }
+        ?: DefaultIssueType.NONE
+
+    private var arrivalInfo: TripReportContext? = reportContext.trip
+    private val agencyName: String? = reportContext.agencyName
+    private val blockId: String? = reportContext.blockId
+
     private val _uiState = MutableStateFlow(
-        InfrastructureIssueUiState(
-            location = IssueLocation(initialLocation.latitude, initialLocation.longitude, initialStop),
-            busStopName = initialStop?.name,
-            servicesVisible = initialStop != null
-        )
+        run {
+            val initialStop = reportContext.initialStop()
+            InfrastructureIssueUiState(
+                location = IssueLocation(reportContext.lat, reportContext.lon, initialStop),
+                busStopName = initialStop?.name,
+                servicesVisible = initialStop != null
+            )
+        }
     )
     val uiState: StateFlow<InfrastructureIssueUiState> = _uiState.asStateFlow()
 
@@ -290,4 +310,12 @@ class InfrastructureIssueViewModel(
             }
         }
     }
+}
+
+/**
+ * The stop the report was started on, rebuilt from the scalar nav-arg fields, or null for a
+ * context-free (map-pin) report. The context carries one coordinate, so the stop sits at it.
+ */
+private fun ReportContext.initialStop(): ObaStop? = stopId?.let { id ->
+    ObaStopElement(id, lat, lon, stopName.orEmpty(), stopCode.orEmpty())
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/report/infrastructure/InfrastructureIssueViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/report/infrastructure/InfrastructureIssueViewModel.kt
@@ -49,25 +49,39 @@ import org.onebusaway.android.ui.report.TripReportContext
  */
 @HiltViewModel
 class InfrastructureIssueViewModel @Inject constructor(
-    savedState: SavedStateHandle,
+    private val savedState: SavedStateHandle,
     private val serviceListRepository: ServiceListRepository,
     private val geocodeRepository: GeocodeAddressRepository
 ) : ViewModel() {
 
     // Launch args arrive via SavedStateHandle from the INFRASTRUCTURE_ISSUE destination's nav-args:
     // the whole stop/location/trip context rides one encoded [ReportContext], and the issue type the
-    // report was started for rides [NavRoutes.ARG_SELECTED_SERVICE] as a [DefaultIssueType] name.
+    // report was started for rides [NavRoutes.ARG_ISSUE_TYPE] as a [DefaultIssueType] name.
     // Decoding here (rather than in the destination) keeps the args process-death-safe and lets the
     // screen be a plain hiltViewModel() call — same shape as TripInfoViewModel / RouteInfoViewModel.
     private val reportContext =
         ReportContext.decode(savedState.get<String>(NavRoutes.ARG_REPORT_CONTEXT))
 
-    private val defaultIssueType = savedState.get<String>(NavRoutes.ARG_SELECTED_SERVICE)
-        ?.let { name -> DefaultIssueType.entries.firstOrNull { it.name == name } }
-        ?: DefaultIssueType.NONE
+    private val defaultIssueType =
+        DefaultIssueType.fromNavArg(savedState.get<String>(NavRoutes.ARG_ISSUE_TYPE))
 
-    /** The arrival being reported on — re-set when the picker chooses one, so not just an arg. */
-    private var arrivalInfo: TripReportContext? = reportContext.trip
+    /**
+     * The arrival being reported on: the launch context's trip, replaced when the picker chooses one.
+     * Unlike the launch args it's written after construction, so it's saved back to [savedState] to
+     * survive process death along with them — otherwise a restore mid-report drops the user back to
+     * the picker with their choice silently gone. Stored through [ReportContext]'s codec (its trip
+     * half) rather than teaching this one field a second serialization.
+     */
+    private var arrivalInfo: TripReportContext? =
+        if (savedState.contains(KEY_PICKED_ARRIVAL)) {
+            ReportContext.decode(savedState[KEY_PICKED_ARRIVAL]).trip
+        } else {
+            reportContext.trip
+        }
+        set(value) {
+            field = value
+            savedState[KEY_PICKED_ARRIVAL] = value?.let { ReportContext(trip = it).encode() }
+        }
 
     private val _uiState = MutableStateFlow(
         run {
@@ -318,3 +332,6 @@ class InfrastructureIssueViewModel @Inject constructor(
 private fun ReportContext.initialStop(): ObaStop? = stopId?.let { id ->
     ObaStopElement(id, lat, lon, stopName.orEmpty(), stopCode.orEmpty())
 }
+
+/** [SavedStateHandle] key for the picker's chosen arrival (not a nav-arg — written by this VM). */
+private const val KEY_PICKED_ARRIVAL = "pickedArrival"

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/report/infrastructure/InfrastructureIssueViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/report/infrastructure/InfrastructureIssueViewModel.kt
@@ -66,9 +66,8 @@ class InfrastructureIssueViewModel @Inject constructor(
         ?.let { name -> DefaultIssueType.entries.firstOrNull { it.name == name } }
         ?: DefaultIssueType.NONE
 
+    /** The arrival being reported on — re-set when the picker chooses one, so not just an arg. */
     private var arrivalInfo: TripReportContext? = reportContext.trip
-    private val agencyName: String? = reportContext.agencyName
-    private val blockId: String? = reportContext.blockId
 
     private val _uiState = MutableStateFlow(
         run {
@@ -256,7 +255,7 @@ class InfrastructureIssueViewModel @Inject constructor(
     }
 
     /** Trip context for the host when launching the trip / Open311-trip forms. */
-    fun tripContext(): Triple<TripReportContext?, String?, String?> = Triple(arrivalInfo, agencyName, blockId)
+    fun tripContext(): Triple<TripReportContext?, String?, String?> = Triple(arrivalInfo, reportContext.agencyName, reportContext.blockId)
 
     /**
      * The current issue location/address/stop, for the hosted Open311 form (was the host activity's

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/report/infrastructure/ServiceListRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/report/infrastructure/ServiceListRepository.kt
@@ -24,8 +24,8 @@ import edu.usf.cutr.open311client.models.ServiceListRequest
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.onebusaway.android.R
-import org.onebusaway.android.report.constants.ReportConstants
-import org.onebusaway.android.report.ui.util.ServiceUtils
+import org.onebusaway.android.ui.report.ReportConstants
+import org.onebusaway.android.ui.report.ServiceUtils
 
 /** Loads the Open311 issue categories available at a location. */
 interface ServiceListRepository {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/report/infrastructure/ServiceListRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/report/infrastructure/ServiceListRepository.kt
@@ -17,10 +17,12 @@
 package org.onebusaway.android.ui.report.infrastructure
 
 import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
 import edu.usf.cutr.open311client.Open311
 import edu.usf.cutr.open311client.Open311Manager
 import edu.usf.cutr.open311client.models.Service
 import edu.usf.cutr.open311client.models.ServiceListRequest
+import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.onebusaway.android.R
@@ -39,7 +41,9 @@ interface ServiceListRepository {
  * prepareServiceList; the transit-marking heuristic stays in [ServiceUtils.markTransitServices]
  * (it needs resources) and the pure sectioning is delegated to [ServiceListMapper].
  */
-class DefaultServiceListRepository(private val context: Context) : ServiceListRepository {
+class DefaultServiceListRepository @Inject constructor(
+    @ApplicationContext private val context: Context
+) : ServiceListRepository {
 
     override suspend fun loadServices(
         latitude: Double,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/report/infrastructure/SimpleArrivalsPicker.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/report/infrastructure/SimpleArrivalsPicker.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.onebusaway.android.report.ui
+package org.onebusaway.android.ui.report.infrastructure
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/report/open311/Open311Repository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/report/open311/Open311Repository.kt
@@ -37,9 +37,9 @@ import kotlinx.coroutines.withContext
 import org.onebusaway.android.R
 import org.onebusaway.android.api.ObaApi
 import org.onebusaway.android.models.ObaStop
-import org.onebusaway.android.report.TripReportContext
-import org.onebusaway.android.report.constants.ReportConstants
-import org.onebusaway.android.report.ui.util.ServiceUtils
+import org.onebusaway.android.ui.report.ReportConstants
+import org.onebusaway.android.ui.report.ServiceUtils
+import org.onebusaway.android.ui.report.TripReportContext
 import org.onebusaway.android.util.BitmapUtils
 import org.onebusaway.android.util.MyTextUtils
 import org.onebusaway.android.util.PreferenceUtils

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/report/problem/ProblemReportRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/report/problem/ProblemReportRepository.kt
@@ -16,6 +16,7 @@
 package org.onebusaway.android.ui.report.problem
 
 import android.location.Location
+import javax.inject.Inject
 import org.onebusaway.android.api.data.ProblemReportDataSource
 
 /** Submits stop/trip problem reports to the OBA REST API. */
@@ -43,7 +44,7 @@ interface ProblemReportRepository {
  * api [ProblemReportDataSource] takes, keeping the wire call (and the legacy `data` param) inside
  * io. A non-OK app-level code or a transport failure maps to [Result.failure] in the service.
  */
-class DefaultProblemReportRepository(
+class DefaultProblemReportRepository @Inject constructor(
     private val reportService: ProblemReportDataSource
 ) : ProblemReportRepository {
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/report/problem/ProblemReportViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/report/problem/ProblemReportViewModel.kt
@@ -18,6 +18,10 @@ package org.onebusaway.android.ui.report.problem
 import android.location.Location
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -28,13 +32,29 @@ import kotlinx.coroutines.launch
  * Holds the editable [ProblemFormState] and drives a single submit through
  * [ProblemReportRepository]. The host supplies the user's [Location] at submit time
  * (kept out of the ViewModel so it stays free of platform location plumbing).
+ *
+ * Assisted-injected: [repository] comes from Dagger, while what is being reported ([params], the
+ * selectable [ProblemCode]s, and the [headsign] shown above the form) are runtime values the issue
+ * screen derives from the focused stop / picked arrival — they are sibling-ViewModel state, not
+ * nav-args, so they can't come from a SavedStateHandle. The screen builds it with
+ * `hiltViewModel(key = …) { it.create(…) }`, one instance per reported stop/trip.
  */
-class ProblemReportViewModel(
-    private val params: ProblemParams,
-    codes: List<ProblemCode>,
-    headsign: String?,
+@HiltViewModel(assistedFactory = ProblemReportViewModel.Factory::class)
+class ProblemReportViewModel @AssistedInject constructor(
+    @Assisted private val params: ProblemParams,
+    @Assisted codes: List<ProblemCode>,
+    @Assisted headsign: String?,
     private val repository: ProblemReportRepository
 ) : ViewModel() {
+
+    @AssistedFactory
+    interface Factory {
+        fun create(
+            params: ProblemParams,
+            codes: List<ProblemCode>,
+            headsign: String?
+        ): ProblemReportViewModel
+    }
 
     private val _formState = MutableStateFlow(
         ProblemFormState(

--- a/onebusaway-android/src/main/res/values/donottranslate.xml
+++ b/onebusaway-android/src/main/res/values/donottranslate.xml
@@ -194,8 +194,6 @@
     <string name="ri_static_user_last_name">User</string>
     <string name="ri_static_user_email">issue-report@onebusaway.org</string>
     <string name="ri_static_user_phone"></string>
-    <string name="ri_selected_service_stop">stop</string>
-    <string name="ri_selected_service_trip">trip</string>
     <string name="ri_app_feedback_email">android-app@onebusaway.org</string>
 
 

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/report/ReportContextTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/report/ReportContextTest.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.onebusaway.android.report
+package org.onebusaway.android.ui.report
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/report/infrastructure/InfrastructureIssueViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/report/infrastructure/InfrastructureIssueViewModelTest.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -31,6 +32,7 @@ import org.onebusaway.android.models.ObaStop
 import org.onebusaway.android.testing.MainDispatcherRule
 import org.onebusaway.android.ui.nav.NavRoutes
 import org.onebusaway.android.ui.report.ReportContext
+import org.onebusaway.android.ui.report.TripReportContext
 import org.onebusaway.android.util.GeoPoint
 
 private class FakeServiceListRepository(private val result: ServiceListResult) : ServiceListRepository {
@@ -63,29 +65,67 @@ class InfrastructureIssueViewModelTest {
 
     private val stop: ObaStop = ObaStopElement("1_75403", 47.6, -122.3, "Pine St & 3rd Ave", "75403")
 
+    private val arrival = TripReportContext(
+        tripId = "1_trip",
+        routeId = "1_100",
+        shortName = "40",
+        routeLongName = "Downtown",
+        headsign = "DOWNTOWN SEATTLE",
+        vehicleId = "1_4321",
+        stopId = "1_75403",
+        serviceDate = 1_700_000_000_000L,
+        predicted = true,
+        predictedArrivalTime = 1_700_000_600_000L,
+        predictedDepartureTime = 1_700_000_600_000L,
+        scheduledArrivalTime = 1_700_000_500_000L,
+        scheduledDepartureTime = 1_700_000_500_000L,
+        hasTripStatus = true,
+        scheduleDeviation = 60L,
+        lastKnownLat = 47.61,
+        lastKnownLon = -122.33
+    )
+
+    /**
+     * The nav-args the INFRASTRUCTURE_ISSUE route carries. [issueTypeArg] is the raw string so tests
+     * can cover the absent and unrecognized cases, not just a well-formed [DefaultIssueType] name.
+     */
+    private fun navArgs(
+        stop: ObaStop? = null,
+        issueTypeArg: String? = DefaultIssueType.NONE.name,
+        trip: TripReportContext? = null,
+        agencyName: String? = null,
+        blockId: String? = null
+    ) = SavedStateHandle(
+        mapOf(
+            NavRoutes.ARG_ISSUE_TYPE to issueTypeArg,
+            NavRoutes.ARG_REPORT_CONTEXT to ReportContext(
+                stopId = stop?.id,
+                stopName = stop?.name,
+                stopCode = stop?.stopCode,
+                lat = 47.6,
+                lon = -122.3,
+                agencyName = agencyName,
+                blockId = blockId,
+                trip = trip
+            ).encode()
+        )
+    )
+
     /**
      * Builds the VM the way the NavHost does — through its nav-args. The launch context goes in as the
      * encoded [ReportContext] the destination's route carries, so these tests exercise the real
-     * SavedStateHandle decode rather than a constructor the app no longer uses.
+     * SavedStateHandle decode rather than a constructor the app no longer uses. Pass [savedState]
+     * explicitly to re-create the VM over a handle a previous instance wrote to (a process-death
+     * restore).
      */
     private fun viewModel(
         stop: ObaStop? = null,
         default: DefaultIssueType = DefaultIssueType.NONE,
         areaManaged: Boolean = true,
-        heuristic: Boolean = false
+        heuristic: Boolean = false,
+        savedState: SavedStateHandle = navArgs(stop, default.name)
     ) = InfrastructureIssueViewModel(
-        savedState = SavedStateHandle(
-            mapOf(
-                NavRoutes.ARG_SELECTED_SERVICE to default.name,
-                NavRoutes.ARG_REPORT_CONTEXT to ReportContext(
-                    stopId = stop?.id,
-                    stopName = stop?.name,
-                    stopCode = stop?.stopCode,
-                    lat = 47.6,
-                    lon = -122.3
-                ).encode()
-            )
-        ),
+        savedState = savedState,
         serviceListRepository = FakeServiceListRepository(
             ServiceListResult(items, open311 = "endpoint", areaManaged, heuristic)
         ),
@@ -184,6 +224,63 @@ class InfrastructureIssueViewModelTest {
 
         assertEquals(ReportTarget.None, vm.uiState.value.target)
         assertEquals(0, vm.uiState.value.selectedIndex)
+    }
+
+    @Test
+    fun `the launch context's trip and agency ids ride through to the trip context`() = runTest {
+        val vm = viewModel(
+            savedState = navArgs(stop, trip = arrival, agencyName = "Metro", blockId = "1_block")
+        )
+
+        advanceUntilIdle()
+
+        assertEquals(Triple(arrival, "Metro", "1_block"), vm.tripContext())
+    }
+
+    @Test
+    fun `a launch trip context pre-fills the trip form without the picker`() = runTest {
+        val vm = viewModel(savedState = navArgs(stop, trip = arrival))
+        advanceUntilIdle()
+
+        vm.onServiceSelected(3)
+
+        val target = vm.uiState.value.target
+        assertTrue(target is ReportTarget.TripProblem)
+        assertEquals(arrival, (target as ReportTarget.TripProblem).arrival)
+    }
+
+    @Test
+    fun `a picked arrival survives a process-death restore`() = runTest {
+        val savedState = navArgs(stop)
+        val vm = viewModel(savedState = savedState)
+        advanceUntilIdle()
+        vm.onArrivalSelected(arrival)
+
+        // Same handle, new instance: what Hilt hands the destination after the process is restored.
+        val restored = viewModel(savedState = savedState)
+        advanceUntilIdle()
+
+        assertEquals(arrival, restored.tripContext().first)
+    }
+
+    @Test
+    fun `an absent issue type pre-selects nothing`() = runTest {
+        val vm = viewModel(savedState = navArgs(stop, issueTypeArg = null))
+
+        advanceUntilIdle()
+
+        assertEquals(ReportTarget.None, vm.uiState.value.target)
+        assertEquals(0, vm.uiState.value.selectedIndex)
+    }
+
+    @Test
+    fun `an unrecognized issue type is a programming error, not a silent NONE`() {
+        // "stop" is the retired resource token the route used to carry; a producer still writing it
+        // should be a hard failure, not a category that quietly stops pre-selecting.
+        val thrown = assertThrows(IllegalArgumentException::class.java) {
+            viewModel(savedState = navArgs(stop, issueTypeArg = "stop"))
+        }
+        assertTrue(thrown.message!!.contains("stop"))
     }
 
     @Test

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/report/infrastructure/InfrastructureIssueViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/report/infrastructure/InfrastructureIssueViewModelTest.kt
@@ -15,6 +15,7 @@
  */
 package org.onebusaway.android.ui.report.infrastructure
 
+import androidx.lifecycle.SavedStateHandle
 import java.io.IOException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -28,6 +29,8 @@ import org.junit.Test
 import org.onebusaway.android.api.adapters.ObaStopElement
 import org.onebusaway.android.models.ObaStop
 import org.onebusaway.android.testing.MainDispatcherRule
+import org.onebusaway.android.ui.nav.NavRoutes
+import org.onebusaway.android.ui.report.ReportContext
 import org.onebusaway.android.util.GeoPoint
 
 private class FakeServiceListRepository(private val result: ServiceListResult) : ServiceListRepository {
@@ -60,22 +63,33 @@ class InfrastructureIssueViewModelTest {
 
     private val stop: ObaStop = ObaStopElement("1_75403", 47.6, -122.3, "Pine St & 3rd Ave", "75403")
 
+    /**
+     * Builds the VM the way the NavHost does — through its nav-args. The launch context goes in as the
+     * encoded [ReportContext] the destination's route carries, so these tests exercise the real
+     * SavedStateHandle decode rather than a constructor the app no longer uses.
+     */
     private fun viewModel(
         stop: ObaStop? = null,
         default: DefaultIssueType = DefaultIssueType.NONE,
         areaManaged: Boolean = true,
         heuristic: Boolean = false
     ) = InfrastructureIssueViewModel(
+        savedState = SavedStateHandle(
+            mapOf(
+                NavRoutes.ARG_SELECTED_SERVICE to default.name,
+                NavRoutes.ARG_REPORT_CONTEXT to ReportContext(
+                    stopId = stop?.id,
+                    stopName = stop?.name,
+                    stopCode = stop?.stopCode,
+                    lat = 47.6,
+                    lon = -122.3
+                ).encode()
+            )
+        ),
         serviceListRepository = FakeServiceListRepository(
             ServiceListResult(items, open311 = "endpoint", areaManaged, heuristic)
         ),
-        geocodeRepository = FakeGeocodeAddressRepository(),
-        initialLocation = GeoPoint(47.6, -122.3),
-        initialStop = stop,
-        defaultIssueType = default,
-        arrivalInfo = null,
-        agencyName = null,
-        blockId = null
+        geocodeRepository = FakeGeocodeAddressRepository()
     )
 
     @Test


### PR DESCRIPTION
Housekeeping on the report / problem-reporting flow, which was the last corner of the app still on the pre-modernization shape. No behavior change intended — this is a package move plus DI wiring.

No tracking issue: this came out of a structural pass over the module tree, not a bug report.

## 1. Fold `report/` into `ui/report/`

The report feature lived in two mutually-importing package trees whose names are near-anagrams: screens in `report/ui/`, ViewModels/repositories/models in `ui/report/`. `report/ui/InfrastructureIssueScreen.kt` imported 20 symbols from `ui/report/`, and `ui/report/` imported back from `report/` (`ReportConstants`, `ServiceUtils`, `TripReportContext`) — a circular package dependency, and the only place in the app where the file name didn't tell you the directory. Every other feature is `ui/<feature>/{Screen,ViewModel,Repository}`.

Each file moved to the subpackage that already owns its concern:

| From | To |
|---|---|
| `report/ReportContext.kt` | `ui/report/` (shared by all) |
| `report/ui/ReportDestinations.kt` | `ui/report/` (cluster nav graph) |
| `report/ui/ReportLauncher.kt` | `ui/report/` (chooser + launcher) |
| `report/constants/ReportConstants.java` | `ui/report/` (used by 2 subpackages) |
| `report/ui/util/ServiceUtils.java` | `ui/report/` (used by 2 subpackages) |
| `report/ui/CustomerServiceDestination.kt` | `ui/report/customerservice/` |
| `report/ui/InfrastructureIssueScreen.kt` | `ui/report/infrastructure/` |
| `report/ui/InfrastructureIssueLauncher.kt` | `ui/report/infrastructure/` |
| `report/ui/SimpleArrivalsPicker.kt` | `ui/report/infrastructure/` |

Package declarations and imports only. Git tracked all ten files (incl. the unit test) as renames, so history follows them. I checked the manifest, ProGuard config, and flavor files for references to the old package — the only hits were in `build/` artifacts.

## 2. Wire the ViewModels through Hilt

`InfrastructureIssueScreen.kt` hand-built four ViewModels inside Composables, constructing their repositories inline — the service-locator pattern #1624 retired everywhere else. Three of the app's six non-`@HiltViewModel` ViewModels were report ones.

**Repositories.** `DefaultServiceListRepository` and `DefaultGeocodeAddressRepository` take only a Context, and `DefaultProblemReportRepository` takes a `ProblemReportDataSource` that `RepositoryModule` already binds — so all three get `@Inject` constructors and `@Binds`, and none is built by hand any more.

**`InfrastructureIssueViewModel` → `@HiltViewModel` + `SavedStateHandle`,** matching `TripInfoViewModel` / `RouteInfoViewModel`. Its eight constructor params were two repositories plus six values the screen decoded out of nav-args; it now reads `ARG_REPORT_CONTEXT` and `ARG_SELECTED_SERVICE` off its own handle, so the screen is a bare `hiltViewModel()` call and `InfrastructureIssueDestination` needs no parameters but its `NavController`.

**`ProblemReportViewModel` → `@HiltViewModel(assistedFactory = …)`.** Its repository comes from the graph; what is being reported (`params`, `codes`, `headsign`) stays assisted, because those are sibling-ViewModel state rather than nav-args.

### One rider worth a look

`ARG_SELECTED_SERVICE` now carries a `DefaultIssueType` name instead of the `ri_selected_service_stop`/`_trip` resource tokens. Those were only ever written and string-compared back through `Context`, which a `SavedStateHandle` can't do. The two `donottranslate` strings are now unused and removed, and `InfrastructureIssueLauncher.startWithService` takes the enum rather than a stringly-typed keyword. All four producers are in-repo and the route has no deep link, so nothing external depends on the old token.

### Two factories remain on purpose

Each is documented at its call site:

- **`Open311ProblemViewModel`** — `DefaultOpen311Repository` takes the category's opaque library `Service` and the issue VM's `Open311` endpoint (runtime values off a sibling ViewModel's state) plus a closure reading that VM's live location. Nothing in it comes from the graph. `RepositoryModule`'s KDoc already codifies this exception.
- **`ArrivalsViewModel`** (the picker) — deliberately plain `@AssistedInject` because the home sheet builds it against a non-Hilt-aware `ViewModelStoreOwner`. Its factory and repository already come from the graph; nothing is hand-constructed.

## Verification

- `assembleObaGoogleDebug` succeeds — so the Hilt graph actually resolves, not just the Kotlin
- main + unit-test + androidTest sources compile clean under `-PwarningsAsErrors=true`
- `spotlessCheck` passes
- Full unit suite: **1160 tests, 0 failures**. The 9 `InfrastructureIssueViewModel` tests now exercise the real `SavedStateHandle` decode rather than a constructor the app no longer uses.

**Not device-verified.** The report flow's runtime behavior — the nav-arg round-trip through the launcher, and the picker → trip-form → Open311 handoff — is exactly what unit tests don't cover. Worth walking "Report a problem" from both the arrivals row and the map before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved infrastructure issue reporting to reliably preserve entered report context during navigation, including process-death restore.
  * Improved report form initialization to keep trip/stop details consistent when reopening the flow.

* **Refactor**
  * Standardized infrastructure issue handling to use clear typed issue categories for stop vs trip.
  * Reorganized reporting screens and navigation to support state-driven extraction.

* **Tests**
  * Updated and expanded infrastructure issue ViewModel tests to validate nav-argument/state restoration and issue-type handling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->