### PR TITLE
Expand a directions leg by its chevron, not by tapping the row

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/DirectionRowFocusTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/DirectionRowFocusTest.kt
@@ -16,9 +16,7 @@
 package org.onebusaway.android.ui.tripresults
 
 import androidx.compose.material3.Text
-import androidx.compose.ui.semantics.SemanticsActions
-import androidx.compose.ui.test.SemanticsMatcher
-import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.platform.app.InstrumentationRegistry
@@ -32,21 +30,14 @@ import org.onebusaway.android.ui.compose.createUnconfinedComposeRule
 import org.onebusaway.android.util.GeoPoint
 
 /**
- * Verifies the trip-log tap wiring in [TripResultsList]. Tapping a **leg header** both highlights it on
- * the map (a transit leg → its route via `onFocusRouteLeg`; a walk leg → its polyline via `onFocusLeg`)
- * *and* expands its minor events inline — a walk's turn steps, a ride's intermediate stops — each of which
- * then focuses its own point. A transit leg's Board stop shows its live ETA strip. Drives the real click
- * wiring by node text, not coordinates.
+ * Verifies the trip-log tap wiring in [TripResultsList]. Tapping a **leg header** highlights it on the
+ * map (a transit leg → its route via `onFocusRouteLeg`; a walk leg → its polyline via `onFocusLeg`); its
+ * minor events — a walk's turn steps, a ride's intermediate stops — expand only via the leg's own chevron
+ * control, never as a side effect of the map-focus tap (#2040). A revealed step/stop then focuses its own
+ * point. A transit leg's Board stop shows its live ETA strip. Drives the real click wiring by node text
+ * (and, for the chevron, its content description), not coordinates.
  */
 class DirectionRowFocusTest {
-
-    /**
-     * The row's own accessibility label for what its tap does. The expand affordance is the row, not the
-     * chevron (which is decorative), so this is the only thing that announces "Show steps" to TalkBack.
-     */
-    private fun hasClickLabel(label: String?) = SemanticsMatcher("click label is $label") {
-        it.config.getOrElseNullable(SemanticsActions.OnClick) { null }?.label == label
-    }
 
     // See createUnconfinedComposeRule for why Unconfined composition is used here (issue #1792).
     @get:Rule
@@ -115,23 +106,36 @@ class DirectionRowFocusTest {
 
     private val fullState = state(listOf(start, walk, transit, arrive))
 
+    // Isolates one expandable leg at a time, so its chevron's content description is the only node
+    // carrying the expand/collapse label — fullState has two expandable legs sharing that label.
+    private val walkOnlyState = state(listOf(start, walk, arrive))
+    private val transitOnlyState = state(listOf(start, transit, arrive))
+
     private val walkAction = context.getString(R.string.step_by_step_non_transit_mode_walk_action)
     private val midStopName = "Capitol Hill Station"
 
     @Test
-    fun tappingWalkHeader_framesTheLeg_andRevealsItsSteps() {
+    fun tappingWalkHeader_framesTheLeg_withoutRevealingItsSteps() {
         var framed: List<GeoPoint>? = null
         var focused: GeoPoint? = null
         composeRule.setContent {
-            TripResultsList(state = fullState, onFocusLeg = { framed = it }, onFocusPoint = { focused = it })
+            TripResultsList(state = walkOnlyState, onFocusLeg = { framed = it }, onFocusPoint = { focused = it })
         }
 
         // The walk's turn steps are collapsed to start.
         composeRule.onNodeWithText(walk.steps.single().text).assertDoesNotExist()
 
-        // Tapping the walk header frames the leg and reveals its steps.
+        // Tapping the walk header frames the leg but does not reveal its steps (#2040) — that's the
+        // chevron's job, checked separately below.
         composeRule.onNodeWithText(walkAction).performClick()
         assertEquals(walkLegPoints, framed)
+        composeRule.onNodeWithText(walk.steps.single().text).assertDoesNotExist()
+
+        // Tapping the chevron reveals the steps without re-framing the leg.
+        framed = null
+        composeRule.onNodeWithContentDescription(context.getString(R.string.trip_plan_expand_leg))
+            .performClick()
+        assertNull(framed)
         composeRule.onNodeWithText(walk.steps.single().text).assertExists()
 
         // The revealed step focuses its own point.
@@ -140,12 +144,12 @@ class DirectionRowFocusTest {
     }
 
     @Test
-    fun tappingTransitHeader_highlightsRoute_andRevealsIntermediateStops() {
+    fun tappingTransitHeader_highlightsRoute_withoutRevealingIntermediateStops() {
         var captured: Pair<RouteLegRef, List<GeoPoint>>? = null
         var focused: GeoPoint? = null
         composeRule.setContent {
             TripResultsList(
-                state = fullState,
+                state = transitOnlyState,
                 onFocusRouteLeg = { rl, pts -> captured = rl to pts },
                 onFocusPoint = { focused = it }
             )
@@ -154,10 +158,17 @@ class DirectionRowFocusTest {
         // The intermediate stop is collapsed to start.
         composeRule.onNodeWithText(midStopName).assertDoesNotExist()
 
-        // Tapping the transit header highlights the route and reveals the stops.
+        // Tapping the transit header highlights the route but does not reveal the stops (#2040).
         composeRule.onNodeWithText(transitTitle).performClick()
         assertEquals("1_100", captured?.first?.routeId)
         assertEquals(transitLegPoints, captured?.second)
+        composeRule.onNodeWithText(midStopName).assertDoesNotExist()
+
+        // Tapping the chevron reveals the stops without re-highlighting the route.
+        captured = null
+        composeRule.onNodeWithContentDescription(context.getString(R.string.trip_plan_expand_leg))
+            .performClick()
+        assertNull(captured)
         composeRule.onNodeWithText(midStopName).assertExists()
 
         // The revealed stop focuses its own point.
@@ -166,29 +177,28 @@ class DirectionRowFocusTest {
     }
 
     @Test
-    fun aLegHeaderAnnouncesWhatItsTapDoesToTheSteps() {
-        composeRule.setContent { TripResultsList(state = fullState) }
+    fun theChevronAnnouncesWhatItsTapDoesToTheSteps() {
+        composeRule.setContent { TripResultsList(state = walkOnlyState) }
 
-        // Collapsed: both headers offer to reveal. The chevron itself is decorative — the label lives on
-        // the row, which is the actual control (an IconButton would be a second, competing target).
-        composeRule.onNodeWithText(walkAction)
-            .assert(hasClickLabel(context.getString(R.string.trip_plan_expand_leg)))
-        composeRule.onNodeWithText(transitTitle)
-            .assert(hasClickLabel(context.getString(R.string.trip_plan_expand_leg)))
+        // Collapsed: the chevron offers to reveal.
+        composeRule.onNodeWithContentDescription(context.getString(R.string.trip_plan_expand_leg))
+            .assertExists()
 
         // …and once expanded it offers the inverse.
-        composeRule.onNodeWithText(walkAction).performClick()
-        composeRule.onNodeWithText(walkAction)
-            .assert(hasClickLabel(context.getString(R.string.trip_plan_collapse_leg)))
+        composeRule.onNodeWithContentDescription(context.getString(R.string.trip_plan_expand_leg))
+            .performClick()
+        composeRule.onNodeWithContentDescription(context.getString(R.string.trip_plan_collapse_leg))
+            .assertExists()
     }
 
     @Test
-    fun aLegWithNoMinorEventsOffersNoExpandLabel() {
+    fun aLegWithNoMinorEventsShowsNoChevron() {
         val bare = walk.copy(steps = emptyList())
         composeRule.setContent { TripResultsList(state = state(listOf(bare, arrive))) }
 
-        // Nothing to reveal, so the row keeps its plain "activate" affordance rather than promising steps.
-        composeRule.onNodeWithText(walkAction).assert(hasClickLabel(null))
+        // Nothing to reveal, so no chevron is rendered at all.
+        composeRule.onNodeWithContentDescription(context.getString(R.string.trip_plan_expand_leg))
+            .assertDoesNotExist()
     }
 
     @Test

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
@@ -44,6 +44,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -539,16 +540,15 @@ private fun LogRow(
 
         is RowContent.WalkHeader -> {
             val walk = content.entry
+            // The row's tap only frames the leg on the map; expanding its steps is the chevron's own
+            // tap target (#2040), not a side effect of this one.
             LogRowScaffold(
                 model = model,
                 onClick = {
                     if (walk.legPoints.isNotEmpty()) onFocusLeg(walk.legPoints) else walk.focusPoint?.let(onFocusPoint)
-                    if (model.expandable) onToggle(i)
                 },
-                // The row is one control that both frames the leg and unfolds its steps, so the expand
-                // wording rides on the row's own click label rather than on a decorative chevron.
-                onClickLabel = expandLabel(model)
-            ) { WalkHeaderContent(walk, model) }
+                onToggleExpand = { onToggle(i) }
+            ) { WalkHeaderContent(walk) }
         }
 
         is RowContent.Step ->
@@ -563,14 +563,10 @@ private fun LogRow(
 
         is RowContent.BoardHeader -> {
             val transit = content.entry
-            LogRowScaffold(model, onClick = null) {
+            LogRowScaffold(model, onClick = null, onToggleExpand = { onToggle(i) }) {
                 BoardContent(
                     entry = transit,
-                    model = model,
-                    onToggle = {
-                        focusTransit(transit, onFocusRouteLeg, onFocusLeg, onFocusPoint)
-                        if (model.expandable) onToggle(i)
-                    },
+                    onFocus = { focusTransit(transit, onFocusRouteLeg, onFocusLeg, onFocusPoint) },
                     onFocusPoint = onFocusPoint,
                     stopEtaStrip = stopEtaStrip
                 )
@@ -642,6 +638,7 @@ private fun LogRowScaffold(
     onClick: (() -> Unit)?,
     onClickLabel: String? = null,
     compact: Boolean = false,
+    onToggleExpand: (() -> Unit)? = null,
     content: @Composable ColumnScope.() -> Unit
 ) {
     val context = LocalContext.current
@@ -729,6 +726,17 @@ private fun LogRowScaffold(
                 ),
             content = content
         )
+        // Its own segment at the row's right edge — centred on the row's full height, not just the
+        // header line's — rather than sharing the content column's Row and bumping that line's height
+        // out to the chevron's touch target (#2040).
+        if (model.expandable && onToggleExpand != null) {
+            ExpandChevron(
+                expanded = model.expanded,
+                onToggle = onToggleExpand,
+                label = expandLabel(model),
+                modifier = Modifier.align(Alignment.CenterVertically)
+            )
+        }
     }
 }
 
@@ -964,17 +972,13 @@ private fun streetActionRes(mode: StreetMode, isTransfer: Boolean): Int = when (
 }
 
 @Composable
-private fun ColumnScope.WalkHeaderContent(entry: TripLogEntry.Walk, model: LogRowModel) {
+private fun ColumnScope.WalkHeaderContent(entry: TripLogEntry.Walk) {
     val context = LocalContext.current
-    Row(verticalAlignment = Alignment.CenterVertically) {
-        Text(
-            text = stringResource(streetActionRes(entry.mode, entry.isTransfer)),
-            style = MaterialTheme.typography.bodyLarge,
-            color = MaterialTheme.colorScheme.onSurface,
-            modifier = Modifier.weight(1f)
-        )
-        if (model.expandable) Chevron(model.expanded)
-    }
+    Text(
+        text = stringResource(streetActionRes(entry.mode, entry.isTransfer)),
+        style = MaterialTheme.typography.bodyLarge,
+        color = MaterialTheme.colorScheme.onSurface
+    )
     val meta = walkMeta(entry, context)
     if (meta.isNotEmpty()) {
         Text(
@@ -1011,20 +1015,20 @@ private fun ColumnScope.StepDistanceContent(distanceMeters: Double) {
 @Composable
 private fun ColumnScope.BoardContent(
     entry: TripLogEntry.Transit,
-    model: LogRowModel,
-    onToggle: () -> Unit,
+    onFocus: () -> Unit,
     onFocusPoint: (GeoPoint) -> Unit,
     stopEtaStrip: @Composable (RouteLegRef, RouteStopRef, List<GeoPoint>) -> Unit
 ) {
     val context = LocalContext.current
-    // The route/headsign/meta block toggles the leg (and highlights it on the map); the board stop + ETA
-    // strip below is its own tap target that zooms to the stop. Because the control is this inner block
-    // rather than the whole row, the scaffold's touch-target floor doesn't reach it — so it carries its
-    // own. (Its content clears 48dp on its own in practice; this is the guarantee, not the usual case.)
+    // The route/headsign/meta block highlights the leg on the map; expanding its steps is the scaffold's
+    // own chevron segment (#2040), not a side effect of this tap. The board stop + ETA strip below is a
+    // third, separate tap target that zooms to the stop. Because this control is this inner block rather
+    // than the whole row, the scaffold's touch-target floor doesn't reach it — so it carries its own. (Its
+    // content clears 48dp on its own in practice; this is the guarantee, not the usual case.)
     Column(
         Modifier
             .defaultMinSize(minHeight = ROW_MIN_TOUCH_HEIGHT)
-            .clickable(onClickLabel = expandLabel(model), onClick = onToggle)
+            .clickable(onClick = onFocus)
     ) {
         // A ride the rider may take on more than one route (#2010) badges them all as one joined
         // roundel; an ordinary ride badges its own route exactly as before. A route that publishes no
@@ -1049,7 +1053,6 @@ private fun ColumnScope.BoardContent(
             } else {
                 Spacer(Modifier.weight(1f))
             }
-            if (model.expandable) Chevron(model.expanded)
         }
         entry.headsign?.let {
             Text(
@@ -1192,18 +1195,20 @@ private fun RealtimeChip(state: RealtimeState) {
 }
 
 /**
- * The expand/collapse chevron shown on a leg with minor events; rotates via the up/down glyph. Purely
- * decorative (no content description) — it isn't its own control, it just pictures what the row's tap
- * will do, which the row announces through its own click label (see [expandLabel]).
+ * The expand/collapse control for a leg with minor events, shown as the up/down chevron glyph. This is
+ * its own tap target — separate from the row's tap, which frames the leg on the map — so opening the
+ * steps is never a side effect of a map-focus tap (#2040). [label] carries the expand/collapse wording
+ * since the glyph swap alone isn't announced to a screen reader.
  */
 @Composable
-private fun Chevron(expanded: Boolean) {
-    Icon(
-        imageVector = if (expanded) AppIcons.KeyboardArrowUp else AppIcons.KeyboardArrowDown,
-        contentDescription = null,
-        tint = MaterialTheme.colorScheme.outline,
-        modifier = Modifier.size(24.dp)
-    )
+private fun ExpandChevron(expanded: Boolean, onToggle: () -> Unit, label: String?, modifier: Modifier = Modifier) {
+    IconButton(onClick = onToggle, modifier = modifier) {
+        Icon(
+            imageVector = if (expanded) AppIcons.KeyboardArrowUp else AppIcons.KeyboardArrowDown,
+            contentDescription = label,
+            tint = MaterialTheme.colorScheme.outline
+        )
+    }
 }
 
 /**


### PR DESCRIPTION
Fixes #2040.

A leg header in the directions drawer did two things on one tap: it framed the leg on the map and it unfolded the leg's minor events. Those are unrelated intentions, and the rider only ever wanted one of them. Tapping a walk leg to see where it goes also shoved every turn step into the list; tapping a ride to highlight its route also pushed the rest of the itinerary down past its intermediate stops. The chevron sitting on the row pictured the expansion but could not be aimed at, so there was no way to ask for one without the other.

The chevron becomes the control. The row's tap now only focuses the map, and expanding is an `IconButton` the rider can hit deliberately.

The expand/collapse wording moves with it. It was riding on the row's click label, which is now wrong — the row no longer expands anything — so it becomes the chevron's content description. The chevron stops being decorative, so it gets a description at all.

### Where the chevron sits

It's placed by `LogRowScaffold` at the row's right edge, centred on the row's full height, rather than inside the header's text `Row`:

- Sharing that `Row` meant a 48dp touch target set the height of the line holding the "Walk" label, padding it out.
- It also centred the glyph on the header line alone, so on a transit row — badge, headsign, meta, board stop, ETA strip — it sat pinned to the top line instead of the row's middle.
- Placing it in the scaffold puts both header kinds' chevrons in one place, so `WalkHeaderContent` and `BoardContent` no longer need the row model to draw one.

### Tests

`DirectionRowFocusTest` drives expansion by the chevron's content description and asserts the separation directly: tapping a header focuses the map and leaves the minor events collapsed, and tapping the chevron reveals them without re-focusing.

Two of its cases used the full itinerary, whose two expandable legs would now both answer to that content description, so they use a single-leg state instead.

### Verification

- `compileObaGoogleDebugKotlin -PwarningsAsErrors=true` — clean
- `spotlessCheck` — clean
- `connectedObaGoogleDebugAndroidTest` for `DirectionRowFocusTest` — 9/9 pass on a Pixel 7 Pro (API 36)
- Installed and eyeballed on device

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Leg headers now focus or highlight the corresponding trip segment on the map without expanding details.
  * Dedicated chevron controls expand or collapse walking steps and intermediate transit stops.
  * Expanded details focus their own map locations without re-triggering route highlighting.
  * Chevron controls provide clear accessibility announcements and are hidden when no additional details are available.

* **Bug Fixes**
  * Improved separation between map focusing and detail expansion for more predictable trip-results interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->