### PR TITLE
Let a release build run without Play API credentials

### DIFF
--- a/onebusaway-android/build.gradle.kts
+++ b/onebusaway-android/build.gradle.kts
@@ -489,16 +489,30 @@ dependencies {
 play {
     // Path to the Google Play service account JSON key file.
     // Set via gradle.properties: PLAY_STORE_JSON_KEY=/path/to/service-account-key.json
-    if (project.hasProperty("PLAY_STORE_JSON_KEY")) {
-        serviceAccountCredentials.set(file(project.property("PLAY_STORE_JSON_KEY") as String))
-    }
+    //
+    // Counts as configured only when the property actually names an existing file, mirroring how
+    // secure.properties is handled above. hasProperty() alone is true for a blank value, and a
+    // property left pointing at a key that hasn't been fetched yet names nothing; either would
+    // fail every release assemble at configuration time instead of falling back below.
+    val credentialsFile = project.findProperty("PLAY_STORE_JSON_KEY")
+        ?.toString()
+        ?.trim()
+        ?.takeIf { it.isNotEmpty() }
+        ?.let { file(it) }
+        ?.takeIf { it.isFile }
+    credentialsFile?.let { serviceAccountCredentials.set(it) }
+
+    // GPP reads credentials from this environment variable too, so it can still authenticate
+    // when the property is unset.
+    val hasCredentials = credentialsFile != null ||
+        !System.getenv("ANDROID_PUBLISHER_CREDENTIALS").isNullOrBlank()
 
     // Auto-increment versionCode from the highest code currently on the Play Store when Play
-    // credentials are configured. Without them, fall back to the versionCode in this file so a
+    // credentials are available. Without them, fall back to the versionCode in this file so a
     // release build works without Play API access — AUTO queries Play on every release assemble,
     // not just on publish, so it otherwise fails the build for anyone who can't reach the API.
     resolutionStrategy.set(
-        if (project.hasProperty("PLAY_STORE_JSON_KEY")) {
+        if (hasCredentials) {
             com.github.triplet.gradle.androidpublisher.ResolutionStrategy.AUTO
         } else {
             com.github.triplet.gradle.androidpublisher.ResolutionStrategy.IGNORE

--- a/onebusaway-android/build.gradle.kts
+++ b/onebusaway-android/build.gradle.kts
@@ -493,8 +493,17 @@ play {
         serviceAccountCredentials.set(file(project.property("PLAY_STORE_JSON_KEY") as String))
     }
 
-    // Auto-increment versionCode based on the highest code currently on the Play Store
-    resolutionStrategy.set(com.github.triplet.gradle.androidpublisher.ResolutionStrategy.AUTO)
+    // Auto-increment versionCode from the highest code currently on the Play Store when Play
+    // credentials are configured. Without them, fall back to the versionCode in this file so a
+    // release build works without Play API access — AUTO queries Play on every release assemble,
+    // not just on publish, so it otherwise fails the build for anyone who can't reach the API.
+    resolutionStrategy.set(
+        if (project.hasProperty("PLAY_STORE_JSON_KEY")) {
+            com.github.triplet.gradle.androidpublisher.ResolutionStrategy.AUTO
+        } else {
+            com.github.triplet.gradle.androidpublisher.ResolutionStrategy.IGNORE
+        }
+    )
 
     // Upload to the open testing (beta) track, matching the existing release workflow
     defaultToAppBundles.set(true)


### PR DESCRIPTION
### Problem

`resolutionStrategy` was unconditionally `AUTO`, so gradle-play-publisher queries Google Play for the next `versionCode` on **every release assemble** — not just on the `publish*` tasks. `assembleObaGoogleRelease` therefore hard-fails without a Play service-account JSON:

```
Execution failed for task ':onebusaway-android:processObaGoogleReleaseVersionCodes'
> No credentials specified.
```

and fails even earlier, at configuration time, when `PLAY_STORE_JSON_KEY` points at a file that isn't there (`property 'extension.serviceAccountCredentials' specifies file '…' which doesn't exist`).

It can't be worked around by skipping the task — `-x processObaGoogleReleaseVersionCodes` just relocates the failure to `createObaGoogleReleaseCompatibleScreenManifests`, which reads `build/intermediates/gpp/<variant>/available-version-codes.txt`.

Net effect: building a signed release APK locally required a Google Cloud service account **and** a Play Console permission grant from an admin — a substantially higher bar than the task actually warrants. Publishing needs that access; building doesn't.

### Change

Fall back to `ResolutionStrategy.IGNORE` when `PLAY_STORE_JSON_KEY` isn't set, mirroring the conditional this file already uses for `secure.properties` (`build.gradle.kts:112`).

### Risk

Low, and confined to the case that previously just failed:

- **With** credentials — unchanged. Publishing still auto-increments from the Play Store.
- **Without** credentials — the build uses the `versionCode` literal in `build.gradle.kts`. The only route to Play for such an artifact is a manual Console upload, where a duplicate `versionCode` is rejected outright. CI doesn't build release variants.

### Verification

- `assembleObaGoogleRelease` with no credentials configured: **BUILD SUCCESSFUL**, where it previously failed.
- APK signed with the real release key — cert SHA-256 `2bd4373931…c2af9422`, matching `signingReport`.
- `spotlessCheck` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Release builds can now complete without Google Play API access when publishing credentials are not configured.
  * Auto-management of Google Play version codes now runs only when valid publishing credentials are available; otherwise it safely falls back to avoid build failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->