### PR TITLE
Split the mode picker into vehicle and street, and add the rider's own bike

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/Otp2PlanRequestBuilder.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/Otp2PlanRequestBuilder.kt
@@ -34,6 +34,7 @@ import org.onebusaway.android.api.graphql.type.PlanLocationInput
 import org.onebusaway.android.api.graphql.type.PlanModesInput
 import org.onebusaway.android.api.graphql.type.PlanPreferencesInput
 import org.onebusaway.android.api.graphql.type.PlanStreetPreferencesInput
+import org.onebusaway.android.api.graphql.type.PlanTransferMode
 import org.onebusaway.android.api.graphql.type.PlanTransitModePreferenceInput
 import org.onebusaway.android.api.graphql.type.PlanTransitModesInput
 import org.onebusaway.android.api.graphql.type.TransferPreferencesInput
@@ -43,7 +44,9 @@ import org.onebusaway.android.api.graphql.type.WalkPreferencesInput
 import org.onebusaway.android.api.graphql.type.WheelchairPreferencesInput
 import org.onebusaway.android.ui.tripplan.BikePreference
 import org.onebusaway.android.ui.tripplan.CyclingPreference
-import org.onebusaway.android.ui.tripplan.TripModes
+import org.onebusaway.android.ui.tripplan.StreetMode
+import org.onebusaway.android.ui.tripplan.TripModeSelection
+import org.onebusaway.android.ui.tripplan.VehicleMode
 import org.onebusaway.android.ui.tripplan.WalkPreference
 import org.onebusaway.android.util.BikeshareAvailability
 
@@ -231,7 +234,7 @@ object Otp2PlanRequestBuilder {
                     bikePreference = builder.getBikePreference()
                 )
             ),
-            modes = buildModes(builder.getModeSetId(), BikeshareAvailability.isTripPlanningEnabled(context)),
+            modes = buildModes(builder.getModeSelection(), BikeshareAvailability.isTripPlanningEnabled(context)),
             numItineraries = NUM_ITINERARIES,
             alternativeLegs = ALTERNATIVE_LEGS
         )
