### PR TITLE
Build release notes from Changelog commit trailers

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -33,6 +33,44 @@ first. The one-time bulk reformat is listed in `.git-blame-ignore-revs`; enable 
 `git config blame.ignoreRevsFile .git-blame-ignore-revs` so `git blame` skips it (GitHub does this
 automatically).
 
+## Changelog entries
+
+Pull requests are squashed when they merge, so your PR becomes one commit on `main`, and that commit
+message is what the release notes are built from. Two things follow from that:
+
+**Write the subject as a changelog line.** Imperative, plain language, issue number at the end — it
+gets read by people scanning a release, not just by people reading `git log`:
+
+```
+Offer bikeshare trips where the OTP2 server supports them (#2017)
+```
+
+**If a rider would notice the change, add a `Changelog:` trailer** at the very end of the message,
+describing the effect in their words rather than the code's:
+
+```
+Changelog: Bikeshare trips now show up in the trip planner.
+```
+
+Most PRs don't need one — refactors, dependency bumps, test changes and internal cleanups are covered
+by their subject line alone. The trailer is for the few changes per release that a rider would notice,
+because "Fold report/ into ui/report/ and wire its ViewModels through Hilt" is the right subject and
+the wrong sentence to show someone waiting for a bus. Keep it to one sentence: a release's trailers
+share a 500-character Google Play budget.
+
+The trailer must be in the trailer block at the end of the message or git won't read it as one. If
+your branch has several commits, check the squashed message in the merge box before merging —
+GitHub concatenates the individual commit messages, which can leave the trailer stranded mid-body.
+`tools/release-notes.sh` warns when that happens.
+
+To have the format in front of you when you commit, opt into the message template:
+
+```bash
+git config commit.template .gitmessage
+```
+
+See [BUILD.md](../docs/BUILD.md#release-notes) for how the notes are generated at release time.
+
 ## Closing policy for issues and pull requests
 
 OneBusAway for Android is a popular project and the capacity to deal with issues and pull requests is limited. Out of respect for our volunteers, issues and pull requests not in line with the guidelines listed in this document may be closed without notice.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,3 +3,5 @@ Please make sure these boxes are checked before submitting your pull request - t
 - [ ] Format your changes with `./gradlew spotlessApply`.
 
 - [ ] Run the unit tests with `gradlew connectedObaGoogleDebugAndroidTest` to make sure you didn't break anything
+
+- [ ] If a rider would notice this change, end your commit message with a `Changelog:` trailer describing the effect in their words — see [Changelog entries](CONTRIBUTING.md#changelog-entries). Most PRs don't need one.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,6 @@ Please make sure these boxes are checked before submitting your pull request - t
 
 - [ ] Format your changes with `./gradlew spotlessApply`.
 
-- [ ] Run the unit tests with `gradlew connectedObaGoogleDebugAndroidTest` to make sure you didn't break anything
+- [ ] Run the unit tests with `./gradlew connectedObaGoogleDebugAndroidTest` to make sure you didn't break anything
 
 - [ ] If a rider would notice this change, end your commit message with a `Changelog:` trailer describing the effect in their words — see [Changelog entries](CONTRIBUTING.md#changelog-entries). Most PRs don't need one.

--- a/.gitmessage
+++ b/.gitmessage
@@ -4,15 +4,13 @@
 # Body: why, and anything a reviewer or a future archaeologist would want.
 #
 # If a rider would notice this change, end the message with a Changelog trailer
-# describing the effect in their words, not the code's. It becomes a bullet in
-# the Play Store "What's new" text and in the GitHub release. Most commits do
-# not need one — the subject line above is already the developer-facing entry.
+# describing the effect in their words, not the code's. Most commits don't need
+# one — the subject line above is already the developer-facing entry.
 #
 #   Changelog: Bikeshare trips now show up in the trip planner.
 #
-# Keep it to one sentence: all of a release's trailers share a 500-character
-# budget, and tools/release-notes.sh fails the release if they overrun it.
+# Keep it to one sentence; a release's trailers share a character budget that
+# tools/release-notes.sh enforces. The trailer has to be in the block at the
+# very end of the message or git won't read it.
 #
-# The trailer must be in the trailer block at the very end of the message, or
-# git will not read it. Squashing a branch through the GitHub merge box
-# concatenates commit messages, so check the final message before merging.
+# See .github/CONTRIBUTING.md#changelog-entries.

--- a/.gitmessage
+++ b/.gitmessage
@@ -1,0 +1,18 @@
+# Subject: what the change does, in the imperative, with the issue number.
+#   Offer bikeshare trips where the OTP2 server supports them (#2017)
+#
+# Body: why, and anything a reviewer or a future archaeologist would want.
+#
+# If a rider would notice this change, end the message with a Changelog trailer
+# describing the effect in their words, not the code's. It becomes a bullet in
+# the Play Store "What's new" text and in the GitHub release. Most commits do
+# not need one — the subject line above is already the developer-facing entry.
+#
+#   Changelog: Bikeshare trips now show up in the trip planner.
+#
+# Keep it to one sentence: all of a release's trailers share a 500-character
+# budget, and tools/release-notes.sh fails the release if they overrun it.
+#
+# The trailer must be in the trailer block at the very end of the message, or
+# git will not read it. Squashing a branch through the GitHub merge box
+# concatenates commit messages, so check the final message before merging.

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -71,7 +71,11 @@ Note that the paths in these files always use the Unix path separator `/`, even 
 
 Before doing each release build, you'll need to:
 1. Set `versionName` in `onebusaway-android/build.gradle.kts` to the appropriate next semantic version name. If you are using the automated publishing workflow (see below), `versionCode` is auto-incremented. Otherwise, bump `versionCode` by 1 manually.
-2. Check `onebusaway-android/src/main/res/values/strings.xml` element `main_help_whatsnew` to make sure that the latest changes we want to highlight for the user are entered there. After update, users see this in a dialog.
+2. Generate the Play Store release notes from the commit trailers (see [Release notes](#release-notes)):
+   ```
+   tools/release-notes.sh play --write
+   ```
+3. Check `onebusaway-android/src/main/res/values/strings.xml` element `main_help_whatsnew`. After update, users see this in a dialog. This string is deliberately generic and translated into four locales, so it normally does not change between releases — it points riders at the release notes rather than restating them.
 
 Then, to build all flavors run:
 
@@ -117,6 +121,46 @@ This creates a `src/obaGoogleRelease/play/` directory with your listing text, gr
 
 The default configuration (in `onebusaway-android/build.gradle.kts`) publishes App Bundles to the **beta** (open testing) track with auto-incrementing `versionCode`. To change the target track, update the `track` property in the `play {}` block to `"internal"`, `"alpha"`, or `"production"`.
 
+### Release notes
+
+Release notes are assembled from the commit messages on `main`. Every PR lands as a single squashed
+commit, so one commit is one change, and the commit message is where that change describes itself.
+
+A commit may end with an optional `Changelog:` trailer stating what the change means to a rider:
+
+```
+Offer bikeshare trips where the OTP2 server supports them (#2017)
+
+<body>
+
+Changelog: Bikeshare trips now show up in the trip planner.
+```
+
+Most commits should not have one. A commit subject is already a good developer-facing changelog line,
+and every subject appears in the GitHub release body regardless. The trailer exists only for the
+handful of changes per release that a rider would actually notice — those need different words than
+the subject line gives them. See [CONTRIBUTING.md](../.github/CONTRIBUTING.md#changelog-entries).
+
+`tools/release-notes.sh` turns those trailers into the two release artifacts:
+
+| Command | Output |
+|---|---|
+| `tools/release-notes.sh play` | The Play Store "What's new" text — the trailers as bullets |
+| `tools/release-notes.sh play --write` | ...and writes it to `src/obaGoogleRelease/play/release-notes/en-US/default.txt`, where GPP picks it up |
+| `tools/release-notes.sh github` | A GitHub release body: the trailers as "Highlights", then every commit subject under "All changes" |
+
+Both read the range since the most recent `v*` tag; pass `--since <ref>` to override.
+
+Google Play caps release notes at 500 characters per locale, and the script **fails** rather than
+truncating when the trailers overrun it — Play cuts from the end, which would drop an entry
+mid-word. Shorten or drop a trailer instead.
+
+The script also warns when a `Changelog:` line was written but not recognized. Git only reads a
+trailer in the block at the very end of a message, and squashing a multi-commit branch through the
+GitHub merge box concatenates the individual commit messages — which can strand a trailer in the
+middle of the body. Setting the repository's squash-merge default to "pull request title and
+description" makes the final message predictable and editable before merge, and avoids this.
+
 ### Release testing protocol
 
 Prior to uploading the app to Google Play, below is the release testing protocol. This effectively mirrors what a user would experience - installing the new release as an update to the existing release.
@@ -139,6 +183,16 @@ git push origin vx.y.z
 ```
 
 Then I create a new release on GitHub using https://github.com/OneBusAway/onebusaway-android/releases/new, and reference this tag. I also attach the compiled APKs. I'll also mark "This is a pre-release" because releases go to the [OBA beta testing group](BETA_TESTING.md) first.
+
+To draft the release body from the commit messages instead of writing it by hand (see
+[Release notes](#release-notes)), generate it before pushing the tag and pass it to `gh`:
+
+```
+tools/release-notes.sh github > /tmp/notes.md
+git push origin vx.y.z
+gh release create vx.y.z --title vx.y.z --notes-file /tmp/notes.md --prerelease \
+    onebusaway-android/build/outputs/apk/obaGoogle/release/obaGoogleRelease-vx.y.z.apk
+```
 
 ### Releasing to Google Play
 

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -75,7 +75,7 @@ Before doing each release build, you'll need to:
    ```
    tools/release-notes.sh play --write
    ```
-3. Check `onebusaway-android/src/main/res/values/strings.xml` element `main_help_whatsnew`. After update, users see this in a dialog. This string is deliberately generic and translated into four locales, so it normally does not change between releases — it points riders at the release notes rather than restating them.
+3. Check `onebusaway-android/src/main/res/values/strings.xml` element `main_help_whatsnew` to make sure that the latest changes we want to highlight for the user are entered there. After update, users see this in a dialog. Note that this string is translated (`values-es`, `values-fi`, `values-it`, `values-pl`), so per-release edits leave those four locales describing the previous release until a translator catches up — which is why the current text is generic and points at the release notes rather than restating them. `release-notes.sh` deliberately does not touch it.
 
 Then, to build all flavors run:
 
@@ -126,20 +126,9 @@ The default configuration (in `onebusaway-android/build.gradle.kts`) publishes A
 Release notes are assembled from the commit messages on `main`. Every PR lands as a single squashed
 commit, so one commit is one change, and the commit message is where that change describes itself.
 
-A commit may end with an optional `Changelog:` trailer stating what the change means to a rider:
-
-```
-Offer bikeshare trips where the OTP2 server supports them (#2017)
-
-<body>
-
-Changelog: Bikeshare trips now show up in the trip planner.
-```
-
-Most commits should not have one. A commit subject is already a good developer-facing changelog line,
-and every subject appears in the GitHub release body regardless. The trailer exists only for the
-handful of changes per release that a rider would actually notice — those need different words than
-the subject line gives them. See [CONTRIBUTING.md](../.github/CONTRIBUTING.md#changelog-entries).
+A commit may end with an optional `Changelog:` trailer stating what the change means to a rider.
+Most commits don't have one — [CONTRIBUTING.md](../.github/CONTRIBUTING.md#changelog-entries) is
+where that convention is defined and is the page to send contributors to.
 
 `tools/release-notes.sh` turns those trailers into the two release artifacts:
 
@@ -147,19 +136,23 @@ the subject line gives them. See [CONTRIBUTING.md](../.github/CONTRIBUTING.md#ch
 |---|---|
 | `tools/release-notes.sh play` | The Play Store "What's new" text — the trailers as bullets |
 | `tools/release-notes.sh play --write` | ...and writes it to `src/obaGoogleRelease/play/release-notes/en-US/default.txt`, where GPP picks it up |
-| `tools/release-notes.sh github` | A GitHub release body: the trailers as "Highlights", then every commit subject under "All changes" |
+| `tools/release-notes.sh github` | The trailers as a "## Highlights" block, to prepend to a generated release body |
 
 Both read the range since the most recent `v*` tag; pass `--since <ref>` to override.
 
-Google Play caps release notes at 500 characters per locale, and the script **fails** rather than
-truncating when the trailers overrun it — Play cuts from the end, which would drop an entry
-mid-word. Shorten or drop a trailer instead.
+Three things worth knowing before you rely on it:
 
-The script also warns when a `Changelog:` line was written but not recognized. Git only reads a
-trailer in the block at the very end of a message, and squashing a multi-commit branch through the
-GitHub merge box concatenates the individual commit messages — which can strand a trailer in the
-middle of the body. Setting the repository's squash-merge default to "pull request title and
-description" makes the final message predictable and editable before merge, and avoids this.
+- **It fails rather than truncating** when the trailers overrun Google Play's per-locale character
+  cap. Play cuts from the end, which would drop an entry mid-word — shorten or drop a trailer instead.
+- **Only `en-US` is generated.** If the Play listing carries other locales, they keep whatever text
+  they already have until someone translates the new notes by hand.
+- **It warns when a `Changelog:` line was written somewhere git won't read it as a trailer**, and
+  names the commits. Git only reads the trailer block at the very end of a message, and squashing a
+  multi-commit branch through the GitHub merge box concatenates the individual commit messages, which
+  can strand one mid-body. In practice this repo's squash commits do keep a parseable trailer block,
+  so the warning is a backstop rather than a routine occurrence. Setting the repository's
+  squash-merge default to "pull request title and description" makes the final message predictable
+  and editable before merge, and rules the case out entirely.
 
 ### Release testing protocol
 
@@ -184,15 +177,17 @@ git push origin vx.y.z
 
 Then I create a new release on GitHub using https://github.com/OneBusAway/onebusaway-android/releases/new, and reference this tag. I also attach the compiled APKs. I'll also mark "This is a pre-release" because releases go to the [OBA beta testing group](BETA_TESTING.md) first.
 
-To draft the release body from the commit messages instead of writing it by hand (see
-[Release notes](#release-notes)), generate it before pushing the tag and pass it to `gh`:
+To draft the release body instead of writing it by hand (see [Release notes](#release-notes)), let
+`gh` generate the commit and PR list and prepend the rider-facing highlights to it:
 
 ```
-tools/release-notes.sh github > /tmp/notes.md
 git push origin vx.y.z
-gh release create vx.y.z --title vx.y.z --notes-file /tmp/notes.md --prerelease \
+gh release create vx.y.z --generate-notes --notes "$(tools/release-notes.sh github)" --prerelease \
     onebusaway-android/build/outputs/apk/obaGoogle/release/obaGoogleRelease-vx.y.z.apk
 ```
+
+`--generate-notes` is GitHub's own release-notes API — it supplies the changed-PR list, authors, and
+the full-changelog link, so the script only has to produce the part GitHub can't know.
 
 ### Releasing to Google Play
 
@@ -200,7 +195,7 @@ After you've created the release on GitHub, head to the [Google Play developer c
 1. Go to OneBusAway main app and then "Testing->Open testing"
 2. Create a new release and upload the new `obaGoogleRelease-vx.y.z.apk` APK
 3. Keep all the existing APKs that are already there as "Included", except the current production release. This makes sure that everyone with older version Android devices can still download the app. So only the current production release should be under "Not Included".
-4. Type in the version number `vx.y.z` in the release name, and you can typically copy the release notes from a previous release and edit accordingly for whatever you want users to see in the "What's new" section of Google Play (typically this should match the in-app string `main_help_whatsnew` mentioned above).
+4. Type in the version number `vx.y.z` in the release name. For the "What's new" text, paste the output of `tools/release-notes.sh play` (see [Release notes](#release-notes)) — if you published with GPP rather than by hand, that text was already uploaded from `release-notes/en-US/default.txt` and there is nothing to paste.
 5. Review and publish release to beta testing group (I usually immediately push to all beta testing users)
 6. Announce beta release on the [onebusaway-developers Google Group](https://groups.google.com/g/onebusaway-developers).
 

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -195,7 +195,7 @@ After you've created the release on GitHub, head to the [Google Play developer c
 1. Go to OneBusAway main app and then "Testing->Open testing"
 2. Create a new release and upload the new `obaGoogleRelease-vx.y.z.apk` APK
 3. Keep all the existing APKs that are already there as "Included", except the current production release. This makes sure that everyone with older version Android devices can still download the app. So only the current production release should be under "Not Included".
-4. Type in the version number `vx.y.z` in the release name. For the "What's new" text, paste the output of `tools/release-notes.sh play` (see [Release notes](#release-notes)) — if you published with GPP rather than by hand, that text was already uploaded from `release-notes/en-US/default.txt` and there is nothing to paste.
+4. Type in the version number `vx.y.z` in the release name, and paste the output of `tools/release-notes.sh play` into the "What's new" section (see [Release notes](#release-notes)). Check what the console already shows before pasting — depending on which GPP task you ran, the notes may have been uploaded from `release-notes/en-US/default.txt` already.
 5. Review and publish release to beta testing group (I usually immediately push to all beta testing users)
 6. Announce beta release on the [onebusaway-developers Google Group](https://groups.google.com/g/onebusaway-developers).
 

--- a/onebusaway-android/src/obaGoogleRelease/play/release-notes/en-US/default.txt
+++ b/onebusaway-android/src/obaGoogleRelease/play/release-notes/en-US/default.txt
@@ -1,0 +1,1 @@
+• Bug fixes: Several bug fixes and fit and finish improvements. See https://bit.ly/oba-android-releases

--- a/onebusaway-android/src/obaGoogleRelease/play/release-notes/en-US/default.txt
+++ b/onebusaway-android/src/obaGoogleRelease/play/release-notes/en-US/default.txt
@@ -1,1 +1,0 @@
-• Bug fixes: Several bug fixes and fit and finish improvements. See https://bit.ly/oba-android-releases

--- a/tools/release-notes.sh
+++ b/tools/release-notes.sh
@@ -52,9 +52,18 @@ while [ $# -gt 0 ]; do
 done
 
 if [ -z "$SINCE" ]; then
-    SINCE="$(git describe --tags --abbrev=0 --match 'v*' 2>/dev/null || true)"
+    # The release tag is normally cut before the notes are generated, so HEAD is
+    # usually the new release. Measuring from the tag on HEAD would give an empty
+    # range and silently produce no notes — measure from the release before it.
+    if git describe --exact-match --tags --match 'v*' HEAD > /dev/null 2>&1; then
+        DESCRIBE_FROM="HEAD^"
+    else
+        DESCRIBE_FROM="HEAD"
+    fi
+
+    SINCE="$(git describe --tags --abbrev=0 --match 'v*' "$DESCRIBE_FROM" 2>/dev/null || true)"
     if [ -z "$SINCE" ]; then
-        echo "Error: no v* tag found to measure from. Pass --since <ref> explicitly." >&2
+        echo "Error: no earlier v* tag found to measure from. Pass --since <ref> explicitly." >&2
         exit 1
     fi
 fi
@@ -106,7 +115,10 @@ case "$COMMAND" in
 
         notes="$(printf '%s\n' "$highlights" | sed 's/^/• /')"
 
-        char_count=${#notes}
+        # Count what actually gets written: the bullets plus the trailing newline
+        # the writes below add, so a payload that lands on the cap is not accepted
+        # here and then rejected by Play.
+        char_count=$(( ${#notes} + 1 ))
         if [ "$char_count" -gt "$PLAY_MAX_CHARS" ]; then
             over=$((char_count - PLAY_MAX_CHARS))
             echo "Error: release notes are $char_count characters, $over over the Play Store limit of $PLAY_MAX_CHARS." >&2

--- a/tools/release-notes.sh
+++ b/tools/release-notes.sh
@@ -1,0 +1,168 @@
+#!/bin/bash
+#
+# release-notes.sh
+#
+# Generates release notes from `Changelog:` commit-message trailers.
+#
+# Because every PR lands on main as a single squashed commit, one commit is one
+# change, and the commit message is a usable place to record what that change
+# means to a rider. A commit may carry an optional trailer:
+#
+#     Changelog: Links shared from iOS now open the right screen.
+#
+# The trailer is optional and most commits should not have one. A commit subject
+# ("Fold report/ into ui/report/ and wire its ViewModels through Hilt (#2016)")
+# is already a fine developer-facing changelog line, and every subject appears in
+# the GitHub release body. The trailer exists only for the handful of changes per
+# release that a rider would actually notice, because those need different words
+# than the subject line gives them.
+#
+# Usage:
+#   tools/release-notes.sh play              # print the Play Store "What's new" text
+#   tools/release-notes.sh play --write      # ...and write it into the GPP tree
+#   tools/release-notes.sh github            # print a GitHub release body
+#
+#   --since <ref>   start from <ref> instead of the most recent v* tag
+#
+
+set -e
+
+# Find the project root (where this script is in tools/)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+# gradle-play-publisher reads release notes from this tree. "default.txt" applies
+# to every track, so the same text carries from the beta upload through the
+# promotion to production. See docs/BUILD.md.
+PLAY_NOTES_FILE="$PROJECT_ROOT/onebusaway-android/src/obaGoogleRelease/play/release-notes/en-US/default.txt"
+
+# Google Play rejects release notes longer than this, per locale.
+PLAY_MAX_CHARS=500
+
+REPO_URL="https://github.com/OneBusAway/onebusaway-android"
+
+COMMAND=""
+SINCE=""
+WRITE=false
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        play|github)
+            COMMAND="$1"
+            shift
+            ;;
+        --since)
+            SINCE="$2"
+            shift 2
+            ;;
+        --write)
+            WRITE=true
+            shift
+            ;;
+        *)
+            echo "Error: unknown argument '$1'" >&2
+            echo "Usage: tools/release-notes.sh {play|github} [--since <ref>] [--write]" >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [ -z "$COMMAND" ]; then
+    echo "Usage: tools/release-notes.sh {play|github} [--since <ref>] [--write]" >&2
+    exit 1
+fi
+
+if [ -z "$SINCE" ]; then
+    SINCE="$(git -C "$PROJECT_ROOT" describe --tags --abbrev=0 --match 'v*' 2>/dev/null || true)"
+    if [ -z "$SINCE" ]; then
+        echo "Error: no v* tag found to measure from. Pass --since <ref> explicitly." >&2
+        exit 1
+    fi
+fi
+
+if ! git -C "$PROJECT_ROOT" rev-parse --verify --quiet "$SINCE" > /dev/null; then
+    echo "Error: '$SINCE' is not a valid ref." >&2
+    exit 1
+fi
+
+RANGE="$SINCE..HEAD"
+
+# Collect the trailer values, oldest commit first. git only recognizes a trailer
+# block at the very end of a commit message, which is exactly what we want: a
+# "Changelog:" line quoted in the middle of a body is not an entry.
+raw_highlights="$(git -C "$PROJECT_ROOT" log --no-merges --reverse \
+    --format='%(trailers:key=Changelog,valueonly=true,unfold=true)' "$RANGE" \
+    | sed '/^[[:space:]]*$/d')"
+
+# Squashing a multi-commit branch through the GitHub merge box concatenates the
+# individual commit messages, which can leave a "Changelog:" line stranded in the
+# middle of the body where git will not read it as a trailer. Count both ways and
+# say so, rather than silently dropping the entry.
+written_count="$(git -C "$PROJECT_ROOT" log --no-merges --format='%B' "$RANGE" \
+    | grep -c '^Changelog:' || true)"
+recognized_count="$(printf '%s' "$raw_highlights" | grep -c . || true)"
+
+if [ "$written_count" -gt "$recognized_count" ]; then
+    echo "Warning: found $written_count 'Changelog:' lines but only $recognized_count parsed as trailers." >&2
+    echo "         A trailer is only recognized in the trailer block at the end of a commit" >&2
+    echo "         message. These commits have one that is not:" >&2
+    git -C "$PROJECT_ROOT" log --no-merges --format='%H %s' "$RANGE" | while read -r sha subject; do
+        in_body="$(git -C "$PROJECT_ROOT" show -s --format='%B' "$sha" | grep -c '^Changelog:' || true)"
+        in_trailer="$(git -C "$PROJECT_ROOT" show -s --format='%(trailers:key=Changelog,valueonly=true,unfold=true)' "$sha" | grep -c . || true)"
+        if [ "$in_body" -gt "$in_trailer" ]; then
+            echo "           ${sha:0:9} $subject" >&2
+        fi
+    done
+    echo "" >&2
+fi
+
+# Drop repeated values, keeping the first occurrence. The same concatenation can
+# also duplicate an entry across the commits it swept together.
+highlights="$(printf '%s\n' "$raw_highlights" | awk 'NF && !seen[$0]++')"
+
+case "$COMMAND" in
+    play)
+        if [ -z "$highlights" ]; then
+            echo "Error: no 'Changelog:' trailers in $RANGE, so there is nothing to tell riders." >&2
+            echo "       Either add a trailer to the commits that changed something visible," >&2
+            echo "       or write ${PLAY_NOTES_FILE#"$PROJECT_ROOT"/} by hand for a maintenance-only release." >&2
+            exit 1
+        fi
+
+        notes="$(printf '%s\n' "$highlights" | sed 's/^/• /')"
+
+        char_count="$(printf '%s' "$notes" | wc -m | tr -d ' ')"
+        if [ "$char_count" -gt "$PLAY_MAX_CHARS" ]; then
+            over=$((char_count - PLAY_MAX_CHARS))
+            echo "Error: release notes are $char_count characters, $over over the Play Store limit of $PLAY_MAX_CHARS." >&2
+            echo "       Shorten or drop a 'Changelog:' trailer — do not let this be truncated," >&2
+            echo "       because Play truncates from the end and would cut an entry mid-word." >&2
+            exit 1
+        fi
+
+        if [ "$WRITE" = true ]; then
+            mkdir -p "$(dirname "$PLAY_NOTES_FILE")"
+            printf '%s\n' "$notes" > "$PLAY_NOTES_FILE"
+            echo "Wrote $char_count/$PLAY_MAX_CHARS characters to:"
+            echo "  ${PLAY_NOTES_FILE#"$PROJECT_ROOT"/}"
+            echo ""
+        fi
+
+        printf '%s\n' "$notes"
+        ;;
+
+    github)
+        if [ -n "$highlights" ]; then
+            echo "## Highlights"
+            echo ""
+            printf '%s\n' "$highlights" | sed 's/^/- /'
+            echo ""
+        fi
+
+        echo "## All changes"
+        echo ""
+        git -C "$PROJECT_ROOT" log --no-merges --reverse --format='- %s' "$RANGE"
+        echo ""
+        echo "**Full changelog**: $REPO_URL/compare/$SINCE...HEAD"
+        ;;
+esac

--- a/tools/release-notes.sh
+++ b/tools/release-notes.sh
@@ -2,136 +2,111 @@
 #
 # release-notes.sh
 #
-# Generates release notes from `Changelog:` commit-message trailers.
+# Assembles release notes from the `Changelog:` trailers on the commits since
+# the last release tag.
 #
-# Because every PR lands on main as a single squashed commit, one commit is one
-# change, and the commit message is a usable place to record what that change
-# means to a rider. A commit may carry an optional trailer:
-#
-#     Changelog: Links shared from iOS now open the right screen.
-#
-# The trailer is optional and most commits should not have one. A commit subject
-# ("Fold report/ into ui/report/ and wire its ViewModels through Hilt (#2016)")
-# is already a fine developer-facing changelog line, and every subject appears in
-# the GitHub release body. The trailer exists only for the handful of changes per
-# release that a rider would actually notice, because those need different words
-# than the subject line gives them.
+# See .github/CONTRIBUTING.md#changelog-entries for when a commit should carry a
+# trailer, and docs/BUILD.md#release-notes for where this sits in a release.
 #
 # Usage:
 #   tools/release-notes.sh play              # print the Play Store "What's new" text
 #   tools/release-notes.sh play --write      # ...and write it into the GPP tree
-#   tools/release-notes.sh github            # print a GitHub release body
+#   tools/release-notes.sh github            # print the highlights for a release body
 #
-#   --since <ref>   start from <ref> instead of the most recent v* tag
+#   --since <ref>   measure from <ref> instead of the most recent v* tag
 #
 
 set -e
 
-# Find the project root (where this script is in tools/)
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+# Every path and git call below is repo-relative.
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
 # gradle-play-publisher reads release notes from this tree. "default.txt" applies
-# to every track, so the same text carries from the beta upload through the
-# promotion to production. See docs/BUILD.md.
-PLAY_NOTES_FILE="$PROJECT_ROOT/onebusaway-android/src/obaGoogleRelease/play/release-notes/en-US/default.txt"
+# to every track, so the same text carries from the beta upload through to the
+# promotion to production. Only en-US is generated; the other Play locales keep
+# whatever text they already have.
+PLAY_NOTES_FILE="onebusaway-android/src/obaGoogleRelease/play/release-notes/en-US/default.txt"
 
 # Google Play rejects release notes longer than this, per locale.
 PLAY_MAX_CHARS=500
 
-REPO_URL="https://github.com/OneBusAway/onebusaway-android"
+usage() {
+    echo "Usage: tools/release-notes.sh {play|github} [--since <ref>] [--write]" >&2
+    exit 1
+}
 
-COMMAND=""
+case "${1-}" in
+    play|github) COMMAND="$1"; shift ;;
+    *) usage ;;
+esac
+
 SINCE=""
 WRITE=false
 
 while [ $# -gt 0 ]; do
     case "$1" in
-        play|github)
-            COMMAND="$1"
-            shift
-            ;;
-        --since)
-            SINCE="$2"
-            shift 2
-            ;;
-        --write)
-            WRITE=true
-            shift
-            ;;
-        *)
-            echo "Error: unknown argument '$1'" >&2
-            echo "Usage: tools/release-notes.sh {play|github} [--since <ref>] [--write]" >&2
-            exit 1
-            ;;
+        --since) SINCE="${2-}"; [ -n "$SINCE" ] || usage; shift 2 ;;
+        --write) WRITE=true; shift ;;
+        *) usage ;;
     esac
 done
 
-if [ -z "$COMMAND" ]; then
-    echo "Usage: tools/release-notes.sh {play|github} [--since <ref>] [--write]" >&2
-    exit 1
-fi
-
 if [ -z "$SINCE" ]; then
-    SINCE="$(git -C "$PROJECT_ROOT" describe --tags --abbrev=0 --match 'v*' 2>/dev/null || true)"
+    SINCE="$(git describe --tags --abbrev=0 --match 'v*' 2>/dev/null || true)"
     if [ -z "$SINCE" ]; then
         echo "Error: no v* tag found to measure from. Pass --since <ref> explicitly." >&2
         exit 1
     fi
 fi
 
-if ! git -C "$PROJECT_ROOT" rev-parse --verify --quiet "$SINCE" > /dev/null; then
+if ! git rev-parse --verify --quiet "$SINCE" > /dev/null; then
     echo "Error: '$SINCE' is not a valid ref." >&2
     exit 1
 fi
 
 RANGE="$SINCE..HEAD"
 
-# Collect the trailer values, oldest commit first. git only recognizes a trailer
-# block at the very end of a commit message, which is exactly what we want: a
-# "Changelog:" line quoted in the middle of a body is not an entry.
-raw_highlights="$(git -C "$PROJECT_ROOT" log --no-merges --reverse \
+# Oldest commit first. git only recognizes a trailer in the block at the very end
+# of a message, which is what we want — a "Changelog:" line quoted mid-body is not
+# an entry. Drop the blank lines commits without a trailer contribute, and repeated
+# values, which a squashed branch can introduce.
+highlights="$(git log --no-merges --reverse \
     --format='%(trailers:key=Changelog,valueonly=true,unfold=true)' "$RANGE" \
-    | sed '/^[[:space:]]*$/d')"
+    | awk 'NF && !seen[$0]++')"
 
 # Squashing a multi-commit branch through the GitHub merge box concatenates the
 # individual commit messages, which can leave a "Changelog:" line stranded in the
-# middle of the body where git will not read it as a trailer. Count both ways and
-# say so, rather than silently dropping the entry.
-written_count="$(git -C "$PROJECT_ROOT" log --no-merges --format='%B' "$RANGE" \
-    | grep -c '^Changelog:' || true)"
-recognized_count="$(printf '%s' "$raw_highlights" | grep -c . || true)"
-
-if [ "$written_count" -gt "$recognized_count" ]; then
-    echo "Warning: found $written_count 'Changelog:' lines but only $recognized_count parsed as trailers." >&2
-    echo "         A trailer is only recognized in the trailer block at the end of a commit" >&2
-    echo "         message. These commits have one that is not:" >&2
-    git -C "$PROJECT_ROOT" log --no-merges --format='%H %s' "$RANGE" | while read -r sha subject; do
-        in_body="$(git -C "$PROJECT_ROOT" show -s --format='%B' "$sha" | grep -c '^Changelog:' || true)"
-        in_trailer="$(git -C "$PROJECT_ROOT" show -s --format='%(trailers:key=Changelog,valueonly=true,unfold=true)' "$sha" | grep -c . || true)"
+# middle of the body where git will not read it as a trailer. Only commits that
+# wrote one can be stranded, so ask git for those and compare the two readings.
+stranded="$(git log --no-merges --reverse --grep='^Changelog:' --format='%H %s' "$RANGE" \
+    | while read -r sha subject; do
+        in_body="$(git show -s --format='%B' "$sha" | grep -c '^Changelog:' || true)"
+        in_trailer="$(git show -s --format='%(trailers:key=Changelog,valueonly=true,unfold=true)' "$sha" | grep -c . || true)"
         if [ "$in_body" -gt "$in_trailer" ]; then
-            echo "           ${sha:0:9} $subject" >&2
+            echo "  ${sha:0:9} $subject"
         fi
-    done
+    done)"
+
+if [ -n "$stranded" ]; then
+    echo "Warning: these commits have a 'Changelog:' line that git did not read as a" >&2
+    echo "         trailer, so it is missing below. A trailer is only recognized in the" >&2
+    echo "         trailer block at the very end of a commit message:" >&2
+    echo "$stranded" >&2
     echo "" >&2
 fi
-
-# Drop repeated values, keeping the first occurrence. The same concatenation can
-# also duplicate an entry across the commits it swept together.
-highlights="$(printf '%s\n' "$raw_highlights" | awk 'NF && !seen[$0]++')"
 
 case "$COMMAND" in
     play)
         if [ -z "$highlights" ]; then
             echo "Error: no 'Changelog:' trailers in $RANGE, so there is nothing to tell riders." >&2
             echo "       Either add a trailer to the commits that changed something visible," >&2
-            echo "       or write ${PLAY_NOTES_FILE#"$PROJECT_ROOT"/} by hand for a maintenance-only release." >&2
+            echo "       or write $PLAY_NOTES_FILE by hand for a maintenance-only release." >&2
             exit 1
         fi
 
         notes="$(printf '%s\n' "$highlights" | sed 's/^/• /')"
 
-        char_count="$(printf '%s' "$notes" | wc -m | tr -d ' ')"
+        char_count=${#notes}
         if [ "$char_count" -gt "$PLAY_MAX_CHARS" ]; then
             over=$((char_count - PLAY_MAX_CHARS))
             echo "Error: release notes are $char_count characters, $over over the Play Store limit of $PLAY_MAX_CHARS." >&2
@@ -143,8 +118,7 @@ case "$COMMAND" in
         if [ "$WRITE" = true ]; then
             mkdir -p "$(dirname "$PLAY_NOTES_FILE")"
             printf '%s\n' "$notes" > "$PLAY_NOTES_FILE"
-            echo "Wrote $char_count/$PLAY_MAX_CHARS characters to:"
-            echo "  ${PLAY_NOTES_FILE#"$PROJECT_ROOT"/}"
+            echo "Wrote $char_count/$PLAY_MAX_CHARS characters to $PLAY_NOTES_FILE"
             echo ""
         fi
 
@@ -152,17 +126,16 @@ case "$COMMAND" in
         ;;
 
     github)
-        if [ -n "$highlights" ]; then
-            echo "## Highlights"
-            echo ""
-            printf '%s\n' "$highlights" | sed 's/^/- /'
-            echo ""
+        # Only the highlights. `gh release create --generate-notes` builds the rest
+        # of the body — commit and PR list, authors, new contributors, the compare
+        # link — and prepends whatever is passed as --notes. See docs/BUILD.md.
+        if [ -z "$highlights" ]; then
+            echo "No 'Changelog:' trailers in $RANGE; the release body will be generated notes only." >&2
+            exit 0
         fi
 
-        echo "## All changes"
+        echo "## Highlights"
         echo ""
-        git -C "$PROJECT_ROOT" log --no-merges --reverse --format='- %s' "$RANGE"
-        echo ""
-        echo "**Full changelog**: $REPO_URL/compare/$SINCE...HEAD"
+        printf '%s\n' "$highlights" | sed 's/^/- /'
         ;;
 esac


### PR DESCRIPTION
Release notes are currently written by hand at release time, and `docs/BUILD.md` tells the maintainer to "copy the release notes from a previous release and edit accordingly." This derives them from the commit messages instead.

## The convention

Every PR lands on `main` as a single squashed commit, so one commit is one change — which makes the commit message a usable place to record what that change means to a rider:

```
Offer bikeshare trips where the OTP2 server supports them (#2017)

<body>

Changelog: Bikeshare trips now show up in the trip planner.
```

**The trailer is optional and most commits should not have one.** Our commit subjects are already release-note quality — "Don't crash when a vehicle's trip is missing from the route references (#2021)" needs no help, and every subject reaches the GitHub release body regardless. The trailer covers the gap a subject can't: "Fold report/ into ui/report/ and wire its ViewModels through Hilt" is the right subject and the wrong sentence to show someone waiting for a bus. Expect a handful per release.

## The tooling

`tools/release-notes.sh` reads the trailers since the last `v*` tag (`--since <ref>` to override):

| Command | Output |
|---|---|
| `play` | Play Store "What's new" text — trailers as bullets |
| `play --write` | ...written to `src/obaGoogleRelease/play/release-notes/en-US/default.txt`, where GPP already looks |
| `github` | A `## Highlights` block to prepend to a generated release body |

`github` emits *only* the highlights: `gh release create --generate-notes` already builds the PR list, authors and compare link, and prepends whatever `--notes` passes. No point re-implementing GitHub's release-notes API.

Play's 500-character-per-locale cap is enforced as a **hard failure, never a truncation** — Play cuts from the end, which would sever an entry mid-word:

```
Error: release notes are 775 characters, 275 over the Play Store limit of 500.
       Shorten or drop a 'Changelog:' trailer — do not let this be truncated,
       because Play truncates from the end and would cut an entry mid-word.
```

## Does squash-merge break the trailers?

This was the main risk, so I checked rather than assumed. Git only recognizes a trailer in the block at the very *end* of a message, and GitHub's merge box concatenates a multi-commit branch's messages — which could strand a trailer mid-body.

Measured on the last 50 commits of `main`: **31 of 31 `Co-authored-by:` lines parse correctly as trailers, zero stranded** — including commits carrying 2–9 concatenated `* ` bullets. The trailing trailer block survives concatenation in practice.

The script still detects the case and names the offending commits, as a backstop:

```
Warning: these commits have a 'Changelog:' line that git did not read as a
         trailer, so it is missing below. ...
  018d4720a Offer bikeshare trips where the OTP2 server supports them (#2017)
```

**Recommended (not included here, needs a maintainer):** setting the repo's squash-merge default to "pull request title and description" makes the final commit message predictable and editable before merge, and rules the case out entirely. Documented in `BUILD.md`; no repository settings are changed by this PR.

## The in-app "What's New?" dialog is deliberately not automated

`main_help_whatsnew` is translated into es/fi/it/pl. Generating it would mean four locales describing the *previous* release every time — worse than today, where the text is generic and correctly translated everywhere. `BUILD.md` now records that as intentional so it doesn't get "fixed" later. Two sinks generated, one left alone.

## No CHANGELOG.md

Deliberate. For a consumer app the GitHub release and the Play listing *are* the changelog; a third in-repo copy is one more thing to keep honest. Easy to add later if something wants to read it.

## Files

- `tools/release-notes.sh` — the generator (bash, matching the existing `tools/` scripts)
- `.gitmessage` — opt-in commit template (`git config commit.template .gitmessage`)
- `.github/CONTRIBUTING.md` — "Changelog entries" section; owns the convention
- `.github/PULL_REQUEST_TEMPLATE.md` — one checkbox
- `docs/BUILD.md` — "Release notes" section, wired into the existing release steps

No app code, no build changes.

## Deliberately not included

- A tag-triggered workflow that auto-creates GitHub releases — that changes the release process rather than supporting it. `BUILD.md` documents the `gh release create` one-liner instead.
- A Gradle task the publish step depends on. It would make stale notes impossible by construction, and is the natural follow-up, but it couples this to the build.
- Locales beyond `en-US`, documented as a known limitation.

## Testing

Verified against real history and a scratch repo: happy path, no-trailers, stranded trailer, duplicate trailer, over-limit, `--write`, bad arguments, and invocation from three different working directories.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automated release-note generation for Google Play “What’s new” and GitHub releases.
  - Release notes now support concise, rider-facing highlights derived from commit `Changelog:` trailers.
  - Google Play output can be written directly for the publishing workflow, with character-limit validation.

- **Documentation**
  - Expanded release workflow docs, including how to generate and paste “What’s new” text and how localization is handled.
  - Updated contribution and PR template guidance for `Changelog:` trailer formatting and placement.
  - Added a structured commit-message template to standardize release-note entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->