### PR TITLE
Make a custom region removable, and stop lying about its distance

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/util/test/RegionUtilTest.java
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/util/test/RegionUtilTest.java
@@ -81,6 +81,47 @@ public class RegionUtilTest {
   }
 
   @Test
+  public void testGetDistanceAwayWithNoBounds() {
+    // A region with no coverage area has an *unknown* distance, not an enormous one. Before the
+    // empty-array guard this returned the Float.MAX_VALUE seed, which the regions list rendered as
+    // ~2.1e35 miles, and which made getClosestRegion treat the region as measurable-but-farthest
+    // rather than skipping it. Custom regions from an `onebusaway://add-region` link have no
+    // bounds.
+    Region noBounds =
+        new Region(
+            -2,
+            "No Bounds",
+            true,
+            "https://api.example.com",
+            null,
+            new Region.Bounds[] {},
+            null,
+            null,
+            "",
+            true,
+            true,
+            false,
+            null,
+            false,
+            null,
+            null,
+            null,
+            false,
+            null,
+            false,
+            false,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            true);
+
+    assertNull(RegionUtils.getDistanceAway(noBounds, mSeattleLoc));
+  }
+
+  @Test
   public void testGetClosestRegion() {
     ArrayList<Region> list = new ArrayList<>();
     list.add(mPsRegion);

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/util/test/RegionUtilTest.java
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/util/test/RegionUtilTest.java
@@ -95,7 +95,10 @@ public class RegionUtilTest {
             "https://api.example.com",
             null,
             new Region.Bounds[] {},
-            null,
+            // Empty, not null: `open311Servers` is a non-null Kotlin Array, so a null here fails the
+            // constructor's checkNotNullParameter intrinsic at runtime — invisible to javac. Same
+            // trap #2022 fixed in the fixed-region flavor.
+            new Region.Open311Server[] {},
             null,
             "",
             true,

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/util/test/RegionUtilTest.java
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/util/test/RegionUtilTest.java
@@ -95,9 +95,9 @@ public class RegionUtilTest {
             "https://api.example.com",
             null,
             new Region.Bounds[] {},
-            // Empty, not null: `open311Servers` is a non-null Kotlin Array, so a null here fails the
-            // constructor's checkNotNullParameter intrinsic at runtime — invisible to javac. Same
-            // trap #2022 fixed in the fixed-region flavor.
+            // Empty, not null: open311Servers is a non-null Kotlin Array, so null fails the
+            // constructor's checkNotNullParameter intrinsic at runtime — invisible to javac.
+            // The same trap #2022 fixed in the fixed-region flavor.
             new Region.Open311Server[] {},
             null,
             "",

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/CustomRegionRemoval.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/CustomRegionRemoval.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.compose.components
+
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import org.onebusaway.android.R
+
+/**
+ * The remove-a-custom-region affordance, shared by the app's two region lists (#2027): the
+ * forced-choice picker (`ui/home/RegionPickerHost`) and the Settings region screen
+ * (`ui/regions/RegionsScreen`).
+ *
+ * The two lists render rows very differently — one is bare text inside an `AlertDialog`, the other a
+ * full row with a check mark and a distance — so the row composables stay separate. What lives here is
+ * the part that must not differ between them: the gesture rule and the confirmation copy. They were
+ * briefly duplicated in both files, which is how the two paths started to drift.
+ */
+
+/**
+ * Makes a region row tappable, and long-pressable to remove when [isRemovable].
+ *
+ * A null `onLongClick` behaves exactly like `clickable`, so a directory region has nothing to mis-hit.
+ * [removeHint] is the accessibility label for the long press — without it the gesture is invisible to a
+ * screen reader, for which it is the only route to removal. Hoist [removeHint] out of the row: at most
+ * one row in a list is custom, so reading the string per row is wasted work.
+ */
+fun Modifier.regionRowClickable(
+    isRemovable: Boolean,
+    removeHint: String,
+    onClick: () -> Unit,
+    onRemove: () -> Unit
+): Modifier = combinedClickable(
+    onClick = onClick,
+    onLongClickLabel = removeHint.takeIf { isRemovable },
+    onLongClick = if (isRemovable) onRemove else null
+)
+
+/**
+ * Confirms removing the custom region named [regionName]. Long press is easy to trigger by accident and
+ * this is destructive, so it asks — and says plainly that the directory regions in the same list are
+ * untouched.
+ */
+@Composable
+fun RemoveCustomRegionDialog(regionName: String, onConfirm: () -> Unit, onDismiss: () -> Unit) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.region_remove_custom_title, regionName)) },
+        text = { Text(stringResource(R.string.region_remove_custom_message)) },
+        confirmButton = {
+            TextButton(onClick = onConfirm) {
+                Text(stringResource(R.string.region_remove_custom_confirm))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.cancel)) }
+        }
+    )
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/RegionPickerHost.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/RegionPickerHost.kt
@@ -15,7 +15,6 @@
  */
 package org.onebusaway.android.ui.home
 