@@ -286,7 +289,7 @@ object Otp2PlanRequestBuilder {
      * "unset" option rather than the midpoint of a scale, so it is omitted and the region's own
      * `bicycle.optimization` tuning survives.
      *
-     * The cycling half is sent regardless of the selected trip mode: it only bears on legs
+     * The cycling half is sent regardless of the selected [StreetMode]: it only bears on legs
      * OTP actually plans by bike, so it is inert on a walk-and-transit plan, and gating it on the
      * mode here would just duplicate — and risk disagreeing with — [buildModes].
      */
@@ -322,63 +325,117 @@ object Otp2PlanRequestBuilder {
     }
 
     /**
-     * Maps [TripModes.*][TripModes] to OTP2's `modes` input, mirroring
-     * [TripRequestBuilder.setModeSetById]'s OTP1 mode-string mapping. [TripModes.TRANSIT_ONLY]
-     * (and an invalid id, matching that method's fallback) leaves `modes` unset entirely — the
-     * schema's own default ("all transit modes usable, WALK for access/egress") already matches
-     * that mode's OTP1 semantics, so there's nothing to express. Takes [bikeshareEnabled] rather
-     * than a `Context` (see [BikeshareAvailability.isTripPlanningEnabled]'s pure overload) so this mapping is a
-     * plain, JVM-unit-testable function; `internal` for `Otp2PlanRequestBuilderTest`.
+     * Composes a [TripModeSelection] into OTP2's `modes` input.
+     *
+     * The two halves are orthogonal and are built independently: [VehicleMode] decides whether this
+     * is a transit search at all and which transit modes are usable, [StreetMode] decides how the
+     * street phases are covered. That is why this is a composition rather than a table of the twelve
+     * combinations — only the *rules* below are per-mode, and each is stated once.
+     *
+     * An all-transit + walk selection leaves `modes` unset entirely: the schema's own default is
+     * "all transit modes usable, WALK for access/egress", so there is nothing to express, and the
+     * request stays byte-identical to what this app sent before the mode split.
+     *
+     * Takes [bikeshareEnabled] rather than a `Context` (see
+     * [BikeshareAvailability.isTripPlanningEnabled]'s pure overload) so this mapping is a plain,
+     * JVM-unit-testable function; `internal` for `Otp2PlanRequestBuilderTest`. A bikeshare selection
+     * on a region without a rental network degrades to walking rather than being refused, matching
+     * what the dialog would have offered.
      */
-    internal fun buildModes(modeId: Int, bikeshareEnabled: Boolean): Optional<PlanModesInput?> = when (modeId) {
-        TripModes.TRANSIT_ONLY -> Optional.Absent
+    internal fun buildModes(selection: TripModeSelection, bikeshareEnabled: Boolean): Optional<PlanModesInput?> {
+        val street = if (selection.street == StreetMode.WALK_AND_BIKESHARE && !bikeshareEnabled) {
+            StreetMode.WALK
+        } else {
+            selection.street
+        }
 
-        TripModes.BUS_ONLY -> onlyTransitModes(TransitMode.BUS)
-
-        TripModes.RAIL_ONLY -> onlyTransitModes(TransitMode.RAIL, TransitMode.TRAM)
-
-        TripModes.TRANSIT_AND_BIKE -> if (bikeshareEnabled) {
-            Optional.present(
+        if (selection.vehicle == VehicleMode.NONE) {
+            // A direct street trip: `directOnly` stops OTP also returning transit itineraries, which
+            // is the whole point of choosing no vehicle.
+            return Optional.present(
                 PlanModesInput(
-                    transit = Optional.present(
-                        PlanTransitModesInput(
-                            // WALK must accompany BICYCLE_RENTAL in the same access/egress list —
-                            // OTP2 rejects a bare BICYCLE_RENTAL leg ("BIKE_RENTAL needs to be
-                            // combined with WALK mode for the same leg", BadRequestError), since a
-                            // rental trip always walks to/from the vehicle. Verified against the
-                            // live OTP 2.x server. #1780.
-                            access = Optional.present(listOf(PlanAccessMode.WALK, PlanAccessMode.BICYCLE_RENTAL)),
-                            egress = Optional.present(listOf(PlanEgressMode.WALK, PlanEgressMode.BICYCLE_RENTAL))
-                        )
+                    direct = Optional.present(directModes(street)),
+                    directOnly = Optional.present(true)
+                )
+            )
+        }
+
+        val transitModes = when (selection.vehicle) {
+            VehicleMode.BUS -> listOf(TransitMode.BUS)
+            // TRAM is included so light rail counts as rail.
+            VehicleMode.RAIL -> listOf(TransitMode.RAIL, TransitMode.TRAM)
+            // Every mode the region runs — the schema default, so send nothing.
+            VehicleMode.ALL_TRANSIT -> null
+            VehicleMode.NONE -> null // unreachable, handled above
+        }
+
+        if (transitModes == null && street == StreetMode.WALK) {
+            return Optional.Absent
+        }
+
+        return Optional.present(
+            PlanModesInput(
+                // The direct suggestion must match how the rider is actually travelling. OTP returns
+                // one alongside the transit results and falls back to it when no transit connection
+                // exists; left unset it defaults to WALK, so a cyclist whose requested vehicle didn't
+                // pan out was offered a multi-hour *walk* (measured: rail-only from an origin with no
+                // Link station in range returned a 9.8 km / 128 min walk). With this set, the same
+                // search falls back to a ride.
+                direct = Optional.present(directModes(street)),
+                transit = Optional.present(
+                    PlanTransitModesInput(
+                        access = accessModes(street),
+                        egress = egressModes(street),
+                        transfer = transferModes(street),
+                        transit = transitModes?.let { modes ->
+                            Optional.present(modes.map { PlanTransitModePreferenceInput(mode = it) })
+                        } ?: Optional.Absent
                     )
                 )
             )
-        } else {
-            Optional.Absent
-        }
-
-        // WALK must accompany BICYCLE_RENTAL here too (see the TRANSIT_AND_BIKE branch above).
-        TripModes.BIKESHARE -> Optional.present(
-            PlanModesInput(
-                direct = Optional.present(listOf(PlanDirectMode.WALK, PlanDirectMode.BICYCLE_RENTAL)),
-                directOnly = Optional.present(true)
-            )
         )
-
-        // Invalid ids are already logged where they originate (TripRequestBuilder.setModeSetById),
-        // and getModeSetId() only ever hands this a value it produced — nothing new to log here.
-        else -> Optional.Absent
     }
 
-    /** `modes.transit.transit`, restricted to exactly [modes] — the shared shape behind the
-     * [TripModes.BUS_ONLY]/[TripModes.RAIL_ONLY] branches above. */
-    private fun onlyTransitModes(vararg modes: TransitMode): Optional<PlanModesInput?> = Optional.present(
-        PlanModesInput(
-            transit = Optional.present(
-                PlanTransitModesInput(
-                    transit = Optional.present(modes.map { PlanTransitModePreferenceInput(mode = it) })
-                )
-            )
-        )
-    )
+    /**
+     * Access modes for [street].
+     *
+     * The two bike modes have **opposite** requirements, which is the one genuinely subtle thing here:
+     *  - `BICYCLE_RENTAL` must be accompanied by `WALK` in the same list — OTP2 rejects a bare rental
+     *    leg ("BIKE_RENTAL needs to be combined with WALK mode for the same leg", BadRequestError),
+     *    since a hired bike must be walked to and from. Verified against the live server (#1780).
+     *  - `BICYCLE` must **not** be: the schema says access "can use cycling only if the mode used for
+     *    transfers and egress is also `BICYCLE`". Your own bike is with you the whole way, so there is
+     *    no phase without it. A stray WALK here silently degrades the plan to walking.
+     *
+     * [StreetMode.WALK] sends nothing, since WALK is the schema's default for every phase.
+     */
+    private fun accessModes(street: StreetMode): Optional<List<PlanAccessMode>?> = when (street) {
+        StreetMode.WALK -> Optional.Absent
+        StreetMode.WALK_AND_BIKESHARE -> Optional.present(listOf(PlanAccessMode.WALK, PlanAccessMode.BICYCLE_RENTAL))
+        StreetMode.BICYCLE -> Optional.present(listOf(PlanAccessMode.BICYCLE))
+    }
+
+    /** Egress modes for [street]; same rules as [accessModes]. */
+    private fun egressModes(street: StreetMode): Optional<List<PlanEgressMode>?> = when (street) {
+        StreetMode.WALK -> Optional.Absent
+        StreetMode.WALK_AND_BIKESHARE -> Optional.present(listOf(PlanEgressMode.WALK, PlanEgressMode.BICYCLE_RENTAL))
+        StreetMode.BICYCLE -> Optional.present(listOf(PlanEgressMode.BICYCLE))
+    }
+
+    /**
+     * Transfer mode for [street]. Only [StreetMode.BICYCLE] sets one: `PlanTransferMode` has no
+     * rental option (a hired bike is returned before boarding, so transfers are walked), and WALK is
+     * already the default.
+     */
+    private fun transferModes(street: StreetMode): Optional<List<PlanTransferMode>?> = when (street) {
+        StreetMode.BICYCLE -> Optional.present(listOf(PlanTransferMode.BICYCLE))
+        StreetMode.WALK, StreetMode.WALK_AND_BIKESHARE -> Optional.Absent
+    }
+
+    /** Direct (no-transit) street modes for [street]; same rental-needs-WALK rule as [accessModes]. */
+    private fun directModes(street: StreetMode): List<PlanDirectMode> = when (street) {
+        StreetMode.WALK -> listOf(PlanDirectMode.WALK)
+        StreetMode.WALK_AND_BIKESHARE -> listOf(PlanDirectMode.WALK, PlanDirectMode.BICYCLE_RENTAL)
+        StreetMode.BICYCLE -> listOf(PlanDirectMode.BICYCLE)
+    }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/Otp2PlanRequestBuilder.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/Otp2PlanRequestBuilder.kt
@@ -15,7 +15,6 @@
  */
 package org.onebusaway.android.directions.util
 
-import android.content.Context
 import com.apollographql.apollo.api.Optional
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
@@ -48,7 +47,6 @@ import org.onebusaway.android.ui.tripplan.StreetMode
 import org.onebusaway.android.ui.tripplan.TripModeSelection
 import org.onebusaway.android.ui.tripplan.VehicleMode
 import org.onebusaway.android.ui.tripplan.WalkPreference
-import org.onebusaway.android.util.BikeshareAvailability
 
 /**
  * Builds the OTP 2.x GraphQL [PlanQuery] variables from a [TripRequestBuilder]'s already-parsed
@@ -56,7 +54,7 @@ import org.onebusaway.android.util.BikeshareAvailability
  * protocol-agnostic getters ([TripRequestBuilder.from]/[TripRequestBuilder.to]/
  * [TripRequestBuilder.dateTime]/[TripRequestBuilder.arriveBy]/
  * [TripRequestBuilder.getWheelchairAccessible]/[TripRequestBuilder.getOptimizeTransfers]/
- * [TripRequestBuilder.getModeSetId]) rather than duplicating request state, so both protocols are
+ * [TripRequestBuilder.getModeSelection]) rather than duplicating request state, so both protocols are
  * driven from one shared bundle-backed builder.
  */
 object Otp2PlanRequestBuilder {
@@ -205,7 +203,7 @@ object Otp2PlanRequestBuilder {
      * @throws IllegalArgumentException if the origin/destination lack real coordinates or no
      * date/time was supplied — mirrors [TripRequestBuilder.buildRequest]'s own validation.
      */
-    fun build(builder: TripRequestBuilder, context: Context): PlanQuery {
+    fun build(builder: TripRequestBuilder): PlanQuery {
         val from = builder.from
         val to = builder.to
         if (from == null || !from.isSet || to == null || !to.isSet) {
@@ -234,7 +232,7 @@ object Otp2PlanRequestBuilder {
                     bikePreference = builder.getBikePreference()
                 )
             ),
-            modes = buildModes(builder.getModeSelection(), BikeshareAvailability.isTripPlanningEnabled(context)),
+            modes = buildModes(builder.getModeSelection()),
             numItineraries = NUM_ITINERARIES,
             alternativeLegs = ALTERNATIVE_LEGS
         )
@@ -336,18 +334,13 @@ object Otp2PlanRequestBuilder {
      * "all transit modes usable, WALK for access/egress", so there is nothing to express, and the
      * request stays byte-identical to what this app sent before the mode split.
      *
-     * Takes [bikeshareEnabled] rather than a `Context` (see
-     * [BikeshareAvailability.isTripPlanningEnabled]'s pure overload) so this mapping is a plain,
-     * JVM-unit-testable function; `internal` for `Otp2PlanRequestBuilderTest`. A bikeshare selection
-     * on a region without a rental network degrades to walking rather than being refused, matching
-     * what the dialog would have offered.
+     * Takes a [selection] the region can serve — `TripRequestBuilder.getModeSelection` degrades one
+     * it can't ([TripModeSelection.availableIn]), so that rule is not restated here. Plain values
+     * rather than a `Context`, so this mapping is a JVM-unit-testable function; `internal` for
+     * `Otp2PlanRequestBuilderTest`.
      */
-    internal fun buildModes(selection: TripModeSelection, bikeshareEnabled: Boolean): Optional<PlanModesInput?> {
-        val street = if (selection.street == StreetMode.WALK_AND_BIKESHARE && !bikeshareEnabled) {
-            StreetMode.WALK
-        } else {
-            selection.street
-        }
+    internal fun buildModes(selection: TripModeSelection): Optional<PlanModesInput?> {
+        val street = selection.street
 
         if (selection.vehicle == VehicleMode.NONE) {
             // A direct street trip: `directOnly` stops OTP also returning transit itineraries, which
@@ -360,15 +353,7 @@ object Otp2PlanRequestBuilder {
             )
         }
 
-        val transitModes = when (selection.vehicle) {
-            VehicleMode.BUS -> listOf(TransitMode.BUS)
-            // TRAM is included so light rail counts as rail.
-            VehicleMode.RAIL -> listOf(TransitMode.RAIL, TransitMode.TRAM)
-            // Every mode the region runs — the schema default, so send nothing.
-            VehicleMode.ALL_TRANSIT -> null
-            VehicleMode.NONE -> null // unreachable, handled above
-        }
-
+        val transitModes = transitModes(selection.vehicle)
         if (transitModes == null && street == StreetMode.WALK) {
             return Optional.Absent
         }
@@ -396,8 +381,19 @@ object Otp2PlanRequestBuilder {
         )
     }
 
+    /** The transit modes [vehicle] restricts the search to, or null for "whatever the region runs". */
+    private fun transitModes(vehicle: VehicleMode): List<TransitMode>? = when (vehicle) {
+        VehicleMode.BUS -> listOf(TransitMode.BUS)
+        // TRAM is included so light rail counts as rail.
+        VehicleMode.RAIL -> listOf(TransitMode.RAIL, TransitMode.TRAM)
+        // Every mode the region runs, and no transit at all, both send no transit-mode restriction —
+        // the schema default. VehicleMode.NONE is a `directOnly` search, handled in buildModes.
+        VehicleMode.ALL_TRANSIT, VehicleMode.NONE -> null
+    }
+
     /**
-     * Access modes for [street].
+     * How [street] is covered in one phase of the trip, in whichever of OTP2's four per-phase mode
+     * enums the caller needs — the tokens differ, the shape does not, so it is stated once here.
      *
      * The two bike modes have **opposite** requirements, which is the one genuinely subtle thing here:
      *  - `BICYCLE_RENTAL` must be accompanied by `WALK` in the same list — OTP2 rejects a bare rental
@@ -407,35 +403,39 @@ object Otp2PlanRequestBuilder {
      *    transfers and egress is also `BICYCLE`". Your own bike is with you the whole way, so there is
      *    no phase without it. A stray WALK here silently degrades the plan to walking.
      *
-     * [StreetMode.WALK] sends nothing, since WALK is the schema's default for every phase.
+     * Sharing one table is what keeps the phases in step: access, egress and the direct suggestion
+     * disagreeing is precisely the silent failure above.
      */
-    private fun accessModes(street: StreetMode): Optional<List<PlanAccessMode>?> = when (street) {
-        StreetMode.WALK -> Optional.Absent
-        StreetMode.WALK_AND_BIKESHARE -> Optional.present(listOf(PlanAccessMode.WALK, PlanAccessMode.BICYCLE_RENTAL))
-        StreetMode.BICYCLE -> Optional.present(listOf(PlanAccessMode.BICYCLE))
-    }
-
-    /** Egress modes for [street]; same rules as [accessModes]. */
-    private fun egressModes(street: StreetMode): Optional<List<PlanEgressMode>?> = when (street) {
-        StreetMode.WALK -> Optional.Absent
-        StreetMode.WALK_AND_BIKESHARE -> Optional.present(listOf(PlanEgressMode.WALK, PlanEgressMode.BICYCLE_RENTAL))
-        StreetMode.BICYCLE -> Optional.present(listOf(PlanEgressMode.BICYCLE))
+    private fun <T> streetModes(street: StreetMode, walk: T, rental: T, bicycle: T): List<T> = when (street) {
+        StreetMode.WALK -> listOf(walk)
+        StreetMode.WALK_AND_BIKESHARE -> listOf(walk, rental)
+        StreetMode.BICYCLE -> listOf(bicycle)
     }
 
     /**
-     * Transfer mode for [street]. Only [StreetMode.BICYCLE] sets one: `PlanTransferMode` has no
-     * rental option (a hired bike is returned before boarding, so transfers are walked), and WALK is
-     * already the default.
+     * [streetModes] for an access/egress phase, where [StreetMode.WALK] sends nothing at all since
+     * WALK is the schema's default for every phase.
+     */
+    private fun <T> streetPhase(street: StreetMode, walk: T, rental: T, bicycle: T): Optional<List<T>?> = if (street == StreetMode.WALK) {
+        Optional.Absent
+    } else {
+        Optional.present(streetModes(street, walk, rental, bicycle))
+    }
+
+    private fun accessModes(street: StreetMode): Optional<List<PlanAccessMode>?> = streetPhase(street, PlanAccessMode.WALK, PlanAccessMode.BICYCLE_RENTAL, PlanAccessMode.BICYCLE)
+
+    private fun egressModes(street: StreetMode): Optional<List<PlanEgressMode>?> = streetPhase(street, PlanEgressMode.WALK, PlanEgressMode.BICYCLE_RENTAL, PlanEgressMode.BICYCLE)
+
+    /**
+     * Transfer mode for [street] — the one phase that doesn't share [streetModes], because
+     * `PlanTransferMode` has no rental option: a hired bike is returned before boarding, so transfers
+     * are walked. Only [StreetMode.BICYCLE] sets anything; WALK is already the default.
      */
     private fun transferModes(street: StreetMode): Optional<List<PlanTransferMode>?> = when (street) {
         StreetMode.BICYCLE -> Optional.present(listOf(PlanTransferMode.BICYCLE))
         StreetMode.WALK, StreetMode.WALK_AND_BIKESHARE -> Optional.Absent
     }
 
-    /** Direct (no-transit) street modes for [street]; same rental-needs-WALK rule as [accessModes]. */
-    private fun directModes(street: StreetMode): List<PlanDirectMode> = when (street) {
-        StreetMode.WALK -> listOf(PlanDirectMode.WALK)
-        StreetMode.WALK_AND_BIKESHARE -> listOf(PlanDirectMode.WALK, PlanDirectMode.BICYCLE_RENTAL)
-        StreetMode.BICYCLE -> listOf(PlanDirectMode.BICYCLE)
-    }
+    /** Direct (no-transit) street modes for [street]; unlike a phase, WALK is spelled out. */
+    private fun directModes(street: StreetMode): List<PlanDirectMode> = streetModes(street, PlanDirectMode.WALK, PlanDirectMode.BICYCLE_RENTAL, PlanDirectMode.BICYCLE)
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/TripRequestBuilder.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/TripRequestBuilder.kt
@@ -144,83 +144,32 @@ class TripRequestBuilder(context: Context, private val mBundle: Bundle) {
 
     /**
      * Records the rider's [TripModeSelection] and, for the OTP1 path, the `mode` query string it
-     * composes to.
-     *
-     * OTP1 takes one flat comma-separated mode list, so the two halves are simply concatenated —
-     * vehicle tokens then street tokens. The mapping reproduces exactly the strings this app sent
-     * before the mode split (`TRANSIT,WALK`, `BUS,WALK`, `RAIL,TRAM,WALK`, and those plus
-     * `BICYCLE_RENT`), so no OTP1 region sees a changed request for a selection it could already
-     * express.
+     * composes to (see [otp1ModeTokens]).
      *
      * Both halves are stored in the bundle by enum *name*, so the selection survives the trip-plan
      * monitor's `copyIntoBundleSimple`/`initFromBundleSimple` round trip — the flat mode id it
-     * replaced was a plain field that did not, which is why `TripPlanRepository` has to re-derive
-     * bike-rental-ness from the mode string.
+     * replaced was a plain field that did not.
      */
     fun setModeSelection(selection: TripModeSelection): TripRequestBuilder {
         mBundle.putString(VEHICLE_MODE, selection.vehicle.name)
         mBundle.putString(STREET_MODE, selection.street.name)
-        mBundle.putString(MODE_SET, TextUtils.join(",", otp1ModeTokens(selection)))
+        val tokens = otp1ModeTokens(
+            selection,
+            mContext.getString(R.string.traverse_mode_bicycle_rent),
+            BikeshareAvailability.isTripPlanningEnabled(mContext)
+        )
+        mBundle.putString(MODE_SET, TextUtils.join(",", tokens))
         return this
     }
 
     /**
-     * The stored selection, with a street mode this region cannot serve degraded to walking.
-     *
-     * Both halves persist across a region change, so a rider who picks bikeshare or their own bike
-     * and then moves to a region without a rental network, or off OTP2, must not silently keep
-     * planning something the server will not do. See [TripModeSelection.isAvailable].
+     * The stored selection, as this region can serve it — the single point where the request path
+     * applies [TripModeSelection.availableIn], so everything downstream may take the result as valid.
      */
-    fun getModeSelection(): TripModeSelection {
-        val stored = TripModeSelection(
-            vehicle = enumValueOrDefault(mBundle.getString(VEHICLE_MODE), VehicleMode.ALL_TRANSIT),
-            street = enumValueOrDefault(mBundle.getString(STREET_MODE), StreetMode.WALK)
-        )
-        val available = TripModeSelection.isAvailable(
-            stored.street,
-            BikeshareAvailability.isTripPlanningEnabled(mContext),
-            usesOtp2
-        )
-        return if (available) stored else stored.copy(street = StreetMode.WALK)
-    }
-
-    /**
-     * The OTP1 `mode` tokens for [selection] — vehicle then street.
-     *
-     * [StreetMode.BICYCLE] has no verified OTP1 equivalent, so it walks instead; the dialog only
-     * offers it on OTP2, and [getModeSelection] already degrades it, so this is the belt to that
-     * braces. A bikeshare selection without a rental network likewise falls back to walking.
-     *
-     * The one non-compositional case is a direct bikeshare trip, which historically sent
-     * `BICYCLE_RENT` alone rather than `WALK,BICYCLE_RENT`. That exact string is preserved: adding
-     * WALK would arguably be more correct, but it is an untested change to every OTP1 region's
-     * bikeshare request, and this refactor is not the place to make it.
-     */
-    private fun otp1ModeTokens(selection: TripModeSelection): List<String> {
-        val bikeRental = mContext.getString(R.string.traverse_mode_bicycle_rent)
-        val street = when (selection.street) {
-            StreetMode.WALK_AND_BIKESHARE ->
-                if (BikeshareAvailability.isTripPlanningEnabled(mContext)) {
-                    listOf(TripMode.WALK.name, bikeRental)
-                } else {
-                    listOf(TripMode.WALK.name)
-                }
-
-            StreetMode.WALK, StreetMode.BICYCLE -> listOf(TripMode.WALK.name)
-        }
-        val vehicle = when (selection.vehicle) {
-            VehicleMode.NONE -> emptyList()
-            VehicleMode.ALL_TRANSIT -> listOf(TripMode.TRANSIT.name)
-            VehicleMode.BUS -> listOf(TripMode.BUS.name)
-            // TRAM is included to allow light rail.
-            VehicleMode.RAIL -> listOf(TripMode.RAIL.name, TripMode.TRAM.name)
-        }
-        // Historical exact string for a direct bikeshare trip (see the KDoc above).
-        if (vehicle.isEmpty() && street.contains(bikeRental)) {
-            return listOf(bikeRental)
-        }
-        return vehicle + street
-    }
+    fun getModeSelection(): TripModeSelection = TripModeSelection(
+        vehicle = enumValueOrDefault(mBundle.getString(VEHICLE_MODE), VehicleMode.ALL_TRANSIT),
+        street = enumValueOrDefault(mBundle.getString(STREET_MODE), StreetMode.WALK)
+    ).availableIn(BikeshareAvailability.isTripPlanningEnabled(mContext), usesOtp2)
 
     private fun getModeString(): String? = mBundle.getString(MODE_SET)
 
@@ -443,6 +392,46 @@ class TripRequestBuilder(context: Context, private val mBundle: Bundle) {
             return TripRequestBuilder(context, target)
         }
     }
+}
+
+/**
+ * The OTP1 `mode` tokens for [selection] — vehicle then street.
+ *
+ * OTP1 takes one flat comma-separated mode list, so the two halves are simply concatenated. The
+ * mapping reproduces exactly the strings this app sent before the mode split (`TRANSIT,WALK`,
+ * `BUS,WALK`, `RAIL,TRAM,WALK`, and those plus `BICYCLE_RENT`), so no OTP1 region sees a changed
+ * request for a selection it could already express — which is what `TripRequestBuilderTest` pins.
+ *
+ * Degrades through [TripModeSelection.availableIn] with `usesOtp2 = false`, which is what makes
+ * [StreetMode.BICYCLE] walk here: the rider's own bike has no verified OTP1 equivalent. Stating it
+ * that way rather than by hand keeps one copy of the availability rule.
+ *
+ * The one non-compositional case is a direct bikeshare trip, which historically sent `BICYCLE_RENT`
+ * alone rather than `WALK,BICYCLE_RENT`. That exact string is preserved: adding WALK would arguably
+ * be more correct, but it is an untested change to every OTP1 region's bikeshare request, and this
+ * refactor is not the place to make it.
+ */
+internal fun otp1ModeTokens(
+    selection: TripModeSelection,
+    bikeRentalToken: String,
+    bikeshareEnabled: Boolean
+): List<String> {
+    val street = when (selection.availableIn(bikeshareEnabled, usesOtp2 = false).street) {
+        StreetMode.WALK_AND_BIKESHARE -> listOf(TripMode.WALK.name, bikeRentalToken)
+        StreetMode.WALK, StreetMode.BICYCLE -> listOf(TripMode.WALK.name)
+    }
+    val vehicle = when (selection.vehicle) {
+        VehicleMode.NONE -> emptyList()
+        VehicleMode.ALL_TRANSIT -> listOf(TripMode.TRANSIT.name)
+        VehicleMode.BUS -> listOf(TripMode.BUS.name)
+        // TRAM is included to allow light rail.
+        VehicleMode.RAIL -> listOf(TripMode.RAIL.name, TripMode.TRAM.name)
+    }
+    // Historical exact string for a direct bikeshare trip (see the KDoc above).
+    if (vehicle.isEmpty() && street.contains(bikeRentalToken)) {
+        return listOf(bikeRentalToken)
+    }
+    return vehicle + street
 }
 
 /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/TripRequestBuilder.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/TripRequestBuilder.kt
@@ -32,7 +32,9 @@ import org.onebusaway.android.api.contract.TripPlanRequest
 import org.onebusaway.android.directions.model.TripMode
 import org.onebusaway.android.ui.tripplan.BikePreference
 import org.onebusaway.android.ui.tripplan.CyclingPreference
-import org.onebusaway.android.ui.tripplan.TripModes
+import org.onebusaway.android.ui.tripplan.StreetMode
+import org.onebusaway.android.ui.tripplan.TripModeSelection
+import org.onebusaway.android.ui.tripplan.VehicleMode
 import org.onebusaway.android.ui.tripplan.WalkPreference
 import org.onebusaway.android.ui.tripplan.enumValueOrDefault
 import org.onebusaway.android.util.BikeshareAvailability
@@ -43,8 +45,6 @@ class TripRequestBuilder(context: Context, private val mBundle: Bundle) {
     // Application context, used to read the region / OTP-config seams (bikeshare availability, the OTP
     // base URL) that used to be reached through the Application static.
     private val mContext: Context = context.applicationContext
-
-    private var mModeId = 0
 
     fun setDepartureTime(instant: Instant): TripRequestBuilder {
         mBundle.putBoolean(ARRIVE_BY, false)
@@ -142,62 +142,84 @@ class TripRequestBuilder(context: Context, private val mBundle: Bundle) {
 
     fun getBikePreference(): BikePreference = enumValueOrDefault(mBundle.getString(BIKE_PREFERENCE), BikePreference.MEDIUM)
 
-    // Built in TraverseModeSet does not work properly so we cannot use request.setMode
-    // This is built from examining dropdown on the OTP webapp
-    // there are also airplane, bike, bike + ride, park + ride, kiss + ride, etc options
-    // transit -> TRANSIT,WALK
-    // bus only -> BUS,WALK
-    // rail only -> RAIL,TRAM,WALK (TRAM is included to allow light rail)
-    fun setModeSetById(id: Int): TripRequestBuilder {
-        mModeId = id
-        val modes: List<String> = when (id) {
-            // Transit only
-            TripModes.TRANSIT_ONLY ->
-                listOf(TripMode.TRANSIT.name, TripMode.WALK.name)
-            // Transit & bikeshare
-            TripModes.TRANSIT_AND_BIKE ->
-                if (BikeshareAvailability.isTripPlanningEnabled(mContext)) {
-                    listOf(
-                        TripMode.TRANSIT.name,
-                        TripMode.WALK.name,
-                        mContext.getString(R.string.traverse_mode_bicycle_rent)
-                    )
-                } else {
-                    listOf(TripMode.TRANSIT.name, TripMode.WALK.name)
-                }
-
-            TripModes.BUS_ONLY ->
-                listOf(TripMode.BUS.name, TripMode.WALK.name)
-
-            TripModes.RAIL_ONLY ->
-                listOf(
-                    TripMode.RAIL.name,
-                    TripMode.TRAM.name,
-                    TripMode.WALK.name
-                )
-
-            TripModes.BIKESHARE ->
-                listOf(mContext.getString(R.string.traverse_mode_bicycle_rent))
-
-            else -> {
-                Log.e(TAG, "Invalid mode set ID")
-                mModeId = -1
-                listOf(TripMode.TRANSIT.name, TripMode.WALK.name)
-            }
-        }
-
-        val modeString = TextUtils.join(",", modes)
-        mBundle.putString(MODE_SET, modeString)
+    /**
+     * Records the rider's [TripModeSelection] and, for the OTP1 path, the `mode` query string it
+     * composes to.
+     *
+     * OTP1 takes one flat comma-separated mode list, so the two halves are simply concatenated —
+     * vehicle tokens then street tokens. The mapping reproduces exactly the strings this app sent
+     * before the mode split (`TRANSIT,WALK`, `BUS,WALK`, `RAIL,TRAM,WALK`, and those plus
+     * `BICYCLE_RENT`), so no OTP1 region sees a changed request for a selection it could already
+     * express.
+     *
+     * Both halves are stored in the bundle by enum *name*, so the selection survives the trip-plan
+     * monitor's `copyIntoBundleSimple`/`initFromBundleSimple` round trip — the flat mode id it
+     * replaced was a plain field that did not, which is why `TripPlanRepository` has to re-derive
+     * bike-rental-ness from the mode string.
+     */
+    fun setModeSelection(selection: TripModeSelection): TripRequestBuilder {
+        mBundle.putString(VEHICLE_MODE, selection.vehicle.name)
+        mBundle.putString(STREET_MODE, selection.street.name)
+        mBundle.putString(MODE_SET, TextUtils.join(",", otp1ModeTokens(selection)))
         return this
     }
 
-    fun getModeSetId(): Int {
-        // IF bike mode is selected in the trip plan additional preferences but bikeshare is not
-        // enabled use the default mode (TRANSIT)
-        if (TripModes.BIKESHARE == mModeId && !BikeshareAvailability.isTripPlanningEnabled(mContext)) {
-            return TripModes.TRANSIT_ONLY
+    /**
+     * The stored selection, with a street mode this region cannot serve degraded to walking.
+     *
+     * Both halves persist across a region change, so a rider who picks bikeshare or their own bike
+     * and then moves to a region without a rental network, or off OTP2, must not silently keep
+     * planning something the server will not do. See [TripModeSelection.isAvailable].
+     */
+    fun getModeSelection(): TripModeSelection {
+        val stored = TripModeSelection(
+            vehicle = enumValueOrDefault(mBundle.getString(VEHICLE_MODE), VehicleMode.ALL_TRANSIT),
+            street = enumValueOrDefault(mBundle.getString(STREET_MODE), StreetMode.WALK)
+        )
+        val available = TripModeSelection.isAvailable(
+            stored.street,
+            BikeshareAvailability.isTripPlanningEnabled(mContext),
+            usesOtp2
+        )
+        return if (available) stored else stored.copy(street = StreetMode.WALK)
+    }
+
+    /**
+     * The OTP1 `mode` tokens for [selection] — vehicle then street.
+     *
+     * [StreetMode.BICYCLE] has no verified OTP1 equivalent, so it walks instead; the dialog only
+     * offers it on OTP2, and [getModeSelection] already degrades it, so this is the belt to that
+     * braces. A bikeshare selection without a rental network likewise falls back to walking.
+     *
+     * The one non-compositional case is a direct bikeshare trip, which historically sent
+     * `BICYCLE_RENT` alone rather than `WALK,BICYCLE_RENT`. That exact string is preserved: adding
+     * WALK would arguably be more correct, but it is an untested change to every OTP1 region's
+     * bikeshare request, and this refactor is not the place to make it.
+     */
+    private fun otp1ModeTokens(selection: TripModeSelection): List<String> {
+        val bikeRental = mContext.getString(R.string.traverse_mode_bicycle_rent)
+        val street = when (selection.street) {
+            StreetMode.WALK_AND_BIKESHARE ->
+                if (BikeshareAvailability.isTripPlanningEnabled(mContext)) {
+                    listOf(TripMode.WALK.name, bikeRental)
+                } else {
+                    listOf(TripMode.WALK.name)
+                }
+
+            StreetMode.WALK, StreetMode.BICYCLE -> listOf(TripMode.WALK.name)
         }
-        return mModeId
+        val vehicle = when (selection.vehicle) {
+            VehicleMode.NONE -> emptyList()
+            VehicleMode.ALL_TRANSIT -> listOf(TripMode.TRANSIT.name)
+            VehicleMode.BUS -> listOf(TripMode.BUS.name)
+            // TRAM is included to allow light rail.
+            VehicleMode.RAIL -> listOf(TripMode.RAIL.name, TripMode.TRAM.name)
+        }
+        // Historical exact string for a direct bikeshare trip (see the KDoc above).
+        if (vehicle.isEmpty() && street.contains(bikeRental)) {
+            return listOf(bikeRental)
+        }
+        return vehicle + street
     }
 
     private fun getModeString(): String? = mBundle.getString(MODE_SET)
@@ -311,6 +333,8 @@ class TripRequestBuilder(context: Context, private val mBundle: Bundle) {
         target.putString(WALK_PREFERENCE, getWalkPreference().name)
         target.putString(CYCLING_PREFERENCE, getCyclingPreference().name)
         target.putString(BIKE_PREFERENCE, getBikePreference().name)
+        target.putString(VEHICLE_MODE, mBundle.getString(VEHICLE_MODE))
+        target.putString(STREET_MODE, mBundle.getString(STREET_MODE))
         target.putString(MODE_SET, getModeString())
         dateTime?.let { target.putLong(DATE_TIME, it.toEpochMilli()) }
     }
@@ -336,6 +360,8 @@ class TripRequestBuilder(context: Context, private val mBundle: Bundle) {
         target.putString(WALK_PREFERENCE, getWalkPreference().name)
         target.putString(CYCLING_PREFERENCE, getCyclingPreference().name)
         target.putString(BIKE_PREFERENCE, getBikePreference().name)
+        target.putString(VEHICLE_MODE, mBundle.getString(VEHICLE_MODE))
+        target.putString(STREET_MODE, mBundle.getString(STREET_MODE))
         target.putString(MODE_SET, getModeString())
         dateTime?.let { target.putLong(DATE_TIME, it.toEpochMilli()) }
     }
@@ -370,6 +396,8 @@ class TripRequestBuilder(context: Context, private val mBundle: Bundle) {
         private const val WALK_PREFERENCE = ".WALK_PREFERENCE"
         private const val CYCLING_PREFERENCE = ".CYCLING_PREFERENCE"
         private const val BIKE_PREFERENCE = ".BIKE_PREFERENCE"
+        private const val VEHICLE_MODE = ".VEHICLE_MODE"
+        private const val STREET_MODE = ".STREET_MODE"
         private const val MODE_SET = ".MODE_SET"
         private const val DATE_TIME = ".DATE_TIME"
 
@@ -407,6 +435,8 @@ class TripRequestBuilder(context: Context, private val mBundle: Bundle) {
             target.putString(CYCLING_PREFERENCE, bundle.getString(CYCLING_PREFERENCE))
             target.putString(BIKE_PREFERENCE, bundle.getString(BIKE_PREFERENCE))
 
+            target.putString(VEHICLE_MODE, bundle.getString(VEHICLE_MODE))
+            target.putString(STREET_MODE, bundle.getString(STREET_MODE))
             target.putString(MODE_SET, bundle.getString(MODE_SET))
             target.putLong(DATE_TIME, bundle.getLong(DATE_TIME))
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
@@ -59,7 +59,6 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -68,7 +67,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
@@ -602,7 +600,6 @@ private fun DirectionsAdvancedSettingsDialog(
     onDismiss: () -> Unit
 ) {
     val context = LocalContext.current
-    val resources = LocalResources.current
     val imperial = remember { !PreferenceUtils.getUnitsAreMetricFromPreferences(context) }
     // Which options this region can actually serve. OTP2 deleted `maxWalkDistance` from its routing
     // API, so the distance field would be silently ignored there (#1780 wired the OTP2 path without
@@ -624,15 +621,18 @@ private fun DirectionsAdvancedSettingsDialog(
         stringResource(R.string.street_mode_walk) to StreetMode.WALK,
         stringResource(R.string.street_mode_walk_and_bikeshare) to StreetMode.WALK_AND_BIKESHARE,
         stringResource(R.string.street_mode_bicycle) to StreetMode.BICYCLE
-    ).filter { (_, mode) -> TripModeSelection.isAvailable(mode, bikeshare, usesOtp2) }
+    ).filter { (_, mode) -> mode.isAvailableIn(bikeshare, usesOtp2) }
 
     val current = remember { viewModel.formState.value }
     var vehicleMode by remember { mutableStateOf(current.modes.vehicle) }
-    // A street mode this region can't serve (a preference carried in from another region) falls back
-    // to walking, so the picker never shows a selection that isn't in its own list.
-    var streetMode by remember {
-        mutableStateOf(current.modes.street.takeIf { m -> streetOptions.any { it.second == m } } ?: StreetMode.WALK)
-    }
+    // Holds the rider's actual choice, including a street mode this region can't serve — a preference
+    // carried in from another region. Confirming the dialog must not overwrite that with the fallback
+    // below; like the max-walk field on OTP2, a setting the rider can't act on here is carried through
+    // untouched rather than eroded. The request degrades it at build time (TripModeSelection.availableIn).
+    var streetMode by remember { mutableStateOf(current.modes.street) }
+    // What the picker can show, by the same rule that filtered its options: an unofferable stored mode
+    // reads as the walking fallback the request will really use.
+    val offeredStreetMode = streetMode.takeIf { it.isAvailableIn(bikeshare, usesOtp2) } ?: StreetMode.WALK
     var minimizeTransfers by remember { mutableStateOf(current.optimizeTransfers) }
     var wheelchair by remember { mutableStateOf(current.wheelchair) }
     // Rounded, not truncated: the field's value is converted back to metres on confirm, so
@@ -690,7 +690,7 @@ private fun DirectionsAdvancedSettingsDialog(
                 PreferenceDropdownRow(
                     label = stringResource(R.string.street_mode_label),
                     options = streetOptions,
-                    selected = streetMode,
+                    selected = offeredStreetMode,
                     onSelected = { streetMode = it },
                     modifier = Modifier.padding(top = 8.dp)
                 )
@@ -702,8 +702,9 @@ private fun DirectionsAdvancedSettingsDialog(
                         onSelectedIndex = { walkPreference = WalkPreference.entries[it] },
                         modifier = Modifier.padding(top = 8.dp)
                     )
-                    // Only meaningful when the plan can contain a bike leg at all.
-                    if (streetMode.usesBike) {
+                    // Only meaningful when the plan can contain a bike leg at all — the offered mode,
+                    // since a stored one this region can't serve won't produce one.
+                    if (offeredStreetMode.usesBike) {
                         PreferenceSliderRow(
                             label = stringResource(R.string.bike_preference_label),
                             stopLabels = bikeStopLabels,
@@ -775,10 +776,10 @@ private fun DirectionsAdvancedSettingsDialog(
                         bikePreference = bikePreference
                     )
                 )
-                PreferenceUtils.saveString(prefKeyVehicleMode, vehicleMode.name)
-                PreferenceUtils.saveString(prefKeyStreetMode, streetMode.name)
                 // Every option is saved whether or not this region's protocol showed its control, so
                 // the value survives a move to a region that can use it (see [AdvancedSettings]).
+                PreferenceUtils.saveString(prefKeyVehicleMode, vehicleMode.name)
+                PreferenceUtils.saveString(prefKeyStreetMode, streetMode.name)
                 PreferenceUtils.saveDouble(prefKeyMaxWalk, maxWalkMeters ?: Double.MAX_VALUE)
                 PreferenceUtils.saveString(prefKeyWalkPreference, walkPreference.name)
                 PreferenceUtils.saveString(prefKeyCyclingPreference, cyclingPreference.name)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
@@ -113,13 +113,15 @@ import org.onebusaway.android.ui.nav.ReminderEditorArgs
 import org.onebusaway.android.ui.tripplan.AdvancedSettings
 import org.onebusaway.android.ui.tripplan.BikePreference
 import org.onebusaway.android.ui.tripplan.CyclingPreference
+import org.onebusaway.android.ui.tripplan.StreetMode
 import org.onebusaway.android.ui.tripplan.TripEndpoint
-import org.onebusaway.android.ui.tripplan.TripModes
+import org.onebusaway.android.ui.tripplan.TripModeSelection
 import org.onebusaway.android.ui.tripplan.TripPlanError
 import org.onebusaway.android.ui.tripplan.TripPlanForm
 import org.onebusaway.android.ui.tripplan.TripPlanFormState
 import org.onebusaway.android.ui.tripplan.TripPlanParams
 import org.onebusaway.android.ui.tripplan.TripPlanViewModel
+import org.onebusaway.android.ui.tripplan.VehicleMode
 import org.onebusaway.android.ui.tripplan.WalkPreference
 import org.onebusaway.android.ui.tripresults.RouteLegRef
 import org.onebusaway.android.ui.tripresults.RouteStopRef
@@ -602,31 +604,34 @@ private fun DirectionsAdvancedSettingsDialog(
     val context = LocalContext.current
     val resources = LocalResources.current
     val imperial = remember { !PreferenceUtils.getUnitsAreMetricFromPreferences(context) }
-    // (display label, trip-mode code) for each option, dropping bikeshare modes when unavailable.
-    val options = remember(resources) {
-        val typed = resources.obtainTypedArray(R.array.transit_mode_array)
-        val labels = resources.getStringArray(R.array.transit_mode_array)
-        val all = (0 until typed.length()).map { i ->
-            labels[i] to TripModes.getTripModeCodeFromSelection(typed.getResourceId(i, 0))
-        }
-        typed.recycle()
-        if (BikeshareAvailability.isTripPlanningEnabled(context)) {
-            all
-        } else {
-            all.filter { it.second != TripModes.BIKESHARE && it.second != TripModes.TRANSIT_AND_BIKE }
-        }
-    }
-    // Which street preferences this region's OTP server can actually act on. OTP2 deleted
-    // `maxWalkDistance` from its routing API, so the distance field would be silently ignored there
-    // (#1780 wired the OTP2 path without it); OTP1 in turn has no cycling-optimization knob that
-    // doesn't collide with the `optimize` parameter "Minimize transfers" already uses. Rather than
-    // show a control the server will drop, each protocol gets the one it honours.
+    // Which options this region can actually serve. OTP2 deleted `maxWalkDistance` from its routing
+    // API, so the distance field would be silently ignored there (#1780 wired the OTP2 path without
+    // it); OTP1 in turn has no cycling-optimization knob that doesn't collide with the `optimize`
+    // parameter "Minimize transfers" already uses, and no verified way to carry the rider's own bike.
+    // Rather than show a control the server will drop, each protocol gets the ones it honours.
     val usesOtp2 = remember { OtpTarget.resolve(context).usesOtp2 }
+    val bikeshare = remember { BikeshareAvailability.isTripPlanningEnabled(context) }
+
+    // The mode choice is two independent questions — what you'll ride, and how you'll cover the
+    // street at either end — so they get a picker each rather than one list of every combination.
+    val vehicleOptions = listOf(
+        stringResource(R.string.vehicle_mode_all_transit) to VehicleMode.ALL_TRANSIT,
+        stringResource(R.string.vehicle_mode_bus) to VehicleMode.BUS,
+        stringResource(R.string.vehicle_mode_rail) to VehicleMode.RAIL,
+        stringResource(R.string.vehicle_mode_none) to VehicleMode.NONE
+    )
+    val streetOptions = listOf(
+        stringResource(R.string.street_mode_walk) to StreetMode.WALK,
+        stringResource(R.string.street_mode_walk_and_bikeshare) to StreetMode.WALK_AND_BIKESHARE,
+        stringResource(R.string.street_mode_bicycle) to StreetMode.BICYCLE
+    ).filter { (_, mode) -> TripModeSelection.isAvailable(mode, bikeshare, usesOtp2) }
+
     val current = remember { viewModel.formState.value }
-    var selectedMode by remember {
-        mutableIntStateOf(
-            options.firstOrNull { it.second == current.modeId }?.second ?: options.first().second
-        )
+    var vehicleMode by remember { mutableStateOf(current.modes.vehicle) }
+    // A street mode this region can't serve (a preference carried in from another region) falls back
+    // to walking, so the picker never shows a selection that isn't in its own list.
+    var streetMode by remember {
+        mutableStateOf(current.modes.street.takeIf { m -> streetOptions.any { it.second == m } } ?: StreetMode.WALK)
     }
     var minimizeTransfers by remember { mutableStateOf(current.optimizeTransfers) }
     var wheelchair by remember { mutableStateOf(current.wheelchair) }
@@ -659,7 +664,8 @@ private fun DirectionsAdvancedSettingsDialog(
 
     // Preference keys resolved in composition (stringResource) so the confirm handler doesn't read
     // resource values off LocalContext.current (lint: LocalContextGetResourceValueCall).
-    val prefKeyTravelBy = stringResource(R.string.preference_key_trip_plan_travel_by)
+    val prefKeyVehicleMode = stringResource(R.string.preference_key_trip_plan_vehicle_mode)
+    val prefKeyStreetMode = stringResource(R.string.preference_key_trip_plan_street_mode)
     val prefKeyMaxWalk = stringResource(R.string.preference_key_trip_plan_maximum_walking_distance)
     val prefKeyWalkPreference = stringResource(R.string.preference_key_trip_plan_walk_preference)
     val prefKeyCyclingPreference = stringResource(R.string.preference_key_trip_plan_cycling_preference)
@@ -676,10 +682,17 @@ private fun DirectionsAdvancedSettingsDialog(
             // switches at the bottom would otherwise be unreachable.
             Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
                 PreferenceDropdownRow(
-                    label = stringResource(R.string.travel_by_label),
-                    options = options,
-                    selected = selectedMode,
-                    onSelected = { selectedMode = it }
+                    label = stringResource(R.string.vehicle_mode_label),
+                    options = vehicleOptions,
+                    selected = vehicleMode,
+                    onSelected = { vehicleMode = it }
+                )
+                PreferenceDropdownRow(
+                    label = stringResource(R.string.street_mode_label),
+                    options = streetOptions,
+                    selected = streetMode,
+                    onSelected = { streetMode = it },
+                    modifier = Modifier.padding(top = 8.dp)
                 )
                 if (usesOtp2) {
                     PreferenceSliderRow(
@@ -690,7 +703,7 @@ private fun DirectionsAdvancedSettingsDialog(
                         modifier = Modifier.padding(top = 8.dp)
                     )
                     // Only meaningful when the plan can contain a bike leg at all.
-                    if (selectedMode == TripModes.TRANSIT_AND_BIKE || selectedMode == TripModes.BIKESHARE) {
+                    if (streetMode.usesBike) {
                         PreferenceSliderRow(
                             label = stringResource(R.string.bike_preference_label),
                             stopLabels = bikeStopLabels,
@@ -753,7 +766,7 @@ private fun DirectionsAdvancedSettingsDialog(
                 }
                 viewModel.applyAdvancedSettings(
                     AdvancedSettings(
-                        modeId = selectedMode,
+                        modes = TripModeSelection(vehicleMode, streetMode),
                         maxWalkMeters = maxWalkMeters,
                         optimizeTransfers = minimizeTransfers,
                         wheelchair = wheelchair,
@@ -762,7 +775,8 @@ private fun DirectionsAdvancedSettingsDialog(
                         bikePreference = bikePreference
                     )
                 )
-                PreferenceUtils.saveInt(prefKeyTravelBy, selectedMode)
+                PreferenceUtils.saveString(prefKeyVehicleMode, vehicleMode.name)
+                PreferenceUtils.saveString(prefKeyStreetMode, streetMode.name)
                 // Every option is saved whether or not this region's protocol showed its control, so
                 // the value survives a move to a region that can use it (see [AdvancedSettings]).
                 PreferenceUtils.saveDouble(prefKeyMaxWalk, maxWalkMeters ?: Double.MAX_VALUE)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/AdvancedSettingsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/AdvancedSettingsRepository.kt
@@ -37,10 +37,23 @@ class DefaultAdvancedSettingsRepository @Inject constructor(
 ) : AdvancedSettingsRepository {
 
     override fun load(): AdvancedSettings {
-        val modeId = PreferenceUtils.getInt(
-            context.getString(R.string.preference_key_trip_plan_travel_by),
-            0
-        )
+        // The two mode halves replaced a single flat `travel_by` id. When they are absent — a rider
+        // upgrading from a build that predates the split — derive the pair from the legacy id rather
+        // than resetting their choice. No migration write: the next save writes the new keys.
+        val storedVehicle = PreferenceUtils.getString(context.getString(R.string.preference_key_trip_plan_vehicle_mode))
+        val modes = if (storedVehicle == null) {
+            TripModeSelection.fromLegacyModeId(
+                PreferenceUtils.getInt(context.getString(R.string.preference_key_trip_plan_travel_by), 0)
+            )
+        } else {
+            TripModeSelection(
+                vehicle = enumValueOrDefault(storedVehicle, VehicleMode.ALL_TRANSIT),
+                street = enumValueOrDefault(
+                    PreferenceUtils.getString(context.getString(R.string.preference_key_trip_plan_street_mode)),
+                    StreetMode.WALK
+                )
+            )
+        }
         val maxWalk = PreferenceUtils.getDouble(
             context.getString(R.string.preference_key_trip_plan_maximum_walking_distance),
             0.0
@@ -68,7 +81,7 @@ class DefaultAdvancedSettingsRepository @Inject constructor(
             BikePreference.MEDIUM
         )
         return AdvancedSettings(
-            modeId = modeId,
+            modes = modes,
             maxWalkMeters = maxWalk.takeIf { it != 0.0 && it != Double.MAX_VALUE },
             optimizeTransfers = optimize,
             wheelchair = wheelchair,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/AdvancedSettingsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/AdvancedSettingsRepository.kt
@@ -40,20 +40,17 @@ class DefaultAdvancedSettingsRepository @Inject constructor(
         // The two mode halves replaced a single flat `travel_by` id. When they are absent — a rider
         // upgrading from a build that predates the split — derive the pair from the legacy id rather
         // than resetting their choice. No migration write: the next save writes the new keys.
-        val storedVehicle = PreferenceUtils.getString(context.getString(R.string.preference_key_trip_plan_vehicle_mode))
-        val modes = if (storedVehicle == null) {
-            TripModeSelection.fromLegacyModeId(
-                PreferenceUtils.getInt(context.getString(R.string.preference_key_trip_plan_travel_by), 0)
-            )
-        } else {
+        val modes = PreferenceUtils.getString(context.getString(R.string.preference_key_trip_plan_vehicle_mode))?.let { vehicle ->
             TripModeSelection(
-                vehicle = enumValueOrDefault(storedVehicle, VehicleMode.ALL_TRANSIT),
+                vehicle = enumValueOrDefault(vehicle, VehicleMode.ALL_TRANSIT),
                 street = enumValueOrDefault(
                     PreferenceUtils.getString(context.getString(R.string.preference_key_trip_plan_street_mode)),
                     StreetMode.WALK
                 )
             )
-        }
+        } ?: TripModeSelection.fromLegacyModeId(
+            PreferenceUtils.getInt(context.getString(R.string.preference_key_trip_plan_travel_by), 0)
+        )
         val maxWalk = PreferenceUtils.getDouble(
             context.getString(R.string.preference_key_trip_plan_maximum_walking_distance),
             0.0

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/Otp2Planner.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/Otp2Planner.kt
@@ -79,7 +79,7 @@ class Otp2Planner @Inject constructor(
      * `@WorkerThread` by contract.
      */
     fun plan(builder: TripRequestBuilder, baseUrl: String): List<TripItinerary> {
-        val query = Otp2PlanRequestBuilder.build(builder, context)
+        val query = Otp2PlanRequestBuilder.build(builder)
         val apolloClient = apolloClientFor(otp2GraphQlEndpoint(baseUrl))
         val data = try {
             runBlocking { apolloClient.query(query).execute() }.dataOrThrow()

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripModeSelection.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripModeSelection.kt
@@ -54,11 +54,26 @@ enum class StreetMode {
 
     /** Whether a plan in this mode can contain a bike leg, and so has bike preferences worth showing. */
     val usesBike: Boolean get() = this != WALK
+
+    /**
+     * Whether a region can serve this mode: bikeshare needs a rental network, and the rider's own
+     * bike is expressible only in the OTP2 request shape (see `Otp2PlanRequestBuilder.buildModes`;
+     * OTP1's flat mode list has no verified equivalent). [VehicleMode] has no such constraint — every
+     * region has transit, and "no transit" is always a valid ask.
+     *
+     * The single statement of this rule. The mode picker filters its options with it, and every
+     * request path degrades through [TripModeSelection.availableIn] rather than restating it.
+     */
+    fun isAvailableIn(bikeshareEnabled: Boolean, usesOtp2: Boolean): Boolean = when (this) {
+        WALK -> true
+        WALK_AND_BIKESHARE -> bikeshareEnabled
+        BICYCLE -> usesOtp2
+    }
 }
 
 /**
- * The rider's full mode choice. Kept as one type so it can be threaded, persisted, and validated as a
- * unit — the two halves constrain each other's availability (see [isAvailable]).
+ * The rider's full mode choice. Kept as one type so it can be threaded, persisted, and degraded as a
+ * unit (see [availableIn]).
  */
 data class TripModeSelection(
     val vehicle: VehicleMode = VehicleMode.ALL_TRANSIT,
@@ -67,36 +82,33 @@ data class TripModeSelection(
     companion object {
 
         /**
-         * Whether this region can serve [street]: bikeshare needs a rental network, and the rider's
-         * own bike is expressible only in the OTP2 request shape (see
-         * `Otp2PlanRequestBuilder.buildModes`). [VehicleMode] has no such constraint — every region
-         * has transit, and "no transit" is always a valid ask.
-         */
-        fun isAvailable(street: StreetMode, bikeshareEnabled: Boolean, usesOtp2: Boolean): Boolean = when (street) {
-            StreetMode.WALK -> true
-            StreetMode.WALK_AND_BIKESHARE -> bikeshareEnabled
-            StreetMode.BICYCLE -> usesOtp2
-        }
-
-        /**
          * The selection behind a legacy `preference_trip_plan_travel_by` value — the flat mode id this
          * pair replaced. Read-only migration: [AdvancedSettingsRepository] falls back to it when the
          * new preferences are absent, and the next save writes the new keys, so a rider's existing
          * choice survives the upgrade without a migration step that could itself go wrong.
          *
-         * The ids are the former `TripModes` constants, kept here rather than left scattered as bare
-         * numbers: 0 transit+bikeshare, 1 bus, 2 rail, 3 bikeshare-only, 4 transit-only, 5 transit +
-         * own bike.
+         * The ids are the former `TripModes` constants — the only values a stored preference can hold —
+         * kept here rather than left scattered as bare numbers: 0 transit+bikeshare, 1 bus, 2 rail,
+         * 3 bikeshare-only, 4 transit-only. Own bike has no legacy id: it is new in this split, so no
+         * rider can have chosen it before.
          */
         fun fromLegacyModeId(modeId: Int): TripModeSelection = when (modeId) {
             0 -> TripModeSelection(VehicleMode.ALL_TRANSIT, StreetMode.WALK_AND_BIKESHARE)
             1 -> TripModeSelection(VehicleMode.BUS, StreetMode.WALK)
             2 -> TripModeSelection(VehicleMode.RAIL, StreetMode.WALK)
             3 -> TripModeSelection(VehicleMode.NONE, StreetMode.WALK_AND_BIKESHARE)
-            5 -> TripModeSelection(VehicleMode.ALL_TRANSIT, StreetMode.BICYCLE)
             // 4 (transit-only) and anything unrecognized land on the default pair, which is what
             // transit-only meant.
             else -> TripModeSelection()
         }
     }
+
+    /**
+     * This selection as the region can serve it: a street mode it can't ([StreetMode.isAvailableIn])
+     * degrades to walking, which is what the server would do anyway.
+     *
+     * Applied on the way to a request, never by rewriting the stored preference — so a rider who picks
+     * their own bike at home and then travels through an OTP1 region still has it when they come back.
+     */
+    fun availableIn(bikeshareEnabled: Boolean, usesOtp2: Boolean): TripModeSelection = if (street.isAvailableIn(bikeshareEnabled, usesOtp2)) this else copy(street = StreetMode.WALK)
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripModes.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripModes.kt
@@ -15,32 +15,88 @@
  */
 package org.onebusaway.android.ui.tripplan
 
-import org.onebusaway.android.R
+/**
+ * What the rider is willing to *ride*, paired with [StreetMode] to describe a whole trip.
+ *
+ * The two are genuinely independent — how you reach a stop says nothing about which vehicles you'll
+ * board — so they are chosen separately rather than enumerated as a flat list of combinations. That
+ * also reaches trips the old single list could not express at all: rail plus your own bike, bus plus
+ * bikeshare, or a plain walking route.
+ */
+enum class VehicleMode {
+    /** No transit at all — a direct street trip, walked or ridden end to end. */
+    NONE,
+
+    /** Any transit mode the region runs; the server's own default. */
+    ALL_TRANSIT,
+    BUS,
+
+    /** Rail, including light rail (OTP models those as separate `RAIL` and `TRAM` modes). */
+    RAIL
+}
 
 /**
- * Utility class to convert between the selected trip mode in the spinner and the trip mode code.
+ * How the rider covers the street portions — reaching the first stop, transferring, and leaving the
+ * last one — or the whole trip when [VehicleMode.NONE].
+ *
+ * The three are mutually exclusive from the router's point of view, and each maps to a different
+ * OTP2 access/egress shape with its own rules; see `Otp2PlanRequestBuilder.buildModes`.
  */
-object TripModes {
+enum class StreetMode {
+    /** On foot. OTP's own default, so it sends nothing. */
+    WALK,
 
-    const val TRANSIT_AND_BIKE = 0
-    const val BUS_ONLY = 1
-    const val RAIL_ONLY = 2
-    const val BIKESHARE = 3
-    const val TRANSIT_ONLY = 4
+    /** On foot plus a hired bike where one is available. Requires a rental network in the region. */
+    WALK_AND_BIKESHARE,
 
-    /**
-     * Return the trip mode code based on the selected label string resource id from the spinner
-     * that shows the trip mode options.
-     *
-     * @param selection string resource id of the selected trip mode in the UI
-     * @return corresponding trip mode code
-     */
-    fun getTripModeCodeFromSelection(selection: Int): Int = when (selection) {
-        R.string.transit_mode_transit_and_bikeshare -> TRANSIT_AND_BIKE
-        R.string.transit_mode_transit_only -> TRANSIT_ONLY
-        R.string.transit_mode_bus -> BUS_ONLY
-        R.string.transit_mode_rail -> RAIL_ONLY
-        R.string.transit_mode_bikeshare -> BIKESHARE
-        else -> -1
+    /** The rider's own bicycle, carried for the whole journey. OTP2-only. */
+    BICYCLE;
+
+    /** Whether a plan in this mode can contain a bike leg, and so has bike preferences worth showing. */
+    val usesBike: Boolean get() = this != WALK
+}
+
+/**
+ * The rider's full mode choice. Kept as one type so it can be threaded, persisted, and validated as a
+ * unit — the two halves constrain each other's availability (see [isAvailable]).
+ */
+data class TripModeSelection(
+    val vehicle: VehicleMode = VehicleMode.ALL_TRANSIT,
+    val street: StreetMode = StreetMode.WALK
+) {
+    companion object {
+
+        /**
+         * Whether this region can serve [street]: bikeshare needs a rental network, and the rider's
+         * own bike is expressible only in the OTP2 request shape (see
+         * `Otp2PlanRequestBuilder.buildModes`). [VehicleMode] has no such constraint — every region
+         * has transit, and "no transit" is always a valid ask.
+         */
+        fun isAvailable(street: StreetMode, bikeshareEnabled: Boolean, usesOtp2: Boolean): Boolean = when (street) {
+            StreetMode.WALK -> true
+            StreetMode.WALK_AND_BIKESHARE -> bikeshareEnabled
+            StreetMode.BICYCLE -> usesOtp2
+        }
+
+        /**
+         * The selection behind a legacy `preference_trip_plan_travel_by` value — the flat mode id this
+         * pair replaced. Read-only migration: [AdvancedSettingsRepository] falls back to it when the
+         * new preferences are absent, and the next save writes the new keys, so a rider's existing
+         * choice survives the upgrade without a migration step that could itself go wrong.
+         *
+         * The ids are the former `TripModes` constants, kept here rather than left scattered as bare
+         * numbers: 0 transit+bikeshare, 1 bus, 2 rail, 3 bikeshare-only, 4 transit-only, 5 transit +
+         * own bike.
+         */
+        fun fromLegacyModeId(modeId: Int): TripModeSelection = when (modeId) {
+            0 -> TripModeSelection(VehicleMode.ALL_TRANSIT, StreetMode.WALK_AND_BIKESHARE)
+            1 -> TripModeSelection(VehicleMode.BUS, StreetMode.WALK)
+            2 -> TripModeSelection(VehicleMode.RAIL, StreetMode.WALK)
+            3 -> TripModeSelection(VehicleMode.NONE, StreetMode.WALK_AND_BIKESHARE)
+            5 -> TripModeSelection(VehicleMode.ALL_TRANSIT, StreetMode.BICYCLE)
+            // 4 (transit-only) and anything unrecognized land on the default pair, which is what
+            // transit-only meant.
+            else -> TripModeSelection()
+        }
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanFormState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanFormState.kt
@@ -88,7 +88,7 @@ sealed interface TripEndpoint {
  * current region's server can act on.
  */
 data class AdvancedSettings(
-    val modeId: Int,
+    val modes: TripModeSelection,
     val maxWalkMeters: Double?,
     val optimizeTransfers: Boolean,
     val wheelchair: Boolean,
@@ -103,7 +103,7 @@ data class TripPlanParams(
     val to: TripEndpoint,
     val dateTimeMillis: Long,
     val arriving: Boolean,
-    val modeId: Int,
+    val modes: TripModeSelection,
     val wheelchair: Boolean,
     val optimizeTransfers: Boolean,
     val maxWalkMeters: Double?,
@@ -122,7 +122,7 @@ data class TripPlanFormState(
     val arriving: Boolean = false,
     val dateLabel: String = "",
     val timeLabel: String = "",
-    val modeId: Int = 0,
+    val modes: TripModeSelection = TripModeSelection(),
     val wheelchair: Boolean = false,
     val optimizeTransfers: Boolean = false,
     val maxWalkMeters: Double? = null,
@@ -137,7 +137,7 @@ data class TripPlanFormState(
     /** The current advanced options, for persistence by the host. */
     val advancedSettings: AdvancedSettings
         get() = AdvancedSettings(
-            modeId = modeId,
+            modes = modes,
             maxWalkMeters = maxWalkMeters,
             optimizeTransfers = optimizeTransfers,
             wheelchair = wheelchair,
@@ -152,7 +152,7 @@ data class TripPlanFormState(
         to = to,
         dateTimeMillis = dateTimeMillis,
         arriving = arriving,
-        modeId = modeId,
+        modes = modes,
         wheelchair = wheelchair,
         optimizeTransfers = optimizeTransfers,
         maxWalkMeters = maxWalkMeters,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanRepository.kt
@@ -143,10 +143,10 @@ class DefaultTripPlanRepository @Inject constructor(
                 first = false
             }
         }.let { params ->
-            // Read from the built mode string, not TripRequestBuilder.mModeId: mModeId is unset after
-            // initFromBundleSimple (the trip-plan-monitor restore path never repopulates it), and even
-            // on the direct path TRANSIT_AND_BIKE only actually requests bike rental when bikeshare is
-            // enabled — the mode string is the one place both facts are already resolved.
+            // Read from the built mode string rather than the selection: what reaches here is a
+            // TripPlanRequest, not the builder, and the string is where the region's bikeshare
+            // availability has already been resolved (a bikeshare pick without a rental network walks
+            // instead — see otp1ModeTokens).
             val bikeRentalToken = context.getString(R.string.traverse_mode_bicycle_rent)
             if (modeStringRequestsBikeRental(request.parameters["mode"], bikeRentalToken)) {
                 // Pre-1.0 servers spell bike rental as "BICYCLE, WALK"; modern ones as "BICYCLE_RENT".
@@ -261,7 +261,7 @@ internal fun otpPlanUrl(baseUrl: String, query: String, oldServer: Boolean): Str
 
 /**
  * True when [modeString] (the OTP `mode` query value built by
- * [org.onebusaway.android.directions.util.TripRequestBuilder.setModeSetById]) includes the bike-rental
+ * [org.onebusaway.android.directions.util.otp1ModeTokens]) includes the bike-rental
  * wire token — pulled out as a standalone, `Context`-free function so this (previously never-true —
  * see #1778) derivation is unit-testable.
  */

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanRepository.kt
@@ -282,7 +282,7 @@ internal fun TripPlanParams.toRequestBuilder(context: Context): TripRequestBuild
         setTo(params.to.toCustomAddress(context))
         val instant = Instant.ofEpochMilli(params.dateTimeMillis)
         if (params.arriving) setArrivalTime(instant) else setDepartureTime(instant)
-        setModeSetById(params.modeId)
+        setModeSelection(params.modes)
         setWheelchairAccessible(params.wheelchair)
         setOptimizeTransfers(params.optimizeTransfers)
         params.maxWalkMeters?.let { setMaxWalkDistance(it) }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanViewModel.kt
@@ -85,7 +85,7 @@ class TripPlanViewModel @Inject constructor(
             dateTimeMillis = initialDateTimeMillis,
             dateLabel = formatDate(initialDateTimeMillis),
             timeLabel = formatTime(initialDateTimeMillis),
-            modeId = initialSettings.modeId,
+            modes = initialSettings.modes,
             maxWalkMeters = initialSettings.maxWalkMeters,
             optimizeTransfers = initialSettings.optimizeTransfers,
             wheelchair = initialSettings.wheelchair,
@@ -238,7 +238,7 @@ class TripPlanViewModel @Inject constructor(
     fun applyAdvancedSettings(settings: AdvancedSettings) {
         _formState.update {
             it.copy(
-                modeId = settings.modeId,
+                modes = settings.modes,
                 maxWalkMeters = settings.maxWalkMeters,
                 optimizeTransfers = settings.optimizeTransfers,
                 wheelchair = settings.wheelchair,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
@@ -768,7 +768,8 @@ private class RowChrome(density: Density, private val model: LogRowModel, timeWi
 
 /**
  * The glyph inside an on-street leg's node. Null for [StreetMode.CAR]: the app ships no car drawable
- * because its planner never asks OTP for car modes (see `TripModes`), and a bare ring is honest where
+ * because its planner never asks OTP for car modes (the mode picker offers none — see
+ * `org.onebusaway.android.ui.tripplan.TripModeSelection`), and a bare ring is honest where
  * a walking figure would be wrong. Add `ic_directions_car` here if car planning is ever offered.
  */
 private fun streetModeIcon(mode: StreetMode): Int? = when (mode) {

--- a/onebusaway-android/src/main/res/values-es/arrays.xml
+++ b/onebusaway-android/src/main/res/values-es/arrays.xml
@@ -141,13 +141,6 @@
         <item>bus</item>
     </string-array>
 
-    <string-array name="transit_mode_array">
-        <item>@string/transit_mode_transit_and_bikeshare</item>
-        <item>@string/transit_mode_transit_only</item>
-        <item>@string/transit_mode_bus</item>
-        <item>@string/transit_mode_rail</item>
-        <item>@string/transit_mode_bikeshare</item>
-    </string-array>
 
 
 </resources>

--- a/onebusaway-android/src/main/res/values-es/strings.xml
+++ b/onebusaway-android/src/main/res/values-es/strings.xml
@@ -1025,12 +1025,6 @@
     <string name="maximum_walk_distance">Distancia máxima a pie: </string>
     <string name="wheelchair_accessible">Evitar las escaleras</string>
 
-    <string name="travel_by_label">Viajar por: </string>
-    <string name="transit_mode_transit_only">Tránsito</string>
-    <string name="transit_mode_transit_and_bikeshare">Tránsito &amp; bicicleta compartida</string>
-    <string name="transit_mode_bus">Solamente en Bus</string>
-    <string name="transit_mode_rail">Solamente en Tren</string>
-    <string name="transit_mode_bikeshare">Solamente Bicilceta Compartida</string>
     <string name="transit_directions_bikeshare_label">Bicicleta Compartida</string>
 
     <!-- Bikeshare info window -->

--- a/onebusaway-android/src/main/res/values-fi/strings.xml
+++ b/onebusaway-android/src/main/res/values-fi/strings.xml
@@ -750,11 +750,6 @@
     <string name="floating_bike_title">Napauta varataksesi tämän pyörän</string>
     <string name="layers_speedial_bikeshare_label">Kaupunkipyörät</string>
     <string name="transit_directions_bikeshare_label">Kaupunkipyörä</string>
-    <string name="transit_mode_bikeshare">Vain kaupunkipyörä</string>
-    <string name="transit_mode_bus">Vain bussi</string>
-    <string name="transit_mode_rail">Vain juna</string>
-    <string name="transit_mode_transit_and_bikeshare">Joukkoliikenne ja kaupunkipyörä</string>
-    <string name="transit_mode_transit_only">Vain joukkoliikenne</string>
 
     <!-- Foreground service -->
 
@@ -805,7 +800,6 @@
     <string name="minimize_transfers">Minimoi vaihdot</string>
     <string name="maximum_walk_distance">Enimmäiskävelymatka:</string>
     <string name="wheelchair_accessible">Vältä portaita</string>
-    <string name="travel_by_label">Matkustustapa: </string>
     <string name="tripplanner_no_server_selected_error">Aluetta ei ole valittu</string>
     <string name="tripplanner_error_not_defined">Pahoittelut, jokin meni pieleen. Yritä uudelleen.</string>
     <string name="tripplanner_error_request_timeout">Tarkista internetyhteys ja yritä uudelleen.</string>

--- a/onebusaway-android/src/main/res/values-it/arrays.xml
+++ b/onebusaway-android/src/main/res/values-it/arrays.xml
@@ -140,13 +140,6 @@
         <item>autobus</item>
     </string-array>
 
-    <string-array name="transit_mode_array">
-        <item>@string/transit_mode_transit_and_bikeshare</item>
-        <item>@string/transit_mode_transit_only</item>
-        <item>@string/transit_mode_bus</item>
-        <item>@string/transit_mode_rail</item>
-        <item>@string/transit_mode_bikeshare</item>
-    </string-array>
 
 
 </resources>

--- a/onebusaway-android/src/main/res/values-it/strings.xml
+++ b/onebusaway-android/src/main/res/values-it/strings.xml
@@ -869,12 +869,6 @@
     <string name="maximum_walk_distance">Massima distanza a piedi:</string>
     <string name="wheelchair_accessible">Evita scale</string>
 
-    <string name="travel_by_label">Viaggia con:</string>
-    <string name="transit_mode_transit_only">Solo mezzi pubblici</string>
-    <string name="transit_mode_transit_and_bikeshare">Mezzi pubblici e bike sharing</string>
-    <string name="transit_mode_bus">Solo autobus</string>
-    <string name="transit_mode_rail">Solo treno</string>
-    <string name="transit_mode_bikeshare">Solo bike sharing</string>
     <string name="transit_directions_bikeshare_label">Bike sharing</string>
 
     <!-- Bikeshare info window -->

--- a/onebusaway-android/src/main/res/values-pl/arrays.xml
+++ b/onebusaway-android/src/main/res/values-pl/arrays.xml
@@ -141,12 +141,5 @@
         <item>autobus</item>
     </string-array>
 
-    <string-array name="transit_mode_array">
-        <item>@string/transit_mode_transit_and_bikeshare</item>
-        <item>@string/transit_mode_transit_only</item>
-        <item>@string/transit_mode_bus</item>
-        <item>@string/transit_mode_rail</item>
-        <item>@string/transit_mode_bikeshare</item>
-    </string-array>
 
 </resources>

--- a/onebusaway-android/src/main/res/values-pl/strings.xml
+++ b/onebusaway-android/src/main/res/values-pl/strings.xml
@@ -983,12 +983,6 @@
     <string name="minimize_transfers">Minimalizuj przesiadki</string>
     <string name="maximum_walk_distance">Maksymalny dystans marszu: </string>
     <string name="wheelchair_accessible">Unikaj schodów</string>
-    <string name="travel_by_label">Podróżuj: </string>
-    <string name="transit_mode_transit_only">Tylko transport publiczny</string>
-    <string name="transit_mode_transit_and_bikeshare">Transport publiczny i rower miejski</string>
-    <string name="transit_mode_bus">Tylko autobus</string>
-    <string name="transit_mode_rail">Tylko kolej</string>
-    <string name="transit_mode_bikeshare">Tylko rower miejski</string>
     <string name="transit_directions_bikeshare_label">Rower miejski</string>
 
     <!-- Bikeshare -->

--- a/onebusaway-android/src/main/res/values/arrays.xml
+++ b/onebusaway-android/src/main/res/values/arrays.xml
@@ -151,13 +151,6 @@
         <item>bus</item>
     </string-array>
 
-    <string-array name="transit_mode_array">
-        <item>@string/transit_mode_transit_and_bikeshare</item>
-        <item>@string/transit_mode_transit_only</item>
-        <item>@string/transit_mode_bus</item>
-        <item>@string/transit_mode_rail</item>
-        <item>@string/transit_mode_bikeshare</item>
-    </string-array>
 
 
 </resources>

--- a/onebusaway-android/src/main/res/values/arrays.xml
+++ b/onebusaway-android/src/main/res/values/arrays.xml
@@ -151,6 +151,4 @@
         <item>bus</item>
     </string-array>
 
-
-
 </resources>

--- a/onebusaway-android/src/main/res/values/donottranslate.xml
+++ b/onebusaway-android/src/main/res/values/donottranslate.xml
@@ -51,6 +51,8 @@
     <string name="preference_key_never_show_location_dialog">never_show_location_dialog</string>
     <string name="preference_key_layer_bikeshare_visible">layer_bike_selected</string>
     <string name="preference_key_trip_plan_travel_by">preference_trip_plan_travel_by</string>
+    <string name="preference_key_trip_plan_vehicle_mode">preference_trip_plan_vehicle_mode</string>
+    <string name="preference_key_trip_plan_street_mode">preference_trip_plan_street_mode</string>
     <string name="preference_key_trip_plan_maximum_walking_distance">preference_trip_plan_maximum_walking_distance</string>
     <string name="preference_key_trip_plan_walk_preference">preference_trip_plan_walk_preference</string>
     <string name="preference_key_trip_plan_cycling_preference">preference_trip_plan_cycling_preference</string>

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -1172,12 +1172,19 @@
     <string name="cycling_preference_safest">Safest route</string>
     <string name="cycling_preference_flattest">Flattest route</string>
 
-    <string name="travel_by_label">Travel by: </string>
-    <string name="transit_mode_transit_only">Transit only</string>
-    <string name="transit_mode_transit_and_bikeshare">Transit &amp; bikeshare</string>
-    <string name="transit_mode_bus">Bus only</string>
-    <string name="transit_mode_rail">Rail only</string>
-    <string name="transit_mode_bikeshare">Bikeshare only</string>
+    <!-- Mode selection, split into two independent questions: which vehicles the rider will board,
+         and how they cover the street portions. Not every street option is offered everywhere -
+         bikeshare needs a rental network, and carrying your own bike needs an OTP2 region. -->
+    <string name="vehicle_mode_label">Ride</string>
+    <string name="vehicle_mode_all_transit">Any transit</string>
+    <string name="vehicle_mode_bus">Bus only</string>
+    <string name="vehicle_mode_rail">Rail only</string>
+    <string name="vehicle_mode_none">No transit</string>
+
+    <string name="street_mode_label">Getting around</string>
+    <string name="street_mode_walk">Walk</string>
+    <string name="street_mode_walk_and_bikeshare">Walk &amp; bikeshare</string>
+    <string name="street_mode_bicycle">My own bike</string>
     <string name="transit_directions_bikeshare_label">Bikeshare</string>
 
     <!-- Bikeshare info window -->

--- a/onebusaway-android/src/test/java/org/onebusaway/android/directions/util/Otp2PlanRequestBuilderTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/directions/util/Otp2PlanRequestBuilderTest.kt
@@ -17,7 +17,6 @@ package org.onebusaway.android.directions.util
 
 import com.apollographql.apollo.api.Optional
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.onebusaway.android.api.graphql.type.CyclingOptimizationType
@@ -38,18 +37,14 @@ import org.onebusaway.android.ui.tripplan.WalkPreference
 /**
  * Covers [Otp2PlanRequestBuilder.buildModes]/[Otp2PlanRequestBuilder.buildPreferences]/
  * [Otp2PlanRequestBuilder.buildStreetPreferences] — the OTP2 `PlanModesInput`/`PlanPreferencesInput`
- * siblings of [TripRequestBuilder.setModeSetById]'s OTP1 mode-string mapping and the
+ * siblings of [otp1ModeTokens]'s OTP1 mode-string mapping and the
  * wheelchair/`optimize=TRANSFERS` request params (#1780), plus the walk/cycling street preferences.
  * A plain JVM unit test (mirrors `ModeStringRequestsBikeRentalTest`'s style): they take plain
  * booleans and enums rather than a `Context`, so no Robolectric/DI is needed.
  */
 class Otp2PlanRequestBuilderTest {
 
-    private fun modesFor(
-        vehicle: VehicleMode,
-        street: StreetMode,
-        bikeshareEnabled: Boolean = true
-    ) = Otp2PlanRequestBuilder.buildModes(TripModeSelection(vehicle, street), bikeshareEnabled)
+    private fun modesFor(vehicle: VehicleMode, street: StreetMode) = Otp2PlanRequestBuilder.buildModes(TripModeSelection(vehicle, street))
 
     @Test
     fun anyTransitOnFootLeavesModesUnset() {
@@ -83,14 +78,6 @@ class Otp2PlanRequestBuilderTest {
         assertEquals(Optional.Absent, transit.transfer)
     }
 
-    @Test
-    fun bikeshareFallsBackToWalkingWithoutARentalNetwork() {
-        assertEquals(
-            modesFor(VehicleMode.ALL_TRANSIT, StreetMode.WALK),
-            modesFor(VehicleMode.ALL_TRANSIT, StreetMode.WALK_AND_BIKESHARE, bikeshareEnabled = false)
-        )
-    }
-
     /**
      * The rider's own bike must request BICYCLE for **all three** phases and never WALK alongside it —
      * the exact inverse of BICYCLE_RENTAL. The schema is explicit that access "can use cycling only
@@ -103,15 +90,6 @@ class Otp2PlanRequestBuilderTest {
         assertEquals(listOf(PlanAccessMode.BICYCLE), requirePresent(transit.access))
         assertEquals(listOf(PlanEgressMode.BICYCLE), requirePresent(transit.egress))
         assertEquals(listOf(PlanTransferMode.BICYCLE), requirePresent(transit.transfer))
-    }
-
-    /** Your own bike needs no rental network, only a bike-routable graph. */
-    @Test
-    fun ownBikeIsUnaffectedByBikeshareAvailability() {
-        assertEquals(
-            modesFor(VehicleMode.ALL_TRANSIT, StreetMode.BICYCLE, bikeshareEnabled = true),
-            modesFor(VehicleMode.ALL_TRANSIT, StreetMode.BICYCLE, bikeshareEnabled = false)
-        )
     }
 
     /**
@@ -158,28 +136,6 @@ class Otp2PlanRequestBuilderTest {
 
         val ownBikeOnly = requirePresent(modesFor(VehicleMode.NONE, StreetMode.BICYCLE))
         assertEquals(listOf(PlanDirectMode.BICYCLE), requirePresent(ownBikeOnly.direct))
-    }
-
-    /** Availability is per street mode; the vehicle half is always offerable. */
-    @Test
-    fun streetModeAvailabilityFollowsTheRegionsCapabilities() {
-        assertTrue(TripModeSelection.isAvailable(StreetMode.WALK, bikeshareEnabled = false, usesOtp2 = false))
-        assertFalse(TripModeSelection.isAvailable(StreetMode.WALK_AND_BIKESHARE, bikeshareEnabled = false, usesOtp2 = true))
-        assertTrue(TripModeSelection.isAvailable(StreetMode.WALK_AND_BIKESHARE, bikeshareEnabled = true, usesOtp2 = false))
-        assertFalse(TripModeSelection.isAvailable(StreetMode.BICYCLE, bikeshareEnabled = true, usesOtp2 = false))
-        assertTrue(TripModeSelection.isAvailable(StreetMode.BICYCLE, bikeshareEnabled = false, usesOtp2 = true))
-    }
-
-    /** A rider's saved flat mode id must survive the split rather than resetting their choice. */
-    @Test
-    fun legacyModeIdsMigrateToTheEquivalentPair() {
-        assertEquals(TripModeSelection(VehicleMode.ALL_TRANSIT, StreetMode.WALK_AND_BIKESHARE), TripModeSelection.fromLegacyModeId(0))
-        assertEquals(TripModeSelection(VehicleMode.BUS, StreetMode.WALK), TripModeSelection.fromLegacyModeId(1))
-        assertEquals(TripModeSelection(VehicleMode.RAIL, StreetMode.WALK), TripModeSelection.fromLegacyModeId(2))
-        assertEquals(TripModeSelection(VehicleMode.NONE, StreetMode.WALK_AND_BIKESHARE), TripModeSelection.fromLegacyModeId(3))
-        assertEquals(TripModeSelection(VehicleMode.ALL_TRANSIT, StreetMode.WALK), TripModeSelection.fromLegacyModeId(4))
-        assertEquals(TripModeSelection(VehicleMode.ALL_TRANSIT, StreetMode.BICYCLE), TripModeSelection.fromLegacyModeId(5))
-        assertEquals("an unknown id lands on the default pair", TripModeSelection(), TripModeSelection.fromLegacyModeId(-1))
     }
 
     @Test

--- a/onebusaway-android/src/test/java/org/onebusaway/android/directions/util/Otp2PlanRequestBuilderTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/directions/util/Otp2PlanRequestBuilderTest.kt
@@ -17,6 +17,7 @@ package org.onebusaway.android.directions.util
 
 import com.apollographql.apollo.api.Optional
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.onebusaway.android.api.graphql.type.CyclingOptimizationType
@@ -25,10 +26,13 @@ import org.onebusaway.android.api.graphql.type.PlanDirectMode
 import org.onebusaway.android.api.graphql.type.PlanEgressMode
 import org.onebusaway.android.api.graphql.type.PlanPreferencesInput
 import org.onebusaway.android.api.graphql.type.PlanStreetPreferencesInput
+import org.onebusaway.android.api.graphql.type.PlanTransferMode
 import org.onebusaway.android.api.graphql.type.TransitMode
 import org.onebusaway.android.ui.tripplan.BikePreference
 import org.onebusaway.android.ui.tripplan.CyclingPreference
-import org.onebusaway.android.ui.tripplan.TripModes
+import org.onebusaway.android.ui.tripplan.StreetMode
+import org.onebusaway.android.ui.tripplan.TripModeSelection
+import org.onebusaway.android.ui.tripplan.VehicleMode
 import org.onebusaway.android.ui.tripplan.WalkPreference
 
 /**
@@ -41,60 +45,141 @@ import org.onebusaway.android.ui.tripplan.WalkPreference
  */
 class Otp2PlanRequestBuilderTest {
 
+    private fun modesFor(
+        vehicle: VehicleMode,
+        street: StreetMode,
+        bikeshareEnabled: Boolean = true
+    ) = Otp2PlanRequestBuilder.buildModes(TripModeSelection(vehicle, street), bikeshareEnabled)
+
     @Test
-    fun transitOnlyLeavesModesUnset() {
-        // The schema's own default (all transit modes, WALK access/egress) already matches
-        // TRANSIT_ONLY's OTP1 semantics — nothing to express.
-        assertEquals(Optional.Absent, Otp2PlanRequestBuilder.buildModes(TripModes.TRANSIT_ONLY, bikeshareEnabled = true))
+    fun anyTransitOnFootLeavesModesUnset() {
+        // The schema's own default is "all transit modes usable, WALK for access/egress", so the
+        // default pair has nothing to express and must keep the request byte-identical to before.
+        assertEquals(Optional.Absent, modesFor(VehicleMode.ALL_TRANSIT, StreetMode.WALK))
     }
 
     @Test
     fun busOnlyRequestsOnlyBusTransitMode() {
-        val modes = requirePresent(Otp2PlanRequestBuilder.buildModes(TripModes.BUS_ONLY, bikeshareEnabled = false))
-        val transit = requirePresent(modes.transit)
-        val transitModes = requirePresent(transit.transit).map { it.mode }
-        assertEquals(listOf(TransitMode.BUS), transitModes)
+        val transit = requirePresent(requirePresent(modesFor(VehicleMode.BUS, StreetMode.WALK)).transit)
+        assertEquals(listOf(TransitMode.BUS), requirePresent(transit.transit).map { it.mode })
+        // Walking is the default for the street phases, so nothing is sent for them.
+        assertEquals(Optional.Absent, transit.access)
+        assertEquals(Optional.Absent, transit.egress)
     }
 
     @Test
     fun railOnlyRequestsRailAndTram() {
-        val modes = requirePresent(Otp2PlanRequestBuilder.buildModes(TripModes.RAIL_ONLY, bikeshareEnabled = false))
-        val transit = requirePresent(modes.transit)
-        val transitModes = requirePresent(transit.transit).map { it.mode }
-        assertEquals(listOf(TransitMode.RAIL, TransitMode.TRAM), transitModes)
+        val transit = requirePresent(requirePresent(modesFor(VehicleMode.RAIL, StreetMode.WALK)).transit)
+        assertEquals(listOf(TransitMode.RAIL, TransitMode.TRAM), requirePresent(transit.transit).map { it.mode })
     }
 
     @Test
-    fun transitAndBikeRequestsBicycleRentalAccessEgressWhenBikeshareEnabled() {
-        val modes = requirePresent(
-            Otp2PlanRequestBuilder.buildModes(TripModes.TRANSIT_AND_BIKE, bikeshareEnabled = true)
-        )
-        val transit = requirePresent(modes.transit)
+    fun bikeshareRequestsWalkAlongsideRentalForAccessAndEgress() {
+        val transit = requirePresent(requirePresent(modesFor(VehicleMode.ALL_TRANSIT, StreetMode.WALK_AND_BIKESHARE)).transit)
         // WALK must accompany BICYCLE_RENTAL — OTP2 rejects a bare BICYCLE_RENTAL leg (#1780).
         assertEquals(listOf(PlanAccessMode.WALK, PlanAccessMode.BICYCLE_RENTAL), requirePresent(transit.access))
         assertEquals(listOf(PlanEgressMode.WALK, PlanEgressMode.BICYCLE_RENTAL), requirePresent(transit.egress))
+        // PlanTransferMode has no rental option — a hired bike is returned before boarding.
+        assertEquals(Optional.Absent, transit.transfer)
     }
 
     @Test
-    fun transitAndBikeFallsBackToUnsetWhenBikeshareDisabled() {
-        // Mirrors setModeSetById's own fallback: TRANSIT_AND_BIKE without bikeshare == TRANSIT_ONLY.
+    fun bikeshareFallsBackToWalkingWithoutARentalNetwork() {
         assertEquals(
-            Optional.Absent,
-            Otp2PlanRequestBuilder.buildModes(TripModes.TRANSIT_AND_BIKE, bikeshareEnabled = false)
+            modesFor(VehicleMode.ALL_TRANSIT, StreetMode.WALK),
+            modesFor(VehicleMode.ALL_TRANSIT, StreetMode.WALK_AND_BIKESHARE, bikeshareEnabled = false)
         )
     }
 
+    /**
+     * The rider's own bike must request BICYCLE for **all three** phases and never WALK alongside it —
+     * the exact inverse of BICYCLE_RENTAL. The schema is explicit that access "can use cycling only
+     * if the mode used for transfers and egress is also `BICYCLE`", so a stray WALK here silently
+     * degrades the plan to walking rather than carrying the bike.
+     */
     @Test
-    fun bikeshareRequestsDirectBicycleRentalOnly() {
-        val modes = requirePresent(Otp2PlanRequestBuilder.buildModes(TripModes.BIKESHARE, bikeshareEnabled = true))
-        // WALK must accompany BICYCLE_RENTAL — OTP2 rejects a bare BICYCLE_RENTAL leg (#1780).
-        assertEquals(listOf(PlanDirectMode.WALK, PlanDirectMode.BICYCLE_RENTAL), requirePresent(modes.direct))
-        assertEquals(true, requirePresent(modes.directOnly))
+    fun ownBikeRequestsBicycleForAccessTransferAndEgress() {
+        val transit = requirePresent(requirePresent(modesFor(VehicleMode.ALL_TRANSIT, StreetMode.BICYCLE)).transit)
+        assertEquals(listOf(PlanAccessMode.BICYCLE), requirePresent(transit.access))
+        assertEquals(listOf(PlanEgressMode.BICYCLE), requirePresent(transit.egress))
+        assertEquals(listOf(PlanTransferMode.BICYCLE), requirePresent(transit.transfer))
     }
 
+    /** Your own bike needs no rental network, only a bike-routable graph. */
     @Test
-    fun invalidModeIdLeavesModesUnset() {
-        assertEquals(Optional.Absent, Otp2PlanRequestBuilder.buildModes(-1, bikeshareEnabled = true))
+    fun ownBikeIsUnaffectedByBikeshareAvailability() {
+        assertEquals(
+            modesFor(VehicleMode.ALL_TRANSIT, StreetMode.BICYCLE, bikeshareEnabled = true),
+            modesFor(VehicleMode.ALL_TRANSIT, StreetMode.BICYCLE, bikeshareEnabled = false)
+        )
+    }
+
+    /**
+     * The point of the split: street and vehicle choices compose, so combinations the old flat list
+     * could not express — rail plus your own bike, bus plus bikeshare — now work.
+     */
+    @Test
+    fun theTwoHalvesCompose() {
+        val railAndOwnBike = requirePresent(requirePresent(modesFor(VehicleMode.RAIL, StreetMode.BICYCLE)).transit)
+        assertEquals(listOf(TransitMode.RAIL, TransitMode.TRAM), requirePresent(railAndOwnBike.transit).map { it.mode })
+        assertEquals(listOf(PlanAccessMode.BICYCLE), requirePresent(railAndOwnBike.access))
+
+        val busAndBikeshare = requirePresent(requirePresent(modesFor(VehicleMode.BUS, StreetMode.WALK_AND_BIKESHARE)).transit)
+        assertEquals(listOf(TransitMode.BUS), requirePresent(busAndBikeshare.transit).map { it.mode })
+        assertEquals(listOf(PlanAccessMode.WALK, PlanAccessMode.BICYCLE_RENTAL), requirePresent(busAndBikeshare.access))
+    }
+
+    /**
+     * A transit search must also carry a direct suggestion matching how the rider travels. OTP falls
+     * back to it when no transit connection exists, and unset it defaults to WALK — which offered a
+     * cyclist a multi-hour walk when their requested vehicle had no service in range.
+     */
+    @Test
+    fun aTransitSearchCarriesADirectSuggestionMatchingTheStreetMode() {
+        val onBike = requirePresent(modesFor(VehicleMode.RAIL, StreetMode.BICYCLE))
+        assertEquals(listOf(PlanDirectMode.BICYCLE), requirePresent(onBike.direct))
+        // ...but it must NOT be directOnly, or the transit results would be suppressed.
+        assertEquals(Optional.Absent, onBike.directOnly)
+
+        val onFootWithRental = requirePresent(modesFor(VehicleMode.BUS, StreetMode.WALK_AND_BIKESHARE))
+        assertEquals(listOf(PlanDirectMode.WALK, PlanDirectMode.BICYCLE_RENTAL), requirePresent(onFootWithRental.direct))
+    }
+
+    /** No vehicle means a direct street trip, and `directOnly` keeps transit out of the results. */
+    @Test
+    fun noTransitRequestsADirectStreetTripOnly() {
+        val walkOnly = requirePresent(modesFor(VehicleMode.NONE, StreetMode.WALK))
+        assertEquals(listOf(PlanDirectMode.WALK), requirePresent(walkOnly.direct))
+        assertEquals(true, requirePresent(walkOnly.directOnly))
+        assertEquals("a direct trip must not also constrain transit", Optional.Absent, walkOnly.transit)
+
+        val bikeshareOnly = requirePresent(modesFor(VehicleMode.NONE, StreetMode.WALK_AND_BIKESHARE))
+        assertEquals(listOf(PlanDirectMode.WALK, PlanDirectMode.BICYCLE_RENTAL), requirePresent(bikeshareOnly.direct))
+
+        val ownBikeOnly = requirePresent(modesFor(VehicleMode.NONE, StreetMode.BICYCLE))
+        assertEquals(listOf(PlanDirectMode.BICYCLE), requirePresent(ownBikeOnly.direct))
+    }
+
+    /** Availability is per street mode; the vehicle half is always offerable. */
+    @Test
+    fun streetModeAvailabilityFollowsTheRegionsCapabilities() {
+        assertTrue(TripModeSelection.isAvailable(StreetMode.WALK, bikeshareEnabled = false, usesOtp2 = false))
+        assertFalse(TripModeSelection.isAvailable(StreetMode.WALK_AND_BIKESHARE, bikeshareEnabled = false, usesOtp2 = true))
+        assertTrue(TripModeSelection.isAvailable(StreetMode.WALK_AND_BIKESHARE, bikeshareEnabled = true, usesOtp2 = false))
+        assertFalse(TripModeSelection.isAvailable(StreetMode.BICYCLE, bikeshareEnabled = true, usesOtp2 = false))
+        assertTrue(TripModeSelection.isAvailable(StreetMode.BICYCLE, bikeshareEnabled = false, usesOtp2 = true))
+    }
+
+    /** A rider's saved flat mode id must survive the split rather than resetting their choice. */
+    @Test
+    fun legacyModeIdsMigrateToTheEquivalentPair() {
+        assertEquals(TripModeSelection(VehicleMode.ALL_TRANSIT, StreetMode.WALK_AND_BIKESHARE), TripModeSelection.fromLegacyModeId(0))
+        assertEquals(TripModeSelection(VehicleMode.BUS, StreetMode.WALK), TripModeSelection.fromLegacyModeId(1))
+        assertEquals(TripModeSelection(VehicleMode.RAIL, StreetMode.WALK), TripModeSelection.fromLegacyModeId(2))
+        assertEquals(TripModeSelection(VehicleMode.NONE, StreetMode.WALK_AND_BIKESHARE), TripModeSelection.fromLegacyModeId(3))
+        assertEquals(TripModeSelection(VehicleMode.ALL_TRANSIT, StreetMode.WALK), TripModeSelection.fromLegacyModeId(4))
+        assertEquals(TripModeSelection(VehicleMode.ALL_TRANSIT, StreetMode.BICYCLE), TripModeSelection.fromLegacyModeId(5))
+        assertEquals("an unknown id lands on the default pair", TripModeSelection(), TripModeSelection.fromLegacyModeId(-1))
     }
 
     @Test
@@ -199,7 +284,10 @@ class Otp2PlanRequestBuilderTest {
     /**
      * No stop may drop below 1.0, OTP's neutral point. Below it the schema says the mode is
      * "preferred over transit", and OTP acts on that by deleting transit itineraries — measured
-     * against a live server, rail + own bike returns nothing at 0.9 and a real itinerary at 1.0.
+     * against a live server, rail + own bike returns nothing at 0.9 and a real BICYCLE+TRAM+BICYCLE
+     * itinerary at 1.0. An earlier scale ran to 0.1 and so made "more cycling" produce *no*
+     * bike-and-transit results at all.
+     *
      * This is stricter than the scalar's own 0.1 validation floor, and unlike that one it fails
      * silently, as an empty result rather than an error.
      */

--- a/onebusaway-android/src/test/java/org/onebusaway/android/directions/util/TripRequestBuilderTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/directions/util/TripRequestBuilderTest.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.directions.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.onebusaway.android.ui.tripplan.StreetMode
+import org.onebusaway.android.ui.tripplan.TripModeSelection
+import org.onebusaway.android.ui.tripplan.VehicleMode
+
+/**
+ * Covers [otp1ModeTokens] — the OTP1 half of the vehicle/street mode split, and the sibling of
+ * [Otp2PlanRequestBuilder.buildModes] that `Otp2PlanRequestBuilderTest` pins.
+ *
+ * The claim under test is a compatibility one: every selection the old flat mode list could express
+ * must still produce the *exact* mode string this app sent before the split, so no OTP1 region sees a
+ * changed request. A plain JVM unit test — the mapping takes the bike-rental token and the bikeshare
+ * flag rather than a `Context`, so no Robolectric/DI is needed.
+ */
+class TripRequestBuilderTest {
+
+    /** The wire token `R.string.traverse_mode_bicycle_rent` resolves to. */
+    private val bikeRental = "BICYCLE_RENT"
+
+    private fun tokens(
+        vehicle: VehicleMode,
+        street: StreetMode,
+        bikeshareEnabled: Boolean = true
+    ) = otp1ModeTokens(TripModeSelection(vehicle, street), bikeRental, bikeshareEnabled).joinToString(",")
+
+    /**
+     * The five selections the pre-split dialog could express, against the exact strings the flat
+     * mode list built. Any drift here changes a live OTP1 region's request.
+     */
+    @Test
+    fun theOldModeListsStringsAreReproducedExactly() {
+        assertEquals("TRANSIT,WALK", tokens(VehicleMode.ALL_TRANSIT, StreetMode.WALK))
+        assertEquals("BUS,WALK", tokens(VehicleMode.BUS, StreetMode.WALK))
+        assertEquals("RAIL,TRAM,WALK", tokens(VehicleMode.RAIL, StreetMode.WALK))
+        assertEquals("TRANSIT,WALK,BICYCLE_RENT", tokens(VehicleMode.ALL_TRANSIT, StreetMode.WALK_AND_BIKESHARE))
+        // A direct bikeshare trip historically sent the rental token alone, with no WALK — the one
+        // non-compositional case, preserved deliberately rather than "fixed" here.
+        assertEquals(bikeRental, tokens(VehicleMode.NONE, StreetMode.WALK_AND_BIKESHARE))
+    }
+
+    /** Mirrors the old flat list's fallback: a bikeshare pick with no rental network walks. */
+    @Test
+    fun bikeshareWithoutARentalNetworkFallsBackToWalking() {
+        assertEquals(
+            tokens(VehicleMode.ALL_TRANSIT, StreetMode.WALK),
+            tokens(VehicleMode.ALL_TRANSIT, StreetMode.WALK_AND_BIKESHARE, bikeshareEnabled = false)
+        )
+        // ...including the direct case, which then has no rental token to return alone.
+        assertEquals("WALK", tokens(VehicleMode.NONE, StreetMode.WALK_AND_BIKESHARE, bikeshareEnabled = false))
+    }
+
+    /**
+     * Own bike has no verified OTP1 equivalent, so it walks. The dialog only offers it on OTP2 and
+     * [TripModeSelection.availableIn] already degrades it — this is the belt to that braces.
+     */
+    @Test
+    fun ownBikeWalksOnOtp1() {
+        assertEquals("TRANSIT,WALK", tokens(VehicleMode.ALL_TRANSIT, StreetMode.BICYCLE))
+        assertEquals("WALK", tokens(VehicleMode.NONE, StreetMode.BICYCLE))
+    }
+
+    /** Combinations the old flat list could not express compose into the obvious token lists. */
+    @Test
+    fun theTwoHalvesCompose() {
+        assertEquals("BUS,WALK,BICYCLE_RENT", tokens(VehicleMode.BUS, StreetMode.WALK_AND_BIKESHARE))
+        assertEquals("RAIL,TRAM,WALK,BICYCLE_RENT", tokens(VehicleMode.RAIL, StreetMode.WALK_AND_BIKESHARE))
+        // No transit at all, on foot — a plain walking route, which the old list had no entry for.
+        assertEquals("WALK", tokens(VehicleMode.NONE, StreetMode.WALK))
+    }
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripModeSelectionTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripModeSelectionTest.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.tripplan
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Covers the rider's mode choice itself — which street modes a region can serve
+ * ([StreetMode.isAvailableIn]), how an unservable one degrades ([TripModeSelection.availableIn]), and
+ * the read-only migration from the flat mode id this pair replaced.
+ *
+ * These are the rules the request builders *consume*, so they live here rather than in either
+ * protocol's test class: both `Otp2PlanRequestBuilder.buildModes` and `otp1ModeTokens` take a
+ * selection that has already been through them.
+ */
+class TripModeSelectionTest {
+
+    /** Availability is per street mode; the vehicle half is always offerable. */
+    @Test
+    fun streetModeAvailabilityFollowsTheRegionsCapabilities() {
+        assertTrue(StreetMode.WALK.isAvailableIn(bikeshareEnabled = false, usesOtp2 = false))
+        // Bikeshare needs a rental network, whichever protocol the region speaks.
+        assertFalse(StreetMode.WALK_AND_BIKESHARE.isAvailableIn(bikeshareEnabled = false, usesOtp2 = true))
+        assertTrue(StreetMode.WALK_AND_BIKESHARE.isAvailableIn(bikeshareEnabled = true, usesOtp2 = false))
+        // The rider's own bike needs OTP2, and no rental network.
+        assertFalse(StreetMode.BICYCLE.isAvailableIn(bikeshareEnabled = true, usesOtp2 = false))
+        assertTrue(StreetMode.BICYCLE.isAvailableIn(bikeshareEnabled = false, usesOtp2 = true))
+    }
+
+    /**
+     * A street mode the region can't serve degrades on the way to a request. The vehicle half is
+     * untouched, and — the point of degrading here rather than rewriting the preference — so is the
+     * original selection.
+     */
+    @Test
+    fun anUnservableStreetModeDegradesToWalking() {
+        val ownBike = TripModeSelection(VehicleMode.RAIL, StreetMode.BICYCLE)
+        assertEquals(
+            TripModeSelection(VehicleMode.RAIL, StreetMode.WALK),
+            ownBike.availableIn(bikeshareEnabled = true, usesOtp2 = false)
+        )
+        assertEquals(ownBike, ownBike.availableIn(bikeshareEnabled = false, usesOtp2 = true))
+
+        val bikeshare = TripModeSelection(VehicleMode.BUS, StreetMode.WALK_AND_BIKESHARE)
+        assertEquals(
+            TripModeSelection(VehicleMode.BUS, StreetMode.WALK),
+            bikeshare.availableIn(bikeshareEnabled = false, usesOtp2 = true)
+        )
+        assertEquals(bikeshare, bikeshare.availableIn(bikeshareEnabled = true, usesOtp2 = false))
+    }
+
+    /** A rider's saved flat mode id must survive the split rather than resetting their choice. */
+    @Test
+    fun legacyModeIdsMigrateToTheEquivalentPair() {
+        assertEquals(TripModeSelection(VehicleMode.ALL_TRANSIT, StreetMode.WALK_AND_BIKESHARE), TripModeSelection.fromLegacyModeId(0))
+        assertEquals(TripModeSelection(VehicleMode.BUS, StreetMode.WALK), TripModeSelection.fromLegacyModeId(1))
+        assertEquals(TripModeSelection(VehicleMode.RAIL, StreetMode.WALK), TripModeSelection.fromLegacyModeId(2))
+        assertEquals(TripModeSelection(VehicleMode.NONE, StreetMode.WALK_AND_BIKESHARE), TripModeSelection.fromLegacyModeId(3))
+        assertEquals(TripModeSelection(VehicleMode.ALL_TRANSIT, StreetMode.WALK), TripModeSelection.fromLegacyModeId(4))
+        // 0-4 were the only TripModes constants, so anything else is a value no rider can have
+        // stored — including own bike, which is new in this split and has no legacy id.
+        assertEquals("an unknown id lands on the default pair", TripModeSelection(), TripModeSelection.fromLegacyModeId(-1))
+        assertEquals("...as does one past the end of the old list", TripModeSelection(), TripModeSelection.fromLegacyModeId(5))
+    }
+
+    /** Bike preferences are worth showing for exactly the modes that can produce a bike leg. */
+    @Test
+    fun onlyTheBikeModesUseABike() {
+        assertFalse(StreetMode.WALK.usesBike)
+        assertTrue(StreetMode.WALK_AND_BIKESHARE.usesBike)
+        assertTrue(StreetMode.BICYCLE.usesBike)
+    }
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripPlanViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripPlanViewModelTest.kt
@@ -48,7 +48,7 @@ class TripPlanViewModelTest {
     @get:Rule
     val mainDispatcherRule = MainDispatcherRule()
 
-    private val settings = AdvancedSettings(modeId = 4, maxWalkMeters = 1600.0, optimizeTransfers = true, wheelchair = false)
+    private val settings = AdvancedSettings(modes = TripModeSelection(), maxWalkMeters = 1600.0, optimizeTransfers = true, wheelchair = false)
     private val origin = TripEndpoint.Geocoded("Origin", lat = 47.6, lon = -122.3)
     private val destination = TripEndpoint.Geocoded("Destination", lat = 47.7, lon = -122.2)
 
@@ -135,7 +135,7 @@ class TripPlanViewModelTest {
     fun `initial state carries the injected settings and cannot submit`() = runTest {
         val vm = viewModel()
         val state = vm.formState.value
-        assertEquals(4, state.modeId)
+        assertEquals(TripModeSelection(), state.modes)
         assertEquals(1600.0, state.maxWalkMeters)
         assertTrue(state.optimizeTransfers)
         assertFalse(state.canSubmit)
@@ -293,11 +293,11 @@ class TripPlanViewModelTest {
     @Test
     fun `applyAdvancedSettings updates the form`() = runTest {
         val vm = viewModel()
-        val updated = AdvancedSettings(modeId = 1, maxWalkMeters = null, optimizeTransfers = false, wheelchair = true)
+        val updated = AdvancedSettings(modes = TripModeSelection(VehicleMode.BUS, StreetMode.WALK), maxWalkMeters = null, optimizeTransfers = false, wheelchair = true)
         vm.applyAdvancedSettings(updated)
         advanceUntilIdle()
         val state = vm.formState.value
-        assertEquals(1, state.modeId)
+        assertEquals(TripModeSelection(VehicleMode.BUS, StreetMode.WALK), state.modes)
         assertTrue(state.wheelchair)
         assertFalse(state.optimizeTransfers)
         assertEquals(null, state.maxWalkMeters)
@@ -309,7 +309,7 @@ class TripPlanViewModelTest {
         setBothEndpoints(vm)
         vm.applyAdvancedSettings(
             AdvancedSettings(
-                modeId = TripModes.TRANSIT_AND_BIKE,
+                modes = TripModeSelection(VehicleMode.ALL_TRANSIT, StreetMode.WALK_AND_BIKESHARE),
                 maxWalkMeters = null,
                 optimizeTransfers = false,
                 wheelchair = false,


### PR DESCRIPTION
> **Stacked on #2024.** Built on `feature/otp2-street-preferences`, so until #2024 merges the diff here also contains its commit. GitHub collapses this to the single commit `Split the mode picker into vehicle and street, and add the rider's own bike` once #2024 lands. **Review/merge #2024 first.**

## The gap

The trip planner could only put a bike in an itinerary by **renting** one. Both bike modes map to `BICYCLE_RENTAL`, so a rider who owns a bike had no way to ask for a plan that carries it onto transit. `PlanAccessMode.BICYCLE` has been in the schema the whole time and the app has never used it.

## Why this restructures the picker instead of adding a sixth entry

Adding "Transit & my bike" to the old **Travel by** list would have made that list worse. Its six entries were already combinations of two independent things — which vehicles the rider boards, and how they cover the street at either end — so most combinations simply didn't exist. There was no way to ask for rail plus your own bike, bus plus bikeshare, or a plain walking route, and every new street option would multiply the list again.

```
Ride:            Any transit | Bus only | Rail only | No transit
Getting around:  Walk | Walk & bikeshare | My own bike
```

`buildModes` **composes** the two rather than tabulating twelve cases. `VehicleMode` decides whether this is a transit search and which transit modes are usable; `StreetMode` decides the access/egress/transfer shape. Only the per-mode rules are stated, each once.

## The rule that makes own-bike not a copy of the rental branch

The two bike modes have **opposite** requirements:

- `BICYCLE_RENTAL` **must** be accompanied by `WALK` — OTP rejects a bare rental leg, since a hired bike must be walked to and from.
- `BICYCLE` must **not** be. The schema: *"access can use cycling only if the mode used for transfers and egress is also `BICYCLE`"*. Your own bike is with you the whole way, so there is no phase without it.

Getting the second wrong doesn't error — the plan silently degrades to walking. A test pins all three phases for that reason, and another pins that own-bike is **not** gated on bikeshare availability (it needs no rental network, only a bike-routable graph) — the mistake you'd make by copying the neighbouring branch.

## `direct` now matches the street mode

OTP returns a direct suggestion alongside transit results and falls back to it when no transit connection exists. Left unset it defaults to `WALK`, so a cyclist whose requested vehicle had no service in range was offered a multi-hour **walk** — measured: rail-only from an origin with no Link station in range returned a 9.8 km / 128 min walk. It is deliberately *not* `directOnly` except under **No transit**, which is what makes that a street route rather than a transit search that tolerates walking.

## Gating and persistence

Availability is per street mode: bikeshare needs a rental network, own bike needs OTP2. The picker lists only what the region can serve, and `getModeSelection` degrades a stored mode the current region can't serve to walking — both halves persist across a region change.

OTP1 takes one flat mode list, so the halves concatenate, reproducing the exact strings sent before the split. That includes the direct bikeshare trip's historical `BICYCLE_RENT` without `WALK`: adding it is arguably more correct but is an untested change to every OTP1 region's bikeshare request, and this isn't the place for it.

The selection now lives in the request bundle by enum name, so it survives the trip-plan monitor's `copyIntoBundleSimple`/`initFromBundleSimple` round trip — the flat mode id it replaced was a plain field that did not. A rider's saved `travel_by` id migrates to the equivalent pair on read, with no migration write.

## Verified against a live server

Combinations the old list could not express now return real itineraries:

```
rail + own bike       ->  BICYCLE + TRAM(1 Line) + BICYCLE
bus  + bikeshare      ->  WALK + BICYCLE + BUS + WALK
no transit + own bike ->  a single BICYCLE leg
any transit + walk    ->  no `modes` sent at all (byte-identical to before)
```

## What I could not verify

**That OTP excludes bike-hostile trips.** Every transit leg returned for the own-bike mode reported `bikesAllowed: ALLOWED` — but that feed marks *every* trip `ALLOWED`, so nothing contradicts the expected filtering and nothing demonstrates it.

**Bike + rail is degraded on the tested deployment** for reasons outside this PR — see #2026. A bike search often returns bus-only itineraries where the walking equivalent uses rail, because of the server's access/egress stop cap. Not fixable client-side.

## Deliberately not included

**Bike-and-park** (`BICYCLE_PARKING` access, walk at the far end) — the natural sibling and a common commute pattern. The probe returned `NO_STOPS_IN_RANGE` and fell back to a 17 km walk, so that deployment has no bike parking in its graph. Offering a mode that silently returns nothing would be worse than not offering it.

## Tests

`Otp2PlanRequestBuilderTest` 29, `TripPlanViewModelTest` 24, both `failures="0" errors="0"`. `testObaGoogleDebugUnitTest`, `compileObaMaplibreDebugKotlin`, `spotlessCheck` green under `-PwarningsAsErrors=true`. Device-verified on an OTP2 region.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added separate vehicle and street mode selection for trip planning, including transit, walking, bikeshare, and bicycle options.
  * Added walking, cycling, and biking preference controls for supported routing services.
  * Preserved advanced trip preferences across sessions and region changes.
  * Added support for transit combined with riding a personal bicycle.

* **Bug Fixes**
  * Improved handling when selected travel modes are unavailable, automatically falling back to walking.
  * Improved routing behavior for bikeshare and bicycle access, transfers, and direct trips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->