### PR TITLE
Let riders tune walking, biking, and bike routing on OTP2 regions

### DIFF
--- a/onebusaway-android/build.gradle.kts
+++ b/onebusaway-android/build.gradle.kts
@@ -337,6 +337,12 @@ apollo {
         // Reluctance (walk/bicycle preferences) is a floating-point cost multiplier — schema.graphqls
         // describes it as "a cost multiplier … The value should be greater than 0. 1 means neutral",
         // so map it to Double rather than leaving it as Apollo's untyped `Any`.
+        //
+        // The two-arg form needs no adapter registration, here or for the numeric scalars above:
+        // Apollo's CustomScalarAdapters.responseAdapterFor falls back on the *mapped class name* when
+        // nothing is registered, so "kotlin.Double" resolves to its built-in DoubleAdapter (and
+        // "kotlin.Int"/"kotlin.Long" likewise). mapScalarToKotlinDouble("Reluctance") is shorthand for
+        // exactly that, not a prerequisite for it. Verified against apollo-api 5.0.1's own bytecode.
         mapScalar("Reluctance", "kotlin.Double")
     }
 }

--- a/onebusaway-android/build.gradle.kts
+++ b/onebusaway-android/build.gradle.kts
@@ -334,6 +334,10 @@ apollo {
         // Cost (TransferPreferencesInput.cost) is seconds, per OTP's own
         // TransferPreferences.cost()/withCost(int) — genuinely numeric, not a string.
         mapScalar("Cost", "kotlin.Int")
+        // Reluctance (walk/bicycle preferences) is a floating-point cost multiplier — schema.graphqls
+        // describes it as "a cost multiplier … The value should be greater than 0. 1 means neutral",
+        // so map it to Double rather than leaving it as Apollo's untyped `Any`.
+        mapScalar("Reluctance", "kotlin.Double")
     }
 }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/Otp2PlanRequestBuilder.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/Otp2PlanRequestBuilder.kt
@@ -21,6 +21,9 @@ import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import org.onebusaway.android.api.graphql.PlanQuery
 import org.onebusaway.android.api.graphql.type.AccessibilityPreferencesInput
+import org.onebusaway.android.api.graphql.type.BicyclePreferencesInput
+import org.onebusaway.android.api.graphql.type.CyclingOptimizationInput
+import org.onebusaway.android.api.graphql.type.CyclingOptimizationType
 import org.onebusaway.android.api.graphql.type.PlanAccessMode
 import org.onebusaway.android.api.graphql.type.PlanCoordinateInput
 import org.onebusaway.android.api.graphql.type.PlanDateTimeInput
@@ -30,13 +33,18 @@ import org.onebusaway.android.api.graphql.type.PlanLabeledLocationInput
 import org.onebusaway.android.api.graphql.type.PlanLocationInput
 import org.onebusaway.android.api.graphql.type.PlanModesInput
 import org.onebusaway.android.api.graphql.type.PlanPreferencesInput
+import org.onebusaway.android.api.graphql.type.PlanStreetPreferencesInput
 import org.onebusaway.android.api.graphql.type.PlanTransitModePreferenceInput
 import org.onebusaway.android.api.graphql.type.PlanTransitModesInput
 import org.onebusaway.android.api.graphql.type.TransferPreferencesInput
 import org.onebusaway.android.api.graphql.type.TransitMode
 import org.onebusaway.android.api.graphql.type.TransitPreferencesInput
+import org.onebusaway.android.api.graphql.type.WalkPreferencesInput
 import org.onebusaway.android.api.graphql.type.WheelchairPreferencesInput
+import org.onebusaway.android.ui.tripplan.BikePreference
+import org.onebusaway.android.ui.tripplan.CyclingPreference
 import org.onebusaway.android.ui.tripplan.TripModes
+import org.onebusaway.android.ui.tripplan.WalkPreference
 import org.onebusaway.android.util.BikeshareAvailability
 
 /**
@@ -88,6 +96,98 @@ object Otp2PlanRequestBuilder {
     private const val OPTIMIZE_TRANSFERS_COST_SECONDS = 1800
 
     /**
+     * The neutral point of both reluctance scales — OTP2's own documented default for
+     * `walk.reluctance` *and* `bicycle.reluctance` ("A multiplier for how bad walking/cycling is,
+     * compared to being in transit for equal lengths of time" — RouteRequest docs, v2.9.0, the
+     * version this directory's schema is pinned to).
+     *
+     * Never actually sent: [WalkPreference.MEDIUM]/[BikePreference.MEDIUM] omit the field, so a
+     * region that tuned its own value in `router-config.json` keeps it, and an all-default request
+     * stays byte-identical to what this app sent before these settings existed. It is the anchor the
+     * other four stops are derived from.
+     */
+    private const val RELUCTANCE_MEDIUM = 2.0
+
+    /**
+     * The ratio between adjacent stops **above** the neutral point: each step away from
+     * [RELUCTANCE_MEDIUM] on the "less of this mode" side multiplies by this, giving 4 and 8.
+     *
+     * Deliberately gentle. An earlier version stepped by 5, putting the far stop at 50, which is past
+     * the point where the setting stops meaning "less of this mode" and starts producing nonsense:
+     * measured against the live server, a direct bike trip at `bicycle.reluctance` 50 comes back at
+     * **4.7 km/h** — OTP routes the rider to *push the bike on foot* the whole way, because at a 50x
+     * penalty walking it is cheaper than riding it. At 2 and 10 the same trip is a normal 14-15 km/h
+     * ride. A "minimum cycling" setting that silently converts the trip to a walk is worse than one
+     * that merely discourages it.
+     */
+    private const val RELUCTANCE_STEP = 2.0
+
+    /**
+     * The bottom of the scale, and a hard floor: **1.0**, OTP's neutral point, where a minute on
+     * foot or on a bike costs the router exactly what a minute on transit does.
+     *
+     * Below 1.0 the setting stops meaning "more of this mode" and starts meaning "**don't use
+     * transit**". That is the schema's own definition — "1 means neutral and values below 1 mean that
+     * something is preferred over transit" — and OTP acts on it literally, deleting transit
+     * itineraries in favour of a street-only one. Measured against the live server, with the
+     * threshold falling exactly at 1.0:
+     *
+     * ```
+     * rail only + own bike, bicycle.reluctance = 0.9  ->  no itineraries, NO_TRANSIT_CONNECTION
+     * rail only + own bike, bicycle.reluctance = 1.0  ->  BICYCLE + TRAM(1 Line) + BICYCLE
+     * ```
+     *
+     * An earlier version of this scale ran down to 0.1 and so put its top two stops inside that
+     * region: asking for *more* cycling made bike-and-transit itineraries vanish entirely, which is
+     * the exact opposite of the label's promise. The app already has a legible way to say "no
+     * transit" — [org.onebusaway.android.ui.tripplan.VehicleMode.NONE] — and two controls that both
+     * mean that, one of them by accident, is worse than one that does.
+     *
+     * (At exactly 1.0 a short trip can still come back street-only with
+     * `WALKING_BETTER_THAN_TRANSIT`. That is a correct answer to "walking is as good as transit to
+     * me", and `resolveOtp2Plan` already returns the walk itinerary rather than an error.)
+     */
+    private const val RELUCTANCE_FLOOR = 1.0
+
+    /**
+     * The stop between [RELUCTANCE_MEDIUM] and [RELUCTANCE_FLOOR] — their geometric mean, √2 ≈ 1.4.
+     *
+     * The scale is deliberately asymmetric: above neutral there is unbounded room, so it steps by
+     * [RELUCTANCE_STEP]; below it there is only a factor of two before [RELUCTANCE_FLOOR], so that
+     * remaining range is split once rather than forced onto the same ratio.
+     */
+    private const val RELUCTANCE_HIGH = 1.4
+
+    /**
+     * The four non-neutral stops: 50 / 10 / (unset) / 1.4 / 1.0. Both scales share one table — the
+     * rider-facing meaning is the same either way, and OTP documents the same 2.0 default for both.
+     *
+     * Note the inversion: *less* of the mode is a *higher* multiplier. It lives here, at the wire
+     * boundary, so the preference enums can stay in plain rider terms.
+     */
+    private const val RELUCTANCE_MINIMUM = RELUCTANCE_MEDIUM * RELUCTANCE_STEP * RELUCTANCE_STEP
+    private const val RELUCTANCE_LOW = RELUCTANCE_MEDIUM * RELUCTANCE_STEP
+    private const val RELUCTANCE_MAXIMUM = RELUCTANCE_FLOOR
+
+    /** The reluctance for [preference], or null at the neutral stop (see [RELUCTANCE_MEDIUM]). */
+    private fun reluctanceFor(preference: WalkPreference): Double? = when (preference) {
+        WalkPreference.MINIMUM -> RELUCTANCE_MINIMUM
+        WalkPreference.LOW -> RELUCTANCE_LOW
+        WalkPreference.MEDIUM -> null
+        WalkPreference.HIGH -> RELUCTANCE_HIGH
+        WalkPreference.MAXIMUM -> RELUCTANCE_MAXIMUM
+    }
+
+    /** The reluctance for [preference], or null at the neutral stop (see [RELUCTANCE_MEDIUM]). */
+    private fun reluctanceFor(preference: BikePreference): Double? = when (preference) {
+        BikePreference.MINIMUM -> RELUCTANCE_MINIMUM
+        BikePreference.LOW -> RELUCTANCE_LOW
+        BikePreference.MEDIUM -> null
+        BikePreference.HIGH -> RELUCTANCE_HIGH
+        BikePreference.MAXIMUM -> RELUCTANCE_MAXIMUM
+    }
+
+    /**
      * @throws IllegalArgumentException if the origin/destination lack real coordinates or no
      * date/time was supplied — mirrors [TripRequestBuilder.buildRequest]'s own validation.
      */
