### PR TITLE
Don't crash when a vehicle's trip is missing from the route references

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/VehicleBitmaps.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/VehicleBitmaps.kt
@@ -116,11 +116,28 @@ object VehicleBitmaps {
         )
 
     /** The vehicle's route type, normalizing cablecar to tram so both the bitmap and key paths agree. */
-    private fun vehicleType(vehicle: VehicleMarker, response: RouteTrips): Int {
-        val status = vehicle.status
-        // Non-null chain matches the former Java (it NPE'd on a missing trip/route too).
-        val type = response.route(response.trip(status.activeTripId)!!.routeId)!!.type
-        return normalizeVehicleType(type)
+    private fun vehicleType(vehicle: VehicleMarker, response: RouteTrips): Int = routeTypeFor(response, vehicle.status.activeTripId)
+
+    /**
+     * The route type behind [activeTripId], or [DEFAULT_VEHICLE_TYPE] when it can't be resolved.
+     *
+     * Both hops are nullable **by contract** — [RouteTrips.trip] and [RouteTrips.route] resolve out of
+     * whatever `references` the poll happened to carry — and a vehicle mid-block-interline can
+     * legitimately report an `activeTripId` this route's poll never fetched (which is why
+     * `TripVehiclesDataSource.trip` exists at all, #1691); a blank id does it too (#2003). This was a
+     * `!!` chain inherited from the former Java, which turned that ordinary data gap into a foreground
+     * process death on the reactive poll path (#2020) — even though `vehicleTitle`, called one line
+     * away in the same reconcile loop, already degraded to "".
+     *
+     * Falling back to the default glyph keeps a real vehicle on the map rather than dropping it, and
+     * because `iconKey` and `vehicleBitmap` both come through here they can't disagree about which
+     * bitmap the fallback names.
+     */
+    @VisibleForTesting
+    internal fun routeTypeFor(response: RouteTrips, activeTripId: String?): Int {
+        val trip = response.trip(activeTripId) ?: return DEFAULT_VEHICLE_TYPE
+        val route = response.route(trip.routeId) ?: return DEFAULT_VEHICLE_TYPE
+        return normalizeVehicleType(route.type)
     }
 
     /**

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/render/VehicleBitmapsTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/render/VehicleBitmapsTest.kt
@@ -18,8 +18,14 @@ package org.onebusaway.android.map.render
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.onebusaway.android.models.ObaRoute
+import org.onebusaway.android.models.ObaTrip
+import org.onebusaway.android.models.ObaTripDetails
+import org.onebusaway.android.models.RouteTrips
 
-/** Pure-logic guards for [VehicleBitmaps]'s route-type normalization (the cablecar→tram promise). */
+/**
+ * Pure-logic guards for [VehicleBitmaps]'s route-type resolution: the cablecar→tram promise, and the
+ * unresolvable-trip/route fallback that replaced the crashing `!!` chain (#2020).
+ */
 class VehicleBitmapsTest {
 
     /**
@@ -52,5 +58,73 @@ class VehicleBitmapsTest {
         )) {
             assertEquals(type.toLong(), VehicleBitmaps.normalizeVehicleType(type).toLong())
         }
+    }
+
+    @Test
+    fun resolvesTheRouteTypeWhenReferencesCarryTripAndRoute() {
+        val response = routeTrips(trip = FakeTrip("trip1", "routeA"), route = FakeRoute(ObaRoute.TYPE_FERRY))
+        assertEquals(ObaRoute.TYPE_FERRY, VehicleBitmaps.routeTypeFor(response, "trip1"))
+    }
+
+    /**
+     * #2020: a vehicle mid-block-interline reports an activeTripId this route's poll never fetched, so
+     * the references pool can't resolve it. That used to be a `!!` and killed the process on the
+     * reactive poll path; it must now degrade to the default glyph.
+     */
+    @Test
+    fun missingTripFallsBackToTheDefaultGlyphInsteadOfThrowing() {
+        val response = routeTrips(trip = null, route = FakeRoute(ObaRoute.TYPE_RAIL))
+        assertEquals(ObaRoute.TYPE_BUS, VehicleBitmaps.routeTypeFor(response, "absent-trip"))
+    }
+
+    /** The trip resolved but its route didn't — the second half of the old `!!` chain. */
+    @Test
+    fun missingRouteFallsBackToTheDefaultGlyphInsteadOfThrowing() {
+        val response = routeTrips(trip = FakeTrip("trip1", "routeA"), route = null)
+        assertEquals(ObaRoute.TYPE_BUS, VehicleBitmaps.routeTypeFor(response, "trip1"))
+    }
+
+    /** A blank/absent id (cf. #2003, where OBA sends "" rather than null for block-edge trip ids). */
+    @Test
+    fun blankOrNullTripIdFallsBackToTheDefaultGlyph() {
+        val response = routeTrips(trip = null, route = null)
+        assertEquals(ObaRoute.TYPE_BUS, VehicleBitmaps.routeTypeFor(response, ""))
+        assertEquals(ObaRoute.TYPE_BUS, VehicleBitmaps.routeTypeFor(response, null))
+    }
+
+    /** Cablecar still collapses onto tram when it *is* resolvable, fallback path notwithstanding. */
+    @Test
+    fun resolvedCablecarStillNormalizesToTram() {
+        val response = routeTrips(trip = FakeTrip("trip1", "routeA"), route = FakeRoute(ObaRoute.TYPE_CABLECAR))
+        assertEquals(ObaRoute.TYPE_TRAM, VehicleBitmaps.routeTypeFor(response, "trip1"))
+    }
+
+    /** A [RouteTrips] whose references pool holds at most the given trip/route. */
+    private fun routeTrips(trip: ObaTrip?, route: ObaRoute?): RouteTrips = object : RouteTrips {
+        override val trips: List<ObaTripDetails> = emptyList()
+        override fun trip(tripId: String?): ObaTrip? = trip.takeIf { !tripId.isNullOrEmpty() }
+        override fun route(routeId: String): ObaRoute? = route
+        override val currentTimeMs: Long = 0L
+    }
+
+    private class FakeTrip(override val id: String, override val routeId: String) : ObaTrip {
+        override val shortName: String? = null
+        override val shapeId: String? = null
+        override val directionId: Int = 0
+        override val serviceId: String? = null
+        override val headsign: String? = null
+        override val timezone: String? = null
+        override val blockId: String? = null
+    }
+
+    private class FakeRoute(override val type: Int) : ObaRoute {
+        override val id: String = "routeA"
+        override val shortName: String? = null
+        override val longName: String? = null
+        override val description: String? = null
+        override val url: String? = null
+        override val color: Int? = null
+        override val textColor: Int? = null
+        override val agencyId: String = "agency"
     }
 }


### PR DESCRIPTION
Fixes #2020 — a `NullPointerException` that kills the app while the vehicle layer is drawing.

## The bug

`VehicleBitmaps.vehicleType` resolved a vehicle's route type through two `!!`s on one line:

```kotlin
val type = response.route(response.trip(status.activeTripId)!!.routeId)!!.type
```

Both lookups are **nullable by contract** — `RouteTrips.trip` is documented "or null when the id is null or absent", `route` "or null when absent", and `TripVehiclesDataSource.routeTripsOf` resolves both straight out of the response's `references`. So any vehicle whose `activeTripId` isn't in that pool took down the process.

That gap is ordinary, not exotic: a vehicle mid-block-interline can report a trip this route's poll never fetched — which is precisely why `TripVehiclesDataSource.trip(tripId)` exists (#1691) — and a blank id does it too (#2003).

Because it sits on the reactive `vehicleSet` path (`GoogleComposeAdapter` StateFlow collect), it repeated on **every poll** containing such a vehicle rather than recovering, so relaunching just re-crashed. Captured three times in ~40 minutes on a Pixel 7 Pro, from *both* arms of `reconcileVehicleMarkers` — the `addMarker(...).icon(...)` path for new markers and the `existing.setIcon(...)` path for refreshed ones.

## Why not just keep the assertion

The `!!` chain carried a comment saying it was deliberate — "Non-null chain matches the former Java (it NPE'd on a missing trip/route too)". Preserving a legacy crash isn't worth a foreground process death, and the codebase already disagrees with itself here: `vehicleTitle`, called **one line away in the same reconcile loop** on the same two lookups, degrades to `""`:

```kotlin
val trip = response.trip(vehicle.status.activeTripId) ?: return ""
val route = response.route(trip.routeId) ?: return ""
```

Same data, same call site — the title path degraded, the icon path crashed.

## The fix

Resolution moves into `routeTypeFor`, falling back to `DEFAULT_VEHICLE_TYPE` — the constant this file already declares and that `renderMarker` already applies to unsupported types, so an unresolvable vehicle now renders exactly like an unsupported one rather than being a special case.

Both `iconKey` and `vehicleBitmap` come through this one function, so the cache key and the bitmap can't disagree about what the fallback names — the consistency the file's docs promise.

Rendering the default glyph keeps a real vehicle on the map instead of dropping it, matching `vehicleTitle`'s degrade-don't-vanish behaviour. Happy to switch to filtering these vehicles out of the layer instead if reviewers prefer that.

Applies to both flavors — `VehicleBitmaps` is in `src/main`, and `MapLibreRenderer` reaches the same code through `vehicleBitmap`.

## Tests

`VehicleBitmapsTest` gains five cases against a `RouteTrips` fake, all JVM-pure (no Robolectric): the resolvable path, missing trip, missing route, blank *and* null id, and that cablecar→tram still holds when it *is* resolvable. `tests="7" failures="0" errors="0"`.

Verified on a clean `origin/main` worktree: `testObaGoogleDebugUnitTest` and `spotlessCheck` both green under `-PwarningsAsErrors=true`.

## Not verified

I could not reproduce the crash deterministically — it needs a real vehicle mid-interline in a live poll. The tests prove the null branches return the default instead of throwing; they don't prove the field crash is gone. The build is on a device now and the route that reproduced it hasn't crashed since, but that's a short window, not confirmation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented vehicle map rendering from crashing when trip or route information is unavailable.
  * Added a reliable default vehicle icon for missing or invalid trip references.
  * Preserved correct vehicle-type normalization, including displaying cablecars as trams.

* **Tests**
  * Added coverage for valid references, missing trips or routes, blank or null trip IDs, and vehicle-type normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->