-import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -37,6 +36,8 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import org.onebusaway.android.R
 import org.onebusaway.android.region.Region
+import org.onebusaway.android.ui.compose.components.RemoveCustomRegionDialog
+import org.onebusaway.android.ui.compose.components.regionRowClickable
 
 /**
  * Renders the forced-choice region picker when [RegionPickerViewModel] reports the repository needs a manual
@@ -58,7 +59,7 @@ fun RegionPickerHost() {
     if (failed) RegionLoadFailedDialog(onRetry = viewModel::retry)
     removing?.let { region ->
         RemoveCustomRegionDialog(
-            region = region,
+            regionName = region.name,
             onConfirm = {
                 removing = null
                 viewModel.remove(region)
@@ -66,28 +67,6 @@ fun RegionPickerHost() {
             onDismiss = { removing = null }
         )
     }
-}
-
-/**
- * Confirms removing a custom region (#2027). Separate from the picker's own dialog so a mis-hit
- * long-press can't delete anything, and worded to make clear only the rider's own added region goes —
- * the directory regions in the same list are untouched.
- */
-@Composable
-private fun RemoveCustomRegionDialog(region: Region, onConfirm: () -> Unit, onDismiss: () -> Unit) {
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = { Text(stringResource(R.string.region_remove_custom_title, region.name)) },
-        text = { Text(stringResource(R.string.region_remove_custom_message)) },
-        confirmButton = {
-            TextButton(onClick = onConfirm) {
-                Text(stringResource(R.string.region_remove_custom_confirm))
-            }
-        },
-        dismissButton = {
-            TextButton(onClick = onDismiss) { Text(stringResource(R.string.cancel)) }
-        }
-    )
 }
 
 /**
@@ -157,12 +136,11 @@ private fun RegionRow(
         text = region.name,
         modifier = Modifier
             .fillMaxWidth()
-            // A null onLongClick behaves exactly like clickable, and onLongClickLabel is what announces
-            // the gesture to a screen reader — for which it is the only route to removal.
-            .combinedClickable(
+            .regionRowClickable(
+                isRemovable = region.custom,
+                removeHint = removeHint,
                 onClick = { onRegionChosen(region) },
-                onLongClickLabel = removeHint.takeIf { region.custom },
-                onLongClick = if (region.custom) ({ onRemoveCustom(region) }) else null
+                onRemove = { onRemoveCustom(region) }
             )
             .padding(vertical = 16.dp)
     )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/regions/RegionsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/regions/RegionsRepository.kt
@@ -37,13 +37,14 @@ import org.onebusaway.android.util.RegionUtils
  *
  * @param distanceMeters distance from the user's last known location, or null when no
  * location (or no distance) is available
- * @param isCurrent whether this is the currently selected region
+ * @param custom whether the rider added this region themselves (an `onebusaway://add-region` link,
+ * #2027) rather than it coming from the OBA regions directory — the ones that can be removed
  */
 data class RegionItem(
     val id: Long,
     val name: String,
     val distanceMeters: Float?,
-    val isCurrent: Boolean
+    val custom: Boolean = false
 )
 
 /** Provides the list of available OBA regions and handles manual region selection. */
