### PR TITLE
Catch bundled-vs-live regions drift nightly, and sync what had already drifted

### DIFF
--- a/.github/workflows/android-nightly.yml
+++ b/.github/workflows/android-nightly.yml
@@ -22,6 +22,14 @@ name: Android Nightly
 #    to run nightly and catches lint regressions (including `abortOnError` NewApi/minSdk violations
 #    the Kotlin warnings gate can't see) that would otherwise sit invisible until someone runs lint
 #    by hand. See issue #1901.
+#
+# 4. regions-drift — src/main/res/raw/regions_v3.json is the app's first-launch and offline region
+#    config, so a field that has drifted away from the live regions directory is a real behaviour
+#    difference for users who haven't refreshed their region cache yet — and invisible to everyone
+#    who has. Puget Sound's otpBaseGraphqlUrl silently drifted that way, and nothing compared the
+#    two files (the unit test pins the bundled value against itself). This leg diffs them on the
+#    fields the app branches on. It lives here rather than on the PR/push workflow because it needs
+#    network, and it fails on drift. See tools/check-regions-drift.py and issue #2019.
 
 on:
   schedule:
@@ -88,6 +96,23 @@ jobs:
           name: lint-report-obaGoogleDebug
           path: onebusaway-android/build/reports/lint-results-obaGoogleDebug.html
           retention-days: 14
+
+  regions-drift:
+    # No JDK, no Gradle, no emulator — it reads two JSON files. Independent of the other legs, so it
+    # runs in parallel and finishes in seconds. See the header for why this exists.
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v7
+        with:
+          # This job only reads files and fetches a public URL; it never pushes, so don't leave the
+          # token in git config.
+          persist-credentials: false
+
+      # No report artifact: unlike the lint leg's HTML, this step's whole output is the plain-text
+      # report, and it's already in the job log.
+      - name: Bundled regions file vs. live regions directory
+        run: tools/check-regions-drift.py
 
   smoke-api23:
     # Boot the minSdk floor: install obaGoogleDebug on an API 23 emulator and run the @SmokeTest

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ play-store-upload-key.json
 .project
 .classpath
 bin/
+__pycache__/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -290,6 +290,25 @@ The app supports multiple OBA server deployments. Region configuration:
 - ObaRegionsTask handles async region discovery
 - Regions API auto-selects server based on device location
 
+### The bundled regions file is a live config source, not a stale copy (#2019)
+
+`onebusaway-android/src/main/res/raw/regions_v3.json` is the **first-launch and offline** source of
+region config (`RegionsClient.parseBundledRegions`), not a checked-in convenience copy of
+`https://regions.onebusaway.org/regions-v3.json`. A device that acts before its first directory
+fetch lands reads the bundled values, so any field the app branches on that has drifted there is a
+real behaviour difference — for exactly those users, and invisible to every device that has already
+refreshed its region cache.
+
+- **`tools/check-regions-drift.py`** diffs the two on the fields the app branches on (endpoints,
+  usability gates, OTP protocol + bikeshare flags, analytics config) plus region add/remove, using
+  *effective* values so an omitted key that decodes to the same default isn't reported. It runs in
+  the nightly `regions-drift` job (network, so not on PRs) and **fails on drift**.
+- When it reports drift, sync the bundled file and update `RegionsDecodeTest`, the one test that
+  pins a bundled value. It pins that value against itself and by construction cannot see directory
+  drift; that's the checker's job. Keep it the only such pin.
+- Branching on a **new** region field means adding it to `CHECKED_FIELDS` in that script, with the
+  default `RegionDto` decodes for it.
+
 ## White-Label / Branding
 
 The app supports white-labeling via Gradle product flavors. See `docs/REBRANDING.md` for full documentation.

--- a/onebusaway-android/src/main/res/raw/regions_v3.json
+++ b/onebusaway-android/src/main/res/raw/regions_v3.json
@@ -8,7 +8,11 @@
         "id": 0,
         "regionName": "Tampa Bay",
         "sidecarBaseUrl": "https://sidecar.onebusaway.org",
