### PR TITLE
Name a route by its name, not its GTFS id, and draw its real mode

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/DirectionRowAlternativeRoutesTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/DirectionRowAlternativeRoutesTest.kt
@@ -76,7 +76,7 @@ class DirectionRowAlternativeRoutesTest {
     private val ride = TripLogEntry.Transit(
         routeShortName = "2 Line",
         routeDisplayName = "2 Line",
-        mode = TransitMode.BUS,
+        mode = TransitMode.RAIL,
         routeColorHex = "0075C4",
         headsign = "Downtown Redmond",
         boardTime = ServerTime(2 * 60_000L),

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/DirectionRowAlternativeRoutesTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/DirectionRowAlternativeRoutesTest.kt
@@ -68,13 +68,15 @@ class DirectionRowAlternativeRoutesTest {
             listOf(
                 RouteBadge("1 Line", 0xFF00A651.toInt()),
                 RouteBadge("2 Line", 0xFF0075C4.toInt())
-            )
+            ),
+            TransitMode.RAIL
         )
     )
 
     private val ride = TripLogEntry.Transit(
         routeShortName = "2 Line",
         routeDisplayName = "2 Line",
+        mode = TransitMode.BUS,
         routeColorHex = "0075C4",
         headsign = "Downtown Redmond",
         boardTime = ServerTime(2 * 60_000L),
@@ -89,7 +91,7 @@ class DirectionRowAlternativeRoutesTest {
     private fun state(routeLeg: RouteLegRef) = TripResultsUiState.Success(
         options = listOf(
             ItineraryOption(
-                mode = ModeSummary.Routes(listOf(routeLeg.badge)),
+                mode = ModeSummary.Routes(listOfNotNull(routeLeg.badge)),
                 durationMinutes = 32L,
                 startTime = ServerTime(0L),
                 endTime = ServerTime(32 * 60_000L)
@@ -124,7 +126,7 @@ class DirectionRowAlternativeRoutesTest {
     fun rideWithoutInterchangeableRoutesBadgesOnlyItsOwnRoute() {
         val soloRef = interlinedLegRef.copy(
             alternatives = emptyList(),
-            badge = LegBadge(listOf(RouteBadge("2 Line", 0xFF0075C4.toInt())))
+            badge = LegBadge(listOf(RouteBadge("2 Line", 0xFF0075C4.toInt())), TransitMode.RAIL)
         )
         composeRule.setContent { TripResultsList(state = state(soloRef)) }
 
@@ -148,7 +150,7 @@ class DirectionRowAlternativeRoutesTest {
             routeColor = "#0075C4"
         ).plannedBadge()
 
-        assertEquals("2 Line", badge.shortName)
-        assertEquals(0xFF0075C4.toInt(), badge.routeColor)
+        assertEquals("2 Line", badge?.shortName)
+        assertEquals(0xFF0075C4.toInt(), badge?.routeColor)
     }
 }

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/DirectionRowFocusTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/DirectionRowFocusTest.kt
@@ -81,9 +81,12 @@ class DirectionRowFocusTest {
         alight = RouteStopRef("1_600", "600", "Rainier & Alaska", alightPoint)
     )
 
+    private val transitTitle = "Route 8 Line"
+
     private val transit = TripLogEntry.Transit(
         routeShortName = "8",
-        routeDisplayName = "Route 8 Line",
+        routeDisplayName = transitTitle,
+        mode = TransitMode.BUS,
         routeColorHex = "1B6EF3",
         headsign = "Rainier Beach",
         boardTime = ServerTime(4 * 60_000L),
@@ -152,7 +155,7 @@ class DirectionRowFocusTest {
         composeRule.onNodeWithText(midStopName).assertDoesNotExist()
 
         // Tapping the transit header highlights the route and reveals the stops.
-        composeRule.onNodeWithText(transit.routeDisplayName).performClick()
+        composeRule.onNodeWithText(transitTitle).performClick()
         assertEquals("1_100", captured?.first?.routeId)
         assertEquals(transitLegPoints, captured?.second)
         composeRule.onNodeWithText(midStopName).assertExists()
@@ -170,7 +173,7 @@ class DirectionRowFocusTest {
         // the row, which is the actual control (an IconButton would be a second, competing target).
         composeRule.onNodeWithText(walkAction)
             .assert(hasClickLabel(context.getString(R.string.trip_plan_expand_leg)))
-        composeRule.onNodeWithText(transit.routeDisplayName)
+        composeRule.onNodeWithText(transitTitle)
             .assert(hasClickLabel(context.getString(R.string.trip_plan_expand_leg)))
 
         // …and once expanded it offers the inverse.

--- a/onebusaway-android/src/main/graphql/otp2/Plan.graphql
+++ b/onebusaway-android/src/main/graphql/otp2/Plan.graphql
@@ -18,8 +18,9 @@ fragment PlaceFields on Place {
 
 # RouteFields is the planned leg's route. AlternativeRouteFields is the deliberately smaller set an
 # alternative leg needs (below): a plan asks for alternatives on every transit leg of every itinerary,
-# so each field there is paid for many times over — it carries only what names the route on a badge
-# and what resolves it onto an OBA id, with no long name or agency timezone.
+# so each field there is paid for many times over — it carries only what names the route and what
+# resolves it onto an OBA id. `longName` is part of naming it: a route that publishes no short name
+# has nothing else to be called, and its id is not a name. Agency `timezone` stays the omission.
 fragment RouteFields on Route {
     gtfsId
     shortName
@@ -31,6 +32,7 @@ fragment RouteFields on Route {
 fragment AlternativeRouteFields on Route {
     gtfsId
     shortName
+    longName
     color
     agency { gtfsId name }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/adapters/Otp2PlanAdapters.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/adapters/Otp2PlanAdapters.kt
@@ -59,8 +59,11 @@ private fun PlanQuery.Leg.toTripLeg(): TripLeg = TripLeg(
     mode = mode?.rawValue.toEnum<TripMode>(),
     route = null, // No OTP2 equivalent of OTP1's flat display-string `route` field.
     routeId = route?.routeFields?.gtfsId,
-    routeShortName = route?.routeFields?.shortName,
-    routeLongName = route?.routeFields?.longName,
+    // Blank→null, same as the OTP1 adapter: GTFS routinely publishes an empty `route_short_name`
+    // (every Washington State Ferries route does), so absence arrives as both null and "".
+    // Normalizing here leaves the domain one representation of "this route has no short name".
+    routeShortName = route?.routeFields?.shortName?.ifBlank { null },
+    routeLongName = route?.routeFields?.longName?.ifBlank { null },
     routeColor = route?.routeFields?.color,
     agencyId = route?.routeFields?.agency?.gtfsId,
     agencyName = route?.routeFields?.agency?.name,
@@ -93,7 +96,8 @@ private fun PlanQuery.Leg.toTripLeg(): TripLeg = TripLeg(
 
 private fun PlanQuery.NextLeg.toTripLegAlternative(): TripLegAlternative = TripLegAlternative(
     routeId = route?.alternativeRouteFields?.gtfsId,
-    routeShortName = route?.alternativeRouteFields?.shortName,
+    routeShortName = route?.alternativeRouteFields?.shortName?.ifBlank { null },
+    routeLongName = route?.alternativeRouteFields?.longName?.ifBlank { null },
     routeColor = route?.alternativeRouteFields?.color,
     agencyId = route?.alternativeRouteFields?.agency?.gtfsId,
     agencyName = route?.alternativeRouteFields?.agency?.name,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/adapters/TripPlanAdapters.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/adapters/TripPlanAdapters.kt
@@ -55,10 +55,13 @@ fun OtpItineraryDto.toTripItinerary(): TripItinerary = TripItinerary(
 
 fun OtpLegDto.toTripLeg(): TripLeg = TripLeg(
     mode = mode.toEnum<TripMode>(),
-    route = route,
+    // Blank→null: GTFS routinely publishes an empty `route_short_name` (every Washington State
+    // Ferries route does), so absence arrives as both null and "". Normalizing here leaves the domain
+    // one representation, instead of every consumer re-deciding whether "" counts as a name.
+    route = route?.ifBlank { null },
     routeId = routeId,
-    routeShortName = routeShortName,
-    routeLongName = routeLongName,
+    routeShortName = routeShortName?.ifBlank { null },
+    routeLongName = routeLongName?.ifBlank { null },
     routeColor = routeColor,
     agencyName = agencyName,
     headsign = headsign,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/model/InterchangeableRoutes.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/model/InterchangeableRoutes.kt
@@ -56,15 +56,18 @@ import org.onebusaway.android.util.ROUTE_NAME_ORDER
  */
 data class InterchangeableRoute(
     val routeId: String,
-    val shortName: String?,
+    /**
+     * The name to show for this route: its short name, else its long name — never its id, for the
+     * reason spelled out on [routeDisplayShortName]. Non-null by construction: a route that publishes
+     * neither is not built at all, because "board any of these" is only actionable if the rider can
+     * tell which vehicle is which.
+     */
+    val displayName: String,
     val routeColor: String?,
     val agencyId: String?,
     val agencyName: String?,
     val headsign: String?
-) {
-    /** The name to show for this route, falling back to the OTP id when it has no short name. */
-    val displayName: String get() = shortName?.takeIf { it.isNotBlank() } ?: routeId
-}
+)
 
 /**
  * The interchangeable routes for each of [TripItinerary.legs], **index-aligned to that list** so a
@@ -89,10 +92,12 @@ private fun TripItinerary.interchangeableRoutesForLeg(index: Int): List<Intercha
         .mapValues { (_, trips) -> trips.maxBy { it.duration } }
         .values
         .filter { it.duration <= budget }
-        .map { candidate ->
+        // Resolving the name here rather than carrying its ingredients means a route the drawer can't
+        // name is never built — see [InterchangeableRoute.displayName].
+        .mapNotNull { candidate ->
             InterchangeableRoute(
                 routeId = requireNotNull(candidate.routeId),
-                shortName = candidate.routeShortName,
+                displayName = candidate.routeShortName ?: candidate.routeLongName ?: return@mapNotNull null,
                 routeColor = candidate.routeColor,
                 agencyId = candidate.agencyId,
                 agencyName = candidate.agencyName,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/model/TripItinerary.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/model/TripItinerary.kt
@@ -121,6 +121,9 @@ data class TripLeg(
 data class TripLegAlternative(
     val routeId: String? = null,
     val routeShortName: String? = null,
+    // Carried for the same reason the planned leg carries it: a route with no short name has to name
+    // itself somehow, and its id is not a name (see [routeDisplayShortName]).
+    val routeLongName: String? = null,
     val routeColor: String? = null,
     val agencyId: String? = null,
     val agencyName: String? = null,
@@ -157,12 +160,36 @@ data class TripStep(
 )
 
 /**
- * The leg's display short name: its route short name, else the OTP1 flat route string, else the route
- * id; null when the leg carries none. As a #662 work-around this deliberately never uses the trip short
- * name. Shared by the directions generator's itinerary title and the interline badge/label logic so the
- * fallback lives in one place.
+ * How a leg names its route, in the three forms the directions UI asks for. They differ only in which
+ * field wins, so they live together — reading one means reading the ordering it *didn't* choose:
+ *
+ *  - [routeDisplayShortName] — the badge. Short name only; null when there isn't one.
+ *  - [routeDisplayLabel] — prose and compact titles. Short name, else the long one.
+ *  - [routeDisplayName] — a row title that already has the badge beside it, so it leads with the long
+ *    name and falls back to the short one.
+ *
+ * None of them falls back to the route **id**. A GTFS id is an identifier, not a name: badging a
+ * Washington State Ferries run (`route_short_name` is empty; the route is named only
+ * "Seattle - Bremerton") as its OTP2 gtfsId `95:74` puts a string on screen that reads like a route
+ * number the rider could look for and will never find. A route with no short name simply has no badge;
+ * callers draw none and use one of the other two. The id fallback was near-harmless on OTP1, where the
+ * flat [TripLeg.route] display string usually caught the gap first; OTP2 has no equivalent field (its
+ * adapter sets `route = null`), which promoted the id from last resort to first.
+ *
+ * All three test null alone, not blankness: the adapters normalize a blank wire name to null on the way
+ * in, so absence has one representation by the time it reaches here.
  */
-fun TripLeg.routeDisplayShortName(): String? = listOf(routeShortName, route, routeId).firstOrNull { !it.isNullOrEmpty() }
+fun TripLeg.routeDisplayShortName(): String? = routeShortName ?: route
+
+/**
+ * The leg's route named as compactly as it can be — for prose and titles, where something has to be
+ * said, as opposed to [routeDisplayShortName], whose absence a badge can express by not being drawn.
+ * As a #662 work-around this deliberately never uses the trip short name.
+ */
+fun TripLeg.routeDisplayLabel(): String? = routeDisplayShortName() ?: routeLongName
+
+/** The fuller name for a row that shows the badge separately, so the long form leads. */
+fun TripLeg.routeDisplayName(): String? = routeLongName ?: routeDisplayShortName()
 
 @Serializable
 data class TripLegGeometry(val points: String? = null, val length: Int = 0)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/DirectionsGenerator.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/DirectionsGenerator.kt
@@ -28,7 +28,7 @@ import org.onebusaway.android.directions.model.TripLeg
 import org.onebusaway.android.directions.model.TripMode
 import org.onebusaway.android.directions.model.TripPlace
 import org.onebusaway.android.directions.model.TripRelativeDirection
-import org.onebusaway.android.directions.model.routeDisplayShortName
+import org.onebusaway.android.directions.model.routeDisplayLabel
 import org.onebusaway.android.time.ServerTime
 
 /**
@@ -376,12 +376,14 @@ class DirectionsGenerator(
                 }
             }
 
-            val tokens = ArrayList<String?>()
+            val tokens = ArrayList<String>()
 
             for (leg in legs) {
                 val mode = leg.mode
                 if (mode?.isTransit == true) {
-                    tokens.add(leg.routeDisplayShortName())
+                    // The label, not the badge name: a title has to say something for a route that
+                    // publishes no short name. A leg that names nothing at all is left out.
+                    leg.routeDisplayLabel()?.let(tokens::add)
                 } else {
                     if (mode == TripMode.BICYCLE) {
                         tokens.add(applicationContext.getString(R.string.transit_directions_bikeshare_label))
@@ -525,6 +527,11 @@ class DirectionsGenerator(
 
         /**
          * Gets the mode icon for the given mode
+         *
+         * Serves the legacy flat [Direction] list only. The Compose trip log has its own narrowed
+         * mapping (`TransitMode`/`transitModeIcon`), which is deliberately not the same: it is total
+         * (no `-1` miss), and it doesn't draw a GONDOLA — an aerial lift — as a boat. Don't reconcile
+         * the two by copying this one's answers onto that one.
          *
          * @return the mode icon for the given mode
          */

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/RouteBadgeChip.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/RouteBadgeChip.kt
@@ -16,16 +16,21 @@
 package org.onebusaway.android.ui.compose.components
 
 import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.CacheDrawScope
 import androidx.compose.ui.draw.clip
@@ -33,7 +38,10 @@ import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
 /** One route on a badge: its short name and (nullable) GTFS color as an ARGB int. */
@@ -52,6 +60,12 @@ private const val SLASH_SLANT_RATIO = 0.5f
 /** The width of the badge's outline and of the line where two routes meet inside it. */
 private val BADGE_LINE_WIDTH = 1.dp
 
+/** The mode glyph's size, and its gap from the name — sized to sit level with the name's cap height
+ *  rather than tower over it. Both scale with the chip. */
+private val BADGE_ICON_SIZE = 11.dp
+
+private val BADGE_ICON_GAP = 2.dp
+
 /**
  * The badge's outline, and the line where two of its routes meet: black in either theme. The chips
  * themselves are pale in light mode and deep in dark mode ([rememberRouteBadgeColors]) but always
@@ -66,10 +80,55 @@ private val BADGE_LINE_COLOR = Color.Black
  * where several routes sit in a row (the stop-focus header's subordinate routes, the trip-plan option
  * cards), as opposed to the large square [LineBadge]. [scale] enlarges the whole chip (text + padding)
  * proportionally — e.g. the directions board badge uses 1.5×.
+ *
+ * [maxWidth] caps the chip and ellipsizes the name past it. Unconstrained by default, since a route
+ * short name is a handful of characters; it's for callers that badge a route by its *long* name because
+ * it publishes no short one ("Seattle - Bremerton"), which would otherwise blow out a row of roundels.
+ *
+ * [leadingIcon] puts a glyph inside the chip, ahead of the name — the mode the route is ridden on, which
+ * a route number alone never says. [leadingIconDescription] labels it for TalkBack; the mode is real
+ * information, not decoration, so it is worth announcing.
  */
 @Composable
-fun RouteBadgeChip(shortName: String, routeColor: Int?, modifier: Modifier = Modifier, scale: Float = 1f) {
+fun RouteBadgeChip(
+    shortName: String,
+    routeColor: Int?,
+    modifier: Modifier = Modifier,
+    scale: Float = 1f,
+    maxWidth: Dp = Dp.Unspecified,
+    leadingIcon: Int? = null,
+    leadingIconDescription: String? = null
+) {
     val (container, content) = rememberRouteBadgeColors(routeColor)
+    Surface(
+        modifier = modifier.widthIn(max = maxWidth),
+        color = container,
+        contentColor = content,
+        shape = BADGE_SHAPE
+    ) {
+        BadgeContent(
+            name = shortName,
+            contentColor = content,
+            scale = scale,
+            horizontalPadding = 3.dp * scale,
+            leadingIcon = leadingIcon,
+            leadingIconDescription = leadingIconDescription
+        )
+    }
+}
+
+/** The badge's inner row — an optional mode glyph, then the route's name. Shared by the plain chip and
+ *  by each segment of the joined one, so the two can't drift on metrics or truncation. */
+@Composable
+private fun BadgeContent(
+    name: String,
+    contentColor: Color,
+    scale: Float,
+    horizontalPadding: Dp,
+    leadingIcon: Int?,
+    leadingIconDescription: String?,
+    modifier: Modifier = Modifier
+) {
     val base = MaterialTheme.typography.labelMedium
     // Scale every text metric together — the line box with the glyphs (labelMedium's 16sp line height
     // would clip a 1.5x-scaled name) and the tracking with both. TextUnit's own `* Float` keeps each
@@ -79,18 +138,26 @@ fun RouteBadgeChip(shortName: String, routeColor: Int?, modifier: Modifier = Mod
         lineHeight = base.lineHeight * scale,
         letterSpacing = base.letterSpacing * scale
     )
-    Surface(
-        modifier = modifier,
-        color = container,
-        contentColor = content,
-        shape = BADGE_SHAPE
+    Row(
+        modifier = modifier.padding(horizontal = horizontalPadding, vertical = 1.dp * scale),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(BADGE_ICON_GAP * scale)
     ) {
+        if (leadingIcon != null) {
+            Icon(
+                painter = painterResource(leadingIcon),
+                contentDescription = leadingIconDescription,
+                tint = contentColor,
+                modifier = Modifier.size(BADGE_ICON_SIZE * scale)
+            )
+        }
         Text(
-            text = shortName,
+            text = name,
             style = style,
             fontWeight = FontWeight.Bold,
             maxLines = 1,
-            modifier = Modifier.padding(horizontal = 3.dp * scale, vertical = 1.dp * scale)
+            overflow = TextOverflow.Ellipsis,
+            color = contentColor
         )
     }
 }
@@ -114,30 +181,34 @@ fun RouteBadgeChip(shortName: String, routeColor: Int?, modifier: Modifier = Mod
  * chip.
  */
 @Composable
-fun RouteBadgeChip(routes: List<RouteBadge>, modifier: Modifier = Modifier, scale: Float = 1f) {
+fun RouteBadgeChip(
+    routes: List<RouteBadge>,
+    modifier: Modifier = Modifier,
+    scale: Float = 1f,
+    maxWidth: Dp = Dp.Unspecified,
+    leadingIcon: Int? = null,
+    leadingIconDescription: String? = null
+) {
     val outlined = modifier.border(BADGE_LINE_WIDTH, BADGE_LINE_COLOR, BADGE_SHAPE)
     if (routes.size == 1) {
         val route = routes.first()
-        RouteBadgeChip(route.shortName, route.routeColor, outlined, scale)
+        RouteBadgeChip(route.shortName, route.routeColor, outlined, scale, maxWidth, leadingIcon, leadingIconDescription)
         return
     }
-    val base = MaterialTheme.typography.labelMedium
-    val style = base.copy(
-        fontSize = base.fontSize * scale,
-        lineHeight = base.lineHeight * scale,
-        letterSpacing = base.letterSpacing * scale
-    )
-    Row(outlined.clip(BADGE_SHAPE).height(IntrinsicSize.Min)) {
+    Row(outlined.widthIn(max = maxWidth).clip(BADGE_SHAPE).height(IntrinsicSize.Min)) {
         routes.forEachIndexed { index, route ->
             val (container, content) = rememberRouteBadgeColors(route.routeColor)
-            Text(
-                text = route.shortName,
-                style = style,
-                fontWeight = FontWeight.Bold,
-                maxLines = 1,
-                color = content,
+            BadgeContent(
+                name = route.shortName,
+                contentColor = content,
+                scale = scale,
                 // Wider than the plain chip's padding: the meeting line leans through the segment edges,
                 // so the extra breathing room keeps a name clear of it and of the neighbouring color.
+                horizontalPadding = 5.dp * scale,
+                // The glyph heads the badge, not each name in it: these routes are interchangeable, so
+                // they are one ride on one mode, and a glyph per segment would read as several.
+                leadingIcon = leadingIcon.takeIf { index == 0 },
+                leadingIconDescription = leadingIconDescription,
                 modifier = Modifier
                     .fillMaxHeight()
                     // drawWithCache, not drawBehind: the band's Path and the line's geometry depend only
@@ -164,7 +235,6 @@ fun RouteBadgeChip(routes: List<RouteBadge>, modifier: Modifier = Modifier, scal
                             }
                         }
                     }
-                    .padding(horizontal = 5.dp * scale, vertical = 1.dp * scale)
             )
         }
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/RouteBadgeChip.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/RouteBadgeChip.kt
@@ -179,6 +179,10 @@ private fun BadgeContent(
  * trip planner (`[2] [1 Line/2 Line]`), so they have to be bounded the same way. The plain chip's other
  * callers keep their un-outlined roundel. [scale] enlarges everything proportionally, as on the plain
  * chip.
+ *
+ * [maxWidth] applies only to that single-route case — see the note at the joined `Row` below.
+ * [leadingIcon] heads the whole badge rather than each name in it: interchangeable routes are one ride
+ * on one mode, so a glyph per segment would read as several legs.
  */
 @Composable
 fun RouteBadgeChip(
@@ -195,7 +199,12 @@ fun RouteBadgeChip(
         RouteBadgeChip(route.shortName, route.routeColor, outlined, scale, maxWidth, leadingIcon, leadingIconDescription)
         return
     }
-    Row(outlined.widthIn(max = maxWidth).clip(BADGE_SHAPE).height(IntrinsicSize.Min)) {
+    // Deliberately uncapped, unlike the plain chip: this Row's children are unweighted, so a bounded max
+    // would be consumed by the first segment and leave the later ones measured at zero width — a route
+    // silently missing from a badge that means "any of these will do" is far worse than a wide chip, and
+    // the option-card row it sits in already scrolls horizontally. [maxWidth] therefore only reaches the
+    // single-route delegation above, which is the case it exists for.
+    Row(outlined.clip(BADGE_SHAPE).height(IntrinsicSize.Min)) {
         routes.forEachIndexed { index, route ->
             val (container, content) = rememberRouteBadgeColors(route.routeColor)
             BadgeContent(

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/Interlines.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/Interlines.kt
@@ -98,8 +98,11 @@ internal object Interlines {
      * How a stay-aboard transition names the route the vehicle becomes ("stay on board for X"). The
      * prose label rather than the badge name — the sentence needs a name even where a badge would be
      * omitted — so a route with only a long name reads "stay on board for Seattle - Bremerton".
+     *
+     * Null when the route names itself in no way at all, so the renderer can reach for the headsign (or
+     * a generic) rather than building a sentence around a blank.
      */
-    fun transitionRouteLabel(leg: TripLeg): String = leg.routeDisplayLabel().orEmpty()
+    fun transitionRouteLabel(leg: TripLeg): String? = leg.routeDisplayLabel()
 }
 
 /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/Interlines.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/Interlines.kt
@@ -19,7 +19,7 @@ import org.onebusaway.android.directions.model.InterchangeableRoute
 import org.onebusaway.android.directions.model.TripItinerary
 import org.onebusaway.android.directions.model.TripLeg
 import org.onebusaway.android.directions.model.interchangeableRoutes
-import org.onebusaway.android.directions.model.routeDisplayShortName
+import org.onebusaway.android.directions.model.routeDisplayLabel
 
 /**
  * Pure interline analysis over a trip's legs (#2000) — no `Context` / OBA-id resolution, so it's
@@ -94,8 +94,12 @@ internal object Interlines {
         return badges
     }
 
-    /** The route's display short name, or empty — see [routeDisplayShortName]. */
-    fun badgeShortName(leg: TripLeg): String = leg.routeDisplayShortName().orEmpty()
+    /**
+     * How a stay-aboard transition names the route the vehicle becomes ("stay on board for X"). The
+     * prose label rather than the badge name — the sentence needs a name even where a badge would be
+     * omitted — so a route with only a long name reads "stay on board for Seattle - Bremerton".
+     */
+    fun transitionRouteLabel(leg: TripLeg): String = leg.routeDisplayLabel().orEmpty()
 }
 
 /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/RouteBadges.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/RouteBadges.kt
@@ -17,7 +17,8 @@ package org.onebusaway.android.ui.tripresults
 
 import org.onebusaway.android.directions.model.InterchangeableRoute
 import org.onebusaway.android.directions.model.TripLeg
-import org.onebusaway.android.directions.model.routeDisplayShortName
+import org.onebusaway.android.directions.model.TripMode
+import org.onebusaway.android.directions.model.routeDisplayLabel
 import org.onebusaway.android.ui.compose.components.RouteBadge
 import org.onebusaway.android.util.ROUTE_NAME_ORDER
 import org.onebusaway.android.util.parseObaHexColor
@@ -33,22 +34,35 @@ import org.onebusaway.android.util.parseObaHexColor
 
 /** The badge for one transit leg: its planned route joined by the routes ruled interchangeable with
  *  it ([org.onebusaway.android.directions.model.interchangeableRoutes]). */
-internal fun legBadge(leg: TripLeg, alternatives: List<InterchangeableRoute>): LegBadge = legBadge(leg.plannedBadge(), alternatives.map { it.badge() })
+internal fun legBadge(leg: TripLeg, alternatives: List<InterchangeableRoute>): LegBadge = legBadge(leg.plannedBadge(), alternatives.map { it.badge() }, leg.mode.transitMode())
 
 /**
  * The leg's badge: [planned] joined by [alternatives], in natural name order. The plan's own choice
  * isn't given pride of place, deliberately — the routes are interchangeable, so "1 Line/2 Line" should
  * read the same whichever one the planner picked; which one it did pick is still on the card's header
  * line and its ETA strip.
+ *
+ * [planned] is null only for a route that names itself in no way at all; an alternative can't be, since
+ * an unnameable one is never built. A leg left with no routes renders as its [mode] instead.
  */
-internal fun legBadge(planned: RouteBadge, alternatives: List<RouteBadge>): LegBadge = LegBadge(
-    (listOf(planned) + alternatives)
+internal fun legBadge(planned: RouteBadge?, alternatives: List<RouteBadge>, mode: TransitMode): LegBadge = LegBadge(
+    (listOfNotNull(planned) + alternatives)
         .distinctBy { it.shortName }
-        .sortedWith(compareBy(ROUTE_NAME_ORDER) { it.shortName })
+        .sortedWith(compareBy(ROUTE_NAME_ORDER) { it.shortName }),
+    mode
 )
 
-/** The transit leg's own roundel: its display short name and parsed GTFS color. */
-internal fun TripLeg.plannedBadge(): RouteBadge = RouteBadge(routeDisplayShortName().orEmpty(), badgeColor(routeColor))
+/**
+ * The transit leg's own roundel: its badge name and parsed GTFS color; null when it names itself in no
+ * way at all.
+ *
+ * Uses the label rather than the badge name, so a route publishing no short name badges its long name
+ * ("Seattle - Bremerton") — the option cards cap the roundel's width and ellipsize, since a long name is
+ * still a better answer to "what do I ride?" than a glyph or, as it once was, a raw GTFS id. The
+ * directions pane still draws no roundel for such a route: it has room to print the long name in full as
+ * the row's title, and doesn't reach for this badge to do it.
+ */
+internal fun TripLeg.plannedBadge(): RouteBadge? = routeDisplayLabel()?.let { RouteBadge(it, badgeColor(routeColor)) }
 
 /** An interchangeable route's roundel, alongside [plannedBadge] in the same leg's badge. */
 internal fun InterchangeableRoute.badge(): RouteBadge = RouteBadge(displayName, badgeColor(routeColor))

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripLogBuilder.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripLogBuilder.kt
@@ -20,6 +20,7 @@ import org.onebusaway.android.directions.model.Direction
 import org.onebusaway.android.directions.model.TripLeg
 import org.onebusaway.android.directions.model.TripMode
 import org.onebusaway.android.directions.model.decodedPoints
+import org.onebusaway.android.directions.model.routeDisplayName
 import org.onebusaway.android.directions.model.routeDisplayShortName
 import org.onebusaway.android.util.GeoPoint
 import org.onebusaway.android.util.geoPointOrNull
@@ -166,8 +167,9 @@ object TripLogBuilder {
     ): TripLogEntry.Transit {
         val routeLeg = ref ?: fallbackRouteLeg(leg)
         return TripLogEntry.Transit(
-            routeShortName = leg.routeDisplayShortName().orEmpty(),
+            routeShortName = leg.routeDisplayShortName(),
             routeDisplayName = leg.routeDisplayName(),
+            mode = leg.mode.transitMode(),
             routeColorHex = leg.routeColor,
             headsign = leg.headsign ?: routeLeg.headsign,
             boardTime = leg.startTime,
@@ -216,9 +218,6 @@ object TripLogBuilder {
 
     /** True for a walk leg flanked by transit on both sides — a transfer, vs. a first/last-mile walk. */
     private fun List<TripLeg>.isTransferAt(i: Int): Boolean = getOrNull(i - 1)?.mode?.isTransit == true && getOrNull(i + 1)?.mode?.isTransit == true
-
-    /** The route's fuller display name for the board title (long name, else the shared short-name fallback). */
-    private fun TripLeg.routeDisplayName(): String = routeLongName?.takeIf { it.isNotBlank() } ?: routeDisplayShortName().orEmpty()
 
     /** Real-time board state from the leg's [TripLeg.realTime] flag + [TripLeg.departureDelay]. */
     private fun TripLeg.realtimeState(): RealtimeState {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsRepository.kt
@@ -123,7 +123,7 @@ class DefaultTripResultsRepository @Inject constructor(
             val leader = legs[chain.leaderIndex]
             val transitions = chain.transitionLegIndices.associateWith { j ->
                 InterlineTransition(
-                    routeShortName = Interlines.badgeShortName(legs[j]),
+                    routeLabel = Interlines.transitionRouteLabel(legs[j]),
                     headsign = legs[j].headsign,
                     stop = legs[j].from.resolveStop(legs[j])
                 )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
@@ -169,6 +169,15 @@ fun TripResultsHeader(
     }
 }
 
+/**
+ * How wide an option card's route roundel may grow before its name ellipsizes. Only bites on a route
+ * badged by its long name (one publishing no short name — see [plannedBadge]); a route number plus its
+ * mode glyph never comes near it. Sized to show enough of a long name to recognize it —
+ * "Seattle - Brem…" — without letting one leg crowd the rest off the card, with room for the glyph the
+ * badge now leads with. Tune here.
+ */
+private val OPTION_BADGE_MAX_WIDTH = 110.dp
+
 @Composable
 private fun OptionCard(
     option: ItineraryOption,
@@ -201,14 +210,33 @@ private fun OptionCard(
                 // One roundel per leg. The gap between legs is deliberately wide, so "two legs" and
                 // "one leg, two interchangeable routes" (which is one seamless chip) can't read as the
                 // same thing (#2010).
-                is ModeSummary.Routes -> Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
-                    mode.badges.forEach { RouteBadgeChip(it.routes) }
+                is ModeSummary.Routes -> Row(
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    // Every badge leads with the mode it's ridden on, which a route number never says on
+                    // its own. A route publishing no short name badges its long name, capped to
+                    // [OPTION_BADGE_MAX_WIDTH] and ellipsized so one wordy name can't crowd the
+                    // other legs off the card; only a route that names itself in no way at all is left
+                    // with the bare glyph.
+                    mode.badges.forEach { badge ->
+                        val glyph = transitModeIcon(badge.mode)
+                        val glyphLabel = stringResource(transitModeLabel(badge.mode))
+                        if (badge.isUnnamed) {
+                            ModeGlyph(glyph, glyphLabel)
+                        } else {
+                            RouteBadgeChip(
+                                badge.routes,
+                                maxWidth = OPTION_BADGE_MAX_WIDTH,
+                                leadingIcon = glyph,
+                                leadingIconDescription = glyphLabel
+                            )
+                        }
+                    }
                 }
-                ModeSummary.Walk -> Icon(
-                    painterResource(R.drawable.ic_directions_walk),
-                    contentDescription = stringResource(R.string.step_by_step_non_transit_mode_walk_action),
-                    // Sized to the route-badge row height so a walk-only card's first line matches.
-                    modifier = Modifier.size(20.dp)
+                ModeSummary.Walk -> ModeGlyph(
+                    R.drawable.ic_directions_walk,
+                    stringResource(R.string.step_by_step_non_transit_mode_walk_action)
                 )
                 is ModeSummary.Label -> Text(
                     text = mode.text,
@@ -779,6 +807,41 @@ private fun streetModeIcon(mode: StreetMode): Int? = when (mode) {
 }
 
 /**
+ * An option card's mode glyph, standing in for a route badge — the walk-only trip's walking figure, or
+ * the vehicle a leg with no route name is ridden on. Sized to the route-badge row height so a card's
+ * first line lines up whichever form it takes, and always labelled: with no badge beside it, this glyph
+ * is the only thing naming that leg.
+ */
+@Composable
+private fun ModeGlyph(iconRes: Int, contentDescription: String) {
+    Icon(painterResource(iconRes), contentDescription = contentDescription, modifier = Modifier.size(20.dp))
+}
+
+/**
+ * The glyph for a transit leg — its Board node on the spine, and the option card's stand-in for a leg
+ * whose route publishes no name. Total over [TransitMode] (which is already narrowed to the art the app
+ * ships), so unlike [streetModeIcon] there is no null case: a ride always draws something.
+ */
+private fun transitModeIcon(mode: TransitMode): Int = when (mode) {
+    TransitMode.BUS -> R.drawable.ic_bus
+    TransitMode.RAIL -> R.drawable.ic_directions_railway
+    TransitMode.SUBWAY -> R.drawable.ic_directions_subway
+    TransitMode.TRAM -> R.drawable.ic_tram
+    // ic_directions_boat, not the byte-identical ic_ferry: it's drawn to match the weight of the
+    // walk/railway/subway glyphs the spine already uses.
+    TransitMode.FERRY -> R.drawable.ic_directions_boat
+}
+
+/** What to call [mode] aloud, for a glyph standing in for a route name. */
+private fun transitModeLabel(mode: TransitMode): Int = when (mode) {
+    TransitMode.BUS -> R.string.step_by_step_transit_mode_bus
+    TransitMode.RAIL -> R.string.step_by_step_transit_mode_rail
+    TransitMode.SUBWAY -> R.string.step_by_step_transit_mode_subway
+    TransitMode.TRAM -> R.string.step_by_step_transit_mode_tram
+    TransitMode.FERRY -> R.string.step_by_step_transit_mode_ferry
+}
+
+/**
  * The node graphic for a row, positioned so its centre sits on the spine's colour-flip point. Route-
  * coloured nodes use [nodeColor] (the leg's colour, already parsed once in [flattenLog]).
  */
@@ -800,7 +863,7 @@ private fun BoxScope.LogNode(content: RowContent, nodeColors: RouteLineColors) {
         is RowContent.WalkHeader ->
             RingNode(24.dp, 1.5.dp, muted.copy(alpha = 0.6f), iconRes = streetModeIcon(content.entry.mode))
         is RowContent.BoardHeader ->
-            FilledNode(26.dp, nodeColor, R.drawable.ic_bus, onNode, 16.dp, shape = RoundedCornerShape(8.dp))
+            FilledNode(26.dp, nodeColor, transitModeIcon(content.entry.mode), onNode, 16.dp, shape = RoundedCornerShape(8.dp))
         is RowContent.ExitNode -> RingNode(22.dp, 3.dp, nodeColor)
         is RowContent.Stop -> RingNode(11.dp, 2.dp, nodeColor)
         is RowContent.Transition ->
@@ -962,18 +1025,20 @@ private fun ColumnScope.BoardContent(
             .clickable(onClickLabel = expandLabel(model), onClick = onToggle)
     ) {
         // A ride the rider may take on more than one route (#2010) badges them all as one joined
-        // roundel; an ordinary ride badges its own route exactly as before.
-        val badge = entry.routeLeg.badge
+        // roundel; an ordinary ride badges its own route exactly as before. A route that publishes no
+        // short name gets no roundel and leads with its long name — see routeDisplayShortName.
+        val joined = entry.routeLeg.badge?.takeIf { it.isInterchangeable }
+        val title = entry.routeDisplayName?.takeIf { it != entry.routeShortName }
         Row(verticalAlignment = Alignment.CenterVertically) {
-            if (badge.isInterchangeable) {
-                RouteBadgeChip(badge.routes, scale = 1.5f)
-            } else {
-                RouteBadgeChip(entry.routeShortName, routeColorInt(entry.routeColorHex), scale = 1.5f)
+            when {
+                joined != null -> RouteBadgeChip(joined.routes, scale = 1.5f)
+                entry.routeShortName != null ->
+                    RouteBadgeChip(entry.routeShortName, routeColorInt(entry.routeColorHex), scale = 1.5f)
             }
-            if (entry.routeDisplayName.isNotEmpty() && entry.routeDisplayName != entry.routeShortName) {
-                Spacer(Modifier.width(8.dp))
+            if (joined != null || entry.routeShortName != null) Spacer(Modifier.width(8.dp))
+            if (title != null) {
                 Text(
-                    text = entry.routeDisplayName,
+                    text = title,
                     style = MaterialTheme.typography.bodyLarge,
                     fontWeight = FontWeight.Medium,
                     color = MaterialTheme.colorScheme.onSurface,
@@ -993,7 +1058,7 @@ private fun ColumnScope.BoardContent(
         }
         // What the joined badge means: any of those routes will do, so board the first to arrive. Each
         // one's own ETA strip sits under the board stop below (#2010).
-        if (badge.isInterchangeable) {
+        if (joined != null) {
             Text(
                 text = stringResource(R.string.directions_whichever_comes_first),
                 style = MaterialTheme.typography.bodyMedium,
@@ -1040,7 +1105,7 @@ private fun ColumnScope.StopContent(stop: LogStop) {
 @Composable
 private fun ColumnScope.TransitionContent(transition: InterlineTransition) {
     val routeLabel = buildString {
-        append(transition.routeShortName.orEmpty())
+        append(transition.routeLabel.orEmpty())
         if (!transition.headsign.isNullOrEmpty()) {
             append(" ")
             append(stringResource(R.string.step_by_step_transit_connector_headsign))
@@ -1177,12 +1242,13 @@ private fun TripResultsPreview() {
                     // A bus leg, then an interchangeable rail pair drawn as one joined badge (#2010).
                     mode = ModeSummary.Routes(
                         listOf(
-                            LegBadge(listOf(RouteBadge("8", 0xFF1B6EF3.toInt()))),
+                            LegBadge(listOf(RouteBadge("8", 0xFF1B6EF3.toInt())), TransitMode.BUS),
                             LegBadge(
                                 listOf(
                                     RouteBadge("1 Line", 0xFF00A651.toInt()),
                                     RouteBadge("2 Line", 0xFF0075C4.toInt())
-                                )
+                                ),
+                                TransitMode.RAIL
                             )
                         )
                     ),
@@ -1192,8 +1258,13 @@ private fun TripResultsPreview() {
                     walkDistanceMeters = 800.0
                 ),
                 ItineraryOption(
+                    // The second leg is a ferry, which publishes no route short name — so it badges its
+                    // long name, capped and ellipsized.
                     mode = ModeSummary.Routes(
-                        listOf(LegBadge(listOf(RouteBadge("48", null))), LegBadge(listOf(RouteBadge("11", null))))
+                        listOf(
+                            LegBadge(listOf(RouteBadge("48", null)), TransitMode.BUS),
+                            LegBadge(listOf(RouteBadge("Seattle - Bremerton", null)), TransitMode.FERRY)
+                        )
                     ),
                     durationMinutes = 41,
                     startTime = ServerTime(0L),
@@ -1218,6 +1289,7 @@ private fun TripResultsPreview() {
                 TripLogEntry.Transit(
                     routeShortName = "8",
                     routeDisplayName = "Route 8",
+                    mode = TransitMode.BUS,
                     routeColorHex = "1B6EF3",
                     headsign = "Rainier Beach",
                     boardTime = ServerTime(4 * 60_000L),
@@ -1236,10 +1308,30 @@ private fun TripResultsPreview() {
                         alight = RouteStopRef("1_600", "600", "Rainier & Alaska", null)
                     )
                 ),
+                // A Washington State Ferries run: no route short name, so no badge — the long name is
+                // the row's title and the boat glyph rides the spine.
+                TripLogEntry.Transit(
+                    routeShortName = "",
+                    routeDisplayName = "Seattle - Bremerton",
+                    mode = TransitMode.FERRY,
+                    routeColorHex = null,
+                    headsign = "Bremerton",
+                    boardTime = ServerTime(24 * 60_000L),
+                    exitTime = ServerTime(84 * 60_000L),
+                    durationMinutes = 60,
+                    realtime = RealtimeState.Unknown,
+                    rideEvents = emptyList(),
+                    routeLeg = RouteLegRef(
+                        routeId = "95_74",
+                        headsign = "Bremerton",
+                        board = RouteStopRef("95_1", null, "Seattle Ferry Terminal", null),
+                        alight = RouteStopRef("95_2", null, "Bremerton Ferry Terminal", null)
+                    )
+                ),
                 TripLogEntry.Terminal(
                     kind = TerminalKind.ARRIVE,
-                    time = ServerTime(32 * 60_000L),
-                    place = "Rainier & Alaska"
+                    time = ServerTime(90 * 60_000L),
+                    place = "Bremerton"
                 )
             )
         )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
@@ -1104,17 +1104,18 @@ private fun ColumnScope.StopContent(stop: LogStop) {
  */
 @Composable
 private fun ColumnScope.TransitionContent(transition: InterlineTransition) {
-    val routeLabel = buildString {
-        append(transition.routeLabel.orEmpty())
-        if (!transition.headsign.isNullOrEmpty()) {
-            append(" ")
-            append(stringResource(R.string.step_by_step_transit_connector_headsign))
-            append(" ")
-            append(transition.headsign)
-        }
-    }.trim()
+    val headsign = transition.headsign?.takeIf { it.isNotEmpty() }
+    // "the vehicle becomes <X>" needs a subject. With a route name, X is that name (plus "to
+    // <headsign>" when there is one). With no name the headsign stands in alone — never behind the "to"
+    // connector, which would read "becomes to Bremerton" — and with neither, the sentence drops the
+    // subject entirely rather than trailing off into a blank.
+    val becomes = when (val route = transition.routeLabel) {
+        null -> headsign
+        else -> headsign?.let { "$route ${stringResource(R.string.step_by_step_transit_connector_headsign)} $it" } ?: route
+    }
     Text(
-        text = stringResource(R.string.step_by_step_transit_interline, routeLabel),
+        text = becomes?.let { stringResource(R.string.step_by_step_transit_interline, it) }
+            ?: stringResource(R.string.step_by_step_transit_interline_unknown_route),
         style = MaterialTheme.typography.bodyMedium,
         fontWeight = FontWeight.SemiBold,
         color = MaterialTheme.colorScheme.onSurface
@@ -1311,7 +1312,7 @@ private fun TripResultsPreview() {
                 // A Washington State Ferries run: no route short name, so no badge — the long name is
                 // the row's title and the boat glyph rides the spine.
                 TripLogEntry.Transit(
-                    routeShortName = "",
+                    routeShortName = null,
                     routeDisplayName = "Seattle - Bremerton",
                     mode = TransitMode.FERRY,
                     routeColorHex = null,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
@@ -15,6 +15,7 @@
  */
 package org.onebusaway.android.ui.tripresults
 
+import org.onebusaway.android.directions.model.TripMode
 import org.onebusaway.android.map.RiddenSegment
 import org.onebusaway.android.time.ServerTime
 import org.onebusaway.android.ui.compose.components.RouteBadge
@@ -59,10 +60,17 @@ sealed interface ModeSummary {
  *
  * [routes] is in natural route-name order rather than plan order, so a corridor reads the same way
  * whichever of its lines the planner happened to pick.
+ *
+ * [routes] is **empty** for a leg whose route publishes no short name — there is no roundel to draw, so
+ * the option card falls back to the leg's [mode] glyph rather than an empty chip or a silently missing
+ * leg (a ferry ride still has to appear on the card).
  */
-data class LegBadge(val routes: List<RouteBadge>) {
+data class LegBadge(val routes: List<RouteBadge>, val mode: TransitMode) {
     /** Whether this leg has more than one route to ride, i.e. the chip is a joined/multicolor one. */
     val isInterchangeable: Boolean get() = routes.size > 1
+
+    /** True when the leg names no route at all, and can only be shown as its mode. */
+    val isUnnamed: Boolean get() = routes.isEmpty()
 }
 
 /**
@@ -120,10 +128,16 @@ sealed interface TripLogEntry {
      * [routeLeg]: tapping the leg highlights the route ([routeLeg] + [legPoints]) and the Board node
      * shows that stop's live ETA strip. [routeColorHex] is the raw GTFS colour (nullable); the renderer
      * re-tones it for the badge and the spine, falling back to a neutral transit colour.
+     *
+     * [routeShortName] is the badge name and is **null when the route publishes none** — the renderer
+     * then draws no roundel and leads with [routeDisplayName]; see
+     * [routeDisplayShortName][org.onebusaway.android.directions.model.routeDisplayShortName]. [mode] is
+     * what the rider boards, and picks the Board node's glyph — a ferry leg must not read as a bus.
      */
     data class Transit(
-        val routeShortName: String,
-        val routeDisplayName: String,
+        val routeShortName: String?,
+        val routeDisplayName: String?,
+        val mode: TransitMode,
         val routeColorHex: String?,
         val headsign: String?,
         val boardTime: ServerTime,
@@ -165,6 +179,33 @@ enum class TerminalKind { START, ARRIVE }
 enum class StreetMode { WALK, BIKE, CAR }
 
 /**
+ * What a [TripLogEntry.Transit] leg is ridden on, narrowed from [TripMode] to the vehicle families the
+ * app ships a glyph for — so the renderer's glyph choice is total and an on-street mode can't reach it.
+ *
+ * [BUS] doubles as the generic: OTP's own umbrella modes (`TRANSIT`/`BUSISH`) and anything unrecognized
+ * land there, which is the status quo for every transit leg and right far more often than not. The
+ * named cases exist so the modes a rider would notice being wrong — a boat drawn as a bus — are right.
+ */
+enum class TransitMode { BUS, RAIL, SUBWAY, TRAM, FERRY }
+
+/**
+ * The vehicle family a transit leg is ridden on, narrowed from the wire mode to the art the app
+ * actually ships.
+ *
+ * Collapsing a cable car onto the tram glyph matches how the map already normalizes route types
+ * (`VehicleBitmaps.normalizeVehicleType`). Aerial lifts and funiculars aren't named here for the same
+ * reason they aren't there: the app ships no art for them, so they take the generic rather than a glyph
+ * that asserts the wrong vehicle. OTP's umbrella modes and a leg with no mode land there too.
+ */
+fun TripMode?.transitMode(): TransitMode = when (this) {
+    TripMode.FERRY -> TransitMode.FERRY
+    TripMode.RAIL, TripMode.TRAINISH -> TransitMode.RAIL
+    TripMode.SUBWAY -> TransitMode.SUBWAY
+    TripMode.TRAM, TripMode.CABLE_CAR -> TransitMode.TRAM
+    else -> TransitMode.BUS
+}
+
+/**
  * One turn-by-turn step of a walk leg: its localized instruction [text] (the maneuver only — the
  * distance is *not* baked in), the step's [distanceMeters] (rendered as a per-step delta in the time
  * column, in the user's units), and the map [point] it refers to (null when the step had no coordinates).
@@ -199,7 +240,8 @@ sealed interface RealtimeState {
  * [alternatives] are the interchangeable routes for this leg (#2010) — the board stop shows each
  * one's live ETA strip under the planned route's, so the rider can see which of them comes first.
  * [badge] is the leg's finished roundel (planned route joined by those alternatives), built once by
- * the repository rather than re-derived per row while composing.
+ * the repository rather than re-derived per row while composing; null where no badge was built at all
+ * (fixtures), which is not the same as a badge that found no route to name.
  */
 data class RouteLegRef(
     val routeId: String?,
@@ -219,18 +261,21 @@ data class RouteLegRef(
     // Empty for an ordinary leg. Carried straight onto [org.onebusaway.android.map.ShowRouteRequest].
     val extraSegments: List<RiddenSegment> = emptyList(),
     val alternatives: List<AlternativeRouteRef> = emptyList(),
-    val badge: LegBadge = LegBadge(emptyList())
+    val badge: LegBadge? = null
 )
 
 /**
  * A stay-aboard interline onto a **different** route within one continuous vehicle ride (#2000): at
- * [stop] the vehicle changes to route [routeShortName] (heading to [headsign]) and the passenger stays
+ * [stop] the vehicle changes to route [routeLabel] (heading to [headsign]) and the passenger stays
  * seated. Rendered as a distinct row between Board and Alight so the directions never tell the rider to
  * get off and reboard. Self-interlines (same route reversing onto itself) produce no transition — the
  * seam vanishes entirely.
+ *
+ * [routeLabel] is the prose label ([Interlines.transitionRouteLabel]), not the badge name: this row is a
+ * sentence, so it names a short-name-less route by its long name rather than saying nothing.
  */
 data class InterlineTransition(
-    val routeShortName: String?,
+    val routeLabel: String?,
     val headsign: String?,
     val stop: RouteStopRef
 )

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -1012,6 +1012,9 @@
     <!-- Shown when the trip stays aboard the same vehicle but its route changes (a stay-aboard
          interline, #2000); %1$s is the new route label, e.g. "12 to Downtown". -->
     <string name="step_by_step_transit_interline">Stay on board — the vehicle becomes %1$s</string>
+    <!-- The same stay-aboard interline where the new route publishes neither a name nor a headsign, so
+         there is nothing to name it by. The instruction still has to be given. -->
+    <string name="step_by_step_transit_interline_unknown_route">Stay on board — the vehicle continues on another route</string>
     <!--                This is exactly the formula that should be used, because the app won't include
                     the destination stop under this text, so would be best to avoid expressions like
                      "stops to destination". For example in the trip Barcelona/Paris/London/New York,

--- a/onebusaway-android/src/test/java/org/onebusaway/android/api/Otp2PlanDecodeTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/api/Otp2PlanDecodeTest.kt
@@ -116,6 +116,7 @@ class Otp2PlanDecodeTest {
                         alternativeRouteFields = AlternativeRouteFields(
                             gtfsId = "1_7",
                             shortName = "7",
+                            longName = "Rainier Beach - Downtown",
                             color = "FF0000",
                             agency = AlternativeRouteFields.Agency(gtfsId = "1_1", name = "Metro")
                         )

--- a/onebusaway-android/src/test/java/org/onebusaway/android/api/Otp2PlanDecodeTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/api/Otp2PlanDecodeTest.kt
@@ -192,6 +192,7 @@ class Otp2PlanDecodeTest {
         val alternative = bus.alternatives[0]
         assertEquals("1_7", alternative.routeId)
         assertEquals("7", alternative.routeShortName)
+        assertEquals("Rainier Beach - Downtown", alternative.routeLongName)
         assertEquals("FF0000", alternative.routeColor)
         assertEquals("1_1", alternative.agencyId)
         assertEquals("Metro", alternative.agencyName)

--- a/onebusaway-android/src/test/java/org/onebusaway/android/directions/model/InterchangeableRoutesTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/directions/model/InterchangeableRoutesTest.kt
@@ -201,6 +201,44 @@ class InterchangeableRoutesTest {
         assertEquals(emptyList<String>(), itinerary(leg).interchangeableRoutes()[0].map { it.displayName })
     }
 
+    /**
+     * A qualifying route with no short name names itself by its long name — never by its GTFS id, which
+     * would put "95:74" on a badge (see [routeDisplayShortName]).
+     */
+    @Test
+    fun alternativeWithNoShortNameIsNamedByItsLongName() {
+        val leg = transitLeg(
+            routeId = "1_100",
+            rideTime = 20.minutes,
+            alternatives = listOf(
+                alternative(
+                    routeId = "95:74",
+                    shortName = null,
+                    rideTime = 20.minutes,
+                    longName = "Seattle - Bremerton"
+                )
+            )
+        )
+
+        assertEquals(listOf("Seattle - Bremerton"), itinerary(leg).interchangeableRoutes()[0].map { it.displayName })
+    }
+
+    /**
+     * A route the drawer can name in no way at all is dropped rather than offered: "board any of these"
+     * is only actionable if the rider can tell the vehicles apart, and a nameless badge segment tells
+     * them nothing.
+     */
+    @Test
+    fun alternativeWithNoNameAtAllIsNotOffered() {
+        val leg = transitLeg(
+            routeId = "1_100",
+            rideTime = 20.minutes,
+            alternatives = listOf(alternative(routeId = "95:74", shortName = null, rideTime = 20.minutes))
+        )
+
+        assertEquals(emptyList<String>(), itinerary(leg).interchangeableRoutes()[0].map { it.displayName })
+    }
+
     private fun itinerary(vararg legs: TripLeg) = TripItinerary(startTime = t0, legs = legs.toList())
 
     private fun transitLeg(
@@ -223,13 +261,15 @@ class InterchangeableRoutesTest {
 
     private fun alternative(
         routeId: String,
-        shortName: String,
+        shortName: String?,
         rideTime: Duration,
+        longName: String? = null,
         fromStopId: String = BOARD_STOP,
         toStopId: String = ALIGHT_STOP
     ) = TripLegAlternative(
         routeId = routeId,
         routeShortName = shortName,
+        routeLongName = longName,
         duration = rideTime,
         fromStopId = fromStopId,
         toStopId = toStopId

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/InterlinesTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/InterlinesTest.kt
@@ -16,6 +16,7 @@
 package org.onebusaway.android.ui.tripresults
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 import org.onebusaway.android.directions.model.InterchangeableRoute
 import org.onebusaway.android.directions.model.TripItinerary
@@ -110,6 +111,23 @@ class InterlinesTest {
         val badges = Interlines.routeBadges(legs, listOf(listOf(interchangeable("2 Line"))))
 
         assertEquals(listOf(listOf("1 Line", "2 Line")), badges.map { badge -> badge.routes.map { it.shortName } })
+    }
+
+    /**
+     * The transition sentence names the route the vehicle becomes: by its short name, else its long one
+     * — and null, not blank, when it has neither, so the renderer can say "continues on another route"
+     * rather than "the vehicle becomes ".
+     */
+    @Test
+    fun transitionRouteLabel_prefersShortNameThenLongNameThenNothing() {
+        assertEquals("12", Interlines.transitionRouteLabel(transit("12")))
+        assertEquals(
+            "Seattle - Bremerton",
+            Interlines.transitionRouteLabel(
+                TripLeg(mode = TripMode.FERRY, routeId = "95:74", routeLongName = "Seattle - Bremerton")
+            )
+        )
+        assertNull(Interlines.transitionRouteLabel(TripLeg(mode = TripMode.FERRY, routeId = "95:74")))
     }
 
     /**

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/InterlinesTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/InterlinesTest.kt
@@ -129,7 +129,7 @@ class InterlinesTest {
 
     private fun interchangeable(shortName: String) = InterchangeableRoute(
         routeId = "route_$shortName",
-        shortName = shortName,
+        displayName = shortName,
         routeColor = null,
         agencyId = null,
         agencyName = null,

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/RouteBadgesTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/RouteBadgesTest.kt
@@ -36,7 +36,8 @@ class RouteBadgesTest {
     fun joinsPlannedAndAlternativeRoutesInNaturalOrder() {
         val badge = legBadge(
             planned = RouteBadge("2 Line", null),
-            alternatives = listOf(RouteBadge("1 Line", null))
+            alternatives = listOf(RouteBadge("1 Line", null)),
+            mode = TransitMode.RAIL
         )
 
         assertEquals(listOf("1 Line", "2 Line"), badge.routes.map { it.shortName })
@@ -46,8 +47,8 @@ class RouteBadgesTest {
     /** …and the mirror-image plan produces the identical badge. */
     @Test
     fun badgeIsTheSameWhicheverRouteThePlanPicked() {
-        val plannedTwo = legBadge(RouteBadge("2 Line", null), listOf(RouteBadge("1 Line", null)))
-        val plannedOne = legBadge(RouteBadge("1 Line", null), listOf(RouteBadge("2 Line", null)))
+        val plannedTwo = legBadge(RouteBadge("2 Line", null), listOf(RouteBadge("1 Line", null)), TransitMode.RAIL)
+        val plannedOne = legBadge(RouteBadge("1 Line", null), listOf(RouteBadge("2 Line", null)), TransitMode.RAIL)
 
         assertEquals(plannedTwo, plannedOne)
     }
@@ -56,7 +57,8 @@ class RouteBadgesTest {
     fun naturalOrderSortsRouteNumbersNumerically() {
         val badge = legBadge(
             planned = RouteBadge("40", null),
-            alternatives = listOf(RouteBadge("550", null), RouteBadge("8", null))
+            alternatives = listOf(RouteBadge("550", null), RouteBadge("8", null)),
+            mode = TransitMode.BUS
         )
 
         assertEquals(listOf("8", "40", "550"), badge.routes.map { it.shortName })
@@ -65,7 +67,7 @@ class RouteBadgesTest {
     /** A leg with nothing interchangeable is a plain one-route badge. */
     @Test
     fun singleRouteLegIsNotInterchangeable() {
-        val badge = legBadge(planned = RouteBadge("8", null), alternatives = emptyList())
+        val badge = legBadge(planned = RouteBadge("8", null), alternatives = emptyList(), mode = TransitMode.BUS)
 
         assertEquals(listOf("8"), badge.routes.map { it.shortName })
         assertFalse(badge.isInterchangeable)
@@ -74,7 +76,7 @@ class RouteBadgesTest {
     /** A route can't appear twice in one badge, however it reached the list. */
     @Test
     fun dropsADuplicateOfThePlannedRoute() {
-        val badge = legBadge(RouteBadge("8", null), listOf(RouteBadge("8", null), RouteBadge("7", null)))
+        val badge = legBadge(RouteBadge("8", null), listOf(RouteBadge("8", null), RouteBadge("7", null)), TransitMode.BUS)
 
         assertEquals(listOf("7", "8"), badge.routes.map { it.shortName })
     }
@@ -90,16 +92,46 @@ class RouteBadgesTest {
             routeLongName = "Rainier Ave"
         ).plannedBadge()
 
-        assertEquals("8", badge.shortName)
+        assertEquals("8", badge?.shortName)
     }
 
-    /** No short name (some feeds only name a route long-form): fall back to the route/id, no color. */
+    /**
+     * A route that publishes no short name badges its long name — never its GTFS id, which is an
+     * identifier and not a name. Washington State Ferries' "Seattle - Bremerton" is the real case: it
+     * used to badge as its OTP2 gtfsId "95:74", which reads like a route number the rider could look
+     * for. (The renderer caps the roundel's width; the name it holds is this one, in full.)
+     */
     @Test
-    fun legBadgeFallsBackToTheRouteIdWhenUnnamed() {
-        val badge = TripLeg(mode = TripMode.BUS, routeId = "1_100").plannedBadge()
+    fun legWithNoShortNameBadgesItsLongNameNotItsRouteId() {
+        val badge = TripLeg(
+            mode = TripMode.FERRY,
+            routeId = "95:74",
+            routeLongName = "Seattle - Bremerton"
+        ).plannedBadge()
 
-        assertEquals("1_100", badge.shortName)
-        assertNull(badge.routeColor)
+        assertEquals("Seattle - Bremerton", badge?.shortName)
+    }
+
+    /** A route that names itself in no way at all has no badge; the card falls back to its mode. */
+    @Test
+    fun legWithNoNameAtAllYieldsAnUnnamedBadgeCarryingItsMode() {
+        val leg = TripLeg(mode = TripMode.FERRY, routeId = "95:74")
+
+        assertNull(leg.plannedBadge())
+
+        val badge = legBadge(leg, emptyList())
+
+        assertTrue(badge.routes.isEmpty())
+        assertTrue(badge.isUnnamed)
+        assertEquals(TransitMode.FERRY, badge.mode)
+    }
+
+    /** OTP1 legs carry a flat display string instead of a short name; it still badges. */
+    @Test
+    fun legBadgeUsesTheOtp1FlatRouteStringWhenThereIsNoShortName() {
+        val badge = TripLeg(mode = TripMode.BUS, routeId = "1_100", route = "8").plannedBadge()
+
+        assertEquals("8", badge?.shortName)
     }
 
     /** A leg's badge is its planned route joined by the routes ruled interchangeable with it. */
@@ -107,22 +139,25 @@ class RouteBadgesTest {
     fun legBadgeJoinsTheLegsRouteWithItsInterchangeableOnes() {
         val leg = TripLeg(mode = TripMode.BUS, routeId = "1_100", routeShortName = "8")
 
-        val badge = legBadge(leg, listOf(interchangeableRoute(shortName = "7")))
+        val badge = legBadge(leg, listOf(interchangeableRoute("7")))
 
         assertEquals(listOf("7", "8"), badge.routes.map { it.shortName })
     }
 
-    /** An interchangeable route badges the same way the planned one does; an unnamed one falls back
-     *  to its route id, so a badge segment is never blank. */
+    /**
+     * An interchangeable route badges the same way the planned one does — and names itself by its long
+     * name, not its id, when it publishes no short name. (A route with neither is dropped upstream by
+     * `interchangeableRoutes()`, so it never reaches a badge at all.)
+     */
     @Test
     fun interchangeableRouteBadgesItsDisplayName() {
-        assertEquals("1 Line", interchangeableRoute(shortName = "1 Line").badge().shortName)
-        assertEquals("40:100479", interchangeableRoute(shortName = null).badge().shortName)
+        assertEquals("1 Line", interchangeableRoute("1 Line").badge().shortName)
+        assertEquals("Seattle - Bremerton", interchangeableRoute("Seattle - Bremerton").badge().shortName)
     }
 
-    private fun interchangeableRoute(shortName: String?) = InterchangeableRoute(
+    private fun interchangeableRoute(displayName: String) = InterchangeableRoute(
         routeId = "40:100479",
-        shortName = shortName,
+        displayName = displayName,
         routeColor = null,
         agencyId = "40:1",
         agencyName = "Sound Transit",

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/TripLogBuilderTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/TripLogBuilderTest.kt
@@ -18,6 +18,7 @@ package org.onebusaway.android.ui.tripresults
 import kotlin.time.Duration.Companion.minutes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.onebusaway.android.directions.model.Direction
@@ -287,7 +288,7 @@ class TripLogBuilderTest {
             transit.rideEvents.map {
                 when (it) {
                     is RideEvent.Stop -> "stop:${it.stop.name}"
-                    is RideEvent.Transition -> "transition:${it.transition.routeShortName}"
+                    is RideEvent.Transition -> "transition:${it.transition.routeLabel}"
                 }
             }
         )
@@ -312,6 +313,44 @@ class TripLogBuilderTest {
 
         assertTrue("a self-interline shows no seam row", transit.rideEvents.none { it is RideEvent.Transition })
         assertEquals(2, transit.stopCount)
+    }
+
+    /**
+     * A ferry leg reaches the renderer as a ferry. The leg's mode used to stop here — the timeline drew
+     * a bus for every ride — so a Washington State Ferries crossing was a bus on a boat's schedule.
+     */
+    @Test
+    fun transitEntry_carriesTheLegsMode() {
+        val ferryLeg = transitLeg.copy(mode = TripMode.FERRY)
+
+        val transit = TripLogBuilder
+            .build(listOf(ferryLeg), listOf(boardDir, alightDir), listOf(transitRef))
+            .filterIsInstance<TripLogEntry.Transit>()
+            .single()
+
+        assertEquals(TransitMode.FERRY, transit.mode)
+    }
+
+    /**
+     * A route with no short name reaches the renderer with no badge name — the cue to draw no roundel —
+     * but still names itself in full, so the row has a title. Its GTFS id never appears.
+     */
+    @Test
+    fun transitEntry_leavesTheBadgeNameAbsentForAnUnnamedRoute() {
+        val ferryLeg = transitLeg.copy(
+            mode = TripMode.FERRY,
+            routeId = "95:74",
+            routeShortName = null,
+            routeLongName = "Seattle - Bremerton"
+        )
+
+        val transit = TripLogBuilder
+            .build(listOf(ferryLeg), listOf(boardDir, alightDir), listOf(transitRef))
+            .filterIsInstance<TripLogEntry.Transit>()
+            .single()
+
+        assertNull(transit.routeShortName)
+        assertEquals("Seattle - Bremerton", transit.routeDisplayName)
     }
 
     @Test

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/TripLogRowsTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/TripLogRowsTest.kt
@@ -57,6 +57,7 @@ class TripLogRowsTest {
     private fun transit(events: List<RideEvent>) = TripLogEntry.Transit(
         routeShortName = "8",
         routeDisplayName = "Route 8",
+        mode = TransitMode.BUS,
         routeColorHex = "1B6EF3",
         headsign = "Rainier Beach",
         boardTime = ServerTime(4 * 60_000L),

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/TripResultsViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/TripResultsViewModelTest.kt
@@ -42,7 +42,7 @@ class TripResultsViewModelTest {
     )
 
     private fun option(shortName: String) = ItineraryOption(
-        mode = ModeSummary.Routes(listOf(LegBadge(listOf(RouteBadge(shortName, routeColor = null))))),
+        mode = ModeSummary.Routes(listOf(LegBadge(listOf(RouteBadge(shortName, routeColor = null)), TransitMode.BUS))),
         durationMinutes = 30,
         startTime = ServerTime(0L),
         endTime = ServerTime(30 * 60_000L)


### PR DESCRIPTION
## What

In the directions pane the Bremerton ferry showed a route badge reading **`95:74`** — its raw OTP2 gtfsId — beside the long name "Seattle - Bremerton", under a **bus** icon.

Two independent bugs.

## The badge

Washington State Ferries publishes no `route_short_name`. Verified against the live server:

```
GET /api/where/route/95_74.json  ->  shortName: "", longName: "Seattle - Bremerton", type: 4 (ferry)
agency 95 = Washington State Ferries
```

`routeDisplayShortName()` fell back short → flat → **id**, so the id reached the UI. A GTFS id is an identifier, not a name: `95:74` reads like a route number the rider could look for and will never find.

The id fallback was near-harmless on OTP1, where the flat `route` display string usually caught the gap first. The OTP2 adapter has no equivalent field and sets `route = null`, which promoted the id from last resort to first — so this is an OTP2-migration regression.

The chain now stops before the id. A route with no short name is named by its **long name**:

- **Option cards** badge it, width-capped and ellipsized (`OPTION_BADGE_MAX_WIDTH`, currently 110dp — easy to tune).
- **Directions pane** draws no roundel and prints the long name in full as the row title; it has the room, so truncating there would lose information for nothing.

The same id fallback lived a second time in `InterchangeableRoute` (the #2010 alternatives). That type now resolves a single non-null `displayName` at construction and isn't built at all for a route it can't name — "board any of these" is only actionable if the rider can tell the vehicles apart. The GraphQL query asks for `longName` on alternatives so it can.

Underneath both: **the adapters never normalized `""` vs `null`**, so absence had two representations and consumers disagreed about which counted (`isNullOrEmpty` in one helper, `isNotBlank` in the next). Both adapters now blank→null at the wire boundary, using the `?.ifBlank { null }` idiom already established by the #2003 fix. That's what lets the naming helpers collapse to a plain elvis chain and deletes the downstream blank-checks. It also tightens `ConversionUtils`, whose `!= null` tests previously let an empty short name through.

## The glyph

Every transit leg's spine node was hardcoded to `ic_bus`, so **ferries, Link and Sounder all rendered as buses**.

`TripLogEntry.Transit` now carries a `TransitMode` — narrowed from the wire mode to the art the app actually ships, mirroring how `Walk` already carries `StreetMode` — and the renderer picks the glyph from it. Cable cars collapse onto the tram glyph to match the map's existing `VehicleBitmaps.normalizeVehicleType`; aerial lifts and funiculars take the generic for the same reason they do there, rather than a glyph asserting the wrong vehicle.

Option-card badges also **lead with that glyph inside the chip**, since a route number alone never says what you're boarding. On a joined "1 Line/2 Line" chip it appears once at the head — those routes are interchangeable, so it's one ride on one mode. It's announced to TalkBack; the mode is information, not decoration.

## Scope note

Arrivals was already correct — `ArrivalInfo.lineName` does short → long → id — and is untouched. Worth flagging that arrivals still ends its chain at the route id where this path no longer does; the two surfaces now differ on principle, which may be worth reconciling separately.

## Testing

- JVM unit tests cover the new naming contract, the mode narrowing, and the alternatives filtering; the two tests that had encoded the id fallback as intent are rewritten.
- `compileObaGoogleDebugKotlin` / `testObaGoogleDebugUnitTest` / `compileObaGoogleDebugAndroidTestKotlin` / `spotlessCheck` all clean under `-PwarningsAsErrors=true`.
- Installed and launched on a Pixel 7 Pro. **Not exercised end-to-end against a live ferry itinerary yet** — the extended `@Preview` covers the badge-less row and the mode glyphs, but a real Seattle→Bremerton plan is still worth a look before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transit results now show vehicle-specific icons for bus, rail, subway, tram, and ferry.
  * Route badge chips now support optional leading mode glyphs and constrained-width display for better truncation.
* **Bug Fixes**
  * Improved handling of missing/blank route names across trip timeline, interchange labels, and “stay aboard” transitions (including an unknown-route instruction).
  * Alternative route mapping now includes long names; unnamed candidates are no longer shown.
* **Tests**
  * Updated and expanded coverage for transit modes, badge behavior, ferry cases, and unnamed/long-name routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->