@@ -62,6 +63,13 @@ interface RegionsRepository {
      * @return true if this call disabled automatic region selection (drives the toast)
      */
     suspend fun selectRegion(id: Long): Boolean
+
+    /**
+     * Removes the custom region with the given id. A directory region is ignored — only regions the
+     * rider added themselves can be removed. Removing the current region re-resolves, so the app
+     * lands on a real region rather than pointing at one that no longer exists.
+     */
+    suspend fun removeRegion(id: Long)
 }
 
 /**
@@ -94,13 +102,12 @@ class DefaultRegionsRepository @Inject constructor(
         regionsById = usable.associateBy { it.id }
 
         val location = locationRepository.lastKnownLocation()
-        val currentRegionId = regionRepository.currentRegion()?.id
         val items = usable.map { region ->
             RegionItem(
                 id = region.id,
                 name = region.name,
                 distanceMeters = location?.let { RegionUtils.getDistanceAway(region, it) },
-                isCurrent = region.id == currentRegionId
+                custom = region.custom
             )
         }
         // Sort by distance only when we have a location, like the legacy picker
@@ -130,5 +137,12 @@ class DefaultRegionsRepository @Inject constructor(
             region.name
         )
         return wasAutoSelectEnabled
+    }
+
+    // deleteCustomRegion ignores a directory region itself, so there is nothing to check here beyond
+    // resolving the id. No analytics: the forced-choice picker deletes through the same domain call
+    // without reporting, and an event on only one of two entry points describes nothing.
+    override suspend fun removeRegion(id: Long) = withContext(Dispatchers.IO) {
+        regionsById[id]?.let { regionRepository.deleteCustomRegion(it) } ?: Unit
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/regions/RegionsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/regions/RegionsScreen.kt
@@ -15,7 +15,6 @@
  */
 package org.onebusaway.android.ui.regions
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -29,8 +28,10 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -47,6 +48,8 @@ import kotlinx.coroutines.launch
 import org.onebusaway.android.R
 import org.onebusaway.android.ui.compose.ListUiState
 import org.onebusaway.android.ui.compose.components.ListScreenScaffold
+import org.onebusaway.android.ui.compose.components.RemoveCustomRegionDialog
+import org.onebusaway.android.ui.compose.components.regionRowClickable
 import org.onebusaway.android.ui.compose.theme.ObaTheme
 import org.onebusaway.android.util.PreferenceUtils
 import org.onebusaway.android.util.RegionUtils
@@ -64,27 +67,46 @@ fun RegionsRoute(
     onRegionSelected: (autoSelectDisabled: Boolean) -> Unit
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
+    val currentRegionId by viewModel.currentRegionId.collectAsStateWithLifecycle()
     val scope = rememberCoroutineScope()
+    // The custom region a long press has proposed removing, if any.
+    var removing by remember { mutableStateOf<RegionItem?>(null) }
     RegionsScreen(
         state = state,
+        currentRegionId = currentRegionId,
         onRetry = { viewModel.load() },
         onRefresh = { viewModel.load(refresh = true) },
         onRegionClick = { region ->
             scope.launch { onRegionSelected(viewModel.selectRegion(region)) }
         },
+        onRegionLongClick = { removing = it },
         onBack = onBack
     )
+    removing?.let { region ->
+        RemoveCustomRegionDialog(
+            regionName = region.name,
+            onConfirm = {
+                removing = null
+                scope.launch { viewModel.removeRegion(region) }
+            },
+            onDismiss = { removing = null }
+        )
+    }
 }
 
 /** Stateless screen content, fully driven by [ListUiState] — previewable and testable. */
 @Composable
 fun RegionsScreen(
     state: ListUiState<RegionItem>,
+    currentRegionId: Long?,
     onRetry: () -> Unit,
     onRefresh: () -> Unit,
     onRegionClick: (RegionItem) -> Unit,
+    onRegionLongClick: (RegionItem) -> Unit,
     onBack: () -> Unit
 ) {
+    // Read once for the whole list rather than per row: at most one row is custom.
+    val removeHint = stringResource(R.string.region_remove_custom_hint)
     ListScreenScaffold(
         title = stringResource(R.string.preferences_region_title),
         onBack = onBack,
@@ -101,17 +123,28 @@ fun RegionsScreen(
             }
         }
     ) { region ->
-        RegionRow(region, onRegionClick)
+        RegionRow(region, region.id == currentRegionId, removeHint, onRegionClick, onRegionLongClick)
     }
 }
 
 @Composable
