### PR TITLE
Give a fixed-region flavor with no Open311 endpoint an empty array, not null

### DIFF
--- a/docs/REBRANDING.md
+++ b/docs/REBRANDING.md
@@ -294,6 +294,16 @@ Users can change the sorting style using the "Sort by" button regardless of the 
 * `false` - The app works across various regions defined in the Regions API (recommended for most brands)
 * `true` - The app is fixed to the region information provided in the flavor configuration
 
+**When `USE_FIXED_REGION` is `true`, `FIXED_REGION_NAME` is required** - it is the one
+`FIXED_REGION_*` field the app cannot start without, and leaving it `null` (the value every
+multi-region flavor uses) crashes on the first launch. Every other `FIXED_REGION_*` field is
+optional in the sense that it will not crash: `FIXED_REGION_OBA_BASE_URL` in particular is
+*silently* accepted as `null`, which builds and installs fine and then simply cannot reach a
+server — so set it too, and set the bounds, or the fixed region will not work.
+
+When `USE_FIXED_REGION` is `false`, the `FIXED_REGION_*` fields are unread; leave them `null` as
+`agencyX.gradle` does.
+
 ### Geocoding Provider
 
 `USE_PELIAS_GEOCODING` - Controls which service is used for searching origins and destinations in trip planning:

--- a/onebusaway-android/flavors/README.md
+++ b/onebusaway-android/flavors/README.md
@@ -131,10 +131,19 @@ buildConfigField "boolean", "USE_FIXED_REGION", "false"
 
 ```groovy
 buildConfigField "boolean", "USE_FIXED_REGION", "true"
+// Required: the app cannot start without a region name.
 buildConfigField "String", "FIXED_REGION_NAME", "\"Your Region\""
+// Not required to launch, but the fixed region can't reach a server without it.
 buildConfigField "String", "FIXED_REGION_OBA_BASE_URL", "\"https://api.example.com/api\""
 // ... configure all region bounds and features
 ```
+
+`FIXED_REGION_NAME` is the only one of these the app will refuse to launch without — it's non-null
+on the region model, so leaving it `null` throws from `RegionUtils.getRegionFromBuildFlavor()` on
+first launch. The rest degrade quietly instead of crashing, which is worse to debug: a null
+`FIXED_REGION_OBA_BASE_URL` installs cleanly and then can't load anything. `FIXED_REGION_OPEN311_*`
+is genuinely optional — a brand with no Open311 endpoint leaves the base URL `null` and gets a
+region with no Open311 servers.
 
 ## Benefits of This Architecture
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/RegionUtils.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/RegionUtils.java
@@ -22,10 +22,12 @@ import android.location.Location;
 import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import org.onebusaway.android.BuildConfig;
 import org.onebusaway.android.R;
 import org.onebusaway.android.api.bridge.RegionsClient;
