### PR TITLE
Get the nightly lint job back to zero findings

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/OtpTarget.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/OtpTarget.kt
@@ -16,8 +16,8 @@
 package org.onebusaway.android.directions.util
 
 import android.content.Context
-import android.net.Uri
 import android.util.Log
+import androidx.core.net.toUri
 import org.onebusaway.android.R
 import org.onebusaway.android.app.di.PreferencesEntryPoint
 import org.onebusaway.android.app.di.RegionEntryPoint
@@ -52,7 +52,7 @@ data class OtpTarget(val baseUrl: String?, val usesOtp2: Boolean) {
                 // Host only, never the whole URL: a hand-entered one can carry credentials in its
                 // userinfo or a token in its query, and Log.d is not stripped from release builds.
                 // The host is the part that actually answers "which server am I talking to?".
-                Log.d(TAG, "Using custom OTP API URL set by user (host: ${Uri.parse(customUrl).host ?: "unparsed"}).")
+                Log.d(TAG, "Using custom OTP API URL set by user (host: ${customUrl.toUri().host ?: "unparsed"}).")
                 // No [Region] to carry the setting for a custom server, so the user sets it.
                 return OtpTarget(
                     baseUrl = customUrl,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
@@ -70,6 +70,7 @@ import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.clipRect
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLocale
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.pluralStringResource
@@ -82,7 +83,6 @@ import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import java.util.Locale
 import kotlinx.coroutines.launch
 import org.onebusaway.android.R
 import org.onebusaway.android.directions.model.TripItinerary
@@ -869,10 +869,12 @@ private fun BoxScope.NodeSlot(size: Dp, content: @Composable BoxScope.() -> Unit
 private fun ColumnScope.TerminalContent(entry: TripLogEntry.Terminal) {
     Text(
         // Locale-aware uppercasing: the bare uppercase() overload is Locale.ROOT, which gets Turkish
-        // dotted/dotless I wrong on a string we just localized.
+        // dotted/dotless I wrong on a string we just localized. Read through LocalLocale rather than
+        // Locale.getDefault(): the latter isn't observable state, so this Text would keep the old
+        // casing after the rider changes their locale until something else recomposed it.
         text = stringResource(
             if (entry.kind == TerminalKind.START) R.string.trip_plan_leaving else R.string.trip_plan_arriving
-        ).uppercase(Locale.getDefault()),
+        ).uppercase(LocalLocale.current.platformLocale),
         style = MaterialTheme.typography.labelSmall,
         color = MaterialTheme.colorScheme.onSurfaceVariant
     )


### PR DESCRIPTION
`lintObaGoogleDebug` had **two errors** on `main`. Neither fails PR CI — `android.yml` passes `-x lint` deliberately, because lint takes ~7–15 min and would dominate that job — so they only surface in the nightly `lint` job in `android-nightly.yml`, where they had been sitting unnoticed.

Both are one-liners, and both predate this branch.

## `NonObservableLocale` — `TripResultsScreen.kt`

`uppercase(Locale.getDefault())` inside a composable. `Locale.getDefault()` isn't observable state, so the trip-plan terminal label ("LEAVING" / "ARRIVING") kept its old casing after the rider changed their locale, until something unrelated happened to recompose it.

```diff
-).uppercase(Locale.getDefault()),
+).uppercase(LocalLocale.current.platformLocale),
```

The locale-aware uppercasing itself is deliberate and unchanged — the bare `uppercase()` overload is `Locale.ROOT`, which gets Turkish dotted/dotless I wrong on a string we just localized. Only the *source* of the locale changes, from a one-shot read to observable state.

## `UseKtx` — `OtpTarget.kt`

```diff
-Log.d(TAG, "… (host: ${Uri.parse(customUrl).host ?: "unparsed"}).")
+Log.d(TAG, "… (host: ${customUrl.toUri().host ?: "unparsed"}).")
```

`androidx.core.net.toUri` is what the rest of the codebase already uses. Introduced by #2024; the `Uri` import goes with it.

## Result

Lint now reports **"No issues found"** — zero errors *and* zero warnings — so the nightly gate is meaningful again rather than permanently red. Verified with `./gradlew :onebusaway-android:lintObaGoogleDebug -PwarningsAsErrors=true`.

1326 unit tests pass, `spotlessCheck` clean, compiles clean under `-PwarningsAsErrors=true`.

Split out from #2036 so each PR is one concern; this one touches no behaviour beyond the locale read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal text capitalization so it updates correctly when the device language or locale changes.
  * Improved handling of custom transit API URLs when recording diagnostic information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->