### PR TITLE
Bring schedule-deviation colors into parity with OBA iOS (#2043)

### DIFF
--- a/docs/REBRANDING.md
+++ b/docs/REBRANDING.md
@@ -122,10 +122,12 @@ All other branded strings use `%1$s` placeholders that automatically substitute 
     <!-- Primary color with a "df" alpha prefix (~87% opaque) -->
     <color name="tutorial_background">#dfYOUR_PRIMARY_COLOR</color>
     <color name="ic_launcher_background">#YOUR_PRIMARY_COLOR</color>
-    <!-- Keep on-time color green even if your theme isn't green -->
-    <color name="stop_info_ontime">#4CAF50</color>
 </resources>
 ```
+
+Do **not** override the `stop_info_*` colors. They encode schedule deviation (early / on time /
+late / no real-time), which is semantic rather than brand identity, and they are intentionally
+independent of `brand_color` so a brand hue can never collide two states into the same color.
 
 To override material 3 colors, please checkout the [theme builder](https://material-foundation.github.io/material-theme-builder).
 

--- a/onebusaway-android/flavors/README.md
+++ b/onebusaway-android/flavors/README.md
@@ -80,10 +80,12 @@ That's it! All other branded strings use `%1$s` placeholders that automatically 
     <!-- Primary color with a "df" alpha prefix (~87% opaque) -->
     <color name="tutorial_background">#dfYOUR_PRIMARY_COLOR</color>
     <color name="ic_launcher_background">#YOUR_PRIMARY_COLOR</color>
-    <!-- Keep on-time arrivals green even if your theme isn't green -->
-    <color name="stop_info_ontime">#4CAF50</color>
 </resources>
 ```
+
+Do **not** override the `stop_info_*` colors. They encode schedule deviation (early / on time /
+late / no real-time), which is semantic rather than brand identity, and they are intentionally
+independent of `brand_color` so a brand hue can never collide two states into the same color.
 To override material 3 colors, please checkout the [theme builder](https://material-foundation.github.io/material-theme-builder).
 
 #### do_not_translate.xml

--- a/onebusaway-android/src/agencyX/res/values/colors.xml
+++ b/onebusaway-android/src/agencyX/res/values/colors.xml
@@ -21,7 +21,8 @@
     <color name="theme_muted">#FFCAD2</color>
     <color name="theme_accent">#E53935</color>
 
-    <color name="stop_info_ontime">#4CAF50</color>
+    <!-- No stop_info_* override: the schedule-deviation palette is semantic, not brand identity,
+         and is no longer derived from brand_color (#2043). -->
 
     <!-- Tutorials -->
     <color name="tutorial_background">#dfF44336</color>

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/map/VehicleIconAllocationTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/map/VehicleIconAllocationTest.kt
@@ -35,6 +35,7 @@ import org.onebusaway.android.api.contract.TripDetailsEntry
 import org.onebusaway.android.api.data.asRouteTrips
 import org.onebusaway.android.extrapolation.extrapolatedVehicles
 import org.onebusaway.android.map.googlemapsv2.BitmapDescriptorCache
+import org.onebusaway.android.map.render.DEFAULT_ROUTE_LINE_COLOR
 import org.onebusaway.android.map.render.VehicleBitmaps
 import org.onebusaway.android.map.render.VehicleMarker
 import org.onebusaway.android.mock.Resources
@@ -321,93 +322,62 @@ class VehicleIconAllocationTest {
     // --- The route display color on the disc (#2043) ---------------------------------------------
 
     /**
-     * The disc takes the route's **display** color, not its raw GTFS value: it goes through
-     * `routeLineColors`, the shared agency-color policy, which keeps the hue but caps chroma and
-     * re-tones for the active theme. Asserted as "not the raw int" because the whole point is that an
-     * agency's literal choice never reaches the map unmediated — a full-chroma near-black would
-     * otherwise render a disc that vanishes into the basemap.
+     * The disc is the color the map is currently *drawing that route's line* with, carried on the
+     * marker by the controller — not something re-derived here from the route's GTFS color. In
+     * stop-focus view `adjacencyRouteColors` gives each shown route a distinct synthesized hue so the
+     * lines can be told apart, and a vehicle wearing its agency's nominal color there would point at
+     * the wrong line.
      */
     @Test
-    fun discUsesTheRouteDisplayColorNotTheRawGtfsColor() {
-        val raw = 0xFF1B6EF3.toInt() // a vivid, fully-saturated agency blue
-        val response = fakeResponse(routeColor = raw)
-        val colors = VehicleBitmaps.markerColors(context, liveVehicle(), response)
+    fun discUsesTheCarriedRouteDisplayColor() {
+        val assigned = 0xFF1B6EF3.toInt()
+        val colors = VehicleBitmaps.markerColors(context, liveVehicle().copy(routeColor = assigned))
 
-        assertNotEquals("the raw GTFS int must not reach the disc", raw, colors.disc)
-        assertNotEquals("the glyph must contrast with the disc", colors.disc, colors.onDisc)
+        assertEquals("the disc is the route's drawn color, unmodified", assigned, colors.disc)
     }
 
-    /** Two different agency colors must still produce two different discs — toning is not flattening. */
+    /** A vehicle whose route has no color falls back exactly as an uncolored polyline does. */
+    @Test
+    fun absentRouteColorFallsBackLikeAnUncoloredLine() {
+        val colors = VehicleBitmaps.markerColors(context, liveVehicle().copy(routeColor = null))
+
+        assertEquals(DEFAULT_ROUTE_LINE_COLOR, colors.disc)
+    }
+
+    /** Two routes drawn in different colors must render two different discs. */
     @Test
     fun differentRouteColorsStayDistinct() {
-        val blue = VehicleBitmaps.markerColors(context, liveVehicle(), fakeResponse(0xFF1B6EF3.toInt()))
-        val orange = VehicleBitmaps.markerColors(context, liveVehicle(), fakeResponse(0xFFF37B1B.toInt()))
+        val blue = VehicleBitmaps.markerColors(context, liveVehicle().copy(routeColor = 0xFF1B6EF3.toInt()))
+        val orange = VehicleBitmaps.markerColors(context, liveVehicle().copy(routeColor = 0xFFF37B1B.toInt()))
 
         assertNotEquals(blue.disc, orange.disc)
     }
 
     /**
-     * An achromatic source (grey/black/white) has no hue to keep, and an absent one has nothing at
-     * all; both take the brand fallback rather than producing a grey disc that would read as the
-     * "no real-time" state.
+     * The glyph and arrow flip by the disc's luminance rather than by the theme, so a route drawn in a
+     * pale yellow doesn't get a white bus glyph washed out on it.
      */
     @Test
-    fun achromaticOrAbsentRouteColorTakesTheBrandFallback() {
-        val brand = VehicleBitmaps.markerColors(context, liveVehicle(), fakeResponse(routeColor = null))
-        val grey = VehicleBitmaps.markerColors(context, liveVehicle(), fakeResponse(0xFF888888.toInt()))
+    fun glyphFlipsToStayLegibleOnLightAndDarkDiscs() {
+        val onDark = VehicleBitmaps.markerColors(context, liveVehicle().copy(routeColor = 0xFF0B1F55.toInt()))
+        val onLight = VehicleBitmaps.markerColors(context, liveVehicle().copy(routeColor = 0xFFFFEB3B.toInt()))
 
-        assertEquals("an achromatic route color falls back like an absent one", brand.disc, grey.disc)
-        assertNotEquals(
-            "the fallback must not be the not-real-time grey",
-            VehicleBitmaps.markerColors(context, staleVehicle(), fakeResponse(null)).disc,
-            brand.disc
-        )
+        assertEquals("white glyph on a dark disc", android.graphics.Color.WHITE, onDark.onDisc)
+        assertEquals("black glyph on a light disc", android.graphics.Color.BLACK, onLight.onDisc)
     }
 
-    /** A vehicle without real-time is grey regardless of how colorful its route is. */
+    /** A vehicle without real-time is grey regardless of how its route is drawn. */
     @Test
     fun withoutRealtimeTheDiscIsGrey() {
-        val stale = VehicleBitmaps.markerColors(context, staleVehicle(), fakeResponse(0xFF1B6EF3.toInt()))
-        val live = VehicleBitmaps.markerColors(context, liveVehicle(), fakeResponse(0xFF1B6EF3.toInt()))
+        val route = 0xFF1B6EF3.toInt()
+        val stale = VehicleBitmaps.markerColors(context, staleVehicle().copy(routeColor = route))
 
-        assertNotEquals(live.disc, stale.disc)
+        assertNotEquals("liveness must still change the disc", route, stale.disc)
     }
 
     private fun liveVehicle(): VehicleMarker = withLiveness(vehicles(response()).first(), isRealtime = true)
 
     private fun staleVehicle(): VehicleMarker = withLiveness(vehicles(response()).first(), isRealtime = false)
-
-    /** A references pool whose single route carries [routeColor], for the display-color assertions. */
-    private fun fakeResponse(routeColor: Int?): RouteTrips {
-        val vehicleTripId = vehicles(response()).first().activeTripId
-        return object : RouteTrips {
-            override val trips: List<ObaTripDetails> = emptyList()
-            override fun trip(tripId: String?): ObaTrip? = FakeTrip(vehicleTripId, "routeA").takeIf { !tripId.isNullOrEmpty() }
-            override fun route(routeId: String): ObaRoute = FakeRoute(routeColor)
-            override val currentTimeMs: Long = 0L
-        }
-    }
-
-    private class FakeTrip(override val id: String, override val routeId: String) : ObaTrip {
-        override val shortName: String? = null
-        override val shapeId: String? = null
-        override val directionId: Int = 0
-        override val serviceId: String? = null
-        override val headsign: String? = null
-        override val timezone: String? = null
-        override val blockId: String? = null
-    }
-
-    private class FakeRoute(override val color: Int?) : ObaRoute {
-        override val id: String = "routeA"
-        override val type: Int = ObaRoute.TYPE_BUS
-        override val shortName: String? = null
-        override val longName: String? = null
-        override val description: String? = null
-        override val url: String? = null
-        override val textColor: Int? = null
-        override val agencyId: String = "agency"
-    }
 
     companion object {
         // Sweep the bearing through all 8 octants within a few frames, then revisit them (no new icons) —

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/map/VehicleIconAllocationTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/map/VehicleIconAllocationTest.kt
@@ -357,7 +357,7 @@ class VehicleIconAllocationTest {
         val stale = staleVehicle().copy(routeColor = 0xFF1B6EF3.toInt())
 
         assertEquals(
-            context.getColor(ScheduleDeviation.Status.SCHEDULED.colorRes),
+            context.getColor(ScheduleDeviation.Status.SCHEDULED.displayColorRes),
             VehicleBitmaps.discColor(context, stale)
         )
     }

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/map/VehicleIconAllocationTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/map/VehicleIconAllocationTest.kt
@@ -120,7 +120,7 @@ class VehicleIconAllocationTest {
                 val octant = VehicleBitmaps.directionIndex(moved)
                 if (lastOctant.put(moved.activeTripId, octant) != octant) {
                     counts.requests++
-                    val key = VehicleBitmaps.iconKey(moved, response)
+                    val key = VehicleBitmaps.iconKey(context, moved, response)
                     counts.keys.add(key)
                     cache.get(key) {
                         counts.bitmapDecodes++
@@ -195,7 +195,7 @@ class VehicleIconAllocationTest {
         val samples = vehicles.flatMap { vehicle ->
             (0 until 8).map { octant ->
                 val moved = vehicle.copy(bearing = octant * 45f)
-                VehicleBitmaps.iconKey(moved, response) to
+                VehicleBitmaps.iconKey(context, moved, response) to
                     VehicleBitmaps.vehicleBitmap(context, moved, response)
             }
         }
@@ -214,13 +214,42 @@ class VehicleIconAllocationTest {
     }
 
     /**
-     * The replay holds `nowMs` fixed and only rotates bearing, so schedule-deviation color never varies —
-     * leaving the key's color dimension unexercised. Hold a vehicle's octant fixed and change only its
-     * deviation (early vs. late, distinct colors): the key must change and the cache must mint a second
-     * descriptor, proving color participates in the key.
+     * The replay only rotates bearing, leaving the key's color dimension unexercised. Hold a vehicle's
+     * octant fixed and flip only its **liveness**: a live vehicle draws in its route color, one without
+     * real-time draws gray (#2043), so the key must change and the cache must mint a second descriptor.
+     *
+     * This replaces an equivalent early-vs-late assertion. Schedule deviation no longer reaches the
+     * marker at all — punctuality now lives in the info window, and the disc means route identity +
+     * liveness — so the deviation variant would assert behavior the app deliberately dropped. The
+     * companion [scheduleDeviationDoesNotAffectTheIcon] pins that new contract from the other side.
      */
     @Test
-    fun changedScheduleDeviationMintsANewDescriptor() {
+    fun changedLivenessMintsANewDescriptor() {
+        val response = response()
+        val vehicle = vehicles(response).firstOrNull()
+        assertTrue("fixture must yield at least one vehicle", vehicle != null)
+
+        val live = withLiveness(vehicle!!, isRealtime = true)
+        val stale = withLiveness(vehicle, isRealtime = false)
+
+        val liveKey = VehicleBitmaps.iconKey(context, live, response)
+        val staleKey = VehicleBitmaps.iconKey(context, stale, response)
+        assertNotEquals("liveness must be part of the icon key", liveKey, staleKey)
+
+        val counts = Counts()
+        val cache = BitmapDescriptorCache(CACHE_SIZE) { counts.allocations++ }
+        cache.get(liveKey) { VehicleBitmaps.vehicleBitmap(context, live, response) }
+        cache.get(staleKey) { VehicleBitmaps.vehicleBitmap(context, stale, response) }
+        assertEquals("a changed disc color must mint a second descriptor", 2, counts.allocations)
+    }
+
+    /**
+     * The other half of the #2043 contract: with liveness and heading held fixed, a wildly different
+     * schedule deviation must produce the *same* icon. A marker that still varied by punctuality would
+     * both re-introduce the meaning the issue removed and silently multiply the icon working set.
+     */
+    @Test
+    fun scheduleDeviationDoesNotAffectTheIcon() {
         val response = response()
         val vehicle = vehicles(response).firstOrNull()
         assertTrue("fixture must yield at least one vehicle", vehicle != null)
@@ -228,15 +257,16 @@ class VehicleIconAllocationTest {
         val early = withRealtimeDeviation(vehicle!!, TimeUnit.MINUTES.toSeconds(-10))
         val late = withRealtimeDeviation(vehicle, TimeUnit.MINUTES.toSeconds(10))
 
-        val earlyKey = VehicleBitmaps.iconKey(early, response)
-        val lateKey = VehicleBitmaps.iconKey(late, response)
-        assertNotEquals("deviation color must be part of the icon key", earlyKey, lateKey)
-
-        val counts = Counts()
-        val cache = BitmapDescriptorCache(CACHE_SIZE) { counts.allocations++ }
-        cache.get(earlyKey) { VehicleBitmaps.vehicleBitmap(context, early, response) }
-        cache.get(lateKey) { VehicleBitmaps.vehicleBitmap(context, late, response) }
-        assertEquals("a changed deviation color must mint a second descriptor", 2, counts.allocations)
+        assertEquals(
+            "schedule deviation must not reach the marker icon",
+            VehicleBitmaps.iconKey(context, early, response),
+            VehicleBitmaps.iconKey(context, late, response)
+        )
+        assertTrue(
+            "an early and a late vehicle must render the identical disc",
+            VehicleBitmaps.vehicleBitmap(context, early, response)
+                .sameAs(VehicleBitmaps.vehicleBitmap(context, late, response))
+        )
     }
 
     /**
@@ -271,8 +301,8 @@ class VehicleIconAllocationTest {
     }
 
     /**
-     * Force the realtime color path and stamp [deviationSeconds] onto a copy of [vehicle], pinning the
-     * bearing so the heading octant is fixed — only the deviation color varies between the variants.
+     * Force the realtime path and stamp [deviationSeconds] onto a copy of [vehicle], pinning the bearing
+     * so the heading octant is fixed — only the schedule deviation varies between the variants.
      */
     private fun withRealtimeDeviation(vehicle: VehicleMarker, deviationSeconds: Long): VehicleMarker = vehicle.copy(
         isRealtime = true,
@@ -282,6 +312,9 @@ class VehicleIconAllocationTest {
         }
     )
 
+    /** A copy of [vehicle] with [isRealtime] forced and the bearing pinned, so only liveness varies. */
+    private fun withLiveness(vehicle: VehicleMarker, isRealtime: Boolean): VehicleMarker = vehicle.copy(isRealtime = isRealtime, bearing = 0f)
+
     companion object {
         // Sweep the bearing through all 8 octants within a few frames, then revisit them (no new icons) —
         // which is the property under test (revisited octants reuse the cached descriptor).
@@ -289,7 +322,7 @@ class VehicleIconAllocationTest {
         private const val SHORT_FRAMES = 60
         private const val LONG_FRAMES = 240
 
-        // Far larger than the snapshot's distinct icons (8 octants x a handful of type/deviation-color
+        // Far larger than the snapshot's distinct icons (8 octants x a handful of type/route-color
         // combos), so eviction never confounds the "allocations independent of frame count" invariant. The
         // production cap is deliberately smaller — it only needs to cover the live working set, not history.
         private const val CACHE_SIZE = 1024

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/map/VehicleIconAllocationTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/map/VehicleIconAllocationTest.kt
@@ -17,6 +17,7 @@ package org.onebusaway.android.map
 
 import android.content.Context
 import android.graphics.Bitmap
+import android.graphics.Color
 import android.util.Log
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
@@ -36,15 +37,14 @@ import org.onebusaway.android.api.data.asRouteTrips
 import org.onebusaway.android.extrapolation.extrapolatedVehicles
 import org.onebusaway.android.map.googlemapsv2.BitmapDescriptorCache
 import org.onebusaway.android.map.render.DEFAULT_ROUTE_LINE_COLOR
+import org.onebusaway.android.map.render.MarkerRendering
 import org.onebusaway.android.map.render.VehicleBitmaps
 import org.onebusaway.android.map.render.VehicleMarker
 import org.onebusaway.android.mock.Resources
-import org.onebusaway.android.models.ObaRoute
-import org.onebusaway.android.models.ObaTrip
-import org.onebusaway.android.models.ObaTripDetails
 import org.onebusaway.android.models.ObaTripStatus
 import org.onebusaway.android.models.RouteTrips
 import org.onebusaway.android.time.WallTime
+import org.onebusaway.android.util.ScheduleDeviation
 
 /**
  * The before/after allocation guard for #1580. `GoogleMapRenderer` re-stamps a gliding vehicle's icon on
@@ -326,53 +326,50 @@ class VehicleIconAllocationTest {
      * marker by the controller — not something re-derived here from the route's GTFS color. In
      * stop-focus view `adjacencyRouteColors` gives each shown route a distinct synthesized hue so the
      * lines can be told apart, and a vehicle wearing its agency's nominal color there would point at
-     * the wrong line.
+     * the wrong line. Asserted as exact equality, so distinctness between routes follows.
      */
     @Test
     fun discUsesTheCarriedRouteDisplayColor() {
         val assigned = 0xFF1B6EF3.toInt()
-        val colors = VehicleBitmaps.markerColors(context, liveVehicle().copy(routeColor = assigned))
 
-        assertEquals("the disc is the route's drawn color, unmodified", assigned, colors.disc)
+        assertEquals(
+            "the disc is the route's drawn color, unmodified",
+            assigned,
+            VehicleBitmaps.discColor(context, liveVehicle().copy(routeColor = assigned))
+        )
     }
 
     /** A vehicle whose route has no color falls back exactly as an uncolored polyline does. */
     @Test
     fun absentRouteColorFallsBackLikeAnUncoloredLine() {
-        val colors = VehicleBitmaps.markerColors(context, liveVehicle().copy(routeColor = null))
-
-        assertEquals(DEFAULT_ROUTE_LINE_COLOR, colors.disc)
-    }
-
-    /** Two routes drawn in different colors must render two different discs. */
-    @Test
-    fun differentRouteColorsStayDistinct() {
-        val blue = VehicleBitmaps.markerColors(context, liveVehicle().copy(routeColor = 0xFF1B6EF3.toInt()))
-        val orange = VehicleBitmaps.markerColors(context, liveVehicle().copy(routeColor = 0xFFF37B1B.toInt()))
-
-        assertNotEquals(blue.disc, orange.disc)
+        assertEquals(
+            DEFAULT_ROUTE_LINE_COLOR,
+            VehicleBitmaps.discColor(context, liveVehicle().copy(routeColor = null))
+        )
     }
 
     /**
-     * The glyph and arrow flip by the disc's luminance rather than by the theme, so a route drawn in a
-     * pale yellow doesn't get a white bus glyph washed out on it.
+     * A vehicle without real-time takes the shared "no prediction" gray, not its route's color — the
+     * marker's one remaining status meaning.
+     */
+    @Test
+    fun withoutRealtimeTheDiscIsTheScheduledGray() {
+        val stale = staleVehicle().copy(routeColor = 0xFF1B6EF3.toInt())
+
+        assertEquals(
+            context.getColor(ScheduleDeviation.Status.SCHEDULED.colorRes),
+            VehicleBitmaps.discColor(context, stale)
+        )
+    }
+
+    /**
+     * The glyph/arrow color flips by the disc's luminance, so a route drawn in a pale yellow doesn't
+     * get a white bus glyph washed out on it. Shared with the route badges via [MarkerRendering].
      */
     @Test
     fun glyphFlipsToStayLegibleOnLightAndDarkDiscs() {
-        val onDark = VehicleBitmaps.markerColors(context, liveVehicle().copy(routeColor = 0xFF0B1F55.toInt()))
-        val onLight = VehicleBitmaps.markerColors(context, liveVehicle().copy(routeColor = 0xFFFFEB3B.toInt()))
-
-        assertEquals("white glyph on a dark disc", android.graphics.Color.WHITE, onDark.onDisc)
-        assertEquals("black glyph on a light disc", android.graphics.Color.BLACK, onLight.onDisc)
-    }
-
-    /** A vehicle without real-time is grey regardless of how its route is drawn. */
-    @Test
-    fun withoutRealtimeTheDiscIsGrey() {
-        val route = 0xFF1B6EF3.toInt()
-        val stale = VehicleBitmaps.markerColors(context, staleVehicle().copy(routeColor = route))
-
-        assertNotEquals("liveness must still change the disc", route, stale.disc)
+        assertEquals("white glyph on a dark disc", Color.WHITE, MarkerRendering.legibleOn(0xFF0B1F55.toInt()))
+        assertEquals("black glyph on a light disc", Color.BLACK, MarkerRendering.legibleOn(0xFFFFEB3B.toInt()))
     }
 
     private fun liveVehicle(): VehicleMarker = withLiveness(vehicles(response()).first(), isRealtime = true)

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/map/VehicleIconAllocationTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/map/VehicleIconAllocationTest.kt
@@ -38,6 +38,9 @@ import org.onebusaway.android.map.googlemapsv2.BitmapDescriptorCache
 import org.onebusaway.android.map.render.VehicleBitmaps
 import org.onebusaway.android.map.render.VehicleMarker
 import org.onebusaway.android.mock.Resources
+import org.onebusaway.android.models.ObaRoute
+import org.onebusaway.android.models.ObaTrip
+import org.onebusaway.android.models.ObaTripDetails
 import org.onebusaway.android.models.ObaTripStatus
 import org.onebusaway.android.models.RouteTrips
 import org.onebusaway.android.time.WallTime
@@ -314,6 +317,97 @@ class VehicleIconAllocationTest {
 
     /** A copy of [vehicle] with [isRealtime] forced and the bearing pinned, so only liveness varies. */
     private fun withLiveness(vehicle: VehicleMarker, isRealtime: Boolean): VehicleMarker = vehicle.copy(isRealtime = isRealtime, bearing = 0f)
+
+    // --- The route display color on the disc (#2043) ---------------------------------------------
+
+    /**
+     * The disc takes the route's **display** color, not its raw GTFS value: it goes through
+     * `routeLineColors`, the shared agency-color policy, which keeps the hue but caps chroma and
+     * re-tones for the active theme. Asserted as "not the raw int" because the whole point is that an
+     * agency's literal choice never reaches the map unmediated — a full-chroma near-black would
+     * otherwise render a disc that vanishes into the basemap.
+     */
+    @Test
+    fun discUsesTheRouteDisplayColorNotTheRawGtfsColor() {
+        val raw = 0xFF1B6EF3.toInt() // a vivid, fully-saturated agency blue
+        val response = fakeResponse(routeColor = raw)
+        val colors = VehicleBitmaps.markerColors(context, liveVehicle(), response)
+
+        assertNotEquals("the raw GTFS int must not reach the disc", raw, colors.disc)
+        assertNotEquals("the glyph must contrast with the disc", colors.disc, colors.onDisc)
+    }
+
+    /** Two different agency colors must still produce two different discs — toning is not flattening. */
+    @Test
+    fun differentRouteColorsStayDistinct() {
+        val blue = VehicleBitmaps.markerColors(context, liveVehicle(), fakeResponse(0xFF1B6EF3.toInt()))
+        val orange = VehicleBitmaps.markerColors(context, liveVehicle(), fakeResponse(0xFFF37B1B.toInt()))
+
+        assertNotEquals(blue.disc, orange.disc)
+    }
+
+    /**
+     * An achromatic source (grey/black/white) has no hue to keep, and an absent one has nothing at
+     * all; both take the brand fallback rather than producing a grey disc that would read as the
+     * "no real-time" state.
+     */
+    @Test
+    fun achromaticOrAbsentRouteColorTakesTheBrandFallback() {
+        val brand = VehicleBitmaps.markerColors(context, liveVehicle(), fakeResponse(routeColor = null))
+        val grey = VehicleBitmaps.markerColors(context, liveVehicle(), fakeResponse(0xFF888888.toInt()))
+
+        assertEquals("an achromatic route color falls back like an absent one", brand.disc, grey.disc)
+        assertNotEquals(
+            "the fallback must not be the not-real-time grey",
+            VehicleBitmaps.markerColors(context, staleVehicle(), fakeResponse(null)).disc,
+            brand.disc
+        )
+    }
+
+    /** A vehicle without real-time is grey regardless of how colorful its route is. */
+    @Test
+    fun withoutRealtimeTheDiscIsGrey() {
+        val stale = VehicleBitmaps.markerColors(context, staleVehicle(), fakeResponse(0xFF1B6EF3.toInt()))
+        val live = VehicleBitmaps.markerColors(context, liveVehicle(), fakeResponse(0xFF1B6EF3.toInt()))
+
+        assertNotEquals(live.disc, stale.disc)
+    }
+
+    private fun liveVehicle(): VehicleMarker = withLiveness(vehicles(response()).first(), isRealtime = true)
+
+    private fun staleVehicle(): VehicleMarker = withLiveness(vehicles(response()).first(), isRealtime = false)
+
+    /** A references pool whose single route carries [routeColor], for the display-color assertions. */
+    private fun fakeResponse(routeColor: Int?): RouteTrips {
+        val vehicleTripId = vehicles(response()).first().activeTripId
+        return object : RouteTrips {
+            override val trips: List<ObaTripDetails> = emptyList()
+            override fun trip(tripId: String?): ObaTrip? = FakeTrip(vehicleTripId, "routeA").takeIf { !tripId.isNullOrEmpty() }
+            override fun route(routeId: String): ObaRoute = FakeRoute(routeColor)
+            override val currentTimeMs: Long = 0L
+        }
+    }
+
+    private class FakeTrip(override val id: String, override val routeId: String) : ObaTrip {
+        override val shortName: String? = null
+        override val shapeId: String? = null
+        override val directionId: Int = 0
+        override val serviceId: String? = null
+        override val headsign: String? = null
+        override val timezone: String? = null
+        override val blockId: String? = null
+    }
+
+    private class FakeRoute(override val color: Int?) : ObaRoute {
+        override val id: String = "routeA"
+        override val type: Int = ObaRoute.TYPE_BUS
+        override val shortName: String? = null
+        override val longName: String? = null
+        override val description: String? = null
+        override val url: String? = null
+        override val textColor: Int? = null
+        override val agencyId: String = "agency"
+    }
 
     companion object {
         // Sweep the bearing through all 8 octants within a few frames, then revisit them (no new icons) —

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/util/test/UIUtilTest.java
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/util/test/UIUtilTest.java
@@ -277,7 +277,9 @@ public class UIUtilTest extends ObaTestCase {
     assertEquals("Arrived at " + formatTime(1438804260000L), arrivalInfo.get(0).getTimeText());
     assertEquals("Departed 2 min late", arrivalInfo.get(1).getStatusText());
     assertEquals("Departed at " + formatTime(1438804320000L), arrivalInfo.get(1).getTimeText());
-    assertEquals("Departed 1 min early", arrivalInfo.get(2).getStatusText());
+    // 60 s early — inside the +/- 1.5 min on-time band adopted from OBA iOS (#2043), so this reads
+    // "on time" rather than "1 min early". Same for indexes 11, 13 (60 s early) and 14 (60 s late).
+    assertEquals("Departed on time", arrivalInfo.get(2).getStatusText());
     assertEquals("Departed at " + formatTime(1438804440000L), arrivalInfo.get(2).getTimeText());
     assertEquals("Arrived on time", arrivalInfo.get(3).getStatusText());
     assertEquals("Arrived at " + formatTime(1438804440000L), arrivalInfo.get(3).getTimeText());
@@ -296,13 +298,13 @@ public class UIUtilTest extends ObaTestCase {
     assertEquals("Departing at " + formatTime(1438804800000L), arrivalInfo.get(9).getTimeText());
     assertEquals("10 min delay", arrivalInfo.get(10).getStatusText());
     assertEquals("Arriving at " + formatTime(1438804860000L), arrivalInfo.get(10).getTimeText());
-    assertEquals("1 min early", arrivalInfo.get(11).getStatusText());
+    assertEquals("On time", arrivalInfo.get(11).getStatusText());
     assertEquals("Arriving at " + formatTime(1438804920000L), arrivalInfo.get(11).getTimeText());
     assertEquals("On time", arrivalInfo.get(12).getStatusText());
     assertEquals("Arriving at " + formatTime(1438805100000L), arrivalInfo.get(12).getTimeText());
-    assertEquals("1 min early", arrivalInfo.get(13).getStatusText());
+    assertEquals("On time", arrivalInfo.get(13).getStatusText());
     assertEquals("Departing at " + formatTime(1438805340000L), arrivalInfo.get(13).getTimeText());
-    assertEquals("1 min delay", arrivalInfo.get(14).getStatusText());
+    assertEquals("On time", arrivalInfo.get(14).getStatusText());
     assertEquals("Arriving at " + formatTime(1438805520000L), arrivalInfo.get(14).getTimeText());
     assertEquals("On time", arrivalInfo.get(15).getStatusText());
     assertEquals("Arriving at " + formatTime(1438805700000L), arrivalInfo.get(15).getTimeText());
@@ -347,7 +349,7 @@ public class UIUtilTest extends ObaTestCase {
 
     assertEquals("On time", arrivalInfo.get(0).getStatusText());
     assertEquals("2 min late", arrivalInfo.get(1).getStatusText());
-    assertEquals("1 min early", arrivalInfo.get(2).getStatusText());
+    assertEquals("On time", arrivalInfo.get(2).getStatusText());
     assertEquals("On time", arrivalInfo.get(3).getStatusText());
     assertEquals("6 min early", arrivalInfo.get(4).getStatusText());
     // Arrivals and departures that will happen in the future
@@ -357,10 +359,10 @@ public class UIUtilTest extends ObaTestCase {
     assertEquals("On time", arrivalInfo.get(8).getStatusText());
     assertEquals("On time", arrivalInfo.get(9).getStatusText());
     assertEquals("10 min delay", arrivalInfo.get(10).getStatusText());
-    assertEquals("1 min early", arrivalInfo.get(11).getStatusText());
+    assertEquals("On time", arrivalInfo.get(11).getStatusText());
     assertEquals("On time", arrivalInfo.get(12).getStatusText());
-    assertEquals("1 min early", arrivalInfo.get(13).getStatusText());
-    assertEquals("1 min delay", arrivalInfo.get(14).getStatusText());
+    assertEquals("On time", arrivalInfo.get(13).getStatusText());
+    assertEquals("On time", arrivalInfo.get(14).getStatusText());
     assertEquals("On time", arrivalInfo.get(15).getStatusText());
     assertEquals("On time", arrivalInfo.get(16).getStatusText());
     assertEquals("4 min delay", arrivalInfo.get(17).getStatusText());

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
@@ -828,7 +828,7 @@ class GoogleMapRenderer(
         private const val MOST_RECENT_DATA_TITLE = "Most recent data"
 
         // Comfortably covers a busy route's live working set — a vehicle type's 8 heading octants across a
-        // handful of schedule-deviation colors, times a few route types, plus the fast-estimate + dot icons
+        // handful of route colors, times a few route types, plus the fast-estimate + dot icons
         // — so descriptors are reused as vehicles turn, not thrashed. Bounded so a long, varied session
         // can't grow it without limit (evicting a still-shown icon just re-wraps it on next request).
         private const val DESCRIPTOR_CACHE_SIZE = 256

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
@@ -667,7 +667,7 @@ class GoogleMapRenderer(
         }
     }
 
-    private fun vehicleIcon(vehicle: VehicleMarker, response: RouteTrips): BitmapDescriptor = descriptorCache.get(VehicleBitmaps.iconKey(vehicle, response, renderedVehicleScale)) {
+    private fun vehicleIcon(vehicle: VehicleMarker, response: RouteTrips): BitmapDescriptor = descriptorCache.get(VehicleBitmaps.iconKey(context, vehicle, response, renderedVehicleScale)) {
         VehicleBitmaps.vehicleBitmap(context, vehicle, response, renderedVehicleScale)
     }
 

--- a/onebusaway-android/src/kiedybus/res/values/colors.xml
+++ b/onebusaway-android/src/kiedybus/res/values/colors.xml
@@ -27,8 +27,8 @@
     <!-- Launcher icon background -->
     <color name="ic_launcher_background">#2196F3</color>
 
-    <!-- Keep on-time color green even though theme is blue -->
-    <color name="stop_info_ontime">#4CAF50</color>
+    <!-- No stop_info_* override: the schedule-deviation palette is semantic, not brand identity,
+         and is no longer derived from brand_color (#2043). -->
 
     <!-- Material 3 -->
     <color name="md_theme_primary">#36618E</color>

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/ConversionUtils.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/ConversionUtils.kt
@@ -277,13 +277,13 @@ object ConversionUtils {
         val beforeTimeString: CharSequence =
             applicationContext.resources.getString(R.string.time_connector_before_time) + " "
 
-        // This is drawn as the text color of the updated time, so it takes the foreground tier.
+        // Drawn as the text color of the updated time at a normal size, so it takes the text tier.
         // Before #2043 it passed a *millisecond* delta to a helper whose parameter was documented as
         // minutes; that was harmless only because the helper was a bare sign test. The deviation is
         // now an explicit Duration, so the units can't drift silently again.
         val color = ContextCompat.getColor(
             applicationContext,
-            ScheduleDeviation.statusColor(
+            ScheduleDeviation.textColor(
                 isRealtime = true,
                 deviation = (newTime - oldTime).milliseconds
             )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/ConversionUtils.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/ConversionUtils.kt
@@ -29,10 +29,11 @@ import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.util.Date
 import java.util.Locale
+import kotlin.time.Duration.Companion.milliseconds
 import org.onebusaway.android.R
-import org.onebusaway.android.util.ArrivalInfoUtils
 import org.onebusaway.android.util.DisplayFormat
 import org.onebusaway.android.util.PreferenceUtils
+import org.onebusaway.android.util.ScheduleDeviation
 
 /**
  * @author Khoa Tran
@@ -276,9 +277,16 @@ object ConversionUtils {
         val beforeTimeString: CharSequence =
             applicationContext.resources.getString(R.string.time_connector_before_time) + " "
 
+        // This is drawn as the text color of the updated time, so it takes the foreground tier.
+        // Before #2043 it passed a *millisecond* delta to a helper whose parameter was documented as
+        // minutes; that was harmless only because the helper was a bare sign test. The deviation is
+        // now an explicit Duration, so the units can't drift silently again.
         val color = ContextCompat.getColor(
             applicationContext,
-            ArrivalInfoUtils.computeColorFromDeviation(newTime - oldTime)
+            ScheduleDeviation.statusColor(
+                isRealtime = true,
+                deviation = (newTime - oldTime).milliseconds
+            )
         )
 
         val newTimeString = SpannableString(timeFormat.format(newDisplay) + " ")

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
@@ -217,6 +217,13 @@ class RouteMapController(
     // the remainder. Null until the first poll lands (the sampler then yields nothing to draw).
     private var latestPoll: VehiclePoll? = null
 
+    // Per-(poll, adjacency-assignment) memo behind [displayedRouteColor], which the per-frame vehicle
+    // sampler calls for every vehicle. Keyed by active trip id; holds nulls, so absence means "not yet
+    // resolved" rather than "no color". Invalidated by identity when either input is replaced.
+    private val routeColorMemo = HashMap<String, Int?>()
+    private var routeColorMemoResponse: RouteTrips? = null
+    private var routeColorMemoAssignment: Map<RouteDirectionKey, Int>? = null
+
     // routeJob is the one-shot route shape/stops/header load; vehicleJob is the long-running periodic
     // vehicle poll, suspended/resumed independently with the map lifecycle (onPause cancels only it).
     private var routeJob: Job? = null
@@ -1051,22 +1058,45 @@ class RouteMapController(
     )
 
     /**
-     * The color the map is currently drawing [activeTripId]'s route with.
+     * The color the map is currently drawing [activeTripId]'s route with — see
+     * [VehicleMarker.routeColor] for why that is deliberately not the route's GTFS color.
      *
-     * This is deliberately the *displayed* color rather than the route's GTFS color. In stop-focus view
-     * [adjacencyRouteColors] hands every shown route a distinct synthesized hue so a rider can tell the
-     * lines apart, and the vehicle has to travel with the line it belongs to — a marker wearing the
-     * agency's nominal color there would point at the wrong line. The lookup mirrors what the polylines
-     * do (`routeColors[key] ?: gtfsColor`, see RouteViewGeometry), so a vehicle and its line resolve
-     * through the same map and can't disagree.
+     * The lookup mirrors what the polylines do (`routeColors[key] ?: gtfsColor`, see
+     * RouteViewGeometry), so a vehicle and its line resolve through the same map and can't disagree.
      *
      * Both reference hops are nullable by contract (the poll carries whatever `references` it carries,
      * and a block-interlined vehicle can report a trip this route's poll never fetched), so an
      * unresolvable route yields null and the renderer falls back like any uncolored line.
+     *
+     * Memoized per (poll, assignment) because this sits on the **per-frame** sampler — [sampleVehicles]
+     * runs at 20 Hz on Google and the display rate on MapLibre, for every vehicle. Uncached, each call
+     * re-materializes reference DTOs and re-parses the route's hex color string, so a 15-vehicle route
+     * would churn thousands of throwaway allocations a second on the frame loop to recompute a value
+     * that can only change when a new poll lands (every 10-30 s).
      */
     private fun displayedRouteColor(response: RouteTrips, activeTripId: String?): Int? {
+        val assignment = _focusedRouteColors.value
+        // Identity compare: a new poll or a new adjacency assignment is always a fresh instance.
+        if (response !== routeColorMemoResponse || assignment !== routeColorMemoAssignment) {
+            routeColorMemoResponse = response
+            routeColorMemoAssignment = assignment
+            routeColorMemo.clear()
+        }
+        val tripId = activeTripId ?: return null
+        // Not getOrPut: a legitimately-null color must stay memoized rather than re-resolving forever.
+        if (!routeColorMemo.containsKey(tripId)) {
+            routeColorMemo[tripId] = resolveDisplayedRouteColor(response, assignment, tripId)
+        }
+        return routeColorMemo[tripId]
+    }
+
+    private fun resolveDisplayedRouteColor(
+        response: RouteTrips,
+        assignment: Map<RouteDirectionKey, Int>,
+        activeTripId: String
+    ): Int? {
         val trip = response.trip(activeTripId) ?: return null
-        val assigned = _focusedRouteColors.value[RouteDirectionKey(trip.routeId, trip.directionId)]
+        val assigned = assignment[RouteDirectionKey(trip.routeId, trip.directionId)]
         return assigned ?: response.route(trip.routeId)?.color
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
@@ -429,7 +429,7 @@ class RouteMapController(
         // polls at a seam); the plain path stays byte-identical to before.
         val vehicles = if (isInterlineComposite) merged.distinctBy { it.status.activeTripId } else merged
         return MapVehicles(
-            markers = vehicles.map { it.toMarker() },
+            markers = vehicles.map { it.toMarker(poll.response) },
             response = poll.response
         )
     }
@@ -1035,9 +1035,10 @@ class RouteMapController(
 
     /**
      * Builds the render [VehicleMarker] from a display-free [ExtrapolatedVehicle], carrying the
-     * draw-time live-vs-scheduled flag through (the renderer picks its icon from it).
+     * draw-time live-vs-scheduled flag through (the renderer picks its icon from it) and the color its
+     * route is currently drawn with (the disc rides its own line's color, #2043).
      */
-    private fun ExtrapolatedVehicle.toMarker(): VehicleMarker = VehicleMarker(
+    private fun ExtrapolatedVehicle.toMarker(response: RouteTrips): VehicleMarker = VehicleMarker(
         // Vehicles are only built for trips with a resolvable active id, so this is non-null here.
         activeTripId = status.activeTripId.orEmpty(),
         point = point,
@@ -1045,8 +1046,29 @@ class RouteMapController(
         status = status,
         fixTimeMs = fixTimeMs,
         bearing = bearing,
-        dataFixPoint = dataFixPoint
+        dataFixPoint = dataFixPoint,
+        routeColor = displayedRouteColor(response, status.activeTripId)
     )
+
+    /**
+     * The color the map is currently drawing [activeTripId]'s route with.
+     *
+     * This is deliberately the *displayed* color rather than the route's GTFS color. In stop-focus view
+     * [adjacencyRouteColors] hands every shown route a distinct synthesized hue so a rider can tell the
+     * lines apart, and the vehicle has to travel with the line it belongs to — a marker wearing the
+     * agency's nominal color there would point at the wrong line. The lookup mirrors what the polylines
+     * do (`routeColors[key] ?: gtfsColor`, see RouteViewGeometry), so a vehicle and its line resolve
+     * through the same map and can't disagree.
+     *
+     * Both reference hops are nullable by contract (the poll carries whatever `references` it carries,
+     * and a block-interlined vehicle can report a trip this route's poll never fetched), so an
+     * unresolvable route yields null and the renderer falls back like any uncolored line.
+     */
+    private fun displayedRouteColor(response: RouteTrips, activeTripId: String?): Int? {
+        val trip = response.trip(activeTripId) ?: return null
+        val assigned = _focusedRouteColors.value[RouteDirectionKey(trip.routeId, trip.directionId)]
+        return assigned ?: response.route(trip.routeId)?.color
+    }
 }
 
 /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
@@ -217,12 +217,15 @@ class RouteMapController(
     // the remainder. Null until the first poll lands (the sampler then yields nothing to draw).
     private var latestPoll: VehiclePoll? = null
 
-    // Per-(poll, adjacency-assignment) memo behind [displayedRouteColor], which the per-frame vehicle
-    // sampler calls for every vehicle. Keyed by active trip id; holds nulls, so absence means "not yet
-    // resolved" rather than "no color". Invalidated by identity when either input is replaced.
+    // Memo behind [displayedRouteColor], which the per-frame vehicle sampler calls for every vehicle.
+    // Keyed by active trip id (unique across the polls in play); holds nulls, so absence means "not yet
+    // resolved" rather than "no color". Invalidated wholesale by [refreshRouteColorMemo] when any input
+    // is replaced — including extraPolls, since a composite's vehicles resolve out of several responses
+    // and a per-call identity check would clear the memo on every alternation.
     private val routeColorMemo = HashMap<String, Int?>()
-    private var routeColorMemoResponse: RouteTrips? = null
-    private var routeColorMemoAssignment: Map<RouteDirectionKey, Int>? = null
+    private var routeColorMemoPoll: VehiclePoll? = null
+    private var routeColorMemoExtras: Map<String, VehiclePoll>? = null
+    private var routeColorMemoAssignment: Map<RouteDirectionKey, Int> = emptyMap()
 
     // routeJob is the one-shot route shape/stops/header load; vehicleJob is the long-running periodic
     // vehicle poll, suspended/resumed independently with the map lifecycle (onPause cancels only it).
@@ -409,6 +412,9 @@ class RouteMapController(
         // routes/directions, so don't direction-filter and merge each extra route's poll — the vehicle
         // must show through every phase, not vanish when it flips direction/route at a seam (#2000).
         val directionFilter = if (isInterlineComposite) null else resolved.directionId
+        // Each vehicle is paired with the poll it came out of: an extra route's vehicle resolves its
+        // trip/route out of *that* route's references, not the leader's, which is the only place its
+        // color can be found (#2043).
         val leaderVehicles = extrapolatedVehicles(
             poll.response,
             setOf(id),
@@ -416,7 +422,7 @@ class RouteMapController(
             directionFilter,
             includeDataFixPoint,
             tripObservationRepository::lookupTripState
-        )
+        ).map { it to poll.response }
         val extraVehicles = if (isInterlineComposite) {
             extraPolls.flatMap { (extraRouteId, extraPoll) ->
                 extrapolatedVehicles(
@@ -426,7 +432,7 @@ class RouteMapController(
                     null,
                     includeDataFixPoint,
                     tripObservationRepository::lookupTripState
-                )
+                ).map { it to extraPoll.response }
             }
         } else {
             emptyList()
@@ -434,9 +440,14 @@ class RouteMapController(
         val merged = leaderVehicles + extraVehicles
         // Dedup only in the composite case (the one shared vehicle can briefly surface in two routes'
         // polls at a seam); the plain path stays byte-identical to before.
-        val vehicles = if (isInterlineComposite) merged.distinctBy { it.status.activeTripId } else merged
+        val vehicles = if (isInterlineComposite) {
+            merged.distinctBy { (vehicle, _) -> vehicle.status.activeTripId }
+        } else {
+            merged
+        }
+        refreshRouteColorMemo(poll, extraPolls, _focusedRouteColors.value)
         return MapVehicles(
-            markers = vehicles.map { it.toMarker(poll.response) },
+            markers = vehicles.map { (vehicle, source) -> vehicle.toMarker(source) },
             response = poll.response
         )
     }
@@ -1068,26 +1079,37 @@ class RouteMapController(
      * and a block-interlined vehicle can report a trip this route's poll never fetched), so an
      * unresolvable route yields null and the renderer falls back like any uncolored line.
      *
-     * Memoized per (poll, assignment) because this sits on the **per-frame** sampler — [sampleVehicles]
-     * runs at 20 Hz on Google and the display rate on MapLibre, for every vehicle. Uncached, each call
-     * re-materializes reference DTOs and re-parses the route's hex color string, so a 15-vehicle route
-     * would churn thousands of throwaway allocations a second on the frame loop to recompute a value
-     * that can only change when a new poll lands (every 10-30 s).
+     * Memoized (see [refreshRouteColorMemo]) because this sits on the **per-frame** sampler —
+     * [sampleVehicles] runs at 20 Hz on Google and the display rate on MapLibre, for every vehicle.
+     * Uncached, each call re-materializes reference DTOs and re-parses the route's hex color string, so
+     * a 15-vehicle route would churn thousands of throwaway allocations a second on the frame loop to
+     * recompute a value that can only change when a new poll lands (every 10-30 s).
      */
     private fun displayedRouteColor(response: RouteTrips, activeTripId: String?): Int? {
-        val assignment = _focusedRouteColors.value
-        // Identity compare: a new poll or a new adjacency assignment is always a fresh instance.
-        if (response !== routeColorMemoResponse || assignment !== routeColorMemoAssignment) {
-            routeColorMemoResponse = response
-            routeColorMemoAssignment = assignment
-            routeColorMemo.clear()
-        }
         val tripId = activeTripId ?: return null
         // Not getOrPut: a legitimately-null color must stay memoized rather than re-resolving forever.
         if (!routeColorMemo.containsKey(tripId)) {
-            routeColorMemo[tripId] = resolveDisplayedRouteColor(response, assignment, tripId)
+            routeColorMemo[tripId] = resolveDisplayedRouteColor(response, routeColorMemoAssignment, tripId)
         }
         return routeColorMemo[tripId]
+    }
+
+    /** Drops the [routeColorMemo] when anything it was derived from has been replaced. */
+    private fun refreshRouteColorMemo(
+        poll: VehiclePoll,
+        extras: Map<String, VehiclePoll>,
+        assignment: Map<RouteDirectionKey, Int>
+    ) {
+        // Identity compares: a new poll, extra-poll map or adjacency assignment is a fresh instance.
+        if (poll !== routeColorMemoPoll ||
+            extras !== routeColorMemoExtras ||
+            assignment !== routeColorMemoAssignment
+        ) {
+            routeColorMemoPoll = poll
+            routeColorMemoExtras = extras
+            routeColorMemoAssignment = assignment
+            routeColorMemo.clear()
+        }
     }
 
     private fun resolveDisplayedRouteColor(

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
@@ -1072,8 +1072,8 @@ class RouteMapController(
      * The color the map is currently drawing [activeTripId]'s route with — see
      * [VehicleMarker.routeColor] for why that is deliberately not the route's GTFS color.
      *
-     * The lookup mirrors what the polylines do (`routeColors[key] ?: gtfsColor`, see
-     * RouteViewGeometry), so a vehicle and its line resolve through the same map and can't disagree.
+     * The lookup mirrors what the polylines do (`routeColors[key] ?: mapRouteLineColorOrNull(gtfs)`,
+     * see RouteViewGeometry), so a vehicle and its line resolve the same way and can't disagree.
      *
      * Both reference hops are nullable by contract (the poll carries whatever `references` it carries,
      * and a block-interlined vehicle can report a trip this route's poll never fetched), so an
@@ -1119,7 +1119,11 @@ class RouteMapController(
     ): Int? {
         val trip = response.trip(activeTripId) ?: return null
         val assigned = assignment[RouteDirectionKey(trip.routeId, trip.directionId)]
-        return assigned ?: response.route(trip.routeId)?.color
+        // Exactly what RouteViewGeometry does for the lines: an adjacency-assigned hue is already a
+        // drawn color and passes through, while an agency's GTFS color goes through the map's route-line
+        // policy (#2041) first. Skipping that policy here would put the disc on the raw agency color
+        // while its line drew the normalized one — the disagreement this resolution exists to prevent.
+        return assigned ?: mapRouteLineColorOrNull(response.route(trip.routeId)?.color)
     }
 }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/compose/VehicleInfoWindow.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/compose/VehicleInfoWindow.kt
@@ -75,7 +75,10 @@ fun VehicleInfoWindow(status: ObaTripStatus, isRealtime: Boolean, response: Rout
     // guard the unreachable null instead of dereferencing (the legacy getTrip/getRoute would NPE).
     val trip = response.trip(status.activeTripId) ?: return
     val route = response.route(trip.routeId) ?: return
-    val deviationMin = status.scheduleDeviation.inWholeMinutes
+    // One bucketing call feeds both halves of the chip, so its words and its color can never disagree
+    // — this is the site where that was starkest, since it produces the label and the fill side by side.
+    val deviationStatus = ScheduleDeviation.status(isRealtime, status.scheduleDeviation)
+    val deviationMinutes = ScheduleDeviation.roundedMinutes(status.scheduleDeviation.absoluteValue)
 
     // [isRealtime] is the drawn marker's live-vs-scheduled flag (from the renderer). Since #2043 the
     // marker itself is colored by route identity rather than punctuality, so this window is where
@@ -88,14 +91,12 @@ fun VehicleInfoWindow(status: ObaTripStatus, isRealtime: Boolean, response: Rout
             " " +
             MyTextUtils.formatDisplayText(trip.headsign),
         statusLabel = if (isRealtime) {
-            ArrivalInfoUtils.computeArrivalLabelFromDelay(res, deviationMin)
+            ArrivalInfoUtils.computeArrivalLabel(res, deviationStatus, deviationMinutes)
         } else {
             stringResource(R.string.stop_info_scheduled)
         },
         // The chip is white text on this color, so it takes the on-fill tier.
-        statusColor = colorResource(
-            ScheduleDeviation.fillColor(isRealtime, status.scheduleDeviation)
-        ),
+        statusColor = colorResource(deviationStatus.fillColorRes),
         occupancyDots = if (isRealtime) occupancyDots(status.occupancyStatus) else 0,
         lastUpdated = lastUpdatedText(res, isRealtime, status, now)
     )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/compose/VehicleInfoWindow.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/compose/VehicleInfoWindow.kt
@@ -55,6 +55,7 @@ import org.onebusaway.android.time.rememberLiveServerTime
 import org.onebusaway.android.ui.compose.theme.ObaTheme
 import org.onebusaway.android.util.ArrivalInfoUtils
 import org.onebusaway.android.util.MyTextUtils
+import org.onebusaway.android.util.ScheduleDeviation
 import org.onebusaway.android.util.getRouteDisplayName
 
 /**
@@ -76,8 +77,10 @@ fun VehicleInfoWindow(status: ObaTripStatus, isRealtime: Boolean, response: Rout
     val route = response.route(trip.routeId) ?: return
     val deviationMin = status.scheduleDeviation.inWholeMinutes
 
-    // [isRealtime] is the drawn marker's live-vs-scheduled flag (from the renderer), so the window can't
-    // disagree with the icon; the arrival listings share the scheduled-vs-deviation coloring via ArrivalInfoUtils.
+    // [isRealtime] is the drawn marker's live-vs-scheduled flag (from the renderer). Since #2043 the
+    // marker itself is colored by route identity rather than punctuality, so this window is where
+    // schedule deviation is expressed on the map — sharing the band and palette with the arrival
+    // listings via ScheduleDeviation.
     VehicleInfoWindowContent(
         title = getRouteDisplayName(route) +
             " " +
@@ -89,7 +92,10 @@ fun VehicleInfoWindow(status: ObaTripStatus, isRealtime: Boolean, response: Rout
         } else {
             stringResource(R.string.stop_info_scheduled)
         },
-        statusColor = colorResource(ArrivalInfoUtils.statusColor(isRealtime, deviationMin)),
+        // The chip is white text on this color, so it takes the on-fill tier.
+        statusColor = colorResource(
+            ScheduleDeviation.fillColor(isRealtime, status.scheduleDeviation)
+        ),
         occupancyDots = if (isRealtime) occupancyDots(status.occupancyStatus) else 0,
         lastUpdated = lastUpdatedText(res, isRealtime, status, now)
     )
@@ -231,7 +237,7 @@ private fun VehicleInfoWindowPreview() {
         VehicleInfoWindowContent(
             title = "44 — Ballard via Wallingford",
             statusLabel = "3 min late",
-            statusColor = colorResource(R.color.stop_info_delayed),
+            statusColor = colorResource(R.color.stop_info_delayed_fill),
             // Two silhouettes: FEW_SEATS_AVAILABLE / STANDING_ROOM_ONLY.
             occupancyDots = 2,
             lastUpdated = "Estimate from data updated 12 sec ago"

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/ContinuationBadgeBitmaps.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/ContinuationBadgeBitmaps.kt
@@ -53,7 +53,7 @@ object ContinuationBadgeBitmaps {
      */
     fun badge(routeShortName: String, color: Int, density: Float, darkMode: Boolean): Bitmap {
         val textPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
-            this.color = legibleTextColor(color)
+            this.color = MarkerRendering.legibleOn(color)
             textSize = TEXT_SIZE_PX
             isFakeBoldText = true
             textAlign = Paint.Align.CENTER
@@ -94,12 +94,6 @@ object ContinuationBadgeBitmaps {
         val baseline = height / 2f - (metrics.ascent + metrics.descent) / 2f
         canvas.drawText(routeShortName, width / 2f, baseline, textPaint)
         return bitmap
-    }
-
-    /** Black or white, whichever contrasts better against [background] by relative luminance. */
-    private fun legibleTextColor(background: Int): Int {
-        val luminance = (0.299 * Color.red(background) + 0.587 * Color.green(background) + 0.114 * Color.blue(background)) / 255
-        return if (luminance > 0.6) Color.BLACK else Color.WHITE
     }
 
     /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
@@ -139,7 +139,14 @@ data class VehicleMarker(
     // The last real fix's position on the route shape (the glide's seed), where the selected vehicle's
     // most-recent-data dot is drawn — so the dot sits at the band's origin, not the raw off-shape reported
     // lat/lng. Null when there's no shape/anchor; the renderer then falls back to the reported location.
-    val dataFixPoint: GeoPoint? = null
+    val dataFixPoint: GeoPoint? = null,
+    // The color this vehicle's route is currently *drawn* with, which is not always its GTFS color: in
+    // stop-focus view adjacencyRouteColors assigns each shown route a distinct hue precisely so they can
+    // be told apart, and the vehicle has to travel with its own line rather than with the agency's
+    // nominal color (#2043). Resolved by the controller from the same map the polylines use, so the two
+    // cannot disagree. Null when the route carries no color and none was assigned; the renderer applies
+    // [DEFAULT_ROUTE_LINE_COLOR], exactly as [RoutePolyline.resolvedColor] does.
+    val routeColor: Int? = null
 )
 
 /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
@@ -140,10 +140,11 @@ data class VehicleMarker(
     // most-recent-data dot is drawn — so the dot sits at the band's origin, not the raw off-shape reported
     // lat/lng. Null when there's no shape/anchor; the renderer then falls back to the reported location.
     val dataFixPoint: GeoPoint? = null,
-    // The color this vehicle's route is currently *drawn* with, which is not always its GTFS color: in
-    // stop-focus view adjacencyRouteColors assigns each shown route a distinct hue precisely so they can
-    // be told apart, and the vehicle has to travel with its own line rather than with the agency's
-    // nominal color (#2043). Resolved by the controller from the same map the polylines use, so the two
+    // The color this vehicle's route is currently *drawn* with, which is rarely its GTFS color: an
+    // agency hue goes through the map's route-line policy (#2041), and in stop-focus view
+    // adjacencyRouteColors assigns each shown route a distinct hue precisely so they can be told apart.
+    // Either way the vehicle has to travel with its own line rather than with the agency's nominal
+    // color (#2043). Resolved by the controller from the same map the polylines use, so the two
     // cannot disagree. Null when the route carries no color and none was assigned; the renderer applies
     // [DEFAULT_ROUTE_LINE_COLOR], exactly as [RoutePolyline.resolvedColor] does.
     val routeColor: Int? = null

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MarkerRendering.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MarkerRendering.kt
@@ -41,6 +41,23 @@ object MarkerRendering {
     const val HEAD_CX = 12f
     const val HEAD_CY = 8f
 
+    /**
+     * Above this relative luminance a background is light enough that white-on-it washes out, so
+     * [legibleOn] flips to black.
+     */
+    private const val LEGIBLE_FLIP_LUMINANCE = 0.6
+
+    /**
+     * Black or white, whichever contrasts better against [background] by relative luminance.
+     *
+     * Shared so every route-colored map element — a vehicle disc, a continuation badge — makes the
+     * same call for the same color, rather than each keeping its own copy of the threshold.
+     */
+    fun legibleOn(background: Int): Int {
+        val luminance = (0.299 * Color.red(background) + 0.587 * Color.green(background) + 0.114 * Color.blue(background)) / 255
+        return if (luminance > LEGIBLE_FLIP_LUMINANCE) Color.BLACK else Color.WHITE
+    }
+
     /** 8-way unit offsets used to stamp a black outline around an element (a cheap dilate). */
     private val OUTLINE_OFFSETS = arrayOf(
         floatArrayOf(-1f, 0f),

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MarkerRendering.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MarkerRendering.kt
@@ -23,6 +23,7 @@ import android.graphics.Paint
 import android.graphics.drawable.Drawable
 import androidx.annotation.DrawableRes
 import androidx.core.content.ContextCompat
+import androidx.core.graphics.ColorUtils
 import androidx.core.graphics.createBitmap
 import androidx.core.graphics.withTranslation
 import org.onebusaway.android.R
@@ -42,21 +43,29 @@ object MarkerRendering {
     const val HEAD_CY = 8f
 
     /**
-     * Above this relative luminance a background is light enough that white-on-it washes out, so
-     * [legibleOn] flips to black.
-     */
-    private const val LEGIBLE_FLIP_LUMINANCE = 0.6
-
-    /**
-     * Black or white, whichever contrasts better against [background] by relative luminance.
+     * Black or white, whichever actually contrasts better against [background].
      *
-     * Shared so every route-colored map element — a vehicle disc, a continuation badge — makes the
-     * same call for the same color, rather than each keeping its own copy of the threshold.
+     * Measured with [ColorUtils.calculateContrast] (WCAG relative luminance) and compared, rather than
+     * cut over at a hand-picked luminance threshold: the two disagree across a wide band of mid-tones,
+     * where a gamma-space cutoff keeps white on backgrounds black would read better on. Comparing the
+     * real contrast ratios also means there is no magic number to justify or keep in sync.
+     *
+     * Shared so every route-colored map element — a vehicle disc, a continuation badge — makes the same
+     * call for the same color. [background] is forced opaque because a route color arrives from the wire
+     * and `calculateContrast` rejects a translucent background.
      */
     fun legibleOn(background: Int): Int {
-        val luminance = (0.299 * Color.red(background) + 0.587 * Color.green(background) + 0.114 * Color.blue(background)) / 255
-        return if (luminance > LEGIBLE_FLIP_LUMINANCE) Color.BLACK else Color.WHITE
+        val opaque = background or OPAQUE_ALPHA
+        return if (ColorUtils.calculateContrast(Color.BLACK, opaque) >
+            ColorUtils.calculateContrast(Color.WHITE, opaque)
+        ) {
+            Color.BLACK
+        } else {
+            Color.WHITE
+        }
     }
+
+    private const val OPAQUE_ALPHA = 0xFF000000.toInt()
 
     /** 8-way unit offsets used to stamp a black outline around an element (a cheap dilate). */
     private val OUTLINE_OFFSETS = arrayOf(

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/VehicleBitmaps.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/VehicleBitmaps.kt
@@ -24,27 +24,22 @@ import android.graphics.Path
 import androidx.annotation.DrawableRes
 import androidx.annotation.VisibleForTesting
 import androidx.collection.LruCache
-import androidx.compose.ui.graphics.Color as ComposeColor
-import androidx.compose.ui.graphics.toArgb
 import androidx.core.content.ContextCompat
 import androidx.core.graphics.createBitmap
 import androidx.core.graphics.withRotation
 import org.onebusaway.android.R
 import org.onebusaway.android.models.ObaRoute
 import org.onebusaway.android.models.RouteTrips
-import org.onebusaway.android.ui.compose.components.RouteLineColors
-import org.onebusaway.android.ui.compose.components.routeLineColors
 import org.onebusaway.android.util.MathUtils
-import org.onebusaway.android.util.ThemeUtils
 
 /**
  * Flavor-neutral generation of vehicle marker bitmaps. Lives in `src/main` so both the Google flavor
  * (wrapping each Bitmap in a `BitmapDescriptor`) and the maplibre flavor (wrapping it in an `Icon`)
  * share one implementation + the LRU cache. This is the icon half of the old `VehicleOverlay`.
  *
- * The marker is composed at draw time — a disc filled with the vehicle's route display color, a mode
- * glyph (bus/rail/…) centered on it, and a heading arrow at the rim, both in the theme's paired
- * on-disc color — rather than decoding one of
+ * The marker is composed at draw time — a disc filled with the color its route is currently drawn
+ * with, a mode glyph (bus/rail/…) centered on it, and a heading arrow at the rim, both in whichever
+ * of black/white reads on that disc — rather than decoding one of
  * the ~225 pre-composited `ic_marker_with_*` rasters. It's a **centered** badge (anchored at its center,
  * not a teardrop tip) so a vehicle sits on the route centerline like the trip map's estimate marker,
  * rather than floating off the line as a pin (#1752).
@@ -76,6 +71,11 @@ object VehicleBitmaps {
     /** Hairline black outline width, in 24-grid units (scales with the marker); ~1px on screen. */
     private const val OUTLINE_GRID = 0.25f
 
+    // Above this relative luminance the disc is light enough that a white glyph would wash out, so the
+    // glyph and arrow flip to black. Same threshold ContinuationBadgeBitmaps uses for route badges, so
+    // a route-colored disc and a route-colored badge make the same call.
+    private const val GLYPH_FLIP_LUMINANCE = 0.6
+
     private val sColoredIconCache = LruCache<String, Bitmap>(MAX_CACHE_SIZE)
 
     // Lazy so loading this object for the pure-logic helpers (e.g. normalizeVehicleType, unit-tested on
@@ -98,7 +98,7 @@ object VehicleBitmaps {
     ): Bitmap = getBitmap(
         context,
         vehicleType(vehicle, response),
-        markerColors(context, vehicle, response),
+        markerColors(context, vehicle),
         directionIndex(vehicle),
         sizeScale
     )
@@ -113,7 +113,7 @@ object VehicleBitmaps {
      * (#2043) is a raw ARGB int off the wire with no resource id to name it. Keying on the resolved
      * value also closes a latent staleness bug the resource-id key had — the same id resolves to a
      * different color after a light/dark switch, which the old key could not tell apart. Both the
-     * disc and the glyph color take part, since the theme flips the glyph independently of the hue.
+     * disc and the glyph color take part, since the glyph flips with the disc's luminance.
      */
     @JvmStatic
     fun iconKey(
@@ -125,7 +125,7 @@ object VehicleBitmaps {
         createBitmapCacheKey(
             vehicleType(vehicle, response),
             directionIndex(vehicle),
-            markerColors(context, vehicle, response),
+            markerColors(context, vehicle),
             sizeScale
         )
 
@@ -175,41 +175,43 @@ object VehicleBitmaps {
      * which is where OBA iOS puts it too (its markers are route-colored and carry only a
      * realtime-vs-not distinction).
      *
-     * The color is the route's **display** color, not its raw GTFS value: it goes through
-     * [routeLineColors], the single place the agency-color policy lives, which keeps the hue but caps
-     * chroma and re-tones to a fixed accent tone for the active theme. So an agency handing us
-     * near-black, near-white or a screaming full-chroma hue can't produce a disc that vanishes into
-     * the basemap or glares against it, and the same route reads as the same color wherever the app
-     * draws it. That policy is documented for exactly this shape — "a spine, stroke or filled
-     * marker".
+     * The disc takes [VehicleMarker.routeColor] — the color the map is **currently drawing that
+     * route's line with** — applying the same [DEFAULT_ROUTE_LINE_COLOR] fallback
+     * [RoutePolyline.resolvedColor] does, so a vehicle and its line always match.
      *
-     * Because the tone is fixed by the theme rather than by the agency, so is the glyph color on top
-     * of it: the dark-theme tone is a *light* disc, so the mode glyph and heading arrow flip to black
-     * there. Taking both from [RouteLineColors] is what keeps that contrast guaranteed by
-     * construction rather than by a comment.
+     * That distinction matters most in stop-focus view, where `adjacencyRouteColors` assigns every
+     * shown route a distinct synthesized hue so a rider can tell the lines apart. A vehicle wearing
+     * its agency's nominal GTFS color there would point at the wrong line — the marker has to travel
+     * with the line it belongs to, which is why the controller resolves the color through the same
+     * map the polylines use rather than this reading `ObaRoute.color` itself.
      *
-     * The route is resolved per vehicle rather than from the shown route, because a cross-route
-     * interline (#2000) merges vehicles from other routes into the same poll. An absent or achromatic
-     * route color yields the brand fallback — the same one
-     * [org.onebusaway.android.ui.tripdetails.TripDetailsRepository] uses for its line.
+     * The glyph and heading arrow take black or white by relative luminance, so they stay legible on
+     * a route color of any brightness without imposing a tone on the disc.
      */
     @VisibleForTesting
-    internal fun markerColors(context: Context, vehicle: VehicleMarker, response: RouteTrips): MarkerColors {
+    internal fun markerColors(context: Context, vehicle: VehicleMarker): MarkerColors {
         if (!vehicle.isRealtime) {
             return MarkerColors(
                 disc = ContextCompat.getColor(context, R.color.stop_info_scheduled_time),
                 onDisc = Color.WHITE
             )
         }
-        val routeColor = response.trip(vehicle.status.activeTripId)
-            ?.let { response.route(it.routeId) }
-            ?.color
-        val brandFallback = RouteLineColors(
-            line = ComposeColor(ContextCompat.getColor(context, R.color.theme_primary)),
-            onLine = ComposeColor.White
-        )
-        val colors = routeLineColors(routeColor, ThemeUtils.isInDarkMode(context), brandFallback)
-        return MarkerColors(disc = colors.line.toArgb(), onDisc = colors.onLine.toArgb())
+        val disc = vehicle.routeColor ?: DEFAULT_ROUTE_LINE_COLOR
+        return MarkerColors(disc = disc, onDisc = legibleGlyphColor(disc))
+    }
+
+    /** Black or white, whichever contrasts better against [background] by relative luminance. */
+    private fun legibleGlyphColor(background: Int): Int {
+        val luminance = (
+            0.299 *
+                Color.red(background) +
+                0.587 *
+                Color.green(background) +
+                0.114 *
+                Color.blue(background)
+            ) /
+            255
+        return if (luminance > GLYPH_FLIP_LUMINANCE) Color.BLACK else Color.WHITE
     }
 
     /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/VehicleBitmaps.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/VehicleBitmaps.kt
@@ -31,6 +31,7 @@ import org.onebusaway.android.R
 import org.onebusaway.android.models.ObaRoute
 import org.onebusaway.android.models.RouteTrips
 import org.onebusaway.android.util.MathUtils
+import org.onebusaway.android.util.ScheduleDeviation
 
 /**
  * Flavor-neutral generation of vehicle marker bitmaps. Lives in `src/main` so both the Google flavor
@@ -71,11 +72,6 @@ object VehicleBitmaps {
     /** Hairline black outline width, in 24-grid units (scales with the marker); ~1px on screen. */
     private const val OUTLINE_GRID = 0.25f
 
-    // Above this relative luminance the disc is light enough that a white glyph would wash out, so the
-    // glyph and arrow flip to black. Same threshold ContinuationBadgeBitmaps uses for route badges, so
-    // a route-colored disc and a route-colored badge make the same call.
-    private const val GLYPH_FLIP_LUMINANCE = 0.6
-
     private val sColoredIconCache = LruCache<String, Bitmap>(MAX_CACHE_SIZE)
 
     // Lazy so loading this object for the pure-logic helpers (e.g. normalizeVehicleType, unit-tested on
@@ -98,7 +94,7 @@ object VehicleBitmaps {
     ): Bitmap = getBitmap(
         context,
         vehicleType(vehicle, response),
-        markerColors(context, vehicle),
+        discColor(context, vehicle),
         directionIndex(vehicle),
         sizeScale
     )
@@ -112,8 +108,8 @@ object VehicleBitmaps {
      * The color component is the **resolved ARGB value**, not a color resource id: a route color
      * (#2043) is a raw ARGB int off the wire with no resource id to name it. Keying on the resolved
      * value also closes a latent staleness bug the resource-id key had — the same id resolves to a
-     * different color after a light/dark switch, which the old key could not tell apart. Both the
-     * disc and the glyph color take part, since the glyph flips with the disc's luminance.
+     * different color after a light/dark switch, which the old key could not tell apart. Only the
+     * disc takes part — the glyph color is derived from it, so it adds no distinguishing power.
      */
     @JvmStatic
     fun iconKey(
@@ -125,7 +121,7 @@ object VehicleBitmaps {
         createBitmapCacheKey(
             vehicleType(vehicle, response),
             directionIndex(vehicle),
-            markerColors(context, vehicle),
+            discColor(context, vehicle),
             sizeScale
         )
 
@@ -162,56 +158,25 @@ object VehicleBitmaps {
     @VisibleForTesting
     fun normalizeVehicleType(routeType: Int): Int = if (routeType == ObaRoute.TYPE_CABLECAR) ObaRoute.TYPE_TRAM else routeType
 
-    /** The disc fill and the glyph/arrow color drawn on it, both as resolved ARGB values. */
-    internal data class MarkerColors(val disc: Int, val onDisc: Int)
-
     /**
-     * The marker's colors: the vehicle's **route color** when it's live, gray when it isn't. So the
-     * marker encodes route identity + liveness, never punctuality (#2043).
+     * The disc color: the vehicle's **route color** when it's live, gray when it isn't. So the marker
+     * encodes route identity + liveness, never punctuality (#2043).
      *
      * At map zoom a colored disc reads as identity — "which line is this?" — not as a schedule
      * judgement, and a rider comparing two discs has no way to tell a hue that means "late" from one
      * that means "the 44". Deviation still has a home on the map: the info window's status chip,
-     * which is where OBA iOS puts it too (its markers are route-colored and carry only a
-     * realtime-vs-not distinction).
+     * which is where OBA iOS puts it too.
      *
-     * The disc takes [VehicleMarker.routeColor] — the color the map is **currently drawing that
-     * route's line with** — applying the same [DEFAULT_ROUTE_LINE_COLOR] fallback
-     * [RoutePolyline.resolvedColor] does, so a vehicle and its line always match.
-     *
-     * That distinction matters most in stop-focus view, where `adjacencyRouteColors` assigns every
-     * shown route a distinct synthesized hue so a rider can tell the lines apart. A vehicle wearing
-     * its agency's nominal GTFS color there would point at the wrong line — the marker has to travel
-     * with the line it belongs to, which is why the controller resolves the color through the same
-     * map the polylines use rather than this reading `ObaRoute.color` itself.
-     *
-     * The glyph and heading arrow take black or white by relative luminance, so they stay legible on
-     * a route color of any brightness without imposing a tone on the disc.
+     * The value is [VehicleMarker.routeColor] — the color the map is currently drawing that route's
+     * line with, which is *not* always its GTFS color; see there — under the same
+     * [DEFAULT_ROUTE_LINE_COLOR] fallback [RoutePolyline.resolvedColor] applies, so a vehicle and its
+     * line always match.
      */
     @VisibleForTesting
-    internal fun markerColors(context: Context, vehicle: VehicleMarker): MarkerColors {
-        if (!vehicle.isRealtime) {
-            return MarkerColors(
-                disc = ContextCompat.getColor(context, R.color.stop_info_scheduled_time),
-                onDisc = Color.WHITE
-            )
-        }
-        val disc = vehicle.routeColor ?: DEFAULT_ROUTE_LINE_COLOR
-        return MarkerColors(disc = disc, onDisc = legibleGlyphColor(disc))
-    }
-
-    /** Black or white, whichever contrasts better against [background] by relative luminance. */
-    private fun legibleGlyphColor(background: Int): Int {
-        val luminance = (
-            0.299 *
-                Color.red(background) +
-                0.587 *
-                Color.green(background) +
-                0.114 *
-                Color.blue(background)
-            ) /
-            255
-        return if (luminance > GLYPH_FLIP_LUMINANCE) Color.BLACK else Color.WHITE
+    internal fun discColor(context: Context, vehicle: VehicleMarker): Int = if (vehicle.isRealtime) {
+        vehicle.routeColor ?: DEFAULT_ROUTE_LINE_COLOR
+    } else {
+        ContextCompat.getColor(context, ScheduleDeviation.Status.SCHEDULED.colorRes)
     }
 
     /**
@@ -236,25 +201,25 @@ object VehicleBitmaps {
     private fun getBitmap(
         context: Context,
         vehicleType: Int,
-        colors: MarkerColors,
+        color: Int,
         halfWind: Int,
         sizeScale: Float
     ): Bitmap {
-        val key = createBitmapCacheKey(vehicleType, halfWind, colors, sizeScale)
+        val key = createBitmapCacheKey(vehicleType, halfWind, color, sizeScale)
         return sColoredIconCache.get(key)
-            ?: renderMarker(context, vehicleType, halfWind, colors, sizeScale)
+            ?: renderMarker(context, vehicleType, halfWind, color, sizeScale)
                 .also { sColoredIconCache.put(key, it) }
     }
 
-    /** [colors] are resolved ARGB values — see [iconKey] for why they can't be resource ids. */
+    /** [color] is a resolved ARGB value — see [iconKey] for why it can't be a resource id. */
     private fun createBitmapCacheKey(
         vehicleType: Int,
         halfWind: Int,
-        colors: MarkerColors,
+        color: Int,
         sizeScale: Float
     ): String {
         val type = if (supportedVehicleType(vehicleType)) vehicleType else DEFAULT_VEHICLE_TYPE
-        return "$type $halfWind ${colors.disc} ${colors.onDisc} ${sizeScale.toBits()}"
+        return "$type $halfWind $color ${sizeScale.toBits()}"
     }
 
     /**
@@ -262,13 +227,7 @@ object VehicleBitmaps {
      * `@Preview` grid (and tests); the production path goes through [vehicleBitmap] which caches.
      */
     @VisibleForTesting
-    fun previewBitmap(
-        context: Context,
-        vehicleType: Int,
-        halfWind: Int,
-        color: Int,
-        onColor: Int = Color.WHITE
-    ): Bitmap = renderMarker(context, vehicleType, halfWind, MarkerColors(color, onColor), 1f)
+    fun previewBitmap(context: Context, vehicleType: Int, halfWind: Int, color: Int): Bitmap = renderMarker(context, vehicleType, halfWind, color, 1f)
 
     /**
      * Composites the colored disc, the mode glyph, and (unless undirected) the heading arrow — each
@@ -276,14 +235,14 @@ object VehicleBitmaps {
      * offsets, then the fill on top) so the disc, glyph, and arrow read distinctly against each other
      * and the map. The disc is centered in the padded bitmap, so consumers anchor it at its center.
      *
-     * The glyph and arrow are drawn in [MarkerColors.onDisc] rather than a hardcoded white, because
-     * the dark theme re-tones a route color to a *light* disc, on which white would disappear.
+     * The glyph and arrow take whichever of black/white reads on [color] rather than a hardcoded
+     * white, since a route may be drawn in a shade too pale to carry white.
      */
     private fun renderMarker(
         context: Context,
         vehicleType: Int,
         halfWind: Int,
-        colors: MarkerColors,
+        color: Int,
         sizeScale: Float
     ): Bitmap {
         val type = if (supportedVehicleType(vehicleType)) vehicleType else DEFAULT_VEHICLE_TYPE
@@ -295,6 +254,7 @@ object VehicleBitmaps {
         val contentPx = (MarkerRendering.GRID * scale).toInt()
         val sizePx = (MarkerRendering.GRID * scale + 2f * pad).toInt()
         val outline = OUTLINE_GRID * scale
+        val onColor = MarkerRendering.legibleOn(color)
         val bitmap = createBitmap(sizePx, sizePx)
         val canvas = Canvas(bitmap)
         // Draw inside a [pad] border so the outline halo has room; the grid geometry is relative to
@@ -302,11 +262,11 @@ object VehicleBitmaps {
         canvas.translate(pad, pad)
 
         // Colored disc (the route's display color, or gray when not real-time) + mode glyph, outlined.
-        MarkerRendering.drawCircleAndGlyph(canvas, context, contentPx, scale, colors.disc, glyphRes(type), colors.onDisc, GLYPH_SIZE, outline)
+        MarkerRendering.drawCircleAndGlyph(canvas, context, contentPx, scale, color, glyphRes(type), onColor, GLYPH_SIZE, outline)
 
         // Heading arrow, rotated about the disc center by the octant (undirected = no arrow).
         if (halfWind != UNDIRECTED) {
-            val arrowPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply { color = colors.onDisc }
+            val arrowPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply { this.color = onColor }
             val center = MarkerRendering.GRID / 2f
             canvas.withRotation(halfWind * 45f, center * scale, center * scale) {
                 val arrow = Path().apply {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/VehicleBitmaps.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/VehicleBitmaps.kt
@@ -24,21 +24,27 @@ import android.graphics.Path
 import androidx.annotation.DrawableRes
 import androidx.annotation.VisibleForTesting
 import androidx.collection.LruCache
+import androidx.compose.ui.graphics.Color as ComposeColor
+import androidx.compose.ui.graphics.toArgb
 import androidx.core.content.ContextCompat
 import androidx.core.graphics.createBitmap
 import androidx.core.graphics.withRotation
 import org.onebusaway.android.R
 import org.onebusaway.android.models.ObaRoute
 import org.onebusaway.android.models.RouteTrips
+import org.onebusaway.android.ui.compose.components.RouteLineColors
+import org.onebusaway.android.ui.compose.components.routeLineColors
 import org.onebusaway.android.util.MathUtils
+import org.onebusaway.android.util.ThemeUtils
 
 /**
  * Flavor-neutral generation of vehicle marker bitmaps. Lives in `src/main` so both the Google flavor
  * (wrapping each Bitmap in a `BitmapDescriptor`) and the maplibre flavor (wrapping it in an `Icon`)
  * share one implementation + the LRU cache. This is the icon half of the old `VehicleOverlay`.
  *
- * The marker is composed at draw time — a disc filled with the vehicle's route color, a white mode
- * glyph (bus/rail/…) centered on it, and a white heading arrow at the rim — rather than decoding one of
+ * The marker is composed at draw time — a disc filled with the vehicle's route display color, a mode
+ * glyph (bus/rail/…) centered on it, and a heading arrow at the rim, both in the theme's paired
+ * on-disc color — rather than decoding one of
  * the ~225 pre-composited `ic_marker_with_*` rasters. It's a **centered** badge (anchored at its center,
  * not a teardrop tip) so a vehicle sits on the route centerline like the trip map's estimate marker,
  * rather than floating off the line as a pin (#1752).
@@ -73,9 +79,7 @@ object VehicleBitmaps {
     private val sColoredIconCache = LruCache<String, Bitmap>(MAX_CACHE_SIZE)
 
     // Lazy so loading this object for the pure-logic helpers (e.g. normalizeVehicleType, unit-tested on
-    // the JVM) doesn't touch android.graphics — only an on-device render allocates the Paints.
-    private val whitePaint by lazy { Paint(Paint.ANTI_ALIAS_FLAG).apply { color = Color.WHITE } }
-
+    // the JVM) doesn't touch android.graphics — only an on-device render allocates the Paint.
     private val blackPaint by lazy { Paint(Paint.ANTI_ALIAS_FLAG).apply { color = Color.BLACK } }
 
     /**
@@ -94,7 +98,7 @@ object VehicleBitmaps {
     ): Bitmap = getBitmap(
         context,
         vehicleType(vehicle, response),
-        markerColor(context, vehicle, response),
+        markerColors(context, vehicle, response),
         directionIndex(vehicle),
         sizeScale
     )
@@ -108,7 +112,8 @@ object VehicleBitmaps {
      * The color component is the **resolved ARGB value**, not a color resource id: a route color
      * (#2043) is a raw ARGB int off the wire with no resource id to name it. Keying on the resolved
      * value also closes a latent staleness bug the resource-id key had — the same id resolves to a
-     * different color after a light/dark switch, which the old key could not tell apart.
+     * different color after a light/dark switch, which the old key could not tell apart. Both the
+     * disc and the glyph color take part, since the theme flips the glyph independently of the hue.
      */
     @JvmStatic
     fun iconKey(
@@ -120,7 +125,7 @@ object VehicleBitmaps {
         createBitmapCacheKey(
             vehicleType(vehicle, response),
             directionIndex(vehicle),
-            markerColor(context, vehicle, response),
+            markerColors(context, vehicle, response),
             sizeScale
         )
 
@@ -157,9 +162,12 @@ object VehicleBitmaps {
     @VisibleForTesting
     fun normalizeVehicleType(routeType: Int): Int = if (routeType == ObaRoute.TYPE_CABLECAR) ObaRoute.TYPE_TRAM else routeType
 
+    /** The disc fill and the glyph/arrow color drawn on it, both as resolved ARGB values. */
+    internal data class MarkerColors(val disc: Int, val onDisc: Int)
+
     /**
-     * The disc color, as a resolved ARGB value: the vehicle's **route color** when it's live, gray
-     * when it isn't. So the marker encodes route identity + liveness, never punctuality (#2043).
+     * The marker's colors: the vehicle's **route color** when it's live, gray when it isn't. So the
+     * marker encodes route identity + liveness, never punctuality (#2043).
      *
      * At map zoom a colored disc reads as identity — "which line is this?" — not as a schedule
      * judgement, and a rider comparing two discs has no way to tell a hue that means "late" from one
@@ -167,19 +175,41 @@ object VehicleBitmaps {
      * which is where OBA iOS puts it too (its markers are route-colored and carry only a
      * realtime-vs-not distinction).
      *
+     * The color is the route's **display** color, not its raw GTFS value: it goes through
+     * [routeLineColors], the single place the agency-color policy lives, which keeps the hue but caps
+     * chroma and re-tones to a fixed accent tone for the active theme. So an agency handing us
+     * near-black, near-white or a screaming full-chroma hue can't produce a disc that vanishes into
+     * the basemap or glares against it, and the same route reads as the same color wherever the app
+     * draws it. That policy is documented for exactly this shape — "a spine, stroke or filled
+     * marker".
+     *
+     * Because the tone is fixed by the theme rather than by the agency, so is the glyph color on top
+     * of it: the dark-theme tone is a *light* disc, so the mode glyph and heading arrow flip to black
+     * there. Taking both from [RouteLineColors] is what keeps that contrast guaranteed by
+     * construction rather than by a comment.
+     *
      * The route is resolved per vehicle rather than from the shown route, because a cross-route
-     * interline (#2000) merges vehicles from other routes into the same poll. `ObaRoute.color` is
-     * nullable — plenty of feeds omit it — so an absent color falls back to the brand color, the same
-     * fallback [org.onebusaway.android.ui.tripdetails.TripDetailsRepository] uses for its line.
+     * interline (#2000) merges vehicles from other routes into the same poll. An absent or achromatic
+     * route color yields the brand fallback — the same one
+     * [org.onebusaway.android.ui.tripdetails.TripDetailsRepository] uses for its line.
      */
     @VisibleForTesting
-    internal fun markerColor(context: Context, vehicle: VehicleMarker, response: RouteTrips): Int {
+    internal fun markerColors(context: Context, vehicle: VehicleMarker, response: RouteTrips): MarkerColors {
         if (!vehicle.isRealtime) {
-            return ContextCompat.getColor(context, R.color.stop_info_scheduled_time)
+            return MarkerColors(
+                disc = ContextCompat.getColor(context, R.color.stop_info_scheduled_time),
+                onDisc = Color.WHITE
+            )
         }
-        val route = response.trip(vehicle.status.activeTripId)
+        val routeColor = response.trip(vehicle.status.activeTripId)
             ?.let { response.route(it.routeId) }
-        return route?.color ?: ContextCompat.getColor(context, R.color.theme_primary)
+            ?.color
+        val brandFallback = RouteLineColors(
+            line = ComposeColor(ContextCompat.getColor(context, R.color.theme_primary)),
+            onLine = ComposeColor.White
+        )
+        val colors = routeLineColors(routeColor, ThemeUtils.isInDarkMode(context), brandFallback)
+        return MarkerColors(disc = colors.line.toArgb(), onDisc = colors.onLine.toArgb())
     }
 
     /**
@@ -204,25 +234,25 @@ object VehicleBitmaps {
     private fun getBitmap(
         context: Context,
         vehicleType: Int,
-        color: Int,
+        colors: MarkerColors,
         halfWind: Int,
         sizeScale: Float
     ): Bitmap {
-        val key = createBitmapCacheKey(vehicleType, halfWind, color, sizeScale)
+        val key = createBitmapCacheKey(vehicleType, halfWind, colors, sizeScale)
         return sColoredIconCache.get(key)
-            ?: renderMarker(context, vehicleType, halfWind, color, sizeScale)
+            ?: renderMarker(context, vehicleType, halfWind, colors, sizeScale)
                 .also { sColoredIconCache.put(key, it) }
     }
 
-    /** [color] is a resolved ARGB value — see [iconKey] for why it can't be a resource id. */
+    /** [colors] are resolved ARGB values — see [iconKey] for why they can't be resource ids. */
     private fun createBitmapCacheKey(
         vehicleType: Int,
         halfWind: Int,
-        color: Int,
+        colors: MarkerColors,
         sizeScale: Float
     ): String {
         val type = if (supportedVehicleType(vehicleType)) vehicleType else DEFAULT_VEHICLE_TYPE
-        return "$type $halfWind $color ${sizeScale.toBits()}"
+        return "$type $halfWind ${colors.disc} ${colors.onDisc} ${sizeScale.toBits()}"
     }
 
     /**
@@ -230,19 +260,28 @@ object VehicleBitmaps {
      * `@Preview` grid (and tests); the production path goes through [vehicleBitmap] which caches.
      */
     @VisibleForTesting
-    fun previewBitmap(context: Context, vehicleType: Int, halfWind: Int, color: Int): Bitmap = renderMarker(context, vehicleType, halfWind, color, 1f)
+    fun previewBitmap(
+        context: Context,
+        vehicleType: Int,
+        halfWind: Int,
+        color: Int,
+        onColor: Int = Color.WHITE
+    ): Bitmap = renderMarker(context, vehicleType, halfWind, MarkerColors(color, onColor), 1f)
 
     /**
-     * Composites the colored disc, white mode glyph, and (unless undirected) white heading arrow — each
+     * Composites the colored disc, the mode glyph, and (unless undirected) the heading arrow — each
      * with a hairline black outline (a cheap 8-way dilate: the element stamped black at [OUTLINE_GRID]
      * offsets, then the fill on top) so the disc, glyph, and arrow read distinctly against each other
      * and the map. The disc is centered in the padded bitmap, so consumers anchor it at its center.
+     *
+     * The glyph and arrow are drawn in [MarkerColors.onDisc] rather than a hardcoded white, because
+     * the dark theme re-tones a route color to a *light* disc, on which white would disappear.
      */
     private fun renderMarker(
         context: Context,
         vehicleType: Int,
         halfWind: Int,
-        color: Int,
+        colors: MarkerColors,
         sizeScale: Float
     ): Bitmap {
         val type = if (supportedVehicleType(vehicleType)) vehicleType else DEFAULT_VEHICLE_TYPE
@@ -260,11 +299,12 @@ object VehicleBitmaps {
         // this translated content origin.
         canvas.translate(pad, pad)
 
-        // Colored disc (the route's color, or gray when not real-time) + white mode glyph, each outlined.
-        MarkerRendering.drawCircleAndGlyph(canvas, context, contentPx, scale, color, glyphRes(type), Color.WHITE, GLYPH_SIZE, outline)
+        // Colored disc (the route's display color, or gray when not real-time) + mode glyph, outlined.
+        MarkerRendering.drawCircleAndGlyph(canvas, context, contentPx, scale, colors.disc, glyphRes(type), colors.onDisc, GLYPH_SIZE, outline)
 
-        // Heading arrow, white, rotated about the disc center by the octant (undirected = no arrow).
+        // Heading arrow, rotated about the disc center by the octant (undirected = no arrow).
         if (halfWind != UNDIRECTED) {
+            val arrowPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply { color = colors.onDisc }
             val center = MarkerRendering.GRID / 2f
             canvas.withRotation(halfWind * 45f, center * scale, center * scale) {
                 val arrow = Path().apply {
@@ -275,7 +315,7 @@ object VehicleBitmaps {
                     close()
                 }
                 MarkerRendering.stampOffsets(canvas, outline) { canvas.drawPath(arrow, blackPaint) }
-                canvas.drawPath(arrow, whitePaint)
+                canvas.drawPath(arrow, arrowPaint)
             }
         }
         return bitmap

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/VehicleBitmaps.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/VehicleBitmaps.kt
@@ -176,7 +176,7 @@ object VehicleBitmaps {
     internal fun discColor(context: Context, vehicle: VehicleMarker): Int = if (vehicle.isRealtime) {
         vehicle.routeColor ?: DEFAULT_ROUTE_LINE_COLOR
     } else {
-        ContextCompat.getColor(context, ScheduleDeviation.Status.SCHEDULED.colorRes)
+        ContextCompat.getColor(context, ScheduleDeviation.Status.SCHEDULED.displayColorRes)
     }
 
     /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/VehicleBitmaps.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/VehicleBitmaps.kt
@@ -30,7 +30,6 @@ import androidx.core.graphics.withRotation
 import org.onebusaway.android.R
 import org.onebusaway.android.models.ObaRoute
 import org.onebusaway.android.models.RouteTrips
-import org.onebusaway.android.util.ArrivalInfoUtils
 import org.onebusaway.android.util.MathUtils
 
 /**
@@ -38,7 +37,7 @@ import org.onebusaway.android.util.MathUtils
  * (wrapping each Bitmap in a `BitmapDescriptor`) and the maplibre flavor (wrapping it in an `Icon`)
  * share one implementation + the LRU cache. This is the icon half of the old `VehicleOverlay`.
  *
- * The marker is composed at draw time — a disc filled with the schedule-deviation color, a white mode
+ * The marker is composed at draw time — a disc filled with the vehicle's route color, a white mode
  * glyph (bus/rail/…) centered on it, and a white heading arrow at the rim — rather than decoding one of
  * the ~225 pre-composited `ic_marker_with_*` rasters. It's a **centered** badge (anchored at its center,
  * not a teardrop tip) so a vehicle sits on the route centerline like the trip map's estimate marker,
@@ -95,23 +94,33 @@ object VehicleBitmaps {
     ): Bitmap = getBitmap(
         context,
         vehicleType(vehicle, response),
-        colorResource(vehicle),
+        markerColor(context, vehicle, response),
         directionIndex(vehicle),
         sizeScale
     )
 
     /**
      * A stable key identifying the icon [vehicleBitmap] returns for this vehicle — its type, heading
-     * octant, schedule-deviation color, and size scale, the only inputs that change the bitmap. A
-     * renderer caches one wrapper (a Google `BitmapDescriptor`) per key so it reuses it across frames
-     * even when the bounded bitmap LRU evicts and recreates the underlying [Bitmap] on a busy route.
+     * octant, disc color, and size scale, the only inputs that change the bitmap. A renderer caches
+     * one wrapper (a Google `BitmapDescriptor`) per key so it reuses it across frames even when the
+     * bounded bitmap LRU evicts and recreates the underlying [Bitmap] on a busy route.
+     *
+     * The color component is the **resolved ARGB value**, not a color resource id: a route color
+     * (#2043) is a raw ARGB int off the wire with no resource id to name it. Keying on the resolved
+     * value also closes a latent staleness bug the resource-id key had — the same id resolves to a
+     * different color after a light/dark switch, which the old key could not tell apart.
      */
     @JvmStatic
-    fun iconKey(vehicle: VehicleMarker, response: RouteTrips, sizeScale: Float = 1f): String = "veh:" +
+    fun iconKey(
+        context: Context,
+        vehicle: VehicleMarker,
+        response: RouteTrips,
+        sizeScale: Float = 1f
+    ): String = "veh:" +
         createBitmapCacheKey(
             vehicleType(vehicle, response),
             directionIndex(vehicle),
-            colorResource(vehicle),
+            markerColor(context, vehicle, response),
             sizeScale
         )
 
@@ -148,16 +157,36 @@ object VehicleBitmaps {
     @VisibleForTesting
     fun normalizeVehicleType(routeType: Int): Int = if (routeType == ObaRoute.TYPE_CABLECAR) ObaRoute.TYPE_TRAM else routeType
 
-    /** The schedule-deviation color (realtime) or the scheduled color — constant between polls. */
-    private fun colorResource(vehicle: VehicleMarker): Int {
-        val deviationMin = vehicle.status.scheduleDeviation.inWholeMinutes
-        return ArrivalInfoUtils.statusColor(vehicle.isRealtime, deviationMin)
+    /**
+     * The disc color, as a resolved ARGB value: the vehicle's **route color** when it's live, gray
+     * when it isn't. So the marker encodes route identity + liveness, never punctuality (#2043).
+     *
+     * At map zoom a colored disc reads as identity — "which line is this?" — not as a schedule
+     * judgement, and a rider comparing two discs has no way to tell a hue that means "late" from one
+     * that means "the 44". Deviation still has a home on the map: the info window's status chip,
+     * which is where OBA iOS puts it too (its markers are route-colored and carry only a
+     * realtime-vs-not distinction).
+     *
+     * The route is resolved per vehicle rather than from the shown route, because a cross-route
+     * interline (#2000) merges vehicles from other routes into the same poll. `ObaRoute.color` is
+     * nullable — plenty of feeds omit it — so an absent color falls back to the brand color, the same
+     * fallback [org.onebusaway.android.ui.tripdetails.TripDetailsRepository] uses for its line.
+     */
+    @VisibleForTesting
+    internal fun markerColor(context: Context, vehicle: VehicleMarker, response: RouteTrips): Int {
+        if (!vehicle.isRealtime) {
+            return ContextCompat.getColor(context, R.color.stop_info_scheduled_time)
+        }
+        val route = response.trip(vehicle.status.activeTripId)
+            ?.let { response.route(it.routeId) }
+        return route?.color ?: ContextCompat.getColor(context, R.color.theme_primary)
     }
 
     /**
      * The 8-way heading slot (0..7) the icon for [vehicle] uses. Exposed so the renderer can cheaply
      * detect when a gliding vehicle's direction arrow needs re-stamping — the tinted bitmap only changes
-     * when this index does (the color is constant between polls). A live vehicle always has a heading, so
+     * when this index does (the disc color is the route's, so it doesn't change between polls). A live
+     * vehicle always has a heading, so
      * the undirected slot ([UNDIRECTED]) isn't reachable from here.
      */
     @JvmStatic
@@ -175,25 +204,25 @@ object VehicleBitmaps {
     private fun getBitmap(
         context: Context,
         vehicleType: Int,
-        colorResource: Int,
+        color: Int,
         halfWind: Int,
         sizeScale: Float
     ): Bitmap {
-        val color = ContextCompat.getColor(context, colorResource)
-        val key = createBitmapCacheKey(vehicleType, halfWind, colorResource, sizeScale)
+        val key = createBitmapCacheKey(vehicleType, halfWind, color, sizeScale)
         return sColoredIconCache.get(key)
             ?: renderMarker(context, vehicleType, halfWind, color, sizeScale)
                 .also { sColoredIconCache.put(key, it) }
     }
 
+    /** [color] is a resolved ARGB value — see [iconKey] for why it can't be a resource id. */
     private fun createBitmapCacheKey(
         vehicleType: Int,
         halfWind: Int,
-        colorResource: Int,
+        color: Int,
         sizeScale: Float
     ): String {
         val type = if (supportedVehicleType(vehicleType)) vehicleType else DEFAULT_VEHICLE_TYPE
-        return "$type $halfWind $colorResource ${sizeScale.toBits()}"
+        return "$type $halfWind $color ${sizeScale.toBits()}"
     }
 
     /**
@@ -231,7 +260,7 @@ object VehicleBitmaps {
         // this translated content origin.
         canvas.translate(pad, pad)
 
-        // Colored disc (schedule-deviation color) + white mode glyph, each outlined.
+        // Colored disc (the route's color, or gray when not real-time) + white mode glyph, each outlined.
         MarkerRendering.drawCircleAndGlyph(canvas, context, contentPx, scale, color, glyphRes(type), Color.WHITE, GLYPH_SIZE, outline)
 
         // Heading arrow, white, rotated about the disc center by the octant (undirected = no arrow).

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalInfo.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalInfo.kt
@@ -191,11 +191,6 @@ class ArrivalInfo(
             isArrival = false
         }
 
-        val scheduledMins = scheduled.epochMs / MS_IN_MINS
-        // 0 when there's no prediction. Only the status label reads these whole-minute values now —
-        // the color is bucketed on the full-precision deviation below (#2043).
-        val predictedMins = predictedTime?.let { it.epochMs / MS_IN_MINS } ?: 0L
-
         // A prediction is only usable when the server actually gave us one. A closed stop keeps
         // `predicted:true` but suppresses the near-term prediction (decoded to a null instant at the
         // wire→domain boundary, issue #1687); keying the ETA off the boolean alone would subtract a 0
@@ -214,11 +209,12 @@ class ArrivalInfo(
         // #1781) exactly consistent with this poll-time value at t=0.
         eta = liveEta(now)
 
-        // The deviation the color is bucketed on stays at full precision: a same-domain ServerTime
-        // subtraction, so no device clock can leak in (#1620). Flooring each instant to whole
-        // minutes first — what this did before #2043 — made "on time" mean the two minute-past-epoch
-        // values were exactly equal, so a bus 20 s late that happened to straddle a minute boundary
-        // rendered in the late color and the green on-time state was nearly never shown.
+        // The deviation stays at full precision: a same-domain ServerTime subtraction, so no device
+        // clock can leak in (#1620). Flooring each instant to whole minutes first — what this did
+        // before #2043 — made "on time" mean the two minute-past-epoch values were exactly equal, so a
+        // bus 20 s late that happened to straddle a minute boundary rendered late and the green
+        // on-time state was nearly never shown. The color and the status label both bucket on the one
+        // [ScheduleDeviation.status] call below, so they can never contradict each other.
         val deviation = predictedTime?.let { it - scheduled } ?: Duration.ZERO
         val deviationStatus = ScheduleDeviation.status(hasPrediction, deviation)
         color = deviationStatus.colorRes
@@ -228,8 +224,8 @@ class ArrivalInfo(
             context,
             now,
             hasPrediction,
-            scheduledMins,
-            predictedMins,
+            deviationStatus,
+            ScheduleDeviation.roundedMinutes(deviation.absoluteValue),
             includeArrivalDepartureInStatusLabel
         )
         timeText = computeTimeLabel(context)
@@ -245,12 +241,18 @@ class ArrivalInfo(
      * @param includeArrivalDeparture true if the arrival/departure label should be included, false
      *                                if it should not
      */
+
+    /**
+     * [deviationStatus] and [deviationMinutes] come from the same [ScheduleDeviation.status] call that
+     * picked [color], so the words and the hue always agree: [deviationMinutes] is the unsigned
+     * magnitude, read only when the status is early or delayed.
+     */
     private fun computeStatusLabel(
         context: Context?,
         now: ServerTime,
         hasPrediction: Boolean,
-        scheduledMins: Long,
-        predictedMins: Long,
+        deviationStatus: ScheduleDeviation.Status,
+        deviationMinutes: Long,
         includeArrivalDeparture: Boolean
     ): String {
         if (context == null) {
@@ -294,63 +296,48 @@ class ArrivalInfo(
         }
 
         if (hasPrediction) {
-            // Real-time info
-            var delay = predictedMins - scheduledMins
+            val minutes = deviationMinutes.toInt()
 
             if (eta >= 0) {
                 // Bus hasn't yet arrived/departed
-                return ArrivalInfoUtils.computeArrivalLabelFromDelay(res, delay)
+                return ArrivalInfoUtils.computeArrivalLabel(res, deviationStatus, deviationMinutes)
             }
 
             // Arrival/departure time has passed
             if (!includeArrivalDeparture) {
                 // Don't include "depart" or "arrive" in label
-                return if (delay > 0) {
-                    // Delayed
-                    res.getQuantityString(
+                return when (deviationStatus) {
+                    ScheduleDeviation.Status.DELAYED -> res.getQuantityString(
                         R.plurals.stop_info_status_late_without_arrive_depart,
-                        delay.toInt(),
-                        delay
+                        minutes,
+                        deviationMinutes
                     )
-                } else if (delay < 0) {
-                    // Early
-                    delay = -delay
-                    res.getQuantityString(
+                    ScheduleDeviation.Status.EARLY -> res.getQuantityString(
                         R.plurals.stop_info_status_early_without_arrive_depart,
-                        delay.toInt(),
-                        delay
+                        minutes,
+                        deviationMinutes
                     )
-                } else {
-                    // On time
-                    context.getString(R.string.stop_info_ontime)
+                    else -> context.getString(R.string.stop_info_ontime)
                 }
             }
 
             return if (isArrival) {
                 // Is an arrival time
-                if (delay > 0) {
-                    // Arrived late
-                    res.getQuantityString(R.plurals.stop_info_arrived_delayed, delay.toInt(), delay)
-                } else if (delay < 0) {
-                    // Arrived early
-                    delay = -delay
-                    res.getQuantityString(R.plurals.stop_info_arrived_early, delay.toInt(), delay)
-                } else {
-                    // Arrived on time
-                    context.getString(R.string.stop_info_arrived_ontime)
+                when (deviationStatus) {
+                    ScheduleDeviation.Status.DELAYED ->
+                        res.getQuantityString(R.plurals.stop_info_arrived_delayed, minutes, deviationMinutes)
+                    ScheduleDeviation.Status.EARLY ->
+                        res.getQuantityString(R.plurals.stop_info_arrived_early, minutes, deviationMinutes)
+                    else -> context.getString(R.string.stop_info_arrived_ontime)
                 }
             } else {
                 // Is a departure time
-                if (delay > 0) {
-                    // Departed late
-                    res.getQuantityString(R.plurals.stop_info_depart_delayed, delay.toInt(), delay)
-                } else if (delay < 0) {
-                    // Departed early
-                    delay = -delay
-                    res.getQuantityString(R.plurals.stop_info_depart_early, delay.toInt(), delay)
-                } else {
-                    // Departed on time
-                    context.getString(R.string.stop_info_departed_ontime)
+                when (deviationStatus) {
+                    ScheduleDeviation.Status.DELAYED ->
+                        res.getQuantityString(R.plurals.stop_info_depart_delayed, minutes, deviationMinutes)
+                    ScheduleDeviation.Status.EARLY ->
+                        res.getQuantityString(R.plurals.stop_info_depart_early, minutes, deviationMinutes)
+                    else -> context.getString(R.string.stop_info_departed_ontime)
                 }
             }
         } else {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalInfo.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalInfo.kt
@@ -220,8 +220,9 @@ class ArrivalInfo(
         // values were exactly equal, so a bus 20 s late that happened to straddle a minute boundary
         // rendered in the late color and the green on-time state was nearly never shown.
         val deviation = predictedTime?.let { it - scheduled } ?: Duration.ZERO
-        color = ScheduleDeviation.statusColor(hasPrediction, deviation)
-        fillColor = ScheduleDeviation.fillColor(hasPrediction, deviation)
+        val deviationStatus = ScheduleDeviation.status(hasPrediction, deviation)
+        color = deviationStatus.colorRes
+        fillColor = deviationStatus.fillColorRes
 
         statusText = computeStatusLabel(
             context,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalInfo.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalInfo.kt
@@ -17,8 +17,10 @@
 package org.onebusaway.android.ui.arrivals
 
 import android.content.Context
+import androidx.annotation.ColorRes
 import java.text.DateFormat
 import java.util.Date
+import kotlin.time.Duration
 import org.onebusaway.android.R
 import org.onebusaway.android.models.ArrivalData
 import org.onebusaway.android.models.Occupancy
@@ -27,6 +29,7 @@ import org.onebusaway.android.time.ServerTime
 import org.onebusaway.android.ui.report.TripReportContext
 import org.onebusaway.android.util.ArrivalInfoUtils
 import org.onebusaway.android.util.DisplayFormat
+import org.onebusaway.android.util.ScheduleDeviation
 import org.onebusaway.android.util.getRouteDisplayName
 
 /**
@@ -51,9 +54,19 @@ class ArrivalInfo(
     val notifyText: String
 
     /**
-     * The resource code for the color that should be used for the arrival time.
+     * The schedule-deviation color for the arrival time, as a color resource id. This is the
+     * **foreground** tier — use it where the color is the text itself.
      */
+    @get:ColorRes
     val color: Int
+
+    /**
+     * The same schedule-deviation state as [color], in the **on-fill** tier: darkened so white text
+     * drawn on top of it clears WCAG AA. Use it wherever the color becomes a filled surface — the
+     * ETA pills and the starred-stop badges — rather than the text.
+     */
+    @get:ColorRes
+    val fillColor: Int
 
     /**
      * True if there is real-time arrival info available for this trip, false if there is not.
@@ -179,7 +192,8 @@ class ArrivalInfo(
         }
 
         val scheduledMins = scheduled.epochMs / MS_IN_MINS
-        // 0 when there's no prediction, preserving the prior sentinel behavior into computeColor below.
+        // 0 when there's no prediction. Only the status label reads these whole-minute values now —
+        // the color is bucketed on the full-precision deviation below (#2043).
         val predictedMins = predictedTime?.let { it.epochMs / MS_IN_MINS } ?: 0L
 
         // A prediction is only usable when the server actually gave us one. A closed stop keeps
@@ -200,7 +214,14 @@ class ArrivalInfo(
         // #1781) exactly consistent with this poll-time value at t=0.
         eta = liveEta(now)
 
-        color = ArrivalInfoUtils.computeColor(scheduledMins, predictedMins)
+        // The deviation the color is bucketed on stays at full precision: a same-domain ServerTime
+        // subtraction, so no device clock can leak in (#1620). Flooring each instant to whole
+        // minutes first — what this did before #2043 — made "on time" mean the two minute-past-epoch
+        // values were exactly equal, so a bus 20 s late that happened to straddle a minute boundary
+        // rendered in the late color and the green on-time state was nearly never shown.
+        val deviation = predictedTime?.let { it - scheduled } ?: Duration.ZERO
+        color = ScheduleDeviation.statusColor(hasPrediction, deviation)
+        fillColor = ScheduleDeviation.fillColor(hasPrediction, deviation)
 
         statusText = computeStatusLabel(
             context,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalInfo.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalInfo.kt
@@ -55,7 +55,8 @@ class ArrivalInfo(
 
     /**
      * The schedule-deviation color for the arrival time, as a color resource id. This is the
-     * **foreground** tier — use it where the color is the text itself.
+     * **display** tier — the ETA is set large enough to carry it; small text wants
+     * [ScheduleDeviation.Status.textColorRes] instead.
      */
     @get:ColorRes
     val color: Int
@@ -217,7 +218,7 @@ class ArrivalInfo(
         // [ScheduleDeviation.status] call below, so they can never contradict each other.
         val deviation = predictedTime?.let { it - scheduled } ?: Duration.ZERO
         val deviationStatus = ScheduleDeviation.status(hasPrediction, deviation)
-        color = deviationStatus.colorRes
+        color = deviationStatus.displayColorRes
         fillColor = deviationStatus.fillColorRes
 
         statusText = computeStatusLabel(

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
@@ -136,8 +136,12 @@ internal fun ArrivalCard(
 /**
  * The visual content of a flat arrival row, driven by primitives so it stays trivially previewable and
  * JVM-testable without the [ArrivalInfo] model (which needs a `Context`/wire data to build).
- * [ArrivalRowContent] adapts the
- * model onto it; the colored status pill and ETA both take the lateness [statusColor].
+ * [ArrivalRowContent] adapts the model onto it.
+ *
+ * The two lateness colors are the two tiers of the same deviation state (#2043): [statusColor] is
+ * the foreground tier, used where the color *is* the text (the big ETA, which is large enough for
+ * WCAG's 3:1 large-text threshold), and [statusFillColor] is the darkened on-fill tier, used where
+ * white label text sits on the color (the status pill) and so needs the full 4.5:1.
  */
 @Composable
 private fun ArrivalRowVisual(
@@ -145,6 +149,7 @@ private fun ArrivalRowVisual(
     headsign: String,
     statusText: String,
     statusColor: Color,
+    statusFillColor: Color,
     timeText: String,
     eta: Long,
     predicted: Boolean,
@@ -174,7 +179,7 @@ private fun ArrivalRowVisual(
             )
             if (statusText.isNotEmpty()) {
                 Spacer(Modifier.height(4.dp))
-                StatusPill(statusText, statusColor)
+                StatusPill(statusText, statusFillColor)
             }
             if (timeText.isNotEmpty()) {
                 // The scheduled/predicted clock time: "Arriving/Departing/Arrived/Departed at 4:27 PM"
@@ -229,6 +234,7 @@ internal fun ArrivalRowContent(
         headsign = arrival.headsign.orEmpty(),
         statusText = arrival.statusText.orEmpty(),
         statusColor = colorResource(arrival.color),
+        statusFillColor = colorResource(arrival.fillColor),
         timeText = arrival.timeText.orEmpty(),
         eta = arrival.eta,
         predicted = arrival.predicted,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
@@ -138,10 +138,9 @@ internal fun ArrivalCard(
  * JVM-testable without the [ArrivalInfo] model (which needs a `Context`/wire data to build).
  * [ArrivalRowContent] adapts the model onto it.
  *
- * The two lateness colors are the two tiers of the same deviation state (#2043): [statusColor] is
- * the foreground tier, used where the color *is* the text (the big ETA, which is large enough for
- * WCAG's 3:1 large-text threshold), and [statusFillColor] is the darkened on-fill tier, used where
- * white label text sits on the color (the status pill) and so needs the full 4.5:1.
+ * The two lateness colors are the two tiers of the same deviation state (#2043): [statusColor] for
+ * the big ETA, where the color *is* the text, and [statusFillColor] for the status pill, where white
+ * text sits on it.
  */
 @Composable
 private fun ArrivalRowVisual(

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStrip.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStrip.kt
@@ -285,7 +285,9 @@ private fun EtaPillWithMenu(
         EtaPill(
             modifier = Modifier.fillMaxHeight(),
             eta = trip.liveEta(liveNow),
-            color = colorResource(trip.color),
+            // The on-fill tier, not `trip.color`: the pill paints this as a Surface with white text
+            // on top, so it needs the darkened variant to clear WCAG AA (#2043).
+            color = colorResource(trip.fillColor),
             predicted = trip.predicted,
             onMap = trip.vehicleOnMap,
             canceled = trip.status == Status.CANCELED,
@@ -541,21 +543,21 @@ private fun EtaPillVariantsPreview() {
                 verticalAlignment = Alignment.Bottom
             ) {
                 // A recent-past arrival: same size as the upcoming ones — negative ETAs aren't shrunk.
-                EtaPill(-3, colorResource(R.color.stop_info_delayed), predicted = true, clockTime = "2:57pm")
-                EtaPill(0, colorResource(R.color.stop_info_ontime), predicted = true, clockTime = "3:00pm")
-                EtaPill(5, colorResource(R.color.stop_info_delayed), predicted = true, clockTime = "3:05pm")
-                EtaPill(12, colorResource(R.color.stop_info_early), predicted = true, clockTime = "3:12pm")
-                EtaPill(22, colorResource(R.color.stop_info_scheduled_time), predicted = false, clockTime = "3:22pm")
+                EtaPill(-3, colorResource(R.color.stop_info_delayed_fill), predicted = true, clockTime = "2:57pm")
+                EtaPill(0, colorResource(R.color.stop_info_ontime_fill), predicted = true, clockTime = "3:00pm")
+                EtaPill(5, colorResource(R.color.stop_info_delayed_fill), predicted = true, clockTime = "3:05pm")
+                EtaPill(12, colorResource(R.color.stop_info_early_fill), predicted = true, clockTime = "3:12pm")
+                EtaPill(22, colorResource(R.color.stop_info_scheduled_fill), predicted = false, clockTime = "3:22pm")
                 EtaPill(
                     8,
-                    colorResource(R.color.stop_info_scheduled_time),
+                    colorResource(R.color.stop_info_scheduled_fill),
                     predicted = false,
                     canceled = true,
                     clockTime = "3:08pm"
                 )
                 // Past an hour: the number switches to hours, the leftover minutes fold into the label (#1777).
-                EtaPill(83, colorResource(R.color.stop_info_scheduled_time), predicted = true, clockTime = "4:23pm")
-                EtaPill(125, colorResource(R.color.stop_info_early), predicted = false, clockTime = "5:05pm")
+                EtaPill(83, colorResource(R.color.stop_info_scheduled_fill), predicted = true, clockTime = "4:23pm")
+                EtaPill(125, colorResource(R.color.stop_info_early_fill), predicted = false, clockTime = "5:05pm")
             }
         }
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/help/HelpDialogs.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/help/HelpDialogs.kt
@@ -15,7 +15,6 @@
  */
 package org.onebusaway.android.ui.home.help
 
-import androidx.annotation.ColorRes
 import androidx.annotation.StringRes
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
@@ -44,6 +43,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import org.onebusaway.android.R
 import org.onebusaway.android.ui.arrivals.components.EtaPill
 import org.onebusaway.android.util.ScheduleDeviation
+import org.onebusaway.android.util.ScheduleDeviation.Status
 
 /**
  * The help-menu options, in the order of the `main_help_options` string-array. Dialog-opening actions
@@ -188,28 +188,12 @@ private fun LegendDialog(onDismiss: () -> Unit) {
         title = { Text(stringResource(R.string.main_help_legend_title)) },
         text = {
             Column(Modifier.verticalScroll(rememberScrollState())) {
+                LegendRow(Status.ON_TIME, predicted = true, label = R.string.main_help_legend_ontime)
+                LegendRow(Status.EARLY, predicted = true, label = R.string.main_help_legend_early)
+                LegendRow(Status.DELAYED, predicted = true, label = R.string.main_help_legend_late)
+                LegendRow(Status.SCHEDULED, predicted = false, label = R.string.main_help_legend_scheduled)
                 LegendRow(
-                    ScheduleDeviation.Status.ON_TIME.fillColorRes,
-                    predicted = true,
-                    label = R.string.main_help_legend_ontime
-                )
-                LegendRow(
-                    ScheduleDeviation.Status.EARLY.fillColorRes,
-                    predicted = true,
-                    label = R.string.main_help_legend_early
-                )
-                LegendRow(
-                    ScheduleDeviation.Status.DELAYED.fillColorRes,
-                    predicted = true,
-                    label = R.string.main_help_legend_late
-                )
-                LegendRow(
-                    ScheduleDeviation.Status.SCHEDULED.fillColorRes,
-                    predicted = false,
-                    label = R.string.main_help_legend_scheduled
-                )
-                LegendRow(
-                    ScheduleDeviation.Status.SCHEDULED.fillColorRes,
+                    Status.SCHEDULED,
                     predicted = false,
                     canceled = true,
                     label = R.string.main_help_legend_canceled
@@ -222,9 +206,10 @@ private fun LegendDialog(onDismiss: () -> Unit) {
     )
 }
 
+/** One legend swatch. Takes the [Status] rather than a color so the tier choice lives in one place. */
 @Composable
 private fun LegendRow(
-    @ColorRes color: Int,
+    status: Status,
     predicted: Boolean,
     @StringRes label: Int,
     canceled: Boolean = false
@@ -233,7 +218,8 @@ private fun LegendRow(
         modifier = Modifier.fillMaxWidth().padding(vertical = 12.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        EtaPill(eta = 5L, color = colorResource(color), predicted = predicted, canceled = canceled)
+        // The pill paints white text on this, so it takes the on-fill tier — as [EtaPill] always does.
+        EtaPill(eta = 5L, color = colorResource(status.fillColorRes), predicted = predicted, canceled = canceled)
         Spacer(Modifier.width(16.dp))
         Text(stringResource(label), style = MaterialTheme.typography.bodyMedium)
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/help/HelpDialogs.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/help/HelpDialogs.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import org.onebusaway.android.R
 import org.onebusaway.android.ui.arrivals.components.EtaPill
+import org.onebusaway.android.util.ScheduleDeviation
 
 /**
  * The help-menu options, in the order of the `main_help_options` string-array. Dialog-opening actions
@@ -174,6 +175,11 @@ private fun TutorialOptOutDialog(onYes: () -> Unit, onNo: () -> Unit, onDismiss:
  * The arrival-color legend. Each row reuses the drawer peek's [EtaPill] (white text on the deviation
  * color, with the pulsing real-time dot) so the sample matches a stop's ETA. Order mirrors the legacy
  * legend: on-time / early / late / scheduled / canceled.
+ *
+ * The swatches come from [ScheduleDeviation.Status] rather than being spelled out as color resources,
+ * so the legend cannot document a palette the app no longer paints (#2043). It takes the pill's
+ * on-fill tier for the same reason [EtaPill] does — white text sits on these. The row *labels* still
+ * have to be kept truthful by hand: they name both the hue and the ±1.5 minute on-time band.
  */
 @Composable
 private fun LegendDialog(onDismiss: () -> Unit) {
@@ -182,12 +188,28 @@ private fun LegendDialog(onDismiss: () -> Unit) {
         title = { Text(stringResource(R.string.main_help_legend_title)) },
         text = {
             Column(Modifier.verticalScroll(rememberScrollState())) {
-                LegendRow(R.color.stop_info_ontime, predicted = true, label = R.string.main_help_legend_ontime)
-                LegendRow(R.color.stop_info_early, predicted = true, label = R.string.main_help_legend_early)
-                LegendRow(R.color.stop_info_delayed, predicted = true, label = R.string.main_help_legend_late)
-                LegendRow(R.color.stop_info_scheduled_time, predicted = false, label = R.string.main_help_legend_scheduled)
                 LegendRow(
-                    R.color.stop_info_scheduled_time,
+                    ScheduleDeviation.Status.ON_TIME.fillColorRes,
+                    predicted = true,
+                    label = R.string.main_help_legend_ontime
+                )
+                LegendRow(
+                    ScheduleDeviation.Status.EARLY.fillColorRes,
+                    predicted = true,
+                    label = R.string.main_help_legend_early
+                )
+                LegendRow(
+                    ScheduleDeviation.Status.DELAYED.fillColorRes,
+                    predicted = true,
+                    label = R.string.main_help_legend_late
+                )
+                LegendRow(
+                    ScheduleDeviation.Status.SCHEDULED.fillColorRes,
+                    predicted = false,
+                    label = R.string.main_help_legend_scheduled
+                )
+                LegendRow(
+                    ScheduleDeviation.Status.SCHEDULED.fillColorRes,
                     predicted = false,
                     canceled = true,
                     label = R.string.main_help_legend_canceled

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/mylists/MyListRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/mylists/MyListRepository.kt
@@ -18,7 +18,6 @@ package org.onebusaway.android.ui.mylists
 import android.content.Context
 import android.text.format.DateUtils
 import androidx.annotation.ArrayRes
-import androidx.annotation.ColorRes
 import androidx.annotation.StringRes
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -392,14 +391,9 @@ private fun ArrivalInfo.toBadge(context: Context): ArrivalBadge {
             getRouteDisplayName(shortName, routeLongName),
             etaText
         ),
-        colorRes = badgeColor(color)
+        // The badge paints white text on this color, so it takes the on-fill tier directly off the
+        // arrival (#2043). This used to reverse-map the foreground color resource id back to a
+        // badge color, which silently fell through to "scheduled" for any id it didn't recognize.
+        colorRes = fillColor
     )
-}
-
-@ColorRes
-private fun badgeColor(@ColorRes arrivalColor: Int): Int = when (arrivalColor) {
-    R.color.stop_info_ontime -> R.color.badge_ontime
-    R.color.stop_info_delayed -> R.color.badge_delayed
-    R.color.stop_info_early -> R.color.badge_early
-    else -> R.color.badge_scheduled
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripdetails/TripDetailsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripdetails/TripDetailsRepository.kt
@@ -225,10 +225,9 @@ class DefaultTripDetailsRepository @Inject constructor(
         isRealtime: Boolean
     ): TripHeader {
         val deviation = status?.scheduleDeviation ?: Duration.ZERO
-        // The on-fill tier: this color becomes the status pill's surface (white text on it) and the
-        // timeline's vehicle dot, not text. The old on-time → theme_primary remap is gone with
-        // #2043 — it existed only because on-time used to resolve to the brand color, which made it
-        // indistinguishable from the header on brand-tinted flavors.
+        // The on-fill tier — this becomes the status pill's surface and the timeline's vehicle dot,
+        // not text. The old on-time → theme_primary remap is gone with #2043: it existed only because
+        // on-time used to resolve to the brand color, colliding with the header on branded flavors.
         val statusColor = ScheduleDeviation.fillColor(isRealtime, deviation)
         return TripHeader(
             routeShortName = route?.shortName.orEmpty(),

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripdetails/TripDetailsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripdetails/TripDetailsRepository.kt
@@ -45,10 +45,10 @@ import org.onebusaway.android.models.ObaTripStatus
 import org.onebusaway.android.models.Status
 import org.onebusaway.android.region.RegionRepository
 import org.onebusaway.android.time.ServiceDate
-import org.onebusaway.android.util.ArrivalInfoUtils
 import org.onebusaway.android.util.DisplayFormat
 import org.onebusaway.android.util.MyTextUtils
 import org.onebusaway.android.util.ObaRequestErrors
+import org.onebusaway.android.util.ScheduleDeviation
 
 /** A loaded snapshot of a trip's header + ordered stops, ready for the UI. */
 data class TripDetailsData(
@@ -225,13 +225,11 @@ class DefaultTripDetailsRepository @Inject constructor(
         isRealtime: Boolean
     ): TripHeader {
         val deviation = status?.scheduleDeviation ?: Duration.ZERO
-        val statusColor = when {
-            status == null || !status.isPredicted -> R.color.stop_info_scheduled_time
-            else -> {
-                val c = ArrivalInfoUtils.computeColorFromDeviation(deviation.inWholeMinutes)
-                if (c == R.color.stop_info_ontime) R.color.theme_primary else c
-            }
-        }
+        // The on-fill tier: this color becomes the status pill's surface (white text on it) and the
+        // timeline's vehicle dot, not text. The old on-time → theme_primary remap is gone with
+        // #2043 — it existed only because on-time used to resolve to the brand color, which made it
+        // indistinguishable from the header on brand-tinted flavors.
+        val statusColor = ScheduleDeviation.fillColor(isRealtime, deviation)
         return TripHeader(
             routeShortName = route?.shortName.orEmpty(),
             headsign = trip?.headsign.orEmpty(),

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripdetails/TripDetailsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripdetails/TripDetailsScreen.kt
@@ -419,7 +419,7 @@ private fun TransitRail(
 private fun TripDetailsPreview() {
     ObaTheme {
         val lineColor = colorResource(R.color.theme_primary)
-        val vehicleColor = colorResource(R.color.stop_info_delayed)
+        val vehicleColor = colorResource(R.color.stop_info_delayed_fill)
         Column {
             TripHeaderSection(
                 TripHeader(
@@ -429,7 +429,7 @@ private fun TripDetailsPreview() {
                     agencyName = "Metro Transit",
                     vehicleId = "1234",
                     statusText = "2 min, 30 sec late (updated 3:01 PM)",
-                    statusColor = R.color.stop_info_delayed,
+                    statusColor = R.color.stop_info_delayed_fill,
                     isRealtime = true
                 )
             )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripLogBuilder.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripLogBuilder.kt
@@ -15,7 +15,6 @@
  */
 package org.onebusaway.android.ui.tripresults
 
-import kotlin.math.roundToLong
 import org.onebusaway.android.directions.model.Direction
 import org.onebusaway.android.directions.model.TripLeg
 import org.onebusaway.android.directions.model.decodedPoints
@@ -217,7 +216,7 @@ object TripLogBuilder {
      * words it, and the band's edges (±90 s) always round to at least 1, so there is no "0 min late".
      */
     private fun TripLeg.realtimeState(): RealtimeState {
-        val minutes = (departureDelay.inWholeSeconds / 60.0).roundToLong()
+        val minutes = ScheduleDeviation.roundedMinutes(departureDelay)
         return when (ScheduleDeviation.status(realTime, departureDelay)) {
             ScheduleDeviation.Status.SCHEDULED -> RealtimeState.Unknown
             ScheduleDeviation.Status.ON_TIME -> RealtimeState.OnTime

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripLogBuilder.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripLogBuilder.kt
@@ -22,6 +22,7 @@ import org.onebusaway.android.directions.model.decodedPoints
 import org.onebusaway.android.directions.model.routeDisplayName
 import org.onebusaway.android.directions.model.routeDisplayShortName
 import org.onebusaway.android.util.GeoPoint
+import org.onebusaway.android.util.ScheduleDeviation
 import org.onebusaway.android.util.geoPointOrNull
 
 /**
@@ -206,14 +207,22 @@ object TripLogBuilder {
     /** True for a walk leg flanked by transit on both sides — a transfer, vs. a first/last-mile walk. */
     private fun List<TripLeg>.isTransferAt(i: Int): Boolean = getOrNull(i - 1)?.mode?.isTransit == true && getOrNull(i + 1)?.mode?.isTransit == true
 
-    /** Real-time board state from the leg's [TripLeg.realTime] flag + [TripLeg.departureDelay]. */
+    /**
+     * Real-time board state from the leg's [TripLeg.realTime] flag + [TripLeg.departureDelay].
+     *
+     * Which bucket the leg falls in is [ScheduleDeviation]'s call, shared with the arrivals drawer
+     * (#2043); this used to round to the nearest minute and treat only an exact 0 as on time, giving
+     * the trip planner a ±30 s window where the rest of the app had none. The rounded minute count
+     * still supplies the "N min late/early" text — the band decides the bucket, the rounding only
+     * words it, and the band's edges (±90 s) always round to at least 1, so there is no "0 min late".
+     */
     private fun TripLeg.realtimeState(): RealtimeState {
-        if (!realTime) return RealtimeState.Unknown
         val minutes = (departureDelay.inWholeSeconds / 60.0).roundToLong()
-        return when {
-            minutes == 0L -> RealtimeState.OnTime
-            minutes > 0L -> RealtimeState.Late(minutes)
-            else -> RealtimeState.Early(-minutes)
+        return when (ScheduleDeviation.status(realTime, departureDelay)) {
+            ScheduleDeviation.Status.SCHEDULED -> RealtimeState.Unknown
+            ScheduleDeviation.Status.ON_TIME -> RealtimeState.OnTime
+            ScheduleDeviation.Status.DELAYED -> RealtimeState.Late(minutes)
+            ScheduleDeviation.Status.EARLY -> RealtimeState.Early(-minutes)
         }
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
@@ -1244,21 +1244,20 @@ private fun StopActionLabel(actionRes: Int, stopName: String?, onClick: (() -> U
 /** The on-time / delayed real-time chip; [RealtimeState.Unknown] renders nothing. */
 @Composable
 private fun RealtimeChip(state: RealtimeState) {
-    // The shared schedule-deviation palette, foreground tier — the chip draws this color as text and
-    // as a dot over a 14%-alpha tint of itself. It used to have its own trip_realtime_* palette whose
-    // polarity contradicted the arrivals drawer: blue meant "early" here and "late" there, in the
-    // same app (#2043). Early keeps its own color rather than the on-time green for the reason it
-    // always did — a vehicle running ahead of schedule is a risk to the rider (they can miss it), not
-    // a reassurance — it is now red, matching arrivals and OBA iOS.
-    val (color, text) = when (state) {
+    // The chip draws its color as text and as a dot over a 14%-alpha tint of itself, so it takes the
+    // foreground tier — off the state's own [ScheduleDeviation.Status] rather than named here, so a
+    // re-hue of the shared palette can't leave this screen behind. It used to carry its own
+    // trip_realtime_* palette whose polarity contradicted the arrivals drawer: blue meant "early"
+    // here and "late" there, in the same app (#2043).
+    val text = when (state) {
         RealtimeState.Unknown -> return
-        RealtimeState.OnTime -> colorResource(R.color.stop_info_ontime) to
-            stringResource(R.string.trip_plan_realtime_on_time)
-        is RealtimeState.Late -> colorResource(R.color.stop_info_delayed) to
+        RealtimeState.OnTime -> stringResource(R.string.trip_plan_realtime_on_time)
+        is RealtimeState.Late ->
             pluralStringResource(R.plurals.trip_plan_realtime_late, state.minutes.toInt(), state.minutes.toInt())
-        is RealtimeState.Early -> colorResource(R.color.stop_info_early) to
+        is RealtimeState.Early ->
             pluralStringResource(R.plurals.trip_plan_realtime_early, state.minutes.toInt(), state.minutes.toInt())
     }
+    val color = colorResource(state.status.colorRes)
     Spacer(Modifier.width(8.dp))
     Row(
         modifier = Modifier

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
@@ -1244,11 +1244,11 @@ private fun StopActionLabel(actionRes: Int, stopName: String?, onClick: (() -> U
 /** The on-time / delayed real-time chip; [RealtimeState.Unknown] renders nothing. */
 @Composable
 private fun RealtimeChip(state: RealtimeState) {
-    // The chip draws its color as text and as a dot over a 14%-alpha tint of itself, so it takes the
-    // foreground tier — off the state's own [ScheduleDeviation.Status] rather than named here, so a
-    // re-hue of the shared palette can't leave this screen behind. It used to carry its own
-    // trip_realtime_* palette whose polarity contradicted the arrivals drawer: blue meant "early"
-    // here and "late" there, in the same app (#2043).
+    // labelMedium text over a 14%-alpha tint of itself, so it takes the text tier: the iOS display
+    // colors sit at 2.7-3.2:1 on that tint, which is what the retired trip_realtime_* palette had been
+    // hand-picked to avoid. Read off the state's own [ScheduleDeviation.Status] rather than named here,
+    // so a re-hue of the shared palette can't leave this screen behind. That palette's polarity
+    // contradicted the arrivals drawer: blue meant "early" here and "late" there, in one app (#2043).
     val text = when (state) {
         RealtimeState.Unknown -> return
         RealtimeState.OnTime -> stringResource(R.string.trip_plan_realtime_on_time)
@@ -1257,7 +1257,7 @@ private fun RealtimeChip(state: RealtimeState) {
         is RealtimeState.Early ->
             pluralStringResource(R.plurals.trip_plan_realtime_early, state.minutes.toInt(), state.minutes.toInt())
     }
-    val color = colorResource(state.status.colorRes)
+    val color = colorResource(state.status.textColorRes)
     Spacer(Modifier.width(8.dp))
     Row(
         modifier = Modifier

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
@@ -1244,15 +1244,19 @@ private fun StopActionLabel(actionRes: Int, stopName: String?, onClick: (() -> U
 /** The on-time / delayed real-time chip; [RealtimeState.Unknown] renders nothing. */
 @Composable
 private fun RealtimeChip(state: RealtimeState) {
+    // The shared schedule-deviation palette, foreground tier — the chip draws this color as text and
+    // as a dot over a 14%-alpha tint of itself. It used to have its own trip_realtime_* palette whose
+    // polarity contradicted the arrivals drawer: blue meant "early" here and "late" there, in the
+    // same app (#2043). Early keeps its own color rather than the on-time green for the reason it
+    // always did — a vehicle running ahead of schedule is a risk to the rider (they can miss it), not
+    // a reassurance — it is now red, matching arrivals and OBA iOS.
     val (color, text) = when (state) {
         RealtimeState.Unknown -> return
-        RealtimeState.OnTime -> colorResource(R.color.trip_realtime_on_time) to
+        RealtimeState.OnTime -> colorResource(R.color.stop_info_ontime) to
             stringResource(R.string.trip_plan_realtime_on_time)
-        is RealtimeState.Late -> colorResource(R.color.trip_realtime_delayed) to
+        is RealtimeState.Late -> colorResource(R.color.stop_info_delayed) to
             pluralStringResource(R.plurals.trip_plan_realtime_late, state.minutes.toInt(), state.minutes.toInt())
-        // Early gets its own colour, not the on-time green: a vehicle running ahead of schedule is a
-        // risk to the rider (they can miss it), not a reassurance.
-        is RealtimeState.Early -> colorResource(R.color.trip_realtime_early) to
+        is RealtimeState.Early -> colorResource(R.color.stop_info_early) to
             pluralStringResource(R.plurals.trip_plan_realtime_early, state.minutes.toInt(), state.minutes.toInt())
     }
     Spacer(Modifier.width(8.dp))

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
@@ -20,6 +20,7 @@ import org.onebusaway.android.map.RiddenSegment
 import org.onebusaway.android.time.ServerTime
 import org.onebusaway.android.ui.compose.components.RouteBadge
 import org.onebusaway.android.util.GeoPoint
+import org.onebusaway.android.util.ScheduleDeviation
 
 /**
  * One of the (up to three) itinerary option cards shown above the directions. Carries structured data
@@ -235,14 +236,31 @@ data class LogStop(val name: String, val point: GeoPoint? = null)
 
 /**
  * The real-time state of a transit board, shown as an on-time / delayed chip. [Unknown] (no real-time
- * data) renders no chip; [OnTime] when the delay rounds to zero whole minutes (i.e. within 30s of
- * schedule either way); [Late]/[Early] carry whole minutes.
+ * data) renders no chip; which of the others applies is [ScheduleDeviation]'s call, shared with the
+ * arrivals drawer (#2043); [Late]/[Early] carry the deviation worded in whole minutes.
+ *
+ * Each case names the [ScheduleDeviation.Status] it displays as, so the chip reads its color off the
+ * shared palette instead of re-spelling the state→color mapping — the same coupling that used to let
+ * this screen and the arrivals drawer disagree about which hue meant "early".
  */
 sealed interface RealtimeState {
-    data object Unknown : RealtimeState
-    data object OnTime : RealtimeState
-    data class Late(val minutes: Long) : RealtimeState
-    data class Early(val minutes: Long) : RealtimeState
+    val status: ScheduleDeviation.Status
+
+    data object Unknown : RealtimeState {
+        override val status = ScheduleDeviation.Status.SCHEDULED
+    }
+
+    data object OnTime : RealtimeState {
+        override val status = ScheduleDeviation.Status.ON_TIME
+    }
+
+    data class Late(val minutes: Long) : RealtimeState {
+        override val status = ScheduleDeviation.Status.DELAYED
+    }
+
+    data class Early(val minutes: Long) : RealtimeState {
+        override val status = ScheduleDeviation.Status.EARLY
+    }
 }
 
 /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/ArrivalInfoUtils.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/ArrivalInfoUtils.java
@@ -116,24 +116,26 @@ public class ArrivalInfoUtils {
   // replacement takes a full-precision kotlin.time.Duration and applies the shared on-time band.
 
   /**
-   * Computes the arrival status label from the delay (i.e., schedule deviation), where positive
-   * means the bus is running late and negative means the bus is running ahead of schedule
+   * Computes the arrival status label for an upcoming arrival.
    *
-   * @param delay schedule deviation, in minutes, for this vehicle where positive means the bus is
-   *     running late and negative means the bus is running ahead of schedule
-   * @return the arrival status label based on the deviation
+   * <p>The bucket comes from {@link ScheduleDeviation}, the same call that picks the color, so the
+   * words and the hue can't contradict each other — before #2043 this took the raw signed minutes
+   * and applied its own strict sign test, which after the on-time band landed meant a vehicle could
+   * read "1 min late" in the on-time green.
+   *
+   * @param status the deviation bucket, from {@link ScheduleDeviation#status}
+   * @param minutes how far off schedule, in whole minutes, unsigned — only read when [status] is
+   *     early or delayed
    */
-  public static @NonNull String computeArrivalLabelFromDelay(@NonNull Resources res, long delay) {
-    if (delay > 0) {
-      // Arriving delayed
-      return res.getQuantityString(R.plurals.stop_info_arrive_delayed, (int) delay, delay);
-    } else if (delay < 0) {
-      // Arriving early
-      delay = -delay;
-      return res.getQuantityString(R.plurals.stop_info_arrive_early, (int) delay, delay);
-    } else {
-      // Arriving on time
-      return res.getString(R.string.stop_info_ontime);
+  public static @NonNull String computeArrivalLabel(
+      @NonNull Resources res, @NonNull ScheduleDeviation.Status status, long minutes) {
+    switch (status) {
+      case DELAYED:
+        return res.getQuantityString(R.plurals.stop_info_arrive_delayed, (int) minutes, minutes);
+      case EARLY:
+        return res.getQuantityString(R.plurals.stop_info_arrive_early, (int) minutes, minutes);
+      default:
+        return res.getString(R.string.stop_info_ontime);
     }
   }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/ArrivalInfoUtils.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/ArrivalInfoUtils.java
@@ -109,52 +109,11 @@ public class ArrivalInfoUtils {
     return preferredIndexes;
   }
 
-  /**
-   * Returns the status color to be used, depending on whether the vehicle is running early, late,
-   * ontime, or if we don't have real-time info (i.e., scheduled)
-   *
-   * @param scheduled the scheduled time, in minutes past unix epoch
-   * @param predicted the predicted time, in minutes past unix epoch
-   * @return the status color to be used, depending on whether the vehicle is running early, late,
-   *     ontime, or if we don't have real-time info (i.e., scheduled)
-   */
-  public static int computeColor(final long scheduled, final long predicted) {
-    return statusColor(predicted != 0, predicted - scheduled);
-  }
-
-  /**
-   * The one live-vs-scheduled color choice shared by the map's vehicle markers/info windows and the
-   * arrival-list rows: the schedule-deviation color when real-time, otherwise the scheduled (gray)
-   * color. [deviationMinutes] is ignored when not real-time.
-   */
-  public static int statusColor(final boolean isRealtime, final long deviationMinutes) {
-    return isRealtime
-        ? computeColorFromDeviation(deviationMinutes)
-        : R.color.stop_info_scheduled_time;
-  }
-
-  /**
-   * Returns the status color to be used, depending on whether the vehicle is running early, late,
-   * ontime, or if we don't have real-time info (i.e., scheduled)
-   *
-   * @param delay the deviation from the scheduled time, in minutes - positive means bus is running
-   *     late, negative means early
-   * @return the status color to be used, depending on whether the vehicle is running early, late,
-   *     ontime, or if we don't have real-time info (i.e., scheduled)
-   */
-  public static int computeColorFromDeviation(final long delay) {
-    // Bus is arriving
-    if (delay > 0) {
-      // Arriving delayed
-      return R.color.stop_info_delayed;
-    } else if (delay < 0) {
-      // Arriving early
-      return R.color.stop_info_early;
-    } else {
-      // Arriving on time
-      return R.color.stop_info_ontime;
-    }
-  }
+  // The schedule-deviation color methods that used to live here (computeColor, statusColor,
+  // computeColorFromDeviation) moved to org.onebusaway.android.util.ScheduleDeviation in #2043.
+  // They bucketed on a strict sign test over whole minutes, so "on time" required the predicted and
+  // scheduled minute-past-epoch to be exactly equal and was nearly unreachable on live data; the
+  // replacement takes a full-precision kotlin.time.Duration and applies the shared on-time band.
 
   /**
    * Computes the arrival status label from the delay (i.e., schedule deviation), where positive

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/ScheduleDeviation.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/ScheduleDeviation.kt
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.onebusaway.android.util
+
+import androidx.annotation.ColorRes
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+import org.onebusaway.android.R
+
+/**
+ * The single source of truth for "how far off schedule is this vehicle, and what color says so"
+ * (#2043).
+ *
+ * Every surface that expresses schedule deviation with color — the arrivals drawer, the ETA pills,
+ * the map's vehicle info window, trip details, the trip planner's real-time chips, the starred-stop
+ * badges and the help legend — resolves through here, so they cannot drift apart on which hue means
+ * what or on what counts as "on time". Before this existed there were five different rules in the
+ * app (whole-minute floors, `inWholeMinutes` truncation, `roundToLong`, and one site that passed
+ * milliseconds to a parameter documented as minutes).
+ *
+ * Deviation is a [Duration]: positive means the vehicle is running **late**, negative means
+ * **early**. Callers pass the deviation at full precision; the band is applied here and only here.
+ */
+object ScheduleDeviation {
+
+    /**
+     * Half-width of the on-time band: a vehicle within this much of its scheduled time reads as on
+     * time rather than early or late.
+     *
+     * **Sanctioned threshold.** `CLAUDE.md` ("No unsanctioned heuristics") gates magic thresholds on
+     * explicit human sign-off, because a number picked by feel passes the happy path and misbehaves
+     * silently at the edges. This one is not invented here: it is the band OBA iOS has shipped for
+     * years — `ArrivalDeparture.scheduleStatus`, `ArrivalDeparture.swift:305`, which buckets on
+     * `minutesDiff < -1.5` / `< 1.5` — and issue #2043 adopts it verbatim to bring the two apps to
+     * parity. The named upstream source *is* the justification; it was approved on that issue rather
+     * than chosen by an implementer.
+     *
+     * Failure mode if it drifts from iOS: the two apps disagree about whether the same vehicle is
+     * "on time", which is precisely the defect #2043 set out to remove.
+     */
+    val ON_TIME_BAND: Duration = 90.seconds
+
+    /**
+     * Bucket a deviation into a display state, matching iOS's boundary handling exactly: the band is
+     * half-open, so a deviation of exactly -[ON_TIME_BAND] is [ON_TIME] while exactly
+     * +[ON_TIME_BAND] is [DELAYED].
+     *
+     * [isRealtime] false means we have no prediction to compare against, so [deviation] is ignored
+     * entirely and the state is [SCHEDULED] regardless of what it holds.
+     */
+    fun status(isRealtime: Boolean, deviation: Duration): Status = when {
+        !isRealtime -> Status.SCHEDULED
+        deviation < -ON_TIME_BAND -> Status.EARLY
+        deviation < ON_TIME_BAND -> Status.ON_TIME
+        else -> Status.DELAYED
+    }
+
+    /**
+     * The **foreground** deviation color — drawn as the text or glyph color on the app surface.
+     * See [Status.colorRes].
+     */
+    @ColorRes
+    fun statusColor(isRealtime: Boolean, deviation: Duration): Int = status(isRealtime, deviation).colorRes
+
+    /**
+     * The **on-fill** deviation color — for a filled surface that carries white text, such as an ETA
+     * pill or a starred-stop badge. See [Status.fillColorRes].
+     */
+    @ColorRes
+    fun fillColor(isRealtime: Boolean, deviation: Duration): Int = status(isRealtime, deviation).fillColorRes
+
+    /**
+     * The four display states a schedule deviation can take.
+     *
+     * Each state owns both of its colors, so a new state cannot be added without deciding what it
+     * looks like on both kinds of surface. (The starred-stop badge used to recover the state by
+     * reverse-matching the returned color resource id, which silently fell through to "scheduled"
+     * for anything unrecognized.)
+     */
+    enum class Status(@param:ColorRes val colorRes: Int, @param:ColorRes val fillColorRes: Int) {
+        /** Running ahead of schedule — the rider can miss it, so this is a warning, not praise. */
+        EARLY(R.color.stop_info_early, R.color.stop_info_early_fill),
+
+        /** Within [ON_TIME_BAND] of schedule. */
+        ON_TIME(R.color.stop_info_ontime, R.color.stop_info_ontime_fill),
+
+        /** Running behind schedule. */
+        DELAYED(R.color.stop_info_delayed, R.color.stop_info_delayed_fill),
+
+        /** No real-time prediction — a timetable time, not a measurement. */
+        SCHEDULED(R.color.stop_info_scheduled_time, R.color.stop_info_scheduled_fill)
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/ScheduleDeviation.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/ScheduleDeviation.kt
@@ -17,6 +17,7 @@
 package org.onebusaway.android.util
 
 import androidx.annotation.ColorRes
+import kotlin.math.roundToLong
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 import org.onebusaway.android.R
@@ -68,6 +69,14 @@ object ScheduleDeviation {
         deviation < ON_TIME_BAND -> Status.ON_TIME
         else -> Status.DELAYED
     }
+
+    /**
+     * The deviation rounded to the nearest whole minute — how a deviation is *worded* once [status]
+     * has decided which bucket it falls in. Rounding (rather than truncating) is what keeps the
+     * wording consistent with the band: the band's edges are at 1.5 minutes, so anything outside it
+     * words as at least "2 min", never a "1 min late" that reads as inside the on-time window.
+     */
+    fun roundedMinutes(deviation: Duration): Long = (deviation.inWholeSeconds / 60.0).roundToLong()
 
     /**
      * The **foreground** deviation color — drawn as the text or glyph color on the app surface.

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/ScheduleDeviation.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/ScheduleDeviation.kt
@@ -79,11 +79,17 @@ object ScheduleDeviation {
     fun roundedMinutes(deviation: Duration): Long = (deviation.inWholeSeconds / 60.0).roundToLong()
 
     /**
-     * The **foreground** deviation color — drawn as the text or glyph color on the app surface.
-     * See [Status.colorRes].
+     * The **display** deviation color — the iOS value, for large text and graphics. See
+     * [Status.displayColorRes], and prefer [textColor] for anything set at a normal size.
      */
     @ColorRes
-    fun statusColor(isRealtime: Boolean, deviation: Duration): Int = status(isRealtime, deviation).colorRes
+    fun displayColor(isRealtime: Boolean, deviation: Duration): Int = status(isRealtime, deviation).displayColorRes
+
+    /**
+     * The **text** deviation color — small text drawn on the app surface. See [Status.textColorRes].
+     */
+    @ColorRes
+    fun textColor(isRealtime: Boolean, deviation: Duration): Int = status(isRealtime, deviation).textColorRes
 
     /**
      * The **on-fill** deviation color — for a filled surface that carries white text, such as an ETA
@@ -95,22 +101,40 @@ object ScheduleDeviation {
     /**
      * The four display states a schedule deviation can take.
      *
-     * Each state owns both of its colors, so a new state cannot be added without deciding what it
-     * looks like on both kinds of surface. (The starred-stop badge used to recover the state by
-     * reverse-matching the returned color resource id, which silently fell through to "scheduled"
-     * for anything unrecognized.)
+     * Each state owns all three of its colors, so a new state cannot be added without deciding what
+     * it looks like on every kind of surface. (The starred-stop badge used to recover the state by
+     * reverse-matching the returned color resource id, which silently fell through to "scheduled" for
+     * anything unrecognized.)
+     *
+     * The three tiers exist because the same state is drawn against three different grounds, each with
+     * its own WCAG floor — they are not stylistic variants:
+     *  - [displayColorRes] — the iOS color, for large text and graphics (3:1). The arrivals drawer's
+     *    30sp ETA, which is the most visible deviation surface in the app and so the one that carries
+     *    the parity.
+     *  - [textColorRes] — small text on the app surface (4.5:1); the trip-planner chip, the directions
+     *    time span. Mode-dependent, since it must contrast with a surface that inverts.
+     *  - [fillColorRes] — a filled surface with white text on it (4.5:1); the ETA pills, the
+     *    starred-stop badges, the status pills. Mode-independent, since white doesn't move.
      */
-    enum class Status(@param:ColorRes val colorRes: Int, @param:ColorRes val fillColorRes: Int) {
+    enum class Status(
+        @param:ColorRes val displayColorRes: Int,
+        @param:ColorRes val textColorRes: Int,
+        @param:ColorRes val fillColorRes: Int
+    ) {
         /** Running ahead of schedule — the rider can miss it, so this is a warning, not praise. */
-        EARLY(R.color.stop_info_early, R.color.stop_info_early_fill),
+        EARLY(R.color.stop_info_early, R.color.stop_info_early_text, R.color.stop_info_early_fill),
 
         /** Within [ON_TIME_BAND] of schedule. */
-        ON_TIME(R.color.stop_info_ontime, R.color.stop_info_ontime_fill),
+        ON_TIME(R.color.stop_info_ontime, R.color.stop_info_ontime_text, R.color.stop_info_ontime_fill),
 
         /** Running behind schedule. */
-        DELAYED(R.color.stop_info_delayed, R.color.stop_info_delayed_fill),
+        DELAYED(R.color.stop_info_delayed, R.color.stop_info_delayed_text, R.color.stop_info_delayed_fill),
 
         /** No real-time prediction — a timetable time, not a measurement. */
-        SCHEDULED(R.color.stop_info_scheduled_time, R.color.stop_info_scheduled_fill)
+        SCHEDULED(
+            R.color.stop_info_scheduled_time,
+            R.color.stop_info_scheduled_text,
+            R.color.stop_info_scheduled_fill
+        )
     }
 }

--- a/onebusaway-android/src/main/res/values-night/colors.xml
+++ b/onebusaway-android/src/main/res/values-night/colors.xml
@@ -38,11 +38,19 @@
 
     <!-- Arrival times header -->
 
+    <!-- Schedule-deviation foreground tier on a dark ground (#2043) — the iOS dark variants
+         (Theme.swift:125-172), which is exactly the mitigation iOS added after its own
+         small-colored-text legibility reports (their #506/#508) and which this app previously
+         lacked entirely. Only the three chromatic states shift; stop_info_scheduled_time is
+         #8E8E93 in both modes (iOS .systemGray), so it isn't restated here.
+
+         The ON-FILL tier (stop_info_*_fill) is likewise mode-independent — white-on-fill contrast
+         is unaffected by the surrounding surface — so it has no night override either. -->
+    <color name="stop_info_ontime">#30D158</color>
+    <color name="stop_info_delayed">#0A84FF</color>
+    <color name="stop_info_early">#FF453A</color>
+
     <!-- Trip Planning -->
-    <!-- Trip-log real-time status chips (lightened for dark ground) -->
-    <color name="trip_realtime_on_time">#5CC98A</color>
-    <color name="trip_realtime_delayed">#E0A83C</color>
-    <color name="trip_realtime_early">#7FB6E0</color>
     <!-- Trip-log timeline endpoint dots (lightened for dark ground) -->
     <color name="trip_origin_marker">#5BB974</color>
     <color name="trip_destination_marker">#F28B82</color>

--- a/onebusaway-android/src/main/res/values-night/colors.xml
+++ b/onebusaway-android/src/main/res/values-night/colors.xml
@@ -50,6 +50,14 @@
     <color name="stop_info_delayed">#0A84FF</color>
     <color name="stop_info_early">#FF453A</color>
 
+    <!-- On a dark ground the display tier is already legible as small text (4.7-7.2:1 against the
+         real-time chip's tint), so the text tier is the same color — except "delayed", where the iOS
+         dark blue lands at 4.39:1 and is nudged up to clear 4.5. -->
+    <color name="stop_info_scheduled_text">@color/stop_info_scheduled_time</color>
+    <color name="stop_info_ontime_text">@color/stop_info_ontime</color>
+    <color name="stop_info_delayed_text">#0A8BFF</color>
+    <color name="stop_info_early_text">@color/stop_info_early</color>
+
     <!-- Trip Planning -->
     <!-- Trip-log timeline endpoint dots (lightened for dark ground) -->
     <color name="trip_origin_marker">#5BB974</color>

--- a/onebusaway-android/src/main/res/values/colors.xml
+++ b/onebusaway-android/src/main/res/values/colors.xml
@@ -52,20 +52,39 @@
 
     <!-- Arrival times header -->
 
-    <!-- Arrival time colors -->
-    <color name="stop_info_scheduled_time">#777777</color>
-    <color name="stop_info_ontime">@color/theme_primary_brand</color>
-    <color name="stop_info_delayed">#504caf</color>
-    <color name="stop_info_early">#af504c</color>
+    <!-- Schedule-deviation palette (#2043), at parity with OBA iOS (Theme.swift:125-172).
+
+         Deliberately NOT brand-tinted: deviation status is semantic, not brand identity, so a
+         white-label flavor overriding brand_color must not be able to collide two states into the
+         same hue (agencyY used to render on-time and late both blue).
+
+         The polarity is the counterintuitive one iOS ships — red = early, blue = late — because a
+         vehicle running ahead of schedule is a risk to the rider (they can miss it), not a
+         reassurance.
+
+         FOREGROUND tier: drawn AS the text/glyph color on the app surface. -->
+    <color name="stop_info_scheduled_time">#8E8E93</color>
+    <color name="stop_info_ontime">#129900</color>
+    <color name="stop_info_delayed">#007AFF</color>
+    <color name="stop_info_early">#FF3B30</color>
 
     <!-- stop_info_occupancy_background is same as navdrawer_background_color_selected, but without transparency so it works on non-white backgrounds -->
     <color name="stop_info_occupancy">@color/stop_info_scheduled_time</color>
 
-    <!-- Darker badge background colors for white text accessibility (WCAG AA 4.5:1) -->
-    <color name="badge_ontime">@color/theme_primary_variant</color>
-    <color name="badge_delayed">#3A37A1</color>
-    <color name="badge_early">#8B3A37</color>
-    <color name="badge_scheduled">#555555</color>
+    <!-- ON-FILL tier: the same four states darkened until white text ON them clears WCAG AA
+         (4.5:1). Used wherever the deviation color is a filled surface carrying white text — the
+         ETA pills (EtaStrip) and the starred-stop badges (MyListRepository) — rather than being
+         the text itself. The iOS hexes above sit at 3.3-4.0:1 under white text, so they cannot be
+         reused here; iOS has this hazard unaddressed and we deliberately don't copy that part.
+
+         Derived from the foreground tier by scaling toward black (see the PR for #2043): white-on
+         is 4.8:1 for all four. Mode-independent by design — white-on-fill contrast doesn't depend
+         on the surrounding surface, and each clears 3:1 as a graphical object against both white
+         and black grounds, so there is no values-night counterpart. -->
+    <color name="stop_info_scheduled_fill">#727276</color>
+    <color name="stop_info_ontime_fill">#108500</color>
+    <color name="stop_info_delayed_fill">#006EE5</color>
+    <color name="stop_info_early_fill">#D63228</color>
 
     <color name="stop_info_arrival_list_background">#eaeaea</color>
 
@@ -90,13 +109,9 @@
     <color name="trip_plan_header_text">@color/md_theme_onSurface</color>
     <color name="trip_plan_card_background_selected">@color/md_theme_secondaryContainer</color>
     <color name="trip_plan_header_text_selected">@color/md_theme_onSecondaryContainer</color>
-    <!-- Trip-log real-time status chips (semantic, not the accent). The chip draws this colour as text
-         over a 14%-alpha tint of itself, so both clear 4.5:1 against that tinted surface, not just the
-         bare background. "Early" is its own colour, not the on-time green: a vehicle running ahead of
-         schedule is something the rider has to act on, not a reassurance. -->
-    <color name="trip_realtime_on_time">#136B39</color>
-    <color name="trip_realtime_delayed">#7E560E</color>
-    <color name="trip_realtime_early">#1F5E8C</color>
+    <!-- The trip-log real-time status chips used to carry their own trip_realtime_* palette, whose
+         polarity contradicted the arrivals drawer (blue meant "early" here and "late" there). They
+         now read the shared stop_info_* foreground tier above (#2043). -->
     <!-- Trip-log timeline endpoint dots: green origin, red destination -->
     <color name="trip_origin_marker">#1E8E3E</color>
     <color name="trip_destination_marker">#D93025</color>

--- a/onebusaway-android/src/main/res/values/colors.xml
+++ b/onebusaway-android/src/main/res/values/colors.xml
@@ -62,11 +62,23 @@
          vehicle running ahead of schedule is a risk to the rider (they can miss it), not a
          reassurance.
 
-         FOREGROUND tier: drawn AS the text/glyph color on the app surface. -->
+         DISPLAY tier: the iOS values themselves. Only for large text and graphics, which WCAG holds
+         to 3:1 — the arrivals drawer's 30sp ETA is the one that matters, and it clears that in both
+         themes. These are NOT safe for small text; see the text tier below. -->
     <color name="stop_info_scheduled_time">#8E8E93</color>
     <color name="stop_info_ontime">#129900</color>
     <color name="stop_info_delayed">#007AFF</color>
     <color name="stop_info_early">#FF3B30</color>
+
+    <!-- TEXT tier: small text drawn on the app surface — the trip-planner's real-time chip and the
+         directions time span. Same hues, darkened until they clear 4.5:1 against the chip's own
+         14%-alpha tint of itself over md_theme_surface, which is the tightest ground any of them sits
+         on (the display tier is 2.7-3.2:1 there, so it can't be reused). Unlike the fill tier this is
+         mode-dependent — it has to contrast with the surface, which inverts between themes. -->
+    <color name="stop_info_scheduled_text">#636367</color>
+    <color name="stop_info_ontime_text">#0E7400</color>
+    <color name="stop_info_delayed_text">#0060C9</color>
+    <color name="stop_info_early_text">#BA2B23</color>
 
     <!-- stop_info_occupancy_background is same as navdrawer_background_color_selected, but without transparency so it works on non-white backgrounds -->
     <color name="stop_info_occupancy">@color/stop_info_scheduled_time</color>

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -107,7 +107,7 @@
     <string name="main_help_legend_ontime">Green means “On time” - within a minute and a half of
         the schedule, either way
     </string>
-    <string name="main_help_legend_late">Blue means “Running late” - more than a minute and a half
+    <string name="main_help_legend_late">Blue means “Running late” - a minute and a half or more
         behind schedule
     </string>
     <string name="main_help_legend_early">Red means “Running early” - more than a minute and a half

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -104,9 +104,15 @@
     <string name="main_help_whatsnew">• <b>Bug fixes</b> Several bug fixes and fit and finish improvements. - See https://bit.ly/oba-android-releases</string>
     <string name="main_help_close">Close</string>
     <string name="main_help_legend_title">Legend</string>
-    <string name="main_help_legend_ontime">Green means “On time”</string>
-    <string name="main_help_legend_late">Blue means “Running late”</string>
-    <string name="main_help_legend_early">Red means “Running early”</string>
+    <string name="main_help_legend_ontime">Green means “On time” - within a minute and a half of
+        the schedule, either way
+    </string>
+    <string name="main_help_legend_late">Blue means “Running late” - more than a minute and a half
+        behind schedule
+    </string>
+    <string name="main_help_legend_early">Red means “Running early” - more than a minute and a half
+        ahead of schedule, so it may leave before you get there
+    </string>
     <string name="main_help_legend_scheduled">Gray means “Scheduled arrival” - We don’t know
         where the bus is now, but the schedule says there is an upcoming arrival
     </string>

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/ArrivalInfoTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/ArrivalInfoTest.kt
@@ -19,6 +19,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.onebusaway.android.R
 import org.onebusaway.android.models.ArrivalData
 import org.onebusaway.android.models.FrequencyWindow
 import org.onebusaway.android.models.Occupancy
@@ -169,6 +170,76 @@ class ArrivalInfoTest {
         val info = genuinePrediction
 
         assertEquals(info.eta, info.liveEta(ServerTime(now.epochMs + 30_000L)))
+    }
+
+    // --- Schedule-deviation color, end to end through the arrivals path (#2043) -------------------
+    //
+    // The band itself is pinned in ScheduleDeviationTest; these assert that ArrivalInfo actually
+    // *reaches* it at full precision. The old code floored each instant to whole minutes and
+    // subtracted, so a sub-minute deviation that straddled a minute boundary was reported as a full
+    // minute late — which is why a 60 s-late bus could never render on-time green.
+
+    /** An arrival [deviationSeconds] off its scheduled time, real-time unless told otherwise. */
+    private fun deviating(deviationSeconds: Long, predicted: Boolean = true) = infoFor(
+        arrival(
+            predicted = predicted,
+            predictedArrivalTime = scheduledArrival + deviationSeconds * 1_000L
+        )
+    )
+
+    @Test
+    fun `a deviation just inside the band renders on time`() {
+        assertEquals(R.color.stop_info_ontime, deviating(-89).color)
+        assertEquals(R.color.stop_info_ontime, deviating(89).color)
+    }
+
+    @Test
+    fun `a deviation just outside the band renders early or late`() {
+        assertEquals(R.color.stop_info_early, deviating(-91).color)
+        assertEquals(R.color.stop_info_delayed, deviating(91).color)
+    }
+
+    /**
+     * The headline acceptance case for #2043. A minute late used to land on the late color because
+     * the two epoch-minute floors differed by one; it is now comfortably inside the band.
+     */
+    @Test
+    fun `a bus one minute late is on time and a bus two minutes late is not`() {
+        assertEquals(R.color.stop_info_ontime, deviating(60).color)
+        assertEquals(R.color.stop_info_delayed, deviating(120).color)
+    }
+
+    /**
+     * A deviation straddling a minute boundary: the predicted instant lands in the next epoch-minute
+     * from the scheduled one despite being only a second late. Flooring first made this "late".
+     */
+    @Test
+    fun `a one-second deviation across a minute boundary is still on time`() {
+        val scheduled = 1_783_119_119_000L // :59 within its epoch-minute
+        val info = infoFor(
+            arrival(
+                predicted = true,
+                predictedArrivalTime = scheduled + 1_000L, // 1 s later, but the next epoch-minute
+                scheduledArrivalTime = scheduled
+            )
+        )
+
+        assertEquals(R.color.stop_info_ontime, info.color)
+    }
+
+    @Test
+    fun `without a prediction the color is scheduled regardless of deviation`() {
+        assertEquals(R.color.stop_info_scheduled_time, deviating(600, predicted = false).color)
+        assertEquals(R.color.stop_info_scheduled_time, deviating(-600, predicted = false).color)
+    }
+
+    /** The pill/badge tier tracks the same state, so the two can't disagree about what's on time. */
+    @Test
+    fun `the fill color tracks the same state as the foreground color`() {
+        assertEquals(R.color.stop_info_ontime_fill, deviating(89).fillColor)
+        assertEquals(R.color.stop_info_delayed_fill, deviating(91).fillColor)
+        assertEquals(R.color.stop_info_early_fill, deviating(-91).fillColor)
+        assertEquals(R.color.stop_info_scheduled_fill, deviating(600, predicted = false).fillColor)
     }
 }
 

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/TripLogBuilderTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/TripLogBuilderTest.kt
@@ -375,16 +375,6 @@ class TripLogBuilderTest {
         assertEquals("Seattle - Bremerton", transit.routeDisplayName)
     }
 
-    @Test
-    fun noRealtime_isUnknown() {
-        val scheduled = transitLeg.copy(realTime = false)
-        val transit = TripLogBuilder
-            .build(listOf(scheduled), listOf(boardDir, alightDir), listOf(transitRef))
-            .filterIsInstance<TripLogEntry.Transit>()
-            .single()
-        assertEquals(RealtimeState.Unknown, transit.realtime)
-    }
-
     // --- The shared on-time band (#2043) ---------------------------------------------------------
     //
     // The trip planner used to round the delay to the nearest minute and call only an exact 0 "on
@@ -414,12 +404,6 @@ class TripLogBuilderTest {
         assertEquals(RealtimeState.Early(2), realtimeStateFor(-91))
     }
 
-    @Test
-    fun bandEdges_matchTheIosHalfOpenComparison() {
-        assertEquals(RealtimeState.OnTime, realtimeStateFor(-90))
-        assertEquals(RealtimeState.Late(2), realtimeStateFor(90))
-    }
-
     /**
      * The band's edges always round to at least one minute, so a Late/Early chip can never read
      * "0 min late" — the case the old `minutes == 0L` bucket used to absorb.
@@ -437,8 +421,10 @@ class TripLogBuilderTest {
         }
     }
 
+    /** No real-time data means no chip, whatever the leg's delay field happens to hold. */
     @Test
-    fun withoutRealtime_deviationIsIgnored() {
+    fun withoutRealtime_isUnknownWhateverTheDeviation() {
+        assertEquals(RealtimeState.Unknown, realtimeStateFor(0, realTime = false))
         assertEquals(RealtimeState.Unknown, realtimeStateFor(600, realTime = false))
         assertEquals(RealtimeState.Unknown, realtimeStateFor(-600, realTime = false))
     }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/TripLogBuilderTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/TripLogBuilderTest.kt
@@ -16,6 +16,7 @@
 package org.onebusaway.android.ui.tripresults
 
 import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -382,5 +383,63 @@ class TripLogBuilderTest {
             .filterIsInstance<TripLogEntry.Transit>()
             .single()
         assertEquals(RealtimeState.Unknown, transit.realtime)
+    }
+
+    // --- The shared on-time band (#2043) ---------------------------------------------------------
+    //
+    // The trip planner used to round the delay to the nearest minute and call only an exact 0 "on
+    // time", giving it a ±30 s window while the arrivals drawer had none. Both now bucket through
+    // ScheduleDeviation, so the same vehicle can't read on-time in one screen and late in the other.
+
+    /** The realtime state for a transit leg whose departure is [delaySeconds] off schedule. */
+    private fun realtimeStateFor(delaySeconds: Long, realTime: Boolean = true): RealtimeState {
+        val leg = transitLeg.copy(realTime = realTime, departureDelay = delaySeconds.seconds)
+        return TripLogBuilder
+            .build(listOf(leg), listOf(boardDir, alightDir), listOf(transitRef))
+            .filterIsInstance<TripLogEntry.Transit>()
+            .single()
+            .realtime
+    }
+
+    @Test
+    fun deviationJustInsideTheBand_isOnTime() {
+        // Both of these used to round to ±1 minute and render as late/early.
+        assertEquals(RealtimeState.OnTime, realtimeStateFor(89))
+        assertEquals(RealtimeState.OnTime, realtimeStateFor(-89))
+    }
+
+    @Test
+    fun deviationJustOutsideTheBand_isLateOrEarly() {
+        assertEquals(RealtimeState.Late(2), realtimeStateFor(91))
+        assertEquals(RealtimeState.Early(2), realtimeStateFor(-91))
+    }
+
+    @Test
+    fun bandEdges_matchTheIosHalfOpenComparison() {
+        assertEquals(RealtimeState.OnTime, realtimeStateFor(-90))
+        assertEquals(RealtimeState.Late(2), realtimeStateFor(90))
+    }
+
+    /**
+     * The band's edges always round to at least one minute, so a Late/Early chip can never read
+     * "0 min late" — the case the old `minutes == 0L` bucket used to absorb.
+     */
+    @Test
+    fun lateAndEarlyChipsNeverReportZeroMinutes() {
+        for (seconds in longArrayOf(91, 120, 200, -91, -120, -200)) {
+            val state = realtimeStateFor(seconds)
+            val minutes = when (state) {
+                is RealtimeState.Late -> state.minutes
+                is RealtimeState.Early -> state.minutes
+                else -> error("$seconds s must bucket as late or early, was $state")
+            }
+            assertTrue("$seconds s must report at least a minute, was $minutes", minutes >= 1)
+        }
+    }
+
+    @Test
+    fun withoutRealtime_deviationIsIgnored() {
+        assertEquals(RealtimeState.Unknown, realtimeStateFor(600, realTime = false))
+        assertEquals(RealtimeState.Unknown, realtimeStateFor(-600, realTime = false))
     }
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/util/ScheduleDeviationTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/util/ScheduleDeviationTest.kt
@@ -21,6 +21,7 @@ import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.onebusaway.android.R
 import org.onebusaway.android.util.ScheduleDeviation.Status
@@ -77,6 +78,21 @@ class ScheduleDeviationTest {
         assertEquals(Status.SCHEDULED, status(Duration.ZERO, isRealtime = false))
         assertEquals(Status.SCHEDULED, status(30.minutes, isRealtime = false))
         assertEquals(Status.SCHEDULED, status((-30).minutes, isRealtime = false))
+    }
+
+    /**
+     * The wording rounds rather than truncates, which is what keeps it consistent with the band: the
+     * edges sit at 1.5 minutes, so anything bucketed early/late words as at least "2 min" and can
+     * never read as a magnitude that falls inside the on-time window.
+     */
+    @Test
+    fun `the worded magnitude never contradicts the band`() {
+        for (seconds in longArrayOf(90, 91, 120, 200)) {
+            val minutes = ScheduleDeviation.roundedMinutes(seconds.seconds)
+            assertEquals("$seconds s must bucket as late", Status.DELAYED, status(seconds.seconds))
+            assertTrue("$seconds s worded as $minutes min would read as on time", minutes >= 2)
+        }
+        assertEquals("just inside the band still rounds to 1", 1L, ScheduleDeviation.roundedMinutes(89.seconds))
     }
 
     @Test

--- a/onebusaway-android/src/test/java/org/onebusaway/android/util/ScheduleDeviationTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/util/ScheduleDeviationTest.kt
@@ -97,10 +97,15 @@ class ScheduleDeviationTest {
 
     @Test
     fun `the color helpers agree with the bucketing`() {
-        assertEquals(R.color.stop_info_early, ScheduleDeviation.statusColor(true, (-91).seconds))
-        assertEquals(R.color.stop_info_ontime, ScheduleDeviation.statusColor(true, 89.seconds))
-        assertEquals(R.color.stop_info_delayed, ScheduleDeviation.statusColor(true, 91.seconds))
-        assertEquals(R.color.stop_info_scheduled_time, ScheduleDeviation.statusColor(false, 91.seconds))
+        assertEquals(R.color.stop_info_early, ScheduleDeviation.displayColor(true, (-91).seconds))
+        assertEquals(R.color.stop_info_ontime, ScheduleDeviation.displayColor(true, 89.seconds))
+        assertEquals(R.color.stop_info_delayed, ScheduleDeviation.displayColor(true, 91.seconds))
+        assertEquals(R.color.stop_info_scheduled_time, ScheduleDeviation.displayColor(false, 91.seconds))
+
+        assertEquals(R.color.stop_info_early_text, ScheduleDeviation.textColor(true, (-91).seconds))
+        assertEquals(R.color.stop_info_ontime_text, ScheduleDeviation.textColor(true, 89.seconds))
+        assertEquals(R.color.stop_info_delayed_text, ScheduleDeviation.textColor(true, 91.seconds))
+        assertEquals(R.color.stop_info_scheduled_text, ScheduleDeviation.textColor(false, 91.seconds))
 
         assertEquals(R.color.stop_info_early_fill, ScheduleDeviation.fillColor(true, (-91).seconds))
         assertEquals(R.color.stop_info_ontime_fill, ScheduleDeviation.fillColor(true, 89.seconds))
@@ -109,23 +114,33 @@ class ScheduleDeviationTest {
     }
 
     /**
-     * The four states must be four *distinct* colors in both tiers. This is what broke on the agencyY
+     * The four states must be four *distinct* colors in every tier. This is what broke on the agencyY
      * flavor, where on-time resolved through the brand color and collided with late — a rebrand could
      * make two states indistinguishable without any code change.
      */
     @Test
-    fun `every state has its own color in both tiers`() {
-        val foreground = Status.entries.map { it.colorRes }
-        val fill = Status.entries.map { it.fillColorRes }
-
-        assertEquals("foreground tier has a distinct color per state", Status.entries.size, foreground.toSet().size)
-        assertEquals("on-fill tier has a distinct color per state", Status.entries.size, fill.toSet().size)
-        for (state in Status.entries) {
-            assertNotEquals(
-                "${state.name} must not use the same resource for text and fill",
-                state.colorRes,
-                state.fillColorRes
-            )
+    fun `every state has its own color in every tier`() {
+        val tiers = mapOf(
+            "display" to Status.entries.map { it.displayColorRes },
+            "text" to Status.entries.map { it.textColorRes },
+            "fill" to Status.entries.map { it.fillColorRes }
+        )
+        for ((tier, colors) in tiers) {
+            assertEquals("$tier tier has a distinct color per state", Status.entries.size, colors.toSet().size)
         }
+    }
+
+    /**
+     * The three tiers exist because the same state is drawn against three different grounds with three
+     * different WCAG floors, so a state must not resolve two of them to one resource — that would mean
+     * a surface silently picked up a color that wasn't checked against its ground.
+     */
+    @Test
+    fun `each state keeps its three tiers separate`() {
+        for (state in Status.entries) {
+            val tiers = setOf(state.displayColorRes, state.textColorRes, state.fillColorRes)
+            assertEquals("${state.name} must resolve three distinct tier resources", 3, tiers.size)
+        }
+        assertNotEquals(Status.ON_TIME.displayColorRes, Status.ON_TIME.fillColorRes)
     }
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/util/ScheduleDeviationTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/util/ScheduleDeviationTest.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.util
+
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+import org.onebusaway.android.R
+import org.onebusaway.android.util.ScheduleDeviation.Status
+
+/**
+ * The on-time band and the two color tiers (#2043).
+ *
+ * Before this, "on time" meant the predicted and scheduled minute-past-epoch were *exactly equal*,
+ * which on live data almost never happened — a bus 20 s late rendered late. The band is OBA iOS's
+ * (`ArrivalDeparture.swift:305`), adopted for parity, so these boundaries are the contract that keeps
+ * the two apps agreeing; they are also the reason the threshold is sanctioned rather than invented.
+ */
+class ScheduleDeviationTest {
+
+    private fun status(deviation: Duration, isRealtime: Boolean = true) = ScheduleDeviation.status(isRealtime, deviation)
+
+    @Test
+    fun `a vehicle just outside the band is early or late`() {
+        assertEquals("91 s ahead is early", Status.EARLY, status((-91).seconds))
+        assertEquals("91 s behind is late", Status.DELAYED, status(91.seconds))
+    }
+
+    @Test
+    fun `a vehicle just inside the band is on time`() {
+        assertEquals("89 s ahead is on time", Status.ON_TIME, status((-89).seconds))
+        assertEquals("89 s behind is on time", Status.ON_TIME, status(89.seconds))
+    }
+
+    /**
+     * iOS buckets with `minutesDiff < -1.5` then `< 1.5`, making the band half-open: exactly 90 s
+     * early is on time, exactly 90 s late is not. Pinned so a later refactor to a symmetric
+     * comparison doesn't silently drift off parity at the edge.
+     */
+    @Test
+    fun `the band edges match the iOS half-open comparison`() {
+        assertEquals("exactly 90 s ahead is still on time", Status.ON_TIME, status((-90).seconds))
+        assertEquals("exactly 90 s behind is late", Status.DELAYED, status(90.seconds))
+    }
+
+    @Test
+    fun `a vehicle exactly on schedule is on time`() {
+        assertEquals(Status.ON_TIME, status(Duration.ZERO))
+    }
+
+    @Test
+    fun `large deviations stay in their buckets`() {
+        assertEquals(Status.EARLY, status((-2).hours))
+        assertEquals(Status.DELAYED, status(2.hours))
+    }
+
+    /** The `predicted == false` case: there is nothing measured, so the deviation must be ignored. */
+    @Test
+    fun `without real-time the state is scheduled regardless of deviation`() {
+        assertEquals(Status.SCHEDULED, status(Duration.ZERO, isRealtime = false))
+        assertEquals(Status.SCHEDULED, status(30.minutes, isRealtime = false))
+        assertEquals(Status.SCHEDULED, status((-30).minutes, isRealtime = false))
+    }
+
+    @Test
+    fun `the color helpers agree with the bucketing`() {
+        assertEquals(R.color.stop_info_early, ScheduleDeviation.statusColor(true, (-91).seconds))
+        assertEquals(R.color.stop_info_ontime, ScheduleDeviation.statusColor(true, 89.seconds))
+        assertEquals(R.color.stop_info_delayed, ScheduleDeviation.statusColor(true, 91.seconds))
+        assertEquals(R.color.stop_info_scheduled_time, ScheduleDeviation.statusColor(false, 91.seconds))
+
+        assertEquals(R.color.stop_info_early_fill, ScheduleDeviation.fillColor(true, (-91).seconds))
+        assertEquals(R.color.stop_info_ontime_fill, ScheduleDeviation.fillColor(true, 89.seconds))
+        assertEquals(R.color.stop_info_delayed_fill, ScheduleDeviation.fillColor(true, 91.seconds))
+        assertEquals(R.color.stop_info_scheduled_fill, ScheduleDeviation.fillColor(false, 91.seconds))
+    }
+
+    /**
+     * The four states must be four *distinct* colors in both tiers. This is what broke on the agencyY
+     * flavor, where on-time resolved through the brand color and collided with late — a rebrand could
+     * make two states indistinguishable without any code change.
+     */
+    @Test
+    fun `every state has its own color in both tiers`() {
+        val foreground = Status.entries.map { it.colorRes }
+        val fill = Status.entries.map { it.fillColorRes }
+
+        assertEquals("foreground tier has a distinct color per state", Status.entries.size, foreground.toSet().size)
+        assertEquals("on-fill tier has a distinct color per state", Status.entries.size, fill.toSet().size)
+        for (state in Status.entries) {
+            assertNotEquals(
+                "${state.name} must not use the same resource for text and fill",
+                state.colorRes,
+                state.fillColorRes
+            )
+        }
+    }
+}


### PR DESCRIPTION
Closes #2043.

Color conveyed schedule deviation in six places that disagreed with each other and with OBA iOS on almost every axis. This brings the whole surface to parity.

## The on-time band

`computeColorFromDeviation` bucketed on a strict sign test, and its input had already been truncated to whole minutes-past-epoch by the caller — so "on time" meant the predicted and scheduled minute-past-epoch were *exactly equal*. A bus 20 s late rendered late, and on live data the green on-time state was nearly never shown.

The color oracle moves out of `ArrivalInfoUtils.java` into Kotlin as `util/ScheduleDeviation` (every caller was already Kotlin), takes a full-precision `kotlin.time.Duration`, and applies iOS's ±1.5 minute band. `ArrivalInfo` stops flooring before the color call; `TripLogBuilder` drops its own `roundToLong` ±30 s window. The five different deviation→minutes rules that existed across the app become one:

| site | was | now |
|---|---|---|
| `ArrivalInfo` | floor each epoch, then subtract — zero-width band | `ScheduleDeviation` |
| `TripDetailsRepository` | `inWholeMinutes` — ±59 s | `ScheduleDeviation` |
| `VehicleBitmaps` / `VehicleInfoWindow` | `inWholeMinutes` — ±59 s | `ScheduleDeviation` |
| `TripLogBuilder` | `roundToLong` — ±30 s | `ScheduleDeviation` |
| `ConversionUtils` | **milliseconds passed to a minutes parameter** | `ScheduleDeviation` |

## The palette

`stop_info_*` adopts the iOS values and is **decoupled from `brand_color`** — deviation status is semantic, not brand identity. agencyY previously rendered on-time and late as the same blue; agencyX and kiedybus hardcoded on-time back to green to paper over it, and those overrides are gone. The `values-night` variants that never existed are added.

The palette is **two tiers**, which is the one place this goes beyond the issue. `EtaPill`, the starred-stop badges, the trip-details status pill and the map info-window chip all paint `Color.White` *on* the deviation color, where the iOS hexes fail AA:

| | white-on-fill |
|---|---|
| `#FF3B30` early | 3.55 |
| `#129900` on time | 3.76 |
| `#007AFF` late | 4.02 |
| `#8E8E93` scheduled | 3.26 |

So the iOS hexes are the **foreground** tier (text/glyph), and a parallel `stop_info_*_fill` tier — darkened to 4.8:1 white-on — backs every filled surface. This generalizes the reasoning the old `badge_*` colors already encoded to the pill, which had identical mechanics. iOS has this hazard unaddressed and we deliberately don't copy that part.

**Known tradeoff, flagged for review:** as *text on a light surface* the foreground hexes are 2.95–4.02:1, below AA for small text. That is inherent to matching the iOS values and is what the app ships today for the arrivals ETA (which is 30sp, comfortably over the 3:1 large-text threshold). The remaining small-text foreground uses are the trip-planner chip label and the directions time span. Happy to darken the light-mode foreground tier if you'd rather have AA than literal parity.

## The map

Vehicle discs are colored by `ObaRoute.color` (brand fallback, gray when not real-time) with no deviation input — at map zoom a colored disc reads as identity, not punctuality, which is also what iOS does. Deviation keeps its home in the info window.

The bitmap cache key becomes the **resolved ARGB** rather than a color resource id, since a route color is a raw ARGB int off the wire with no resource id. That also closes a latent staleness bug: the same resource id resolving to a different color across a light/dark switch was invisible to the old key.

Note `iconKey` gains a `Context` parameter to resolve the fallback.

## Dependent palettes

- `trip_realtime_*` retired — its blue meant "early" where the arrivals drawer's blue meant "late", in the same app.
- `badge_*` re-derived from the new palette and re-verified for contrast (they can't just alias it).
- The trip-details on-time → `theme_primary` remap dropped; it existed only because on-time was brand-tinted.
- The help legend reads its swatches from `ScheduleDeviation.Status` so it can't document a palette the app no longer paints, and its labels now state the band.
- `MyListRepository.badgeColor` reverse-mapped the foreground color resource id back to a badge color and silently fell through to "scheduled" for anything unrecognized — the badge now takes the fill tier off the arrival directly.

## Sign-off needed: the ±1.5 minute threshold

±1.5 min is a magic threshold, which CLAUDE.md's "No unsanctioned heuristics" rule gates on explicit human approval rather than an implementer's judgment. It is sanctioned by a **named upstream source** — the iOS app's shipped behavior, `ArrivalDeparture.swift:305` — rather than invented, and the assumption, its provenance and its failure mode are documented at the constant. Calling it out here per that rule.

## Testing

- `ScheduleDeviationTest` (new, 8 tests) — band boundaries including the half-open edges at exactly ±90 s, the not-real-time case, and that all four states have distinct colors in both tiers (the agencyY collision, as a test).
- `ArrivalInfoTest` (+7) — the arrivals path end to end at ±89/±91 s, the headline "60 s late is green / 120 s late is blue" case, a 1-second deviation straddling a minute boundary (the exact shape the old flooring got wrong), and `predicted == false`.
- `TripLogBuilderTest` (+5) — the same boundaries through the trip-planner path, plus that a Late/Early chip can never read "0 min".
- `VehicleIconAllocationTest` — the early-vs-late key assertion is replaced by a liveness one, plus a new test pinning that deviation must **not** affect the icon.
- `./gradlew testObaGoogleDebugUnitTest` green; `compileObaGoogleDebugKotlin` + `compileObaMaplibreDebugKotlin` + `compileObaGoogleDebugAndroidTestKotlin` clean under `-PwarningsAsErrors=true`; `spotlessCheck` clean; resources process for all four brands.

Not run locally: `lintObaGoogleDebug` (per CLAUDE.md, left to CI) and the instrumented suite.

## Not done

On-device visual verification of the light/dark swatches and the route-colored markers — the test phone is shared, so I left it alone. Worth a look before merge, particularly the ETA strip in dark mode and a route whose feed omits `route.color` (should fall back to brand).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized schedule-deviation styling with separate foreground and filled “chip” tiers across arrivals, trip details, real-time chips, and help legends.
  * Vehicle marker icons now use resolved route-color contrast for clearer realtime vs scheduled visuals.
* **Bug Fixes**
  * Improved vehicle icon caching so icons update correctly across renderer contexts, and ensured schedule-deviation changes don’t incorrectly alter icons.
* **Documentation**
  * Updated rebranding and help legend guidance to discourage overriding `stop_info_*` timing colors and clarified on-time/early/late thresholds.
* **Tests**
  * Added/expanded schedule-deviation boundary/bucketing and icon allocation/cache tests, including prediction-off cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->