@@ -112,7 +212,13 @@ object Otp2PlanRequestBuilder {
             destination = PlanLabeledLocationInput(location = coordinateLocation(to.latitude, to.longitude)),
             dateTime = Optional.present(planDateTime),
             preferences = Optional.present(
-                buildPreferences(builder.getWheelchairAccessible(), builder.getOptimizeTransfers())
+                buildPreferences(
+                    wheelchairAccessible = builder.getWheelchairAccessible(),
+                    optimizeTransfers = builder.getOptimizeTransfers(),
+                    walkPreference = builder.getWalkPreference(),
+                    cyclingPreference = builder.getCyclingPreference(),
+                    bikePreference = builder.getBikePreference()
+                )
             ),
             modes = buildModes(builder.getModeSetId(), BikeshareAvailability.isTripPlanningEnabled(context)),
             numItineraries = NUM_ITINERARIES,
@@ -125,10 +231,19 @@ object Otp2PlanRequestBuilder {
     /**
      * @param optimizeTransfers mirrors [TripRequestBuilder.getOptimizeTransfers] — OTP1's
      * `optimize=TRANSFERS` vs. the `QUICK` default; see [OPTIMIZE_TRANSFERS_COST_SECONDS].
+     * @param walkPreference the OTP2-only stand-in for OTP1's `maxWalkDistance`, which this API
+     * has no equivalent for at all (see [WalkPreference]).
+     * @param cyclingPreference OTP2-only; OTP1's single `optimize` parameter is already spent on
+     * [optimizeTransfers] (see [CyclingPreference]).
+     * @param bikePreference OTP2-only; the nearest thing to a bike-distance setting, which no OTP
+     * version provides (see [BikePreference]).
      */
     internal fun buildPreferences(
         wheelchairAccessible: Boolean,
-        optimizeTransfers: Boolean
+        optimizeTransfers: Boolean,
+        walkPreference: WalkPreference = WalkPreference.MEDIUM,
+        cyclingPreference: CyclingPreference = CyclingPreference.DEFAULT,
+        bikePreference: BikePreference = BikePreference.MEDIUM
     ): PlanPreferencesInput = PlanPreferencesInput(
         accessibility = Optional.present(
             AccessibilityPreferencesInput(
@@ -137,6 +252,7 @@ object Otp2PlanRequestBuilder {
                 )
             )
         ),
+        street = buildStreetPreferences(walkPreference, cyclingPreference, bikePreference),
         transit = if (optimizeTransfers) {
             Optional.present(
                 TransitPreferencesInput(
@@ -149,6 +265,60 @@ object Otp2PlanRequestBuilder {
             Optional.Absent
         }
     )
+
+    /**
+     * `preferences.street` — walk reluctance, bike reluctance and cycling optimization, each omitted
+     * when the rider left it on its neutral stop ([WalkPreference.MEDIUM]/[BikePreference.MEDIUM]/
+     * [CyclingPreference.DEFAULT]) so the region's own router-config values survive. When *all three*
+     * are neutral the whole `street` block is absent rather than sent empty, which is also exactly
+     * what this app did before these settings existed.
+     *
+     * The cycling half is sent regardless of the selected trip mode: it only bears on legs
+     * OTP actually plans by bike, so it is inert on a walk-and-transit plan, and gating it on the
+     * mode here would just duplicate — and risk disagreeing with — [buildModes].
+     */
+    internal fun buildStreetPreferences(
+        walkPreference: WalkPreference,
+        cyclingPreference: CyclingPreference,
+        bikePreference: BikePreference = BikePreference.MEDIUM
+    ): Optional<PlanStreetPreferencesInput?> {
+        val walkReluctance = reluctanceFor(walkPreference)
+        val bikeReluctance = reluctanceFor(bikePreference)
+        val optimization = when (cyclingPreference) {
+            CyclingPreference.DEFAULT -> null
+            CyclingPreference.FASTEST -> CyclingOptimizationType.SHORTEST_DURATION
+            CyclingPreference.SAFEST -> CyclingOptimizationType.SAFEST_STREETS
+            CyclingPreference.FLATTEST -> CyclingOptimizationType.FLAT_STREETS
+        }
+        if (walkReluctance == null && bikeReluctance == null && optimization == null) {
+            return Optional.Absent
+        }
+        // The two bicycle knobs share one input object, so build it once from whichever are set —
+        // choosing an optimization must not pin a reluctance the rider never asked for, or vice versa.
+        val bicycle = if (bikeReluctance == null && optimization == null) {
+            Optional.Absent
+        } else {
+            Optional.present(
+                BicyclePreferencesInput(
+                    reluctance = bikeReluctance?.let { Optional.present(it) } ?: Optional.Absent,
+                    // CyclingOptimizationInput is a @oneOf input — exactly one of `type`/`triangle`
+                    // may be present, and Apollo's generated `init` asserts it. Only `type` is ever
+                    // set here.
+                    optimization = optimization?.let {
+                        Optional.present(CyclingOptimizationInput(type = Optional.present(it)))
+                    } ?: Optional.Absent
+                )
+            )
+        }
+        return Optional.present(
+            PlanStreetPreferencesInput(
+                walk = walkReluctance?.let {
+                    Optional.present(WalkPreferencesInput(reluctance = Optional.present(it)))
+                } ?: Optional.Absent,
+                bicycle = bicycle
+            )
+        )
+    }
 
     /**
      * Maps [TripModes.*][TripModes] to OTP2's `modes` input, mirroring

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/Otp2PlanRequestBuilder.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/Otp2PlanRequestBuilder.kt
@@ -96,15 +96,24 @@ object Otp2PlanRequestBuilder {
     private const val OPTIMIZE_TRANSFERS_COST_SECONDS = 1800
 
     /**
-     * The neutral point of both reluctance scales — OTP2's own documented default for
+     * The neutral point of both reluctance scales: **2.0**, OTP2's own documented default for
      * `walk.reluctance` *and* `bicycle.reluctance` ("A multiplier for how bad walking/cycling is,
      * compared to being in transit for equal lengths of time" — RouteRequest docs, v2.9.0, the
-     * version this directory's schema is pinned to).
+     * version this directory's schema is pinned to). It is the anchor the other four stops are
+     * derived from, and the value [WalkPreference.MEDIUM]/[BikePreference.MEDIUM] send.
      *
-     * Never actually sent: [WalkPreference.MEDIUM]/[BikePreference.MEDIUM] omit the field, so a
-     * region that tuned its own value in `router-config.json` keeps it, and an all-default request
-     * stays byte-identical to what this app sent before these settings existed. It is the anchor the
-     * other four stops are derived from.
+     * **Sent explicitly rather than omitted**, which is a deliberate trade. Omitting it would let a
+     * region that tuned its own reluctance in `router-config.json` keep that tuning — but it would
+     * also make the middle of a five-point slider mean "whatever this region configured", so the
+     * rider-visible ordering could invert: against a region at 6.0, "Low" (4.0) would produce *more*
+     * walking than "Medium". A slider whose labels can run backwards is worse than one that
+     * overrides a server default, so every stop states its multiplier and the scale is monotonic on
+     * every region.
+     *
+     * The cost is real and worth naming: on an OTP2 region this app no longer inherits a
+     * region-configured walk/bike reluctance, even for a rider who never opened the dialog.
+     * [CyclingPreference.DEFAULT] is *not* a midpoint — there is no ordering for it to invert — so it
+     * still omits `bicycle.optimization` and leaves that piece of the region's tuning alone.
      */
     private const val RELUCTANCE_MEDIUM = 2.0
 
@@ -116,9 +125,10 @@ object Otp2PlanRequestBuilder {
      * the point where the setting stops meaning "less of this mode" and starts producing nonsense:
      * measured against the live server, a direct bike trip at `bicycle.reluctance` 50 comes back at
      * **4.7 km/h** — OTP routes the rider to *push the bike on foot* the whole way, because at a 50x
-     * penalty walking it is cheaper than riding it. At 2 and 10 the same trip is a normal 14-15 km/h
-     * ride. A "minimum cycling" setting that silently converts the trip to a walk is worse than one
-     * that merely discourages it.
+     * penalty walking it is cheaper than riding it. The same trip is a normal 14-15 km/h ride at a
+     * reluctance of 2 and still at 10, so the nonsense is specific to the far end of that old scale.
+     * A "minimum cycling" setting that silently converts the trip to a walk is worse than one that
+     * merely discourages it.
      */
     private const val RELUCTANCE_STEP = 2.0
 
@@ -139,9 +149,9 @@ object Otp2PlanRequestBuilder {
      *
      * An earlier version of this scale ran down to 0.1 and so put its top two stops inside that
      * region: asking for *more* cycling made bike-and-transit itineraries vanish entirely, which is
-     * the exact opposite of the label's promise. The app already has a legible way to say "no
-     * transit" — [org.onebusaway.android.ui.tripplan.VehicleMode.NONE] — and two controls that both
-     * mean that, one of them by accident, is worse than one that does.
+     * the exact opposite of the label's promise. Nothing in the advanced-settings dialog offers
+     * "street only, no transit" on purpose, so a slider stop that silently becomes one is a trap
+     * rather than a feature.
      *
      * (At exactly 1.0 a short trip can still come back street-only with
      * `WALKING_BETTER_THAN_TRANSIT`. That is a correct answer to "walking is as good as transit to
@@ -159,8 +169,9 @@ object Otp2PlanRequestBuilder {
     private const val RELUCTANCE_HIGH = 1.4
 
     /**
-     * The four non-neutral stops: 50 / 10 / (unset) / 1.4 / 1.0. Both scales share one table — the
-     * rider-facing meaning is the same either way, and OTP documents the same 2.0 default for both.
+     * The two stops above the neutral point, completing the scale: **8 / 4 / 2 / 1.4 / 1.0**. Both
+     * scales share one table — the rider-facing meaning is the same either way, and OTP documents the
+     * same 2.0 default for both.
      *
      * Note the inversion: *less* of the mode is a *higher* multiplier. It lives here, at the wire
      * boundary, so the preference enums can stay in plain rider terms.
@@ -169,20 +180,20 @@ object Otp2PlanRequestBuilder {
     private const val RELUCTANCE_LOW = RELUCTANCE_MEDIUM * RELUCTANCE_STEP
     private const val RELUCTANCE_MAXIMUM = RELUCTANCE_FLOOR
 
-    /** The reluctance for [preference], or null at the neutral stop (see [RELUCTANCE_MEDIUM]). */
-    private fun reluctanceFor(preference: WalkPreference): Double? = when (preference) {
+    /** The reluctance for [preference]; every stop states one (see [RELUCTANCE_MEDIUM]). */
+    private fun reluctanceFor(preference: WalkPreference): Double = when (preference) {
         WalkPreference.MINIMUM -> RELUCTANCE_MINIMUM
         WalkPreference.LOW -> RELUCTANCE_LOW
-        WalkPreference.MEDIUM -> null
+        WalkPreference.MEDIUM -> RELUCTANCE_MEDIUM
         WalkPreference.HIGH -> RELUCTANCE_HIGH
         WalkPreference.MAXIMUM -> RELUCTANCE_MAXIMUM
     }
 
-    /** The reluctance for [preference], or null at the neutral stop (see [RELUCTANCE_MEDIUM]). */
-    private fun reluctanceFor(preference: BikePreference): Double? = when (preference) {
+    /** The reluctance for [preference]; every stop states one (see [RELUCTANCE_MEDIUM]). */
+    private fun reluctanceFor(preference: BikePreference): Double = when (preference) {
         BikePreference.MINIMUM -> RELUCTANCE_MINIMUM
         BikePreference.LOW -> RELUCTANCE_LOW
-        BikePreference.MEDIUM -> null
+        BikePreference.MEDIUM -> RELUCTANCE_MEDIUM
         BikePreference.HIGH -> RELUCTANCE_HIGH
         BikePreference.MAXIMUM -> RELUCTANCE_MAXIMUM
     }
@@ -241,9 +252,9 @@ object Otp2PlanRequestBuilder {
     internal fun buildPreferences(
         wheelchairAccessible: Boolean,
         optimizeTransfers: Boolean,
-        walkPreference: WalkPreference = WalkPreference.MEDIUM,
-        cyclingPreference: CyclingPreference = CyclingPreference.DEFAULT,
-        bikePreference: BikePreference = BikePreference.MEDIUM
+        walkPreference: WalkPreference,
+        cyclingPreference: CyclingPreference,
+        bikePreference: BikePreference
     ): PlanPreferencesInput = PlanPreferencesInput(
         accessibility = Optional.present(
             AccessibilityPreferencesInput(
@@ -267,11 +278,13 @@ object Otp2PlanRequestBuilder {
     )
 
     /**
-     * `preferences.street` — walk reluctance, bike reluctance and cycling optimization, each omitted
-     * when the rider left it on its neutral stop ([WalkPreference.MEDIUM]/[BikePreference.MEDIUM]/
-     * [CyclingPreference.DEFAULT]) so the region's own router-config values survive. When *all three*
-     * are neutral the whole `street` block is absent rather than sent empty, which is also exactly
-     * what this app did before these settings existed.
+     * `preferences.street` — walk reluctance, bike reluctance and cycling optimization.
+     *
+     * Both reluctances are always present, including at the neutral stop, so the five-point scales
+     * keep their rider-visible ordering on every region; see [RELUCTANCE_MEDIUM] for that trade-off
+     * and what it costs. `bicycle.optimization` is the exception: [CyclingPreference.DEFAULT] is an
+     * "unset" option rather than the midpoint of a scale, so it is omitted and the region's own
+     * `bicycle.optimization` tuning survives.
      *
      * The cycling half is sent regardless of the selected trip mode: it only bears on legs
      * OTP actually plans by bike, so it is inert on a walk-and-transit plan, and gating it on the
@@ -280,42 +293,30 @@ object Otp2PlanRequestBuilder {
     internal fun buildStreetPreferences(
         walkPreference: WalkPreference,
         cyclingPreference: CyclingPreference,
-        bikePreference: BikePreference = BikePreference.MEDIUM
+        bikePreference: BikePreference
     ): Optional<PlanStreetPreferencesInput?> {
-        val walkReluctance = reluctanceFor(walkPreference)
-        val bikeReluctance = reluctanceFor(bikePreference)
         val optimization = when (cyclingPreference) {
             CyclingPreference.DEFAULT -> null
             CyclingPreference.FASTEST -> CyclingOptimizationType.SHORTEST_DURATION
             CyclingPreference.SAFEST -> CyclingOptimizationType.SAFEST_STREETS
             CyclingPreference.FLATTEST -> CyclingOptimizationType.FLAT_STREETS
         }
-        if (walkReluctance == null && bikeReluctance == null && optimization == null) {
-            return Optional.Absent
-        }
-        // The two bicycle knobs share one input object, so build it once from whichever are set —
-        // choosing an optimization must not pin a reluctance the rider never asked for, or vice versa.
-        val bicycle = if (bikeReluctance == null && optimization == null) {
-            Optional.Absent
-        } else {
-            Optional.present(
-                BicyclePreferencesInput(
-                    reluctance = bikeReluctance?.let { Optional.present(it) } ?: Optional.Absent,
-                    // CyclingOptimizationInput is a @oneOf input — exactly one of `type`/`triangle`
-                    // may be present, and Apollo's generated `init` asserts it. Only `type` is ever
-                    // set here.
-                    optimization = optimization?.let {
-                        Optional.present(CyclingOptimizationInput(type = Optional.present(it)))
-                    } ?: Optional.Absent
-                )
-            )
-        }
         return Optional.present(
             PlanStreetPreferencesInput(
-                walk = walkReluctance?.let {
-                    Optional.present(WalkPreferencesInput(reluctance = Optional.present(it)))
-                } ?: Optional.Absent,
-                bicycle = bicycle
+                walk = Optional.present(
+                    WalkPreferencesInput(reluctance = Optional.present(reluctanceFor(walkPreference)))
+                ),
+                bicycle = Optional.present(
+                    BicyclePreferencesInput(
+                        reluctance = Optional.present(reluctanceFor(bikePreference)),
+                        // CyclingOptimizationInput is a @oneOf input — exactly one of `type`/`triangle`
+                        // may be present, and Apollo's generated `init` asserts it. Only `type` is ever
+                        // set here.
+                        optimization = optimization?.let {
+                            Optional.present(CyclingOptimizationInput(type = Optional.present(it)))
+                        } ?: Optional.Absent
+                    )
+                )
             )
         )
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/OtpTarget.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/OtpTarget.kt
@@ -45,7 +45,6 @@ data class OtpTarget(val baseUrl: String?, val usesOtp2: Boolean) {
          * from the URL shape or a failed request. [baseUrl] is null when neither a custom URL nor a
          * region is available.
          */
-        @JvmStatic
         fun resolve(context: Context): OtpTarget {
             val appContext = context.applicationContext
             val customUrl = customOtpApiUrl(appContext)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/OtpTarget.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/OtpTarget.kt
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.directions.util
+
+import android.content.Context
+import android.net.Uri
+import android.util.Log
+import org.onebusaway.android.R
+import org.onebusaway.android.app.di.PreferencesEntryPoint
+import org.onebusaway.android.app.di.RegionEntryPoint
+
+/**
+ * The OTP server a trip-plan request targets: its [baseUrl] and whether it speaks OTP 2.x GraphQL.
+ *
+ * Lifted out of [TripRequestBuilder] so the two callers that need the protocol answer share one
+ * definition: the builder itself (which endpoint to hit, and which request shape to build) and the
+ * advanced-settings UI (which street preferences are even expressible — OTP2 has no
+ * `maxWalkDistance`, OTP1 has no cycling-optimization knob that doesn't collide with `optimize`).
+ * Duplicating the resolution in the UI would let the dialog and the request disagree about which
+ * server the plan is going to.
+ */
+data class OtpTarget(val baseUrl: String?, val usesOtp2: Boolean) {
+
+    companion object {
+
+        private const val TAG = "OtpTarget"
+
+        /**
+         * Resolves the custom-URL-or-region branch once so a caller's base URL and its protocol
+         * can't disagree (#1780). Protocol selection is explicit — a custom server's manual
+         * `..._is_graphql` preference, or a region publishing an `otpBaseGraphqlUrl` — never sniffed
+         * from the URL shape or a failed request. [baseUrl] is null when neither a custom URL nor a
+         * region is available.
+         */
+        @JvmStatic
+        fun resolve(context: Context): OtpTarget {
+            val appContext = context.applicationContext
+            val customUrl = customOtpApiUrl(appContext)
+            if (customUrl != null) {
+                // Host only, never the whole URL: a hand-entered one can carry credentials in its
+                // userinfo or a token in its query, and Log.d is not stripped from release builds.
+                // The host is the part that actually answers "which server am I talking to?".
+                Log.d(TAG, "Using custom OTP API URL set by user (host: ${Uri.parse(customUrl).host ?: "unparsed"}).")
+                // No [Region] to carry the setting for a custom server, so the user sets it.
+                return OtpTarget(
+                    baseUrl = customUrl,
+                    usesOtp2 = PreferencesEntryPoint.get(appContext)
+                        .getBoolean(R.string.preference_key_otp_api_url_is_graphql, false)
+                )
+            }
+            // No custom URL and no selected region: baseUrl stays null so the caller
+            // (TripPlanRepository) surfaces a "no server selected" error instead of crashing.
+            val region = RegionEntryPoint.get(appContext).currentRegion() ?: return OtpTarget(null, false)
+            // An OTP2 region publishes its GraphQL endpoint separately (a different host than the
+            // OTP1 REST server); route to it when present, else the OTP1 REST base URL. Reads
+            // [org.onebusaway.android.region.Region.usesOtp2] rather than re-deriving it, so a
+            // region's endpoint and its per-protocol capability flags are resolved from one
+            // definition.
+            return OtpTarget(
+                baseUrl = if (region.usesOtp2) region.otpBaseGraphqlUrl else region.otpBaseUrl,
+                usesOtp2 = region.usesOtp2
+            )
+        }
+
+        /**
+         * The user's custom OTP API URL preference, or null if unset/blank — the "is a custom server
+         * configured" signal [resolve] branches on.
+         *
+         * Trimmed so the code matches that description: a whitespace-only value would otherwise read
+         * as a configured server, suppressing region-based selection entirely and then failing every
+         * request. Defence in depth rather than a live bug — the settings screen already trims before
+         * storing (`AdvancedSettingsViewModel.onCustomOtpApiUrlChanged`) — but this is the reader that
+         * decides which server the app talks to, so it should not depend on every writer behaving.
+         */
+        private fun customOtpApiUrl(context: Context): String? = PreferencesEntryPoint.get(context)
+            .getString(context.getString(R.string.preference_key_otp_api_url), null as String?)
+            ?.trim()
+            ?.takeUnless { it.isEmpty() }
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/TripRequestBuilder.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/TripRequestBuilder.kt
@@ -222,22 +222,20 @@ class TripRequestBuilder(context: Context, private val mBundle: Bundle) {
         // OTP expects date/time in this format
         val zoned = d.atZone(ZoneId.systemDefault())
 
-        val parameters = mutableMapOf(
-            "fromPlace" to fromParam,
-            "toPlace" to toParam,
-            "optimize" to getOptimizeType(),
-            "wheelchair" to getWheelchairAccessible().toString(),
-            "arriveBy" to arriveBy.toString(),
-            "date" to DATE_FORMATTER.format(zoned),
-            "time" to TIME_FORMATTER.format(zoned),
-            // Our default. This could be configurable.
-            "showIntermediateStops" to true.toString()
+        return TripPlanRequest(
+            otp1PlanParameters(
+                fromPlace = fromParam,
+                toPlace = toParam,
+                optimize = getOptimizeType(),
+                wheelchair = getWheelchairAccessible(),
+                arriveBy = arriveBy,
+                date = DATE_FORMATTER.format(zoned),
+                time = TIME_FORMATTER.format(zoned),
+                maxWalkDistanceMeters = getMaxWalkDistance(),
+                // Request mode set does not work properly
+                modeString = getModeString()
+            )
         )
-        getMaxWalkDistance()?.let { parameters["maxWalkDistance"] = it.toString() }
-        // Request mode set does not work properly
-        mBundle.getString(MODE_SET)?.let { parameters["mode"] = it }
-
-        return TripPlanRequest(parameters)
     }
 
     /** The OTP server this request targets; see [OtpTarget.resolve]. */
@@ -415,4 +413,45 @@ class TripRequestBuilder(context: Context, private val mBundle: Bundle) {
             return TripRequestBuilder(context, target)
         }
     }
+}
+
+/**
+ * The OTP 1.x REST query parameters, assembled from already-parsed values — the whole of what an OTP1
+ * plan request carries. Split out of [TripRequestBuilder.buildRequest] (which stays the thin
+ * `Bundle`-reading half) so the wire contract is a pure function a JVM unit test can pin, the way
+ * [Otp2PlanRequestBuilder]'s `build*` helpers already are.
+ *
+ * Worth pinning because the two protocols share one builder while accepting disjoint settings: OTP1
+ * takes [maxWalkDistanceMeters], which OTP2 removed from its routing API, and OTP2 takes the street
+ * preferences ([WalkPreference]/[BikePreference]/[CyclingPreference]), which have no OTP1 equivalent
+ * that doesn't collide with [optimize]. Neither protocol may leak the other's settings into a request
+ * the server will reject or silently ignore.
+ *
+ * @param optimize OTP1's single-valued `optimize` — `TRANSFERS` or `QUICK`; the reason
+ * [CyclingPreference] has no OTP1 form, since `SAFE`/`FLAT` here would displace it.
+ * @param maxWalkDistanceMeters omitted when null, i.e. when the rider set no cap.
+ * @param modeString the built mode-set token list, omitted when unset.
+ */
+internal fun otp1PlanParameters(
+    fromPlace: String,
+    toPlace: String,
+    optimize: String,
+    wheelchair: Boolean,
+    arriveBy: Boolean,
+    date: String,
+    time: String,
+    maxWalkDistanceMeters: Double?,
+    modeString: String?
+): Map<String, String> = buildMap {
+    put("fromPlace", fromPlace)
+    put("toPlace", toPlace)
+    put("optimize", optimize)
+    put("wheelchair", wheelchair.toString())
+    put("arriveBy", arriveBy.toString())
+    put("date", date)
+    put("time", time)
+    // Our default. This could be configurable.
+    put("showIntermediateStops", true.toString())
+    maxWalkDistanceMeters?.let { put("maxWalkDistance", it.toString()) }
+    modeString?.let { put("mode", it) }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/TripRequestBuilder.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/TripRequestBuilder.kt
@@ -29,10 +29,12 @@ import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import org.onebusaway.android.R
 import org.onebusaway.android.api.contract.TripPlanRequest
-import org.onebusaway.android.app.di.PreferencesEntryPoint
-import org.onebusaway.android.app.di.RegionEntryPoint
 import org.onebusaway.android.directions.model.TripMode
+import org.onebusaway.android.ui.tripplan.BikePreference
+import org.onebusaway.android.ui.tripplan.CyclingPreference
 import org.onebusaway.android.ui.tripplan.TripModes
+import org.onebusaway.android.ui.tripplan.WalkPreference
+import org.onebusaway.android.ui.tripplan.enumValueOrDefault
 import org.onebusaway.android.util.BikeshareAvailability
 import org.onebusaway.android.util.RegionUtils
 
@@ -96,6 +98,10 @@ class TripRequestBuilder(context: Context, private val mBundle: Bundle) {
 
     fun getWheelchairAccessible(): Boolean = mBundle.getBoolean(WHEELCHAIR_ACCESSIBLE)
 
+    /**
+     * OTP1 only. OTP2 removed `maxWalkDistance` from its routing API, so the OTP2 request path
+     * ignores this and reads [getWalkPreference] instead — see [WalkPreference].
+     */
     fun setMaxWalkDistance(walkDistance: Double): TripRequestBuilder {
         mBundle.putDouble(MAX_WALK_DISTANCE, walkDistance)
         return this
@@ -105,6 +111,36 @@ class TripRequestBuilder(context: Context, private val mBundle: Bundle) {
         val d = mBundle.getDouble(MAX_WALK_DISTANCE)
         return if (d != 0.0 && d != Double.MAX_VALUE) d else null
     }
+
+    /**
+     * OTP2 only (see [WalkPreference]); the OTP1 request path uses [setMaxWalkDistance]. Stored by
+     * enum *name* rather than ordinal so reordering the enum can't silently reinterpret a value
+     * already sitting in a saved Bundle or in preferences.
+     */
+    fun setWalkPreference(preference: WalkPreference): TripRequestBuilder {
+        mBundle.putString(WALK_PREFERENCE, preference.name)
+        return this
+    }
+
+    fun getWalkPreference(): WalkPreference = enumValueOrDefault(mBundle.getString(WALK_PREFERENCE), WalkPreference.MEDIUM)
+
+    /** OTP2 only — OTP1's single `optimize` parameter is already spent on [setOptimizeTransfers]
+     * (see [CyclingPreference]). */
+    fun setCyclingPreference(preference: CyclingPreference): TripRequestBuilder {
+        mBundle.putString(CYCLING_PREFERENCE, preference.name)
+        return this
+    }
+
+    fun getCyclingPreference(): CyclingPreference = enumValueOrDefault(mBundle.getString(CYCLING_PREFERENCE), CyclingPreference.DEFAULT)
+
+    /** OTP2 only — the nearest thing to a bike-distance setting, which no OTP version has
+     * (see [BikePreference]). */
+    fun setBikePreference(preference: BikePreference): TripRequestBuilder {
+        mBundle.putString(BIKE_PREFERENCE, preference.name)
+        return this
+    }
+
+    fun getBikePreference(): BikePreference = enumValueOrDefault(mBundle.getString(BIKE_PREFERENCE), BikePreference.MEDIUM)
 
     // Built in TraverseModeSet does not work properly so we cannot use request.setMode
     // This is built from examining dropdown on the OTP webapp
@@ -204,48 +240,9 @@ class TripRequestBuilder(context: Context, private val mBundle: Bundle) {
         return TripPlanRequest(parameters)
     }
 
-    /**
-     * The user's custom OTP API URL preference, or null if unset/blank — the "is a custom server
-     * configured" signal [otpTarget] branches on.
-     */
-    private val customOtpApiUrl: String?
-        get() = PreferencesEntryPoint.get(mContext)
-            .getString(mContext.getString(R.string.preference_key_otp_api_url), null as String?)
-            ?.takeUnless { TextUtils.isEmpty(it) }
-
-    /** The OTP server a request targets: its [baseUrl] and whether it speaks OTP 2.x GraphQL. */
-    private data class OtpTarget(val baseUrl: String?, val usesOtp2: Boolean)
-
-    /**
-     * Resolves the custom-URL-or-region branch once so [formattedOtpBaseUrl] and [usesOtp2] can't
-     * disagree (#1780). Protocol selection is explicit — a custom server's manual `..._is_graphql`
-     * preference, or a region publishing an `otpBaseGraphqlUrl` — never sniffed from the URL shape
-     * or a failed request. [baseUrl] is null when neither a custom URL nor a region is available.
-     */
+    /** The OTP server this request targets; see [OtpTarget.resolve]. */
     private val otpTarget: OtpTarget
-        get() {
-            val customUrl = customOtpApiUrl
-            if (customUrl != null) {
-                Log.d(TAG, "Using custom OTP API URL set by user '$customUrl'.")
-                // No [Region] to carry the setting for a custom server, so the user sets it.
-                return OtpTarget(
-                    baseUrl = customUrl,
-                    usesOtp2 = PreferencesEntryPoint.get(mContext)
-                        .getBoolean(R.string.preference_key_otp_api_url_is_graphql, false)
-                )
-            }
-            // No custom URL and no selected region: baseUrl stays null so the caller
-            // (TripPlanRepository) surfaces a "no server selected" error instead of crashing.
-            val region = RegionEntryPoint.get(mContext).currentRegion() ?: return OtpTarget(null, false)
-            // An OTP2 region publishes its GraphQL endpoint separately (a different host than the
-            // OTP1 REST server); route to it when present, else the OTP1 REST base URL. Reads
-            // [Region.usesOtp2] rather than re-deriving it, so a region's endpoint and its
-            // per-protocol capability flags are resolved from one definition.
-            return OtpTarget(
-                baseUrl = if (region.usesOtp2) region.otpBaseGraphqlUrl else region.otpBaseUrl,
-                usesOtp2 = region.usesOtp2
-            )
-        }
+        get() = OtpTarget.resolve(mContext)
 
     /**
      * The [otpTarget] base URL with a scheme ensured and formatted, or null if no server is
@@ -313,6 +310,9 @@ class TripRequestBuilder(context: Context, private val mBundle: Bundle) {
         target.putBoolean(OPTIMIZE_TRANSFERS, getOptimizeTransfers())
         target.putBoolean(WHEELCHAIR_ACCESSIBLE, getWheelchairAccessible())
         getMaxWalkDistance()?.let { target.putDouble(MAX_WALK_DISTANCE, it) }
+        target.putString(WALK_PREFERENCE, getWalkPreference().name)
+        target.putString(CYCLING_PREFERENCE, getCyclingPreference().name)
+        target.putString(BIKE_PREFERENCE, getBikePreference().name)
         target.putString(MODE_SET, getModeString())
         dateTime?.let { target.putLong(DATE_TIME, it.toEpochMilli()) }
     }
@@ -335,6 +335,9 @@ class TripRequestBuilder(context: Context, private val mBundle: Bundle) {
         target.putBoolean(OPTIMIZE_TRANSFERS, getOptimizeTransfers())
         target.putBoolean(WHEELCHAIR_ACCESSIBLE, getWheelchairAccessible())
         getMaxWalkDistance()?.let { target.putDouble(MAX_WALK_DISTANCE, it) }
+        target.putString(WALK_PREFERENCE, getWalkPreference().name)
+        target.putString(CYCLING_PREFERENCE, getCyclingPreference().name)
+        target.putString(BIKE_PREFERENCE, getBikePreference().name)
         target.putString(MODE_SET, getModeString())
         dateTime?.let { target.putLong(DATE_TIME, it.toEpochMilli()) }
     }
@@ -366,6 +369,9 @@ class TripRequestBuilder(context: Context, private val mBundle: Bundle) {
         private const val OPTIMIZE_TRANSFERS = ".OPTIMIZE_TRANSFERS"
         private const val WHEELCHAIR_ACCESSIBLE = ".WHEELCHAIR_ACCESSIBLE"
         private const val MAX_WALK_DISTANCE = ".MAX_WALK_DISTANCE"
+        private const val WALK_PREFERENCE = ".WALK_PREFERENCE"
+        private const val CYCLING_PREFERENCE = ".CYCLING_PREFERENCE"
+        private const val BIKE_PREFERENCE = ".BIKE_PREFERENCE"
         private const val MODE_SET = ".MODE_SET"
         private const val DATE_TIME = ".DATE_TIME"
 
@@ -399,6 +405,9 @@ class TripRequestBuilder(context: Context, private val mBundle: Bundle) {
             target.putBoolean(OPTIMIZE_TRANSFERS, bundle.getBoolean(OPTIMIZE_TRANSFERS))
             target.putBoolean(WHEELCHAIR_ACCESSIBLE, bundle.getBoolean(WHEELCHAIR_ACCESSIBLE))
             target.putDouble(MAX_WALK_DISTANCE, bundle.getDouble(MAX_WALK_DISTANCE))
+            target.putString(WALK_PREFERENCE, bundle.getString(WALK_PREFERENCE))
+            target.putString(CYCLING_PREFERENCE, bundle.getString(CYCLING_PREFERENCE))
+            target.putString(BIKE_PREFERENCE, bundle.getString(BIKE_PREFERENCE))
 
             target.putString(MODE_SET, bundle.getString(MODE_SET))
             target.putLong(DATE_TIME, bundle.getLong(DATE_TIME))

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
@@ -52,6 +52,7 @@ import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Slider
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -73,8 +74,10 @@ import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.liveRegion
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -83,10 +86,12 @@ import com.google.android.material.timepicker.MaterialTimePicker
 import com.google.android.material.timepicker.TimeFormat
 import java.util.Calendar
 import java.util.TimeZone
+import kotlin.math.roundToInt
 import org.onebusaway.android.R
 import org.onebusaway.android.app.di.LocationEntryPoint
 import org.onebusaway.android.directions.model.TripItinerary
 import org.onebusaway.android.directions.util.ConversionUtils
+import org.onebusaway.android.directions.util.OtpTarget
 import org.onebusaway.android.map.ShowRouteRequest
 import org.onebusaway.android.ui.arrivals.ArrivalsUiState
 import org.onebusaway.android.ui.arrivals.ArrivalsViewModel
@@ -105,6 +110,8 @@ import org.onebusaway.android.ui.home.arrivals.rememberArrivalsSession
 import org.onebusaway.android.ui.icons.AppIcons
 import org.onebusaway.android.ui.nav.ReminderEditorArgs
 import org.onebusaway.android.ui.tripplan.AdvancedSettings
+import org.onebusaway.android.ui.tripplan.BikePreference
+import org.onebusaway.android.ui.tripplan.CyclingPreference
 import org.onebusaway.android.ui.tripplan.TripEndpoint
 import org.onebusaway.android.ui.tripplan.TripModes
 import org.onebusaway.android.ui.tripplan.TripPlanError
@@ -112,6 +119,7 @@ import org.onebusaway.android.ui.tripplan.TripPlanForm
 import org.onebusaway.android.ui.tripplan.TripPlanFormState
 import org.onebusaway.android.ui.tripplan.TripPlanParams
 import org.onebusaway.android.ui.tripplan.TripPlanViewModel
+import org.onebusaway.android.ui.tripplan.WalkPreference
 import org.onebusaway.android.ui.tripresults.RouteLegRef
 import org.onebusaway.android.ui.tripresults.RouteStopRef
 import org.onebusaway.android.ui.tripresults.TripResultsSheet
@@ -607,6 +615,12 @@ private fun DirectionsAdvancedSettingsDialog(
             all.filter { it.second != TripModes.BIKESHARE && it.second != TripModes.TRANSIT_AND_BIKE }
         }
     }
+    // Which street preferences this region's OTP server can actually act on. OTP2 deleted
+    // `maxWalkDistance` from its routing API, so the distance field would be silently ignored there
+    // (#1780 wired the OTP2 path without it); OTP1 in turn has no cycling-optimization knob that
+    // doesn't collide with the `optimize` parameter "Minimize transfers" already uses. Rather than
+    // show a control the server will drop, each protocol gets the one it honours.
+    val usesOtp2 = remember { OtpTarget.resolve(context).usesOtp2 }
     val current = remember { viewModel.formState.value }
     var selectedMode by remember {
         mutableIntStateOf(
@@ -622,12 +636,31 @@ private fun DirectionsAdvancedSettingsDialog(
             }.orEmpty()
         )
     }
-    var expanded by remember { mutableStateOf(false) }
+    var walkPreference by remember { mutableStateOf(current.walkPreference) }
+    var cyclingPreference by remember { mutableStateOf(current.cyclingPreference) }
+    var bikePreference by remember { mutableStateOf(current.bikePreference) }
+
+    // One shared five-stop label set, ordered least -> most, matching the enums' declaration order
+    // so the slider index maps straight onto them.
+    // Generated from the enums rather than written out, so the slider's index->label mapping can't
+    // drift from the declaration order it depends on. The `when`s below are exhaustive, so adding a
+    // stop to either enum is a compile error here rather than a silently mislabelled slider.
+    val walkStopLabels = WalkPreference.entries.map { it.label() }
+    val bikeStopLabels = BikePreference.entries.map { it.label() }
+    val cyclingOptions = listOf(
+        stringResource(R.string.cycling_preference_default) to CyclingPreference.DEFAULT,
+        stringResource(R.string.cycling_preference_fastest) to CyclingPreference.FASTEST,
+        stringResource(R.string.cycling_preference_safest) to CyclingPreference.SAFEST,
+        stringResource(R.string.cycling_preference_flattest) to CyclingPreference.FLATTEST
+    )
 
     // Preference keys resolved in composition (stringResource) so the confirm handler doesn't read
     // resource values off LocalContext.current (lint: LocalContextGetResourceValueCall).
     val prefKeyTravelBy = stringResource(R.string.preference_key_trip_plan_travel_by)
     val prefKeyMaxWalk = stringResource(R.string.preference_key_trip_plan_maximum_walking_distance)
+    val prefKeyWalkPreference = stringResource(R.string.preference_key_trip_plan_walk_preference)
+    val prefKeyCyclingPreference = stringResource(R.string.preference_key_trip_plan_cycling_preference)
+    val prefKeyBikePreference = stringResource(R.string.preference_key_trip_plan_bike_preference)
     val prefKeyMinimizeTransfers = stringResource(R.string.preference_key_trip_plan_minimize_transfers)
     val prefKeyAvoidStairs = stringResource(R.string.preference_key_trip_plan_avoid_stairs)
 
@@ -635,45 +668,61 @@ private fun DirectionsAdvancedSettingsDialog(
         onDismissRequest = onDismiss,
         title = { Text(stringResource(R.string.trip_plan_advanced_settings)) },
         text = {
-            Column {
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Text(stringResource(R.string.travel_by_label))
-                    Spacer(Modifier.width(8.dp))
-                    Box {
-                        TextButton(onClick = { expanded = true }) {
-                            Text(options.firstOrNull { it.second == selectedMode }?.first.orEmpty())
-                        }
-                        DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
-                            options.forEach { (label, code) ->
-                                DropdownMenuItem(
-                                    text = { Text(label) },
-                                    onClick = {
-                                        selectedMode = code
-                                        expanded = false
-                                    }
-                                )
-                            }
-                        }
-                    }
-                }
-                Row(
-                    modifier = Modifier.padding(top = 8.dp),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Text(stringResource(R.string.maximum_walk_distance), modifier = Modifier.weight(1f))
-                    OutlinedTextField(
-                        value = maxWalk,
-                        onValueChange = { new -> maxWalk = new.filter { it.isDigit() } },
-                        singleLine = true,
-                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-                        modifier = Modifier.width(96.dp)
+            // Scrollable: the OTP2 branch adds two sliders and a dropdown on top of the existing
+            // rows, and AlertDialog content doesn't scroll on its own — at large font scales the
+            // switches at the bottom would otherwise be unreachable.
+            Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
+                PreferenceDropdownRow(
+                    label = stringResource(R.string.travel_by_label),
+                    options = options,
+                    selected = selectedMode,
+                    onSelected = { selectedMode = it }
+                )
+                if (usesOtp2) {
+                    PreferenceSliderRow(
+                        label = stringResource(R.string.walk_preference_label),
+                        stopLabels = walkStopLabels,
+                        selectedIndex = walkPreference.ordinal,
+                        onSelectedIndex = { walkPreference = WalkPreference.entries[it] },
+                        modifier = Modifier.padding(top = 8.dp)
                     )
-                    Spacer(Modifier.width(4.dp))
-                    Text(
-                        stringResource(
-                            if (imperial) R.string.feet_abbreviation else R.string.meters_abbreviation
+                    // Only meaningful when the plan can contain a bike leg at all.
+                    if (selectedMode == TripModes.TRANSIT_AND_BIKE || selectedMode == TripModes.BIKESHARE) {
+                        PreferenceSliderRow(
+                            label = stringResource(R.string.bike_preference_label),
+                            stopLabels = bikeStopLabels,
+                            selectedIndex = bikePreference.ordinal,
+                            onSelectedIndex = { bikePreference = BikePreference.entries[it] },
+                            modifier = Modifier.padding(top = 8.dp)
                         )
-                    )
+                        PreferenceDropdownRow(
+                            label = stringResource(R.string.cycling_preference_label),
+                            options = cyclingOptions,
+                            selected = cyclingPreference,
+                            onSelected = { cyclingPreference = it },
+                            modifier = Modifier.padding(top = 8.dp)
+                        )
+                    }
+                } else {
+                    Row(
+                        modifier = Modifier.padding(top = 8.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(stringResource(R.string.maximum_walk_distance), modifier = Modifier.weight(1f))
+                        OutlinedTextField(
+                            value = maxWalk,
+                            onValueChange = { new -> maxWalk = new.filter { it.isDigit() } },
+                            singleLine = true,
+                            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                            modifier = Modifier.width(96.dp)
+                        )
+                        Spacer(Modifier.width(4.dp))
+                        Text(
+                            stringResource(
+                                if (imperial) R.string.feet_abbreviation else R.string.meters_abbreviation
+                            )
+                        )
+                    }
                 }
                 SwitchRow(
                     label = stringResource(R.string.minimize_transfers),
@@ -693,14 +742,136 @@ private fun DirectionsAdvancedSettingsDialog(
                     if (imperial) ConversionUtils.feetToMeters(it) else it
                 }
                 viewModel.applyAdvancedSettings(
-                    AdvancedSettings(selectedMode, maxWalkMeters, minimizeTransfers, wheelchair)
+                    AdvancedSettings(
+                        modeId = selectedMode,
+                        maxWalkMeters = maxWalkMeters,
+                        optimizeTransfers = minimizeTransfers,
+                        wheelchair = wheelchair,
+                        walkPreference = walkPreference,
+                        cyclingPreference = cyclingPreference,
+                        bikePreference = bikePreference
+                    )
                 )
                 PreferenceUtils.saveInt(prefKeyTravelBy, selectedMode)
+                // Every option is saved whether or not this region's protocol showed its control, so
+                // the value survives a move to a region that can use it (see [AdvancedSettings]).
                 PreferenceUtils.saveDouble(prefKeyMaxWalk, maxWalkMeters ?: Double.MAX_VALUE)
+                PreferenceUtils.saveString(prefKeyWalkPreference, walkPreference.name)
+                PreferenceUtils.saveString(prefKeyCyclingPreference, cyclingPreference.name)
+                PreferenceUtils.saveString(prefKeyBikePreference, bikePreference.name)
                 PreferenceUtils.saveBoolean(prefKeyMinimizeTransfers, minimizeTransfers)
                 PreferenceUtils.saveBoolean(prefKeyAvoidStairs, wheelchair)
                 onDismiss()
             }) { Text(stringResource(R.string.ok)) }
         }
     )
+}
+
+/** The rider-facing name of this stop. Exhaustive so a new stop can't be added without a label. */
+@Composable
+private fun WalkPreference.label(): String = when (this) {
+    WalkPreference.MINIMUM -> stringResource(R.string.street_preference_minimum)
+    WalkPreference.LOW -> stringResource(R.string.street_preference_low)
+    WalkPreference.MEDIUM -> stringResource(R.string.street_preference_medium)
+    WalkPreference.HIGH -> stringResource(R.string.street_preference_high)
+    WalkPreference.MAXIMUM -> stringResource(R.string.street_preference_maximum)
+}
+
+/** As [WalkPreference.label]; the two scales share one set of stop names. */
+@Composable
+private fun BikePreference.label(): String = when (this) {
+    BikePreference.MINIMUM -> stringResource(R.string.street_preference_minimum)
+    BikePreference.LOW -> stringResource(R.string.street_preference_low)
+    BikePreference.MEDIUM -> stringResource(R.string.street_preference_medium)
+    BikePreference.HIGH -> stringResource(R.string.street_preference_high)
+    BikePreference.MAXIMUM -> stringResource(R.string.street_preference_maximum)
+}
+
+/**
+ * A labelled discrete slider for an ordinal preference: the label with the current stop's name
+ * right-aligned above the track, and the two extremes named beneath it.
+ *
+ * [stopLabels] is ordered least → most and its indices are the enum's `ordinal`s, so the slider
+ * position *is* the enum value — no separate value table to keep in step. [Slider.steps] counts the
+ * stops *between* the ends, hence `size - 2`.
+ */
+@Composable
+private fun PreferenceSliderRow(
+    label: String,
+    stopLabels: List<String>,
+    selectedIndex: Int,
+    onSelectedIndex: (Int) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(label, modifier = Modifier.weight(1f))
+            Text(
+                stopLabels.getOrElse(selectedIndex) { "" },
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.primary
+            )
+        }
+        Slider(
+            value = selectedIndex.toFloat(),
+            onValueChange = { onSelectedIndex(it.roundToInt().coerceIn(stopLabels.indices)) },
+            valueRange = 0f..(stopLabels.size - 1).toFloat(),
+            steps = stopLabels.size - 2,
+            // The stop name lives in a sibling Text, so without these a screen reader announces the
+            // raw position ("2 of 4") and nothing about what the control is.
+            modifier = Modifier.semantics {
+                contentDescription = label
+                stateDescription = stopLabels.getOrElse(selectedIndex) { "" }
+            }
+        )
+        Row(modifier = Modifier.fillMaxWidth()) {
+            Text(
+                stopLabels.first(),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(Modifier.weight(1f))
+            Text(
+                stopLabels.last(),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+/**
+ * A labelled dropdown row in the advanced-settings dialog: the label, then a button showing the
+ * selected option's label that opens the menu. [options] pairs each display label with the value it
+ * selects; the button falls back to blank if [selected] isn't among them.
+ */
+@Composable
+private fun <T> PreferenceDropdownRow(
+    label: String,
+    options: List<Pair<String, T>>,
+    selected: T,
+    onSelected: (T) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var expanded by remember { mutableStateOf(false) }
+    Row(modifier = modifier, verticalAlignment = Alignment.CenterVertically) {
+        Text(label)
+        Spacer(Modifier.width(8.dp))
+        Box {
+            TextButton(onClick = { expanded = true }) {
+                Text(options.firstOrNull { it.second == selected }?.first.orEmpty())
+            }
+            DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+                options.forEach { (optionLabel, value) ->
+                    DropdownMenuItem(
+                        text = { Text(optionLabel) },
+                        onClick = {
+                            onSelected(value)
+                            expanded = false
+                        }
+                    )
+                }
+            }
+        }
+    }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
@@ -87,6 +87,7 @@ import com.google.android.material.timepicker.TimeFormat
 import java.util.Calendar
 import java.util.TimeZone
 import kotlin.math.roundToInt
+import kotlin.math.roundToLong
 import org.onebusaway.android.R
 import org.onebusaway.android.app.di.LocationEntryPoint
 import org.onebusaway.android.directions.model.TripItinerary
@@ -629,10 +630,13 @@ private fun DirectionsAdvancedSettingsDialog(
     }
     var minimizeTransfers by remember { mutableStateOf(current.optimizeTransfers) }
     var wheelchair by remember { mutableStateOf(current.wheelchair) }
+    // Rounded, not truncated: the field's value is converted back to metres on confirm, so
+    // truncating here would shave a little off the stored distance every time the dialog is opened
+    // and confirmed (1600 m -> 5249 ft -> 1599.8 m -> 5248 ft -> …).
     var maxWalk by remember {
         mutableStateOf(
             current.maxWalkMeters?.let {
-                (if (imperial) ConversionUtils.metersToFeet(it) else it).toLong().toString()
+                (if (imperial) ConversionUtils.metersToFeet(it) else it).roundToLong().toString()
             }.orEmpty()
         )
     }
@@ -640,11 +644,10 @@ private fun DirectionsAdvancedSettingsDialog(
     var cyclingPreference by remember { mutableStateOf(current.cyclingPreference) }
     var bikePreference by remember { mutableStateOf(current.bikePreference) }
 
-    // One shared five-stop label set, ordered least -> most, matching the enums' declaration order
-    // so the slider index maps straight onto them.
-    // Generated from the enums rather than written out, so the slider's index->label mapping can't
-    // drift from the declaration order it depends on. The `when`s below are exhaustive, so adding a
-    // stop to either enum is a compile error here rather than a silently mislabelled slider.
+    // One shared five-stop label set, ordered least -> most. Generated from the enums rather than
+    // written out, so the slider's index->label mapping can't drift from the declaration order it
+    // depends on, and the `when`s below are exhaustive, so adding a stop to either enum is a compile
+    // error here rather than a silently mislabelled slider.
     val walkStopLabels = WalkPreference.entries.map { it.label() }
     val bikeStopLabels = BikePreference.entries.map { it.label() }
     val cyclingOptions = listOf(
@@ -738,8 +741,15 @@ private fun DirectionsAdvancedSettingsDialog(
         },
         confirmButton = {
             TextButton(onClick = {
-                val maxWalkMeters: Double? = maxWalk.takeIf { it.isNotEmpty() }?.toDouble()?.let {
-                    if (imperial) ConversionUtils.feetToMeters(it) else it
+                // On an OTP2 region the metres field was never shown, so there is no edited value to
+                // read: carry the stored one through untouched rather than round-tripping it through
+                // an unshown field, which would erode a setting the rider can't see.
+                val maxWalkMeters: Double? = if (usesOtp2) {
+                    current.maxWalkMeters
+                } else {
+                    maxWalk.takeIf { it.isNotEmpty() }?.toDouble()?.let {
+                        if (imperial) ConversionUtils.feetToMeters(it) else it
+                    }
                 }
                 viewModel.applyAdvancedSettings(
                     AdvancedSettings(

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/AdvancedSettingsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/AdvancedSettingsRepository.kt
@@ -53,8 +53,8 @@ class DefaultAdvancedSettingsRepository @Inject constructor(
             context.getString(R.string.preference_key_trip_plan_avoid_stairs),
             false
         )
-        // Stored by enum name; an absent or unrecognized value falls back to "let the server
-        // decide" (see enumValueOrDefault).
+        // Stored by enum name; an absent or unrecognized value falls back to the neutral stop
+        // (see enumValueOrDefault).
         val walkPreference = enumValueOrDefault(
             PreferenceUtils.getString(context.getString(R.string.preference_key_trip_plan_walk_preference)),
             WalkPreference.MEDIUM

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/AdvancedSettingsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/AdvancedSettingsRepository.kt
@@ -53,11 +53,28 @@ class DefaultAdvancedSettingsRepository @Inject constructor(
             context.getString(R.string.preference_key_trip_plan_avoid_stairs),
             false
         )
+        // Stored by enum name; an absent or unrecognized value falls back to "let the server
+        // decide" (see enumValueOrDefault).
+        val walkPreference = enumValueOrDefault(
+            PreferenceUtils.getString(context.getString(R.string.preference_key_trip_plan_walk_preference)),
+            WalkPreference.MEDIUM
+        )
+        val cyclingPreference = enumValueOrDefault(
+            PreferenceUtils.getString(context.getString(R.string.preference_key_trip_plan_cycling_preference)),
+            CyclingPreference.DEFAULT
+        )
+        val bikePreference = enumValueOrDefault(
+            PreferenceUtils.getString(context.getString(R.string.preference_key_trip_plan_bike_preference)),
+            BikePreference.MEDIUM
+        )
         return AdvancedSettings(
             modeId = modeId,
             maxWalkMeters = maxWalk.takeIf { it != 0.0 && it != Double.MAX_VALUE },
             optimizeTransfers = optimize,
-            wheelchair = wheelchair
+            wheelchair = wheelchair,
+            walkPreference = walkPreference,
+            cyclingPreference = cyclingPreference,
+            bikePreference = bikePreference
         )
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/StreetPreferences.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/StreetPreferences.kt
@@ -36,7 +36,7 @@ enum class WalkPreference {
     MINIMUM,
     LOW,
 
-    /** The neutral point — sends nothing, so the region's own configured reluctance applies. */
+    /** The neutral point — OTP's own documented default reluctance, stated explicitly. */
     MEDIUM,
     HIGH,
     MAXIMUM
@@ -59,7 +59,7 @@ enum class BikePreference {
     MINIMUM,
     LOW,
 
-    /** The neutral point — sends nothing, so the region's own configured reluctance applies. */
+    /** The neutral point — OTP's own documented default reluctance, stated explicitly. */
     MEDIUM,
     HIGH,
     MAXIMUM
@@ -97,9 +97,9 @@ enum class CyclingPreference {
 /**
  * The [T] whose name is [name], or [default] when [name] is null or unrecognized.
  *
- * Both preferences are persisted (and carried through Bundles) by enum *name*, so reordering an
- * enum can't reinterpret a stored value the way an ordinal would. An unrecognized name means the
- * value was written by a build that knows an option this one doesn't — falling back to the
- * "send nothing, let the server decide" default is the only reading that can't misroute.
+ * Every one of these preferences is persisted (and carried through Bundles) by enum *name*, so
+ * reordering an enum can't reinterpret a stored value the way an ordinal would. An unrecognized name
+ * means the value was written by a build that knows an option this one doesn't — falling back to the
+ * neutral/unset default is the only reading that can't misroute.
  */
 internal inline fun <reified T : Enum<T>> enumValueOrDefault(name: String?, default: T): T = enumValues<T>().firstOrNull { it.name == name } ?: default

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/StreetPreferences.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/StreetPreferences.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.tripplan
+
+/**
+ * How much walking the rider wants in an itinerary, on a five-point scale.
+ *
+ * Named for the **amount of walking**, which is what the rider is choosing; the OTP field behind it
+ * (`walk.reluctance`) runs the other way, so [MINIMUM] walking is the *highest* reluctance and
+ * [MAXIMUM] the lowest. Keeping the scale in rider terms and the inversion at the wire boundary
+ * (`Otp2PlanRequestBuilder`) means no call site has to remember which direction the number goes.
+ *
+ * The OTP2 replacement for the OTP1-only "maximum walk distance" field: OTP2 removed
+ * `maxWalkDistance` from the routing API outright (its own migration guide names `walkReluctance` as
+ * the way to "reduce the amount of walking … in returned itineraries", with the surviving hard caps
+ * living in the *server's* `router-config.json` as `maxAccessEgressDurationForMode`, not in a
+ * request). So on an OTP2 region the rider states a preference, not a cap — and the UI says so.
+ *
+ * Deliberately carries no numbers: the reluctance values live at the wire boundary with their
+ * sourcing, so this type stays a plain statement of intent that the OTP1 path can ignore.
+ */
+enum class WalkPreference {
+    MINIMUM,
+    LOW,
+
+    /** The neutral point — sends nothing, so the region's own configured reluctance applies. */
+    MEDIUM,
+    HIGH,
+    MAXIMUM
+}
+
+/**
+ * How much cycling the rider wants in an itinerary, on the same five-point scale as [WalkPreference]
+ * and inverted the same way ([MINIMUM] cycling is the highest `bicycle.reluctance`).
+ *
+ * The closest thing there is to "how far will it route me by bike": **no** OTP version has ever had a
+ * `maxBikeDistance`, and OTP2's routing API carries no street-leg distance or duration cap at all
+ * (the only hard limit, `accessEgress.maxDurationForMode`, is server-side `router-config.json`). So
+ * this does not raise a ceiling — it stops the router preferring a transit leg over a longer ride,
+ * which is what actually lengthens bike legs in practice.
+ *
+ * If the region's server caps bike access/egress duration, that cap binds first and no value here
+ * gets past it; the symptom is bike legs bunching just under a fixed number regardless of setting.
+ */
+enum class BikePreference {
+    MINIMUM,
+    LOW,
+
+    /** The neutral point — sends nothing, so the region's own configured reluctance applies. */
+    MEDIUM,
+    HIGH,
+    MAXIMUM
+}
+
+/**
+ * What a cycling leg should be optimized for — OTP2's `CyclingOptimizationType`, as rider intent.
+ *
+ * Distinct from [BikePreference]: this picks *which streets* a bike leg uses, not *how much* cycling
+ * the router is willing to put in the itinerary.
+ *
+ * OTP2-only on purpose. OTP1 expresses the same idea through its single-valued `optimize` query
+ * parameter, which this app already spends on `TRANSFERS` vs `QUICK` (the "minimize transfers"
+ * switch, see `TripRequestBuilder.getOptimizeType`); sending `SAFE`/`FLAT` there would silently
+ * switch minimize-transfers off. Rather than have one setting quietly disable another, the OTP1 path
+ * leaves cycling optimization alone.
+ *
+ * [DEFAULT] omits the field entirely rather than naming OTP's documented default (`safe-streets`),
+ * so a region that tuned `bicycle.optimization` in its own router config keeps that tuning.
+ */
+enum class CyclingPreference {
+    /** Send nothing; the region's own configured cycling optimization applies. */
+    DEFAULT,
+
+    /** Shortest duration, ignoring how safe the streets are. */
+    FASTEST,
+
+    /** The safest streets, weighted even above OTP's default `safe-streets`. */
+    SAFEST,
+
+    /** Flattest route — emphasizes avoiding elevation change over safety or duration. */
+    FLATTEST
+}
+
+/**
+ * The [T] whose name is [name], or [default] when [name] is null or unrecognized.
+ *
+ * Both preferences are persisted (and carried through Bundles) by enum *name*, so reordering an
+ * enum can't reinterpret a stored value the way an ordinal would. An unrecognized name means the
+ * value was written by a build that knows an option this one doesn't — falling back to the
+ * "send nothing, let the server decide" default is the only reading that can't misroute.
+ */
+internal inline fun <reified T : Enum<T>> enumValueOrDefault(name: String?, default: T): T = enumValues<T>().firstOrNull { it.name == name } ?: default

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanFormState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanFormState.kt
@@ -78,12 +78,23 @@ sealed interface TripEndpoint {
     data class MapPoint(override val lat: Double, override val lon: Double) : TripEndpoint
 }
 
-/** The advanced trip options, persisted in preferences by the host. */
+/**
+ * The advanced trip options, persisted in preferences by the host.
+ *
+ * [maxWalkMeters] and [walkPreference] express the same wish through the two protocols' different
+ * vocabularies — a hard cap OTP1 accepts, a reluctance OTP2 accepts — and neither server sees the
+ * other's field. Both are carried (and persisted) at all times so switching regions doesn't discard
+ * whichever one the previous region used; the advanced-settings dialog shows only the one the
+ * current region's server can act on.
+ */
 data class AdvancedSettings(
     val modeId: Int,
     val maxWalkMeters: Double?,
     val optimizeTransfers: Boolean,
-    val wheelchair: Boolean
+    val wheelchair: Boolean,
+    val walkPreference: WalkPreference = WalkPreference.MEDIUM,
+    val cyclingPreference: CyclingPreference = CyclingPreference.DEFAULT,
+    val bikePreference: BikePreference = BikePreference.MEDIUM
 )
 
 /** A fully-specified plan request handed to [TripPlanRepository]. */
@@ -95,7 +106,10 @@ data class TripPlanParams(
     val modeId: Int,
     val wheelchair: Boolean,
     val optimizeTransfers: Boolean,
-    val maxWalkMeters: Double?
+    val maxWalkMeters: Double?,
+    val walkPreference: WalkPreference = WalkPreference.MEDIUM,
+    val cyclingPreference: CyclingPreference = CyclingPreference.DEFAULT,
+    val bikePreference: BikePreference = BikePreference.MEDIUM
 )
 
 /** The trip-plan form (origin/destination, when, and the advanced options). */
@@ -111,7 +125,10 @@ data class TripPlanFormState(
     val modeId: Int = 0,
     val wheelchair: Boolean = false,
     val optimizeTransfers: Boolean = false,
-    val maxWalkMeters: Double? = null
+    val maxWalkMeters: Double? = null,
+    val walkPreference: WalkPreference = WalkPreference.MEDIUM,
+    val cyclingPreference: CyclingPreference = CyclingPreference.DEFAULT,
+    val bikePreference: BikePreference = BikePreference.MEDIUM
 ) {
     /** Mirrors TripRequestBuilder.ready(): both endpoints must resolve to coordinates. */
     val canSubmit: Boolean
@@ -119,7 +136,15 @@ data class TripPlanFormState(
 
     /** The current advanced options, for persistence by the host. */
     val advancedSettings: AdvancedSettings
-        get() = AdvancedSettings(modeId, maxWalkMeters, optimizeTransfers, wheelchair)
+        get() = AdvancedSettings(
+            modeId = modeId,
+            maxWalkMeters = maxWalkMeters,
+            optimizeTransfers = optimizeTransfers,
+            wheelchair = wheelchair,
+            walkPreference = walkPreference,
+            cyclingPreference = cyclingPreference,
+            bikePreference = bikePreference
+        )
 
     /** Builds the plan request; only call when [canSubmit] is true. */
     fun toParams(): TripPlanParams = TripPlanParams(
@@ -130,7 +155,10 @@ data class TripPlanFormState(
         modeId = modeId,
         wheelchair = wheelchair,
         optimizeTransfers = optimizeTransfers,
-        maxWalkMeters = maxWalkMeters
+        maxWalkMeters = maxWalkMeters,
+        walkPreference = walkPreference,
+        cyclingPreference = cyclingPreference,
+        bikePreference = bikePreference
     )
 }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanRepository.kt
@@ -270,7 +270,8 @@ internal fun modeStringRequestsBikeRental(modeString: String?, bikeRentalToken: 
 /**
  * Assembles a [TripRequestBuilder] from these [TripPlanParams]. Shared by the UI plan path
  * ([DefaultTripPlanRepository]) and the trip-plan-change monitor, so the request that produced the
- * results is re-planned identically (same modes / wheelchair / optimize / max-walk).
+ * results is re-planned identically (same modes / wheelchair / optimize / max-walk / street
+ * preferences).
  */
 internal fun TripPlanParams.toRequestBuilder(context: Context): TripRequestBuilder {
     val params = this

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanRepository.kt
@@ -285,6 +285,9 @@ internal fun TripPlanParams.toRequestBuilder(context: Context): TripRequestBuild
         setWheelchairAccessible(params.wheelchair)
         setOptimizeTransfers(params.optimizeTransfers)
         params.maxWalkMeters?.let { setMaxWalkDistance(it) }
+        setWalkPreference(params.walkPreference)
+        setCyclingPreference(params.cyclingPreference)
+        setBikePreference(params.bikePreference)
     }
 }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanViewModel.kt
@@ -88,7 +88,10 @@ class TripPlanViewModel @Inject constructor(
             modeId = initialSettings.modeId,
             maxWalkMeters = initialSettings.maxWalkMeters,
             optimizeTransfers = initialSettings.optimizeTransfers,
-            wheelchair = initialSettings.wheelchair
+            wheelchair = initialSettings.wheelchair,
+            walkPreference = initialSettings.walkPreference,
+            cyclingPreference = initialSettings.cyclingPreference,
+            bikePreference = initialSettings.bikePreference
         )
     )
     val formState: StateFlow<TripPlanFormState> = _formState.asStateFlow()
@@ -238,7 +241,10 @@ class TripPlanViewModel @Inject constructor(
                 modeId = settings.modeId,
                 maxWalkMeters = settings.maxWalkMeters,
                 optimizeTransfers = settings.optimizeTransfers,
-                wheelchair = settings.wheelchair
+                wheelchair = settings.wheelchair,
+                walkPreference = settings.walkPreference,
+                cyclingPreference = settings.cyclingPreference,
+                bikePreference = settings.bikePreference
             )
         }
         replanOrClearResult()

--- a/onebusaway-android/src/main/res/values/donottranslate.xml
+++ b/onebusaway-android/src/main/res/values/donottranslate.xml
@@ -52,6 +52,9 @@
     <string name="preference_key_layer_bikeshare_visible">layer_bike_selected</string>
     <string name="preference_key_trip_plan_travel_by">preference_trip_plan_travel_by</string>
     <string name="preference_key_trip_plan_maximum_walking_distance">preference_trip_plan_maximum_walking_distance</string>
+    <string name="preference_key_trip_plan_walk_preference">preference_trip_plan_walk_preference</string>
+    <string name="preference_key_trip_plan_cycling_preference">preference_trip_plan_cycling_preference</string>
+    <string name="preference_key_trip_plan_bike_preference">preference_trip_plan_bike_preference</string>
     <string name="preference_key_trip_plan_minimize_transfers">preference_trip_plan_minimize_transfers</string>
     <string name="preference_key_trip_plan_avoid_stairs">preference_trip_plan_avoid_stairs</string>
     <string name="preference_key_notification_sound">preference_notification_sound</string>

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -1153,6 +1153,25 @@
     <string name="maximum_walk_distance">Maximum walk distance: </string>
     <string name="wheelchair_accessible">Avoid stairs</string>
 
+    <!-- Walking / biking amount, a shared five-point scale. Shown instead of "Maximum walk
+         distance" on OTP2 regions, whose routing API has no distance cap at all - the rider states
+         how much of the mode they want, so the wording must not promise a limit. The five stop
+         names are shared by both scales. -->
+    <string name="walk_preference_label">Walking</string>
+    <string name="bike_preference_label">Biking</string>
+    <string name="street_preference_minimum">Minimum</string>
+    <string name="street_preference_low">Low</string>
+    <string name="street_preference_medium">Medium</string>
+    <string name="street_preference_high">High</string>
+    <string name="street_preference_maximum">Maximum</string>
+
+    <!-- Which streets a bike leg should use. Shown alongside the biking preference above. -->
+    <string name="cycling_preference_label">Bike route</string>
+    <string name="cycling_preference_default">Normal</string>
+    <string name="cycling_preference_fastest">Fastest route</string>
+    <string name="cycling_preference_safest">Safest route</string>
+    <string name="cycling_preference_flattest">Flattest route</string>
+
     <string name="travel_by_label">Travel by: </string>
     <string name="transit_mode_transit_only">Transit only</string>
     <string name="transit_mode_transit_and_bikeshare">Transit &amp; bikeshare</string>

--- a/onebusaway-android/src/test/java/org/onebusaway/android/directions/util/Otp1PlanParametersTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/directions/util/Otp1PlanParametersTest.kt
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.directions.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Covers [otp1PlanParameters] — the OTP 1.x REST sibling of [Otp2PlanRequestBuilder]'s
+ * `buildPreferences`/`buildStreetPreferences`. A plain JVM unit test: it takes already-parsed values
+ * rather than a `Bundle`, so no Robolectric is needed.
+ *
+ * The point is the boundary between the protocols. One builder feeds both, but they accept disjoint
+ * settings — OTP1 has `maxWalkDistance` and no street preferences, OTP2 the reverse — so what OTP1
+ * sends is pinned exactly, key set included, rather than asserted field by field.
+ */
+class Otp1PlanParametersTest {
+
+    @Test
+    fun aFullRequestCarriesExactlyTheOtp1Parameters() {
+        assertEquals(
+            mapOf(
+                "fromPlace" to "47.6,-122.3",
+                "toPlace" to "47.7,-122.4",
+                "optimize" to "TRANSFERS",
+                "wheelchair" to "true",
+                "arriveBy" to "true",
+                "date" to "07-26-2026",
+                "time" to "8:30am",
+                "showIntermediateStops" to "true",
+                "maxWalkDistance" to "1600.0",
+                "mode" to "TRANSIT,WALK"
+            ),
+            parameters(maxWalkDistanceMeters = 1600.0, modeString = "TRANSIT,WALK")
+        )
+    }
+
+    /**
+     * The street preferences are OTP2-only and must not appear here under any name. OTP1 would ignore
+     * an unknown query parameter silently, so a leak would look like a working setting while changing
+     * nothing — and `optimize` is already spent on TRANSFERS/QUICK, so a cycling optimization sent
+     * here would displace the minimize-transfers switch rather than sit alongside it.
+     */
+    @Test
+    fun noStreetPreferenceLeaksIntoTheOtp1Request() {
+        val keys = parameters(maxWalkDistanceMeters = 1600.0, modeString = "TRANSIT,WALK").keys
+        assertEquals(
+            setOf(
+                "fromPlace",
+                "toPlace",
+                "optimize",
+                "wheelchair",
+                "arriveBy",
+                "date",
+                "time",
+                "showIntermediateStops",
+                "maxWalkDistance",
+                "mode"
+            ),
+            keys
+        )
+    }
+
+    /** Both optional parameters drop out rather than being sent empty. */
+    @Test
+    fun anUncappedWalkAndUnsetModeOmitTheirParameters() {
+        val params = parameters(maxWalkDistanceMeters = null, modeString = null)
+        assertEquals(null, params["maxWalkDistance"])
+        assertEquals(null, params["mode"])
+        assertEquals(8, params.size)
+    }
+
+    /** `optimize` is OTP1's single-valued knob, and minimize-transfers owns it. */
+    @Test
+    fun optimizeCarriesWhicheverValueTheCallerResolved() {
+        assertEquals("QUICK", parameters(optimize = "QUICK")["optimize"])
+        assertEquals("TRANSFERS", parameters(optimize = "TRANSFERS")["optimize"])
+    }
+
+    private fun parameters(
+        optimize: String = "TRANSFERS",
+        maxWalkDistanceMeters: Double? = null,
+        modeString: String? = null
+    ): Map<String, String> = otp1PlanParameters(
+        fromPlace = "47.6,-122.3",
+        toPlace = "47.7,-122.4",
+        optimize = optimize,
+        wheelchair = true,
+        arriveBy = true,
+        date = "07-26-2026",
+        time = "8:30am",
+        maxWalkDistanceMeters = maxWalkDistanceMeters,
+        modeString = modeString
+    )
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/directions/util/Otp2PlanRequestBuilderTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/directions/util/Otp2PlanRequestBuilderTest.kt
@@ -17,19 +17,26 @@ package org.onebusaway.android.directions.util
 
 import com.apollographql.apollo.api.Optional
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.onebusaway.android.api.graphql.type.CyclingOptimizationType
 import org.onebusaway.android.api.graphql.type.PlanAccessMode
 import org.onebusaway.android.api.graphql.type.PlanDirectMode
 import org.onebusaway.android.api.graphql.type.PlanEgressMode
 import org.onebusaway.android.api.graphql.type.TransitMode
+import org.onebusaway.android.ui.tripplan.BikePreference
+import org.onebusaway.android.ui.tripplan.CyclingPreference
 import org.onebusaway.android.ui.tripplan.TripModes
+import org.onebusaway.android.ui.tripplan.WalkPreference
+import org.onebusaway.android.ui.tripplan.enumValueOrDefault
 
 /**
- * Covers [Otp2PlanRequestBuilder.buildModes]/[Otp2PlanRequestBuilder.buildPreferences] — the OTP2
- * `PlanModesInput`/`PlanPreferencesInput` siblings of [TripRequestBuilder.setModeSetById]'s OTP1
- * mode-string mapping and the wheelchair/`optimize=TRANSFERS` request params (#1780). A plain JVM
- * unit test (mirrors `ModeStringRequestsBikeRentalTest`'s style): both take plain booleans rather
- * than a `Context`, so no Robolectric/DI is needed.
+ * Covers [Otp2PlanRequestBuilder.buildModes]/[Otp2PlanRequestBuilder.buildPreferences]/
+ * [Otp2PlanRequestBuilder.buildStreetPreferences] — the OTP2 `PlanModesInput`/`PlanPreferencesInput`
+ * siblings of [TripRequestBuilder.setModeSetById]'s OTP1 mode-string mapping and the
+ * wheelchair/`optimize=TRANSFERS` request params (#1780), plus the walk/cycling street preferences.
+ * A plain JVM unit test (mirrors `ModeStringRequestsBikeRentalTest`'s style): they take plain
+ * booleans and enums rather than a `Context`, so no Robolectric/DI is needed.
  */
 class Otp2PlanRequestBuilderTest {
 
@@ -119,6 +126,239 @@ class Otp2PlanRequestBuilderTest {
     fun defaultTransfersLeaveTransitPreferencesUnset() {
         val prefs = Otp2PlanRequestBuilder.buildPreferences(wheelchairAccessible = false, optimizeTransfers = false)
         assertEquals(Optional.Absent, prefs.transit)
+    }
+
+    @Test
+    fun defaultStreetPreferencesAreOmittedEntirely() {
+        // Both defaults means "let the region's own router-config decide" — send no `street` block
+        // at all rather than an empty one, which is also what this app sent before these settings
+        // existed.
+        assertEquals(
+            Optional.Absent,
+            Otp2PlanRequestBuilder.buildStreetPreferences(WalkPreference.MEDIUM, CyclingPreference.DEFAULT)
+        )
+        val prefs = Otp2PlanRequestBuilder.buildPreferences(wheelchairAccessible = false, optimizeTransfers = false)
+        assertEquals(Optional.Absent, prefs.street)
+    }
+
+    /**
+     * The scale is 8 / 4 / (unset) / 1.4 / 1.0 — OTP2's documented 2.0 default at the neutral stop,
+     * stepped by a factor of two above it and split geometrically down to the 1.0 floor below it.
+     * Pinned exactly because these are the numbers that actually reach the server.
+     */
+    @Test
+    fun walkPreferenceWalksTheFivePointReluctanceScale() {
+        assertEquals(8.0, walkReluctanceFor(WalkPreference.MINIMUM), 1e-9)
+        assertEquals(4.0, walkReluctanceFor(WalkPreference.LOW), 1e-9)
+        assertEquals(1.4, walkReluctanceFor(WalkPreference.HIGH), 1e-9)
+        assertEquals(1.0, walkReluctanceFor(WalkPreference.MAXIMUM), 1e-9)
+    }
+
+    /** Same table for cycling — OTP documents the same 2.0 default for both. */
+    @Test
+    fun bikePreferenceWalksTheSameFivePointScale() {
+        assertEquals(8.0, bikeReluctanceFor(BikePreference.MINIMUM), 1e-9)
+        assertEquals(4.0, bikeReluctanceFor(BikePreference.LOW), 1e-9)
+        assertEquals(1.4, bikeReluctanceFor(BikePreference.HIGH), 1e-9)
+        assertEquals(1.0, bikeReluctanceFor(BikePreference.MAXIMUM), 1e-9)
+    }
+
+    /**
+     * Every stop must land inside the range OTP's `Reluctance` scalar actually accepts. The bound is
+     * NOT in the vendored schema (its doc comment only says "should be greater than 0") — it was
+     * found by a live server rejecting 0.08:
+     *
+     *   "... is not a valid 'Reluctance' - Reluctance needs to be between 0.1 and 100000.0"
+     *
+     * An out-of-range value fails the whole plan with a GraphQL validation error, so this guards
+     * anyone re-deriving the scale (e.g. changing RELUCTANCE_STEP) from silently breaking planning.
+     */
+
+    /**
+     * No stop may drop below 1.0, OTP's neutral point. Below it the schema says the mode is
+     * "preferred over transit", and OTP acts on that by deleting transit itineraries — measured
+     * against a live server, rail + own bike returns nothing at 0.9 and a real itinerary at 1.0.
+     * This is stricter than the scalar's own 0.1 validation floor, and unlike that one it fails
+     * silently, as an empty result rather than an error.
+     */
+    @Test
+    fun noStopAsksTheRouterToPreferStreetOverTransit() {
+        val all = WalkPreference.entries.mapNotNull { walkReluctanceFor2(it) } +
+            BikePreference.entries.mapNotNull { bikeReluctanceFor2(it) }
+        assertTrue("every reluctance must be >= 1.0 (OTP's neutral point)", all.all { it >= 1.0 })
+    }
+
+    @Test
+    fun everyStopIsInsideTheRangeTheServerAccepts() {
+        val all = WalkPreference.entries.mapNotNull { walkReluctanceFor2(it) } +
+            BikePreference.entries.mapNotNull { bikeReluctanceFor2(it) }
+        assertEquals("all five stops, both scales, minus the two neutral ones", 8, all.size)
+        assertTrue("every reluctance must be >= 0.1", all.all { it >= 0.1 })
+        assertTrue("every reluctance must be <= 100000.0", all.all { it <= 100_000.0 })
+    }
+
+    /** Null at the neutral stop (which sends nothing), else the reluctance. */
+    private fun walkReluctanceFor2(preference: WalkPreference): Double? {
+        val street = Otp2PlanRequestBuilder.buildStreetPreferences(preference, CyclingPreference.DEFAULT, BikePreference.MEDIUM)
+        if (street == Optional.Absent) return null
+        return requirePresent(requirePresent(requirePresent(street).walk).reluctance)
+    }
+
+    private fun bikeReluctanceFor2(preference: BikePreference): Double? {
+        val street = Otp2PlanRequestBuilder.buildStreetPreferences(WalkPreference.MEDIUM, CyclingPreference.DEFAULT, preference)
+        if (street == Optional.Absent) return null
+        return requirePresent(requirePresent(requirePresent(street).bicycle).reluctance)
+    }
+
+    /**
+     * The scale is inverted on purpose — *less* walking is a *higher* multiplier — and every stop
+     * must stay strictly inside the schema's "should be greater than 0" contract. A 0 would make
+     * street time free, letting an arbitrarily long walk beat any transit itinerary.
+     */
+    @Test
+    fun theScaleDecreasesMonotonicallyAndStaysAboveZero() {
+        val ordered = listOf(
+            WalkPreference.MINIMUM,
+            WalkPreference.LOW,
+            WalkPreference.HIGH,
+            WalkPreference.MAXIMUM
+        ).map { walkReluctanceFor(it) }
+        assertEquals("more walking must never cost more", ordered.sortedDescending(), ordered)
+        assertTrue("every stop must stay > 0", ordered.all { it > 0.0 })
+    }
+
+    /** The neutral stop sends nothing, so a region's own router-config reluctance survives. */
+    @Test
+    fun theMediumStopSendsNoReluctanceAtAll() {
+        assertEquals(
+            Optional.Absent,
+            Otp2PlanRequestBuilder.buildStreetPreferences(
+                WalkPreference.MEDIUM,
+                CyclingPreference.DEFAULT,
+                BikePreference.MEDIUM
+            )
+        )
+    }
+
+    @Test
+    fun defaultWalkPreferenceLeavesWalkUnsetEvenWhenCyclingIsSet() {
+        // The two halves are independent: choosing a cycling optimization must not pin a walk
+        // reluctance the rider never asked for.
+        val street = requirePresent(
+            Otp2PlanRequestBuilder.buildStreetPreferences(WalkPreference.MEDIUM, CyclingPreference.FASTEST)
+        )
+        assertEquals(Optional.Absent, street.walk)
+        assertEquals(
+            CyclingOptimizationType.SHORTEST_DURATION,
+            requirePresent(requirePresent(requirePresent(street.bicycle).optimization).type)
+        )
+    }
+
+    @Test
+    fun defaultCyclingPreferenceLeavesBicycleUnsetEvenWhenWalkIsSet() {
+        val street = requirePresent(
+            Otp2PlanRequestBuilder.buildStreetPreferences(WalkPreference.MINIMUM, CyclingPreference.DEFAULT)
+        )
+        assertEquals(Optional.Absent, street.bicycle)
+        assertEquals(8.0, requirePresent(requirePresent(street.walk).reluctance), 1e-9)
+    }
+
+    @Test
+    fun cyclingPreferenceMapsToTheOtpOptimizationType() {
+        assertEquals(CyclingOptimizationType.SHORTEST_DURATION, cyclingOptimizationFor(CyclingPreference.FASTEST))
+        assertEquals(CyclingOptimizationType.SAFEST_STREETS, cyclingOptimizationFor(CyclingPreference.SAFEST))
+        assertEquals(CyclingOptimizationType.FLAT_STREETS, cyclingOptimizationFor(CyclingPreference.FLATTEST))
+    }
+
+    @Test
+    fun unknownStoredPreferenceNameFallsBackToTheServerDefault() {
+        // Persisted by name, so a value written by a build that knows an option this one doesn't
+        // must degrade to "send nothing" rather than to some arbitrary neighbouring option.
+        assertEquals(WalkPreference.MEDIUM, enumValueOrDefault("MODERATE_WALKS", WalkPreference.MEDIUM))
+        assertEquals(WalkPreference.MEDIUM, enumValueOrDefault(null, WalkPreference.MEDIUM))
+        assertEquals(CyclingPreference.SAFEST, enumValueOrDefault("SAFEST", CyclingPreference.DEFAULT))
+    }
+
+    /**
+     * The two bicycle knobs share one `BicyclePreferencesInput`, so each must be able to travel
+     * without the other — picking a route optimization must not pin a reluctance the rider never
+     * chose, and vice versa.
+     */
+    @Test
+    fun theTwoBicycleSettingsTravelIndependently() {
+        val reluctanceOnly = requirePresent(
+            requirePresent(
+                Otp2PlanRequestBuilder.buildStreetPreferences(
+                    WalkPreference.MEDIUM,
+                    CyclingPreference.DEFAULT,
+                    BikePreference.MAXIMUM
+                )
+            ).bicycle
+        )
+        assertEquals(1.0, requirePresent(reluctanceOnly.reluctance), 1e-9)
+        assertEquals(Optional.Absent, reluctanceOnly.optimization)
+
+        val optimizationOnly = requirePresent(
+            requirePresent(
+                Otp2PlanRequestBuilder.buildStreetPreferences(
+                    WalkPreference.MEDIUM,
+                    CyclingPreference.SAFEST,
+                    BikePreference.MEDIUM
+                )
+            ).bicycle
+        )
+        assertEquals(Optional.Absent, optimizationOnly.reluctance)
+        assertEquals(
+            CyclingOptimizationType.SAFEST_STREETS,
+            requirePresent(requirePresent(optimizationOnly.optimization).type)
+        )
+    }
+
+    @Test
+    fun bothBicycleSettingsRideInOneInputWhenBothAreSet() {
+        val bicycle = requirePresent(
+            requirePresent(
+                Otp2PlanRequestBuilder.buildStreetPreferences(
+                    WalkPreference.MEDIUM,
+                    CyclingPreference.FLATTEST,
+                    BikePreference.MINIMUM
+                )
+            ).bicycle
+        )
+        assertEquals(8.0, requirePresent(bicycle.reluctance), 1e-9)
+        assertEquals(
+            CyclingOptimizationType.FLAT_STREETS,
+            requirePresent(requirePresent(bicycle.optimization).type)
+        )
+    }
+
+    @Test
+    fun allThreeDefaultsStillOmitStreetPreferencesEntirely() {
+        assertEquals(
+            Optional.Absent,
+            Otp2PlanRequestBuilder.buildStreetPreferences(
+                WalkPreference.MEDIUM,
+                CyclingPreference.DEFAULT,
+                BikePreference.MEDIUM
+            )
+        )
+    }
+
+    private fun bikeReluctanceFor(preference: BikePreference): Double {
+        val street = requirePresent(
+            Otp2PlanRequestBuilder.buildStreetPreferences(WalkPreference.MEDIUM, CyclingPreference.DEFAULT, preference)
+        )
+        return requirePresent(requirePresent(street.bicycle).reluctance)
+    }
+
+    private fun walkReluctanceFor(preference: WalkPreference): Double {
+        val street = requirePresent(Otp2PlanRequestBuilder.buildStreetPreferences(preference, CyclingPreference.DEFAULT))
+        return requirePresent(requirePresent(street.walk).reluctance)
+    }
+
+    private fun cyclingOptimizationFor(preference: CyclingPreference): CyclingOptimizationType {
+        val street = requirePresent(Otp2PlanRequestBuilder.buildStreetPreferences(WalkPreference.MEDIUM, preference))
+        return requirePresent(requirePresent(requirePresent(street.bicycle).optimization).type)
     }
 
     /** Unwraps an [Optional.Present]'s non-null value, failing the test on [Optional.Absent] or a

--- a/onebusaway-android/src/test/java/org/onebusaway/android/directions/util/Otp2PlanRequestBuilderTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/directions/util/Otp2PlanRequestBuilderTest.kt
@@ -23,12 +23,13 @@ import org.onebusaway.android.api.graphql.type.CyclingOptimizationType
 import org.onebusaway.android.api.graphql.type.PlanAccessMode
 import org.onebusaway.android.api.graphql.type.PlanDirectMode
 import org.onebusaway.android.api.graphql.type.PlanEgressMode
+import org.onebusaway.android.api.graphql.type.PlanPreferencesInput
+import org.onebusaway.android.api.graphql.type.PlanStreetPreferencesInput
 import org.onebusaway.android.api.graphql.type.TransitMode
 import org.onebusaway.android.ui.tripplan.BikePreference
 import org.onebusaway.android.ui.tripplan.CyclingPreference
 import org.onebusaway.android.ui.tripplan.TripModes
 import org.onebusaway.android.ui.tripplan.WalkPreference
-import org.onebusaway.android.ui.tripplan.enumValueOrDefault
 
 /**
  * Covers [Otp2PlanRequestBuilder.buildModes]/[Otp2PlanRequestBuilder.buildPreferences]/
@@ -99,23 +100,19 @@ class Otp2PlanRequestBuilderTest {
     @Test
     fun preferencesCarryTheWheelchairFlagEitherWay() {
         val enabled = requirePresent(
-            requirePresent(
-                Otp2PlanRequestBuilder.buildPreferences(wheelchairAccessible = true, optimizeTransfers = false).accessibility
-            ).wheelchair
+            requirePresent(preferences(wheelchairAccessible = true, optimizeTransfers = false).accessibility).wheelchair
         ).enabled
         assertEquals(true, requirePresent(enabled))
 
         val disabled = requirePresent(
-            requirePresent(
-                Otp2PlanRequestBuilder.buildPreferences(wheelchairAccessible = false, optimizeTransfers = false).accessibility
-            ).wheelchair
+            requirePresent(preferences(wheelchairAccessible = false, optimizeTransfers = false).accessibility).wheelchair
         ).enabled
         assertEquals(false, requirePresent(disabled))
     }
 
     @Test
     fun optimizeTransfersSetsTheHistoricalOtp1TransferCost() {
-        val prefs = Otp2PlanRequestBuilder.buildPreferences(wheelchairAccessible = false, optimizeTransfers = true)
+        val prefs = preferences(wheelchairAccessible = false, optimizeTransfers = true)
         val transferCost = requirePresent(requirePresent(requirePresent(prefs.transit).transfer).cost)
         // 1800s (30 min) is what OTP1's optimize=TRANSFERS actually added to transferPenalty —
         // see the sourced comment on Otp2PlanRequestBuilder.OPTIMIZE_TRANSFERS_COST_SECONDS.
@@ -124,32 +121,45 @@ class Otp2PlanRequestBuilderTest {
 
     @Test
     fun defaultTransfersLeaveTransitPreferencesUnset() {
-        val prefs = Otp2PlanRequestBuilder.buildPreferences(wheelchairAccessible = false, optimizeTransfers = false)
+        val prefs = preferences(wheelchairAccessible = false, optimizeTransfers = false)
         assertEquals(Optional.Absent, prefs.transit)
     }
 
+    /** [Otp2PlanRequestBuilder.buildPreferences] with the street preferences on their neutral stops. */
+    private fun preferences(wheelchairAccessible: Boolean, optimizeTransfers: Boolean): PlanPreferencesInput = Otp2PlanRequestBuilder.buildPreferences(
+        wheelchairAccessible = wheelchairAccessible,
+        optimizeTransfers = optimizeTransfers,
+        walkPreference = WalkPreference.MEDIUM,
+        cyclingPreference = CyclingPreference.DEFAULT,
+        bikePreference = BikePreference.MEDIUM
+    )
+
+    /**
+     * The neutral stop is stated on the wire, not omitted: both reluctances carry OTP's own
+     * documented 2.0 default so the five-point scales keep their ordering on a region that tuned its
+     * own reluctance (see `Otp2PlanRequestBuilder.RELUCTANCE_MEDIUM`). `bicycle.optimization` is the
+     * one piece still left unset at its default stop — it is an "unset" option, not a midpoint, so
+     * there is no ordering for a region's own value to invert.
+     */
     @Test
-    fun defaultStreetPreferencesAreOmittedEntirely() {
-        // Both defaults means "let the region's own router-config decide" — send no `street` block
-        // at all rather than an empty one, which is also what this app sent before these settings
-        // existed.
-        assertEquals(
-            Optional.Absent,
-            Otp2PlanRequestBuilder.buildStreetPreferences(WalkPreference.MEDIUM, CyclingPreference.DEFAULT)
-        )
-        val prefs = Otp2PlanRequestBuilder.buildPreferences(wheelchairAccessible = false, optimizeTransfers = false)
-        assertEquals(Optional.Absent, prefs.street)
+    fun theNeutralStopStatesOtpsOwnDefaultsAndLeavesOptimizationUnset() {
+        val street = street()
+        assertEquals(2.0, requirePresent(requirePresent(street.walk).reluctance), 1e-9)
+        val bicycle = requirePresent(street.bicycle)
+        assertEquals(2.0, requirePresent(bicycle.reluctance), 1e-9)
+        assertEquals(Optional.Absent, bicycle.optimization)
     }
 
     /**
-     * The scale is 8 / 4 / (unset) / 1.4 / 1.0 — OTP2's documented 2.0 default at the neutral stop,
-     * stepped by a factor of two above it and split geometrically down to the 1.0 floor below it.
-     * Pinned exactly because these are the numbers that actually reach the server.
+     * The scale is 8 / 4 / 2 / 1.4 / 1.0 — OTP2's documented 2.0 default at the neutral stop, stepped
+     * by a factor of two above it and split geometrically down to the 1.0 floor below it. Pinned
+     * exactly because these are the numbers that actually reach the server.
      */
     @Test
     fun walkPreferenceWalksTheFivePointReluctanceScale() {
         assertEquals(8.0, walkReluctanceFor(WalkPreference.MINIMUM), 1e-9)
         assertEquals(4.0, walkReluctanceFor(WalkPreference.LOW), 1e-9)
+        assertEquals(2.0, walkReluctanceFor(WalkPreference.MEDIUM), 1e-9)
         assertEquals(1.4, walkReluctanceFor(WalkPreference.HIGH), 1e-9)
         assertEquals(1.0, walkReluctanceFor(WalkPreference.MAXIMUM), 1e-9)
     }
@@ -159,8 +169,46 @@ class Otp2PlanRequestBuilderTest {
     fun bikePreferenceWalksTheSameFivePointScale() {
         assertEquals(8.0, bikeReluctanceFor(BikePreference.MINIMUM), 1e-9)
         assertEquals(4.0, bikeReluctanceFor(BikePreference.LOW), 1e-9)
+        assertEquals(2.0, bikeReluctanceFor(BikePreference.MEDIUM), 1e-9)
         assertEquals(1.4, bikeReluctanceFor(BikePreference.HIGH), 1e-9)
         assertEquals(1.0, bikeReluctanceFor(BikePreference.MAXIMUM), 1e-9)
+    }
+
+    /**
+     * The scale is inverted on purpose — *less* of the mode is a *higher* multiplier — and it must
+     * decrease **strictly**, across *every* stop including the neutral one. Two things ride on that:
+     * two slider positions must never send the same value, and no stop may be out of order with its
+     * neighbours (the reason the neutral stop states its multiplier rather than deferring to whatever
+     * the region configured, which could sit anywhere on or off the scale).
+     *
+     * Every stop must also stay strictly inside the schema's "should be greater than 0" contract. A 0
+     * would make street time free, letting an arbitrarily long walk beat any transit itinerary.
+     */
+    @Test
+    fun bothScalesDecreaseStrictlyAcrossEveryStopAndStayAboveZero() {
+        for (scale in listOf(walkScale(), bikeScale())) {
+            assertEquals("every stop must be on the wire", 5, scale.size)
+            assertTrue("every stop must stay > 0", scale.all { it > 0.0 })
+            assertTrue(
+                "more of the mode must always cost strictly less: $scale",
+                scale.zipWithNext().all { (higher, lower) -> higher > lower }
+            )
+        }
+    }
+
+    /**
+     * No stop may drop below 1.0, OTP's neutral point. Below it the schema says the mode is
+     * "preferred over transit", and OTP acts on that by deleting transit itineraries — measured
+     * against a live server, rail + own bike returns nothing at 0.9 and a real itinerary at 1.0.
+     * This is stricter than the scalar's own 0.1 validation floor, and unlike that one it fails
+     * silently, as an empty result rather than an error.
+     */
+    @Test
+    fun noStopAsksTheRouterToPreferStreetOverTransit() {
+        assertTrue(
+            "every reluctance must be >= 1.0 (OTP's neutral point)",
+            (walkScale() + bikeScale()).all { it >= 1.0 }
+        )
     }
 
     /**
@@ -173,94 +221,12 @@ class Otp2PlanRequestBuilderTest {
      * An out-of-range value fails the whole plan with a GraphQL validation error, so this guards
      * anyone re-deriving the scale (e.g. changing RELUCTANCE_STEP) from silently breaking planning.
      */
-
-    /**
-     * No stop may drop below 1.0, OTP's neutral point. Below it the schema says the mode is
-     * "preferred over transit", and OTP acts on that by deleting transit itineraries — measured
-     * against a live server, rail + own bike returns nothing at 0.9 and a real itinerary at 1.0.
-     * This is stricter than the scalar's own 0.1 validation floor, and unlike that one it fails
-     * silently, as an empty result rather than an error.
-     */
-    @Test
-    fun noStopAsksTheRouterToPreferStreetOverTransit() {
-        val all = WalkPreference.entries.mapNotNull { walkReluctanceFor2(it) } +
-            BikePreference.entries.mapNotNull { bikeReluctanceFor2(it) }
-        assertTrue("every reluctance must be >= 1.0 (OTP's neutral point)", all.all { it >= 1.0 })
-    }
-
     @Test
     fun everyStopIsInsideTheRangeTheServerAccepts() {
-        val all = WalkPreference.entries.mapNotNull { walkReluctanceFor2(it) } +
-            BikePreference.entries.mapNotNull { bikeReluctanceFor2(it) }
-        assertEquals("all five stops, both scales, minus the two neutral ones", 8, all.size)
+        val all = walkScale() + bikeScale()
+        assertEquals("all five stops of both scales", 10, all.size)
         assertTrue("every reluctance must be >= 0.1", all.all { it >= 0.1 })
         assertTrue("every reluctance must be <= 100000.0", all.all { it <= 100_000.0 })
-    }
-
-    /** Null at the neutral stop (which sends nothing), else the reluctance. */
-    private fun walkReluctanceFor2(preference: WalkPreference): Double? {
-        val street = Otp2PlanRequestBuilder.buildStreetPreferences(preference, CyclingPreference.DEFAULT, BikePreference.MEDIUM)
-        if (street == Optional.Absent) return null
-        return requirePresent(requirePresent(requirePresent(street).walk).reluctance)
-    }
-
-    private fun bikeReluctanceFor2(preference: BikePreference): Double? {
-        val street = Otp2PlanRequestBuilder.buildStreetPreferences(WalkPreference.MEDIUM, CyclingPreference.DEFAULT, preference)
-        if (street == Optional.Absent) return null
-        return requirePresent(requirePresent(requirePresent(street).bicycle).reluctance)
-    }
-
-    /**
-     * The scale is inverted on purpose — *less* walking is a *higher* multiplier — and every stop
-     * must stay strictly inside the schema's "should be greater than 0" contract. A 0 would make
-     * street time free, letting an arbitrarily long walk beat any transit itinerary.
-     */
-    @Test
-    fun theScaleDecreasesMonotonicallyAndStaysAboveZero() {
-        val ordered = listOf(
-            WalkPreference.MINIMUM,
-            WalkPreference.LOW,
-            WalkPreference.HIGH,
-            WalkPreference.MAXIMUM
-        ).map { walkReluctanceFor(it) }
-        assertEquals("more walking must never cost more", ordered.sortedDescending(), ordered)
-        assertTrue("every stop must stay > 0", ordered.all { it > 0.0 })
-    }
-
-    /** The neutral stop sends nothing, so a region's own router-config reluctance survives. */
-    @Test
-    fun theMediumStopSendsNoReluctanceAtAll() {
-        assertEquals(
-            Optional.Absent,
-            Otp2PlanRequestBuilder.buildStreetPreferences(
-                WalkPreference.MEDIUM,
-                CyclingPreference.DEFAULT,
-                BikePreference.MEDIUM
-            )
-        )
-    }
-
-    @Test
-    fun defaultWalkPreferenceLeavesWalkUnsetEvenWhenCyclingIsSet() {
-        // The two halves are independent: choosing a cycling optimization must not pin a walk
-        // reluctance the rider never asked for.
-        val street = requirePresent(
-            Otp2PlanRequestBuilder.buildStreetPreferences(WalkPreference.MEDIUM, CyclingPreference.FASTEST)
-        )
-        assertEquals(Optional.Absent, street.walk)
-        assertEquals(
-            CyclingOptimizationType.SHORTEST_DURATION,
-            requirePresent(requirePresent(requirePresent(street.bicycle).optimization).type)
-        )
-    }
-
-    @Test
-    fun defaultCyclingPreferenceLeavesBicycleUnsetEvenWhenWalkIsSet() {
-        val street = requirePresent(
-            Otp2PlanRequestBuilder.buildStreetPreferences(WalkPreference.MINIMUM, CyclingPreference.DEFAULT)
-        )
-        assertEquals(Optional.Absent, street.bicycle)
-        assertEquals(8.0, requirePresent(requirePresent(street.walk).reluctance), 1e-9)
     }
 
     @Test
@@ -270,59 +236,32 @@ class Otp2PlanRequestBuilderTest {
         assertEquals(CyclingOptimizationType.FLAT_STREETS, cyclingOptimizationFor(CyclingPreference.FLATTEST))
     }
 
-    @Test
-    fun unknownStoredPreferenceNameFallsBackToTheServerDefault() {
-        // Persisted by name, so a value written by a build that knows an option this one doesn't
-        // must degrade to "send nothing" rather than to some arbitrary neighbouring option.
-        assertEquals(WalkPreference.MEDIUM, enumValueOrDefault("MODERATE_WALKS", WalkPreference.MEDIUM))
-        assertEquals(WalkPreference.MEDIUM, enumValueOrDefault(null, WalkPreference.MEDIUM))
-        assertEquals(CyclingPreference.SAFEST, enumValueOrDefault("SAFEST", CyclingPreference.DEFAULT))
-    }
-
     /**
-     * The two bicycle knobs share one `BicyclePreferencesInput`, so each must be able to travel
-     * without the other — picking a route optimization must not pin a reluctance the rider never
-     * chose, and vice versa.
+     * The walk and bicycle halves travel independently: choosing a cycling optimization must not
+     * disturb the walk reluctance, and choosing a walk reluctance must not invent an optimization the
+     * rider never picked.
      */
     @Test
-    fun theTwoBicycleSettingsTravelIndependently() {
-        val reluctanceOnly = requirePresent(
-            requirePresent(
-                Otp2PlanRequestBuilder.buildStreetPreferences(
-                    WalkPreference.MEDIUM,
-                    CyclingPreference.DEFAULT,
-                    BikePreference.MAXIMUM
-                )
-            ).bicycle
-        )
-        assertEquals(1.0, requirePresent(reluctanceOnly.reluctance), 1e-9)
-        assertEquals(Optional.Absent, reluctanceOnly.optimization)
-
-        val optimizationOnly = requirePresent(
-            requirePresent(
-                Otp2PlanRequestBuilder.buildStreetPreferences(
-                    WalkPreference.MEDIUM,
-                    CyclingPreference.SAFEST,
-                    BikePreference.MEDIUM
-                )
-            ).bicycle
-        )
-        assertEquals(Optional.Absent, optimizationOnly.reluctance)
+    fun theWalkAndBicycleHalvesTravelIndependently() {
+        val cyclingOnly = street(cyclingPreference = CyclingPreference.FASTEST)
+        assertEquals(2.0, requirePresent(requirePresent(cyclingOnly.walk).reluctance), 1e-9)
         assertEquals(
-            CyclingOptimizationType.SAFEST_STREETS,
-            requirePresent(requirePresent(optimizationOnly.optimization).type)
+            CyclingOptimizationType.SHORTEST_DURATION,
+            requirePresent(requirePresent(requirePresent(cyclingOnly.bicycle).optimization).type)
         )
+
+        val walkOnly = street(walkPreference = WalkPreference.MINIMUM)
+        assertEquals(8.0, requirePresent(requirePresent(walkOnly.walk).reluctance), 1e-9)
+        assertEquals(Optional.Absent, requirePresent(walkOnly.bicycle).optimization)
     }
 
+    /** The two bicycle knobs share one `BicyclePreferencesInput`, so both must fit in it at once. */
     @Test
     fun bothBicycleSettingsRideInOneInputWhenBothAreSet() {
         val bicycle = requirePresent(
-            requirePresent(
-                Otp2PlanRequestBuilder.buildStreetPreferences(
-                    WalkPreference.MEDIUM,
-                    CyclingPreference.FLATTEST,
-                    BikePreference.MINIMUM
-                )
+            street(
+                cyclingPreference = CyclingPreference.FLATTEST,
+                bikePreference = BikePreference.MINIMUM
             ).bicycle
         )
         assertEquals(8.0, requirePresent(bicycle.reluctance), 1e-9)
@@ -332,34 +271,31 @@ class Otp2PlanRequestBuilderTest {
         )
     }
 
-    @Test
-    fun allThreeDefaultsStillOmitStreetPreferencesEntirely() {
-        assertEquals(
-            Optional.Absent,
-            Otp2PlanRequestBuilder.buildStreetPreferences(
-                WalkPreference.MEDIUM,
-                CyclingPreference.DEFAULT,
-                BikePreference.MEDIUM
-            )
-        )
-    }
+    /** Both reluctance scales, ordered least → most of the mode, as they reach the server. */
+    private fun walkScale(): List<Double> = WalkPreference.entries.map { walkReluctanceFor(it) }
 
-    private fun bikeReluctanceFor(preference: BikePreference): Double {
-        val street = requirePresent(
-            Otp2PlanRequestBuilder.buildStreetPreferences(WalkPreference.MEDIUM, CyclingPreference.DEFAULT, preference)
-        )
-        return requirePresent(requirePresent(street.bicycle).reluctance)
-    }
+    private fun bikeScale(): List<Double> = BikePreference.entries.map { bikeReluctanceFor(it) }
 
-    private fun walkReluctanceFor(preference: WalkPreference): Double {
-        val street = requirePresent(Otp2PlanRequestBuilder.buildStreetPreferences(preference, CyclingPreference.DEFAULT))
-        return requirePresent(requirePresent(street.walk).reluctance)
-    }
+    private fun walkReluctanceFor(preference: WalkPreference): Double = requirePresent(requirePresent(street(walkPreference = preference).walk).reluctance)
 
-    private fun cyclingOptimizationFor(preference: CyclingPreference): CyclingOptimizationType {
-        val street = requirePresent(Otp2PlanRequestBuilder.buildStreetPreferences(WalkPreference.MEDIUM, preference))
-        return requirePresent(requirePresent(requirePresent(street.bicycle).optimization).type)
-    }
+    private fun bikeReluctanceFor(preference: BikePreference): Double = requirePresent(requirePresent(street(bikePreference = preference).bicycle).reluctance)
+
+    private fun cyclingOptimizationFor(preference: CyclingPreference): CyclingOptimizationType = requirePresent(
+        requirePresent(requirePresent(street(cyclingPreference = preference).bicycle).optimization).type
+    )
+
+    /**
+     * [Otp2PlanRequestBuilder.buildStreetPreferences] with every unnamed preference on its neutral
+     * stop. The neutral defaults live here rather than on the production function, so a real call
+     * site that forgets a preference fails to compile instead of silently sending neutral.
+     */
+    private fun street(
+        walkPreference: WalkPreference = WalkPreference.MEDIUM,
+        cyclingPreference: CyclingPreference = CyclingPreference.DEFAULT,
+        bikePreference: BikePreference = BikePreference.MEDIUM
+    ): PlanStreetPreferencesInput = requirePresent(
+        Otp2PlanRequestBuilder.buildStreetPreferences(walkPreference, cyclingPreference, bikePreference)
+    )
 
     /** Unwraps an [Optional.Present]'s non-null value, failing the test on [Optional.Absent] or a
      * present-but-null value (mirrors `dataOrThrow` elsewhere: absent-when-a-value-was-expected is a

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/StreetPreferencesTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/StreetPreferencesTest.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.tripplan
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Covers [enumValueOrDefault], the reader every street preference passes through on its way out of
+ * preferences or a saved `Bundle`. The wire mapping of these enums lives in
+ * `Otp2PlanRequestBuilderTest`; this is only about surviving the round trip through storage.
+ */
+class StreetPreferencesTest {
+
+    @Test
+    fun aStoredNameRoundTripsToItsOwnValue() {
+        // Persisted by name rather than ordinal, so reordering an enum can't reinterpret a value
+        // already sitting in storage. Every stop of both scales must come back as itself.
+        for (preference in WalkPreference.entries) {
+            assertEquals(preference, enumValueOrDefault(preference.name, WalkPreference.MEDIUM))
+        }
+        for (preference in BikePreference.entries) {
+            assertEquals(preference, enumValueOrDefault(preference.name, BikePreference.MEDIUM))
+        }
+        for (preference in CyclingPreference.entries) {
+            assertEquals(preference, enumValueOrDefault(preference.name, CyclingPreference.DEFAULT))
+        }
+    }
+
+    @Test
+    fun anUnknownOrMissingNameFallsBackToTheNeutralStop() {
+        // An unrecognized name means a build that knows an option this one doesn't wrote it. Falling
+        // back to the neutral stop is the only reading that can't misroute; picking a neighbour would
+        // quietly change what the rider asked for.
+        assertEquals(WalkPreference.MEDIUM, enumValueOrDefault("MODERATE_WALKS", WalkPreference.MEDIUM))
+        assertEquals(WalkPreference.MEDIUM, enumValueOrDefault(null, WalkPreference.MEDIUM))
+        assertEquals(WalkPreference.MEDIUM, enumValueOrDefault("", WalkPreference.MEDIUM))
+        assertEquals(BikePreference.MEDIUM, enumValueOrDefault("MINIMUM_ISH", BikePreference.MEDIUM))
+        assertEquals(CyclingPreference.DEFAULT, enumValueOrDefault("HILLIEST", CyclingPreference.DEFAULT))
+    }
+
+    @Test
+    fun theMatchIsExactRatherThanFuzzy() {
+        // Case and whitespace variants are not the stored form, so they must not resolve — a near
+        // miss is a value this build doesn't understand, not a hint to guess from.
+        assertEquals(WalkPreference.MEDIUM, enumValueOrDefault("minimum", WalkPreference.MEDIUM))
+        assertEquals(WalkPreference.MEDIUM, enumValueOrDefault(" MINIMUM ", WalkPreference.MEDIUM))
+    }
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripPlanViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripPlanViewModelTest.kt
@@ -304,6 +304,30 @@ class TripPlanViewModelTest {
     }
 
     @Test
+    fun `applyAdvancedSettings carries the street preferences into the plan request`() = runTest {
+        val vm = viewModel()
+        setBothEndpoints(vm)
+        vm.applyAdvancedSettings(
+            AdvancedSettings(
+                modeId = TripModes.TRANSIT_AND_BIKE,
+                maxWalkMeters = null,
+                optimizeTransfers = false,
+                wheelchair = false,
+                walkPreference = WalkPreference.MINIMUM,
+                cyclingPreference = CyclingPreference.FLATTEST,
+                bikePreference = BikePreference.MAXIMUM
+            )
+        )
+        advanceUntilIdle()
+        // They must reach TripPlanParams, not just the form: the params are what builds the request
+        // and what the trip-plan-change monitor re-plans with.
+        val params = (vm.planState.value as PlanResult.Success).params
+        assertEquals(WalkPreference.MINIMUM, params?.walkPreference)
+        assertEquals(CyclingPreference.FLATTEST, params?.cyclingPreference)
+        assertEquals(BikePreference.MAXIMUM, params?.bikePreference)
+    }
+
+    @Test
     fun `a classified plan failure surfaces its TripPlanError`() = runTest {
         val error = TripPlanError(TripPlanError.Category.SCHEDULE, R.string.tripplanner_error_no_transit_times)
         val vm = viewModel(plan = FakeTripPlanRepository(Result.failure(TripPlanException(error))))


### PR DESCRIPTION
## The bug this starts from

The advanced-settings dialog offers one street knob — **Maximum walk distance** — and on OTP2 regions it does nothing. OTP2 removed `maxWalkDistance` from its routing API, and `Otp2PlanRequestBuilder` never populated `preferences.street`, so the value was silently dropped. A rider could set 400 m and be routed onto a kilometre of walking, with no indication the setting was inert.

There is no OTP2 distance cap to send instead. The surviving hard limits (`accessEgress.maxDuration` / `maxDurationForMode`) live in the **server's** `router-config.json`, not in a request, and OTP's own [migration guide](https://docs.opentripplanner.org/en/v2.1.0/OTP2-MigrationGuide/) names `walkReluctance` as the way to "reduce the amount of walking … in returned itineraries".

So the OTP2 path gets a *preference* rather than a cap, and the UI says so. OTP1 regions keep the metres field, which they do honour, unchanged.

**Deliberately not attempted:** translating the entered metres into a reluctance. No sanctioned mapping exists, the field would still promise a cap the server never enforces, and inventing one is exactly the magnitude heuristic CLAUDE.md rules out. Both values persist at all times, so moving between an OTP1 and an OTP2 region doesn't discard whichever the other protocol uses.

## What a rider sees

| | OTP2 region | OTP1 region |
|---|---|---|
| Walking | **5-point slider** | — |
| Biking | **5-point slider** ¹ | — |
| Bike route | **dropdown** ¹ | — |
| Maximum walk distance | — | metres/feet field |

¹ only when a bike mode is selected.

**Biking** → `bicycle.reluctance`. Worth being precise: **no OTP version has ever had a `maxBikeDistance`**, so this cannot raise a ceiling. It stops the optimizer trading a longer ride away for a transit leg, which is what actually lengthens bike legs. If the region caps bike access/egress duration server-side, that binds first.

**Bike route** → `bicycle.optimization` (`SHORTEST_DURATION` / `SAFEST_STREETS` / `FLAT_STREETS`). Distinct from the above: *which streets* a leg uses, not *how much* cycling.

Both OTP2-only. OTP1's single `optimize` parameter is already spent on `TRANSFERS` vs `QUICK` by the minimize-transfers switch, so sending `SAFE`/`FLAT` there would silently turn that setting off.

## The scale: 8 / 4 / 2 / 1.4 / 1.0

Every stop states its multiplier, **including the neutral one**, and the scale is bounded at both ends by behaviour measured against a live OTP 2.x server rather than by taste.

### Why the neutral stop is sent rather than omitted

An earlier revision omitted the field at Medium, so a region that tuned its own reluctance in `router-config.json` kept that tuning and an all-default request stayed byte-identical to what the app sent before these settings existed. That reads well and is wrong: it makes the middle of a five-point slider mean *"whatever this region configured"*, which need not sit between its neighbours. Against a region at 6.0, "Low" (4.0) produces **more** walking than "Medium" — the labels run backwards. Worse, the monotonicity test excluded the neutral stop, so CI was shaped so it could never see this.

A slider whose labels can invert is worse than one that overrides a server default, so Medium now sends OTP's own documented default, 2.0, explicitly.

**The cost, named plainly:** on an OTP2 region this app no longer inherits a region-configured `walk.reluctance` / `bicycle.reluctance`, even for a rider who never opened the dialog. A deployment that had tuned those values will see 2.0 instead. `bicycle.optimization` is the exception and still omits at its default stop — "Normal" is an *unset* option rather than a midpoint, so there is no ordering for a region's own value to invert, and that piece of the tuning survives.

### Why the ends are where they are

Earlier revisions of this PR had both bounds wrong.

**Nothing may go below 1.0.** The schema says a reluctance under 1 means the mode is "preferred over transit", and OTP acts on that literally by deleting transit itineraries:

```
rail only + own bike, bicycle.reluctance = 0.9  ->  no itineraries, NO_TRANSIT_CONNECTION
rail only + own bike, bicycle.reluctance = 1.0  ->  BICYCLE + TRAM(1 Line) + BICYCLE
```

An earlier version ran to 0.1 and so put its top two stops inside that region: asking for *more* cycling made bike-and-transit itineraries vanish. Note this bound is **stricter than the scalar's own validation floor** — values below 0.1 are rejected outright with a GraphQL error, but 0.1–0.9 are accepted and fail *silently*, as an empty result.

**The step is 2, not 5, so the far stop is 8 rather than 50.** At `bicycle.reluctance` 50 a direct bike trip comes back at **4.7 km/h** — OTP routes the rider to push the bike on foot, because at a 50× penalty walking it is cheaper than riding. The same trip is a normal 14–15 km/h ride at 2 and still at 10. A "minimum cycling" setting that silently converts the trip to a walk is worse than one that merely discourages cycling.

Unit tests pin every generated stop inside both bounds, and assert both scales decrease **strictly across all five stops**, so retuning the scale — or reintroducing an omitted stop whose effective value could land out of order — fails in CI rather than on a rider's phone.

## Also in here

- **`OtpTarget`** — lifts the custom-URL-or-region protocol resolution out of `TripRequestBuilder` so the dialog and the request builder resolve it from one definition rather than the UI re-deriving it and drifting.
- **`otp1PlanParameters`** — splits the OTP 1.x query-parameter assembly out of `TripRequestBuilder.buildRequest`, leaving that the thin `Bundle`-reading half. The OTP1 wire contract is now a pure function a JVM test can pin, which is what proves no street preference leaks into an OTP1 request. `Bundle`/`Context` aren't available in `src/test` and there's no Robolectric, so `buildRequest` itself couldn't be tested. No behaviour change; only the map builder moved.
- **The max-walk field no longer erodes.** On an OTP2 region the metres field isn't shown, so confirming the dialog used to round-trip the stored value through a field the rider couldn't see (1600 m → 5249 ft → 1599.8 m → 5248 ft → …). It's now carried through untouched there, and the field rounds rather than truncates, which fixes the same erosion on the OTP1 path.
- **`mapScalar("Reluctance", "kotlin.Double")`** — the generated input was landing as Apollo's untyped `Any`.

## Testing

All JVM-pure, `failures="0" errors="0"`:

| | tests |
|---|---|
| `Otp2PlanRequestBuilderTest` | 19 |
| `TripPlanViewModelTest` | 24 |
| `Otp1PlanParametersTest` | 4 |
| `StreetPreferencesTest` | 3 |

Coverage includes the exact wire values at every stop, strict monotonicity across both full scales, both bounds above, the neutral stop stating 2.0 while `bicycle.optimization` stays unset, the walk and bicycle halves travelling independently in one shared input, the exact OTP1 parameter map and its key set, the name round-trip through storage for every stop (with exact rather than fuzzy matching), and the preferences reaching `TripPlanParams` — which is what builds the request and what the trip-plan-change monitor re-plans with.

Verified on a clean `origin/main` worktree: `testObaGoogleDebugUnitTest`, `compileObaMaplibreDebugKotlin`, `spotlessCheck` all green under `-PwarningsAsErrors=true`.

## Not verified

- **The device pass predates the neutral-stop change.** The on-device run against an OTP2 region exercised the revision that omitted the field at Medium. What changed since is the value sent at that one stop (nothing → 2.0), which the unit tests pin exactly, but it has not been re-exercised on a device.
- Whether lower reluctance produces longer legs on a given deployment — that depends on the region's access/egress config, which no client setting can see or exceed. See #2026 for a measured case where it dominates entirely.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OTP2 advanced trip-planning controls for walking effort, biking effort, and cycling route preferences.
  * Preferences are saved and restored between sessions and applied when planning or replanning trips.
  * Added context-sensitive settings, including bike options when cycling is available.
  * Improved support for selecting and resolving configured trip-planning services.

* **Bug Fixes**
  * Preserved existing OTP1 behavior while preventing OTP2-only preferences from affecting OTP1 requests.

* **Tests**
  * Expanded coverage for preference mapping, persistence, request construction, and trip replanning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->