### PR TITLE
iOS parity: handle the shared deep-link scheme (#2027)

### DIFF
--- a/docs/CUSTOM_SERVERS.md
+++ b/docs/CUSTOM_SERVERS.md
@@ -7,6 +7,21 @@ Before doing anything, check out the [system architecture diagrams](SYSTEM_ARCHI
 
 Also, note that while you can test your OBA server with a HTTP URL (see section below), you'll need to enable SSL for HTTPS before launching in the Regions API.
  
+## Two mechanisms
+
+There are two independent ways to point the app at a server you control:
+
+1. **The API-URL preferences** documented below (Settings → Advanced). These set an OBA and/or OTP URL
+   directly and switch the app out of region resolution entirely — there is no region, just a pair of
+   URLs. Good for poking at a test server.
+2. **A custom region** — an `onebusaway://add-region?name=…&oba-url=…` deep link, which creates a real
+   named region that persists, appears in the region picker, and survives regions-directory refreshes.
+   See [`DEEP_LINKING.md`](DEEP_LINKING.md). Better for a deployment you'll come back to, and the only
+   one of the two that can carry a sidecar/analytics config.
+
+They don't stack: applying any region (including a custom one) clears the custom OBA URL preference, so
+whichever you did last is what's in effect.
+
 ## Configuration
 
 In the app, go to "Settings->Advanced".  You should see a screen like:

--- a/docs/CUSTOM_SERVERS.md
+++ b/docs/CUSTOM_SERVERS.md
@@ -19,8 +19,14 @@ There are two independent ways to point the app at a server you control:
    See [`DEEP_LINKING.md`](DEEP_LINKING.md). Better for a deployment you'll come back to, and the only
    one of the two that can carry a sidecar/analytics config.
 
-They don't stack: applying any region (including a custom one) clears the custom OBA URL preference, so
-whichever you did last is what's in effect.
+They mostly don't stack: applying any region (including a custom one) always clears the custom **OBA**
+URL preference, so whichever you did last decides where transit data comes from.
+
+The custom **OTP** URL is narrower — `RegionRepository.applyRegion` clears it only when the region being
+applied actually publishes an `otpBaseUrl`. So if you set a custom OTP URL and then switch to a region
+with no trip planner of its own (including a custom region added without `otp-url`), that custom OTP URL
+stays in effect. That is long-standing behaviour for every region, not something custom regions
+introduce; clear the preference by hand if you don't want it.
 
 ## Configuration
 

--- a/docs/DEEP_LINKING.md
+++ b/docs/DEEP_LINKING.md
@@ -1,0 +1,86 @@
+# Deep Linking
+
+OneBusAway for Android answers the same deep links as
+[OneBusAway for iOS](https://developer.onebusaway.org/projects/ios), so a link shared from either app
+opens the same screen on the other ([#2027](https://github.com/OneBusAway/onebusaway-android/issues/2027)).
+
+Two families of link, both handled by `HomeActivity` (the app's single Activity):
+
+| Link | Opens |
+| --- | --- |
+| `onebusaway://view-stop?stopID=1_75403&regionID=1` | That stop's arrivals |
+| `onebusaway://add-region?name=…&oba-url=…&otp-url=…` | Applies custom API URLs, stays on the map |
+| `https://onebusaway.co/regions/1/stops/1_75403/trips?trip_id=1_18196913&service_date=1698307200.0&stop_sequence=5` | That trip's details, scrolled to the stop in the path |
+
+## Custom-scheme links
+
+Every brand answers to the cross-platform `onebusaway://` scheme **and** to its own scheme
+(`kiedybus://` for KiedyBus) — set per brand as the `deepLinkScheme` manifest placeholder plus the
+matching `DEEP_LINK_SCHEME` build-config field in `onebusaway-android/flavors/<brand>.gradle`.
+`IntentRouteMapper.APP_SCHEMES` is the Kotlin-side copy of that set.
+
+`view-stop` needs `stopID` (an agency-qualified stop id such as `1_75403`, percent-encoded).
+
+`add-region` reads `oba-url` and `otp-url`; each is applied only if it validates. Ampersands inside a
+nested URL must be percent-encoded as `%26`.
+
+## Web links (Android App Links)
+
+`https://` links on the OneBusAway web/sidecar hosts — `onebusaway.co`, `www.onebusaway.co`,
+`sidecar.onebusaway.org` — mirroring the iOS app's associated domains. Only the trip endpoint is a
+deep link:
+
+```
+https://<host>/regions/{regionID}/stops/{stopID}/trips?trip_id=…&service_date=…&stop_sequence=…
+```
+
+The filter lives in `onebusaway-android/src/oba/AndroidManifest.xml` (the OBA brand only — a
+white-label brand can't verify hosts it doesn't own; a brand with its own web host should add its own
+flavor manifest with the same shape).
+
+> **Server-side step still outstanding:** `android:autoVerify="true"` only takes effect once each host
+> serves `/.well-known/assetlinks.json` listing the app's package name
+> (`com.joulespersecond.seattlebusbot`) and its release signing-certificate SHA-256 fingerprint. Until
+> then these links keep opening in the browser — nothing regresses, and the filter can still be
+> exercised directly with `adb` (below). See
+> [Verify Android App Links](https://developer.android.com/training/app-links/verify-android-applinks).
+
+## What's deliberately *not* supported
+
+- **Stop-only web paths** (`/regions/{id}/stops/{id}` with no `/trips`) are not deep links, matching
+  iOS; they fall through to the browser.
+- **`add-region`'s `name` / `sidecar-url` / `umami-url` / `umami-id` parameters** are ignored. Android's
+  custom-server mechanism is a pair of API-URL preferences (see
+  [`CUSTOM_SERVERS.md`](CUSTOM_SERVERS.md)), not a synthetic named region, so it has nowhere to put
+  them. Full parity here needs a real custom-region model.
+- **Parameters no Android screen consumes** are recognized and ignored rather than required, so any
+  link iOS accepts is accepted here: `regionID` (iOS parses it but also only ever searches the current
+  region — an incoming link for a stop outside the active region will fail to load), and the trip
+  link's `service_date`, `stop_sequence`, `title`, `vehicle_id`, and `destination_stop_id`.
+- **iOS `NSUserActivity` handoff / Siri / Spotlight** types have no Android equivalent.
+
+## Testing
+
+An `adb` VIEW intent exercises a filter regardless of App Links verification:
+
+```bash
+# Stop
+adb shell am start -a android.intent.action.VIEW \
+  -d 'onebusaway://view-stop?stopID=1_75403&regionID=1' \
+  com.joulespersecond.seattlebusbot
+
+# Trip (keep the URL single-quoted so the shell doesn't split on &)
+adb shell am start -a android.intent.action.VIEW \
+  -d 'https://onebusaway.co/regions/1/stops/1_75403/trips?trip_id=1_18196913&service_date=1698307200.0&stop_sequence=5' \
+  com.joulespersecond.seattlebusbot
+```
+
+## Implementation
+
+- `ui/nav/ExternalDeepLinks.kt` — the pure link → target-screen parser (unit-tested in
+  `ExternalDeepLinksTest`); `WEB_HOSTS` must match the manifest filter's hosts.
+- `ui/nav/IntentRouteMapper.kt` — decomposes the intent's `Uri`, then decides the NavHost route
+  (`decide`, unit-tested in `IntentRouteMapperTest`).
+- `ui/HomeActivity.kt` — runs the side effect `add-region` implies (`applyIntentSideEffects`).
+- `ui/nav/DeepLinkUris.kt` — separate concern: the app's *internal* `content://` stop/route
+  vocabulary, used by pinned launcher shortcuts and in-app launches.

--- a/docs/DEEP_LINKING.md
+++ b/docs/DEEP_LINKING.md
@@ -9,7 +9,7 @@ Two families of link, both handled by `HomeActivity` (the app's single Activity)
 | Link | What it does |
 | --- | --- |
 | `onebusaway://view-stop?stopID=1_75403&regionID=1` | Opens that stop's arrivals |
-| `onebusaway://add-region?oba-url=…&otp-url=…` | Points the app at those API servers. Opens no screen — see below |
+| `onebusaway://add-region?name=…&oba-url=…` | Adds that named region and switches to it, after the rider confirms — see below |
 | `https://onebusaway.co/regions/1/stops/1_75403/trips?trip_id=1_18196913&service_date=1698307200.0&stop_sequence=5` | Opens that trip's details, scrolled to the stop in the path |
 
 ## Custom-scheme links
@@ -24,26 +24,70 @@ brand advertises.
 
 `view-stop` needs `stopID` (an agency-qualified stop id such as `1_75403`, percent-encoded).
 
-`add-region` reads `oba-url` and `otp-url`; each is applied only if it validates. Ampersands inside a
-nested URL must be percent-encoded as `%26`.
+### `add-region`
 
-Unlike the other two links, `add-region` names no destination — it's a settings change, not a screen.
-It navigates nowhere (`IntentRouteMapper` returns `RouteDecision.None`), so the app simply opens on its
-usual home screen, the map. What changed is where the app's requests go:
+Adds a **custom region** — a real, named, persisted region, the same thing the link creates on iOS — and
+makes it current. Ampersands inside a nested URL must be percent-encoded as `%26`.
 
-- **`oba-url`** becomes the OBA API server, and applying it **clears the selected region** — the app
-  stops resolving a region at all and talks to that server directly. This is the same state the
-  Settings custom-API-URL path produces; see [`CUSTOM_SERVERS.md`](CUSTOM_SERVERS.md).
-- **`otp-url`** becomes the trip-planning (OTP) server. On its own it leaves the region alone.
+| Parameter | Required | Becomes |
+| --- | --- | --- |
+| `name` | **yes** | The region's display name, as shown in the region picker |
+| `oba-url` | **yes** | `Region.obaBaseUrl` — the OBA REST server |
+| `otp-url` | no | `Region.otpBaseUrl` — the trip-planning server |
+| `sidecar-url` | no | `Region.sidecarBaseUrl` |
+| `umami-url` / `umami-id` | no | `Region.umamiAnalytics` |
 
-The name `add-region` is inherited from iOS, where the link really does add a named region. Android has
-no custom-region model, so it can only set these URLs — which is also why `name`, `sidecar-url`,
-`umami-url` and `umami-id` are ignored (below).
+A custom region behaves like a directory region with three deliberate differences:
 
-> Note that "validates" here means *well-formed*, not *trusted*, and this filter is `BROWSABLE` — so any
-> web page can repoint the app's API server with no confirmation. That predates this vocabulary (it was
-> the old `SettingsActivity` VIEW filter) and is tracked in
-> [#2030](https://github.com/OneBusAway/onebusaway-android/issues/2030).
+- **It survives regions-directory refreshes.** `RegionDao.replaceAll` deletes only `custom = 0` rows, so
+  a refresh can't take the rider's own region with it, and `RegionCache.loadRegions` unions custom
+  regions back into every result.
+- **It is never auto-selected, and never auto-*replaced*.** It carries no bounds, so `getClosestRegion`
+  can't measure a distance to it; and `resolveRegionStatus` leaves a current custom region alone
+  regardless of what's nearest, because following an `add-region` link is an explicit choice that
+  auto-selection must not silently undo.
+- **Its id is negative** (counting down from `-2`), so it can't collide with a directory id (those are
+  `>= 0`) or with the `-1` "no region" sentinel in the region-id preference. Ids are never reused, so a
+  stale reference resolves to nothing rather than to somebody else's server.
+
+Re-sending the same `oba-url` **updates that region in place** rather than adding a duplicate.
+
+Capability flags (`supportsObaDiscoveryApis`, `supportsObaRealtimeApis`) are set true because
+`RegionUtils.isRegionUsable` requires them — they are *declarations*, not observations: nothing has
+probed the server. If it doesn't serve those APIs, requests fail visibly like any unreachable server.
+`contactEmail` is left empty rather than filled with a placeholder (iOS hardcodes
+`example@example.com`), which correctly hides the "email a problem report" option instead of mailing a
+made-up address.
+
+Once added, a custom region appears in the region picker like any other. **Long-press it there to
+remove it** — the way back out of a link you regret. Removing the region you're currently on re-resolves
+as if none had been set.
+
+The pre-existing Settings → Advanced custom-API-URL preferences are a separate, unchanged mechanism (see
+[`CUSTOM_SERVERS.md`](CUSTOM_SERVERS.md)); a custom region supersedes them, since applying any region
+clears the custom OBA URL preference.
+
+#### The link is confirmed, not applied
+
+The filter is `BROWSABLE`, so **any web page can fire an `add-region` link at the app**, and accepting one
+repoints every transit request the app makes. `HomeActivity` therefore hands the parsed request to
+`AddRegionViewModel`, which stages it and writes nothing until the rider accepts a dialog naming the
+servers involved ([#2030](https://github.com/OneBusAway/onebusaway-android/issues/2030)). Declining
+writes nothing at all.
+
+This is a **deliberate divergence from iOS**, which applies the region with no prompt. The dialog leads
+with the server URLs rather than the region name, because the name is attacker-supplied text and says
+nothing about where the data would come from.
+
+#### Breaking change: `name` is now required
+
+Before this, `onebusaway://add-region?oba-url=…` (no `name`) set a pair of API-URL *preferences* and
+created no region. That link **no longer resolves at all** — matching iOS, which requires `name`. A
+nameless region has nothing to show in the picker, so there is no sensible region to build from it.
+Links in the wild that omit `name` need one added.
+
+It still navigates nowhere (`IntentRouteMapper` returns `RouteDecision.None`): the app opens on its usual
+home screen, the map, with the new region active.
 
 ## Web links (Android App Links)
 
@@ -97,10 +141,6 @@ opening the page they tapped.
 
 - **Stop-only web paths** (`/regions/{id}/stops/{id}` with no `/trips`) are not deep links, matching
   iOS; they fall through to the browser.
-- **`add-region`'s `name` / `sidecar-url` / `umami-url` / `umami-id` parameters** are ignored. Android's
-  custom-server mechanism is a pair of API-URL preferences (see
-  [`CUSTOM_SERVERS.md`](CUSTOM_SERVERS.md)), not a synthetic named region, so it has nowhere to put
-  them. Full parity here needs a real custom-region model.
 - **Parameters no Android screen consumes** are recognized and ignored rather than required, so any
   link iOS accepts is accepted here: `regionID` (iOS parses it but also only ever searches the current
   region — an incoming link for a stop outside the active region will fail to load), and the trip
@@ -115,6 +155,11 @@ An `adb` VIEW intent exercises a filter regardless of App Links verification:
 # Stop
 adb shell am start -a android.intent.action.VIEW \
   -d 'onebusaway://view-stop?stopID=1_75403&regionID=1' \
+  com.joulespersecond.seattlebusbot
+
+# Custom region (raises the confirmation dialog; nothing is written until you accept)
+adb shell am start -a android.intent.action.VIEW \
+  -d 'onebusaway://add-region?name=Test%20Deployment&oba-url=https://api.example.com' \
   com.joulespersecond.seattlebusbot
 
 # Trip (keep the URL single-quoted so the shell doesn't split on &)
@@ -132,8 +177,13 @@ adb shell am start -a android.intent.action.VIEW \
   normalization — that a JVM test can't reach.
 - `ui/nav/IntentRouteMapper.kt` — maps the parsed link to a NavHost route (`decide`, unit-tested in
   `IntentRouteMapperTest`).
-- `ui/HomeActivity.kt` — runs the side effects a link implies (`applyIntentSideEffects`): the
-  `add-region` URL apply, and the browser handoff for an unroutable web link.
+- `ui/HomeActivity.kt` — runs the side effects a link implies (`applyIntentSideEffects`): staging an
+  `add-region` request for confirmation, and the browser handoff for an unroutable web link.
+- `region/CustomRegions.kt` — the custom-region model (`CustomRegionRequest`, id allocation, and the
+  `Region` built from a link), unit-tested in `CustomRegionsTest`.
+- `ui/home/AddRegionViewModel.kt` + `ui/home/AddRegionDialog.kt` — the consent gate, unit-tested in
+  `AddRegionViewModelTest`.
+- `ui/home/RegionPickerHost.kt` — the picker, including long-press-to-remove for custom regions.
 - `util/ExternalIntents.kt` — `openInBrowser`, the explicit-package browser handoff (and the `<queries>`
   element in `src/main/AndroidManifest.xml` that makes browsers visible to it on API 30+).
 - `ui/nav/DeepLinkUris.kt` — separate concern: the app's *internal* `content://` stop/route

--- a/docs/DEEP_LINKING.md
+++ b/docs/DEEP_LINKING.md
@@ -15,9 +15,11 @@ Two families of link, both handled by `HomeActivity` (the app's single Activity)
 ## Custom-scheme links
 
 Every brand answers to the cross-platform `onebusaway://` scheme **and** to its own scheme
-(`kiedybus://` for KiedyBus) — set per brand as the `deepLinkScheme` manifest placeholder plus the
-matching `DEEP_LINK_SCHEME` build-config field in `onebusaway-android/flavors/<brand>.gradle`.
-`IntentRouteMapper.APP_SCHEMES` is the Kotlin-side copy of that set.
+(`kiedybus://` for KiedyBus). A brand's scheme is declared once, as the `deepLinkScheme` manifest
+placeholder — defaulted to `onebusaway` in `defaultConfig` and overridden in
+`onebusaway-android/flavors/<brand>.gradle`. `BuildConfig.DEEP_LINK_SCHEME` (and through it
+`ExternalDeepLinks.APP_SCHEMES`) is derived from that placeholder in `build.gradle.kts`, so the
+manifest filter and the parser can't disagree about which scheme a brand advertises.
 
 `view-stop` needs `stopID` (an agency-qualified stop id such as `1_75403`, percent-encoded).
 
@@ -77,10 +79,11 @@ adb shell am start -a android.intent.action.VIEW \
 
 ## Implementation
 
-- `ui/nav/ExternalDeepLinks.kt` — the pure link → target-screen parser (unit-tested in
-  `ExternalDeepLinksTest`); `WEB_HOSTS` must match the manifest filter's hosts.
-- `ui/nav/IntentRouteMapper.kt` — decomposes the intent's `Uri`, then decides the NavHost route
-  (`decide`, unit-tested in `IntentRouteMapperTest`).
+- `ui/nav/ExternalDeepLinks.kt` — owns this whole vocabulary (schemes, hosts, path shape, parameter
+  names) and parses a link into what it means; `parse` is pure and unit-tested in
+  `ExternalDeepLinksTest`. `WEB_HOSTS` must match the manifest filter's hosts.
+- `ui/nav/IntentRouteMapper.kt` — maps the parsed link to a NavHost route (`decide`, unit-tested in
+  `IntentRouteMapperTest`).
 - `ui/HomeActivity.kt` — runs the side effect `add-region` implies (`applyIntentSideEffects`).
 - `ui/nav/DeepLinkUris.kt` — separate concern: the app's *internal* `content://` stop/route
   vocabulary, used by pinned launcher shortcuts and in-app launches.

--- a/docs/DEEP_LINKING.md
+++ b/docs/DEEP_LINKING.md
@@ -32,7 +32,7 @@ nested URL must be percent-encoded as `%26`.
 `sidecar.onebusaway.org` — mirroring the iOS app's associated domains. Only the trip endpoint is a
 deep link:
 
-```
+```text
 https://<host>/regions/{regionID}/stops/{stopID}/trips?trip_id=…&service_date=…&stop_sequence=…
 ```
 

--- a/docs/DEEP_LINKING.md
+++ b/docs/DEEP_LINKING.md
@@ -117,10 +117,12 @@ design rather than a config knob, so it isn't half-wired.
 >
 > - **API 31+** — an unverified domain is not offered to the app at all, so the link opens in the
 >   browser exactly as before. No user-visible change.
-> - **API 23–30** — there is no such gating. The app still *matches* the filter, so tapping a
->   `onebusaway.co` link raises the browser-or-OneBusAway **disambiguation chooser** instead of going
->   straight to the browser. That is a real behaviour change for those users, and it persists until the
->   `assetlinks.json` files are live.
+> - **API 23–30** — there is no such gating. The app still *matches* the filter, so an unverified
+>   `onebusaway.co` link falls into ordinary intent disambiguation: tapping one **may raise** the
+>   browser-or-OneBusAway chooser rather than going straight to the browser. It won't if the rider
+>   already has a default handler set for those links — a default, once chosen, is respected. Either
+>   way it's a behaviour change for those users, and it persists until the `assetlinks.json` files are
+>   live.
 >
 > The filter can be exercised directly with `adb` (below) regardless of verification state.
 

--- a/docs/DEEP_LINKING.md
+++ b/docs/DEEP_LINKING.md
@@ -6,11 +6,11 @@ opens the same screen on the other ([#2027](https://github.com/OneBusAway/onebus
 
 Two families of link, both handled by `HomeActivity` (the app's single Activity):
 
-| Link | Opens |
+| Link | What it does |
 | --- | --- |
-| `onebusaway://view-stop?stopID=1_75403&regionID=1` | That stop's arrivals |
-| `onebusaway://add-region?oba-url=…&otp-url=…` | Applies custom API URLs, stays on the map |
-| `https://onebusaway.co/regions/1/stops/1_75403/trips?trip_id=1_18196913&service_date=1698307200.0&stop_sequence=5` | That trip's details, scrolled to the stop in the path |
+| `onebusaway://view-stop?stopID=1_75403&regionID=1` | Opens that stop's arrivals |
+| `onebusaway://add-region?oba-url=…&otp-url=…` | Points the app at those API servers. Opens no screen — see below |
+| `https://onebusaway.co/regions/1/stops/1_75403/trips?trip_id=1_18196913&service_date=1698307200.0&stop_sequence=5` | Opens that trip's details, scrolled to the stop in the path |
 
 ## Custom-scheme links
 
@@ -26,6 +26,19 @@ brand advertises.
 
 `add-region` reads `oba-url` and `otp-url`; each is applied only if it validates. Ampersands inside a
 nested URL must be percent-encoded as `%26`.
+
+Unlike the other two links, `add-region` names no destination — it's a settings change, not a screen.
+It navigates nowhere (`IntentRouteMapper` returns `RouteDecision.None`), so the app simply opens on its
+usual home screen, the map. What changed is where the app's requests go:
+
+- **`oba-url`** becomes the OBA API server, and applying it **clears the selected region** — the app
+  stops resolving a region at all and talks to that server directly. This is the same state the
+  Settings custom-API-URL path produces; see [`CUSTOM_SERVERS.md`](CUSTOM_SERVERS.md).
+- **`otp-url`** becomes the trip-planning (OTP) server. On its own it leaves the region alone.
+
+The name `add-region` is inherited from iOS, where the link really does add a named region. Android has
+no custom-region model, so it can only set these URLs — which is also why `name`, `sidecar-url`,
+`umami-url` and `umami-id` are ignored (below).
 
 > Note that "validates" here means *well-formed*, not *trusted*, and this filter is `BROWSABLE` — so any
 > web page can repoint the app's API server with no confirmation. That predates this vocabulary (it was

--- a/docs/DEEP_LINKING.md
+++ b/docs/DEEP_LINKING.md
@@ -59,9 +59,13 @@ probed the server. If it doesn't serve those APIs, requests fail visibly like an
 `example@example.com`), which correctly hides the "email a problem report" option instead of mailing a
 made-up address.
 
-Once added, a custom region appears in the region picker like any other. **Long-press it there to
-remove it** — the way back out of a link you regret. Removing the region you're currently on re-resolves
-as if none had been set.
+Once added, a custom region appears in the region picker like any other. **Long-press it in the
+forced-choice picker (`RegionPickerHost`) to remove it** — the way back out of a link you regret.
+Removing the region you're currently on re-resolves as if none had been set.
+
+Note the Settings → Agencies region list is a separate surface (`ui/regions/`), whose `RegionItem`
+doesn't carry the `custom` flag, so it lists custom regions without marking them or offering removal.
+Plumbing the flag through it is worth doing and is not done here.
 
 The pre-existing Settings → Advanced custom-API-URL preferences are a separate, unchanged mechanism (see
 [`CUSTOM_SERVERS.md`](CUSTOM_SERVERS.md)); a custom region supersedes them, since applying any region

--- a/docs/DEEP_LINKING.md
+++ b/docs/DEEP_LINKING.md
@@ -9,7 +9,7 @@ Two families of link, both handled by `HomeActivity` (the app's single Activity)
 | Link | Opens |
 | --- | --- |
 | `onebusaway://view-stop?stopID=1_75403&regionID=1` | That stop's arrivals |
-| `onebusaway://add-region?name=…&oba-url=…&otp-url=…` | Applies custom API URLs, stays on the map |
+| `onebusaway://add-region?oba-url=…&otp-url=…` | Applies custom API URLs, stays on the map |
 | `https://onebusaway.co/regions/1/stops/1_75403/trips?trip_id=1_18196913&service_date=1698307200.0&stop_sequence=5` | That trip's details, scrolled to the stop in the path |
 
 ## Custom-scheme links
@@ -18,13 +18,19 @@ Every brand answers to the cross-platform `onebusaway://` scheme **and** to its 
 (`kiedybus://` for KiedyBus). A brand's scheme is declared once, as the `deepLinkScheme` manifest
 placeholder — defaulted to `onebusaway` in `defaultConfig` and overridden in
 `onebusaway-android/flavors/<brand>.gradle`. `BuildConfig.DEEP_LINK_SCHEME` (and through it
-`ExternalDeepLinks.APP_SCHEMES`) is derived from that placeholder in `build.gradle.kts`, so the
-manifest filter and the parser can't disagree about which scheme a brand advertises.
+`ExternalDeepLinks.APP_SCHEMES`) is derived from that placeholder by the `androidComponents.onVariants`
+block in `build.gradle.kts`, so the manifest filter and the parser can't disagree about which scheme a
+brand advertises.
 
 `view-stop` needs `stopID` (an agency-qualified stop id such as `1_75403`, percent-encoded).
 
 `add-region` reads `oba-url` and `otp-url`; each is applied only if it validates. Ampersands inside a
 nested URL must be percent-encoded as `%26`.
+
+> Note that "validates" here means *well-formed*, not *trusted*, and this filter is `BROWSABLE` — so any
+> web page can repoint the app's API server with no confirmation. That predates this vocabulary (it was
+> the old `SettingsActivity` VIEW filter) and is tracked in
+> [#2030](https://github.com/OneBusAway/onebusaway-android/issues/2030).
 
 ## Web links (Android App Links)
 
@@ -36,16 +42,43 @@ deep link:
 https://<host>/regions/{regionID}/stops/{stopID}/trips?trip_id=…&service_date=…&stop_sequence=…
 ```
 
-The filter lives in `onebusaway-android/src/oba/AndroidManifest.xml` (the OBA brand only — a
-white-label brand can't verify hosts it doesn't own; a brand with its own web host should add its own
-flavor manifest with the same shape).
+The filter lives in `onebusaway-android/src/oba/AndroidManifest.xml`, the OBA brand only. These hosts
+belong to the OneBusAway deployment, and only the brand that owns a host can verify it — App Links
+verification matches the *installed* app's signing certificate against the host's `assetlinks.json`.
+`ExternalDeepLinks.WEB_HOSTS` is likewise a single OBA-owned set, not a per-brand value: giving a brand
+web links of its own means both a flavor manifest and a brand-specific host set, which is a feature to
+design rather than a config knob, so it isn't half-wired.
 
-> **Server-side step still outstanding:** `android:autoVerify="true"` only takes effect once each host
-> serves `/.well-known/assetlinks.json` listing the app's package name
-> (`com.joulespersecond.seattlebusbot`) and its release signing-certificate SHA-256 fingerprint. Until
-> then these links keep opening in the browser — nothing regresses, and the filter can still be
-> exercised directly with `adb` (below). See
+> **Server-side step still outstanding:** `android:autoVerify="true"` only takes effect once each of
+> `onebusaway.co`, `www.onebusaway.co`, and `sidecar.onebusaway.org` serves `/.well-known/assetlinks.json`
+> listing the app's package name (`com.joulespersecond.seattlebusbot`) and its release
+> signing-certificate SHA-256 fingerprint. See
 > [Verify Android App Links](https://developer.android.com/training/app-links/verify-android-applinks).
+>
+> **Until that lands, the filter is not inert.** Verification failure means different things by API
+> level, and `minSdk` is 23:
+>
+> - **API 31+** — an unverified domain is not offered to the app at all, so the link opens in the
+>   browser exactly as before. No user-visible change.
+> - **API 23–30** — there is no such gating. The app still *matches* the filter, so tapping a
+>   `onebusaway.co` link raises the browser-or-OneBusAway **disambiguation chooser** instead of going
+>   straight to the browser. That is a real behaviour change for those users, and it persists until the
+>   `assetlinks.json` files are live.
+>
+> The filter can be exercised directly with `adb` (below) regardless of verification state.
+
+### Links the filter claims but the parser can't route
+
+An intent-filter is necessarily a *superset* of `ExternalDeepLinks.parse`: it cannot inspect the query
+string (so it can't require `trip_id`), and `pathPattern` is a `PATTERN_SIMPLE_GLOB` whose `.*` spans
+`/` (so it can't require exactly one path segment per wildcard — `pathAdvancedPattern` can, but it is
+API 31+). So the app can be launched for a `onebusaway.co` URL it has no screen for.
+
+`ExternalDeepLinks.isUnhandledWebLink` identifies those, and `HomeActivity.applyIntentSideEffects` hands
+them back to the browser via `ExternalIntents.openInBrowser` — which resolves an explicit browser
+package first, since a plain `ACTION_VIEW` would match our own filter again and bounce straight back.
+Without this, a trimmed or unrecognized link would silently strand the user on the map instead of
+opening the page they tapped.
 
 ## What's deliberately *not* supported
 
@@ -82,8 +115,13 @@ adb shell am start -a android.intent.action.VIEW \
 - `ui/nav/ExternalDeepLinks.kt` — owns this whole vocabulary (schemes, hosts, path shape, parameter
   names) and parses a link into what it means; `parse` is pure and unit-tested in
   `ExternalDeepLinksTest`. `WEB_HOSTS` must match the manifest filter's hosts.
+  `ExternalDeepLinksUriTest` (instrumented) covers the `Uri` decomposition — opaque URIs, case
+  normalization — that a JVM test can't reach.
 - `ui/nav/IntentRouteMapper.kt` — maps the parsed link to a NavHost route (`decide`, unit-tested in
   `IntentRouteMapperTest`).
-- `ui/HomeActivity.kt` — runs the side effect `add-region` implies (`applyIntentSideEffects`).
+- `ui/HomeActivity.kt` — runs the side effects a link implies (`applyIntentSideEffects`): the
+  `add-region` URL apply, and the browser handoff for an unroutable web link.
+- `util/ExternalIntents.kt` — `openInBrowser`, the explicit-package browser handoff (and the `<queries>`
+  element in `src/main/AndroidManifest.xml` that makes browsers visible to it on API 30+).
 - `ui/nav/DeepLinkUris.kt` — separate concern: the app's *internal* `content://` stop/route
   vocabulary, used by pinned launcher shortcuts and in-app launches.

--- a/docs/REBRANDING.md
+++ b/docs/REBRANDING.md
@@ -66,7 +66,9 @@ android.productFlavors {
     newBrandName {
         dimension "brand"
         applicationId "com.newbrandname.android"  // Your unique package name
-        manifestPlaceholders = [databaseAuthority: applicationId.toString() + '.provider']
+        manifestPlaceholders = [databaseAuthority: applicationId.toString() + '.provider',
+                                deepLinkScheme: "newbrandname"]  // Your custom URL scheme
+        buildConfigField "String", "DEEP_LINK_SCHEME", "\"newbrandname\""  // Same value as above
         buildConfigField "int", "ARRIVAL_INFO_STYLE", "0"
         buildConfigField "boolean", "USE_FIXED_REGION", "false"  // or "true" for single-region
         // ... other configuration options

--- a/docs/REBRANDING.md
+++ b/docs/REBRANDING.md
@@ -67,8 +67,7 @@ android.productFlavors {
         dimension "brand"
         applicationId "com.newbrandname.android"  // Your unique package name
         manifestPlaceholders = [databaseAuthority: applicationId.toString() + '.provider',
-                                deepLinkScheme: "newbrandname"]  // Your custom URL scheme
-        buildConfigField "String", "DEEP_LINK_SCHEME", "\"newbrandname\""  // Same value as above
+                                deepLinkScheme: "newbrandname"]  // Optional: your own URL scheme
         buildConfigField "int", "ARRIVAL_INFO_STYLE", "0"
         buildConfigField "boolean", "USE_FIXED_REGION", "false"  // or "true" for single-region
         // ... other configuration options

--- a/onebusaway-android/build.gradle.kts
+++ b/onebusaway-android/build.gradle.kts
@@ -60,6 +60,14 @@ android {
 
         // This enables us to tell when we're running unit tests on CI (#1010 for Travis, #1072 for GitHub)
         buildConfigField("String", "CI", "\"" + System.getenv("CI") + "\"")
+
+        // The custom deep-link scheme the app answers to (#2027), consumed by the manifest's
+        // custom-scheme intent-filter. Every brand answers to the cross-platform `onebusaway` scheme,
+        // so this default is all most brands need; a brand with its own scheme (KiedyBus) overrides the
+        // placeholder in its flavor file. Declared ONLY here — BuildConfig.DEEP_LINK_SCHEME is derived
+        // from it below, so the manifest and the Kotlin side (ExternalDeepLinks.APP_SCHEMES) cannot
+        // disagree about which scheme a brand advertises.
+        manifestPlaceholders["deepLinkScheme"] = "onebusaway"
     }
 
     // Expose the exported Room schemas to instrumented tests so MigrationTestHelper can load them.
@@ -307,6 +315,27 @@ androidComponents {
 // Load brand flavor configurations from flavors/ directory
 // See flavors/README.md for instructions on adding new white-label brands
 apply(from = "flavors/load-flavors.gradle")
+
+/*
+ * Derive each brand's BuildConfig.DEEP_LINK_SCHEME from its `deepLinkScheme` manifest placeholder
+ * (defaulted in defaultConfig, overridden by the one brand that has its own scheme). The scheme is
+ * therefore declared exactly ONCE per brand: the manifest's custom-scheme intent-filter and the Kotlin
+ * side that parses those links (org.onebusaway.android.ui.nav.ExternalDeepLinks.APP_SCHEMES) read the
+ * same value by construction, so a brand can't advertise a scheme it then refuses to parse (#2027).
+ *
+ * Runs after the flavor files above have been applied, and reads the DSL rather than the variant API
+ * because `Variant.manifestPlaceholders` is a lazy MapProperty that can't be queried during
+ * configuration (and BuildConfigField takes a value, not a Provider).
+ */
+android.productFlavors.filter { it.dimension == "brand" }.forEach { flavor ->
+    val scheme = flavor.manifestPlaceholders["deepLinkScheme"]
+        ?: android.defaultConfig.manifestPlaceholders["deepLinkScheme"]
+        ?: throw GradleException(
+            "No `deepLinkScheme` manifest placeholder for brand '${flavor.name}' or in defaultConfig; " +
+                "see onebusaway-android/flavors/README.md"
+        )
+    flavor.buildConfigField("String", "DEEP_LINK_SCHEME", "\"" + scheme + "\"")
+}
 
 // Exclude all classes from dependencies that conflict with Android platform classes (#849)
 configurations.all {

--- a/onebusaway-android/build.gradle.kts
+++ b/onebusaway-android/build.gradle.kts
@@ -65,8 +65,8 @@ android {
         // custom-scheme intent-filter. Every brand answers to the cross-platform `onebusaway` scheme,
         // so this default is all most brands need; a brand with its own scheme (KiedyBus) overrides the
         // placeholder in its flavor file. Declared ONLY here — BuildConfig.DEEP_LINK_SCHEME is derived
-        // from it below, so the manifest and the Kotlin side (ExternalDeepLinks.APP_SCHEMES) cannot
-        // disagree about which scheme a brand advertises.
+        // from it in the androidComponents.onVariants block below, so the manifest and the Kotlin side
+        // (ExternalDeepLinks.APP_SCHEMES) cannot disagree about which scheme a brand advertises.
         manifestPlaceholders["deepLinkScheme"] = "onebusaway"
     }
 
@@ -303,6 +303,33 @@ androidComponents {
         )
     }
 
+    /*
+     * Derive BuildConfig.DEEP_LINK_SCHEME from the variant's `deepLinkScheme` manifest placeholder
+     * (defaulted in defaultConfig, overridden by a brand that has its own scheme). The scheme is
+     * therefore declared exactly ONCE per brand: the manifest's custom-scheme intent-filter and the
+     * Kotlin side that parses those links (org.onebusaway.android.ui.nav.ExternalDeepLinks.APP_SCHEMES)
+     * read the same value by construction, so a brand can't advertise a scheme it then refuses to
+     * parse (#2027).
+     *
+     * Done through the variant API rather than by walking `android.productFlavors` after
+     * `flavors/load-flavors.gradle`, so it carries no ordering dependency: a brand registered by
+     * anything applied later is still covered. `manifestPlaceholders` is a lazy MapProperty and
+     * `buildConfigFields` accepts a Provider, so the placeholder is read once the whole DSL is final.
+     */
+    onVariants(selector().all()) { variant ->
+        val scheme = variant.manifestPlaceholders.getting("deepLinkScheme")
+        variant.buildConfigFields?.put(
+            "DEEP_LINK_SCHEME",
+            scheme.map {
+                BuildConfigField(
+                    "String",
+                    "\"" + it + "\"",
+                    "This brand's custom deep-link scheme (see src/main/AndroidManifest.xml)."
+                )
+            }
+        )
+    }
+
     onVariants(selector().withBuildType("release")) { variant ->
         // Append the version name to the end of aligned APKs
         variant.outputs.forEach { output ->
@@ -315,27 +342,6 @@ androidComponents {
 // Load brand flavor configurations from flavors/ directory
 // See flavors/README.md for instructions on adding new white-label brands
 apply(from = "flavors/load-flavors.gradle")
-
-/*
- * Derive each brand's BuildConfig.DEEP_LINK_SCHEME from its `deepLinkScheme` manifest placeholder
- * (defaulted in defaultConfig, overridden by the one brand that has its own scheme). The scheme is
- * therefore declared exactly ONCE per brand: the manifest's custom-scheme intent-filter and the Kotlin
- * side that parses those links (org.onebusaway.android.ui.nav.ExternalDeepLinks.APP_SCHEMES) read the
- * same value by construction, so a brand can't advertise a scheme it then refuses to parse (#2027).
- *
- * Runs after the flavor files above have been applied, and reads the DSL rather than the variant API
- * because `Variant.manifestPlaceholders` is a lazy MapProperty that can't be queried during
- * configuration (and BuildConfigField takes a value, not a Provider).
- */
-android.productFlavors.filter { it.dimension == "brand" }.forEach { flavor ->
-    val scheme = flavor.manifestPlaceholders["deepLinkScheme"]
-        ?: android.defaultConfig.manifestPlaceholders["deepLinkScheme"]
-        ?: throw GradleException(
-            "No `deepLinkScheme` manifest placeholder for brand '${flavor.name}' or in defaultConfig; " +
-                "see onebusaway-android/flavors/README.md"
-        )
-    flavor.buildConfigField("String", "DEEP_LINK_SCHEME", "\"" + scheme + "\"")
-}
 
 // Exclude all classes from dependencies that conflict with Android platform classes (#849)
 configurations.all {

--- a/onebusaway-android/flavors/README.md
+++ b/onebusaway-android/flavors/README.md
@@ -32,10 +32,10 @@ Edit the file and update:
 2. **Application ID** - Your unique package name (e.g., `com.mybrand.transit`)
 3. **Pelias key reference** - Update `getPeliasKey(name)` (or use empty string)
 4. **Region settings** - Set `USE_FIXED_REGION` and related fields
-5. **Deep-link scheme** - Set the `deepLinkScheme` manifest placeholder and the matching
-   `DEEP_LINK_SCHEME` build-config field to your brand's own custom URL scheme (see
-   [`docs/DEEP_LINKING.md`](../../docs/DEEP_LINKING.md)). Both are **required** — the manifest
-   won't merge without the placeholder.
+5. **Deep-link scheme** (optional) - Every brand answers to the shared `onebusaway://` scheme. If
+   yours also needs its own (as `kiedybus.gradle` does), set the `deepLinkScheme` manifest
+   placeholder — and only that; `BuildConfig.DEEP_LINK_SCHEME` is derived from it. See
+   [`docs/DEEP_LINKING.md`](../../docs/DEEP_LINKING.md).
 
 ### Step 2: Create Resource Directory
 

--- a/onebusaway-android/flavors/README.md
+++ b/onebusaway-android/flavors/README.md
@@ -32,6 +32,10 @@ Edit the file and update:
 2. **Application ID** - Your unique package name (e.g., `com.mybrand.transit`)
 3. **Pelias key reference** - Update `getPeliasKey(name)` (or use empty string)
 4. **Region settings** - Set `USE_FIXED_REGION` and related fields
+5. **Deep-link scheme** - Set the `deepLinkScheme` manifest placeholder and the matching
+   `DEEP_LINK_SCHEME` build-config field to your brand's own custom URL scheme (see
+   [`docs/DEEP_LINKING.md`](../../docs/DEEP_LINKING.md)). Both are **required** — the manifest
+   won't merge without the placeholder.
 
 ### Step 2: Create Resource Directory
 

--- a/onebusaway-android/flavors/agencyX.gradle
+++ b/onebusaway-android/flavors/agencyX.gradle
@@ -11,7 +11,10 @@ android.productFlavors {
     agencyX {
         dimension "brand"
         applicationId "org.agencyx.android" // Unique listing of this brand on app store
-        manifestPlaceholders = [databaseAuthority: applicationId.toString() + '.provider']
+        manifestPlaceholders = [databaseAuthority: applicationId.toString() + '.provider', deepLinkScheme: "onebusaway"]
+        // The brand's own custom deep-link scheme, matching OneBusAway for iOS. Kept in step
+        // with the deepLinkScheme manifest placeholder above (IntentRouteMapper.APP_SCHEMES).
+        buildConfigField "String", "DEEP_LINK_SCHEME", "\"onebusaway\""
         buildConfigField "boolean", "USE_FIXED_REGION", "false" // Supports multi-region
         buildConfigField "boolean", "USE_PELIAS_GEOCODING", "true"
         buildConfigField "String", "PELIAS_API_KEY", "\"" + getPeliasKey("agencyX") + "\""

--- a/onebusaway-android/flavors/agencyX.gradle
+++ b/onebusaway-android/flavors/agencyX.gradle
@@ -11,10 +11,7 @@ android.productFlavors {
     agencyX {
         dimension "brand"
         applicationId "org.agencyx.android" // Unique listing of this brand on app store
-        manifestPlaceholders = [databaseAuthority: applicationId.toString() + '.provider', deepLinkScheme: "onebusaway"]
-        // The brand's own custom deep-link scheme, matching OneBusAway for iOS. Kept in step
-        // with the deepLinkScheme manifest placeholder above (IntentRouteMapper.APP_SCHEMES).
-        buildConfigField "String", "DEEP_LINK_SCHEME", "\"onebusaway\""
+        manifestPlaceholders = [databaseAuthority: applicationId.toString() + '.provider']
         buildConfigField "boolean", "USE_FIXED_REGION", "false" // Supports multi-region
         buildConfigField "boolean", "USE_PELIAS_GEOCODING", "true"
         buildConfigField "String", "PELIAS_API_KEY", "\"" + getPeliasKey("agencyX") + "\""

--- a/onebusaway-android/flavors/agencyY.gradle
+++ b/onebusaway-android/flavors/agencyY.gradle
@@ -11,7 +11,10 @@ android.productFlavors {
     agencyY {
         dimension "brand"
         applicationId "org.agencyy.android" // Unique listing of this brand on app store
-        manifestPlaceholders = [databaseAuthority: applicationId.toString() + '.provider']
+        manifestPlaceholders = [databaseAuthority: applicationId.toString() + '.provider', deepLinkScheme: "onebusaway"]
+        // The brand's own custom deep-link scheme, matching OneBusAway for iOS. Kept in step
+        // with the deepLinkScheme manifest placeholder above (IntentRouteMapper.APP_SCHEMES).
+        buildConfigField "String", "DEEP_LINK_SCHEME", "\"onebusaway\""
         buildConfigField "boolean", "USE_FIXED_REGION", "true" // Does not support multi-region
         buildConfigField "boolean", "USE_PELIAS_GEOCODING", "true"
         buildConfigField "String", "PELIAS_API_KEY", "\"" + getPeliasKey("agencyY") + "\""

--- a/onebusaway-android/flavors/agencyY.gradle
+++ b/onebusaway-android/flavors/agencyY.gradle
@@ -11,10 +11,7 @@ android.productFlavors {
     agencyY {
         dimension "brand"
         applicationId "org.agencyy.android" // Unique listing of this brand on app store
-        manifestPlaceholders = [databaseAuthority: applicationId.toString() + '.provider', deepLinkScheme: "onebusaway"]
-        // The brand's own custom deep-link scheme, matching OneBusAway for iOS. Kept in step
-        // with the deepLinkScheme manifest placeholder above (IntentRouteMapper.APP_SCHEMES).
-        buildConfigField "String", "DEEP_LINK_SCHEME", "\"onebusaway\""
+        manifestPlaceholders = [databaseAuthority: applicationId.toString() + '.provider']
         buildConfigField "boolean", "USE_FIXED_REGION", "true" // Does not support multi-region
         buildConfigField "boolean", "USE_PELIAS_GEOCODING", "true"
         buildConfigField "String", "PELIAS_API_KEY", "\"" + getPeliasKey("agencyY") + "\""

--- a/onebusaway-android/flavors/kiedybus.gradle
+++ b/onebusaway-android/flavors/kiedybus.gradle
@@ -11,7 +11,10 @@ android.productFlavors {
     kiedybus {
         dimension "brand"
         applicationId "pl.kiedybus.android" // Unique listing of this brand on app store
-        manifestPlaceholders = [databaseAuthority: applicationId.toString() + '.provider']
+        manifestPlaceholders = [databaseAuthority: applicationId.toString() + '.provider', deepLinkScheme: "kiedybus"]
+        // The brand's own custom deep-link scheme, matching OneBusAway for iOS. Kept in step
+        // with the deepLinkScheme manifest placeholder above (IntentRouteMapper.APP_SCHEMES).
+        buildConfigField "String", "DEEP_LINK_SCHEME", "\"kiedybus\""
         buildConfigField "boolean", "USE_FIXED_REGION", "false" // Supports multi-region
         buildConfigField "boolean", "USE_PELIAS_GEOCODING", "true"
         buildConfigField "String", "PELIAS_API_KEY", "\"" + getPeliasKey("kiedybus") + "\""

--- a/onebusaway-android/flavors/kiedybus.gradle
+++ b/onebusaway-android/flavors/kiedybus.gradle
@@ -11,10 +11,10 @@ android.productFlavors {
     kiedybus {
         dimension "brand"
         applicationId "pl.kiedybus.android" // Unique listing of this brand on app store
-        manifestPlaceholders = [databaseAuthority: applicationId.toString() + '.provider', deepLinkScheme: "kiedybus"]
-        // The brand's own custom deep-link scheme, matching OneBusAway for iOS. Kept in step
-        // with the deepLinkScheme manifest placeholder above (IntentRouteMapper.APP_SCHEMES).
-        buildConfigField "String", "DEEP_LINK_SCHEME", "\"kiedybus\""
+        // Overrides the defaultConfig `onebusaway` deep-link scheme with this brand's own, matching
+        // OneBusAway for iOS. BuildConfig.DEEP_LINK_SCHEME is derived from it (see build.gradle.kts).
+        manifestPlaceholders = [databaseAuthority: applicationId.toString() + '.provider',
+                                deepLinkScheme: "kiedybus"]
         buildConfigField "boolean", "USE_FIXED_REGION", "false" // Supports multi-region
         buildConfigField "boolean", "USE_PELIAS_GEOCODING", "true"
         buildConfigField "String", "PELIAS_API_KEY", "\"" + getPeliasKey("kiedybus") + "\""

--- a/onebusaway-android/flavors/oba.gradle
+++ b/onebusaway-android/flavors/oba.gradle
@@ -11,10 +11,7 @@ android.productFlavors {
         dimension "brand"
         isDefault = true
         applicationId "com.joulespersecond.seattlebusbot"
-        manifestPlaceholders = [databaseAuthority: "com.joulespersecond.oba", deepLinkScheme: "onebusaway"]
-        // The brand's own custom deep-link scheme, matching OneBusAway for iOS. Kept in step
-        // with the deepLinkScheme manifest placeholder above (IntentRouteMapper.APP_SCHEMES).
-        buildConfigField "String", "DEEP_LINK_SCHEME", "\"onebusaway\""
+        manifestPlaceholders = [databaseAuthority: "com.joulespersecond.oba"]
         buildConfigField "boolean", "USE_FIXED_REGION", "false" // Supports multi-region
         buildConfigField "boolean", "USE_PELIAS_GEOCODING", "true"
         buildConfigField "String", "PELIAS_API_KEY", "\"" + getPeliasKey("oba") + "\""

--- a/onebusaway-android/flavors/oba.gradle
+++ b/onebusaway-android/flavors/oba.gradle
@@ -11,7 +11,10 @@ android.productFlavors {
         dimension "brand"
         isDefault = true
         applicationId "com.joulespersecond.seattlebusbot"
-        manifestPlaceholders = [databaseAuthority: "com.joulespersecond.oba"]
+        manifestPlaceholders = [databaseAuthority: "com.joulespersecond.oba", deepLinkScheme: "onebusaway"]
+        // The brand's own custom deep-link scheme, matching OneBusAway for iOS. Kept in step
+        // with the deepLinkScheme manifest placeholder above (IntentRouteMapper.APP_SCHEMES).
+        buildConfigField "String", "DEEP_LINK_SCHEME", "\"onebusaway\""
         buildConfigField "boolean", "USE_FIXED_REGION", "false" // Supports multi-region
         buildConfigField "boolean", "USE_PELIAS_GEOCODING", "true"
         buildConfigField "String", "PELIAS_API_KEY", "\"" + getPeliasKey("oba") + "\""

--- a/onebusaway-android/schemas/org.onebusaway.android.database.AppDatabase/10.json
+++ b/onebusaway-android/schemas/org.onebusaway.android.database.AppDatabase/10.json
@@ -1,0 +1,886 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 10,
+    "identityHash": "acd03bcf8bb67ea3ce3cdb7048fd166c",
+    "entities": [
+      {
+        "tableName": "studies",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`study_id` INTEGER NOT NULL, `name` TEXT NOT NULL, `description` TEXT NOT NULL, `is_subscribed` INTEGER NOT NULL, PRIMARY KEY(`study_id`))",
+        "fields": [
+          {
+            "fieldPath": "study_id",
+            "columnName": "study_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "is_subscribed",
+            "columnName": "is_subscribed",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "study_id"
+          ]
+        }
+      },
+      {
+        "tableName": "surveys",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`survey_id` INTEGER NOT NULL, `study_id` INTEGER NOT NULL, `name` TEXT NOT NULL, `state` INTEGER NOT NULL, PRIMARY KEY(`survey_id`), FOREIGN KEY(`study_id`) REFERENCES `studies`(`study_id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "survey_id",
+            "columnName": "survey_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "study_id",
+            "columnName": "study_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "survey_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_surveys_study_id",
+            "unique": false,
+            "columnNames": [
+              "study_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_surveys_study_id` ON `${TABLE_NAME}` (`study_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "studies",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "study_id"
+            ],
+            "referencedColumns": [
+              "study_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "alerts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "stops",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` TEXT NOT NULL, `code` TEXT NOT NULL, `name` TEXT NOT NULL, `direction` TEXT NOT NULL, `use_count` INTEGER NOT NULL, `latitude` REAL NOT NULL, `longitude` REAL NOT NULL, `user_name` TEXT, `access_time` INTEGER, `favorite` INTEGER, `region_id` INTEGER, PRIMARY KEY(`_id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "code",
+            "columnName": "code",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "direction",
+            "columnName": "direction",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "useCount",
+            "columnName": "use_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userName",
+            "columnName": "user_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "accessTime",
+            "columnName": "access_time",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "favorite",
+            "columnName": "favorite",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "regionId",
+            "columnName": "region_id",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "_id"
+          ]
+        }
+      },
+      {
+        "tableName": "routes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` TEXT NOT NULL, `short_name` TEXT NOT NULL, `long_name` TEXT, `use_count` INTEGER NOT NULL, `user_name` TEXT, `access_time` INTEGER, `favorite` INTEGER, `url` TEXT, `region_id` INTEGER, PRIMARY KEY(`_id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shortName",
+            "columnName": "short_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longName",
+            "columnName": "long_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "useCount",
+            "columnName": "use_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userName",
+            "columnName": "user_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "accessTime",
+            "columnName": "access_time",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "favorite",
+            "columnName": "favorite",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "regionId",
+            "columnName": "region_id",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "_id"
+          ]
+        }
+      },
+      {
+        "tableName": "trips",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` TEXT NOT NULL, `stop_id` TEXT NOT NULL, `route_id` TEXT, `departure` INTEGER NOT NULL, `headsign` TEXT, `name` TEXT NOT NULL, `reminder` INTEGER NOT NULL, `alarm_delete_path` TEXT NOT NULL, `service_date` INTEGER NOT NULL, `stop_sequence` INTEGER NOT NULL, `trip_id` TEXT NOT NULL, `vehicle_id` TEXT, PRIMARY KEY(`_id`, `stop_id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stopId",
+            "columnName": "stop_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "routeId",
+            "columnName": "route_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "departure",
+            "columnName": "departure",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "headsign",
+            "columnName": "headsign",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reminder",
+            "columnName": "reminder",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "alarmDeletePath",
+            "columnName": "alarm_delete_path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serviceDate",
+            "columnName": "service_date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stopSequence",
+            "columnName": "stop_sequence",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tripId",
+            "columnName": "trip_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vehicleId",
+            "columnName": "vehicle_id",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "_id",
+            "stop_id"
+          ]
+        }
+      },
+      {
+        "tableName": "trip_alerts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `trip_id` TEXT NOT NULL, `stop_id` TEXT NOT NULL, `start_time` INTEGER NOT NULL, `state` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tripId",
+            "columnName": "trip_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stopId",
+            "columnName": "stop_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startTime",
+            "columnName": "start_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "_id"
+          ]
+        }
+      },
+      {
+        "tableName": "service_alerts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` TEXT NOT NULL, `marked_read_time` INTEGER, `hidden` INTEGER, PRIMARY KEY(`_id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "markedReadTime",
+            "columnName": "marked_read_time",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "hidden",
+            "columnName": "hidden",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "_id"
+          ]
+        }
+      },
+      {
+        "tableName": "regions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER NOT NULL, `name` TEXT NOT NULL, `oba_base_url` TEXT NOT NULL, `siri_base_url` TEXT NOT NULL, `lang` TEXT NOT NULL, `contact_email` TEXT NOT NULL, `supports_api_discovery` INTEGER NOT NULL, `supports_api_realtime` INTEGER NOT NULL, `supports_siri_realtime` INTEGER NOT NULL, `twitter_url` TEXT, `experimental` INTEGER, `stop_info_url` TEXT, `otp_base_url` TEXT, `otp_contact_email` TEXT, `supports_otp_bikeshare` INTEGER, `otp_base_graphql_url` TEXT, `supports_otp_graphql_bikeshare` INTEGER, `supports_embedded_social` INTEGER, `payment_android_app_id` TEXT, `payment_warning_title` TEXT, `payment_warning_body` TEXT, `sidecar_base_url` TEXT DEFAULT 'https://onebusaway.co', `plausible_analytics_server_url` TEXT, `umami_analytics_url` TEXT, `umami_analytics_id` TEXT, `custom` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`_id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "obaBaseUrl",
+            "columnName": "oba_base_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "siriBaseUrl",
+            "columnName": "siri_base_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "lang",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contactEmail",
+            "columnName": "contact_email",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "supportsObaDiscovery",
+            "columnName": "supports_api_discovery",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "supportsObaRealtime",
+            "columnName": "supports_api_realtime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "supportsSiriRealtime",
+            "columnName": "supports_siri_realtime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "twitterUrl",
+            "columnName": "twitter_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "experimental",
+            "columnName": "experimental",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "stopInfoUrl",
+            "columnName": "stop_info_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "otpBaseUrl",
+            "columnName": "otp_base_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "otpContactEmail",
+            "columnName": "otp_contact_email",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "supportsOtpBikeshare",
+            "columnName": "supports_otp_bikeshare",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "otpBaseGraphqlUrl",
+            "columnName": "otp_base_graphql_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "supportsOtpGraphqlBikeshare",
+            "columnName": "supports_otp_graphql_bikeshare",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "supportsEmbeddedSocial",
+            "columnName": "supports_embedded_social",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "paymentAndroidAppId",
+            "columnName": "payment_android_app_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "paymentWarningTitle",
+            "columnName": "payment_warning_title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "paymentWarningBody",
+            "columnName": "payment_warning_body",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sidecarBaseUrl",
+            "columnName": "sidecar_base_url",
+            "affinity": "TEXT",
+            "defaultValue": "'https://onebusaway.co'"
+          },
+          {
+            "fieldPath": "plausibleAnalyticsServerUrl",
+            "columnName": "plausible_analytics_server_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "umamiAnalyticsUrl",
+            "columnName": "umami_analytics_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "umamiAnalyticsId",
+            "columnName": "umami_analytics_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "custom",
+            "columnName": "custom",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "_id"
+          ]
+        }
+      },
+      {
+        "tableName": "region_bounds",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `region_id` INTEGER NOT NULL, `lat` REAL NOT NULL, `lon` REAL NOT NULL, `lat_span` REAL NOT NULL, `lon_span` REAL NOT NULL, FOREIGN KEY(`region_id`) REFERENCES `regions`(`_id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "regionId",
+            "columnName": "region_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "lat",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "lon",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "latSpan",
+            "columnName": "lat_span",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lonSpan",
+            "columnName": "lon_span",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_region_bounds_region_id",
+            "unique": false,
+            "columnNames": [
+              "region_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_region_bounds_region_id` ON `${TABLE_NAME}` (`region_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "regions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "region_id"
+            ],
+            "referencedColumns": [
+              "_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "open311_servers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `region_id` INTEGER NOT NULL, `jurisdiction` TEXT, `api_key` TEXT NOT NULL, `open311_base_url` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "regionId",
+            "columnName": "region_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "jurisdiction",
+            "columnName": "jurisdiction",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "apiKey",
+            "columnName": "api_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "baseUrl",
+            "columnName": "open311_base_url",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "_id"
+          ]
+        }
+      },
+      {
+        "tableName": "nav_stops",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `nav_id` TEXT NOT NULL, `start_time` INTEGER NOT NULL, `trip_id` TEXT NOT NULL, `destination_id` TEXT NOT NULL, `before_id` TEXT NOT NULL, `seq_num` INTEGER NOT NULL, `is_active` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "navId",
+            "columnName": "nav_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startTime",
+            "columnName": "start_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tripId",
+            "columnName": "trip_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "destinationId",
+            "columnName": "destination_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "beforeId",
+            "columnName": "before_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sequence",
+            "columnName": "seq_num",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "active",
+            "columnName": "is_active",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "_id"
+          ]
+        }
+      },
+      {
+        "tableName": "cached_stops",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` TEXT NOT NULL, `code` TEXT, `name` TEXT, `direction` TEXT, `latitude` REAL NOT NULL, `longitude` REAL NOT NULL, `location_type` INTEGER NOT NULL, `route_ids` TEXT NOT NULL, `wheelchair_boarding` TEXT, `region_id` INTEGER NOT NULL, `last_seen` INTEGER NOT NULL, PRIMARY KEY(`_id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "code",
+            "columnName": "code",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "direction",
+            "columnName": "direction",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "locationType",
+            "columnName": "location_type",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "routeIds",
+            "columnName": "route_ids",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wheelchairBoarding",
+            "columnName": "wheelchair_boarding",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "regionId",
+            "columnName": "region_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSeen",
+            "columnName": "last_seen",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cached_stops_region_id_latitude_longitude",
+            "unique": false,
+            "columnNames": [
+              "region_id",
+              "latitude",
+              "longitude"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_stops_region_id_latitude_longitude` ON `${TABLE_NAME}` (`region_id`, `latitude`, `longitude`)"
+          },
+          {
+            "name": "index_cached_stops_region_id_last_seen",
+            "unique": false,
+            "columnNames": [
+              "region_id",
+              "last_seen"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_stops_region_id_last_seen` ON `${TABLE_NAME}` (`region_id`, `last_seen`)"
+          }
+        ]
+      },
+      {
+        "tableName": "cached_route_types",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` TEXT NOT NULL, `type` INTEGER NOT NULL, `region_id` INTEGER NOT NULL, `last_seen` INTEGER NOT NULL, PRIMARY KEY(`_id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "regionId",
+            "columnName": "region_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSeen",
+            "columnName": "last_seen",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cached_route_types_region_id_last_seen",
+            "unique": false,
+            "columnNames": [
+              "region_id",
+              "last_seen"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_route_types_region_id_last_seen` ON `${TABLE_NAME}` (`region_id`, `last_seen`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'acd03bcf8bb67ea3ce3cdb7048fd166c')"
+    ]
+  }
+}

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/database/AppDatabaseMigrationTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/database/AppDatabaseMigrationTest.kt
@@ -33,8 +33,10 @@ import org.onebusaway.android.SmokeTest
  * before dropping it (#1751) and adds the `surveys.study_id` foreign-key child index (#1739); and that
  * [MIGRATION_5_6] adds `regions.otp_base_graphql_url` defaulting existing rows to OTP1 (#1780); that
  * [MIGRATION_6_7] drops the retired `stop_routes_filter` table; that [MIGRATION_7_8] adds
- * `cached_stops.wheelchair_boarding` as NULL for existing rows (#1029); and that [MIGRATION_8_9] adds
- * `regions.supports_otp_graphql_bikeshare` as NULL (reading back as false) for existing rows.
+ * `cached_stops.wheelchair_boarding` as NULL for existing rows (#1029); that [MIGRATION_8_9] adds
+ * `regions.supports_otp_graphql_bikeshare` as NULL (reading back as false) for existing rows; and that
+ * [MIGRATION_9_10] adds `regions.custom` as 0, so every region cached before custom regions existed
+ * (#2027) reads back as a directory region and survives no differently than before.
  */
 @SmokeTest // API-23 floor smoke subset (#1818): exercises Room migrations + java.time desugaring
 @RunWith(AndroidJUnit4::class)
@@ -227,6 +229,33 @@ class AppDatabaseMigrationTest {
             assertTrue(
                 "pre-existing region should have NULL supports_otp_graphql_bikeshare (reads back false)",
                 c.isNull(0)
+            )
+        }
+        db.close()
+    }
+
+    @Test
+    fun migrate9To10_addsCustomColumnDefaultingExistingRegionsToDirectory() {
+        helper.createDatabase(TEST_DB, 9).use { db ->
+            // A pre-existing region, cached before custom regions existed - so a directory region.
+            db.execSQL(
+                "INSERT INTO regions " +
+                    "(_id, name, oba_base_url, siri_base_url, lang, contact_email, " +
+                    "supports_api_discovery, supports_api_realtime, supports_siri_realtime) " +
+                    "VALUES (1, 'Puget Sound', 'https://oba', 'https://siri', 'en_US', 'a@b.c', 1, 1, 1)"
+            )
+        }
+
+        // runMigrationsAndValidate asserts the resulting schema matches the exported 10.json - which is
+        // what pins the NOT NULL DEFAULT 0 to the entity's declared defaultValue.
+        val db = helper.runMigrationsAndValidate(TEST_DB, 10, true, MIGRATION_9_10)
+
+        db.query("SELECT custom FROM regions WHERE _id = 1").use { c ->
+            c.moveToFirst()
+            assertEquals(
+                "a region cached before custom regions existed must read back as a directory region",
+                0,
+                c.getInt(0)
             )
         }
         db.close()

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/mock/MockRegion.java
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/mock/MockRegion.java
@@ -93,7 +93,8 @@ public class MockRegion {
         null,
         "https://onebusaway.co",
         null,
-        null); // UmamiAnalyticsConfig — disabled in test regions
+        null, // UmamiAnalyticsConfig — disabled in test regions
+        false); // custom: mock regions stand in for directory regions, not rider-added ones
   }
 
   /**
@@ -135,7 +136,8 @@ public class MockRegion {
         null,
         "https://onebusaway.co",
         null,
-        null); // UmamiAnalyticsConfig — disabled in test regions
+        null, // UmamiAnalyticsConfig — disabled in test regions
+        false); // custom: mock regions stand in for directory regions, not rider-added ones
   }
 
   /**
@@ -178,7 +180,8 @@ public class MockRegion {
         null,
         "https://onebusaway.co",
         null,
-        null); // UmamiAnalyticsConfig — disabled in test regions
+        null, // UmamiAnalyticsConfig — disabled in test regions
+        false); // custom: mock regions stand in for directory regions, not rider-added ones
   }
 
   /**
@@ -221,7 +224,8 @@ public class MockRegion {
         null,
         "https://onebusaway.co",
         null,
-        null); // UmamiAnalyticsConfig — disabled in test regions
+        null, // UmamiAnalyticsConfig — disabled in test regions
+        false); // custom: mock regions stand in for directory regions, not rider-added ones
   }
 
   /**
@@ -264,7 +268,8 @@ public class MockRegion {
         null,
         "https://onebusaway.co",
         null,
-        null); // UmamiAnalyticsConfig — disabled in test regions
+        null, // UmamiAnalyticsConfig — disabled in test regions
+        false); // custom: mock regions stand in for directory regions, not rider-added ones
   }
 
   /**
@@ -307,7 +312,8 @@ public class MockRegion {
         null,
         "https://onebusaway.co",
         null,
-        null); // UmamiAnalyticsConfig — disabled in test regions
+        null, // UmamiAnalyticsConfig — disabled in test regions
+        false); // custom: mock regions stand in for directory regions, not rider-added ones
   }
 
   /**
@@ -348,7 +354,8 @@ public class MockRegion {
         null,
         "https://onebusaway.co",
         null,
-        null); // UmamiAnalyticsConfig — disabled in test regions
+        null, // UmamiAnalyticsConfig — disabled in test regions
+        false); // custom: mock regions stand in for directory regions, not rider-added ones
   }
 
   /**
@@ -389,6 +396,7 @@ public class MockRegion {
         null,
         "https://onebusaway.co",
         null,
-        null); // UmamiAnalyticsConfig — disabled in test regions
+        null, // UmamiAnalyticsConfig — disabled in test regions
+        false); // custom: mock regions stand in for directory regions, not rider-added ones
   }
 }

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/nav/ExternalDeepLinksUriTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/nav/ExternalDeepLinksUriTest.kt
@@ -36,8 +36,11 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class ExternalDeepLinksUriTest {
 
+    // Method names are camelCase, not the backtick-with-spaces style the JVM unit tests use: these get
+    // dexed, and D8 rejects spaces in a SimpleName below DEX version 040.
+
     @Test
-    fun `a custom-scheme stop URI parses`() {
+    fun customSchemeStopUri_parses() {
         assertEquals(
             ExternalDeepLinks.Target.Stop("1_75403"),
             ExternalDeepLinks.parse("onebusaway://view-stop?stopID=1_75403&regionID=1".toUri())
@@ -45,7 +48,7 @@ class ExternalDeepLinksUriTest {
     }
 
     @Test
-    fun `a percent-encoded stop id is decoded`() {
+    fun percentEncodedStopId_isDecoded() {
         assertEquals(
             ExternalDeepLinks.Target.Stop("1_7 5403"),
             ExternalDeepLinks.parse("onebusaway://view-stop?stopID=1_7%205403".toUri())
@@ -53,7 +56,7 @@ class ExternalDeepLinksUriTest {
     }
 
     @Test
-    fun `a web trip URI parses`() {
+    fun webTripUri_parses() {
         assertEquals(
             ExternalDeepLinks.Target.Trip(tripId = "1_18196913", stopId = "1_75403"),
             ExternalDeepLinks.parse(
@@ -66,7 +69,7 @@ class ExternalDeepLinksUriTest {
     }
 
     @Test
-    fun `an opaque URI is rejected rather than throwing`() {
+    fun opaqueUri_isRejected_ratherThanThrowing() {
         // No `//`, so this is opaque: Uri.getQueryParameterNames() throws UnsupportedOperationException
         // on it. toLink() guards that with isHierarchical; without the guard this test crashes.
         assertNull(ExternalDeepLinks.parse("onebusaway:view-stop?stopID=1_75403".toUri()))
@@ -74,7 +77,7 @@ class ExternalDeepLinksUriTest {
     }
 
     @Test
-    fun `scheme and host are matched case-insensitively`() {
+    fun schemeAndHost_matchCaseInsensitively() {
         // IntentFilter matches these case-insensitively, so a link that reaches us may carry any case;
         // toLink() normalizes before the parser's equality comparisons.
         assertEquals(
@@ -90,14 +93,14 @@ class ExternalDeepLinksUriTest {
     }
 
     @Test
-    fun `the app's internal content URIs are not external deep links`() {
+    fun internalContentUri_isNotAnExternalDeepLink() {
         val internal = "content://com.joulespersecond.oba/stops/1_75403".toUri()
         assertNull(ExternalDeepLinks.parse(internal))
         assertFalse(ExternalDeepLinks.isUnhandledWebLink(internal))
     }
 
     @Test
-    fun `a claimed but unroutable web URI is reported as an unhandled web link`() {
+    fun claimedButUnroutableWebUri_isUnhandledWebLink() {
         // The intent-filter can't require trip_id, so this URL launches the app with nowhere to go;
         // HomeActivity hands it back to the browser on the strength of this predicate.
         val trimmed = "https://onebusaway.co/regions/1/stops/1_75403/trips".toUri()

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/nav/ExternalDeepLinksUriTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/nav/ExternalDeepLinksUriTest.kt
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.nav
+
+import androidx.core.net.toUri
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Covers [ExternalDeepLinks]'s `Uri` decomposition — the one Android-dependent part of the deep-link
+ * vocabulary, and so the one part `ExternalDeepLinksTest` (a pure JVM test over the already-decomposed
+ * `Link`) can't reach. `android.net.Uri` is stubbed in unit tests, so these run on a device.
+ *
+ * What's actually at risk here is the decomposition's edge behaviour rather than the vocabulary:
+ * `getQueryParameterNames()` throws on an opaque URI, and scheme/host arrive with whatever case the
+ * sender used while the parser compares them by equality.
+ */
+@RunWith(AndroidJUnit4::class)
+class ExternalDeepLinksUriTest {
+
+    @Test
+    fun `a custom-scheme stop URI parses`() {
+        assertEquals(
+            ExternalDeepLinks.Target.Stop("1_75403"),
+            ExternalDeepLinks.parse("onebusaway://view-stop?stopID=1_75403&regionID=1".toUri())
+        )
+    }
+
+    @Test
+    fun `a percent-encoded stop id is decoded`() {
+        assertEquals(
+            ExternalDeepLinks.Target.Stop("1_7 5403"),
+            ExternalDeepLinks.parse("onebusaway://view-stop?stopID=1_7%205403".toUri())
+        )
+    }
+
+    @Test
+    fun `a web trip URI parses`() {
+        assertEquals(
+            ExternalDeepLinks.Target.Trip(tripId = "1_18196913", stopId = "1_75403"),
+            ExternalDeepLinks.parse(
+                (
+                    "https://onebusaway.co/regions/1/stops/1_75403/trips" +
+                        "?trip_id=1_18196913&service_date=1698307200.0&stop_sequence=5"
+                    ).toUri()
+            )
+        )
+    }
+
+    @Test
+    fun `an opaque URI is rejected rather than throwing`() {
+        // No `//`, so this is opaque: Uri.getQueryParameterNames() throws UnsupportedOperationException
+        // on it. toLink() guards that with isHierarchical; without the guard this test crashes.
+        assertNull(ExternalDeepLinks.parse("onebusaway:view-stop?stopID=1_75403".toUri()))
+        assertNull(ExternalDeepLinks.parse("mailto:someone@example.com".toUri()))
+    }
+
+    @Test
+    fun `scheme and host are matched case-insensitively`() {
+        // IntentFilter matches these case-insensitively, so a link that reaches us may carry any case;
+        // toLink() normalizes before the parser's equality comparisons.
+        assertEquals(
+            ExternalDeepLinks.Target.Stop("1_75403"),
+            ExternalDeepLinks.parse("OneBusAway://view-stop?stopID=1_75403".toUri())
+        )
+        assertEquals(
+            ExternalDeepLinks.Target.Trip(tripId = "1_18196913", stopId = "1_75403"),
+            ExternalDeepLinks.parse(
+                "HTTPS://OneBusAway.CO/regions/1/stops/1_75403/trips?trip_id=1_18196913".toUri()
+            )
+        )
+    }
+
+    @Test
+    fun `the app's internal content URIs are not external deep links`() {
+        val internal = "content://com.joulespersecond.oba/stops/1_75403".toUri()
+        assertNull(ExternalDeepLinks.parse(internal))
+        assertFalse(ExternalDeepLinks.isUnhandledWebLink(internal))
+    }
+
+    @Test
+    fun `a claimed but unroutable web URI is reported as an unhandled web link`() {
+        // The intent-filter can't require trip_id, so this URL launches the app with nowhere to go;
+        // HomeActivity hands it back to the browser on the strength of this predicate.
+        val trimmed = "https://onebusaway.co/regions/1/stops/1_75403/trips".toUri()
+        assertNull(ExternalDeepLinks.parse(trimmed))
+        assertTrue(ExternalDeepLinks.isUnhandledWebLink(trimmed))
+    }
+}

--- a/onebusaway-android/src/main/AndroidManifest.xml
+++ b/onebusaway-android/src/main/AndroidManifest.xml
@@ -49,6 +49,17 @@
         android:glEsVersion="0x00020000"
         android:required="true"/>
 
+    <!-- Package visibility (API 30+): ExternalIntents.openInBrowser enumerates the device's browsers so
+         it can hand back a web deep link this app was launched for but can't route
+         (ExternalDeepLinks.isUnhandledWebLink). Without this it would see no browser and give up. -->
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <category android:name="android.intent.category.BROWSABLE" />
+            <data android:scheme="https" />
+        </intent>
+    </queries>
+
     <application
         android:allowBackup="false"
         android:name="org.onebusaway.android.app.Application"
@@ -100,7 +111,12 @@
                  `onebusaway` is the cross-platform scheme every brand answers to; ${deepLinkScheme} is
                  the brand's own (identical for the OBA brand, `kiedybus` for KiedyBus). The placeholder
                  is the single declaration of that scheme — ExternalDeepLinks.APP_SCHEMES is derived
-                 from it via BuildConfig.DEEP_LINK_SCHEME (see build.gradle.kts). -->
+                 from it via BuildConfig.DEEP_LINK_SCHEME (see build.gradle.kts).
+
+                 For every brand except KiedyBus the two <data> schemes below therefore resolve to the
+                 same string, and the merged manifest carries `onebusaway` twice. That is intentional and
+                 inert (a filter's scheme set is a set), and it's the price of declaring the brand scheme
+                 in exactly one place: a manifest can't emit an element conditionally. -->
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 

--- a/onebusaway-android/src/main/AndroidManifest.xml
+++ b/onebusaway-android/src/main/AndroidManifest.xml
@@ -88,18 +88,28 @@
             <intent-filter>
                 <action android:name="android.intent.action.SEARCH" />
             </intent-filter>
-            <!-- The `onebusaway://add-region` deep link (former SettingsActivity VIEW
-                 filter). HomeActivity.applyIntentSideEffects reads the oba-url/otp-url query params,
-                 applies the custom API URL(s), and stays on the home/map path (IntentRouteMapper). -->
+            <!-- Custom-scheme deep links, the same vocabulary OneBusAway for iOS handles
+                 (#2027) — see org.onebusaway.android.ui.nav.ExternalDeepLinks. Note that a filter's
+                 <data> attributes combine as a cross product, so every scheme below matches every host:
+
+                   <scheme>://add-region?oba-url=… — HomeActivity.applyIntentSideEffects reads the
+                       oba-url/otp-url query params, applies the custom API URL(s), and stays on the
+                       home/map path (the former SettingsActivity VIEW filter).
+                   <scheme>://view-stop?stopID=…&regionID=… — opens that stop's arrivals.
+
+                 `onebusaway` is the cross-platform scheme every brand answers to; ${deepLinkScheme} is
+                 the brand's own (identical for the OBA brand, `kiedybus` for KiedyBus — set per brand in
+                 flavors/*.gradle). IntentRouteMapper.APP_SCHEMES is the Kotlin-side copy of this set. -->
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
 
-                <data
-                    android:host="add-region"
-                    android:scheme="onebusaway" />
+                <data android:scheme="onebusaway" />
+                <data android:scheme="${deepLinkScheme}" />
+                <data android:host="add-region" />
+                <data android:host="view-stop" />
             </intent-filter>
             <meta-data
                 android:name="android.app.searchable"

--- a/onebusaway-android/src/main/AndroidManifest.xml
+++ b/onebusaway-android/src/main/AndroidManifest.xml
@@ -103,8 +103,9 @@
                  (#2027) — see org.onebusaway.android.ui.nav.ExternalDeepLinks. Note that a filter's
                  <data> attributes combine as a cross product, so every scheme below matches every host:
 
-                   <scheme>://add-region?oba-url=… — HomeActivity.applyIntentSideEffects reads the
-                       oba-url/otp-url query params, applies the custom API URL(s), and stays on the
+                   <scheme>://add-region?name=…&oba-url=… — HomeActivity.applyIntentSideEffects stages
+                       the request for the rider's confirmation (AddRegionDialog); accepting it adds a
+                       custom region and switches to it. Routes nowhere, so the app stays on the
                        home/map path (the former SettingsActivity VIEW filter).
                    <scheme>://view-stop?stopID=…&regionID=… — opens that stop's arrivals.
 

--- a/onebusaway-android/src/main/AndroidManifest.xml
+++ b/onebusaway-android/src/main/AndroidManifest.xml
@@ -98,8 +98,9 @@
                    <scheme>://view-stop?stopID=…&regionID=… — opens that stop's arrivals.
 
                  `onebusaway` is the cross-platform scheme every brand answers to; ${deepLinkScheme} is
-                 the brand's own (identical for the OBA brand, `kiedybus` for KiedyBus — set per brand in
-                 flavors/*.gradle). IntentRouteMapper.APP_SCHEMES is the Kotlin-side copy of this set. -->
+                 the brand's own (identical for the OBA brand, `kiedybus` for KiedyBus). The placeholder
+                 is the single declaration of that scheme — ExternalDeepLinks.APP_SCHEMES is derived
+                 from it via BuildConfig.DEEP_LINK_SCHEME (see build.gradle.kts). -->
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/app/di/DatabaseModule.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/app/di/DatabaseModule.kt
@@ -32,6 +32,7 @@ import org.onebusaway.android.database.MIGRATION_5_6
 import org.onebusaway.android.database.MIGRATION_6_7
 import org.onebusaway.android.database.MIGRATION_7_8
 import org.onebusaway.android.database.MIGRATION_8_9
+import org.onebusaway.android.database.MIGRATION_9_10
 import org.onebusaway.android.database.oba.DefaultImportGate
 import org.onebusaway.android.database.oba.ImportGate
 import org.onebusaway.android.database.oba.LegacyDataImporter
@@ -73,7 +74,8 @@ object DatabaseModule {
         MIGRATION_5_6,
         MIGRATION_6_7,
         MIGRATION_7_8,
-        MIGRATION_8_9
+        MIGRATION_8_9,
+        MIGRATION_9_10
     ).build()
 
     @Provides

--- a/onebusaway-android/src/main/java/org/onebusaway/android/database/AppDatabase.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/database/AppDatabase.kt
@@ -77,7 +77,7 @@ import org.onebusaway.android.database.widealerts.entity.AlertEntity
         CachedStopRecord::class,
         CachedRouteTypeRecord::class
     ],
-    version = 9,
+    version = 10,
     exportSchema = true
 )
 abstract class AppDatabase : RoomDatabase() {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/database/Migrations.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/database/Migrations.kt
@@ -208,3 +208,18 @@ val MIGRATION_8_9 = object : Migration(8, 9) {
         )
     }
 }
+
+/**
+ * Adds `regions.custom`: whether the row is a user-added custom region (the `add-region` deep link,
+ * #2027) rather than one from the OBA regions directory. Every existing cached row is a directory row,
+ * so the NOT NULL DEFAULT 0 is exactly right — and the default must be declared here *and* as
+ * `defaultValue = "0"` on the entity column, or Room's identity check fails against the exported
+ * `10.json`. Purely additive, no other v10 table/column changes. Verified by AppDatabaseMigrationTest.
+ */
+val MIGRATION_9_10 = object : Migration(9, 10) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            "ALTER TABLE `regions` ADD COLUMN `custom` INTEGER NOT NULL DEFAULT 0"
+        )
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/database/oba/ObaEntities.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/database/oba/ObaEntities.kt
@@ -136,7 +136,12 @@ data class RegionRecord(
     val sidecarBaseUrl: String? = null,
     @ColumnInfo(name = "plausible_analytics_server_url") val plausibleAnalyticsServerUrl: String? = null,
     @ColumnInfo(name = "umami_analytics_url") val umamiAnalyticsUrl: String? = null,
-    @ColumnInfo(name = "umami_analytics_id") val umamiAnalyticsId: String? = null
+    @ColumnInfo(name = "umami_analytics_id") val umamiAnalyticsId: String? = null,
+    // Whether this row is a user-added custom region (the `add-region` deep link, #2027) rather than a
+    // row from the OBA regions directory. It is the flag that keeps the row out of the directory
+    // refresh's blast radius: RegionDao.replaceAll deletes only `custom = 0` rows, so a custom region
+    // survives every refresh, and custom ids are negative so they can never collide with directory ids.
+    @ColumnInfo(name = "custom", defaultValue = "0") val custom: Int = 0
 )
 
 @Entity(

--- a/onebusaway-android/src/main/java/org/onebusaway/android/database/oba/RegionDao.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/database/oba/RegionDao.kt
@@ -62,28 +62,75 @@ interface RegionDao {
     @Insert
     suspend fun insertOpen311Servers(servers: List<Open311ServerRecord>)
 
-    @Query("DELETE FROM regions")
-    suspend fun clearRegions()
+    /**
+     * Clears the *directory* regions, leaving user-added custom ones (#2027) in place — the regions
+     * directory has no opinion about them, so a refresh must not take them with it.
+     */
+    @Query("DELETE FROM regions WHERE custom = 0")
+    suspend fun clearDirectoryRegions()
 
     /**
      * The legacy open311_servers table has no foreign key (see [Open311ServerRecord]), so it must be
-     * cleared explicitly; region_bounds cascades off [clearRegions].
+     * cleared explicitly; region_bounds cascades off the region delete. Scoped to the rows whose region
+     * is going away, for the same reason as [clearDirectoryRegions]. (A custom region never has Open311
+     * servers today — the deep link can't supply any — but scoping it keeps the two deletes consistent.)
      */
-    @Query("DELETE FROM open311_servers")
-    suspend fun clearOpen311Servers()
+    @Query("DELETE FROM open311_servers WHERE region_id IN (SELECT _id FROM regions WHERE custom = 0)")
+    suspend fun clearDirectoryOpen311Servers()
+
+    /** The user-added custom regions (#2027), which [replaceAll] deliberately preserves. */
+    @Transaction
+    @Query("SELECT * FROM regions WHERE custom != 0")
+    suspend fun getCustomRegions(): List<RegionWithChildren>
 
     /**
-     * Atomically replaces the whole region cache (the legacy `saveToProvider`): clear all three
-     * tables, then insert each region with its children. Callers filter to usable regions first.
+     * The lowest region id in the table, or null when it's empty. Custom regions are numbered downwards
+     * from -2, so the next id is `min(this, -1) - 1` — see `RegionCache.saveCustom`. (-1 is the "no
+     * region" sentinel in the region-id preference, and directory ids are non-negative.)
+     */
+    @Query("SELECT MIN(_id) FROM regions")
+    suspend fun minRegionId(): Long?
+
+    /** The custom region served by [obaBaseUrl], or null — the key re-adding an existing region matches on. */
+    @Transaction
+    @Query("SELECT * FROM regions WHERE custom != 0 AND oba_base_url = :obaBaseUrl LIMIT 1")
+    suspend fun customRegionByObaUrl(obaBaseUrl: String): RegionWithChildren?
+
+    /** Removes one region and its children (region_bounds cascades; open311 has no FK, so it's explicit). */
+    @Transaction
+    suspend fun deleteRegionById(id: Long) {
+        deleteOpen311ServersForRegion(id)
+        deleteRegionRow(id)
+    }
+
+    @Query("DELETE FROM open311_servers WHERE region_id = :id")
+    suspend fun deleteOpen311ServersForRegion(id: Long)
+
+    @Query("DELETE FROM regions WHERE _id = :id")
+    suspend fun deleteRegionRow(id: Long)
+
+    /**
+     * Atomically replaces the *directory* region cache (the legacy `saveToProvider`): clear the
+     * directory rows and their children, then insert each region with its children. Callers filter to
+     * usable regions first. User-added custom regions are left untouched — see [clearDirectoryRegions].
      */
     @Transaction
     suspend fun replaceAll(regions: List<RegionWithChildren>) {
-        clearOpen311Servers()
-        clearRegions() // region_bounds cascades
+        clearDirectoryOpen311Servers()
+        clearDirectoryRegions() // region_bounds cascades
         for (entry in regions) {
             insertRegion(entry.region)
             insertBounds(entry.bounds)
             insertOpen311Servers(entry.open311Servers)
         }
+    }
+
+    /** Inserts or replaces one custom region and its children (there are no bounds to write today). */
+    @Transaction
+    suspend fun upsertCustomRegion(entry: RegionWithChildren) {
+        deleteRegionById(entry.region.id)
+        insertRegion(entry.region)
+        insertBounds(entry.bounds)
+        insertOpen311Servers(entry.open311Servers)
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/database/oba/RegionDao.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/database/oba/RegionDao.kt
@@ -91,10 +91,13 @@ interface RegionDao {
     @Query("SELECT MIN(_id) FROM regions")
     suspend fun minRegionId(): Long?
 
-    /** The custom region served by [obaBaseUrl], or null — the key re-adding an existing region matches on. */
-    @Transaction
-    @Query("SELECT * FROM regions WHERE custom != 0 AND oba_base_url = :obaBaseUrl LIMIT 1")
-    suspend fun customRegionByObaUrl(obaBaseUrl: String): RegionWithChildren?
+    /**
+     * The id of the custom region served by [obaBaseUrl], or null — the key re-adding an existing region
+     * matches on. Reads only the id: the caller reuses it and nothing else, and selecting the whole
+     * [RegionWithChildren] would cost a transaction plus a query per `@Relation`.
+     */
+    @Query("SELECT _id FROM regions WHERE custom != 0 AND oba_base_url = :obaBaseUrl LIMIT 1")
+    suspend fun customRegionIdByObaUrl(obaBaseUrl: String): Long?
 
     /** Removes one region and its children (region_bounds cascades; open311 has no FK, so it's explicit). */
     @Transaction
@@ -118,17 +121,23 @@ interface RegionDao {
     suspend fun replaceAll(regions: List<RegionWithChildren>) {
         clearDirectoryOpen311Servers()
         clearDirectoryRegions() // region_bounds cascades
-        for (entry in regions) {
-            insertRegion(entry.region)
-            insertBounds(entry.bounds)
-            insertOpen311Servers(entry.open311Servers)
-        }
+        regions.forEach { insertEntry(it) }
     }
 
     /** Inserts or replaces one custom region and its children (there are no bounds to write today). */
     @Transaction
     suspend fun upsertCustomRegion(entry: RegionWithChildren) {
         deleteRegionById(entry.region.id)
+        insertEntry(entry)
+    }
+
+    /**
+     * Inserts one region and its children. Parent first: `region_bounds` has a foreign key onto
+     * `regions`, so the order is load-bearing — which is the reason both writers share this rather than
+     * each spelling out the three inserts.
+     */
+    @Transaction
+    suspend fun insertEntry(entry: RegionWithChildren) {
         insertRegion(entry.region)
         insertBounds(entry.bounds)
         insertOpen311Servers(entry.open311Servers)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/region/ApiUrlValidator.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/region/ApiUrlValidator.kt
@@ -23,7 +23,7 @@ import java.net.URL
 
 /**
  * Stateless validator for a custom OBA/OTP API URL — the rule for "is this a usable region API URL".
- * Used by the region domain ([RegionRepository.applyCustomApiUrls], applying the `add-region` deep
+ * Used by the region domain ([RegionRepository.addCustomRegion], validating an `add-region` deep
  * link) and by the advanced settings screen
  * ([org.onebusaway.android.ui.settings.AdvancedSettingsViewModel]) for live input validation. It lives
  * in the neutral `region` package so both can depend on it without a `region` → `ui` back-dependency.

--- a/onebusaway-android/src/main/java/org/onebusaway/android/region/CustomRegions.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/region/CustomRegions.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.region
+
+/**
+ * The user-supplied half of a custom region — exactly what an `add-region` deep link can say (#2027),
+ * with no ids, defaults or capability flags decided yet. [ExternalDeepLinks] produces one of these,
+ * the confirmation dialog renders it, and [customRegion] turns it into a [Region].
+ *
+ * [name] and [obaBaseUrl] are required (matching OneBusAway for iOS); everything else is optional.
+ */
+data class CustomRegionRequest(
+    val name: String,
+    val obaBaseUrl: String,
+    val otpBaseUrl: String? = null,
+    val sidecarBaseUrl: String? = null,
+    val umamiAnalyticsUrl: String? = null,
+    val umamiAnalyticsId: String? = null
+)
+
+/**
+ * The first id handed to a custom region. Directory ids are non-negative (Tampa is 0) and -1 is the
+ * "no region" sentinel in the region-id preference, so custom regions count downwards from here and
+ * can never collide with either. See [nextCustomRegionId].
+ */
+internal const val FIRST_CUSTOM_REGION_ID = -2L
+
+/**
+ * The next custom-region id given the lowest id already in the cache ([minId], null when empty) — one
+ * below everything present, so no two *live* regions can share an id.
+ *
+ * Note this reads the live minimum rather than a persisted counter, so removing the lowest custom region
+ * does free its id for the next one. That is safe because the only durable reference to a region id is
+ * the region-id preference, and removing the current region rewrites it (see
+ * `RegionRepository.deleteCustomRegion`) — there is no dangling id left to be re-pointed at a different
+ * server. A monotonic counter would need its own persisted state to buy nothing.
+ */
+internal fun nextCustomRegionId(minId: Long?): Long = if (minId == null || minId > FIRST_CUSTOM_REGION_ID) FIRST_CUSTOM_REGION_ID else minId - 1
+
+/**
+ * Builds the [Region] for [request] under [id].
+ *
+ * The capability flags are **declarations, not observations** — nothing has probed this server. They are
+ * set true because that is what makes a region usable at all (`RegionUtils.isRegionUsable` requires
+ * active + discovery + realtime, and rejects experimental regions unless the rider opted in), and a
+ * region the app refuses to use would make the link pointless. The failure mode is honest and local: if
+ * the server doesn't actually serve those APIs, its requests fail and the rider sees the same errors as
+ * any unreachable server — nothing silently reads as empty data.
+ *
+ * [Region.bounds] is deliberately empty: a deep link carries no coverage area, and `getClosestRegion`
+ * skips a region it can't measure a distance to, so a custom region is never auto-selected. It is
+ * reachable by the link itself and by the region picker.
+ *
+ * [Region.contactEmail] is left blank rather than filled with a placeholder (iOS hardcodes
+ * `example@example.com`): the "email a problem report" option keys off it, and mailing a made-up
+ * address is worse than not offering the option.
+ */
+internal fun customRegion(id: Long, request: CustomRegionRequest): Region = Region(
+    id = id,
+    name = request.name,
+    active = true,
+    custom = true,
+    obaBaseUrl = request.obaBaseUrl,
+    otpBaseUrl = request.otpBaseUrl,
+    sidecarBaseUrl = request.sidecarBaseUrl,
+    umamiAnalytics = request.umamiAnalyticsUrl?.let {
+        Region.UmamiAnalyticsConfig(url = it, id = request.umamiAnalyticsId)
+    },
+    // See the KDoc: declared so the region is usable, not observed from the server.
+    supportsObaDiscoveryApis = true,
+    supportsObaRealtimeApis = true,
+    experimental = false,
+    bounds = emptyArray(),
+    contactEmail = ""
+)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/region/CustomRegions.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/region/CustomRegions.kt
@@ -51,7 +51,7 @@ internal const val NO_REGION_ID = -1L
  * The first id handed to a custom region — one below [NO_REGION_ID], so the two can never be confused.
  * See [nextCustomRegionId].
  */
-internal const val FIRST_CUSTOM_REGION_ID = -2L
+internal const val FIRST_CUSTOM_REGION_ID = NO_REGION_ID - 1
 
 /**
  * The region id stored in the preference, or null when it means "no region" ([NO_REGION_ID]).
@@ -71,7 +71,7 @@ internal fun persistedRegionId(stored: Long): Long? = stored.takeIf { it != NO_R
  * `RegionRepository.deleteCustomRegion`) — there is no dangling id left to be re-pointed at a different
  * server. A monotonic counter would need its own persisted state to buy nothing.
  */
-internal fun nextCustomRegionId(minId: Long?): Long = if (minId == null || minId > FIRST_CUSTOM_REGION_ID) FIRST_CUSTOM_REGION_ID else minId - 1
+internal fun nextCustomRegionId(minId: Long?): Long = minOf(minId ?: NO_REGION_ID, NO_REGION_ID) - 1
 
 /**
  * Builds the [Region] for [request] under [id].

--- a/onebusaway-android/src/main/java/org/onebusaway/android/region/CustomRegions.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/region/CustomRegions.kt
@@ -31,12 +31,35 @@ data class CustomRegionRequest(
     val umamiAnalyticsId: String? = null
 )
 
+/*
+ * The region id space, in one place, because custom regions are the reason it has structure at all:
+ *
+ *   >= 0   a region from the OBA regions directory (Tampa is 0)
+ *   -1     [NO_REGION_ID] — the region-id preference's "no region set" sentinel
+ *   <= -2  a user-added custom region (#2027)
+ *
+ * Anything reading or writing the region-id preference must go through [NO_REGION_ID] rather than
+ * testing the sign: `id < 0` would swallow every custom region, which is exactly the bug that shipped
+ * in the first draft of this feature (a custom region survived in the database but was never restored
+ * at cold start, so the app silently fell back to resolution on every launch).
+ */
+
+/** The region-id preference value meaning "no region is set". */
+internal const val NO_REGION_ID = -1L
+
 /**
- * The first id handed to a custom region. Directory ids are non-negative (Tampa is 0) and -1 is the
- * "no region" sentinel in the region-id preference, so custom regions count downwards from here and
- * can never collide with either. See [nextCustomRegionId].
+ * The first id handed to a custom region — one below [NO_REGION_ID], so the two can never be confused.
+ * See [nextCustomRegionId].
  */
 internal const val FIRST_CUSTOM_REGION_ID = -2L
+
+/**
+ * The region id stored in the preference, or null when it means "no region" ([NO_REGION_ID]).
+ *
+ * Pure so the sentinel rule is unit-tested rather than living inline in the `Context`-coupled
+ * repository — see `RegionRepository.loadPersistedRegion`, its only caller.
+ */
+internal fun persistedRegionId(stored: Long): Long? = stored.takeIf { it != NO_REGION_ID }
 
 /**
  * The next custom-region id given the lowest id already in the cache ([minId], null when empty) — one

--- a/onebusaway-android/src/main/java/org/onebusaway/android/region/Region.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/region/Region.kt
@@ -63,7 +63,14 @@ data class Region(
     val paymentWarningBody: String? = null,
     val sidecarBaseUrl: String? = "",
     val plausibleAnalyticsServerUrl: String? = "",
-    val umamiAnalytics: UmamiAnalyticsConfig? = null
+    val umamiAnalytics: UmamiAnalyticsConfig? = null,
+    // A user-added region (the `add-region` deep link, #2027) rather than one from the OBA regions
+    // directory. Three things key off it: the cache preserves these rows across a directory refresh,
+    // their ids are negative so they can't collide with directory ids, and [resolveRegionStatus] never
+    // auto-replaces one — the rider chose this server deliberately, so a closer directory region
+    // silently taking over would undo that. Custom regions carry no [bounds], so they are also never
+    // auto-*selected* (getClosestRegion can't measure a distance to them).
+    val custom: Boolean = false
 ) {
     val umamiAnalyticsUrl: String? get() = umamiAnalytics?.url
     val umamiAnalyticsId: String? get() = umamiAnalytics?.id

--- a/onebusaway-android/src/main/java/org/onebusaway/android/region/RegionCache.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/region/RegionCache.kt
@@ -68,6 +68,11 @@ class RegionCache @Inject constructor(
      * The legacy `RegionUtils.getRegions` source-fallback: prefer the cache (unless [forceReload]),
      * then the server, then — if forced — the cache again, then the bundled resource. A server or
      * resource result is persisted. Null only when every source failed.
+     *
+     * Every return path includes the user's custom regions (#2027). The cache paths get them for free
+     * (they're rows like any other); the server/bundled paths have to union them back in, since the
+     * regions directory has never heard of them — without that, a forced reload would drop the rider's
+     * own region out of the picker list.
      */
     suspend fun loadRegions(forceReload: Boolean): List<Region>? {
         if (!forceReload) {
@@ -88,6 +93,36 @@ class RegionCache @Inject constructor(
         }
 
         save(results)
-        return results
+        return results + customRegions()
+    }
+
+    /** The user-added custom regions (#2027); empty when there are none. */
+    suspend fun customRegions(): List<Region> {
+        importGate.awaitReady()
+        return regionDao.getCustomRegions().map { RegionMapper.toRegion(it) }
+    }
+
+    /**
+     * Persists [request] as a custom region and returns it.
+     *
+     * Re-adding a server already present updates that region in place — matched on the exact
+     * [Region.obaBaseUrl], so it keeps its id and stays the same entity to anything holding a reference
+     * (the persisted region-id preference, most of all). Otherwise it gets a fresh id from
+     * [nextCustomRegionId]. Deliberately does *not* go through [save], whose `isRegionUsable` filter and
+     * whole-cache replace are the directory refresh's business.
+     */
+    suspend fun saveCustom(request: CustomRegionRequest): Region {
+        importGate.awaitReady()
+        val existingId = regionDao.customRegionByObaUrl(request.obaBaseUrl)?.region?.id
+        val region = customRegion(existingId ?: nextCustomRegionId(regionDao.minRegionId()), request)
+        regionDao.upsertCustomRegion(RegionMapper.toEntities(region))
+        return region
+    }
+
+    /** Removes a custom region. A directory region is never deleted here — the refresh owns those rows. */
+    suspend fun deleteCustom(region: Region) {
+        importGate.awaitReady()
+        if (!region.custom) return
+        regionDao.deleteRegionById(region.id)
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/region/RegionCache.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/region/RegionCache.kt
@@ -97,7 +97,7 @@ class RegionCache @Inject constructor(
     }
 
     /** The user-added custom regions (#2027); empty when there are none. */
-    suspend fun customRegions(): List<Region> {
+    private suspend fun customRegions(): List<Region> {
         importGate.awaitReady()
         return regionDao.getCustomRegions().map { RegionMapper.toRegion(it) }
     }
@@ -113,7 +113,7 @@ class RegionCache @Inject constructor(
      */
     suspend fun saveCustom(request: CustomRegionRequest): Region {
         importGate.awaitReady()
-        val existingId = regionDao.customRegionByObaUrl(request.obaBaseUrl)?.region?.id
+        val existingId = regionDao.customRegionIdByObaUrl(request.obaBaseUrl)
         val region = customRegion(existingId ?: nextCustomRegionId(regionDao.minRegionId()), request)
         regionDao.upsertCustomRegion(RegionMapper.toEntities(region))
         return region

--- a/onebusaway-android/src/main/java/org/onebusaway/android/region/RegionMapper.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/region/RegionMapper.kt
@@ -67,7 +67,8 @@ object RegionMapper {
             paymentWarningBody = r.paymentWarningBody,
             sidecarBaseUrl = r.sidecarBaseUrl,
             plausibleAnalyticsServerUrl = r.plausibleAnalyticsServerUrl,
-            umamiAnalytics = umami
+            umamiAnalytics = umami,
+            custom = r.custom > 0
         )
     }
 
@@ -98,7 +99,8 @@ object RegionMapper {
             sidecarBaseUrl = region.sidecarBaseUrl,
             plausibleAnalyticsServerUrl = region.plausibleAnalyticsServerUrl,
             umamiAnalyticsUrl = region.umamiAnalyticsUrl,
-            umamiAnalyticsId = region.umamiAnalyticsId
+            umamiAnalyticsId = region.umamiAnalyticsId,
+            custom = region.custom.toInt()
         ),
         bounds = region.bounds.map {
             RegionBoundRecord(

--- a/onebusaway-android/src/main/java/org/onebusaway/android/region/RegionRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/region/RegionRepository.kt
@@ -92,12 +92,21 @@ interface RegionRepository {
     fun clear()
 
     /**
-     * Applies custom OBA / OTP API URLs (e.g. from the `onebusaway://add-region` deep link), validating
-     * each via [ApiUrlValidator]: a valid [obaUrl] is persisted and the current region is [clear]ed (a
-     * custom OBA endpoint replaces region resolution); a valid [otpUrl] is persisted. Null or invalid
-     * URLs are ignored. The caller is only responsible for parsing the URLs out of the intent.
+     * Persists [request] as a user-added custom region (the `add-region` deep link, #2027) and makes it
+     * current, returning it. Re-adding a server that is already a custom region updates it in place.
+     *
+     * The caller is responsible for having obtained the rider's consent first — this is a silent write
+     * that repoints every API the app talks to, so `AddRegionViewModel` gates it behind a confirmation
+     * dialog. Validating the URLs is this layer's job ([ApiUrlValidator]); an invalid [request] is
+     * rejected with null rather than half-applied.
      */
-    fun applyCustomApiUrls(obaUrl: String?, otpUrl: String?)
+    suspend fun addCustomRegion(request: CustomRegionRequest): Region?
+
+    /**
+     * Removes a user-added custom region. If it was the current region, the app falls back to
+     * resolution ([refresh]) as if none had been set. A directory region is ignored.
+     */
+    suspend fun deleteCustomRegion(region: Region)
 
     /**
      * Applies [region] as the active region directly — the canonical region write (A7): the OBA API
@@ -264,9 +273,13 @@ class DefaultRegionRepository @Inject constructor(
                 applyRegion(status.region, true)
                 status
             }
-            // Same region as before: refresh its contents silently (auto-select only).
+            // Same region as before: refresh its contents silently (auto-select only). Re-applying
+            // `closest` is only a *contents* refresh while it really is the current region — which
+            // Unchanged no longer implies on its own, because a current custom region (#2027) is
+            // Unchanged without ever being the closest (it has no bounds to measure). So match on id;
+            // otherwise this would quietly switch the rider off the server they chose.
             RegionStatus.Unchanged -> {
-                if (autoSelect && closest != null) {
+                if (autoSelect && closest != null && closest.id == current?.id) {
                     applyRegion(closest, false)
                 } else {
                     holder.activated(current) // clear the transient Resolving; region is unchanged
@@ -291,15 +304,30 @@ class DefaultRegionRepository @Inject constructor(
         applyRegion(null, true)
     }
 
-    override fun applyCustomApiUrls(obaUrl: String?, otpUrl: String?) {
-        // Order matters: persist the OBA URL first, then clear() — clear() applies a null region, which
-        // leaves the custom OBA URL pref untouched (applyRegion only clears it when a region is set).
-        if (obaUrl != null && ApiUrlValidator.validateUrl(obaUrl)) {
-            prefs.setString(R.string.preference_key_oba_api_url, obaUrl)
-            clear()
-        }
-        if (otpUrl != null && ApiUrlValidator.validateUrl(otpUrl)) {
-            prefs.setString(R.string.preference_key_otp_api_url, otpUrl)
+    override suspend fun addCustomRegion(request: CustomRegionRequest): Region? = withContext(Dispatchers.IO) {
+        // Reject rather than half-apply: a region whose OBA URL doesn't parse can't serve anything,
+        // and an unusable OTP URL shouldn't drag the whole region down with it — so the OBA URL is a
+        // precondition and a bad OTP URL is simply dropped.
+        if (!ApiUrlValidator.validateUrl(request.obaBaseUrl)) return@withContext null
+        val sanitized = request.copy(
+            otpBaseUrl = request.otpBaseUrl?.takeIf { ApiUrlValidator.validateUrl(it) }
+        )
+        val region = regionCache.saveCustom(sanitized)
+        // A region supersedes the preference-based custom API URLs entirely (applyRegion clears the
+        // OBA one), so the two mechanisms can't both be half-active. See docs/CUSTOM_SERVERS.md.
+        applyRegion(region, true)
+        region
+    }
+
+    override suspend fun deleteCustomRegion(region: Region) = withContext(Dispatchers.IO) {
+        if (!region.custom) return@withContext
+        val wasCurrent = this@DefaultRegionRepository.region.value?.id == region.id
+        regionCache.deleteCustom(region)
+        // Deleting the region you're standing on leaves no region at all; re-resolve so the app lands
+        // somewhere real (auto-select, or the picker) instead of silently pointing at a deleted server.
+        if (wasCurrent) {
+            applyRegion(null, true)
+            refresh()
         }
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/region/RegionRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/region/RegionRepository.kt
@@ -194,8 +194,10 @@ class DefaultRegionRepository @Inject constructor(
 
     /** Loads the persisted current region (by the saved region-id) from the cache, or null if none. */
     private suspend fun loadPersistedRegion(): Region? {
-        val id = prefs.getLong(R.string.preference_key_region, -1L)
-        if (id < 0) return null
+        // Only NO_REGION_ID means "nothing set". Testing the sign instead would discard every custom
+        // region (#2027), whose ids are <= -2 — the region would survive in the database but never be
+        // restored at cold start. See the id-space comment in CustomRegions.kt.
+        val id = persistedRegionId(prefs.getLong(R.string.preference_key_region, NO_REGION_ID)) ?: return null
         return regionCache.cachedRegion(id)
     }
 
@@ -207,7 +209,7 @@ class DefaultRegionRepository @Inject constructor(
         // (every reader observes [region] or reads its value), plus the persisted region-id pref and the
         // custom-URL clears. The region-derived subsystems (Plausible rebuild, Open311 re-init) react to
         // the published flow, not here.
-        prefs.setLong(R.string.preference_key_region, region?.id ?: -1L)
+        prefs.setLong(R.string.preference_key_region, region?.id ?: NO_REGION_ID)
         if (region != null) {
             prefs.setString(R.string.preference_key_oba_api_url, null) // using a region → clear custom OBA URL
             if (regionChanged && region.otpBaseUrl != null) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/region/RegionResolution.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/region/RegionResolution.kt
@@ -79,6 +79,12 @@ internal fun resolveRegionStatus(
     closest: Region?,
     autoSelect: Boolean
 ): RegionStatus {
+    // A custom region (#2027) is a deliberate choice of server — the rider followed an `add-region`
+    // link and confirmed it, or picked it from the list. Auto-selection must not quietly hand them back
+    // to whichever directory region happens to be nearest, so it is left alone regardless of [closest].
+    // (A custom region carries no bounds, so it can never *be* the closest either.) Switching away is
+    // still possible; it just has to be explicit, through the picker.
+    if (current?.custom == true) return RegionStatus.Unchanged
     // The manual-selection cases carry an empty list here; the repository fills in the usable
     // regions (it alone holds the fetched results) before returning to the caller.
     if (!autoSelect) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.kt
@@ -267,16 +267,27 @@ class HomeActivity : AppCompatActivity() {
     /**
      * Runs the domain mutations implied by certain incoming intents, kept out of [IntentRouteMapper]'s
      * pure route mapping so that stays a side-effect-free translator: the `add-region` deep link applies
-     * custom API URLs (clearing the region), and the FCM payload clears the now-fired reminder.
+     * custom API URLs (clearing the region), an unroutable web link goes back to the browser, and the FCM
+     * payload clears the now-fired reminder.
      */
     private fun applyIntentSideEffects(intent: Intent?) {
         if (intent == null) return
-        val deepLink = intent.data?.let { ExternalDeepLinks.parse(it) }
+        val data = intent.data
+        val deepLink = data?.let { ExternalDeepLinks.parse(it) }
         if (deepLink is ExternalDeepLinks.Target.AddRegion) {
             // Validating and applying the URLs is the region domain's job; ExternalDeepLinks just read
             // them off the URI.
             regionRepository.applyCustomApiUrls(obaUrl = deepLink.obaUrl, otpUrl = deepLink.otpUrl)
             return
+        }
+        // The web intent-filter is necessarily broader than the parser (it can't see the query string,
+        // and pathPattern globs span '/'), so we can be launched for a onebusaway.co URL that routes
+        // nowhere. Give it back to the browser instead of stranding the user on the map. This activity
+        // deliberately stays alive behind it: the same call runs for warm relaunches (LaunchIntentEffect
+        // feeds it both cold and onNewIntent intents), and finishing there would tear down a session the
+        // user is in the middle of. If no browser will take it we fall through and land on home/map.
+        if (data != null && ExternalDeepLinks.isUnhandledWebLink(data)) {
+            if (ExternalIntents.openInBrowser(this, data)) return
         }
         intent.getStringExtra(ReminderUtils.ARRIVAL_PAYLOAD_KEY)?.let { arrivalJson ->
             reminderRepository.deleteReminderFromPayload(arrivalJson)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.kt
@@ -271,9 +271,7 @@ class HomeActivity : AppCompatActivity() {
     private fun applyIntentSideEffects(intent: Intent?) {
         if (intent == null) return
         val data = intent.data
-        if (data?.scheme == IntentRouteMapper.ADD_REGION_SCHEME &&
-            data.host == IntentRouteMapper.ADD_REGION_HOST
-        ) {
+        if (data != null && IntentRouteMapper.isAddRegionUri(data)) {
             // Validating and applying the URLs is the region domain's job; we just parse them off the URI.
             regionRepository.applyCustomApiUrls(
                 obaUrl = data.getQueryParameter("oba-url"),

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.kt
@@ -275,9 +275,9 @@ class HomeActivity : AppCompatActivity() {
 
     /**
      * Runs the domain mutations implied by certain incoming intents, kept out of [IntentRouteMapper]'s
-     * pure route mapping so that stays a side-effect-free translator: the `add-region` deep link applies
-     * custom API URLs (clearing the region), an unroutable web link goes back to the browser, and the FCM
-     * payload clears the now-fired reminder.
+     * pure route mapping so that stays a side-effect-free translator: an `add-region` deep link is staged
+     * for the rider's confirmation, an unroutable web link goes back to the browser, and the FCM payload
+     * clears the now-fired reminder.
      */
     private fun applyIntentSideEffects(intent: Intent?) {
         if (intent == null) return
@@ -296,8 +296,14 @@ class HomeActivity : AppCompatActivity() {
         // deliberately stays alive behind it: the same call runs for warm relaunches (LaunchIntentEffect
         // feeds it both cold and onNewIntent intents), and finishing there would tear down a session the
         // user is in the middle of. If no browser will take it we fall through and land on home/map.
-        if (data != null && ExternalDeepLinks.isUnhandledWebLink(data)) {
-            if (ExternalIntents.openInBrowser(this, data)) return
+        // `deepLink == null` short-circuits the check for anything that already routed — a link with a
+        // destination is by definition not unhandled, so the common case never re-reads the URI.
+        if (deepLink == null &&
+            data != null &&
+            ExternalDeepLinks.isUnhandledWebLink(data) &&
+            ExternalIntents.openInBrowser(this, data)
+        ) {
+            return
         }
         intent.getStringExtra(ReminderUtils.ARRIVAL_PAYLOAD_KEY)?.let { arrivalJson ->
             reminderRepository.deleteReminderFromPayload(arrivalJson)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.kt
@@ -40,10 +40,11 @@ import org.onebusaway.android.directions.util.OTPConstants
 import org.onebusaway.android.directions.util.TripRequestBuilder
 import org.onebusaway.android.map.MapParams
 import org.onebusaway.android.map.MapViewModel
-import org.onebusaway.android.region.RegionRepository
 import org.onebusaway.android.ui.arrivals.ArrivalsLoaded
 import org.onebusaway.android.ui.arrivals.ArrivalsViewModel
 import org.onebusaway.android.ui.home.AccessibilityAnalyticsEffect
+import org.onebusaway.android.ui.home.AddRegionDialog
+import org.onebusaway.android.ui.home.AddRegionViewModel
 import org.onebusaway.android.ui.home.FocusedStop
 import org.onebusaway.android.ui.home.HomeActivityActions
 import org.onebusaway.android.ui.home.HomeAnalyticsEffect
@@ -84,10 +85,6 @@ class HomeActivity : AppCompatActivity() {
     @Inject
     lateinit var arrivalsViewModelFactory: ArrivalsViewModel.Factory
 
-    // The add-region deep link applies custom API URLs through this (rather than reaching Application.get()).
-    @Inject
-    lateinit var regionRepository: RegionRepository
-
     @Inject
     lateinit var reminderRepository: org.onebusaway.android.reminders.ReminderRepository
 
@@ -118,6 +115,9 @@ class HomeActivity : AppCompatActivity() {
 
     // The help / what's-new / legend dialogs feature module. Activity-scoped.
     private val helpViewModel: HelpViewModel by viewModels()
+
+    /** Holds an incoming `add-region` deep link until the rider confirms it (#2030). */
+    private val addRegionViewModel: AddRegionViewModel by viewModels()
 
     // Trip planner, now hosted on HOME (directions focus) rather than a standalone destination. Activity-
     // scoped so the reactive form + results survive config changes while HOME is on screen; TripPlanViewModel
@@ -168,6 +168,15 @@ class HomeActivity : AppCompatActivity() {
                     )
                 )
                 PaymentWarningDialog(viewModel.paymentWarning, viewModel::dismissPaymentWarning)
+                // The `add-region` consent gate, a sibling of the region picker below: it must overlay
+                // whatever screen the deep link landed on, so it lives at the setContent root too.
+                AddRegionDialog(
+                    pending = addRegionViewModel.pending,
+                    invalid = addRegionViewModel.invalid,
+                    onConfirm = addRegionViewModel::confirm,
+                    onDecline = addRegionViewModel::decline,
+                    onDismissInvalid = addRegionViewModel::dismissInvalid
+                )
                 // The forced region picker, driven reactively off the repository (RegionPickerViewModel). At the
                 // setContent root so its window overlays whatever screen triggered the re-resolve.
                 RegionPickerHost()
@@ -275,9 +284,10 @@ class HomeActivity : AppCompatActivity() {
         val data = intent.data
         val deepLink = data?.let { ExternalDeepLinks.parse(it) }
         if (deepLink is ExternalDeepLinks.Target.AddRegion) {
-            // Validating and applying the URLs is the region domain's job; ExternalDeepLinks just read
-            // them off the URI.
-            regionRepository.applyCustomApiUrls(obaUrl = deepLink.obaUrl, otpUrl = deepLink.otpUrl)
+            // Staged, not applied: adding a region repoints every API the app talks to, and this filter
+            // is BROWSABLE, so any web page can fire the link. The rider confirms it first (#2030) —
+            // AddRegionDialog. Validating the URLs is then the region domain's job.
+            addRegionViewModel.request(deepLink.request)
             return
         }
         // The web intent-filter is necessarily broader than the parser (it can't see the query string,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.kt
@@ -61,6 +61,7 @@ import org.onebusaway.android.ui.home.donation.DonationViewModel
 import org.onebusaway.android.ui.home.help.HelpAction
 import org.onebusaway.android.ui.home.help.HelpViewModel
 import org.onebusaway.android.ui.home.weather.WeatherViewModel
+import org.onebusaway.android.ui.nav.ExternalDeepLinks
 import org.onebusaway.android.ui.nav.IntentRouteMapper
 import org.onebusaway.android.ui.nav.NavHelp
 import org.onebusaway.android.ui.nav.NavRoutes
@@ -270,13 +271,11 @@ class HomeActivity : AppCompatActivity() {
      */
     private fun applyIntentSideEffects(intent: Intent?) {
         if (intent == null) return
-        val data = intent.data
-        if (data != null && IntentRouteMapper.isAddRegionUri(data)) {
-            // Validating and applying the URLs is the region domain's job; we just parse them off the URI.
-            regionRepository.applyCustomApiUrls(
-                obaUrl = data.getQueryParameter("oba-url"),
-                otpUrl = data.getQueryParameter("otp-url")
-            )
+        val deepLink = intent.data?.let { ExternalDeepLinks.parse(it) }
+        if (deepLink is ExternalDeepLinks.Target.AddRegion) {
+            // Validating and applying the URLs is the region domain's job; ExternalDeepLinks just read
+            // them off the URI.
+            regionRepository.applyCustomApiUrls(obaUrl = deepLink.obaUrl, otpUrl = deepLink.otpUrl)
             return
         }
         intent.getStringExtra(ReminderUtils.ARRIVAL_PAYLOAD_KEY)?.let { arrivalJson ->

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/AddRegionDialog.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/AddRegionDialog.kt
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.home
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlinx.coroutines.flow.StateFlow
+import org.onebusaway.android.R
+import org.onebusaway.android.region.CustomRegionRequest
+
+/**
+ * The consent gate for an `add-region` deep link (#2027, #2030), rendered at the activity's setContent
+ * root alongside [RegionPickerHost] so it overlays whatever screen the link landed on.
+ *
+ * The dialog names the servers the link would switch to, because that host is the only thing the rider
+ * can actually judge: the region *name* is attacker-controlled text and says nothing about where the
+ * data comes from. Declining is the safe default, so Cancel is the dismiss action and back/scrim both
+ * decline rather than leaving the request hanging.
+ */
+@Composable
+internal fun AddRegionDialog(
+    pending: StateFlow<CustomRegionRequest?>,
+    invalid: StateFlow<Boolean>,
+    onConfirm: () -> Unit,
+    onDecline: () -> Unit,
+    onDismissInvalid: () -> Unit
+) {
+    val request by pending.collectAsStateWithLifecycle()
+    val isInvalid by invalid.collectAsStateWithLifecycle()
+
+    request?.let { AddRegionConfirmDialog(it, onConfirm, onDecline) }
+    if (isInvalid) AddRegionInvalidDialog(onDismissInvalid)
+}
+
+@Composable
+private fun AddRegionConfirmDialog(
+    request: CustomRegionRequest,
+    onConfirm: () -> Unit,
+    onDecline: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDecline,
+        title = { Text(stringResource(R.string.add_region_title, request.name)) },
+        text = {
+            Column {
+                Text(stringResource(R.string.add_region_message, stringResource(R.string.app_name)))
+                ServerRow(stringResource(R.string.add_region_server_oba), request.obaBaseUrl)
+                request.otpBaseUrl?.let {
+                    ServerRow(stringResource(R.string.add_region_server_otp), it)
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onConfirm) { Text(stringResource(R.string.add_region_confirm)) }
+        },
+        dismissButton = {
+            TextButton(onClick = onDecline) { Text(stringResource(R.string.cancel)) }
+        }
+    )
+}
+
+/**
+ * One "what it is → where it points" row. The URL gets the emphasis and is allowed two lines before
+ * ellipsizing, so a long path can't push the host out of view — the host is the part that matters.
+ */
+@Composable
+private fun ServerRow(label: String, url: String) {
+    Column(Modifier.padding(top = 12.dp)) {
+        Text(text = label, style = MaterialTheme.typography.labelMedium)
+        Text(
+            text = url,
+            style = MaterialTheme.typography.bodyMedium,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis
+        )
+    }
+}
+
+/** Mirrors iOS's error alert: the link named a server address that isn't a usable URL. */
+@Composable
+private fun AddRegionInvalidDialog(onDismiss: () -> Unit) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.add_region_invalid_title)) },
+        text = { Text(stringResource(R.string.add_region_invalid_message)) },
+        confirmButton = {
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.ok)) }
+        }
+    )
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/AddRegionDialog.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/AddRegionDialog.kt
@@ -36,9 +36,9 @@ import org.onebusaway.android.region.CustomRegionRequest
  * The consent gate for an `add-region` deep link (#2027, #2030), rendered at the activity's setContent
  * root alongside [RegionPickerHost] so it overlays whatever screen the link landed on.
  *
- * The dialog names the servers the link would switch to, because that host is the only thing the rider
- * can actually judge: the region *name* is attacker-controlled text and says nothing about where the
- * data comes from. Declining is the safe default, so Cancel is the dismiss action and back/scrim both
+ * The dialog names **every** server the link would configure, because those hosts are the only thing the
+ * rider can actually judge: the region *name* is attacker-controlled text and says nothing about where
+ * the data comes from. Declining is the safe default, so Cancel is the dismiss action and back/scrim both
  * decline rather than leaving the request hanging.
  */
 @Composable
@@ -71,6 +71,15 @@ private fun AddRegionConfirmDialog(
                 ServerRow(stringResource(R.string.add_region_server_oba), request.obaBaseUrl)
                 request.otpBaseUrl?.let {
                     ServerRow(stringResource(R.string.add_region_server_otp), it)
+                }
+                // Every endpoint the link would persist has to be on screen, not just the two the rider
+                // is most likely to think about: consenting to a region consents to all of them, and the
+                // analytics host in particular is one they'd want to see before agreeing.
+                request.sidecarBaseUrl?.let {
+                    ServerRow(stringResource(R.string.add_region_server_sidecar), it)
+                }
+                request.umamiAnalyticsUrl?.let {
+                    ServerRow(stringResource(R.string.add_region_server_umami), it)
                 }
             }
         },

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/AddRegionViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/AddRegionViewModel.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.home
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import org.onebusaway.android.region.CustomRegionRequest
+import org.onebusaway.android.region.RegionRepository
+
+/**
+ * The consent gate on the `add-region` deep link (#2027, #2030).
+ *
+ * The link's intent-filter is `BROWSABLE`, so **any web page** can fire one at the app, and accepting it
+ * repoints every transit request the app makes at a server of the sender's choosing. That is a decision
+ * only the rider can make, so nothing is written until [confirm]: `HomeActivity` hands the parsed request
+ * here via [request], the dialog renders it, and only a confirm reaches [RegionRepository]. This is a
+ * deliberate divergence from OneBusAway for iOS, which applies the region with no prompt.
+ *
+ * [invalid] carries the one failure the rider needs to hear about — a request the region domain rejected
+ * because its OBA URL isn't a valid URL — mirroring iOS's error alert.
+ */
+@HiltViewModel
+class AddRegionViewModel @Inject constructor(
+    private val regionRepo: RegionRepository
+) : ViewModel() {
+
+    // The request awaiting the rider's decision, or null when there is nothing to confirm.
+    private val _pending = MutableStateFlow<CustomRegionRequest?>(null)
+    val pending: StateFlow<CustomRegionRequest?> = _pending.asStateFlow()
+
+    // Set when a confirmed request was rejected as unusable; cleared by [dismissInvalid].
+    private val _invalid = MutableStateFlow(false)
+    val invalid: StateFlow<Boolean> = _invalid.asStateFlow()
+
+    /**
+     * Stages an incoming `add-region` link for confirmation. A second link arriving before the first is
+     * answered replaces it — the newest link is the one the rider just followed, and stacking consent
+     * dialogs would invite answering the wrong one.
+     */
+    fun request(request: CustomRegionRequest) {
+        _pending.value = request
+    }
+
+    /** The rider accepted: add the region and switch to it. */
+    fun confirm() {
+        val request = _pending.value ?: return
+        _pending.value = null
+        viewModelScope.launch {
+            if (regionRepo.addCustomRegion(request) == null) _invalid.value = true
+        }
+    }
+
+    /** The rider declined (or dismissed the dialog): drop the request, write nothing. */
+    fun decline() {
+        _pending.value = null
+    }
+
+    /** Acknowledges the [invalid] alert. */
+    fun dismissInvalid() {
+        _invalid.value = false
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/RegionPickerHost.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/RegionPickerHost.kt
@@ -15,7 +15,6 @@
  */
 package org.onebusaway.android.ui.home
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -32,8 +31,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.onLongClick
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.DialogProperties
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -133,8 +130,10 @@ private fun RegionChooserDialog(
         title = { Text(stringResource(R.string.region_choose_region)) },
         text = {
             Column(Modifier.verticalScroll(rememberScrollState())) {
+                // Read once for the whole list, not once per row: at most one row is custom.
+                val removeHint = stringResource(R.string.region_remove_custom_hint)
                 regions.forEach { region ->
-                    RegionRow(region, onRegionChosen, onRemoveCustom)
+                    RegionRow(region, removeHint, onRegionChosen, onRemoveCustom)
                 }
             }
         },
@@ -150,27 +149,20 @@ private fun RegionChooserDialog(
 @Composable
 private fun RegionRow(
     region: Region,
+    removeHint: String,
     onRegionChosen: (Region) -> Unit,
     onRemoveCustom: (Region) -> Unit
 ) {
-    val removeHint = stringResource(R.string.region_remove_custom_hint)
     Text(
         text = region.name,
         modifier = Modifier
             .fillMaxWidth()
-            .then(
-                if (region.custom) {
-                    Modifier
-                        .combinedClickable(
-                            onClick = { onRegionChosen(region) },
-                            onLongClick = { onRemoveCustom(region) }
-                        )
-                        // The long-press is otherwise invisible to a screen reader, which is the only
-                        // route to removal — so announce it rather than leaving it discoverable by feel.
-                        .semantics { onLongClick(label = removeHint, action = null) }
-                } else {
-                    Modifier.clickable { onRegionChosen(region) }
-                }
+            // A null onLongClick behaves exactly like clickable, and onLongClickLabel is what announces
+            // the gesture to a screen reader — for which it is the only route to removal.
+            .combinedClickable(
+                onClick = { onRegionChosen(region) },
+                onLongClickLabel = removeHint.takeIf { region.custom },
+                onLongClick = if (region.custom) ({ onRemoveCustom(region) }) else null
             )
             .padding(vertical = 16.dp)
     )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/RegionPickerHost.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/RegionPickerHost.kt
@@ -16,6 +16,7 @@
 package org.onebusaway.android.ui.home
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -31,6 +32,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.onLongClick
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.DialogProperties
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -51,8 +54,43 @@ fun RegionPickerHost() {
     val regions by viewModel.picker.collectAsStateWithLifecycle()
     val failed by viewModel.failed.collectAsStateWithLifecycle()
     // NeedsManualChoice and Failed are mutually exclusive repository states, so at most one shows.
-    regions?.let { RegionChooserDialog(it, viewModel::choose) }
+    // The region pending removal confirmation, if the rider long-pressed a custom one.
+    var removing by remember { mutableStateOf<Region?>(null) }
+
+    regions?.let { RegionChooserDialog(it, viewModel::choose, onRemoveCustom = { removing = it }) }
     if (failed) RegionLoadFailedDialog(onRetry = viewModel::retry)
+    removing?.let { region ->
+        RemoveCustomRegionDialog(
+            region = region,
+            onConfirm = {
+                removing = null
+                viewModel.remove(region)
+            },
+            onDismiss = { removing = null }
+        )
+    }
+}
+
+/**
+ * Confirms removing a custom region (#2027). Separate from the picker's own dialog so a mis-hit
+ * long-press can't delete anything, and worded to make clear only the rider's own added region goes —
+ * the directory regions in the same list are untouched.
+ */
+@Composable
+private fun RemoveCustomRegionDialog(region: Region, onConfirm: () -> Unit, onDismiss: () -> Unit) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.region_remove_custom_title, region.name)) },
+        text = { Text(stringResource(R.string.region_remove_custom_message)) },
+        confirmButton = {
+            TextButton(onClick = onConfirm) {
+                Text(stringResource(R.string.region_remove_custom_confirm))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.cancel)) }
+        }
+    )
 }
 
 /**
@@ -84,7 +122,11 @@ private fun RegionLoadFailedDialog(onRetry: () -> Unit) {
  * back/scrim do nothing, since the app can't function without a region.
  */
 @Composable
-private fun RegionChooserDialog(regions: List<Region>, onRegionChosen: (Region) -> Unit) {
+private fun RegionChooserDialog(
+    regions: List<Region>,
+    onRegionChosen: (Region) -> Unit,
+    onRemoveCustom: (Region) -> Unit
+) {
     AlertDialog(
         onDismissRequest = { },
         properties = DialogProperties(dismissOnBackPress = false, dismissOnClickOutside = false),
@@ -92,16 +134,44 @@ private fun RegionChooserDialog(regions: List<Region>, onRegionChosen: (Region) 
         text = {
             Column(Modifier.verticalScroll(rememberScrollState())) {
                 regions.forEach { region ->
-                    Text(
-                        text = region.name,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .clickable { onRegionChosen(region) }
-                            .padding(vertical = 16.dp)
-                    )
+                    RegionRow(region, onRegionChosen, onRemoveCustom)
                 }
             }
         },
         confirmButton = { }
+    )
+}
+
+/**
+ * One region in the picker. A custom region the rider added (#2027) additionally long-presses to remove
+ * — the only way back out of a bad `add-region` link short of clearing app data. Directory regions have
+ * no long-press, so there is nothing to mis-hit on the rows the rider can't delete anyway.
+ */
+@Composable
+private fun RegionRow(
+    region: Region,
+    onRegionChosen: (Region) -> Unit,
+    onRemoveCustom: (Region) -> Unit
+) {
+    val removeHint = stringResource(R.string.region_remove_custom_hint)
+    Text(
+        text = region.name,
+        modifier = Modifier
+            .fillMaxWidth()
+            .then(
+                if (region.custom) {
+                    Modifier
+                        .combinedClickable(
+                            onClick = { onRegionChosen(region) },
+                            onLongClick = { onRemoveCustom(region) }
+                        )
+                        // The long-press is otherwise invisible to a screen reader, which is the only
+                        // route to removal — so announce it rather than leaving it discoverable by feel.
+                        .semantics { onLongClick(label = removeHint, action = null) }
+                } else {
+                    Modifier.clickable { onRegionChosen(region) }
+                }
+            )
+            .padding(vertical = 16.dp)
     )
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/RegionPickerViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/RegionPickerViewModel.kt
@@ -74,4 +74,12 @@ class RegionPickerViewModel @Inject constructor(
     fun retry() {
         viewModelScope.launch { regionRepo.refresh() }
     }
+
+    /**
+     * Removes a custom region the rider added (#2027) — the escape hatch from an `add-region` link they
+     * regret. The repository ignores a directory region, and re-resolves if the removed one was current.
+     */
+    fun remove(region: Region) {
+        viewModelScope.launch { regionRepo.deleteCustomRegion(region) }
+    }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/nav/ExternalDeepLinks.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/nav/ExternalDeepLinks.kt
@@ -178,7 +178,28 @@ object ExternalDeepLinks {
     fun isUnhandledWebLink(uri: Uri): Boolean = isUnhandledWebLink(uri.toLink())
 
     /** @see isUnhandledWebLink */
-    fun isUnhandledWebLink(link: Link): Boolean = link.scheme == WEB_SCHEME && link.host in WEB_HOSTS && parseWebLink(link) == null
+    fun isUnhandledWebLink(link: Link): Boolean = link.scheme == WEB_SCHEME &&
+        link.host in WEB_HOSTS &&
+        isClaimedWebPath(link.pathSegments) &&
+        parseWebLink(link) == null
+
+    /**
+     * Whether the web intent-filter's `pathPattern` would match [pathSegments] — i.e. whether this app
+     * actually claims the URL. Must stay in step with `src/oba/AndroidManifest.xml`, like [WEB_HOSTS] does.
+     *
+     * An exact translation of `/regions/.*` + `/stops/.*` + `/trips` under `PATTERN_SIMPLE_GLOB`, where
+     * `.*` spans `/`: first segment `regions`, last segment `trips`, and a `stops` segment in between with
+     * at least one segment either side of it (each `.*` stands where a decoded path segment must exist).
+     *
+     * Without this, *every* `https` URL on an OBA host counted as "claimed", so an explicit intent for a
+     * URL the filter never claimed — `https://onebusaway.co/about`, say — would have been bounced out to a
+     * browser instead of simply opening the app.
+     */
+    private fun isClaimedWebPath(pathSegments: List<String>): Boolean {
+        if (pathSegments.size < 5) return false
+        if (pathSegments.first() != "regions" || pathSegments.last() != "trips") return false
+        return (2..pathSegments.size - 3).any { pathSegments[it] == "stops" }
+    }
 
     /** `/regions/{regionID}/stops/{stopID}/trips?trip_id=…` — the only recognized web path shape. */
     private fun parseWebLink(link: Link): Target? {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/nav/ExternalDeepLinks.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/nav/ExternalDeepLinks.kt
@@ -66,8 +66,11 @@ object ExternalDeepLinks {
     private const val PARAM_OBA_URL = "oba-url"
     private const val PARAM_OTP_URL = "otp-url"
 
+    /** App links are `https` only — a plaintext link to one of [WEB_HOSTS] is not a deep link. */
+    private const val WEB_SCHEME = "https"
+
     /**
-     * Hosts whose `https://` links are app links, mirroring the iOS app's associated domains
+     * Hosts whose [WEB_SCHEME] links are app links, mirroring the iOS app's associated domains
      * (`applinks:onebusaway.co`, `applinks:www.onebusaway.co`, `applinks:sidecar.onebusaway.org`).
      */
     val WEB_HOSTS = setOf("onebusaway.co", "www.onebusaway.co", "sidecar.onebusaway.org")
@@ -106,7 +109,7 @@ object ExternalDeepLinks {
      */
     fun parse(link: Link, appSchemes: Set<String> = APP_SCHEMES): Target? = when {
         link.scheme in appSchemes -> parseAppSchemeLink(link)
-        link.host in WEB_HOSTS -> parseWebLink(link)
+        link.scheme == WEB_SCHEME && link.host in WEB_HOSTS -> parseWebLink(link)
         else -> null
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/nav/ExternalDeepLinks.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/nav/ExternalDeepLinks.kt
@@ -125,9 +125,12 @@ object ExternalDeepLinks {
      */
     fun parse(link: Link, appSchemes: Set<String> = APP_SCHEMES): Target? = when {
         link.scheme in appSchemes -> parseAppSchemeLink(link)
-        link.scheme == WEB_SCHEME && link.host in WEB_HOSTS -> parseWebLink(link)
+        link.isWebLink -> parseWebLink(link)
         else -> null
     }
+
+    /** On one of [WEB_HOSTS] over [WEB_SCHEME] — the shared precondition of the two web-link readers. */
+    private val Link.isWebLink: Boolean get() = scheme == WEB_SCHEME && host in WEB_HOSTS
 
     private fun parseAppSchemeLink(link: Link): Target? = when (link.host) {
         VIEW_STOP_HOST -> link.params.nonBlank(PARAM_STOP_ID)?.let { Target.Stop(it) }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/nav/ExternalDeepLinks.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/nav/ExternalDeepLinks.kt
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.nav
+
+/**
+ * The **cross-platform** OneBusAway deep-link vocabulary — the same links OneBusAway for iOS handles,
+ * so a link shared from either app opens the same screen (#2027). Two families:
+ *
+ *  1. **Custom scheme** (`onebusaway://`, plus the brand's own scheme — see `BuildConfig.DEEP_LINK_SCHEME`):
+ *     - `onebusaway://view-stop?stopID=1_75403&regionID=1` → that stop's arrivals.
+ *     - `onebusaway://add-region?...` → applies custom API URLs. Handled separately (it's a side effect,
+ *       not a route): see [IntentRouteMapper.ADD_REGION_HOST] and `HomeActivity.applyIntentSideEffects`.
+ *  2. **Web links** (iOS "universal links") on [WEB_HOSTS]:
+ *     - `https://onebusaway.co/regions/{regionID}/stops/{stopID}/trips?trip_id=…` → that trip's details.
+ *
+ * This object is the *pure* parser: it maps an already-decomposed URI ([Link]) to the [Target] screen,
+ * with no Android or app-state dependency, so the whole vocabulary is JVM-unit-testable.
+ * [IntentRouteMapper.read] does the `Uri` decomposition and feeds the [Target] into the route decision.
+ *
+ * Distinct from [DeepLinkUris], which is the app's *internal* `content://` stop/route vocabulary
+ * (pinned launcher shortcuts and in-app launches).
+ *
+ * **Divergences from iOS, all deliberate:**
+ *  - Parameters iOS carries that no Android screen consumes are recognized and ignored rather than
+ *    required: `regionID` (iOS parses it but also only ever searches the current region), and the trip
+ *    link's `service_date` / `stop_sequence` / `title` / `vehicle_id` / `destination_stop_id`. A link
+ *    is accepted whenever it carries the ids the target screen actually needs, so every link iOS
+ *    accepts is accepted here too.
+ *  - Like iOS, a *stop-only* web path (`/regions/{id}/stops/{id}` with no `/trips`) is **not** a deep
+ *    link; it falls through to the browser.
+ */
+object ExternalDeepLinks {
+
+    /** Custom-scheme host that opens a stop's arrivals: `<app-scheme>://view-stop`. */
+    const val VIEW_STOP_HOST = "view-stop"
+
+    /** `view-stop` query parameters (iOS spelling — camelCase, unlike the web links' snake_case). */
+    const val PARAM_STOP_ID = "stopID"
+
+    /** Recognized for cross-platform link compatibility; unused (see the class doc's divergences). */
+    const val PARAM_REGION_ID = "regionID"
+
+    /**
+     * Hosts whose `https://` links are app links. Mirrors the iOS app's associated domains
+     * (`applinks:onebusaway.co`, `applinks:www.onebusaway.co`, `applinks:sidecar.onebusaway.org`); the
+     * manifest intent-filter must list the same set.
+     */
+    val WEB_HOSTS = setOf("onebusaway.co", "www.onebusaway.co", "sidecar.onebusaway.org")
+
+    // Web trip-link path shape: /regions/{regionID}/stops/{stopID}/trips
+    private const val REGIONS_SEGMENT = "regions"
+    private const val STOPS_SEGMENT = "stops"
+    private const val TRIPS_SEGMENT = "trips"
+    private const val TRIP_PATH_LENGTH = 5
+    private const val STOP_ID_INDEX = 3
+
+    /** The web trip link's trip id — the only one of its parameters an Android screen consumes. */
+    const val PARAM_TRIP_ID = "trip_id"
+
+    /** An incoming URI, decomposed into the parts [parse] reads. Query values are already decoded. */
+    data class Link(
+        val scheme: String?,
+        val host: String?,
+        val pathSegments: List<String>,
+        val params: Map<String, String>
+    )
+
+    /** The screen a recognized deep link targets. */
+    sealed interface Target {
+        /** `view-stop`: open [stopId]'s arrivals. */
+        data class Stop(val stopId: String) : Target
+
+        /** A web trip link: open [tripId]'s details, scrolled to [stopId] (the stop in the path). */
+        data class Trip(val tripId: String, val stopId: String) : Target
+    }
+
+    /**
+     * Maps [link] to the screen it targets, or null if it isn't a recognized deep link (including the
+     * `add-region` link, which routes nowhere).
+     *
+     * [appSchemes] is the set of custom schemes this build answers to — `onebusaway` plus the brand's
+     * own scheme. Passed in rather than read from `BuildConfig` to keep this parser pure.
+     */
+    fun parse(link: Link, appSchemes: Set<String>): Target? = when {
+        link.scheme in appSchemes -> parseAppSchemeLink(link)
+        link.host in WEB_HOSTS -> parseWebLink(link)
+        else -> null
+    }
+
+    private fun parseAppSchemeLink(link: Link): Target? = when (link.host) {
+        VIEW_STOP_HOST -> link.params[PARAM_STOP_ID]?.takeIf { it.isNotBlank() }?.let { Target.Stop(it) }
+        else -> null
+    }
+
+    /** `/regions/{regionID}/stops/{stopID}/trips?trip_id=…` — the only recognized web path shape. */
+    private fun parseWebLink(link: Link): Target? {
+        val segments = link.pathSegments
+        if (segments.size != TRIP_PATH_LENGTH) return null
+        if (segments[0] != REGIONS_SEGMENT ||
+            segments[2] != STOPS_SEGMENT ||
+            segments[4] != TRIPS_SEGMENT
+        ) {
+            return null
+        }
+        val stopId = segments[STOP_ID_INDEX].takeIf { it.isNotBlank() } ?: return null
+        val tripId = link.params[PARAM_TRIP_ID]?.takeIf { it.isNotBlank() } ?: return null
+        return Target.Trip(tripId = tripId, stopId = stopId)
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/nav/ExternalDeepLinks.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/nav/ExternalDeepLinks.kt
@@ -28,13 +28,15 @@ import org.onebusaway.android.BuildConfig
  *     `https://onebusaway.co/regions/{regionID}/stops/{stopID}/trips?trip_id=…`.
  *
  * Every recognized link becomes a [Target]. [parse] is pure — [Link] is an already-decomposed URI with
- * no Android or app-state dependency — so the whole vocabulary is JVM-unit-testable; the `Uri` overload
- * is the thin Android-facing entry point its two callers use ([IntentRouteMapper] to route, and
- * `HomeActivity.applyIntentSideEffects` to run the domain mutation [Target.AddRegion] implies).
+ * no Android or app-state dependency — so the whole vocabulary is JVM-unit-testable; the `Uri` overloads
+ * are the thin Android-facing entry points its callers use ([IntentRouteMapper] to route, and
+ * `HomeActivity.applyIntentSideEffects` to run the domain mutation [Target.AddRegion] implies and to
+ * hand [isUnhandledWebLink] URLs back to the browser).
  *
  * The manifest's intent-filters are the gate that decides which of these links reach the app at all, and
  * must stay in step with the scheme/host sets here — see `src/main/AndroidManifest.xml` (custom scheme)
- * and `src/oba/AndroidManifest.xml` (web links).
+ * and `src/oba/AndroidManifest.xml` (web links). The web filter is necessarily *broader* than [parse]
+ * (see [isUnhandledWebLink]); the custom-scheme filter matches it exactly.
  *
  * Distinct from [DeepLinkUris], the app's *internal* `content://` stop/route vocabulary (pinned launcher
  * shortcuts and in-app launches). `docs/DEEP_LINKING.md` documents this vocabulary for link authors,
@@ -72,6 +74,12 @@ object ExternalDeepLinks {
     /**
      * Hosts whose [WEB_SCHEME] links are app links, mirroring the iOS app's associated domains
      * (`applinks:onebusaway.co`, `applinks:www.onebusaway.co`, `applinks:sidecar.onebusaway.org`).
+     *
+     * These are the OneBusAway deployment's own hosts, and deliberately not a per-brand value: only a
+     * brand that owns a host can verify it (App Links verification matches the *installed* app's signing
+     * certificate), so the matching intent-filter lives in `src/oba/AndroidManifest.xml` alone. A brand
+     * wanting web links of its own needs both a flavor manifest and a host set — that's a real feature,
+     * not a config tweak, so it isn't half-wired here. See `docs/DEEP_LINKING.md`.
      */
     val WEB_HOSTS = setOf("onebusaway.co", "www.onebusaway.co", "sidecar.onebusaway.org")
 
@@ -122,8 +130,30 @@ object ExternalDeepLinks {
         else -> null
     }
 
+    /**
+     * True when [uri] is a link the web intent-filter claims but [parse] can't turn into a screen.
+     *
+     * That gap is unavoidable, not a bug to close in the manifest: an intent-filter can't see the query
+     * string at all (so it can't require `trip_id`), and `pathPattern` is a `PATTERN_SIMPLE_GLOB` whose
+     * `.*` spans `/` (so it can't require exactly one segment per wildcard; `pathAdvancedPattern` would,
+     * but it is API 31+ and `minSdk` is 23). The filter is therefore a superset of this parser, and the
+     * app can be launched for a URL that routes nowhere. `HomeActivity.applyIntentSideEffects` hands
+     * those back to the browser rather than silently dropping the user on the map.
+     *
+     * Custom-scheme links are deliberately excluded: their filter matches [parse] exactly (scheme × host,
+     * no path or query involved), nothing else on the device would handle a `onebusaway://` URL, and
+     * they are not web pages — an unrecognized one is a dead link either way, so home/map is the right
+     * landing.
+     */
+    fun isUnhandledWebLink(uri: Uri): Boolean = isUnhandledWebLink(uri.toLink())
+
+    /** @see isUnhandledWebLink */
+    fun isUnhandledWebLink(link: Link): Boolean = link.scheme == WEB_SCHEME && link.host in WEB_HOSTS && parseWebLink(link) == null
+
     /** `/regions/{regionID}/stops/{stopID}/trips?trip_id=…` — the only recognized web path shape. */
     private fun parseWebLink(link: Link): Target? {
+        // `Uri.getPathSegments()` drops empty segments, so a real URI can't produce a blank stopId; the
+        // check guards the directly-constructed [Link]s that [parse]'s pure entry point also accepts.
         val (regions, _, stops, stopId, trips) = link.pathSegments.takeIf { it.size == 5 } ?: return null
         if (regions != "regions" || stops != "stops" || trips != "trips" || stopId.isBlank()) return null
         val tripId = link.params.nonBlank(PARAM_TRIP_ID) ?: return null
@@ -136,12 +166,17 @@ object ExternalDeepLinks {
     /**
      * Decomposes a data URI into the plain parts [parse] reads.
      *
+     * Scheme and host are lowercased (locale-independently), because they are case-*insensitive* per
+     * RFC 3986 while `Uri` reports them verbatim and this parser compares them by equality. The
+     * intent-filter that let the URI in matched case-insensitively too, so without this a
+     * `HTTPS://OneBusAway.co/…` link would clear the filter and then fail to parse.
+     *
      * `getQueryParameterNames()`/`getQueryParameter()` throw on an opaque URI (one with no hierarchical
      * part, e.g. `onebusaway:view-stop?…` without the `//`), so [Uri.isHierarchical] guards them.
      */
     private fun Uri.toLink(): Link = Link(
-        scheme = scheme,
-        host = host,
+        scheme = scheme?.lowercase(),
+        host = host?.lowercase(),
         pathSegments = pathSegments,
         params = if (isHierarchical) {
             queryParameterNames.associateWith { getQueryParameter(it).orEmpty() }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/nav/ExternalDeepLinks.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/nav/ExternalDeepLinks.kt
@@ -17,13 +17,15 @@ package org.onebusaway.android.ui.nav
 
 import android.net.Uri
 import org.onebusaway.android.BuildConfig
+import org.onebusaway.android.region.CustomRegionRequest
 
 /**
  * The one place that knows the **externally reachable** OneBusAway deep-link vocabulary — schemes,
  * hosts, path shape and query-parameter names. It is the same vocabulary OneBusAway for iOS handles, so
  * a link shared from either app opens the same screen (#2027). Two families:
  *
- *  1. **Custom scheme** ([APP_SCHEMES]): `<scheme>://view-stop?stopID=…` and `<scheme>://add-region?…`.
+ *  1. **Custom scheme** ([APP_SCHEMES]): `<scheme>://view-stop?stopID=…` and
+ *     `<scheme>://add-region?name=…&oba-url=…`.
  *  2. **Web links** (iOS "universal links") on [WEB_HOSTS]:
  *     `https://onebusaway.co/regions/{regionID}/stops/{stopID}/trips?trip_id=…`.
  *
@@ -57,7 +59,7 @@ object ExternalDeepLinks {
     /** Custom-scheme host that opens a stop's arrivals. */
     private const val VIEW_STOP_HOST = "view-stop"
 
-    /** Custom-scheme host that applies custom API URLs. */
+    /** Custom-scheme host that adds a user-supplied region and switches to it. */
     private const val ADD_REGION_HOST = "add-region"
 
     // Query-parameter names. The custom-scheme links use iOS's camelCase spelling; the web links use
@@ -65,8 +67,12 @@ object ExternalDeepLinks {
     // recognized-and-ignored list in docs/DEEP_LINKING.md.
     private const val PARAM_STOP_ID = "stopID"
     private const val PARAM_TRIP_ID = "trip_id"
+    private const val PARAM_NAME = "name"
     private const val PARAM_OBA_URL = "oba-url"
     private const val PARAM_OTP_URL = "otp-url"
+    private const val PARAM_SIDECAR_URL = "sidecar-url"
+    private const val PARAM_UMAMI_URL = "umami-url"
+    private const val PARAM_UMAMI_ID = "umami-id"
 
     /** App links are `https` only — a plaintext link to one of [WEB_HOSTS] is not a deep link. */
     private const val WEB_SCHEME = "https"
@@ -100,10 +106,12 @@ object ExternalDeepLinks {
         data class Trip(val tripId: String, val stopId: String) : Target
 
         /**
-         * `add-region`: apply these custom API URLs. Routes nowhere — it's a domain mutation, run by
-         * `HomeActivity.applyIntentSideEffects`; validating the URLs is the region domain's job.
+         * `add-region`: add [request] as a custom region and switch to it. Routes nowhere — it's a
+         * domain mutation, and one that repoints every API the app talks to, so
+         * `HomeActivity.applyIntentSideEffects` hands it to `AddRegionViewModel` to confirm with the
+         * rider first (#2030) rather than applying it. Validating the URLs is the region domain's job.
          */
-        data class AddRegion(val obaUrl: String?, val otpUrl: String?) : Target
+        data class AddRegion(val request: CustomRegionRequest) : Target
     }
 
     /** Reads [uri] as a deep link, or null if it isn't one. */
@@ -123,11 +131,33 @@ object ExternalDeepLinks {
 
     private fun parseAppSchemeLink(link: Link): Target? = when (link.host) {
         VIEW_STOP_HOST -> link.params.nonBlank(PARAM_STOP_ID)?.let { Target.Stop(it) }
-        ADD_REGION_HOST -> Target.AddRegion(
-            obaUrl = link.params.nonBlank(PARAM_OBA_URL),
-            otpUrl = link.params.nonBlank(PARAM_OTP_URL)
-        )
+        ADD_REGION_HOST -> parseAddRegionLink(link)
         else -> null
+    }
+
+    /**
+     * `add-region?name=…&oba-url=…` — the rest is optional.
+     *
+     * Both `name` and `oba-url` are **required**, matching OneBusAway for iOS: the result is a named
+     * region the rider will later pick out of a list, so a nameless one has nothing to show, and a
+     * region with no OBA server can't answer anything. A link missing either is not a deep link.
+     *
+     * Note this is stricter than the pre-#2027 Android behaviour, where `add-region?oba-url=…` alone set
+     * a pair of API-URL preferences. Such a link no longer resolves — see `docs/DEEP_LINKING.md`.
+     */
+    private fun parseAddRegionLink(link: Link): Target? {
+        val name = link.params.nonBlank(PARAM_NAME) ?: return null
+        val obaUrl = link.params.nonBlank(PARAM_OBA_URL) ?: return null
+        return Target.AddRegion(
+            CustomRegionRequest(
+                name = name,
+                obaBaseUrl = obaUrl,
+                otpBaseUrl = link.params.nonBlank(PARAM_OTP_URL),
+                sidecarBaseUrl = link.params.nonBlank(PARAM_SIDECAR_URL),
+                umamiAnalyticsUrl = link.params.nonBlank(PARAM_UMAMI_URL),
+                umamiAnalyticsId = link.params.nonBlank(PARAM_UMAMI_ID)
+            )
+        )
     }
 
     /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/nav/ExternalDeepLinks.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/nav/ExternalDeepLinks.kt
@@ -15,60 +15,62 @@
  */
 package org.onebusaway.android.ui.nav
 
+import android.net.Uri
+import org.onebusaway.android.BuildConfig
+
 /**
- * The **cross-platform** OneBusAway deep-link vocabulary — the same links OneBusAway for iOS handles,
- * so a link shared from either app opens the same screen (#2027). Two families:
+ * The one place that knows the **externally reachable** OneBusAway deep-link vocabulary — schemes,
+ * hosts, path shape and query-parameter names. It is the same vocabulary OneBusAway for iOS handles, so
+ * a link shared from either app opens the same screen (#2027). Two families:
  *
- *  1. **Custom scheme** (`onebusaway://`, plus the brand's own scheme — see `BuildConfig.DEEP_LINK_SCHEME`):
- *     - `onebusaway://view-stop?stopID=1_75403&regionID=1` → that stop's arrivals.
- *     - `onebusaway://add-region?...` → applies custom API URLs. Handled separately (it's a side effect,
- *       not a route): see [IntentRouteMapper.ADD_REGION_HOST] and `HomeActivity.applyIntentSideEffects`.
+ *  1. **Custom scheme** ([APP_SCHEMES]): `<scheme>://view-stop?stopID=…` and `<scheme>://add-region?…`.
  *  2. **Web links** (iOS "universal links") on [WEB_HOSTS]:
- *     - `https://onebusaway.co/regions/{regionID}/stops/{stopID}/trips?trip_id=…` → that trip's details.
+ *     `https://onebusaway.co/regions/{regionID}/stops/{stopID}/trips?trip_id=…`.
  *
- * This object is the *pure* parser: it maps an already-decomposed URI ([Link]) to the [Target] screen,
- * with no Android or app-state dependency, so the whole vocabulary is JVM-unit-testable.
- * [IntentRouteMapper.read] does the `Uri` decomposition and feeds the [Target] into the route decision.
+ * Every recognized link becomes a [Target]. [parse] is pure — [Link] is an already-decomposed URI with
+ * no Android or app-state dependency — so the whole vocabulary is JVM-unit-testable; the `Uri` overload
+ * is the thin Android-facing entry point its two callers use ([IntentRouteMapper] to route, and
+ * `HomeActivity.applyIntentSideEffects` to run the domain mutation [Target.AddRegion] implies).
  *
- * Distinct from [DeepLinkUris], which is the app's *internal* `content://` stop/route vocabulary
- * (pinned launcher shortcuts and in-app launches).
+ * The manifest's intent-filters are the gate that decides which of these links reach the app at all, and
+ * must stay in step with the scheme/host sets here — see `src/main/AndroidManifest.xml` (custom scheme)
+ * and `src/oba/AndroidManifest.xml` (web links).
  *
- * **Divergences from iOS, all deliberate:**
- *  - Parameters iOS carries that no Android screen consumes are recognized and ignored rather than
- *    required: `regionID` (iOS parses it but also only ever searches the current region), and the trip
- *    link's `service_date` / `stop_sequence` / `title` / `vehicle_id` / `destination_stop_id`. A link
- *    is accepted whenever it carries the ids the target screen actually needs, so every link iOS
- *    accepts is accepted here too.
- *  - Like iOS, a *stop-only* web path (`/regions/{id}/stops/{id}` with no `/trips`) is **not** a deep
- *    link; it falls through to the browser.
+ * Distinct from [DeepLinkUris], the app's *internal* `content://` stop/route vocabulary (pinned launcher
+ * shortcuts and in-app launches). `docs/DEEP_LINKING.md` documents this vocabulary for link authors,
+ * including which iOS parameters are deliberately recognized-and-ignored here.
  */
 object ExternalDeepLinks {
 
-    /** Custom-scheme host that opens a stop's arrivals: `<app-scheme>://view-stop`. */
-    const val VIEW_STOP_HOST = "view-stop"
-
-    /** `view-stop` query parameters (iOS spelling — camelCase, unlike the web links' snake_case). */
-    const val PARAM_STOP_ID = "stopID"
-
-    /** Recognized for cross-platform link compatibility; unused (see the class doc's divergences). */
-    const val PARAM_REGION_ID = "regionID"
+    /** The cross-platform scheme every brand answers to, shared with OneBusAway for iOS. */
+    private const val SHARED_SCHEME = "onebusaway"
 
     /**
-     * Hosts whose `https://` links are app links. Mirrors the iOS app's associated domains
-     * (`applinks:onebusaway.co`, `applinks:www.onebusaway.co`, `applinks:sidecar.onebusaway.org`); the
-     * manifest intent-filter must list the same set.
+     * The custom schemes this build answers to: [SHARED_SCHEME] plus the brand's own
+     * (`BuildConfig.DEEP_LINK_SCHEME` — `kiedybus` for KiedyBus, the same string for the OBA brand,
+     * derived from the `deepLinkScheme` manifest placeholder so the two can't disagree).
+     */
+    val APP_SCHEMES: Set<String> = setOf(SHARED_SCHEME, BuildConfig.DEEP_LINK_SCHEME)
+
+    /** Custom-scheme host that opens a stop's arrivals. */
+    private const val VIEW_STOP_HOST = "view-stop"
+
+    /** Custom-scheme host that applies custom API URLs. */
+    private const val ADD_REGION_HOST = "add-region"
+
+    // Query-parameter names. The custom-scheme links use iOS's camelCase spelling; the web links use
+    // the sidecar's snake_case. Only the ones an Android screen consumes are named here — see the
+    // recognized-and-ignored list in docs/DEEP_LINKING.md.
+    private const val PARAM_STOP_ID = "stopID"
+    private const val PARAM_TRIP_ID = "trip_id"
+    private const val PARAM_OBA_URL = "oba-url"
+    private const val PARAM_OTP_URL = "otp-url"
+
+    /**
+     * Hosts whose `https://` links are app links, mirroring the iOS app's associated domains
+     * (`applinks:onebusaway.co`, `applinks:www.onebusaway.co`, `applinks:sidecar.onebusaway.org`).
      */
     val WEB_HOSTS = setOf("onebusaway.co", "www.onebusaway.co", "sidecar.onebusaway.org")
-
-    // Web trip-link path shape: /regions/{regionID}/stops/{stopID}/trips
-    private const val REGIONS_SEGMENT = "regions"
-    private const val STOPS_SEGMENT = "stops"
-    private const val TRIPS_SEGMENT = "trips"
-    private const val TRIP_PATH_LENGTH = 5
-    private const val STOP_ID_INDEX = 3
-
-    /** The web trip link's trip id — the only one of its parameters an Android screen consumes. */
-    const val PARAM_TRIP_ID = "trip_id"
 
     /** An incoming URI, decomposed into the parts [parse] reads. Query values are already decoded. */
     data class Link(
@@ -78,45 +80,70 @@ object ExternalDeepLinks {
         val params: Map<String, String>
     )
 
-    /** The screen a recognized deep link targets. */
+    /** What a recognized deep link means. */
     sealed interface Target {
         /** `view-stop`: open [stopId]'s arrivals. */
         data class Stop(val stopId: String) : Target
 
         /** A web trip link: open [tripId]'s details, scrolled to [stopId] (the stop in the path). */
         data class Trip(val tripId: String, val stopId: String) : Target
+
+        /**
+         * `add-region`: apply these custom API URLs. Routes nowhere — it's a domain mutation, run by
+         * `HomeActivity.applyIntentSideEffects`; validating the URLs is the region domain's job.
+         */
+        data class AddRegion(val obaUrl: String?, val otpUrl: String?) : Target
     }
 
+    /** Reads [uri] as a deep link, or null if it isn't one. */
+    fun parse(uri: Uri): Target? = parse(uri.toLink())
+
     /**
-     * Maps [link] to the screen it targets, or null if it isn't a recognized deep link (including the
-     * `add-region` link, which routes nowhere).
+     * Maps [link] to what it means, or null if it isn't a recognized deep link.
      *
-     * [appSchemes] is the set of custom schemes this build answers to — `onebusaway` plus the brand's
-     * own scheme. Passed in rather than read from `BuildConfig` to keep this parser pure.
+     * [appSchemes] defaults to this build's [APP_SCHEMES]; tests pass an explicit set to exercise a
+     * brand scheme other than the one they were built for.
      */
-    fun parse(link: Link, appSchemes: Set<String>): Target? = when {
+    fun parse(link: Link, appSchemes: Set<String> = APP_SCHEMES): Target? = when {
         link.scheme in appSchemes -> parseAppSchemeLink(link)
         link.host in WEB_HOSTS -> parseWebLink(link)
         else -> null
     }
 
     private fun parseAppSchemeLink(link: Link): Target? = when (link.host) {
-        VIEW_STOP_HOST -> link.params[PARAM_STOP_ID]?.takeIf { it.isNotBlank() }?.let { Target.Stop(it) }
+        VIEW_STOP_HOST -> link.params.nonBlank(PARAM_STOP_ID)?.let { Target.Stop(it) }
+        ADD_REGION_HOST -> Target.AddRegion(
+            obaUrl = link.params.nonBlank(PARAM_OBA_URL),
+            otpUrl = link.params.nonBlank(PARAM_OTP_URL)
+        )
         else -> null
     }
 
     /** `/regions/{regionID}/stops/{stopID}/trips?trip_id=…` — the only recognized web path shape. */
     private fun parseWebLink(link: Link): Target? {
-        val segments = link.pathSegments
-        if (segments.size != TRIP_PATH_LENGTH) return null
-        if (segments[0] != REGIONS_SEGMENT ||
-            segments[2] != STOPS_SEGMENT ||
-            segments[4] != TRIPS_SEGMENT
-        ) {
-            return null
-        }
-        val stopId = segments[STOP_ID_INDEX].takeIf { it.isNotBlank() } ?: return null
-        val tripId = link.params[PARAM_TRIP_ID]?.takeIf { it.isNotBlank() } ?: return null
+        val (regions, _, stops, stopId, trips) = link.pathSegments.takeIf { it.size == 5 } ?: return null
+        if (regions != "regions" || stops != "stops" || trips != "trips" || stopId.isBlank()) return null
+        val tripId = link.params.nonBlank(PARAM_TRIP_ID) ?: return null
         return Target.Trip(tripId = tripId, stopId = stopId)
     }
+
+    /** A parameter present with no value reads as `""` (`Uri.getQueryParameter`) — treat it as absent. */
+    private fun Map<String, String>.nonBlank(name: String): String? = this[name]?.takeIf { it.isNotBlank() }
+
+    /**
+     * Decomposes a data URI into the plain parts [parse] reads.
+     *
+     * `getQueryParameterNames()`/`getQueryParameter()` throw on an opaque URI (one with no hierarchical
+     * part, e.g. `onebusaway:view-stop?…` without the `//`), so [Uri.isHierarchical] guards them.
+     */
+    private fun Uri.toLink(): Link = Link(
+        scheme = scheme,
+        host = host,
+        pathSegments = pathSegments,
+        params = if (isHierarchical) {
+            queryParameterNames.associateWith { getQueryParameter(it).orEmpty() }
+        } else {
+            emptyMap()
+        }
+    )
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/nav/IntentRouteMapper.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/nav/IntentRouteMapper.kt
@@ -17,8 +17,11 @@ package org.onebusaway.android.ui.nav
 
 import android.app.SearchManager
 import android.content.Intent
+import android.net.Uri
+import org.onebusaway.android.BuildConfig
 import org.onebusaway.android.ui.arrivals.ArrivalsIntents
 import org.onebusaway.android.ui.mylists.MyTabs
+import org.onebusaway.android.ui.tripdetails.TripDetailsLauncher
 import org.onebusaway.android.util.ReminderUtils
 
 /**
@@ -28,14 +31,23 @@ import org.onebusaway.android.util.ReminderUtils
  * `Intent`/`Uri`/JSON reads ([routeForIntent] -> [read]).
  *
  * Routing only — side-effect free: the domain mutations some intents imply (the `add-region` URL apply,
- * the FCM arrival-reminder clear) run in `HomeActivity.applyIntentSideEffects`, which shares the
- * [ADD_REGION_SCHEME]/[ADD_REGION_HOST] constants from here and [ReminderUtils.ARRIVAL_PAYLOAD_KEY].
+ * the FCM arrival-reminder clear) run in `HomeActivity.applyIntentSideEffects`, which shares
+ * [isAddRegionUri] from here and reads [ReminderUtils.ARRIVAL_PAYLOAD_KEY].
+ *
+ * The externally-reachable deep-link vocabulary itself lives in [ExternalDeepLinks].
  */
 object IntentRouteMapper {
 
-    /** The exported `onebusaway://add-region` deep link (an exported manifest intent-filter). */
-    const val ADD_REGION_SCHEME = "onebusaway"
+    /** Host of the exported `<app-scheme>://add-region` deep link (a manifest intent-filter). */
     const val ADD_REGION_HOST = "add-region"
+
+    /**
+     * The custom schemes this build answers to: the cross-platform `onebusaway` scheme (shared with
+     * OneBusAway for iOS, so every brand answers to it) plus the brand's own
+     * (`BuildConfig.DEEP_LINK_SCHEME` — `kiedybus` for KiedyBus, the same string for the OBA brand).
+     * Must stay in step with the manifest's custom-scheme intent-filter (`${deepLinkScheme}`).
+     */
+    val APP_SCHEMES: Set<String> = setOf("onebusaway", BuildConfig.DEEP_LINK_SCHEME)
 
     private const val NIGHT_LIGHT_ACTIVITY = "NightLightActivity"
 
@@ -45,6 +57,8 @@ object IntentRouteMapper {
         val navRoute: String? = null,
         /** The exported add-region deep link — routes nowhere (stays on home/map; URLs apply as a side effect). */
         val isAddRegion: Boolean = false,
+        /** The screen a cross-platform (iOS-parity) deep link targets; null if the data URI isn't one. */
+        val deepLinkTarget: ExternalDeepLinks.Target? = null,
         /** System search ([Intent.ACTION_SEARCH]); [searchQuery] is the (possibly empty) query. */
         val isSearch: Boolean = false,
         val searchQuery: String = "",
@@ -86,6 +100,15 @@ object IntentRouteMapper {
     fun routeForIntent(intent: Intent?): String? = intent?.let { decide(read(it)).toRoute() }
 
     /**
+     * Whether [uri] is the `add-region` deep link, i.e. the intent carries custom API URLs to apply.
+     * Shared with `HomeActivity.applyIntentSideEffects`, which runs that (side-effecting) apply.
+     */
+    fun isAddRegionUri(uri: Uri?): Boolean {
+        val scheme = uri?.scheme ?: return false
+        return scheme in APP_SCHEMES && uri.host == ADD_REGION_HOST
+    }
+
+    /**
      * The pure route-precedence decision over [input] — the exact branch order of the former
      * `HomeActivity.routeForIntent`.
      */
@@ -95,6 +118,17 @@ object IntentRouteMapper {
         // The exported add-region deep link applies custom API URLs as a side effect (HomeActivity); for
         // routing it stays on the home/map path (the legacy handler went Home).
         if (input.isAddRegion) return RouteDecision.None
+        // The other exported deep links — the cross-platform (iOS-parity) stop / trip links. A web trip
+        // link names the stop it was shared from, so open the trip scrolled to that stop.
+        when (val target = input.deepLinkTarget) {
+            is ExternalDeepLinks.Target.Stop -> return RouteDecision.Arrivals(target.stopId)
+            is ExternalDeepLinks.Target.Trip -> return RouteDecision.TripDetails(
+                tripId = target.tripId,
+                stopId = target.stopId,
+                scrollMode = TripDetailsLauncher.SCROLL_MODE_STOP
+            )
+            null -> Unit
+        }
         // System search (HomeActivity is the default_searchable target): open the search destination.
         if (input.isSearch) return RouteDecision.Search(input.searchQuery)
         // The FCM arrival payload clears its fired reminder as a side effect; here it just opens arrivals
@@ -148,7 +182,8 @@ object IntentRouteMapper {
         val tabTag = data?.let { MyTabs.defaultTabFromUri(it) }
         return RouteIntent(
             navRoute = intent.getStringExtra(NavRoutes.EXTRA_NAV_ROUTE),
-            isAddRegion = data?.scheme == ADD_REGION_SCHEME && data.host == ADD_REGION_HOST,
+            isAddRegion = isAddRegionUri(data),
+            deepLinkTarget = data?.let { ExternalDeepLinks.parse(it.toLink(), APP_SCHEMES) },
             isSearch = intent.action == Intent.ACTION_SEARCH,
             searchQuery = intent.getStringExtra(SearchManager.QUERY).orEmpty(),
             hasArrivalPayload = arrivalJson != null,
@@ -167,4 +202,22 @@ object IntentRouteMapper {
             arrivalsStopName = intent.getStringExtra(ArrivalsIntents.STOP_NAME)
         )
     }
+
+    /**
+     * Decomposes this data URI into the plain parts [ExternalDeepLinks.parse] reads. Query values come
+     * out percent-decoded (`Uri.getQueryParameter`); a parameter present with no value reads as `""`,
+     * which the parser rejects the same way it rejects an absent one.
+     */
+    private fun Uri.toLink(): ExternalDeepLinks.Link = ExternalDeepLinks.Link(
+        scheme = scheme,
+        host = host,
+        pathSegments = pathSegments.orEmpty(),
+        // getQueryParameterNames()/getQueryParameter() throw on an opaque URI (no hierarchical part);
+        // isHierarchical guards that — `onebusaway:view-stop?...` (no `//`) is opaque, for instance.
+        params = if (isHierarchical) {
+            queryParameterNames.associateWith { getQueryParameter(it).orEmpty() }
+        } else {
+            emptyMap()
+        }
+    )
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/nav/IntentRouteMapper.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/nav/IntentRouteMapper.kt
@@ -17,8 +17,6 @@ package org.onebusaway.android.ui.nav
 
 import android.app.SearchManager
 import android.content.Intent
-import android.net.Uri
-import org.onebusaway.android.BuildConfig
 import org.onebusaway.android.ui.arrivals.ArrivalsIntents
 import org.onebusaway.android.ui.mylists.MyTabs
 import org.onebusaway.android.ui.tripdetails.TripDetailsLauncher
@@ -31,23 +29,12 @@ import org.onebusaway.android.util.ReminderUtils
  * `Intent`/`Uri`/JSON reads ([routeForIntent] -> [read]).
  *
  * Routing only — side-effect free: the domain mutations some intents imply (the `add-region` URL apply,
- * the FCM arrival-reminder clear) run in `HomeActivity.applyIntentSideEffects`, which shares
- * [isAddRegionUri] from here and reads [ReminderUtils.ARRIVAL_PAYLOAD_KEY].
+ * the FCM arrival-reminder clear) run in `HomeActivity.applyIntentSideEffects`, which reads the same
+ * [ExternalDeepLinks.Target]/[ReminderUtils.ARRIVAL_PAYLOAD_KEY] the routing does.
  *
  * The externally-reachable deep-link vocabulary itself lives in [ExternalDeepLinks].
  */
 object IntentRouteMapper {
-
-    /** Host of the exported `<app-scheme>://add-region` deep link (a manifest intent-filter). */
-    const val ADD_REGION_HOST = "add-region"
-
-    /**
-     * The custom schemes this build answers to: the cross-platform `onebusaway` scheme (shared with
-     * OneBusAway for iOS, so every brand answers to it) plus the brand's own
-     * (`BuildConfig.DEEP_LINK_SCHEME` — `kiedybus` for KiedyBus, the same string for the OBA brand).
-     * Must stay in step with the manifest's custom-scheme intent-filter (`${deepLinkScheme}`).
-     */
-    val APP_SCHEMES: Set<String> = setOf("onebusaway", BuildConfig.DEEP_LINK_SCHEME)
 
     private const val NIGHT_LIGHT_ACTIVITY = "NightLightActivity"
 
@@ -55,10 +42,12 @@ object IntentRouteMapper {
     data class RouteIntent(
         /** An explicit in-app route ([NavRoutes.EXTRA_NAV_ROUTE]); cross-screen launches carry it verbatim. */
         val navRoute: String? = null,
-        /** The exported add-region deep link — routes nowhere (stays on home/map; URLs apply as a side effect). */
-        val isAddRegion: Boolean = false,
-        /** The screen a cross-platform (iOS-parity) deep link targets; null if the data URI isn't one. */
-        val deepLinkTarget: ExternalDeepLinks.Target? = null,
+        /**
+         * What the data URI means as an exported deep link, or null if it isn't one. Classified by
+         * [ExternalDeepLinks] — the same shape of fact as [tabTag] (a URI recognized by the object that
+         * owns that vocabulary), so [decide] only has to dispatch it.
+         */
+        val deepLink: ExternalDeepLinks.Target? = null,
         /** System search ([Intent.ACTION_SEARCH]); [searchQuery] is the (possibly empty) query. */
         val isSearch: Boolean = false,
         val searchQuery: String = "",
@@ -100,33 +89,23 @@ object IntentRouteMapper {
     fun routeForIntent(intent: Intent?): String? = intent?.let { decide(read(it)).toRoute() }
 
     /**
-     * Whether [uri] is the `add-region` deep link, i.e. the intent carries custom API URLs to apply.
-     * Shared with `HomeActivity.applyIntentSideEffects`, which runs that (side-effecting) apply.
-     */
-    fun isAddRegionUri(uri: Uri?): Boolean {
-        val scheme = uri?.scheme ?: return false
-        return scheme in APP_SCHEMES && uri.host == ADD_REGION_HOST
-    }
-
-    /**
      * The pure route-precedence decision over [input] — the exact branch order of the former
      * `HomeActivity.routeForIntent`.
      */
     fun decide(input: RouteIntent): RouteDecision {
         // In-app / cross-screen launches carry their destination route verbatim (see [navIntent]).
         input.navRoute?.let { return RouteDecision.Verbatim(it) }
-        // The exported add-region deep link applies custom API URLs as a side effect (HomeActivity); for
-        // routing it stays on the home/map path (the legacy handler went Home).
-        if (input.isAddRegion) return RouteDecision.None
-        // The other exported deep links — the cross-platform (iOS-parity) stop / trip links. A web trip
-        // link names the stop it was shared from, so open the trip scrolled to that stop.
-        when (val target = input.deepLinkTarget) {
+        // The exported (iOS-parity) deep links. A web trip link names the stop it was shared from, so
+        // open the trip scrolled to that stop; add-region applies its URLs as a side effect
+        // (HomeActivity) and for routing stays on the home/map path (the legacy handler went Home).
+        when (val target = input.deepLink) {
             is ExternalDeepLinks.Target.Stop -> return RouteDecision.Arrivals(target.stopId)
             is ExternalDeepLinks.Target.Trip -> return RouteDecision.TripDetails(
                 tripId = target.tripId,
                 stopId = target.stopId,
                 scrollMode = TripDetailsLauncher.SCROLL_MODE_STOP
             )
+            is ExternalDeepLinks.Target.AddRegion -> return RouteDecision.None
             null -> Unit
         }
         // System search (HomeActivity is the default_searchable target): open the search destination.
@@ -182,8 +161,7 @@ object IntentRouteMapper {
         val tabTag = data?.let { MyTabs.defaultTabFromUri(it) }
         return RouteIntent(
             navRoute = intent.getStringExtra(NavRoutes.EXTRA_NAV_ROUTE),
-            isAddRegion = isAddRegionUri(data),
-            deepLinkTarget = data?.let { ExternalDeepLinks.parse(it.toLink(), APP_SCHEMES) },
+            deepLink = data?.let { ExternalDeepLinks.parse(it) },
             isSearch = intent.action == Intent.ACTION_SEARCH,
             searchQuery = intent.getStringExtra(SearchManager.QUERY).orEmpty(),
             hasArrivalPayload = arrivalJson != null,
@@ -202,22 +180,4 @@ object IntentRouteMapper {
             arrivalsStopName = intent.getStringExtra(ArrivalsIntents.STOP_NAME)
         )
     }
-
-    /**
-     * Decomposes this data URI into the plain parts [ExternalDeepLinks.parse] reads. Query values come
-     * out percent-decoded (`Uri.getQueryParameter`); a parameter present with no value reads as `""`,
-     * which the parser rejects the same way it rejects an absent one.
-     */
-    private fun Uri.toLink(): ExternalDeepLinks.Link = ExternalDeepLinks.Link(
-        scheme = scheme,
-        host = host,
-        pathSegments = pathSegments.orEmpty(),
-        // getQueryParameterNames()/getQueryParameter() throw on an opaque URI (no hierarchical part);
-        // isHierarchical guards that — `onebusaway:view-stop?...` (no `//`) is opaque, for instance.
-        params = if (isHierarchical) {
-            queryParameterNames.associateWith { getQueryParameter(it).orEmpty() }
-        } else {
-            emptyMap()
-        }
-    )
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/nav/IntentRouteMapper.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/nav/IntentRouteMapper.kt
@@ -96,17 +96,18 @@ object IntentRouteMapper {
         // In-app / cross-screen launches carry their destination route verbatim (see [navIntent]).
         input.navRoute?.let { return RouteDecision.Verbatim(it) }
         // The exported (iOS-parity) deep links. A web trip link names the stop it was shared from, so
-        // open the trip scrolled to that stop; add-region applies its URLs as a side effect
-        // (HomeActivity) and for routing stays on the home/map path (the legacy handler went Home).
-        when (val target = input.deepLink) {
-            is ExternalDeepLinks.Target.Stop -> return RouteDecision.Arrivals(target.stopId)
-            is ExternalDeepLinks.Target.Trip -> return RouteDecision.TripDetails(
-                tripId = target.tripId,
-                stopId = target.stopId,
-                scrollMode = TripDetailsLauncher.SCROLL_MODE_STOP
-            )
-            is ExternalDeepLinks.Target.AddRegion -> return RouteDecision.None
-            null -> Unit
+        // open the trip scrolled to that stop; add-region is staged for the rider's confirmation as a
+        // side effect (HomeActivity) and for routing stays on the home/map path.
+        input.deepLink?.let { target ->
+            return when (target) {
+                is ExternalDeepLinks.Target.Stop -> RouteDecision.Arrivals(target.stopId)
+                is ExternalDeepLinks.Target.Trip -> RouteDecision.TripDetails(
+                    tripId = target.tripId,
+                    stopId = target.stopId,
+                    scrollMode = TripDetailsLauncher.SCROLL_MODE_STOP
+                )
+                is ExternalDeepLinks.Target.AddRegion -> RouteDecision.None
+            }
         }
         // System search (HomeActivity is the default_searchable target): open the search destination.
         if (input.isSearch) return RouteDecision.Search(input.searchQuery)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/ExternalIntents.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/ExternalIntents.kt
@@ -23,6 +23,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
+import android.net.Uri
 import android.os.Build
 import android.text.TextUtils
 import android.widget.Toast
@@ -47,6 +48,78 @@ object ExternalIntents {
             Toast.makeText(context, context.getString(R.string.browser_error), Toast.LENGTH_SHORT)
                 .show()
         }
+    }
+
+    /**
+     * A scheme-only `https` URI, used to enumerate the device's browsers. Every browser's web filter is
+     * a bare `<data android:scheme="https"/>` with no authority, so they all match it — while the app's
+     * own web-link filter, which requires a host and a path, cannot. That asymmetry is what keeps
+     * [openInBrowser] from resolving back to this app and looping.
+     */
+    private val BROWSER_PROBE_URI = "https:".toUri()
+
+    /**
+     * Opens [uri] in a browser, explicitly excluding this app, and reports whether it could.
+     *
+     * A plain `ACTION_VIEW` (as [goToUrl] fires) is wrong for a URL this app was *launched* for: it
+     * would match our own web-link intent-filter again and bounce straight back. So the target browser
+     * is resolved up front and set as the intent's package. Used to hand back an App Link the manifest
+     * filter claims but the parser can't route — see `ExternalDeepLinks.isUnhandledWebLink`.
+     *
+     * Browsers are enumerated rather than assumed so the user's default is honoured; when the device has
+     * browsers but no default among them, the chooser is restricted to those explicit intents (a plain
+     * `createChooser` over the URL would list this app again).
+     */
+    fun openInBrowser(context: Context, uri: Uri): Boolean {
+        val manager = context.packageManager
+        val probe = Intent(Intent.ACTION_VIEW, BROWSER_PROBE_URI)
+            .addCategory(Intent.CATEGORY_BROWSABLE)
+        val browsers = manager.browserPackages(probe)
+            .filterNot { it == context.packageName }
+            .distinct()
+        if (browsers.isEmpty()) return false
+
+        val open = Intent(Intent.ACTION_VIEW, uri).addCategory(Intent.CATEGORY_BROWSABLE)
+        val preferred = manager.defaultBrowserPackage(probe)?.takeIf { it in browsers }
+        val launch = if (preferred != null) {
+            Intent(open).setPackage(preferred)
+        } else {
+            val explicit = browsers.map { Intent(open).setPackage(it) }
+            Intent.createChooser(explicit.first(), null).apply {
+                putExtra(Intent.EXTRA_INITIAL_INTENTS, explicit.drop(1).toTypedArray())
+            }
+        }
+        return try {
+            context.startActivity(launch)
+            true
+        } catch (e: ActivityNotFoundException) {
+            false
+        }
+    }
+
+    /** Package names of every activity that handles [probe] (see [BROWSER_PROBE_URI]). */
+    private fun PackageManager.browserPackages(probe: Intent): List<String> {
+        val matches = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            queryIntentActivities(probe, PackageManager.ResolveInfoFlags.of(PackageManager.MATCH_DEFAULT_ONLY.toLong()))
+        } else {
+            // The ResolveInfoFlags overload is API 33+ and minSdk is 23, so the pre-33 path has to use
+            // the int overload that API 33 deprecated.
+            @Suppress("DEPRECATION")
+            queryIntentActivities(probe, PackageManager.MATCH_DEFAULT_ONLY)
+        }
+        return matches.map { it.activityInfo.packageName }
+    }
+
+    /** The user's default browser, or null if the device has none set (the chooser would show). */
+    private fun PackageManager.defaultBrowserPackage(probe: Intent): String? {
+        val match = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            resolveActivity(probe, PackageManager.ResolveInfoFlags.of(PackageManager.MATCH_DEFAULT_ONLY.toLong()))
+        } else {
+            // See browserPackages: the typed-flags overload needs API 33.
+            @Suppress("DEPRECATION")
+            resolveActivity(probe, PackageManager.MATCH_DEFAULT_ONLY)
+        }
+        return match?.activityInfo?.packageName
     }
 
     fun goToPhoneDialer(context: Context, url: String) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/ExternalIntents.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/ExternalIntents.kt
@@ -51,12 +51,20 @@ object ExternalIntents {
     }
 
     /**
-     * A scheme-only `https` URI, used to enumerate the device's browsers. Every browser's web filter is
-     * a bare `<data android:scheme="https"/>` with no authority, so they all match it — while the app's
-     * own web-link filter, which requires a host and a path, cannot. That asymmetry is what keeps
-     * [openInBrowser] from resolving back to this app and looping.
+     * The URI used to enumerate the device's browsers.
+     *
+     * It carries a **host**, deliberately. A scheme-only `https:` URI is *opaque* — `getHost()` is null —
+     * and `IntentFilter.AuthorityEntry.match` fails any filter that declares a host, wildcard included.
+     * So a browser registering `<data android:scheme="https" android:host="*"/>` rather than a bare
+     * scheme would be missed entirely, and on a device where that was the only browser [openInBrowser]
+     * would find nothing to hand the link to.
+     *
+     * `example.com` is the IANA-reserved example domain: nothing is ever fetched (this URI only ever
+     * reaches `PackageManager`), no real site can claim it, and — the property that matters — it is not
+     * one of `ExternalDeepLinks.WEB_HOSTS`, so this app's own web-link filter cannot match it. That is
+     * what keeps [openInBrowser] from resolving back to us and looping.
      */
-    private val BROWSER_PROBE_URI = "https:".toUri()
+    private val BROWSER_PROBE_URI = "https://example.com".toUri()
 
     /**
      * Opens [uri] in a browser, explicitly excluding this app, and reports whether it could.
@@ -93,6 +101,9 @@ object ExternalIntents {
             context.startActivity(launch)
             true
         } catch (e: ActivityNotFoundException) {
+            // Nothing to log or surface: the browser was resolved a moment ago, so this is the narrow
+            // race where it was uninstalled/disabled in between. Reporting false is the whole contract —
+            // the caller falls back to opening the app normally.
             false
         }
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/RegionUtils.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/RegionUtils.java
@@ -424,7 +424,8 @@ public class RegionUtils {
             BuildConfig.FIXED_REGION_PAYMENT_WARNING_BODY,
             BuildConfig.FIXED_REGION_SIDECAR_BASE_URL,
             BuildConfig.FIXED_REGION_PLAUSIBLE_ANALYTICS_SERVER_URL,
-            null); // No Umami config for the fixed-region build flavor
+            null, // No Umami config for the fixed-region build flavor
+            false); // custom: this is the build flavor's own region, not one a rider added (#2027)
     return region;
   }
 }

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -534,6 +534,8 @@
     </string>
     <string name="add_region_server_oba">Transit data</string>
     <string name="add_region_server_otp">Trip planning</string>
+    <string name="add_region_server_sidecar">Alarms and shared links</string>
+    <string name="add_region_server_umami">Usage analytics</string>
     <string name="add_region_confirm">Add region</string>
     <string name="add_region_invalid_title">Couldn’t add region</string>
     <string name="add_region_invalid_message">That link’s server address isn’t a valid URL.</string>

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -525,6 +525,26 @@
     <string name="region_load_failed_title">Couldn’t load regions</string>
     <string name="region_load_failed_message">Check your connection and try again.</string>
 
+    <!-- Custom regions added by an `onebusaway://add-region` link (#2027). The confirmation is a
+         security gate, not a courtesy: any web page can fire one of these links, and accepting it
+         repoints every transit request the app makes. %1$s in the message is the app name. -->
+    <string name="add_region_title">Add “%1$s”?</string>
+    <string name="add_region_message">This link wants %1$s to get all of its transit data from a
+        different server. Only continue if you trust whoever sent you the link.
+    </string>
+    <string name="add_region_server_oba">Transit data</string>
+    <string name="add_region_server_otp">Trip planning</string>
+    <string name="add_region_confirm">Add region</string>
+    <string name="add_region_invalid_title">Couldn’t add region</string>
+    <string name="add_region_invalid_message">That link’s server address isn’t a valid URL.</string>
+    <string name="region_remove_custom_title">Remove “%1$s”?</string>
+    <string name="region_remove_custom_message">This removes the region you added from this list. The
+        transit agency’s own regions aren’t affected.
+    </string>
+    <string name="region_remove_custom_confirm">Remove</string>
+    <!-- Accessibility label for the long-press-to-remove affordance on a custom region row. -->
+    <string name="region_remove_custom_hint">Long press to remove</string>
+
     <!--  Bug report -->
     <!-- Note: %1$s is replaced with app_name for white-label support -->
     <string name="bug_report_subject">%1$s Android: Feedback</string>

--- a/onebusaway-android/src/oba/AndroidManifest.xml
+++ b/onebusaway-android/src/oba/AndroidManifest.xml
@@ -1,28 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  OBA-brand-only manifest additions, merged into src/main/AndroidManifest.xml for the `oba`
-  brand flavor only.
+  Android App Links for the OneBusAway web/sidecar hosts, merged into src/main's HomeActivity for
+  the `oba` brand only. Parsed by org.onebusaway.android.ui.nav.ExternalDeepLinks (whose WEB_HOSTS
+  must list the same hosts); see docs/DEEP_LINKING.md for the link format, the outstanding
+  assetlinks.json step that autoVerify depends on, and how to test these links.
 
-  Android App Links for the OneBusAway web/sidecar hosts — the Android half of the iOS app's
-  associated domains (applinks:onebusaway.co, applinks:www.onebusaway.co,
-  applinks:sidecar.onebusaway.org), so a trip link shared from either app opens the same screen
-  (#2027):
+  Why this is in the `oba` source set and not src/main: these hosts belong to the OBA deployment. A
+  white-label brand can never verify them — verification matches the *installed app's* signing
+  certificate against the host's assetlinks.json — and on API < 31 an unverifiable filter would
+  still put that brand in the link-handling chooser for someone else's links. A brand with its own
+  web host should add its own flavor manifest with the same shape.
 
-      https://<host>/regions/{regionID}/stops/{stopID}/trips?trip_id=…&service_date=…&stop_sequence=…
-
-  Parsed by org.onebusaway.android.ui.nav.ExternalDeepLinks, whose WEB_HOSTS must list the same
-  hosts. The pathPrefix keeps the filter off the rest of the site (the marketing pages).
-
-  This lives in the `oba` source set rather than src/main because these hosts belong to the OBA
-  deployment: a white-label brand can never verify them (verification matches the *installed app's*
-  signing certificate against the host's assetlinks.json), and on API < 31 an unverifiable filter
-  would still put that brand in the link-handling chooser for someone else's links. A brand with its
-  own web host should add its own flavor manifest with the same shape.
-
-  autoVerify requires https://<host>/.well-known/assetlinks.json to list this app's package name and
-  release signing-certificate SHA-256 fingerprint. Until those files are published, verification
-  fails and the links keep opening in the browser (nothing regresses); `adb shell am start -a
-  android.intent.action.VIEW -d '<url>' <package>` exercises the filter regardless.
+  The pathPrefix keeps the filter off the rest of the site (the marketing pages).
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 

--- a/onebusaway-android/src/oba/AndroidManifest.xml
+++ b/onebusaway-android/src/oba/AndroidManifest.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  OBA-brand-only manifest additions, merged into src/main/AndroidManifest.xml for the `oba`
+  brand flavor only.
+
+  Android App Links for the OneBusAway web/sidecar hosts — the Android half of the iOS app's
+  associated domains (applinks:onebusaway.co, applinks:www.onebusaway.co,
+  applinks:sidecar.onebusaway.org), so a trip link shared from either app opens the same screen
+  (#2027):
+
+      https://<host>/regions/{regionID}/stops/{stopID}/trips?trip_id=…&service_date=…&stop_sequence=…
+
+  Parsed by org.onebusaway.android.ui.nav.ExternalDeepLinks, whose WEB_HOSTS must list the same
+  hosts. The pathPrefix keeps the filter off the rest of the site (the marketing pages).
+
+  This lives in the `oba` source set rather than src/main because these hosts belong to the OBA
+  deployment: a white-label brand can never verify them (verification matches the *installed app's*
+  signing certificate against the host's assetlinks.json), and on API < 31 an unverifiable filter
+  would still put that brand in the link-handling chooser for someone else's links. A brand with its
+  own web host should add its own flavor manifest with the same shape.
+
+  autoVerify requires https://<host>/.well-known/assetlinks.json to list this app's package name and
+  release signing-certificate SHA-256 fingerprint. Until those files are published, verification
+  fails and the links keep opening in the browser (nothing regresses); `adb shell am start -a
+  android.intent.action.VIEW -d '<url>' <package>` exercises the filter regardless.
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application>
+        <!-- exported is repeated from src/main (identical value, so it merges cleanly): lint checks
+             this source manifest on its own, and an intent-filter here without it is an error. -->
+        <activity
+            android:name="org.onebusaway.android.ui.HomeActivity"
+            android:exported="true">
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="https" />
+                <data android:host="onebusaway.co" />
+                <data android:host="www.onebusaway.co" />
+                <data android:host="sidecar.onebusaway.org" />
+                <data android:pathPrefix="/regions/" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/onebusaway-android/src/oba/AndroidManifest.xml
+++ b/onebusaway-android/src/oba/AndroidManifest.xml
@@ -11,7 +11,13 @@
   still put that brand in the link-handling chooser for someone else's links. A brand with its own
   web host should add its own flavor manifest with the same shape.
 
-  The pathPrefix keeps the filter off the rest of the site (the marketing pages).
+  The pathPattern claims only the trip endpoint, so the rest of the site (the marketing pages, and a
+  region/stop page the parser doesn't recognize) keeps opening in the browser rather than launching
+  the app to land nowhere. It's a PATTERN_SIMPLE_GLOB, where `.` is any character and `*` is
+  zero-or-more of the preceding one, so `.*` spans `/` too — it can't require a *single* segment per
+  wildcard. ExternalDeepLinks.parse is the exact check (it requires precisely five path segments);
+  this filter just has to be no broader than it needs to be. Path shape doesn't affect autoVerify,
+  which matches on host.
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
@@ -31,7 +37,7 @@
                 <data android:host="onebusaway.co" />
                 <data android:host="www.onebusaway.co" />
                 <data android:host="sidecar.onebusaway.org" />
-                <data android:pathPrefix="/regions/" />
+                <data android:pathPattern="/regions/.*/stops/.*/trips" />
             </intent-filter>
         </activity>
     </application>

--- a/onebusaway-android/src/oba/AndroidManifest.xml
+++ b/onebusaway-android/src/oba/AndroidManifest.xml
@@ -8,16 +8,24 @@
   Why this is in the `oba` source set and not src/main: these hosts belong to the OBA deployment. A
   white-label brand can never verify them — verification matches the *installed app's* signing
   certificate against the host's assetlinks.json — and on API < 31 an unverifiable filter would
-  still put that brand in the link-handling chooser for someone else's links. A brand with its own
-  web host should add its own flavor manifest with the same shape.
+  still put that brand in the link-handling chooser for someone else's links. Giving a brand web
+  links of its own needs a brand-specific host set as well as a flavor manifest (see WEB_HOSTS);
+  that's a feature to design, not a file to copy.
+
+  NOTE that the API < 31 caveat above applies to the OBA brand too, until the assetlinks.json files
+  are live: on API 23-30 an unverified filter still matches, so these links raise the
+  browser-or-OneBusAway chooser rather than going straight to the browser. On API 31+ an unverified
+  domain isn't offered to the app at all. docs/DEEP_LINKING.md spells this out.
 
   The pathPattern claims only the trip endpoint, so the rest of the site (the marketing pages, and a
   region/stop page the parser doesn't recognize) keeps opening in the browser rather than launching
   the app to land nowhere. It's a PATTERN_SIMPLE_GLOB, where `.` is any character and `*` is
   zero-or-more of the preceding one, so `.*` spans `/` too — it can't require a *single* segment per
-  wildcard. ExternalDeepLinks.parse is the exact check (it requires precisely five path segments);
-  this filter just has to be no broader than it needs to be. Path shape doesn't affect autoVerify,
-  which matches on host.
+  wildcard. ExternalDeepLinks.parse is the exact check (it requires precisely five path segments and
+  a trip_id, which a filter can't express at all); this filter just has to be no broader than it
+  needs to be. What slips through the gap is handed back to the browser —
+  ExternalDeepLinks.isUnhandledWebLink, applied in HomeActivity.applyIntentSideEffects. Path shape
+  doesn't affect autoVerify, which matches on host.
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 

--- a/onebusaway-android/src/oba/AndroidManifest.xml
+++ b/onebusaway-android/src/oba/AndroidManifest.xml
@@ -13,8 +13,9 @@
   that's a feature to design, not a file to copy.
 
   NOTE that the API < 31 caveat above applies to the OBA brand too, until the assetlinks.json files
-  are live: on API 23-30 an unverified filter still matches, so these links raise the
-  browser-or-OneBusAway chooser rather than going straight to the browser. On API 31+ an unverified
+  are live: on API 23-30 an unverified filter still matches, so these links fall into ordinary intent
+  disambiguation and may raise the browser-or-OneBusAway chooser rather than going straight to the
+  browser (a default handler the rider already chose is still respected). On API 31+ an unverified
   domain isn't offered to the app at all. docs/DEEP_LINKING.md spells this out.
 
   The pathPattern claims only the trip endpoint, so the rest of the site (the marketing pages, and a

--- a/onebusaway-android/src/test/java/org/onebusaway/android/region/CustomRegionsTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/region/CustomRegionsTest.kt
@@ -61,11 +61,12 @@ class CustomRegionsTest {
     }
 
     @Test
-    fun `custom ids never collide with the no-region sentinel or a directory id`() {
-        // -1 is what the region-id preference stores for "no region"; directory ids are >= 0.
-        val ids = generateSequence(nextCustomRegionId(null)) { nextCustomRegionId(it) }.take(50)
-        ids.forEach { id ->
-            assertTrue("id $id must be below the -1 sentinel", id < -1L)
+    fun `every allocated custom id stays below the sentinel and survives the preference`() {
+        // Two properties over one sequence: an allocated id can never be read as a directory id
+        // (`>= 0`) nor as the "no region" sentinel (`-1`), which is what makes it round-trip.
+        generateSequence(nextCustomRegionId(null), ::nextCustomRegionId).take(50).forEach { id ->
+            assertTrue("id $id must be below the sentinel", id < NO_REGION_ID)
+            assertNotNull("id $id must survive the preference", persistedRegionId(id))
         }
     }
 
@@ -91,12 +92,6 @@ class CustomRegionsTest {
     fun `a directory region id survives a round trip through the preference`() {
         assertEquals(0L, persistedRegionId(0L)) // Tampa
         assertEquals(1L, persistedRegionId(1L))
-    }
-
-    @Test
-    fun `no allocated custom id can ever be mistaken for the sentinel`() {
-        val ids = generateSequence(nextCustomRegionId(null)) { nextCustomRegionId(it) }.take(50)
-        ids.forEach { id -> assertNotNull("id $id must survive the preference", persistedRegionId(id)) }
     }
 
     // --- the region built from a request ---

--- a/onebusaway-android/src/test/java/org/onebusaway/android/region/CustomRegionsTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/region/CustomRegionsTest.kt
@@ -17,6 +17,7 @@ package org.onebusaway.android.region
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -66,6 +67,36 @@ class CustomRegionsTest {
         ids.forEach { id ->
             assertTrue("id $id must be below the -1 sentinel", id < -1L)
         }
+    }
+
+    // --- the region-id preference sentinel ---
+
+    @Test
+    fun `the no-region sentinel reads back as no region`() {
+        assertNull(persistedRegionId(NO_REGION_ID))
+    }
+
+    @Test
+    fun `a custom region id survives a round trip through the preference`() {
+        // The bug this rule exists for: reading the preference as `id < 0` rather than
+        // `id != NO_REGION_ID` discarded every custom region at cold start — it stayed in the database
+        // but was never restored, so the app silently fell back to region resolution on each launch.
+        // The rule now lives only in persistedRegionId, which is what this pins; the repository call site
+        // itself is private and Context-coupled, so it isn't reachable from a JVM test.
+        assertEquals(FIRST_CUSTOM_REGION_ID, persistedRegionId(FIRST_CUSTOM_REGION_ID))
+        assertEquals(-7L, persistedRegionId(-7L))
+    }
+
+    @Test
+    fun `a directory region id survives a round trip through the preference`() {
+        assertEquals(0L, persistedRegionId(0L)) // Tampa
+        assertEquals(1L, persistedRegionId(1L))
+    }
+
+    @Test
+    fun `no allocated custom id can ever be mistaken for the sentinel`() {
+        val ids = generateSequence(nextCustomRegionId(null)) { nextCustomRegionId(it) }.take(50)
+        ids.forEach { id -> assertNotNull("id $id must survive the preference", persistedRegionId(id)) }
     }
 
     // --- the region built from a request ---

--- a/onebusaway-android/src/test/java/org/onebusaway/android/region/CustomRegionsTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/region/CustomRegionsTest.kt
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.region
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for the custom-region model behind the `add-region` deep link (#2027): id allocation, and
+ * the invariants [customRegion] has to hold for the resulting region to actually be usable and to stay
+ * out of automatic region selection.
+ */
+class CustomRegionsTest {
+
+    private val request = CustomRegionRequest(
+        name = "Test Deployment",
+        obaBaseUrl = "https://api.example.com",
+        otpBaseUrl = "https://otp.example.com",
+        sidecarBaseUrl = "https://sidecar.example.com",
+        umamiAnalyticsUrl = "https://umami.example.com",
+        umamiAnalyticsId = "abc123"
+    )
+
+    // --- id allocation ---
+
+    @Test
+    fun `the first custom region on an empty cache gets the first custom id`() {
+        assertEquals(FIRST_CUSTOM_REGION_ID, nextCustomRegionId(minId = null))
+    }
+
+    @Test
+    fun `a cache holding only directory regions still gets the first custom id`() {
+        // Directory ids are non-negative (Tampa is 0), so the minimum tells us nothing is custom yet.
+        assertEquals(FIRST_CUSTOM_REGION_ID, nextCustomRegionId(minId = 0L))
+        assertEquals(FIRST_CUSTOM_REGION_ID, nextCustomRegionId(minId = 5L))
+    }
+
+    @Test
+    fun `each new custom id goes below every id present`() {
+        // Live regions can't collide. (Removing the lowest one does free its id again — see the KDoc for
+        // why that's safe: no durable reference to a removed region's id survives.)
+        assertEquals(-3L, nextCustomRegionId(minId = -2L))
+        assertEquals(-4L, nextCustomRegionId(minId = -3L))
+    }
+
+    @Test
+    fun `custom ids never collide with the no-region sentinel or a directory id`() {
+        // -1 is what the region-id preference stores for "no region"; directory ids are >= 0.
+        val ids = generateSequence(nextCustomRegionId(null)) { nextCustomRegionId(it) }.take(50)
+        ids.forEach { id ->
+            assertTrue("id $id must be below the -1 sentinel", id < -1L)
+        }
+    }
+
+    // --- the region built from a request ---
+
+    @Test
+    fun `a custom region carries every field the link supplied`() {
+        val region = customRegion(FIRST_CUSTOM_REGION_ID, request)
+        assertEquals("Test Deployment", region.name)
+        assertEquals("https://api.example.com", region.obaBaseUrl)
+        assertEquals("https://otp.example.com", region.otpBaseUrl)
+        assertEquals("https://sidecar.example.com", region.sidecarBaseUrl)
+        assertEquals("https://umami.example.com", region.umamiAnalyticsUrl)
+        assertEquals("abc123", region.umamiAnalyticsId)
+        assertEquals(FIRST_CUSTOM_REGION_ID, region.id)
+    }
+
+    @Test
+    fun `a custom region is marked custom`() {
+        // The flag the cache, the picker and resolveRegionStatus all key off.
+        assertTrue(customRegion(FIRST_CUSTOM_REGION_ID, request).custom)
+    }
+
+    @Test
+    fun `a custom region satisfies the usability requirements`() {
+        // RegionUtils.isRegionUsable requires all four, or the app refuses to use the region at all -
+        // which would make the link pointless. These are declarations, not observations; see the KDoc.
+        val region = customRegion(FIRST_CUSTOM_REGION_ID, request)
+        assertTrue("active", region.active)
+        assertTrue("discovery APIs", region.supportsObaDiscoveryApis)
+        assertTrue("realtime APIs", region.supportsObaRealtimeApis)
+        assertFalse("must not be experimental (that would need an opt-in)", region.experimental)
+    }
+
+    @Test
+    fun `a custom region has no bounds, so it can never be auto-selected`() {
+        // getClosestRegion skips a region it can't measure a distance to. A deep link carries no
+        // coverage area, so this is the honest representation as well as the safe one.
+        assertTrue(customRegion(FIRST_CUSTOM_REGION_ID, request).bounds.isEmpty())
+    }
+
+    @Test
+    fun `a custom region has no umami config when the link supplied no url`() {
+        val region = customRegion(FIRST_CUSTOM_REGION_ID, request.copy(umamiAnalyticsUrl = null))
+        assertNull(region.umamiAnalytics)
+    }
+
+    @Test
+    fun `a custom region has no contact email, so no problem-report address is offered`() {
+        // Deliberately not iOS's placeholder example@example.com: ReportTypeRepository offers the
+        // email-a-problem option when a contact address exists, and mailing a made-up one is worse.
+        assertTrue(customRegion(FIRST_CUSTOM_REGION_ID, request).contactEmail.isNullOrEmpty())
+    }
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/region/RegionStatusTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/region/RegionStatusTest.kt
@@ -125,4 +125,42 @@ class RegionStatusTest {
             resolveRegionStatus(current = region(1), closest = region(2), autoSelect = false)
         )
     }
+
+    // --- custom regions (#2027) are never auto-replaced ---
+
+    @Test
+    fun `a current custom region survives a nearer directory region`() {
+        // The rider deliberately chose this server (an add-region link they confirmed, or a manual
+        // pick). Without this guard, auto-select would hand them straight back to whichever directory
+        // region is closest and silently undo it.
+        assertEquals(
+            RegionStatus.Unchanged,
+            resolveRegionStatus(
+                current = region(-2, custom = true),
+                closest = region(1),
+                autoSelect = true
+            )
+        )
+    }
+
+    @Test
+    fun `a current custom region is unchanged with auto-select off too`() {
+        assertEquals(
+            RegionStatus.Unchanged,
+            resolveRegionStatus(
+                current = region(-2, custom = true),
+                closest = null,
+                autoSelect = false
+            )
+        )
+    }
+
+    @Test
+    fun `a current directory region is still replaced by a nearer one`() {
+        // The guard must be scoped to custom regions — ordinary auto-select behaviour is unchanged.
+        assertEquals(
+            RegionStatus.Changed(region(2)),
+            resolveRegionStatus(current = region(1), closest = region(2), autoSelect = true)
+        )
+    }
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/region/RegionTestFixtures.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/region/RegionTestFixtures.kt
@@ -59,8 +59,10 @@ internal class FakeRegionRepository(initial: Region? = null) : RegionRepository 
     override fun applyRegion(region: Region?, regionChanged: Boolean) = emit(region)
 
     override suspend fun addCustomRegion(request: CustomRegionRequest): Region? {
-        addedCustomRegions.add(request)
+        // Reject before recording, mirroring the real repository: an invalid request is never saved, so a
+        // fake that records it first would let a test pass on behaviour production doesn't have.
         if (!addCustomRegionSucceeds) return null
+        addedCustomRegions.add(request)
         // Mirror the real repo's observable effect: the new region becomes current.
         val added = customRegion(FIRST_CUSTOM_REGION_ID, request)
         emit(added)
@@ -68,6 +70,9 @@ internal class FakeRegionRepository(initial: Region? = null) : RegionRepository 
     }
 
     override suspend fun deleteCustomRegion(region: Region) {
+        // The real repository ignores a directory region outright; so must this, or a test could rely on
+        // deleting one working.
+        if (!region.custom) return
         deletedCustomRegions.add(region)
         if (_region.value?.id == region.id) emit(null)
     }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/region/RegionTestFixtures.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/region/RegionTestFixtures.kt
@@ -37,7 +37,15 @@ internal class FakeRegionRepository(initial: Region? = null) : RegionRepository 
     var refreshResult: RegionStatus = RegionStatus.Unchanged
     var refreshCount = 0
     val chosen = mutableListOf<Region>()
-    val customApiUrls = mutableListOf<Pair<String?, String?>>()
+
+    /** Custom regions added via [addCustomRegion], in order. */
+    val addedCustomRegions = mutableListOf<CustomRegionRequest>()
+
+    /** Custom regions passed to [deleteCustomRegion], in order. */
+    val deletedCustomRegions = mutableListOf<Region>()
+
+    /** When false, [addCustomRegion] reports the request as unusable (the invalid-URL path). */
+    var addCustomRegionSucceeds = true
 
     override suspend fun refresh(): RegionStatus {
         refreshCount++
@@ -50,10 +58,18 @@ internal class FakeRegionRepository(initial: Region? = null) : RegionRepository 
     override fun clear() = emit(null)
     override fun applyRegion(region: Region?, regionChanged: Boolean) = emit(region)
 
-    override fun applyCustomApiUrls(obaUrl: String?, otpUrl: String?) {
-        customApiUrls.add(obaUrl to otpUrl)
-        // Mirror the real repo's observable effect: a custom OBA endpoint clears the current region.
-        if (obaUrl != null) emit(null)
+    override suspend fun addCustomRegion(request: CustomRegionRequest): Region? {
+        addedCustomRegions.add(request)
+        if (!addCustomRegionSucceeds) return null
+        // Mirror the real repo's observable effect: the new region becomes current.
+        val added = customRegion(FIRST_CUSTOM_REGION_ID, request)
+        emit(added)
+        return added
+    }
+
+    override suspend fun deleteCustomRegion(region: Region) {
+        deletedCustomRegions.add(region)
+        if (_region.value?.id == region.id) emit(null)
     }
 
     fun emit(region: Region?) {
@@ -73,7 +89,8 @@ internal fun region(
     id: Long,
     supportsOtpBikeshare: Boolean = false,
     twitterUrl: String? = null,
-    otpContactEmail: String? = null
+    otpContactEmail: String? = null,
+    custom: Boolean = false
 ): Region = Region(
     id = id,
     name = "Region $id",
@@ -101,5 +118,6 @@ internal fun region(
     paymentWarningBody = null,
     sidecarBaseUrl = null,
     plausibleAnalyticsServerUrl = null,
-    umamiAnalytics = null
+    umamiAnalytics = null,
+    custom = custom
 )

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/AddRegionViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/AddRegionViewModelTest.kt
@@ -99,6 +99,7 @@ class AddRegionViewModelTest {
         advanceUntilIdle()
 
         assertTrue("an unusable server address must be reported, not swallowed", viewModel.invalid.value)
+        assertTrue("a rejected request must not have been saved", repo.addedCustomRegions.isEmpty())
 
         viewModel.dismissInvalid()
         assertFalse(viewModel.invalid.value)

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/AddRegionViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/AddRegionViewModelTest.kt
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.home
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.onebusaway.android.region.CustomRegionRequest
+import org.onebusaway.android.region.FakeRegionRepository
+import org.onebusaway.android.testing.MainDispatcherRule
+
+/**
+ * Unit tests for the consent gate on the `add-region` deep link (#2027, #2030).
+ *
+ * The property that matters is the *negative* one: staging a request must write nothing at all, because
+ * any web page can fire one of these links. Everything else follows from that.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class AddRegionViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private lateinit var repo: FakeRegionRepository
+    private lateinit var viewModel: AddRegionViewModel
+
+    private val request = CustomRegionRequest(
+        name = "Test Deployment",
+        obaBaseUrl = "https://api.example.com"
+    )
+
+    @Before
+    fun setUp() {
+        repo = FakeRegionRepository()
+        viewModel = AddRegionViewModel(repo)
+    }
+
+    @Test
+    fun `staging a request writes nothing`() = runTest {
+        viewModel.request(request)
+
+        assertEquals(request, viewModel.pending.value)
+        assertTrue("no region may be added before the rider confirms", repo.addedCustomRegions.isEmpty())
+    }
+
+    @Test
+    fun `declining writes nothing and clears the request`() = runTest {
+        viewModel.request(request)
+        viewModel.decline()
+
+        assertNull(viewModel.pending.value)
+        assertTrue(repo.addedCustomRegions.isEmpty())
+    }
+
+    @Test
+    fun `confirming adds the region`() = runTest {
+        viewModel.request(request)
+        viewModel.confirm()
+        advanceUntilIdle()
+
+        assertEquals(listOf(request), repo.addedCustomRegions)
+        assertNull("the dialog closes once confirmed", viewModel.pending.value)
+        assertFalse(viewModel.invalid.value)
+    }
+
+    @Test
+    fun `confirming with nothing staged is a no-op`() = runTest {
+        viewModel.confirm()
+        advanceUntilIdle()
+
+        assertTrue(repo.addedCustomRegions.isEmpty())
+    }
+
+    @Test
+    fun `a rejected request surfaces the invalid alert`() = runTest {
+        repo.addCustomRegionSucceeds = false
+        viewModel.request(request)
+        viewModel.confirm()
+        advanceUntilIdle()
+
+        assertTrue("an unusable server address must be reported, not swallowed", viewModel.invalid.value)
+
+        viewModel.dismissInvalid()
+        assertFalse(viewModel.invalid.value)
+    }
+
+    @Test
+    fun `a second link replaces the one still awaiting an answer`() = runTest {
+        val other = request.copy(name = "Other", obaBaseUrl = "https://other.example.com")
+        viewModel.request(request)
+        viewModel.request(other)
+
+        // Stacked consent dialogs would invite answering the wrong one; the newest link is the one the
+        // rider just followed.
+        assertEquals(other, viewModel.pending.value)
+
+        viewModel.confirm()
+        advanceUntilIdle()
+        assertEquals(listOf(other), repo.addedCustomRegions)
+    }
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/RegionPickerViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/RegionPickerViewModelTest.kt
@@ -122,4 +122,34 @@ class RegionPickerViewModelTest {
         assertEquals(1, repo.refreshCount)
         assertFalse(vm.failed.value)
     }
+
+    // --- removing a custom region (#2027) ---
+
+    @Test
+    fun `remove deletes a custom region`() = runTest {
+        val custom = region(-2, custom = true)
+        val repo = FakeRegionRepository(custom)
+        val vm = RegionPickerViewModel(repo)
+        advanceUntilIdle()
+
+        vm.remove(custom)
+        advanceUntilIdle()
+
+        assertEquals(listOf(custom), repo.deletedCustomRegions)
+    }
+
+    @Test
+    fun `remove leaves a directory region alone`() = runTest {
+        // The only way out of an add-region link is long-pressing the region it added; a directory
+        // region has no such affordance, and the repository ignores one if it somehow arrives here.
+        val directory = region(1)
+        val repo = FakeRegionRepository(directory)
+        val vm = RegionPickerViewModel(repo)
+        advanceUntilIdle()
+
+        vm.remove(directory)
+        advanceUntilIdle()
+
+        assertTrue(repo.deletedCustomRegions.isEmpty())
+    }
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/nav/ExternalDeepLinksTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/nav/ExternalDeepLinksTest.kt
@@ -145,6 +145,13 @@ class ExternalDeepLinksTest {
     }
 
     @Test
+    fun `a plaintext http trip link is not a deep link`() {
+        // App links are https-only; the manifest filter grants no http scheme, and the same host over
+        // http is not one of our links.
+        assertNull(parse(webLink().copy(scheme = "http"), schemes))
+    }
+
+    @Test
     fun `a trip link carrying the full iOS parameter set ignores what no screen consumes`() {
         val target = parse(
             webLink(

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/nav/ExternalDeepLinksTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/nav/ExternalDeepLinksTest.kt
@@ -1,0 +1,177 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.nav
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.onebusaway.android.ui.nav.ExternalDeepLinks.Link
+import org.onebusaway.android.ui.nav.ExternalDeepLinks.Target
+import org.onebusaway.android.ui.nav.ExternalDeepLinks.parse
+
+/**
+ * Unit tests for the cross-platform (iOS-parity) deep-link parser (#2027). The `Uri` decomposition
+ * lives in `IntentRouteMapper.read`, so these exercise the pure vocabulary: which links are
+ * recognized, which are deliberately not, and what each maps to.
+ */
+class ExternalDeepLinksTest {
+
+    /** Both schemes the OBA brand answers to; a brand build adds its own (e.g. `kiedybus`). */
+    private val schemes = setOf("onebusaway", "kiedybus")
+
+    private fun appLink(host: String, params: Map<String, String> = emptyMap(), scheme: String = "onebusaway") = Link(scheme = scheme, host = host, pathSegments = emptyList(), params = params)
+
+    private fun webLink(
+        host: String = "onebusaway.co",
+        pathSegments: List<String> = listOf("regions", "1", "stops", "1_75403", "trips"),
+        params: Map<String, String> = mapOf("trip_id" to "1_18196913")
+    ) = Link(scheme = "https", host = host, pathSegments = pathSegments, params = params)
+
+    // --- view-stop ---
+
+    @Test
+    fun `view-stop opens the stop named by stopID`() {
+        val target = parse(
+            appLink("view-stop", mapOf("stopID" to "1_75403", "regionID" to "1")),
+            schemes
+        )
+        assertEquals(Target.Stop("1_75403"), target)
+    }
+
+    @Test
+    fun `view-stop is recognized under the brand's own scheme too`() {
+        val target = parse(
+            appLink("view-stop", mapOf("stopID" to "1_75403"), scheme = "kiedybus"),
+            schemes
+        )
+        assertEquals(Target.Stop("1_75403"), target)
+    }
+
+    @Test
+    fun `view-stop under an unknown scheme is not a deep link`() {
+        val link = appLink("view-stop", mapOf("stopID" to "1_75403"), scheme = "someotherapp")
+        assertNull(parse(link, schemes))
+    }
+
+    @Test
+    fun `view-stop without a regionID still opens the stop`() {
+        // Deliberate divergence from iOS, which requires regionID even though it never uses it: the
+        // stop id is all the arrivals screen needs, so we don't drop an otherwise-usable link.
+        assertEquals(
+            Target.Stop("1_75403"),
+            parse(appLink("view-stop", mapOf("stopID" to "1_75403")), schemes)
+        )
+    }
+
+    @Test
+    fun `view-stop without a stopID is not a deep link`() {
+        assertNull(parse(appLink("view-stop", mapOf("regionID" to "1")), schemes))
+    }
+
+    @Test
+    fun `view-stop with a blank stopID is not a deep link`() {
+        // A `?stopID=` with no value reads as "" (Uri.getQueryParameter), same as absent.
+        assertNull(parse(appLink("view-stop", mapOf("stopID" to "")), schemes))
+    }
+
+    @Test
+    fun `add-region is not a route - its URLs apply as a side effect`() {
+        assertNull(parse(appLink("add-region", mapOf("oba-url" to "https://api.example.com")), schemes))
+    }
+
+    @Test
+    fun `an unknown custom-scheme host is not a deep link`() {
+        assertNull(parse(appLink("view-route", mapOf("routeId" to "1_100194")), schemes))
+    }
+
+    // --- web (app link) trip links ---
+
+    @Test
+    fun `a web trip link opens the trip at the stop in its path`() {
+        assertEquals(
+            Target.Trip(tripId = "1_18196913", stopId = "1_75403"),
+            parse(webLink(), schemes)
+        )
+    }
+
+    @Test
+    fun `every associated host is recognized`() {
+        ExternalDeepLinks.WEB_HOSTS.forEach { host ->
+            assertEquals(
+                "host $host",
+                Target.Trip(tripId = "1_18196913", stopId = "1_75403"),
+                parse(webLink(host = host), schemes)
+            )
+        }
+    }
+
+    @Test
+    fun `a trip link on an unrelated host is not a deep link`() {
+        assertNull(parse(webLink(host = "example.com"), schemes))
+    }
+
+    @Test
+    fun `a trip link carrying the full iOS parameter set ignores what no screen consumes`() {
+        val target = parse(
+            webLink(
+                params = mapOf(
+                    "trip_id" to "1_18196913",
+                    "service_date" to "1698307200.0",
+                    "stop_sequence" to "5",
+                    "title" to "Link Light Rail",
+                    "vehicle_id" to "1_1234",
+                    "destination_stop_id" to "1_75414"
+                )
+            ),
+            schemes
+        )
+        assertEquals(Target.Trip(tripId = "1_18196913", stopId = "1_75403"), target)
+    }
+
+    @Test
+    fun `a trip link without a trip_id is not a deep link`() {
+        assertNull(parse(webLink(params = mapOf("service_date" to "1698307200.0")), schemes))
+    }
+
+    @Test
+    fun `a stop-only web path is not a deep link`() {
+        // Matches iOS: only the /trips endpoint decodes; a stop page falls through to the browser.
+        assertNull(parse(webLink(pathSegments = listOf("regions", "1", "stops", "1_75403")), schemes))
+    }
+
+    @Test
+    fun `a trip path with a trailing segment is not a deep link`() {
+        val path = listOf("regions", "1", "stops", "1_75403", "trips", "extra")
+        assertNull(parse(webLink(pathSegments = path), schemes))
+    }
+
+    @Test
+    fun `a misspelled trip path is not a deep link`() {
+        val path = listOf("regions", "1", "stations", "1_75403", "trips")
+        assertNull(parse(webLink(pathSegments = path), schemes))
+    }
+
+    @Test
+    fun `a trip link with a blank stop id in its path is not a deep link`() {
+        val path = listOf("regions", "1", "stops", "", "trips")
+        assertNull(parse(webLink(pathSegments = path), schemes))
+    }
+
+    @Test
+    fun `a bare host with no path is not a deep link`() {
+        assertNull(parse(webLink(pathSegments = emptyList(), params = emptyMap()), schemes))
+    }
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/nav/ExternalDeepLinksTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/nav/ExternalDeepLinksTest.kt
@@ -271,6 +271,20 @@ class ExternalDeepLinksTest {
     }
 
     @Test
+    fun `a web path the manifest filter never claims is not an unhandled web link`() {
+        // The filter only claims /regions/*/stops/*/trips. A URL outside that — reachable only via an
+        // explicit intent, since the OS wouldn't route it here — must simply open the app, not get
+        // bounced out to a browser.
+        assertFalse(ExternalDeepLinks.isUnhandledWebLink(webLink(pathSegments = listOf("about"))))
+        assertFalse(ExternalDeepLinks.isUnhandledWebLink(webLink(pathSegments = emptyList())))
+        assertFalse(
+            ExternalDeepLinks.isUnhandledWebLink(
+                webLink(pathSegments = listOf("regions", "1", "stops", "1_75403"))
+            )
+        )
+    }
+
+    @Test
     fun `links we were never claiming are not unhandled web links`() {
         // Only the web filter is broader than the parser. A foreign host never reached us, an http URL
         // isn't in the filter, and an unrecognized custom-scheme link is a dead link, not a web page —

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/nav/ExternalDeepLinksTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/nav/ExternalDeepLinksTest.kt
@@ -21,6 +21,7 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.onebusaway.android.BuildConfig
+import org.onebusaway.android.region.CustomRegionRequest
 import org.onebusaway.android.ui.nav.ExternalDeepLinks.Link
 import org.onebusaway.android.ui.nav.ExternalDeepLinks.Target
 import org.onebusaway.android.ui.nav.ExternalDeepLinks.parse
@@ -95,29 +96,79 @@ class ExternalDeepLinksTest {
         assertNull(parse(appLink("view-stop", mapOf("stopID" to "")), schemes))
     }
 
-    // --- add-region (recognized here, but applied as a side effect rather than routed) ---
+    // --- add-region: a full custom-region request (#2027), applied only after the rider confirms ---
 
     @Test
-    fun `add-region carries the custom API URLs`() {
+    fun `add-region carries the whole region the link describes`() {
         val target = parse(
             appLink(
                 "add-region",
-                mapOf("oba-url" to "https://api.example.com", "otp-url" to "https://otp.example.com")
+                mapOf(
+                    "name" to "Test Deployment",
+                    "oba-url" to "https://api.example.com",
+                    "otp-url" to "https://otp.example.com",
+                    "sidecar-url" to "https://sidecar.example.com",
+                    "umami-url" to "https://umami.example.com",
+                    "umami-id" to "abc123"
+                )
             ),
             schemes
         )
         assertEquals(
-            Target.AddRegion(obaUrl = "https://api.example.com", otpUrl = "https://otp.example.com"),
+            Target.AddRegion(
+                CustomRegionRequest(
+                    name = "Test Deployment",
+                    obaBaseUrl = "https://api.example.com",
+                    otpBaseUrl = "https://otp.example.com",
+                    sidecarBaseUrl = "https://sidecar.example.com",
+                    umamiAnalyticsUrl = "https://umami.example.com",
+                    umamiAnalyticsId = "abc123"
+                )
+            ),
             target
         )
     }
 
     @Test
-    fun `add-region reports absent and blank URLs alike as null`() {
-        // Validating and applying the URLs is the region domain's job; absent means "don't touch it".
+    fun `add-region needs only a name and an oba-url`() {
         assertEquals(
-            Target.AddRegion(obaUrl = "https://api.example.com", otpUrl = null),
-            parse(appLink("add-region", mapOf("oba-url" to "https://api.example.com", "otp-url" to "")), schemes)
+            Target.AddRegion(
+                CustomRegionRequest(name = "Test", obaBaseUrl = "https://api.example.com")
+            ),
+            parse(
+                appLink("add-region", mapOf("name" to "Test", "oba-url" to "https://api.example.com")),
+                schemes
+            )
+        )
+    }
+
+    @Test
+    fun `add-region without a name is not a deep link`() {
+        // Matches iOS, which requires it. Note this is stricter than pre-#2027 Android, where a bare
+        // `add-region?oba-url=...` set a pair of API-URL preferences — see docs/DEEP_LINKING.md.
+        assertNull(parse(appLink("add-region", mapOf("oba-url" to "https://api.example.com")), schemes))
+    }
+
+    @Test
+    fun `add-region without an oba-url is not a deep link`() {
+        // A region with no OBA server can't answer anything, so there is nothing to add.
+        assertNull(parse(appLink("add-region", mapOf("name" to "Test")), schemes))
+    }
+
+    @Test
+    fun `add-region treats blank parameters as absent`() {
+        assertNull(parse(appLink("add-region", mapOf("name" to "", "oba-url" to "https://api.example.com")), schemes))
+        assertEquals(
+            Target.AddRegion(
+                CustomRegionRequest(name = "Test", obaBaseUrl = "https://api.example.com", otpBaseUrl = null)
+            ),
+            parse(
+                appLink(
+                    "add-region",
+                    mapOf("name" to "Test", "oba-url" to "https://api.example.com", "otp-url" to "")
+                ),
+                schemes
+            )
         )
     }
 

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/nav/ExternalDeepLinksTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/nav/ExternalDeepLinksTest.kt
@@ -87,9 +87,30 @@ class ExternalDeepLinksTest {
         assertNull(parse(appLink("view-stop", mapOf("stopID" to "")), schemes))
     }
 
+    // --- add-region (recognized here, but applied as a side effect rather than routed) ---
+
     @Test
-    fun `add-region is not a route - its URLs apply as a side effect`() {
-        assertNull(parse(appLink("add-region", mapOf("oba-url" to "https://api.example.com")), schemes))
+    fun `add-region carries the custom API URLs`() {
+        val target = parse(
+            appLink(
+                "add-region",
+                mapOf("oba-url" to "https://api.example.com", "otp-url" to "https://otp.example.com")
+            ),
+            schemes
+        )
+        assertEquals(
+            Target.AddRegion(obaUrl = "https://api.example.com", otpUrl = "https://otp.example.com"),
+            target
+        )
+    }
+
+    @Test
+    fun `add-region reports absent and blank URLs alike as null`() {
+        // Validating and applying the URLs is the region domain's job; absent means "don't touch it".
+        assertEquals(
+            Target.AddRegion(obaUrl = "https://api.example.com", otpUrl = null),
+            parse(appLink("add-region", mapOf("oba-url" to "https://api.example.com", "otp-url" to "")), schemes)
+        )
     }
 
     @Test
@@ -147,31 +168,17 @@ class ExternalDeepLinksTest {
     }
 
     @Test
-    fun `a stop-only web path is not a deep link`() {
-        // Matches iOS: only the /trips endpoint decodes; a stop page falls through to the browser.
-        assertNull(parse(webLink(pathSegments = listOf("regions", "1", "stops", "1_75403")), schemes))
-    }
-
-    @Test
-    fun `a trip path with a trailing segment is not a deep link`() {
-        val path = listOf("regions", "1", "stops", "1_75403", "trips", "extra")
-        assertNull(parse(webLink(pathSegments = path), schemes))
-    }
-
-    @Test
-    fun `a misspelled trip path is not a deep link`() {
-        val path = listOf("regions", "1", "stations", "1_75403", "trips")
-        assertNull(parse(webLink(pathSegments = path), schemes))
-    }
-
-    @Test
-    fun `a trip link with a blank stop id in its path is not a deep link`() {
-        val path = listOf("regions", "1", "stops", "", "trips")
-        assertNull(parse(webLink(pathSegments = path), schemes))
-    }
-
-    @Test
-    fun `a bare host with no path is not a deep link`() {
-        assertNull(parse(webLink(pathSegments = emptyList(), params = emptyMap()), schemes))
+    fun `only the exact trips path shape is a deep link`() {
+        val rejected = listOf(
+            // Matches iOS: only the /trips endpoint decodes; a stop page falls through to the browser.
+            listOf("regions", "1", "stops", "1_75403"),
+            listOf("regions", "1", "stops", "1_75403", "trips", "extra"),
+            listOf("regions", "1", "stations", "1_75403", "trips"),
+            listOf("regions", "1", "stops", "", "trips"),
+            emptyList()
+        )
+        rejected.forEach { path ->
+            assertNull("path $path", parse(webLink(pathSegments = path), schemes))
+        }
     }
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/nav/ExternalDeepLinksTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/nav/ExternalDeepLinksTest.kt
@@ -16,23 +16,31 @@
 package org.onebusaway.android.ui.nav
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.onebusaway.android.BuildConfig
 import org.onebusaway.android.ui.nav.ExternalDeepLinks.Link
 import org.onebusaway.android.ui.nav.ExternalDeepLinks.Target
 import org.onebusaway.android.ui.nav.ExternalDeepLinks.parse
 
 /**
- * Unit tests for the cross-platform (iOS-parity) deep-link parser (#2027). The `Uri` decomposition
- * lives in `IntentRouteMapper.read`, so these exercise the pure vocabulary: which links are
- * recognized, which are deliberately not, and what each maps to.
+ * Unit tests for the cross-platform (iOS-parity) deep-link parser (#2027). These exercise the pure
+ * vocabulary — which links are recognized, which are deliberately not, and what each maps to. The
+ * `Uri` decomposition that feeds it (`ExternalDeepLinks.toLink`) needs a real `android.net.Uri`, so it
+ * is covered by the instrumented `ExternalDeepLinksUriTest` instead.
  */
 class ExternalDeepLinksTest {
 
     /** Both schemes the OBA brand answers to; a brand build adds its own (e.g. `kiedybus`). */
     private val schemes = setOf("onebusaway", "kiedybus")
 
-    private fun appLink(host: String, params: Map<String, String> = emptyMap(), scheme: String = "onebusaway") = Link(scheme = scheme, host = host, pathSegments = emptyList(), params = params)
+    private fun appLink(
+        host: String,
+        params: Map<String, String> = emptyMap(),
+        scheme: String = "onebusaway"
+    ) = Link(scheme = scheme, host = host, pathSegments = emptyList(), params = params)
 
     private fun webLink(
         host: String = "onebusaway.co",
@@ -181,11 +189,64 @@ class ExternalDeepLinksTest {
             listOf("regions", "1", "stops", "1_75403"),
             listOf("regions", "1", "stops", "1_75403", "trips", "extra"),
             listOf("regions", "1", "stations", "1_75403", "trips"),
+            // Unreachable from a real Uri (getPathSegments() drops empty segments); guards the pure
+            // entry point, which any caller may hand a directly-constructed Link.
             listOf("regions", "1", "stops", "", "trips"),
             emptyList()
         )
         rejected.forEach { path ->
             assertNull("path $path", parse(webLink(pathSegments = path), schemes))
         }
+    }
+
+    // --- links the manifest filter claims but the parser can't route (handed back to the browser) ---
+
+    @Test
+    fun `a claimed web link the parser can't route is an unhandled web link`() {
+        // The intent-filter can't see the query string, so a trip URL stripped of its trip_id still
+        // launches the app; it must go back to the browser rather than land on the map.
+        assertTrue(ExternalDeepLinks.isUnhandledWebLink(webLink(params = emptyMap())))
+        // pathPattern's `.*` spans '/', so a deeper path clears the filter too.
+        assertTrue(
+            ExternalDeepLinks.isUnhandledWebLink(
+                webLink(pathSegments = listOf("regions", "1", "x", "stops", "1_75403", "trips"))
+            )
+        )
+    }
+
+    @Test
+    fun `a routable web link is not an unhandled web link`() {
+        assertFalse(ExternalDeepLinks.isUnhandledWebLink(webLink()))
+    }
+
+    @Test
+    fun `links we were never claiming are not unhandled web links`() {
+        // Only the web filter is broader than the parser. A foreign host never reached us, an http URL
+        // isn't in the filter, and an unrecognized custom-scheme link is a dead link, not a web page —
+        // handing any of these to a browser would be wrong.
+        assertFalse(ExternalDeepLinks.isUnhandledWebLink(webLink(host = "example.com")))
+        assertFalse(ExternalDeepLinks.isUnhandledWebLink(webLink().copy(scheme = "http")))
+        assertFalse(ExternalDeepLinks.isUnhandledWebLink(appLink("view-route")))
+    }
+
+    // --- the per-brand scheme derived from the deepLinkScheme manifest placeholder ---
+
+    @Test
+    fun `this build answers to the shared scheme and to its own`() {
+        // Guards the Gradle wiring itself (deepLinkScheme placeholder -> BuildConfig.DEEP_LINK_SCHEME ->
+        // APP_SCHEMES), which every other test in this class bypasses by passing an explicit scheme set.
+        // A placeholder that failed to resolve would surface here as a blank or literal-"${…}" scheme.
+        assertTrue("shared scheme missing", "onebusaway" in ExternalDeepLinks.APP_SCHEMES)
+        assertTrue("brand scheme is blank", BuildConfig.DEEP_LINK_SCHEME.isNotBlank())
+        assertFalse("placeholder unresolved", BuildConfig.DEEP_LINK_SCHEME.contains("$"))
+        assertTrue(BuildConfig.DEEP_LINK_SCHEME in ExternalDeepLinks.APP_SCHEMES)
+    }
+
+    @Test
+    fun `the default appSchemes overload accepts this build's own scheme`() {
+        assertEquals(
+            Target.Stop("1_75403"),
+            parse(appLink("view-stop", mapOf("stopID" to "1_75403"), scheme = BuildConfig.DEEP_LINK_SCHEME))
+        )
     }
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/nav/IntentRouteMapperTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/nav/IntentRouteMapperTest.kt
@@ -21,6 +21,7 @@ import org.onebusaway.android.ui.mylists.MyTabs
 import org.onebusaway.android.ui.nav.IntentRouteMapper.RouteDecision
 import org.onebusaway.android.ui.nav.IntentRouteMapper.RouteIntent
 import org.onebusaway.android.ui.nav.IntentRouteMapper.decide
+import org.onebusaway.android.ui.tripdetails.TripDetailsLauncher
 
 /**
  * Unit tests for the pure route-precedence decision [IntentRouteMapper.decide] — the branch order +
@@ -168,6 +169,59 @@ class IntentRouteMapperTest {
         assertEquals(
             RouteDecision.None,
             decide(RouteIntent(pathSegments = listOf("service_alerts", "abc")))
+        )
+    }
+
+    // --- cross-platform (iOS-parity) deep links; the URI parsing itself is ExternalDeepLinksTest ---
+
+    @Test
+    fun `a view-stop deep link opens that stop's arrivals`() {
+        assertEquals(
+            RouteDecision.Arrivals("1_75403"),
+            decide(RouteIntent(deepLinkTarget = ExternalDeepLinks.Target.Stop("1_75403")))
+        )
+    }
+
+    @Test
+    fun `a web trip deep link opens the trip scrolled to the shared stop`() {
+        assertEquals(
+            RouteDecision.TripDetails("1_18196913", "1_75403", TripDetailsLauncher.SCROLL_MODE_STOP),
+            decide(
+                RouteIntent(
+                    deepLinkTarget = ExternalDeepLinks.Target.Trip(
+                        tripId = "1_18196913",
+                        stopId = "1_75403"
+                    )
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `add-region still wins over a deep-link target on the same URI`() {
+        // Belt-and-braces on the branch order: add-region's URLs apply as a side effect and it stays
+        // on the home/map path, so it must not be overtaken by a later routing branch.
+        assertEquals(
+            RouteDecision.None,
+            decide(
+                RouteIntent(
+                    isAddRegion = true,
+                    deepLinkTarget = ExternalDeepLinks.Target.Stop("1_75403")
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `a deep-link target beats the content data-URI path branches`() {
+        assertEquals(
+            RouteDecision.Arrivals("1_75403"),
+            decide(
+                RouteIntent(
+                    deepLinkTarget = ExternalDeepLinks.Target.Stop("1_75403"),
+                    pathSegments = listOf(DeepLinkUris.ROUTES_PATH, "1_100224")
+                )
+            )
         )
     }
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/nav/IntentRouteMapperTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/nav/IntentRouteMapperTest.kt
@@ -56,7 +56,13 @@ class IntentRouteMapperTest {
         // The URLs apply as a side effect (HomeActivity); routing stays on the home/map path.
         assertEquals(
             RouteDecision.None,
-            decide(RouteIntent(isAddRegion = true, isSearch = true, searchQuery = "x"))
+            decide(
+                RouteIntent(
+                    deepLink = ExternalDeepLinks.Target.AddRegion("https://api.example.com", null),
+                    isSearch = true,
+                    searchQuery = "x"
+                )
+            )
         )
     }
 
@@ -178,7 +184,7 @@ class IntentRouteMapperTest {
     fun `a view-stop deep link opens that stop's arrivals`() {
         assertEquals(
             RouteDecision.Arrivals("1_75403"),
-            decide(RouteIntent(deepLinkTarget = ExternalDeepLinks.Target.Stop("1_75403")))
+            decide(RouteIntent(deepLink = ExternalDeepLinks.Target.Stop("1_75403")))
         )
     }
 
@@ -188,25 +194,10 @@ class IntentRouteMapperTest {
             RouteDecision.TripDetails("1_18196913", "1_75403", TripDetailsLauncher.SCROLL_MODE_STOP),
             decide(
                 RouteIntent(
-                    deepLinkTarget = ExternalDeepLinks.Target.Trip(
+                    deepLink = ExternalDeepLinks.Target.Trip(
                         tripId = "1_18196913",
                         stopId = "1_75403"
                     )
-                )
-            )
-        )
-    }
-
-    @Test
-    fun `add-region still wins over a deep-link target on the same URI`() {
-        // Belt-and-braces on the branch order: add-region's URLs apply as a side effect and it stays
-        // on the home/map path, so it must not be overtaken by a later routing branch.
-        assertEquals(
-            RouteDecision.None,
-            decide(
-                RouteIntent(
-                    isAddRegion = true,
-                    deepLinkTarget = ExternalDeepLinks.Target.Stop("1_75403")
                 )
             )
         )
@@ -218,7 +209,7 @@ class IntentRouteMapperTest {
             RouteDecision.Arrivals("1_75403"),
             decide(
                 RouteIntent(
-                    deepLinkTarget = ExternalDeepLinks.Target.Stop("1_75403"),
+                    deepLink = ExternalDeepLinks.Target.Stop("1_75403"),
                     pathSegments = listOf(DeepLinkUris.ROUTES_PATH, "1_100224")
                 )
             )

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/nav/IntentRouteMapperTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/nav/IntentRouteMapperTest.kt
@@ -17,6 +17,7 @@ package org.onebusaway.android.ui.nav
 
 import org.junit.Assert.assertEquals
 import org.junit.Test
+import org.onebusaway.android.region.CustomRegionRequest
 import org.onebusaway.android.ui.mylists.MyTabs
 import org.onebusaway.android.ui.nav.IntentRouteMapper.RouteDecision
 import org.onebusaway.android.ui.nav.IntentRouteMapper.RouteIntent
@@ -58,7 +59,9 @@ class IntentRouteMapperTest {
             RouteDecision.None,
             decide(
                 RouteIntent(
-                    deepLink = ExternalDeepLinks.Target.AddRegion("https://api.example.com", null),
+                    deepLink = ExternalDeepLinks.Target.AddRegion(
+                        CustomRegionRequest(name = "Test", obaBaseUrl = "https://api.example.com")
+                    ),
                     isSearch = true,
                     searchQuery = "x"
                 )


### PR DESCRIPTION
Fixes #2027. Fixes #2030.

OneBusAway for iOS answers a [documented set of deep links](https://developer.onebusaway.org/projects/ios); Android answered only one of them (`onebusaway://add-region`), so a stop or trip link shared from iOS — or from the sidecar web UI — dead-ended in a browser. This adopts the same vocabulary.

| Link | Opens |
| --- | --- |
| `onebusaway://view-stop?stopID=1_75403&regionID=1` | that stop's arrivals |
| `https://onebusaway.co/regions/1/stops/1_75403/trips?trip_id=…&service_date=…&stop_sequence=…` | that trip's details, scrolled to the stop in the path |

Custom-scheme links also resolve under a brand's own scheme now (`kiedybus://` for KiedyBus, matching iOS). The cross-platform `onebusaway` scheme keeps working for every brand, so no existing link regresses.

## Design

`ExternalDeepLinks` owns this vocabulary end to end — schemes, hosts, path shape, parameter names — and parses a link into what it *means* (`Target.Stop` / `Target.Trip` / `Target.AddRegion`). `parse` is pure (its input is an already-decomposed URI), so the whole vocabulary is JVM-unit-tested; a thin `Uri` overload is the Android-facing entry point. `IntentRouteMapper` maps the parsed link to a NavHost route through its existing route-precedence decision, and `HomeActivity` runs the domain mutation `add-region` implies. Both new links land on destinations that were already reachable, so nothing downstream changes.

Each brand's scheme is declared **once**, as the `deepLinkScheme` manifest placeholder (defaulted to `onebusaway` in `defaultConfig`, overridden only by KiedyBus). `BuildConfig.DEEP_LINK_SCHEME` — and through it `ExternalDeepLinks.APP_SCHEMES` — is derived from that placeholder, so the manifest filter and the parser can't disagree about which scheme a brand advertises. The derivation runs in `androidComponents.onVariants`, reading `manifestPlaceholders` as the lazy `MapProperty` it is and handing `buildConfigFields` a `Provider` — so it carries no ordering dependency on when a flavor is registered.

The `https` app-link filter lives in a new `src/oba/AndroidManifest.xml` rather than `src/main`: these hosts belong to the OBA deployment, a white-label brand can never verify them (verification matches the *installed* app's signing certificate), and on API < 31 an unverifiable filter would still drag that brand into the link-handling chooser for someone else's links.

## Needs a server-side step, and is *not* inert until it lands

`android:autoVerify="true"` only takes effect once `onebusaway.co`, `www.onebusaway.co`, and `sidecar.onebusaway.org` each serve `/.well-known/assetlinks.json` listing `com.joulespersecond.seattlebusbot` and the release signing certificate's SHA-256 fingerprint. Worth a companion issue on the server side.

Until then the consequence differs by API level, and `minSdk` is 23:

| API level | Behaviour before `assetlinks.json` is live |
| --- | --- |
| 31+ | An unverified domain isn't offered to the app at all — the link opens in the browser exactly as today. No user-visible change. |
| 23–30 | No such gating. The app still *matches* the filter, so tapping a `onebusaway.co` link raises the browser-or-OneBusAway **disambiguation chooser** instead of going straight to the browser. |

So this does change behaviour for users on Android 6–11 the moment it ships — the same argument `src/oba/AndroidManifest.xml` already makes for keeping the filter out of `src/main`, applied to the OBA brand itself. Flagging it rather than gating on it; **if you'd rather not take that until the server side is ready, drop `src/oba/AndroidManifest.xml` and the rest of the PR stands unchanged.** Documented in `docs/DEEP_LINKING.md`.

The filter can be exercised directly regardless of verification state:

```bash
adb shell am start -a android.intent.action.VIEW \
  -d 'onebusaway://view-stop?stopID=1_75403&regionID=1' \
  com.joulespersecond.seattlebusbot
```

## Links the filter claims but the parser can't route

An intent-filter is necessarily a *superset* of `ExternalDeepLinks.parse`: it can't inspect the query string (so it can't require `trip_id`), and `pathPattern` is a `PATTERN_SIMPLE_GLOB` whose `.*` spans `/` (`pathAdvancedPattern` would fix that, but it's API 31+). So a trimmed or deeper `onebusaway.co` URL can launch the app with nowhere to go.

`ExternalDeepLinks.isUnhandledWebLink` identifies those and `HomeActivity` hands them back to the browser via `ExternalIntents.openInBrowser`, which resolves an explicit browser package first — a plain `ACTION_VIEW` would re-match our own filter and bounce straight back. The new `<queries>` element makes browsers visible to that resolution on API 30+. Without this the user's link is swallowed and they land on the map instead of the page they tapped.

## Custom regions (full `add-region` parity) + a consent gate

`add-region` used to set a pair of API-URL preferences: no region, no name, nothing in the picker, and every iOS parameter beyond the two URLs discarded. It now creates a **real named, persisted, selectable region** — what the link does on iOS — and, unlike iOS, asks the rider first.

| Parameter | Required | Becomes |
| --- | --- | --- |
| `name` | **yes** | The region's display name in the picker |
| `oba-url` | **yes** | `Region.obaBaseUrl` |
| `otp-url` | no | `Region.otpBaseUrl` |
| `sidecar-url` | no | `Region.sidecarBaseUrl` |
| `umami-url` / `umami-id` | no | `Region.umamiAnalytics` |

**Persistence.** A `custom` flag on the regions table (Room **v10**, additive, `NOT NULL DEFAULT 0`) keeps a rider's region out of the directory refresh's blast radius: `RegionDao.replaceAll` deletes only `custom = 0` rows, and `RegionCache.loadRegions` unions the custom ones back into every return path — otherwise a forced reload drops the region out of the picker list. Ids are negative, counting down from `-2`, so they can't collide with a directory id (`>= 0`) or the `-1` "no region" sentinel. Re-sending the same `oba-url` updates that region in place rather than duplicating it.

**Never auto-selected, never auto-replaced.** A custom region carries no bounds, so `getClosestRegion` already skipped it — but auto-select would still have switched *away* from it to whatever was nearest, silently undoing the link. `resolveRegionStatus` now leaves a current custom region alone.

> That guard exposed a latent bug worth calling out: `refresh()`'s `Unchanged` branch re-applies `closest` as a "refresh its contents silently" step, which is only sound while `closest` **is** the current region. `Unchanged` no longer implies that, so it now matches on id. Without the fix a custom region would have been quietly replaced on the next refresh anyway.

**Consent (fixes #2030).** The filter is `BROWSABLE`, so any web page can fire an `add-region` link, and accepting one repoints every API the app talks to. `HomeActivity` stages the parsed request in `AddRegionViewModel`; **nothing is written** until the rider accepts a dialog naming the servers involved. The dialog leads with the server URLs rather than the region name, because the name is attacker-supplied text and says nothing about where data would come from. Declining writes nothing. This is a deliberate divergence from iOS, which applies the region with no prompt.

**Removal.** Custom regions appear in the region picker like any other and **long-press to remove** — the way back out of a link you regret. Removing the region you're currently on re-resolves as if none had been set.

**Declared, not observed.** `supportsObaDiscoveryApis`/`supportsObaRealtimeApis` are set true because `RegionUtils.isRegionUsable` requires them; nothing has probed the server, and that is documented at the construction site along with its failure mode (requests fail visibly, like any unreachable server — nothing silently reads as empty). `contactEmail` is left empty rather than iOS's hardcoded `example@example.com`, which correctly hides the "email a problem report" option instead of mailing a made-up address.

### ⚠️ Breaking: `name` is now required

A bare `onebusaway://add-region?oba-url=…` **no longer resolves at all**, matching iOS. This was the explicitly chosen trade-off over keeping a legacy preferences fallback: a nameless region has nothing to show in a picker. Any link in the wild that omits `name` needs one added. Called out in `docs/DEEP_LINKING.md`.

## Deliberate divergences from iOS

All documented in `docs/DEEP_LINKING.md`:

- Parameters no Android screen consumes are **recognized and ignored** rather than required — `regionID` (iOS parses it but also only ever searches the current region), and the trip link's `service_date`, `stop_sequence`, `title`, `vehicle_id`, `destination_stop_id`. So every link iOS accepts is accepted here.
- Stop-only web paths (`/regions/{id}/stops/{id}` with no `/trips`) stay non-links, matching iOS.
- iOS `NSUserActivity` handoff / Siri / Spotlight have no Android equivalent.

## Testing

- **1267 unit tests** green, including 22 new ones: `CustomRegionsTest` (id allocation + the invariants a link-built region must hold), `AddRegionViewModelTest` (the consent gate — chiefly that staging writes *nothing*), the rewritten `add-region` parsing, and the `resolveRegionStatus` custom-region guard.
- **15 instrumented tests** green on a physical device (Pixel 7 Pro, API 36), including a new `migrate9To10` test asserting a region cached before custom regions existed reads back as a directory region, validated against the exported `10.json`.
- `spotlessCheck`, `assembleObaGoogleDebug`, `assembleKiedybusGoogleDebug` pass. Merged manifests checked for `oba` / `kiedybus` / `agencyX`; `BuildConfig.DEEP_LINK_SCHEME` checked per brand.
- Not exercised end-to-end on a device: the `adb` commands in `docs/DEEP_LINKING.md` are the useful manual check, and the `add-region` one now raises the confirmation dialog.

**On the pre-existing lint error:** `lintObaGoogleDebug` reports one error, `NonObservableLocale` at `TripResultsScreen.kt:875` (`uppercase(Locale.getDefault())` in a composable). It is unrelated to this branch — the line is identical on `main` and this PR doesn't touch that file. It will **not** turn this PR's CI red: `.github/workflows/android.yml` passes `-x lint` on the PR/push path deliberately (lint is ~7–15 min and would dominate that job), and lint runs instead in the nightly `lint` job. So it needs its own fix on `main`, not a fix here — happy to do it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consent-gated `add-region` deep linking to create custom regions and confirm failures, plus long-press removal from the region picker.
  * Expanded deep linking to support `view-stop` arrivals and App Links trip URLs (with stop-scrolling).
  * Introduced brand-specific deep-link schemes and verified OneBusAway/App Links handling.
* **Documentation**
  * Published deep-link behavior/specs and updated flavor, custom server, and rebranding guidance.
* **Bug Fixes**
  * Improved routing for unsupported/invalid links and correctly hands unhandled web links back to the browser.
* **Tests**
  * Added unit and instrumentation coverage for deep-link parsing, routing, and `add-region` consent logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