-private fun RegionRow(region: RegionItem, onClick: (RegionItem) -> Unit) {
+private fun RegionRow(
+    region: RegionItem,
+    isCurrent: Boolean,
+    removeHint: String,
+    onClick: (RegionItem) -> Unit,
+    onLongClick: (RegionItem) -> Unit
+) {
     Column {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .clickable { onClick(region) }
+                .regionRowClickable(
+                    isRemovable = region.custom,
+                    removeHint = removeHint,
+                    onClick = { onClick(region) },
+                    onRemove = { onLongClick(region) }
+                )
                 .padding(horizontal = 16.dp, vertical = 12.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
@@ -119,13 +152,13 @@ private fun RegionRow(region: RegionItem, onClick: (RegionItem) -> Unit) {
             // layout's INVISIBLE check mark
             Icon(
                 painter = painterResource(R.drawable.ic_checkmark_holo_light),
-                contentDescription = if (region.isCurrent) {
+                contentDescription = if (isCurrent) {
                     stringResource(R.string.checkmark_description)
                 } else {
                     null
                 },
                 tint = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.alpha(if (region.isCurrent) 1f else 0f)
+                modifier = Modifier.alpha(if (isCurrent) 1f else 0f)
             )
             Spacer(Modifier.width(16.dp))
             Column {
@@ -172,14 +205,16 @@ private fun RegionsScreenSuccessPreview() {
         RegionsScreen(
             state = ListUiState.Success(
                 listOf(
-                    RegionItem(1, "Puget Sound", 1500f, isCurrent = true),
-                    RegionItem(2, "Tampa Bay", 4_500_000f, isCurrent = false),
-                    RegionItem(3, "No-location Region", null, isCurrent = false)
+                    RegionItem(1, "Puget Sound", 1500f),
+                    RegionItem(2, "Tampa Bay", 4_500_000f),
+                    RegionItem(3, "No-location Region", null)
                 )
             ),
             onRetry = {},
             onRefresh = {},
+            currentRegionId = 1L,
             onRegionClick = {},
+            onRegionLongClick = {},
             onBack = {}
         )
     }
@@ -193,7 +228,9 @@ private fun RegionsScreenLoadingPreview() {
             state = ListUiState.Loading,
             onRetry = {},
             onRefresh = {},
+            currentRegionId = 1L,
             onRegionClick = {},
+            onRegionLongClick = {},
             onBack = {}
         )
     }
@@ -207,7 +244,9 @@ private fun RegionsScreenErrorPreview() {
             state = ListUiState.Error,
             onRetry = {},
             onRefresh = {},
+            currentRegionId = 1L,
             onRegionClick = {},
+            onRegionLongClick = {},
             onBack = {}
         )
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/regions/RegionsViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/regions/RegionsViewModel.kt
@@ -15,16 +15,45 @@
  */
 package org.onebusaway.android.ui.regions
 
+import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import org.onebusaway.android.region.RegionRepository
 import org.onebusaway.android.ui.compose.ListLoadingViewModel
 
 /** ViewModel for the region picker screen. */
 @HiltViewModel
-class RegionsViewModel @Inject constructor(private val repository: RegionsRepository) : ListLoadingViewModel<RegionItem>() {
+class RegionsViewModel @Inject constructor(
+    private val repository: RegionsRepository,
+    regionRepository: RegionRepository
+) : ListLoadingViewModel<RegionItem>() {
+
+    /**
+     * The current region's id, or null when none is set. The screen compares each row against this
+     * rather than reading a flag stored on the row: there is one current region, and
+     * `RegionRepository.region` already owns it, so copying it into every [RegionItem] at load time
+     * only created something that could go stale — which it did. The region genuinely can change while
+     * this list is on screen: removing the current region re-resolves, and with auto-selection off that
+     * raises the forced-choice picker over this screen, so the rider's pick happens elsewhere.
+     *
+     * Read from the domain [RegionRepository] directly rather than relayed through [RegionsRepository],
+     * matching how the other region-observing view models do it (see
+     * [org.onebusaway.android.ui.home.weather.WeatherViewModel]).
+     */
+    private val _currentRegionId = MutableStateFlow<Long?>(null)
+    val currentRegionId: StateFlow<Long?> = _currentRegionId.asStateFlow()
 
     init {
         load()
+        // A manual collector rather than stateIn(SharingStarted...): the other region VMs use this
+        // idiom because a never-completing sharing collector leaks across JVM unit tests.
+        viewModelScope.launch {
+            regionRepository.region.collect { _currentRegionId.value = it?.id }
+        }
     }
 
     /**
@@ -40,4 +69,14 @@ class RegionsViewModel @Inject constructor(private val repository: RegionsReposi
      * @return true if this selection disabled automatic region selection
      */
     suspend fun selectRegion(item: RegionItem): Boolean = repository.selectRegion(item.id)
+
+    /**
+     * Removes a custom region the rider added ([RegionItem.custom]) and reloads the list so it
+     * disappears. Reads from the local cache rather than forcing a server fetch — the removal is a
+     * local write, and the directory has nothing to say about it.
+     */
+    suspend fun removeRegion(item: RegionItem) {
+        repository.removeRegion(item.id)
+        load()
+    }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/RegionUtils.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/RegionUtils.java
@@ -148,7 +148,12 @@ public class RegionUtils {
    */
   public static @Nullable Float getDistanceAway(@NonNull Region region, double lat, double lon) {
     Region.Bounds[] bounds = region.getBounds();
-    if (bounds == null) {
+    // No bounds at all means the distance is unknown, not enormous. An *empty* array used to fall
+    // through the loop below and return the Float.MAX_VALUE seed, which is 2.1e35 miles once
+    // converted — the regions list rendered that verbatim, and getClosestRegion's "couldn't measure
+    // the distance" branch was unreachable for such a region. A custom region added by an
+    // `onebusaway://add-region` link (#2027) carries no bounds, which is how that surfaced.
+    if (bounds == null || bounds.length == 0) {
       return null;
     }
     float[] results = new float[1];

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/regions/RegionsViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/regions/RegionsViewModelTest.kt
@@ -21,9 +21,13 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
+import org.onebusaway.android.region.FakeRegionRepository
+import org.onebusaway.android.region.Region
+import org.onebusaway.android.region.region
 import org.onebusaway.android.testing.MainDispatcherRule
 import org.onebusaway.android.ui.compose.ListUiState
 
@@ -36,6 +40,8 @@ private class FakeRegionsRepository(
 
     var selectedId: Long? = null
 
+    val removedIds = mutableListOf<Long>()
+
     override suspend fun getRegions(refresh: Boolean): Result<List<RegionItem>> {
         lastRefresh = refresh
         return result
@@ -45,7 +51,17 @@ private class FakeRegionsRepository(
         selectedId = id
         return selectRegionReturns
     }
+
+    override suspend fun removeRegion(id: Long) {
+        removedIds.add(id)
+    }
 }
+
+/** The VM under test, with a controllable domain repository supplying the current region. */
+private fun viewModel(
+    repository: RegionsRepository,
+    currentRegion: Region? = null
+) = RegionsViewModel(repository, FakeRegionRepository(currentRegion))
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class RegionsViewModelTest {
@@ -54,14 +70,15 @@ class RegionsViewModelTest {
     val mainDispatcherRule = MainDispatcherRule()
 
     private val regions = listOf(
-        RegionItem(1, "Puget Sound", 1500f, isCurrent = true),
-        RegionItem(2, "Tampa Bay", 4_500_000f, isCurrent = false),
-        RegionItem(3, "No-location Region", null, isCurrent = false)
+        RegionItem(1, "Puget Sound", 1500f),
+        RegionItem(2, "Tampa Bay", 4_500_000f),
+        RegionItem(3, "No-location Region", null),
+        RegionItem(-2, "Deep Link Bench", null, custom = true)
     )
 
     @Test
     fun `initial state is Loading before the load completes`() = runTest {
-        val viewModel = RegionsViewModel(FakeRegionsRepository(Result.success(regions)))
+        val viewModel = viewModel(FakeRegionsRepository(Result.success(regions)))
 
         assertEquals(ListUiState.Loading, viewModel.state.value)
     }
@@ -69,7 +86,7 @@ class RegionsViewModelTest {
     @Test
     fun `load emits Success with the repository's regions`() = runTest {
         val repository = FakeRegionsRepository(Result.success(regions))
-        val viewModel = RegionsViewModel(repository)
+        val viewModel = viewModel(repository)
 
         advanceUntilIdle()
 
@@ -79,7 +96,7 @@ class RegionsViewModelTest {
 
     @Test
     fun `load emits Error when the repository fails`() = runTest {
-        val viewModel = RegionsViewModel(FakeRegionsRepository(Result.failure(IOException())))
+        val viewModel = viewModel(FakeRegionsRepository(Result.failure(IOException())))
 
         advanceUntilIdle()
 
@@ -89,7 +106,7 @@ class RegionsViewModelTest {
     @Test
     fun `retry after a failure goes through Loading and recovers`() = runTest {
         val repository = FakeRegionsRepository(Result.failure(IOException()))
-        val viewModel = RegionsViewModel(repository)
+        val viewModel = viewModel(repository)
         advanceUntilIdle()
         assertEquals(ListUiState.Error, viewModel.state.value)
 
@@ -104,7 +121,7 @@ class RegionsViewModelTest {
     @Test
     fun `refresh forces a server fetch`() = runTest {
         val repository = FakeRegionsRepository(Result.success(regions))
-        val viewModel = RegionsViewModel(repository)
+        val viewModel = viewModel(repository)
         advanceUntilIdle()
 
         viewModel.load(refresh = true)
@@ -117,7 +134,7 @@ class RegionsViewModelTest {
     @Test
     fun `selectRegion delegates to the repository and returns its result`() = runTest {
         val repository = FakeRegionsRepository(Result.success(regions))
-        val viewModel = RegionsViewModel(repository)
+        val viewModel = viewModel(repository)
 
         repository.selectRegionReturns = true
         assertTrue(viewModel.selectRegion(regions[1]))
@@ -126,5 +143,48 @@ class RegionsViewModelTest {
         repository.selectRegionReturns = false
         assertFalse(viewModel.selectRegion(regions[0]))
         assertEquals(1L, repository.selectedId)
+    }
+
+    // --- removing a custom region (#2027) ---
+
+    @Test
+    fun `removeRegion removes the region and reloads the list`() = runTest {
+        val repo = FakeRegionsRepository(Result.success(regions))
+        val vm = viewModel(repo)
+        advanceUntilIdle()
+        repo.lastRefresh = null
+
+        vm.removeRegion(regions.last())
+        advanceUntilIdle()
+
+        assertEquals(listOf(-2L), repo.removedIds)
+        // Reloaded from the local cache: the removal is a local write, so forcing a server fetch
+        // would be wasted work.
+        assertEquals(false, repo.lastRefresh)
+    }
+
+    // --- the current-region mark tracks the live region, not the load (#2027 follow-up) ---
+
+    @Test
+    fun `the current region id follows the repository while the list stays put`() {
+        val repo = FakeRegionsRepository(Result.success(regions))
+        val domain = FakeRegionRepository(region(1))
+        runTest {
+            val vm = RegionsViewModel(repo, domain)
+            advanceUntilIdle()
+            assertEquals(1L, vm.currentRegionId.value)
+
+            // Removing the current region re-resolves, and with auto-selection off that raises the
+            // forced-choice picker over this screen — so the region changes without this list
+            // reloading. The check mark has to follow anyway; it used to be captured at load time.
+            domain.emit(null)
+            advanceUntilIdle()
+            assertNull(vm.currentRegionId.value)
+
+            domain.emit(region(2))
+            advanceUntilIdle()
+            assertEquals(2L, vm.currentRegionId.value)
+            assertEquals("the list itself must not have reloaded", false, repo.lastRefresh)
+        }
     }
 }


### PR DESCRIPTION
Follow-ups to the custom regions added in #2028. All three were found by installing the merged build and using it, not by reading it.

## 1. A custom region reported a distance of ~2.1×10³⁵ miles

`RegionUtils.getDistanceAway` guarded `bounds == null` but not `bounds.length == 0`. An **empty** array fell straight through the loop and returned the `minDistance` seed it was initialised with — `Float.MAX_VALUE`, which is 2.11e35 once converted to miles. The region list rendered that verbatim. Custom regions carry no bounds, which is how it surfaced.

```java
if (bounds == null || bounds.length == 0) {
  return null;
}
```

Fixed in the shared util rather than by giving custom regions synthetic bounds — the distance genuinely is *unknown*, and fabricating coverage the region doesn't have is the kind of guess `CLAUDE.md`'s "No unsanctioned heuristics" rules out. `distanceText(null)` already renders "unavailable", and the sort (`distanceMeters ?: Float.MAX_VALUE`) already puts unknowns last. Both callers already handled null. Any region with zero bounds benefits, not just custom ones.

> Worth recording: this also means several comments (mine, from #2028) described a mechanism the code didn't have. They said a custom region is never auto-selected because `getClosestRegion` "skips a region it can't measure a distance to". It didn't skip it — it measured `MAX_VALUE` and merely lost every comparison. The outcome was right by accident. After this fix the mechanism is the one documented.

## 2. Accepting an `add-region` link was close to a one-way door

Long-press-to-remove existed only in the forced-choice picker (`RegionPickerHost`), which `RegionState.NeedsManualChoice` raises — and `resolveRegionStatus` returns `Unchanged` unconditionally while a custom region is active, so that state never arises. **Removal was unreachable.** The only recovery was Settings → Agencies → pick another region, leaving the custom entry in the list forever.

The Settings region list now offers the same long-press, with a confirmation.

## 3. The check mark didn't follow the region

`RegionItem.isCurrent` was a copy of a fact `RegionRepository.region` already owns — its own KDoc calls that flow "the single source of truth for the current region" — snapshotted when the list loaded.

It went stale in exactly the flow above: removing the current region re-resolves, and with auto-selection off that raises the forced picker **over** the Settings list. The rider picks there, the dialog closes, and the list behind it still shows the flags computed when there was no region at all — so nothing was marked, and nothing ever would have been.

The field is deleted. The screen compares each row against a live `currentRegionId` from the ViewModel. One value, not one flag per row, and nothing to go stale.

## Shared, not written twice

The gesture rule and the confirmation dialog now live in `ui/compose/components/CustomRegionRemoval.kt`, used by both region surfaces. The row layouts stay separate — one is bare text inside an `AlertDialog`, the other a row with a check mark and a distance — but the parts that must not differ are shared. `RegionPickerHost` came out 22 lines shorter than before this branch.

The duplication had already produced a divergence: an analytics event that fired on removal from Settings but not from the picker, describing neither. Dropped. If removal analytics is wanted it belongs in `RegionRepository.deleteCustomRegion`, where both paths pass through.

`RegionsViewModel` also now reads the domain `RegionRepository` directly instead of through a one-line `.map` pass-through on the UI-layer repository, matching what `WeatherViewModel` and `RegionPickerViewModel` already do for this exact derivation.

## Testing

- **1328 unit tests** green, 3 new: the removal path, and one asserting the mark tracks `1 → null → 2` **without the list reloading** — the sequence that was broken.
- An instrumented case pinning `getDistanceAway` to null for empty bounds. Not run locally (no emulator on this machine); CI's API 33 job covers it.
- `spotlessCheck` clean; compiles clean under `-PwarningsAsErrors=true`.
- Installed on a physical device (API 36) and checked: the region reads "unavailable", long-press offers removal, and the check mark follows a pick made in the forced picker.

## Not done here

`RegionUtilTest`'s new case builds a `Region` with ~28 positional constructor args, matching the eight existing `MockRegion` factories. `RegionTestFixtures.region()` would be ideal but is `internal` in `src/test`, so it isn't on the `androidTest` classpath, and Java can't use Kotlin default arguments anyway. Adding `@JvmOverloads` to `Region`'s constructor would shrink all nine call sites — worth its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added accessible long-press removal for custom regions with a confirmation dialog.
  - Region selection is now driven by a live current-region id and reflected consistently in the UI.
- **Bug Fixes**
  - Regions with no coverage bounds (null or empty) now correctly report distance as unknown (`null`) instead of an invalid large value.
- **Tests**
  - Updated and expanded ViewModel and repository tests to cover custom-region removal, current-region id updates, and unknown-distance behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->