### PR TITLE
Route focus header: a direction dropdown, not a cycle button (#2033)

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/home/map/FocusBannerTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/home/map/FocusBannerTest.kt
@@ -18,11 +18,13 @@ package org.onebusaway.android.ui.home.map
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.getUnclippedBoundsInRoot
 import androidx.compose.ui.test.longClick
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -30,10 +32,12 @@ import androidx.compose.ui.test.performTouchInput
 import androidx.test.platform.app.InstrumentationRegistry
 import kotlin.math.abs
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.onebusaway.android.R
+import org.onebusaway.android.models.RouteMapDirection
 import org.onebusaway.android.ui.compose.createUnconfinedComposeRule
 
 class FocusBannerTest {
@@ -99,7 +103,10 @@ class FocusBannerTest {
     private fun setRouteBanner(
         scheduleUrl: String? = null,
         onShowSchedule: (String) -> Unit = {},
-        onFrameRoute: () -> Unit = {}
+        onFrameRoute: () -> Unit = {},
+        directions: List<RouteMapDirection> = emptyList(),
+        currentDirectionId: Int? = null,
+        onSelectDirection: (Int?) -> Unit = {}
     ) {
         composeRule.setContent {
             FocusBanner(
@@ -110,7 +117,9 @@ class FocusBannerTest {
                         longName = ROUTE_LONG_NAME,
                         agency = "Metro",
                         routeId = "1_40",
-                        scheduleUrl = scheduleUrl
+                        scheduleUrl = scheduleUrl,
+                        directions = directions,
+                        currentDirectionId = currentDirectionId
                     ),
                     isFavorite = false
                 ),
@@ -119,12 +128,71 @@ class FocusBannerTest {
                 onShowAlerts = {},
                 onClearSubordinateRoute = {},
                 onRecenterStop = {},
-                onSelectDirection = {},
+                onSelectDirection = onSelectDirection,
                 onFrameRoute = onFrameRoute,
                 onShowSchedule = onShowSchedule,
                 onHeight = {}
             )
         }
+    }
+
+    private fun openDirectionMenu() = composeRule.onNodeWithContentDescription(
+        context.getString(R.string.route_header_select_direction)
+    ).assertIsDisplayed().performClick()
+
+    /**
+     * The whole point of #2033: the menu always offers "All directions", so a route narrowed to one
+     * direction can be widened back. The old swap button could only cycle between directions.
+     */
+    @Test
+    fun directionMenuOffersAllDirectionsAlongsideTheNamedOnes() {
+        var selected: Int? = -1
+        setRouteBanner(
+            directions = TWO_DIRECTIONS,
+            currentDirectionId = 1,
+            onSelectDirection = { selected = it }
+        )
+        // The header states the menu's current value.
+        composeRule.onNodeWithText(NORTHGATE).assertIsDisplayed()
+
+        openDirectionMenu()
+        composeRule.onNodeWithText(DOWNTOWN).assertIsDisplayed()
+        // The shown direction is now on screen twice: the subtitle and its own (checked) menu row.
+        composeRule.onAllNodesWithText(NORTHGATE).assertCountEquals(2)
+
+        composeRule.onNodeWithText(context.getString(R.string.route_header_all_directions))
+            .performClick()
+        assertNull(selected)
+    }
+
+    /** Picking a named direction reports that direction's id. */
+    @Test
+    fun directionMenuSelectsANamedDirection() {
+        var selected: Int? = null
+        setRouteBanner(
+            directions = TWO_DIRECTIONS,
+            currentDirectionId = null,
+            onSelectDirection = { selected = it }
+        )
+        // Shown whole, the subtitle reads as the menu's default rather than a headsign.
+        composeRule.onNodeWithText(context.getString(R.string.route_header_all_directions))
+            .assertIsDisplayed()
+
+        openDirectionMenu()
+        composeRule.onNodeWithText(DOWNTOWN).performClick()
+        assertEquals(0, selected)
+    }
+
+    /** A route with nothing to choose between shows neither the menu nor a direction line. */
+    @Test
+    fun singleDirectionRouteHasNoDirectionMenu() {
+        setRouteBanner(directions = listOf(RouteMapDirection(0, DOWNTOWN)))
+
+        composeRule.onNodeWithContentDescription(
+            context.getString(R.string.route_header_select_direction)
+        ).assertDoesNotExist()
+        composeRule.onNodeWithText(context.getString(R.string.route_header_all_directions))
+            .assertDoesNotExist()
     }
 
     @Test
@@ -235,5 +303,8 @@ class FocusBannerTest {
     private companion object {
         const val ROUTE_LONG_NAME = "Downtown - Northgate"
         const val SCHEDULE_URL = "https://example.org/route/40/schedule"
+        const val DOWNTOWN = "to Downtown"
+        const val NORTHGATE = "to Northgate"
+        val TWO_DIRECTIONS = listOf(RouteMapDirection(0, DOWNTOWN), RouteMapDirection(1, NORTHGATE))
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
@@ -59,7 +59,7 @@ import org.onebusaway.android.util.getRouteDisplayName
  * The route-mode header content (the old `R.id.route_info` overlay): the route's short/long name +
  * agency, or a loading state while the route loads. Published while a route is shown and rendered
  * as a Compose overlay by the home screen. Null when not in route mode. [directions] +
- * [currentDirectionId] drive the header's switch-direction affordance (empty/size-1 = no switch).
+ * [currentDirectionId] drive the header's direction menu (empty/size-1 = nothing to choose, no menu).
  */
 data class RouteHeader(
     val loading: Boolean,
@@ -559,13 +559,15 @@ class MapViewModel @Inject constructor(
     fun restoreViewport(viewport: MapViewport) = mapHost.restoreViewport(viewport)
 
     /**
-     * Switch the shown route to another of its directions (one of the header's [RouteHeader.directions]
-     * ids) via the header's swap affordance. Re-filters the stops + vehicles in place (no reload /
-     * reframe). On a real switch, persists the choice and retires the launch anchor
-     * ([MapParams.ROUTE_DIRECTION_STOP_ID]) so a process-death restore honors this explicit selection
-     * rather than re-resolving the anchor stop.
+     * Switch the shown route to one of its directions (an id from the header's
+     * [RouteHeader.directions]), or to the whole route when [directionId] is null, via the header's
+     * direction menu. Re-filters the stops + vehicles in place (no reload / reframe). On a real switch,
+     * persists the choice and retires the launch anchor ([MapParams.ROUTE_DIRECTION_STOP_ID]) so a
+     * process-death restore honors this explicit selection rather than re-resolving the anchor stop —
+     * which matters most for the whole-route choice, where the anchor would otherwise re-narrow the map
+     * to the very direction the user just left.
      */
-    fun selectRouteDirection(directionId: Int) {
+    fun selectRouteDirection(directionId: Int?) {
         if (!routeController.selectDirection(directionId)) return
         savedStateHandle[MapParams.ROUTE_DIRECTION_STOP_ID] = null
         savedStateHandle[MapParams.ROUTE_DIRECTION_ID] = directionId

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
@@ -1120,7 +1120,7 @@ sealed interface LoadedRoute {
 
     /**
      * The route resolved: its [route] and serving [agencyName], the route's selectable [directions]
-     * (id + headsign, for the header's switch affordance), and the [currentDirectionId] shown now
+     * (id + headsign, for the header's direction menu), and the [currentDirectionId] shown now
      * (null = whole route).
      */
     data class Loaded(

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/DirectionHeadsign.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/DirectionHeadsign.kt
@@ -25,6 +25,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -43,16 +44,35 @@ import org.onebusaway.android.ui.icons.AppIcons
  */
 @Composable
 internal fun DirectionHeadsign(direction: String, modifier: Modifier = Modifier) {
+    DirectionLine(AppIcons.ArrowForward, direction, modifier)
+}
+
+/**
+ * The same line for a route shown whole, with a double-headed arrow in place of the one-way "toward"
+ * arrow: the whole route runs both ways and heads toward no single destination, so the one-way glyph
+ * would misdescribe it. Used for the map route header's "All directions".
+ */
+@Composable
+internal fun DirectionBothWays(label: String, modifier: Modifier = Modifier) {
+    DirectionLine(MaterialSymbols.BothDirections, label, modifier)
+}
+
+/**
+ * The shared layout + type treatment of a direction line, so the one-way and both-ways variants stay
+ * set identically (and start at the same x) rather than drifting apart.
+ */
+@Composable
+private fun DirectionLine(icon: ImageVector, text: String, modifier: Modifier) {
     Row(modifier = modifier, verticalAlignment = Alignment.CenterVertically) {
         Icon(
-            imageVector = AppIcons.ArrowForward,
+            imageVector = icon,
             contentDescription = null,
             tint = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier.size(18.dp)
         )
         Spacer(Modifier.width(4.dp))
         Text(
-            text = direction,
+            text = text,
             style = MaterialTheme.typography.bodyMedium,
             fontFamily = FontFamily.Monospace,
             letterSpacing = (-0.1).sp,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/MaterialSymbols.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/MaterialSymbols.kt
@@ -183,6 +183,31 @@ internal object MaterialSymbols {
         }
     }
 
+    /**
+     * The double-headed arrow — "both ways" — for a route direction line naming no single
+     * destination. Source glyph `arrow_range`, exported at the axes above plus ROND 50.
+     */
+    val BothDirections: ImageVector by lazy {
+        symbol("arrow_range") {
+            moveTo(7f, 17f)
+            lineTo(2f, 12f)
+            lineTo(7f, 7f)
+            lineTo(8.4f, 8.4f)
+            lineTo(5.83f, 11f)
+            horizontalLineTo(18.18f)
+            lineTo(15.6f, 8.4f)
+            lineTo(17f, 7f)
+            lineToRelative(5f, 5f)
+            lineToRelative(-5f, 5f)
+            lineTo(15.6f, 15.6f)
+            lineTo(18.18f, 13f)
+            horizontalLineTo(5.83f)
+            lineTo(8.4f, 15.6f)
+            lineTo(7f, 17f)
+            close()
+        }
+    }
+
     val Report: ImageVector by lazy {
         symbol("report") {
             moveTo(12f, 17f)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -670,7 +670,7 @@ fun HomeScreen(
                                             onRecenterStop = {
                                                 homeViewModel.recenterOnFocusedStop(mapViewModel.viewport)
                                             },
-                                            // The switch-direction affordance calls straight into the map VM (which
+                                            // The direction menu calls straight into the map VM (which
                                             // re-filters stops/vehicles + persists the choice), like the height report below.
                                             onSelectRouteDirection = { directionId ->
                                                 homeViewModel.selectStandaloneRouteDirection(directionId)
@@ -949,7 +949,7 @@ private fun BoxScope.HomeMapOverlays(
     onShowAlerts: () -> Unit,
     onClearSubordinateRoute: () -> Unit,
     onRecenterStop: () -> Unit,
-    onSelectRouteDirection: (Int) -> Unit,
+    onSelectRouteDirection: (Int?) -> Unit,
     onFrameRoute: () -> Unit,
     onLearnMore: () -> Unit,
     onOpenSurvey: (url: String) -> Unit,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
@@ -430,8 +430,8 @@ class HomeViewModel @Inject constructor(
         emitMapDirective(MapDirective.ShowRoute(request, stopScoped = false))
     }
 
-    /** Persist a direction chosen from the standalone route banner. */
-    fun selectStandaloneRouteDirection(directionId: Int) {
+    /** Persist a direction chosen from the standalone route banner (null = the whole route). */
+    fun selectStandaloneRouteDirection(directionId: Int?) {
         val focus = _currentFocus.value as? CurrentFocus.Route ?: return
         replaceFocus(CurrentFocus.Route(focus.target.copy(directionId = directionId)))
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/FocusBanner.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/FocusBanner.kt
@@ -35,8 +35,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -44,7 +44,6 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.VerticalDivider
 import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
@@ -55,12 +54,16 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.selected
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.text.style.TextOverflow
@@ -74,17 +77,18 @@ import org.onebusaway.android.map.RouteHeader
 import org.onebusaway.android.models.RouteMapDirection
 import org.onebusaway.android.models.WheelchairBoarding
 import org.onebusaway.android.ui.compose.components.CenteredLongPressMenu
+import org.onebusaway.android.ui.compose.components.DirectionBothWays
 import org.onebusaway.android.ui.compose.components.DirectionHeadsign
 import org.onebusaway.android.ui.compose.components.LineBadge
 import org.onebusaway.android.ui.compose.components.MaterialSymbols
 import org.onebusaway.android.ui.compose.components.MenuRow
-import org.onebusaway.android.ui.compose.components.RadioOptionList
 import org.onebusaway.android.ui.compose.components.RouteBadgeChip
 import org.onebusaway.android.ui.compose.components.rememberRouteBadgeColors
 import org.onebusaway.android.ui.compose.theme.ObaTheme
+import org.onebusaway.android.ui.icons.AppIcons
 import org.onebusaway.android.util.DisplayFormat
 
-// The banner's route action icons (switch-direction / cancel) share one size + tint so they read as
+// The banner's route action icons (direction menu / cancel) share one size + tint so they read as
 // one control group: a larger-than-default 36dp icon in a deliberately tightened 40dp touch box
 // (below Material's 48dp default — a conscious trade-off for a compact header banner).
 private val HEADER_ICON_SIZE = 36.dp
@@ -152,7 +156,7 @@ fun FocusBanner(
     onShowAlerts: () -> Unit,
     onClearSubordinateRoute: () -> Unit,
     onRecenterStop: () -> Unit,
-    onSelectDirection: (Int) -> Unit,
+    onSelectDirection: (Int?) -> Unit,
     onFrameRoute: () -> Unit,
     onShowSchedule: (String) -> Unit,
     onHeight: (Int) -> Unit,
@@ -285,7 +289,7 @@ private fun StopFocusBanner(
                 BannerAlertAction(onClick = onShowAlerts)
             }
             HeaderIconButton(
-                iconRes = R.drawable.ic_navigation_close,
+                painter = painterResource(R.drawable.ic_navigation_close),
                 contentDescription = stringResource(android.R.string.cancel),
                 onClick = onClose
             )
@@ -408,7 +412,7 @@ private fun CompactRouteDismissAction(onClick: () -> Unit) {
 @Composable
 private fun RouteFocusBanner(
     state: FocusBannerState.Route,
-    onSelectDirection: (Int) -> Unit,
+    onSelectDirection: (Int?) -> Unit,
     onFrameRoute: () -> Unit,
     onShowSchedule: (String) -> Unit,
     onClose: () -> Unit
@@ -426,9 +430,12 @@ private fun RouteFocusBanner(
             Spacer(Modifier.weight(1f))
         } else {
             // The current direction's headsign (blank falls back to a generic label); null when the
-            // route is shown whole (no direction selected), so the subtitle is hidden.
+            // route is shown whole (no direction selected).
             val unnamed = stringResource(R.string.route_direction_unnamed)
             val directionLabel = header.currentDirection?.labelOr(unnamed)
+            // A route with a single direction has nothing to choose between — no menu, and no line
+            // stating a choice the user can't make.
+            val hasDirectionMenu = header.directions.size >= 2
             Row(
                 Modifier
                     .weight(1f)
@@ -467,10 +474,18 @@ private fun RouteFocusBanner(
                             overflow = TextOverflow.Ellipsis
                         )
                     }
+                    // The direction line states the menu's current value; the chevron beside it is the
+                    // control that changes it. Deliberately not a trigger itself — it sits inside the
+                    // banner body, whose tap reframes the route and whose long press opens the
+                    // schedule, and a nested clickable would consume both on this line.
                     if (directionLabel != null) {
                         // The same arrow-glyph + tightened-monospace treatment as an arrivals row, so
                         // the headsign reads identically on both surfaces (#1823).
                         DirectionHeadsign(directionLabel)
+                    } else if (hasDirectionMenu) {
+                        // Set like a headsign, but with the two-way arrow: the whole route runs both
+                        // ways, so the one-way "toward" glyph would misdescribe it.
+                        DirectionBothWays(stringResource(R.string.route_header_all_directions))
                     }
                     if (header.agency.isNotEmpty()) {
                         // One type-scale step below the direction line so it recedes as secondary info.
@@ -478,9 +493,8 @@ private fun RouteFocusBanner(
                     }
                 }
             }
-            // A route with a single direction has nothing to switch to — the affordance is hidden.
-            if (header.directions.size >= 2) {
-                SwitchDirectionAction(
+            if (hasDirectionMenu) {
+                DirectionMenuAction(
                     directions = header.directions,
                     currentDirectionId = header.currentDirectionId,
                     onSelectDirection = onSelectDirection
@@ -488,7 +502,7 @@ private fun RouteFocusBanner(
             }
         }
         HeaderIconButton(
-            iconRes = R.drawable.ic_navigation_close,
+            painter = painterResource(R.drawable.ic_navigation_close),
             contentDescription = stringResource(android.R.string.cancel),
             onClick = onClose
         )
@@ -583,18 +597,18 @@ private fun BannerAlertAction(onClick: () -> Unit) {
 
 /**
  * A route-header action icon button in the shared header style: the [HEADER_ICON_SIZE] icon tinted with
- * the nav-drawer icon color, in the tightened [HEADER_ICON_BUTTON_SIZE] box. Used by the switch-direction
+ * the nav-drawer icon color, in the tightened [HEADER_ICON_BUTTON_SIZE] box. Used by the direction-menu
  * and cancel actions.
  */
 @Composable
 private fun HeaderIconButton(
-    @DrawableRes iconRes: Int,
+    painter: Painter,
     contentDescription: String,
     onClick: () -> Unit
 ) {
     IconButton(onClick = onClick, modifier = Modifier.size(HEADER_ICON_BUTTON_SIZE)) {
         Icon(
-            painter = painterResource(iconRes),
+            painter = painter,
             contentDescription = contentDescription,
             tint = colorResource(R.color.navdrawer_icon_tint),
             modifier = Modifier.size(HEADER_ICON_SIZE)
@@ -603,50 +617,65 @@ private fun HeaderIconButton(
 }
 
 /**
- * The swap-direction icon button. With exactly two directions a tap toggles to the other; with more it
- * opens a radio picker of the directions' headsigns. [currentDirectionId] is the shown direction (null
- * when the route is shown whole — a whole-route launch); a toggle from there picks the first direction.
+ * The direction picker: a caret button opening a menu whose first entry is "All directions" (the whole
+ * route), followed by each of the route's named directions. [currentDirectionId] is the shown direction,
+ * null when the route is shown whole.
+ *
+ * This replaced a swap button that *cycled* directions (#2033). Cycling could only ever land on a
+ * direction, so a route entered whole — or switched once — had no way back to both directions; the menu
+ * makes the whole route a first-class, always-reachable choice rather than only an entry state.
  */
 @Composable
-private fun SwitchDirectionAction(
+private fun DirectionMenuAction(
     directions: List<RouteMapDirection>,
     currentDirectionId: Int?,
-    onSelectDirection: (Int) -> Unit
+    onSelectDirection: (Int?) -> Unit
 ) {
-    var showPicker by remember { mutableStateOf(false) }
-    HeaderIconButton(
-        iconRes = R.drawable.ic_swap_direction,
-        contentDescription = stringResource(R.string.route_header_switch_direction),
-        onClick = {
-            if (directions.size == 2) {
-                onSelectDirection(directions.first { it.directionId != currentDirectionId }.directionId)
-            } else {
-                showPicker = true
+    var expanded by remember { mutableStateOf(false) }
+    Box {
+        HeaderIconButton(
+            painter = rememberVectorPainter(AppIcons.KeyboardArrowDown),
+            contentDescription = stringResource(R.string.route_header_select_direction),
+            onClick = { expanded = true }
+        )
+        DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            val unnamed = stringResource(R.string.route_direction_unnamed)
+            DirectionMenuItem(
+                label = stringResource(R.string.route_header_all_directions),
+                selected = currentDirectionId == null
+            ) {
+                expanded = false
+                onSelectDirection(null)
+            }
+            directions.forEach { direction ->
+                DirectionMenuItem(
+                    label = direction.labelOr(unnamed),
+                    selected = direction.directionId == currentDirectionId
+                ) {
+                    expanded = false
+                    onSelectDirection(direction.directionId)
+                }
+            }
+        }
+    }
+}
+
+/**
+ * One direction choice. The check glyph is decorative — the row carries its state as `selected`
+ * semantics, so a screen reader announces the current direction instead of relying on the icon.
+ */
+@Composable
+private fun DirectionMenuItem(label: String, selected: Boolean, onClick: () -> Unit) {
+    DropdownMenuItem(
+        modifier = Modifier.semantics { this.selected = selected },
+        text = { Text(label) },
+        onClick = onClick,
+        trailingIcon = {
+            if (selected) {
+                Icon(imageVector = AppIcons.Check, contentDescription = null)
             }
         }
     )
-    if (showPicker) {
-        val unnamed = stringResource(R.string.route_direction_unnamed)
-        AlertDialog(
-            onDismissRequest = { showPicker = false },
-            title = { Text(stringResource(R.string.route_header_switch_direction)) },
-            text = {
-                RadioOptionList(
-                    options = directions.map { it.labelOr(unnamed) }.toTypedArray(),
-                    selectedIndex = directions.indexOfFirst { it.directionId == currentDirectionId },
-                    onSelect = { index ->
-                        showPicker = false
-                        onSelectDirection(directions[index].directionId)
-                    }
-                )
-            },
-            confirmButton = {
-                TextButton(onClick = { showPicker = false }) {
-                    Text(stringResource(android.R.string.cancel))
-                }
-            }
-        )
-    }
 }
 
 /** The direction's headsign, or [unnamed] when the stop group carried no display name. */
@@ -696,6 +725,33 @@ private fun FocusBannerPreview() {
                             RouteMapDirection(1, "to Northgate")
                         ),
                         currentDirectionId = 0
+                    ),
+                    isFavorite = false
+                ),
+                onClose = {},
+                onToggleFavorite = {},
+                onShowAlerts = {},
+                onClearSubordinateRoute = {},
+                onRecenterStop = {},
+                onSelectDirection = {},
+                onFrameRoute = {},
+                onShowSchedule = {},
+                onHeight = {}
+            )
+            Spacer(Modifier.size(12.dp))
+            // The same route shown whole — the direction menu's default, which the subtitle states.
+            FocusBanner(
+                state = FocusBannerState.Route(
+                    RouteHeader(
+                        loading = false,
+                        shortName = "40",
+                        longName = "Downtown Seattle - Northgate",
+                        agency = "King County Metro",
+                        directions = listOf(
+                            RouteMapDirection(0, "to Downtown Seattle"),
+                            RouteMapDirection(1, "to Northgate")
+                        ),
+                        currentDirectionId = null
                     ),
                     isFavorite = false
                 ),

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/icons/AppIcons.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/icons/AppIcons.kt
@@ -62,6 +62,18 @@ object AppIcons {
         }
     }
 
+    val Check: ImageVector by lazy(LazyThreadSafetyMode.NONE) {
+        materialIcon(name = "check") {
+            moveTo(9f, 16.17f)
+            lineTo(4.83f, 12f)
+            lineToRelative(-1.42f, 1.41f)
+            lineTo(9f, 19f)
+            lineTo(21f, 7f)
+            lineToRelative(-1.41f, -1.41f)
+            close()
+        }
+    }
+
     val Info: ImageVector by lazy(LazyThreadSafetyMode.NONE) {
         materialIcon(name = "info") {
             moveTo(12.98f, 9f)

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -340,8 +340,10 @@
     <string name="route_info_context_showonmap">Show on map</string>
     <string name="route_info_no_shape_data">Sorry, map information isn’t available for this route
     </string>
-    <!-- Route map header: switch which direction of the route is shown -->
-    <string name="route_header_switch_direction">Switch direction</string>
+    <!-- Route map header: open the menu choosing which direction of the route is shown -->
+    <string name="route_header_select_direction">Select direction</string>
+    <!-- Route map header: the direction menu's default — show the whole route, both directions -->
+    <string name="route_header_all_directions">All directions</string>
     <!-- Route map header: tap the banner body to reframe the map to the route's full extent -->
     <string name="route_header_frame_route">Frame route on map</string>
     <!-- Fallback label for a route direction whose headsign is missing -->


### PR DESCRIPTION
Fixes #2033.

## The problem

The map's route focus header offered a swap button that **cycled** through the route's direction variants. Cycling can only ever land *on* a direction, so a route shown whole — the state every whole-route launch starts in — had no way back once you switched. With more than two variants the button opened a modal radio dialog instead of switching. Whole-route was reachable only as an entry state, never as a choice.

## The change

A chevron opening a dropdown: **All directions** first, then each named direction, with a check on the current one. The whole route becomes a first-class, always-reachable option.

Everything below the UI already modelled this — `RouteMapController.selectDirection` takes a nullable id where null means the whole route, and `RouteTarget.directionId` is already `Int?`. Only the UI couldn't express it, so the plumbing change is just widening three callbacks to `Int?`: `FocusBanner.onSelectDirection`, `MapViewModel.selectRouteDirection`, `HomeViewModel.selectStandaloneRouteDirection`.

The header's direction line now states the menu's current value rather than going blank when the route is shown whole. Both readings share one layout and type treatment (`DirectionLine`): the one-way "toward" arrow for a headsign, the double-headed `arrow_range` glyph for "All directions", which heads toward no single destination.

## Worth a reviewer's eye

**Restore behaviour.** Selecting "All directions" clears the launch anchor (`ROUTE_DIRECTION_STOP_ID`) alongside the direction id. That clearing already existed for a direction switch, but it carries more weight here: without it, a process-death restore would re-resolve the anchor stop and snap the map straight back to the direction the user just widened out of.

**Gesture boundary.** The direction line is deliberately *not* a second trigger for the menu. It sits inside the banner body, whose tap reframes the route and whose long press opens the schedule; a nested clickable would consume both on that line. The chevron is the only trigger. There's a comment at the site so this isn't re-attempted.

**Strings.** `route_header_switch_direction` → `route_header_select_direction`, plus new `route_header_all_directions`. Both were untranslated, so no `values-*` churn.

**Icons.** `AppIcons.Check` (classic Material Icons) and `MaterialSymbols.BothDirections` (`arrow_range`, at that file's documented axes plus ROND 50). `ic_swap_direction` stays — `TripPlanForm` still uses it.

## Testing

`FocusBannerTest` built its `RouteHeader` with no directions, so the direction affordance had **no coverage at all**. Adds three cases: the menu offering "All directions" alongside the named ones and reporting null, selecting a named direction by id, and a single-direction route showing neither menu nor direction line.

- `compileObaGoogleDebugKotlin` + `compileObaGoogleDebugAndroidTestKotlin` clean under `-PwarningsAsErrors=true`
- `spotlessCheck` and `testObaGoogleDebugUnitTest` pass
- 10/10 `FocusBannerTest` green on a physical Pixel 7 Pro (API 36), and verified by hand in the running app

Lint was left to CI per the repo guidance on not running it locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a route direction menu to the map header.
  * Choose “All directions” or a specific route direction.
  * Added visual indicators for all-direction and selected-direction states.
* **Bug Fixes**
  * Route selections now correctly persist when switching between a specific direction and all directions.
* **Tests**
  * Added coverage for direction menu options, selections, and single-direction routes where the menu is hidden.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->