@@ -333,13 +335,45 @@ public class RegionUtils {
   }
 
   /**
+   * The region's Open311 servers, or an <em>empty</em> array when the flavor configures no Open311
+   * base URL.
+   *
+   * <p>Empty rather than null on purpose: {@link Region#getOpen311Servers()} is a non-null Kotlin
+   * property (defaulting to {@code emptyArray()}), so handing it null crashes the constructor. A
+   * flavor omitting {@code FIXED_REGION_OPEN311_BASE_URL} is an ordinary configuration — "this
+   * agency has no Open311 endpoint" — not an error, so it must produce a region with no Open311
+   * servers rather than no region at all.
+   */
+  @VisibleForTesting
+  static @NonNull Region.Open311Server[] open311ServersFrom(
+      @Nullable String jurisdictionId, @Nullable String apiKey, @Nullable String baseUrl) {
+    if (baseUrl == null) {
+      return new Region.Open311Server[0];
+    }
+    return new Region.Open311Server[] {new Region.Open311Server(jurisdictionId, apiKey, baseUrl)};
+  }
+
+  /**
    * Retrieves hard-coded region information from the build flavor defined in build.gradle. If a
    * fixed region is defined in a build flavor, it does not allow region roaming.
    *
+   * <p>Only reached when {@code USE_FIXED_REGION} is true, so every {@code FIXED_REGION_*} field
+   * the non-null half of {@link Region} depends on must actually be configured. The one that isn't
+   * nullable in {@code Region} — and is literally {@code null} in the flavors that don't use a
+   * fixed region — is the name, so it is checked by hand: R8 rewrites Kotlin's parameter null-check
+   * into {@code Object.getClass()}, which in a release build reports only "Attempt to invoke
+   * virtual method 'java.lang.Class java.lang.Object.getClass()' on a null object reference" and
+   * names no field. A rebrander who forgets a {@code buildConfigField} should be told which one.
+   *
    * @return hard-coded region information from the build flavor defined in build.gradle
+   * @throws NullPointerException if the flavor sets USE_FIXED_REGION without a region name
    */
   public static @NonNull Region getRegionFromBuildFlavor() {
     final int regionId = Integer.MAX_VALUE; // This doesn't get used, but needs to be positive
+    final String name =
+        Objects.requireNonNull(
+            BuildConfig.FIXED_REGION_NAME,
+            "FIXED_REGION_NAME must be set in the build flavor when USE_FIXED_REGION is true");
     Region.Bounds[] boundsArray = new Region.Bounds[1];
     Region.Bounds bounds =
         new Region.Bounds(
@@ -347,24 +381,16 @@ public class RegionUtils {
             BuildConfig.FIXED_REGION_BOUNDS_LAT_SPAN, BuildConfig.FIXED_REGION_BOUNDS_LON_SPAN);
     boundsArray[0] = bounds;
 
-    Region.Open311Server[] open311Array = new Region.Open311Server[1];
-    Region.Open311Server open311Server;
-
-    if (BuildConfig.FIXED_REGION_OPEN311_BASE_URL != null) {
-      open311Server =
-          new Region.Open311Server(
-              BuildConfig.FIXED_REGION_OPEN311_JURISDICTION_ID,
-              BuildConfig.FIXED_REGION_OPEN311_API_KEY,
-              BuildConfig.FIXED_REGION_OPEN311_BASE_URL);
-      open311Array[0] = open311Server;
-    } else {
-      open311Array = null;
-    }
+    Region.Open311Server[] open311Array =
+        open311ServersFrom(
+            BuildConfig.FIXED_REGION_OPEN311_JURISDICTION_ID,
+            BuildConfig.FIXED_REGION_OPEN311_API_KEY,
+            BuildConfig.FIXED_REGION_OPEN311_BASE_URL);
 
     Region region =
         new Region(
             regionId,
-            BuildConfig.FIXED_REGION_NAME,
+            name,
             true,
             BuildConfig.FIXED_REGION_OBA_BASE_URL,
             BuildConfig.FIXED_REGION_SIRI_BASE_URL,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/RegionUtils.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/RegionUtils.java
@@ -343,11 +343,20 @@ public class RegionUtils {
    * flavor omitting {@code FIXED_REGION_OPEN311_BASE_URL} is an ordinary configuration — "this
    * agency has no Open311 endpoint" — not an error, so it must produce a region with no Open311
    * servers rather than no region at all.
+   *
+   * <p>Blank counts as unconfigured alongside null. A {@code buildConfigField} is written by hand
+   * in a Groovy flavor file, where "no endpoint" is spelled {@code "null"} by convention but {@code
+   * "\"\""} is the equally natural typo, and the two must not mean different things — an empty base
+   * URL would otherwise register a live-but-broken endpoint with {@code Open311Manager}. This is
+   * normalizing two spellings of "unset" at the config boundary, not inferring intent from the
+   * value: the same rule is already applied to the sibling field one layer down (Open311Subsystem's
+   * {@code jurisdictionId?.takeIf { it.isNotEmpty() }}) and to the OTP2 endpoint's configured/not
+   * test ({@code Region.usesOtp2}).
    */
   @VisibleForTesting
   static @NonNull Region.Open311Server[] open311ServersFrom(
       @Nullable String jurisdictionId, @Nullable String apiKey, @Nullable String baseUrl) {
-    if (baseUrl == null) {
+    if (baseUrl == null || baseUrl.trim().isEmpty()) {
       return new Region.Open311Server[0];
     }
     return new Region.Open311Server[] {new Region.Open311Server(jurisdictionId, apiKey, baseUrl)};

--- a/onebusaway-android/src/test/java/org/onebusaway/android/util/RegionUtilsOpen311Test.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/util/RegionUtilsOpen311Test.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.util
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.onebusaway.android.region.Region
+
+/**
+ * Guards [RegionUtils.open311ServersFrom], the fixed-region build flavor's Open311 array.
+ *
+ * A plain JVM test: the helper takes its three values as parameters rather than reading
+ * `BuildConfig` (which is a per-variant constant a unit test can't vary), so the no-Open311 case is
+ * reachable without building a flavor that has one.
+ */
+class RegionUtilsOpen311Test {
+
+    /**
+     * The regression. A flavor with no `FIXED_REGION_OPEN311_BASE_URL` used to produce a **null**
+     * array, which `Region`'s non-null `open311Servers` rejected — crashing the app at launch, with
+     * an R8-rewritten message naming no field. Having no Open311 endpoint is ordinary configuration,
+     * so it must yield a region with no Open311 servers.
+     */
+    @Test
+    fun noBaseUrlYieldsAnEmptyArrayNotNull() {
+        val servers = RegionUtils.open311ServersFrom("jurisdiction", "key", null)
+        assertArrayEquals(emptyArray<Region.Open311Server>(), servers)
+        // The point of the fix: this is exactly what Region's own default is, so it constructs.
+        assertEquals("a region with no Open311 servers still builds", 0, Region(open311Servers = servers).open311Servers.size)
+    }
+
+    @Test
+    fun aBaseUrlYieldsThatOneServer() {
+        val servers = RegionUtils.open311ServersFrom("jurisdiction", "key", "https://example.org/open311/v2/")
+        assertEquals(1, servers.size)
+        assertEquals("jurisdiction", servers[0].jurisdictionId)
+        assertEquals("key", servers[0].apiKey)
+        assertEquals("https://example.org/open311/v2/", servers[0].baseUrl)
+    }
+
+    /**
+     * A null jurisdiction id / api key alongside a real base URL is a shipped configuration
+     * (`agencyY` sets `FIXED_REGION_OPEN311_JURISDICTION_ID` to null), and both are nullable on
+     * [Region.Open311Server] — so it must build rather than throw.
+     */
+    @Test
+    fun nullJurisdictionAndKeyAreCarriedThrough() {
+        val servers = RegionUtils.open311ServersFrom(null, null, "https://example.org/open311/v2/")
+        assertEquals(1, servers.size)
+        assertEquals(null, servers[0].jurisdictionId)
+        assertEquals(null, servers[0].apiKey)
+    }
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/util/RegionUtilsOpen311Test.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/util/RegionUtilsOpen311Test.kt
@@ -43,6 +43,18 @@ class RegionUtilsOpen311Test {
         assertEquals("a region with no Open311 servers still builds", 0, Region(open311Servers = servers).open311Servers.size)
     }
 
+    /**
+     * A blank base URL is the same fact as a missing one. `buildConfigField` values are hand-written
+     * in a Groovy flavor file, where "no endpoint" is spelled `null` by convention but `""` is the
+     * equally natural typo; letting the two diverge would register an endpoint with an empty base URL
+     * against `Open311Manager` — live, and broken — instead of registering none.
+     */
+    @Test
+    fun aBlankBaseUrlCountsAsNoBaseUrl() {
+        assertEquals(0, RegionUtils.open311ServersFrom("jurisdiction", "key", "").size)
+        assertEquals(0, RegionUtils.open311ServersFrom("jurisdiction", "key", "   ").size)
+    }
+
     @Test
     fun aBaseUrlYieldsThatOneServer() {
         val servers = RegionUtils.open311ServersFrom("jurisdiction", "key", "https://example.org/open311/v2/")


### PR DESCRIPTION
`getRegionFromBuildFlavor` handed `Region` a **null** Open311 array whenever the flavor configured no `FIXED_REGION_OPEN311_BASE_URL`:

```java
} else {
  open311Array = null;
}
```

`Region.open311Servers` is a non-null Kotlin property (defaulting to `emptyArray()`), so that crashes the constructor and kills the app at launch. Having no Open311 endpoint is ordinary configuration — "this agency doesn't run one" — and should yield a region with no Open311 servers, not no region at all.

## Latent, but a trap laid directly under rebranders

Not currently reachable on a shipped build: `agencyY` is the only flavor with `USE_FIXED_REGION=true`, and it happens to set an Open311 URL. But `kiedybus` already has a **null** one alongside a non-null name, so flipping its flag would hit this on the first launch — and it's precisely the path `docs/REBRANDING.md` sends a new white-label brand down. Every `FIXED_REGION_*` field is optional-looking in the flavor file; only two of them are load-bearing for `Region`'s non-null half.

## The diagnostics are the other half

R8 rewrites Kotlin's non-null parameter check into `Object.getClass()`, so a release build (`isMinifyEnabled = true`) reports:

```
java.lang.NullPointerException: Attempt to invoke virtual method
'java.lang.Class java.lang.Object.getClass()' on a null object reference
    at org.onebusaway.android.region.Region.<init>(Unknown Source:6)
    at org.onebusaway.android.util.RegionUtils.getRegionFromBuildFlavor(...)
```

— naming **no field**. You cannot tell from that which `buildConfigField` you forgot. The region name is the other argument that is non-null in `Region` while being literally `null` in the flavors that don't use a fixed region, so it now gets an explicit check that says which one is missing:

```java
Objects.requireNonNull(
    BuildConfig.FIXED_REGION_NAME,
    "FIXED_REGION_NAME must be set in the build flavor when USE_FIXED_REGION is true");
```

Failing loudly at the source, rather than letting a missing field surface later as an anonymous NPE.

## Tests

Extracting `open311ServersFrom` is what makes the broken branch testable at all — it takes its three values as parameters instead of reading `BuildConfig`, which is a per-variant constant a unit test can't vary. New `RegionUtilsOpen311Test` (JVM, no Robolectric) covers the empty case, the one-server case, and the null-jurisdiction/key case that `agencyY` actually ships. `tests="3" failures="0" errors="0"`.

To be straight about coverage: the empty-array test can't be run against the pre-fix code, because the helper it calls didn't exist then — the old `null` was inline. What it does pin is the property that matters, asserting the result actually constructs a `Region`, which is what used to blow up.

Also ran `assembleAgencyYGoogleDebug`, since `agencyY` is the only flavor that executes this code. `spotlessCheck` and `testObaGoogleDebugUnitTest` green under `-PwarningsAsErrors=true`.

## Scope

Deliberately left alone: `FIXED_REGION_OBA_BASE_URL` is nullable on `Region`, so a fixed region without one doesn't crash — it just quietly won't work. Validating that too is defensible but it's a behavior change for existing flavors rather than a crash fix, so it isn't in here.

Found while investigating an unexplained crash report; unrelated to #2020.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Open311 handling so missing or blank base URLs result in no servers instead of null values.
  - Tightened fixed-region configuration to require a non-null region name, avoiding unclear startup issues.
  - Preserved Open311 jurisdiction and API key details when configured.

- **Tests**
  - Expanded regression tests to cover `null`, empty, and whitespace-only Open311 base URLs, plus jurisdiction/key carry-through behavior.

- **Documentation**
  - Updated fixed vs. multi-region configuration guidance with clearer warnings for single-region flavors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->