-        "plausibleAnalyticsServerUrl": "https://analytics.tampa.onebusawaycloud.com/api",
+        "plausibleAnalyticsServerUrl": null,
+        "umamiAnalytics": {
+          "url": "https://analytics.onebusawaycloud.com",
+          "id": "34c436d4-9df1-49ca-81a5-6a0dc0e2bfb1"
+        },
         "obaBaseUrl": "https://api.tampa.onebusawaycloud.com/",
         "siriBaseUrl": null,
         "bounds": [
@@ -58,6 +62,10 @@
         "regionName": "Puget Sound",
         "sidecarBaseUrl": "https://sidecar.onebusaway.org",
         "plausibleAnalyticsServerUrl": null,
+        "umamiAnalytics": {
+          "url": "https://analytics.onebusawaycloud.com",
+          "id": "1678b0f2-e7e7-46bf-9027-d609895f8d58"
+        },
         "obaBaseUrl": "https://api.pugetsound.onebusaway.org/",
         "siriBaseUrl": "https://pugetsound.onebusaway.org/onebusaway-api-webapp/siri/",
         "bounds": [
@@ -129,7 +137,7 @@
         "stopInfoUrl": null,
         "open311Servers": [],
         "otpBaseUrl": "https://otp.prod.sound.obaweb.org/otp/routers/default/",
-        "otpBaseGraphqlUrl": "https://peq6qe6fei.execute-api.us-west-2.amazonaws.com/prod/otp",
+        "otpBaseGraphqlUrl": "https://sound-transit-otp.ibi-transit.com/otp/",
         "otpContactEmail": "otp-pugetsound@onebusaway.org",
         "supportsEmbeddedSocial": false,
         "supportsOtpBikeshare": false,
@@ -225,6 +233,10 @@
         "regionName": "San Diego",
         "sidecarBaseUrl": "https://sidecar.onebusaway.org",
         "plausibleAnalyticsServerUrl": null,
+        "umamiAnalytics": {
+          "url": "https://analytics.onebusawaycloud.com",
+          "id": "0f8e9d22-7ba2-4a3d-babf-796f4c9ed8d4"
+        },
         "obaBaseUrl": "https://realtime.sdmts.com/api/",
         "siriBaseUrl": null,
         "bounds": [
@@ -358,7 +370,11 @@
         "id": 16,
         "regionName": "Davis, CA",
         "sidecarBaseUrl": "https://sidecar.onebusaway.org",
-        "plausibleAnalyticsServerUrl": "https://analytics.unitrans.onebusawaycloud.com/api",
+        "plausibleAnalyticsServerUrl": null,
+        "umamiAnalytics": {
+          "url": "https://analytics.onebusawaycloud.com",
+          "id": "f934d27d-f349-4308-8917-6b4e35d340b4"
+        },
         "obaBaseUrl": "https://api.unitrans.onebusawaycloud.com",
         "siriBaseUrl": null,
         "bounds": [

--- a/onebusaway-android/src/test/java/org/onebusaway/android/api/RegionsDecodeTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/api/RegionsDecodeTest.kt
@@ -61,13 +61,19 @@ class RegionsDecodeTest {
      * base; the client appends `/gtfs/v1`). Puget Sound is pointed at its OTP2 GraphQL server;
      * every other bundled region stays on OTP1 REST (null). Guards both the intended flip and
      * against an accidental one elsewhere.
+     *
+     * The host asserted here is pinned against the *bundled* file only — by construction this test
+     * can't notice the bundled value drifting away from the live regions directory, which is how
+     * Puget Sound came to ship a stale `execute-api` host (#2019). That comparison belongs to
+     * `tools/check-regions-drift.py`, run by the nightly `regions-drift` job because it needs
+     * network. When that job reports drift, sync the bundled file and update this expectation.
      */
     @Test
     fun bundledRegionsSelectOtpProtocolByGraphqlUrl() {
         val regions = decode("src/main/res/raw/regions_v3.json").map { it.toObaRegion() }
         val pugetSound = regions.single { it.name == "Puget Sound" }
         assertEquals(
-            "https://peq6qe6fei.execute-api.us-west-2.amazonaws.com/prod/otp",
+            "https://sound-transit-otp.ibi-transit.com/otp/",
             pugetSound.otpBaseGraphqlUrl
         )
         regions.filter { it.name != "Puget Sound" }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/Otp2GraphQlEndpointTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/Otp2GraphQlEndpointTest.kt
@@ -27,14 +27,13 @@ class Otp2GraphQlEndpointTest {
 
     @Test
     fun appendsGtfsV1ToOtpBase() {
-        // The Puget Sound OTP2 server this wires up (#1780) — base verified to serve the OTP root,
-        // base + /gtfs/v1 verified to serve the GraphQL endpoint.
         assertEquals(
-            "https://peq6qe6fei.execute-api.us-west-2.amazonaws.com/prod/otp/gtfs/v1",
-            otp2GraphQlEndpoint("https://peq6qe6fei.execute-api.us-west-2.amazonaws.com/prod/otp")
+            "https://example.opentripplanner.org/otp/gtfs/v1",
+            otp2GraphQlEndpoint("https://example.opentripplanner.org/otp")
         )
     }
 
+    /** The directory publishes some OTP2 bases with a trailing slash, Puget Sound's among them. */
     @Test
     fun toleratesTrailingSlashWithoutDoublingIt() {
         assertEquals(

--- a/tools/check-regions-drift.py
+++ b/tools/check-regions-drift.py
@@ -42,7 +42,7 @@ Exit status: 0 no drift, 1 drift found, 2 the check itself could not run.
 import argparse
 import json
 import sys
-import urllib.error
+import traceback
 import urllib.request
 import xml.etree.ElementTree as ElementTree
 from pathlib import Path
@@ -104,10 +104,10 @@ class CheckError(Exception):
 
 
 def read_text(path):
-    """File contents as text, converting the OSError into this check's own failure channel."""
+    """File contents as text, converting IO and decode failures into this check's failure channel."""
     try:
         return Path(path).read_text(encoding="utf-8")
-    except OSError as e:
+    except (OSError, ValueError) as e:  # ValueError covers a non-UTF-8 file (UnicodeDecodeError)
         raise CheckError(f"could not read {path}: {e}") from e
 
 
@@ -119,19 +119,27 @@ def regions_directory_url(resource_path):
         raise CheckError(f"could not parse {resource_path}: {e}") from e
     for string in resources.iter("string"):
         if string.get("name") == REGIONS_URL_RESOURCE_NAME:
-            return string.text
+            # An empty element (`<string name="regions_api_url"/>`) parses to None, which would
+            # otherwise reach urlopen and crash rather than reporting what is actually wrong.
+            url = (string.text or "").strip()
+            if not url:
+                raise CheckError(f"<string name=\"{REGIONS_URL_RESOURCE_NAME}\"> in {resource_path} is empty")
+            return url
     raise CheckError(f"no <string name=\"{REGIONS_URL_RESOURCE_NAME}\"> in {resource_path}")
 
 
 def fetch(url):
     """Response body at `url` as text; an unreachable directory is a CheckError, not drift."""
-    # An explicit User-Agent is required, not politeness: the directory host answers 403 to
-    # urllib's default `Python-urllib/3.x`.
-    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
     try:
+        # An explicit User-Agent is required, not politeness: the directory host answers 403 to
+        # urllib's default `Python-urllib/3.x`. Built inside the try because a malformed URL fails
+        # here, at Request(), rather than at urlopen().
+        request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
         with urllib.request.urlopen(request, timeout=60) as response:
             return response.read().decode("utf-8")
-    except (urllib.error.URLError, OSError) as e:
+    # URLError/HTTPError are OSError subclasses; ValueError covers both a malformed URL and a
+    # non-UTF-8 response body.
+    except (OSError, ValueError) as e:
         raise CheckError(f"could not fetch {url}: {e}") from e
 
 
@@ -243,4 +251,11 @@ if __name__ == "__main__":
         sys.exit(main(sys.argv[1:]))
     except CheckError as e:
         print(f"error: {e}", file=sys.stderr)
+        sys.exit(2)
+    except Exception:
+        # Python exits 1 on an uncaught exception, and 1 is this script's "drift found" status --
+        # so a crash would be reported to CI as drift. Keep the traceback, but land on the
+        # documented "the check itself could not run" status instead of enumerating every
+        # exception type that could ever reach here.
+        traceback.print_exc()
         sys.exit(2)

--- a/tools/check-regions-drift.py
+++ b/tools/check-regions-drift.py
@@ -43,6 +43,7 @@ import argparse
 import json
 import sys
 import traceback
+import urllib.parse
 import urllib.request
 import xml.etree.ElementTree as ElementTree
 from pathlib import Path
@@ -124,6 +125,12 @@ def regions_directory_url(resource_path):
             url = (string.text or "").strip()
             if not url:
                 raise CheckError(f"<string name=\"{REGIONS_URL_RESOURCE_NAME}\"> in {resource_path} is empty")
+            # urlopen honours `file:`, so a resource pointing at a local path would be "fetched"
+            # into a comparison of the bundled file against itself -- reporting No drift forever.
+            # Refuse anything that isn't a real fetch, for the same reason check_fields_exist
+            # refuses a stale field name: this check failing loudly beats it rotting green.
+            if urllib.parse.urlparse(url).scheme not in ("http", "https"):
+                raise CheckError(f"{REGIONS_URL_RESOURCE_NAME} is not an http(s) URL: {url}")
             return url
     raise CheckError(f"no <string name=\"{REGIONS_URL_RESOURCE_NAME}\"> in {resource_path}")
 

--- a/tools/check-regions-drift.py
+++ b/tools/check-regions-drift.py
@@ -104,10 +104,11 @@ class CheckError(Exception):
 
 
 def read_text(path):
+    """File contents as text, converting the OSError into this check's own failure channel."""
     try:
         return Path(path).read_text(encoding="utf-8")
     except OSError as e:
-        raise CheckError(f"could not read {path}: {e}")
+        raise CheckError(f"could not read {path}: {e}") from e
 
 
 def regions_directory_url(resource_path):
@@ -115,7 +116,7 @@ def regions_directory_url(resource_path):
     try:
         resources = ElementTree.fromstring(read_text(resource_path))
     except ElementTree.ParseError as e:
-        raise CheckError(f"could not parse {resource_path}: {e}")
+        raise CheckError(f"could not parse {resource_path}: {e}") from e
     for string in resources.iter("string"):
         if string.get("name") == REGIONS_URL_RESOURCE_NAME:
             return string.text
@@ -123,6 +124,7 @@ def regions_directory_url(resource_path):
 
 
 def fetch(url):
+    """Response body at `url` as text; an unreachable directory is a CheckError, not drift."""
     # An explicit User-Agent is required, not politeness: the directory host answers 403 to
     # urllib's default `Python-urllib/3.x`.
     request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
@@ -130,15 +132,23 @@ def fetch(url):
         with urllib.request.urlopen(request, timeout=60) as response:
             return response.read().decode("utf-8")
     except (urllib.error.URLError, OSError) as e:
-        raise CheckError(f"could not fetch {url}: {e}")
+        raise CheckError(f"could not fetch {url}: {e}") from e
 
 
 def load_regions(text, source):
     """Return {id: region} from a regions-vN.json envelope."""
     try:
-        return {r["id"]: r for r in json.loads(text)["data"]["list"]}
+        regions = {}
+        for region in json.loads(text)["data"]["list"]:
+            region_id = region["id"]
+            # Keying by id would otherwise let a duplicate silently shadow its twin, and the
+            # shadowed entry is the one that might have drifted -- a false "No drift".
+            if region_id in regions:
+                raise CheckError(f"{source} lists region id {region_id} more than once")
+            regions[region_id] = region
+        return regions
     except (ValueError, KeyError, TypeError) as e:
-        raise CheckError(f"{source} is not a regions directory envelope: {e}")
+        raise CheckError(f"{source} is not a regions directory envelope: {e}") from e
 
 
 def check_fields_exist(regions, source):
@@ -159,6 +169,7 @@ def effective(region, field):
 
 
 def describe(region_id, region):
+    """`[id] Name` — regions are keyed by id, but the name is what a reader recognizes."""
     return f"[{region_id}] {region.get('regionName', '?')}"
 
 
@@ -191,6 +202,7 @@ def find_drift(bundled, live):
 
 
 def main(argv):
+    """Run the check and return the process exit status: 0 no drift, 1 drift found."""
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     parser.add_argument("--bundled", default=BUNDLED_REGIONS, help="path to the bundled regions file")
     parser.add_argument("--live-file", help="compare against this local file instead of fetching")

--- a/tools/check-regions-drift.py
+++ b/tools/check-regions-drift.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2026 Open Transit Software Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Compare the bundled regions file against the live regions directory (issue #2019).
+
+`onebusaway-android/src/main/res/raw/regions_v3.json` is not a convenience copy of the regions
+directory -- it is the app's **first-launch and offline** source of region config
+(RegionsClient.parseBundledRegions). A device that plans a trip before the first directory fetch
+lands reads the bundled values, so any field the app branches on that has drifted there is a live
+behaviour difference for exactly those users, and it is invisible to every device that has already
+refreshed its region cache. That is a nasty bug shape to debug from a report, so this check
+compares the two and fails on drift.
+
+It ran because Puget Sound's `otpBaseGraphqlUrl` had silently drifted: the bundled file pointed at
+an `execute-api` host while the directory had moved on. Both happened to still be up, so nothing
+was broken -- but that field decides whether trip planning speaks OTP2 at all (#1780) and gates
+Puget Sound's bikeshare itineraries (#2017), so retiring the stale host would have quietly broken
+first-launch trip planning in Seattle.
+
+Run by the `regions-drift` leg of .github/workflows/android-nightly.yml. Needs network, so it is
+deliberately kept off the PR/push workflow.
+
+Usage (from the repo root):
+    tools/check-regions-drift.py                       # fetch the live directory
+    tools/check-regions-drift.py --live-file live.json # compare against a local copy instead
+
+Exit status: 0 no drift, 1 drift found, 2 the check itself could not run.
+"""
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.request
+import xml.etree.ElementTree as ElementTree
+from pathlib import Path
+
+# Mirrors RegionsClient: the app reads the bundled file from res/raw and the directory URL from the
+# `regions_api_url` string resource, so read the URL from that resource rather than restating it
+# here -- otherwise a regions-v3 -> -v4 bump moves the app and leaves this check happily comparing
+# against a directory nobody reads.
+BUNDLED_REGIONS = "onebusaway-android/src/main/res/raw/regions_v3.json"
+REGIONS_URL_RESOURCE = "onebusaway-android/src/main/res/values/donottranslate.xml"
+REGIONS_URL_RESOURCE_NAME = "regions_api_url"
+USER_AGENT = "onebusaway-android regions-drift-check (+https://github.com/OneBusAway/onebusaway-android)"
+
+# The fields the app actually branches on, each with the value RegionDto decodes when the key is
+# absent (or explicitly null -- the client decodes with coerceInputValues, so both land on the
+# default). Comparing *effective* values this way keeps a merely-cosmetic difference, such as the
+# directory stating `"supportsOtpGraphqlBikeshare": false` where the bundled file omits it, from
+# being reported as drift.
+#
+# Adding a field here is the price of branching on a new one: if the app's behaviour depends on it,
+# a bundled/live disagreement is a first-launch behaviour difference. Keep the defaults in sync with
+# RegionDto in api/contract/ObaApiModels.kt. A name that no longer matches the wire -- a typo, or a
+# field the directory renamed -- would otherwise read as the default on both sides and compare equal
+# forever, so `check_fields_exist` fails the run instead of letting the check rot green.
+#
+# Deliberately *not* checked:
+#   - `bounds` -- region geometry is retuned often and by tiny float amounts; diffing it would make
+#     this check noisy enough to be ignored, which is worse than not running it.
+#   - `open311Servers` -- a nested list whose bundled/live entries differ only in null-vs-"" for an
+#     unread jurisdiction id.
+#   - purely presentational fields (twitterUrl, contactEmail, payment warning copy, ...) -- stale
+#     copy on first launch is not a broken app.
+CHECKED_FIELDS = {
+    "regionName": "",
+    # Region usability gates -- RegionUtils.isRegionUsable. Drift here can hide a region from, or
+    # wrongly offer it to, a first-launch user.
+    "active": False,
+    "experimental": False,
+    "supportsObaDiscoveryApis": False,
+    "supportsObaRealtimeApis": False,
+    # Endpoints. A stale host is the failure this check exists for.
+    "obaBaseUrl": None,
+    "sidecarBaseUrl": None,
+    "otpBaseUrl": None,
+    "otpBaseGraphqlUrl": None,
+    # Trip-planning capability flags, per protocol (see Region.supportsOtpGraphqlBikeshare).
+    "supportsOtpBikeshare": False,
+    "supportsOtpGraphqlBikeshare": False,
+    # Analytics config -- AnalyticsProvider branches on both being present.
+    "plausibleAnalyticsServerUrl": None,
+    "umamiAnalytics": None,
+    # Gates the fare-payment entry point.
+    "paymentAndroidAppId": None,
+}
+
+
+class CheckError(Exception):
+    """The check itself could not run (unreadable input, failed fetch, stale field list)."""
+
+
+def read_text(path):
+    try:
+        return Path(path).read_text(encoding="utf-8")
+    except OSError as e:
+        raise CheckError(f"could not read {path}: {e}")
+
+
+def regions_directory_url(resource_path):
+    """The `regions_api_url` string resource — the directory URL the app itself fetches."""
+    try:
+        resources = ElementTree.fromstring(read_text(resource_path))
+    except ElementTree.ParseError as e:
+        raise CheckError(f"could not parse {resource_path}: {e}")
+    for string in resources.iter("string"):
+        if string.get("name") == REGIONS_URL_RESOURCE_NAME:
+            return string.text
+    raise CheckError(f"no <string name=\"{REGIONS_URL_RESOURCE_NAME}\"> in {resource_path}")
+
+
+def fetch(url):
+    # An explicit User-Agent is required, not politeness: the directory host answers 403 to
+    # urllib's default `Python-urllib/3.x`.
+    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    try:
+        with urllib.request.urlopen(request, timeout=60) as response:
+            return response.read().decode("utf-8")
+    except (urllib.error.URLError, OSError) as e:
+        raise CheckError(f"could not fetch {url}: {e}")
+
+
+def load_regions(text, source):
+    """Return {id: region} from a regions-vN.json envelope."""
+    try:
+        return {r["id"]: r for r in json.loads(text)["data"]["list"]}
+    except (ValueError, KeyError, TypeError) as e:
+        raise CheckError(f"{source} is not a regions directory envelope: {e}")
+
+
+def check_fields_exist(regions, source):
+    """Fail if a checked field appears on no region — the name has gone stale (see CHECKED_FIELDS)."""
+    unknown = [f for f in CHECKED_FIELDS if not any(f in r for r in regions.values())]
+    if unknown:
+        raise CheckError(
+            f"CHECKED_FIELDS names no region in {source} carries: {', '.join(unknown)}. "
+            "Either the name is misspelled or the directory renamed the field; left as-is it would "
+            "compare equal on both sides forever and this check would rot green."
+        )
+
+
+def effective(region, field):
+    """The value RegionDto decodes for `field`: an absent or null key means the default."""
+    value = region.get(field)
+    return CHECKED_FIELDS[field] if value is None else value
+
+
+def describe(region_id, region):
+    return f"[{region_id}] {region.get('regionName', '?')}"
+
+
+def find_drift(bundled, live):
+    """Return a list of human-readable drift lines; empty means the two agree."""
+    drift = []
+
+    for region_id in sorted(set(live) - set(bundled)):
+        drift.append(
+            f"{describe(region_id, live[region_id])}: in the live directory but not bundled -- "
+            "first-launch users in this region get no config at all"
+        )
+    for region_id in sorted(set(bundled) - set(live)):
+        drift.append(
+            f"{describe(region_id, bundled[region_id])}: bundled but gone from the live directory -- "
+            "first-launch users may be sent to a retired deployment"
+        )
+
+    for region_id in sorted(set(bundled) & set(live)):
+        for field in CHECKED_FIELDS:
+            bundled_value = effective(bundled[region_id], field)
+            live_value = effective(live[region_id], field)
+            if bundled_value != live_value:
+                drift.append(
+                    f"{describe(region_id, live[region_id])}: {field}\n"
+                    f"    bundled: {json.dumps(bundled_value)}\n"
+                    f"    live:    {json.dumps(live_value)}"
+                )
+    return drift
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--bundled", default=BUNDLED_REGIONS, help="path to the bundled regions file")
+    parser.add_argument("--live-file", help="compare against this local file instead of fetching")
+    args = parser.parse_args(argv)
+
+    live_source = args.live_file or regions_directory_url(REGIONS_URL_RESOURCE)
+    live_text = read_text(args.live_file) if args.live_file else fetch(live_source)
+
+    bundled = load_regions(read_text(args.bundled), args.bundled)
+    live = load_regions(live_text, live_source)
+    check_fields_exist(live, live_source)
+
+    print(f"bundled: {args.bundled} ({len(bundled)} regions)")
+    print(f"live:    {live_source} ({len(live)} regions)")
+    print(f"fields:  {', '.join(CHECKED_FIELDS)}\n")
+
+    drift = find_drift(bundled, live)
+    if not drift:
+        print("No drift: the bundled fail-safe file agrees with the live directory.")
+        return 0
+
+    print(f"Drift found in {len(drift)} place(s):\n")
+    for line in drift:
+        print(f"  * {line}")
+    print(
+        "\nThe bundled file is the first-launch and offline source, so these are real behaviour\n"
+        "differences for users who have not yet refreshed their region cache. Sync the fields\n"
+        "above into\n"
+        f"    {args.bundled}\n"
+        "and update any test that pins one of them (see RegionsDecodeTest). Issue #2019 has the\n"
+        "background."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main(sys.argv[1:]))
+    except CheckError as e:
+        print(f"error: {e}", file=sys.stderr)
+        sys.exit(2)


### PR DESCRIPTION
Fixes #2019.

`onebusaway-android/src/main/res/raw/regions_v3.json` is the app's **first-launch and offline**
region config, not a convenience copy of the live directory: a device that acts before its first
regions fetch lands reads the bundled values. So a field the app branches on that has drifted there
is a real behaviour difference for exactly those users — and invisible to every device that has
already refreshed its region cache. Nothing compared the two files, and `RegionsDecodeTest` pins the
bundled value against itself, so the drift below sat unnoticed.

## Sync the fields that had drifted

- **Puget Sound's `otpBaseGraphqlUrl`**, from the `execute-api` host to the
  `sound-transit-otp.ibi-transit.com` one the directory now publishes. That field decides whether
  trip planning speaks OTP2 at all (#1780) and gates Puget Sound's bikeshare itineraries (#2017),
  so retiring the stale host would have quietly broken first-launch trip planning in Seattle.
  Verified behaviour-neutral today: both hosts answer a `planConnection` query with byte-identical
  itineraries, i.e. they front the same deployment.
- **Analytics config** for Tampa Bay, Puget Sound, San Diego and Davis, which the directory migrated
  from Plausible to Umami. The bundled file still carried two dead `plausibleAnalyticsServerUrl`
  hosts and no `umamiAnalytics` block. Flagging this one for a maintainer eye: it means Puget Sound
  and San Diego now emit Umami events from first launch rather than from the first directory
  refresh a few minutes later, which is what the live directory already asks for on every
  already-synced device.

## Catch the next one: `tools/check-regions-drift.py` + a nightly `regions-drift` leg

Diffs the two sources on the fields the app branches on — endpoints, the `RegionUtils.isRegionUsable`
gates, the per-protocol OTP flags, analytics config, `paymentAndroidAppId` — plus region add/remove,
and fails on drift.

- Comparison is on **effective** values (absent or explicit null decodes to the `RegionDto` default),
  so the directory stating a default the bundled file omits isn't reported as drift.
- `bounds` and `open311Servers` are deliberately excluded, with the rationale at the site: geometry
  is retuned constantly by tiny float amounts, and the Open311 entries differ only in null-vs-`""`
  for an unread jurisdiction id. A check noisy enough to be ignored is worse than no check.
- The directory URL is read from the `regions_api_url` string resource the app itself fetches,
  rather than restated — otherwise a `regions-v3` → `-v4` bump would move the app and leave this
  check comparing against a directory nobody reads.
- `CHECKED_FIELDS` necessarily restates `RegionDto`'s decode-defaults in Python. The dangerous
  failure there is a stale *name*: it would read as the default on both sides and compare equal
  forever, leaving the check green. `check_fields_exist` fails the run instead.

It's a nightly leg rather than a unit test because it needs network, which the PR/push workflow
deliberately doesn't have. Exit codes: 0 no drift, 1 drift, 2 the check itself could not run.

## Tests

`RegionsDecodeTest` had the stale host hard-coded; it keeps an exact pin (now the **only** place a
bundled value is pinned) with a note that it cannot by construction see directory drift.
`Otp2GraphQlEndpointTest` was also using the real Puget Sound host as its example — that's a pure
string-join function, so it goes back to a synthetic host and drops a second update site.

`./gradlew spotlessCheck testObaGoogleDebugUnitTest -PwarningsAsErrors=true` passes. Lint left to CI
per the repo guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Updated regional analytics settings, including adding Umami analytics for additional regions and adjusting plausible analytics where applicable.
  - Refreshed the Puget Sound GraphQL endpoint configuration for consistent trip planning.
- **Maintenance**
  - Added a nightly verification to detect and report drift between the bundled offline region configuration and live region data.
- **Documentation**
  - Expanded guidance explaining how the bundled regions file is treated as a live offline source and how drift should be handled.
- **Chores / Tests**
  - Ignored Python bytecode cache folders and updated related endpoint assertions in tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->