### PR TITLE
Demote freeways on the Google basemap

### DIFF
--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleComposeAdapter.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleComposeAdapter.kt
@@ -437,14 +437,12 @@ private fun applyMyLocation(map: GoogleMap, context: Context, enabled: Boolean) 
     map.isMyLocationEnabled = enabled && granted
 }
 
-/** The map style for the current night-mode state: the dark theme, or POI removal in light mode. */
-private fun resolveMapStyle(context: Context): MapStyleOptions = if (ThemeUtils.isInDarkMode(context)) {
-    MapStyleOptions.loadRawResourceStyle(context, R.raw.dark_map)
-} else {
-    // Light mode: hide POIs (ported from GoogleMapHost.onMapReady) and bus-stop icons,
-    // which are redundant with our own stop markers.
-    MapStyleOptions(
-        "[{\"featureType\":\"poi\",\"elementType\":\"all\",\"stylers\":[{\"visibility\":\"off\"}]}," +
-            "{\"featureType\":\"transit.station.bus\",\"elementType\":\"all\",\"stylers\":[{\"visibility\":\"off\"}]}]"
-    )
-}
+/**
+ * The map style for the current night-mode state. Both are raw resources rather than one being an
+ * inline string, so the two stay comparable — the rules that quiet the basemap (POIs, the basemap's own
+ * bus stops, freeways) have to be kept in step across them, and that is hard to see in escaped JSON.
+ */
+private fun resolveMapStyle(context: Context): MapStyleOptions = MapStyleOptions.loadRawResourceStyle(
+    context,
+    if (ThemeUtils.isInDarkMode(context)) R.raw.dark_map else R.raw.light_map
+)

--- a/onebusaway-android/src/main/res/raw/dark_map.json
+++ b/onebusaway-android/src/main/res/raw/dark_map.json
@@ -108,33 +108,6 @@
     ]
   },
   {
-    "featureType": "road.highway",
-    "elementType": "geometry.fill",
-    "stylers": [
-      {
-        "color": "#746855"
-      }
-    ]
-  },
-  {
-    "featureType": "road.highway",
-    "elementType": "geometry.stroke",
-    "stylers": [
-      {
-        "color": "#1f2835"
-      }
-    ]
-  },
-  {
-    "featureType": "road.highway",
-    "elementType": "labels.text.fill",
-    "stylers": [
-      {
-        "color": "#f3d19c"
-      }
-    ]
-  },
-  {
     "featureType": "road.local",
     "elementType": "geometry.fill",
     "stylers": [
@@ -203,6 +176,42 @@
     "stylers": [
       {
         "lightness": -20
+      }
+    ]
+  },
+  {
+    "_comment": "Freeways and their ramps, demoted to the local-street colours this style already defines. road.highway is the parent of road.highway.controlled_access, so mainlines and on/off ramps are covered together. Appended so it overrides the road.highway colours set earlier in this file.",
+    "featureType": "road.highway",
+    "elementType": "geometry.fill",
+    "stylers": [
+      {
+        "color": "#38414e"
+      },
+      {
+        "weight": 1
+      }
+    ]
+  },
+  {
+    "_comment": "Matching casing, so the demoted freeway reads as one of the ordinary streets around it.",
+    "featureType": "road.highway",
+    "elementType": "geometry.stroke",
+    "stylers": [
+      {
+        "color": "#212a37"
+      },
+      {
+        "weight": 1
+      }
+    ]
+  },
+  {
+    "_comment": "Shields and route numbers are pure driving chrome, and the heaviest thing left once the lines are quiet.",
+    "featureType": "road.highway",
+    "elementType": "labels",
+    "stylers": [
+      {
+        "visibility": "off"
       }
     ]
   }

--- a/onebusaway-android/src/main/res/raw/light_map.json
+++ b/onebusaway-android/src/main/res/raw/light_map.json
@@ -1,0 +1,26 @@
+[
+  {
+    "_comment": "POIs are redundant with, and noisier than, the transit content the map draws.",
+    "featureType": "poi",
+    "elementType": "all",
+    "stylers": [{ "visibility": "off" }]
+  },
+  {
+    "_comment": "The basemap's own bus-stop icons duplicate our stop markers.",
+    "featureType": "transit.station.bus",
+    "elementType": "all",
+    "stylers": [{ "visibility": "off" }]
+  },
+  {
+    "_comment": "Freeways and their ramps, demoted to look like ordinary streets. road.highway is the parent of road.highway.controlled_access, so this covers the mainlines and the on/off ramps together - the ramps are what stayed at full strength when only controlled_access was styled. Relative stylers rather than a fixed colour, so this stays a demotion of whatever the basemap's own road palette is instead of a guess at it: saturation strips the orange, lightness pushes it back toward the street fill, weight takes off the extra width. Nobody plans a bus trip by freeway, so the widest, highest-contrast lines on the map were carrying the least information on it.",
+    "featureType": "road.highway",
+    "elementType": "geometry",
+    "stylers": [{ "saturation": -100 }, { "lightness": 45 }, { "weight": 1 }]
+  },
+  {
+    "_comment": "The shields and route numbers are the heaviest thing left once the lines are quiet, and they are pure driving chrome.",
+    "featureType": "road.highway",
+    "elementType": "labels",
+    "stylers": [{ "visibility": "off" }]
+  }
+]


### PR DESCRIPTION
A transit map's widest, highest-contrast lines were its freeways — the one thing on it nobody using this app is travelling by. They out-drew the transit content around them, and on a map whose job is route geometry that is exactly backwards.

`road.highway` now renders in the local-street palette instead of being hidden: saturation stripped and lightness raised in light mode, and set to the exact `road.local` colours the dark style already names in dark mode. The roads stay legible as streets; they just stop shouting.

**Why the parent feature type.** Styling `road.highway.controlled_access` alone demotes the mainlines but leaves every on- and off-ramp at full strength — the ramps are classified under the parent. `road.highway` covers both together. Arterials keep their own styling deliberately: buses run on those, and transit geometry drawn without them would float unanchored.

Shields and route numbers go with it. Once the lines are quiet they become the heaviest thing left, and they are pure driving chrome.

### Also here

- The dark style's original tan freeway colours (`#746855` / `#1f2835` / `#f3d19c`) are **removed** rather than shadowed by later rules. Both render identically, but one rule per `featureType`/`elementType` doesn't depend on later-wins ordering to be correct.
- The light style moves from an escaped one-line JSON string inside `GoogleComposeAdapter` to `res/raw/light_map.json`, alongside the dark one. The two have to be kept in step — every rule that quiets the basemap belongs in both — and that is not something you can see in escaped JSON. `resolveMapStyle` now just picks a resource by theme.

### Scope

maplibre is unchanged: its styles come from OpenFreeMap URLs, so there is no local stylesheet to edit and its freeways stay as they are. Worth knowing if the flavors are expected to look alike.

Split out of #2018, where this was found while trying to make drawn route lines read against the basemap. It stands on its own and doesn't depend on anything else there.

### Verification

Light mode checked on a Pixel 7 Pro. **Dark mode has not been looked at on a device** — the colours were matched by reading `road.local` out of the stylesheet rather than by eye, so that's the thing worth a second pair of eyes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated light and dark map styles.
  * Improved map readability by reducing highway prominence and hiding highway labels.
  * Reduced visual clutter by suppressing points of interest and map bus-stop icons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->