### PR TITLE
Give the directions map a colour language, and one for the whole map (#2041)

### DIFF
--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
@@ -59,6 +59,7 @@ import org.onebusaway.android.map.render.MarkerRendering
 import org.onebusaway.android.map.render.PingTarget
 import org.onebusaway.android.map.render.RouteBadge
 import org.onebusaway.android.map.render.RouteContinuation
+import org.onebusaway.android.map.render.RouteLineDash
 import org.onebusaway.android.map.render.RoutePolyline
 import org.onebusaway.android.map.render.RoutePolylineReconciler
 import org.onebusaway.android.map.render.StopMarker
@@ -403,9 +404,12 @@ class GoogleMapRenderer(
     }
 
     private fun PolylineOptions.applyDashPattern(polyline: RoutePolyline): PolylineOptions {
-        if (polyline.dashed) {
-            pattern(listOf(Dash(CONTINUATION_DASH_LENGTH_PX), Gap(CONTINUATION_GAP_LENGTH_PX)))
+        val dashLengthPx = when (polyline.dash) {
+            RouteLineDash.NONE -> return this
+            RouteLineDash.HINT -> HINT_DASH_LENGTH_PX
+            RouteLineDash.TRAIL -> TRAIL_DASH_LENGTH_PX
         }
+        pattern(listOf(Dash(dashLengthPx), Gap(DASH_GAP_LENGTH_PX)))
         return this
     }
 
@@ -809,10 +813,14 @@ class GoogleMapRenderer(
         // The stamp bitmap is twice as long as its chevron, halving repetition without shrinking it.
         private const val CHEVRON_REPEAT_SCALE = 2
 
-        // The route-continuation line's dash pattern (#1691), in screen pixels like every other gms
-        // polyline dimension here.
-        private const val CONTINUATION_DASH_LENGTH_PX = 24f
-        private const val CONTINUATION_GAP_LENGTH_PX = 16f
+        // The dash rhythms named by RouteLineDash, in screen pixels like every other gms polyline
+        // dimension here. A TRAIL stride is twice a HINT's over the same gap, so an itinerary's walking
+        // and cycling legs read as a broken path rather than as the route-continuation line's tight
+        // preview dashes (#1691) — without the dashes running so long that a short leg draws as one
+        // unbroken stroke.
+        private const val HINT_DASH_LENGTH_PX = 24f
+        private const val TRAIL_DASH_LENGTH_PX = HINT_DASH_LENGTH_PX * 2f
+        private const val DASH_GAP_LENGTH_PX = 16f
 
         // The (arbitrary, constant) ease key for a TripEstimateMarker's single-marker easer.
         private const val ESTIMATE_EASE_KEY = "estimate"

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/OTPConstants.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/OTPConstants.kt
@@ -15,7 +15,6 @@
  */
 package org.onebusaway.android.directions.util
 
-import androidx.core.graphics.toColorInt
 import java.util.Locale
 import java.util.concurrent.TimeUnit
 
@@ -65,9 +64,6 @@ object OTPConstants {
 
     // flag to indicate intent sent by or on behalf of TripPlanActivity
     const val INTENT_SOURCE = "org.onebusaway.android.INTENT_SOURCE"
-
-    @JvmField
-    val OTP_TRANSIT_COLOR = "#006500".toColorInt()
 
     enum class Source { ACTIVITY, NOTIFICATION }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/AdjacencyRouteColors.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/AdjacencyRouteColors.kt
@@ -19,7 +19,8 @@ import android.annotation.SuppressLint
 import com.google.android.material.color.utilities.Hct
 
 /**
- * Assigns focused-stop route identities HCT hues at a common chroma and tone. Duplicate identities
+ * Assigns focused-stop route identities hues around the circle, rendered by [mapRouteLineColor] at the
+ * map's common route chroma and tone. Duplicate identities
  * retain their first position. Colors in [retained] survive a presentation handoff. Newly introduced
  * identities take the hue farthest from every color already in
  * use, successively filling the largest gaps around the circle. This keeps every continuing route
@@ -39,23 +40,18 @@ internal fun <K : Any> adjacencyRouteColors(
     if (assigned.isEmpty()) {
         val hueStep = HUE_CIRCLE_DEGREES / keys.size
         keys.forEachIndexed { index, key ->
-            assigned[key] = routeColor(index * hueStep)
+            assigned[key] = mapRouteLineColor(index * hueStep)
         }
     } else {
         val usedHues = assigned.values.mapTo(mutableListOf()) { Hct.fromInt(it).hue }
         keys.filterNot(assigned::containsKey).forEach { key ->
-            val color = routeColor(widestHueGapMidpoint(usedHues))
+            val color = mapRouteLineColor(widestHueGapMidpoint(usedHues))
             assigned[key] = color
             usedHues += Hct.fromInt(color).hue
         }
     }
     return keys.associateWith(assigned::getValue)
 }
-
-// Hct is Material Components' vendored color-science util (LIBRARY_GROUP); no public equivalent
-// exists, so this is deliberate long-term use, not a migration to track (same as LineBadge).
-@SuppressLint("RestrictedApi")
-private fun routeColor(hue: Double): Int = Hct.from(hue, ADJACENCY_ROUTE_CHROMA, ADJACENCY_ROUTE_TONE).toInt()
 
 private fun widestHueGapMidpoint(hues: List<Double>): Double {
     val sorted = hues.sorted()
@@ -65,5 +61,3 @@ private fun widestHueGapMidpoint(hues: List<Double>): Double {
 }
 
 private const val HUE_CIRCLE_DEGREES = 360.0
-private const val ADJACENCY_ROUTE_CHROMA = 75.0
-private const val ADJACENCY_ROUTE_TONE = 55.0

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/DirectionsMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/DirectionsMapController.kt
@@ -15,22 +15,20 @@
  */
 package org.onebusaway.android.map
 
-import android.graphics.Color
-import android.util.Log
 import org.onebusaway.android.directions.model.TripItinerary
 import org.onebusaway.android.directions.model.TripLeg
 import org.onebusaway.android.directions.model.TripLegGeometry
 import org.onebusaway.android.directions.model.TripMode
 import org.onebusaway.android.directions.model.TripVertexType
 import org.onebusaway.android.directions.model.decodedPoints
-import org.onebusaway.android.directions.util.OTPConstants
 import org.onebusaway.android.map.render.RoutePolyline
 import org.onebusaway.android.models.ObaShape
 import org.onebusaway.android.util.GeoPoint
+import org.onebusaway.android.util.parseObaHexColor
 
 /**
  * The trip-plan directions use case (the legacy `DirectionsMapController`): draws an itinerary's legs
- * (each polyline in its own mode color) plus start/end pins, and frames the whole itinerary. A
+ * (each polyline styled by [itineraryLegStyle]) plus start/end pins, and frames the whole itinerary. A
  * synchronous driver over [MapHost] — it has no loader of its own (the itinerary is handed in), so it
  * just writes polylines + markers and dispatches the framing camera command.
  *
@@ -78,17 +76,21 @@ class DirectionsMapController(private val host: MapHost) {
         val endLat = endPlace.lat
         val endLon = endPlace.lon
 
-        // Build every leg's polyline (each in its own mode color), then append them in one write —
+        // Build every leg's polyline (each in its own mode/route style), then append them in one write —
         // matching the legacy per-leg append but without rebuilding the polyline list n times.
         val legPolylines = legs.mapNotNull { leg ->
             val geometry = leg.legGeometry ?: return@mapNotNull null
             val shape = LegShape(geometry)
             if (shape.length > 0) {
-                // An itinerary leg is traversed one way; keep its travel-direction chevrons.
+                val style = itineraryLegStyle(leg.legKind(), parseObaHexColor(leg.routeColor))
+                // Every leg's points run in travel order, so whether it stamps chevrons is the style's
+                // call — a dashed on-street stroke declines them (see [itineraryLegStyle]).
                 RoutePolyline(
-                    resolveLegColor(leg),
+                    style.color,
                     shape.points,
-                    directional = true
+                    widthProfile = style.widthProfile,
+                    directional = style.directional,
+                    dash = style.dash
                 )
             } else {
                 null
@@ -151,23 +153,6 @@ class DirectionsMapController(private val host: MapHost) {
         return point?.let { EndpointMarker(it, host.addMarker(it.latitude, it.longitude, hue)) }
     }
 
-    private fun resolveLegColor(leg: TripLeg): Int {
-        // Color for transit routes when planning a trip.
-        if (leg.mode?.isTransit == true) {
-            return OTPConstants.OTP_TRANSIT_COLOR
-        }
-        // Use the route's custom color if available.
-        leg.routeColor?.let { hex ->
-            try {
-                return java.lang.Long.decode("0xFF$hex").toInt()
-            } catch (ex: Exception) {
-                Log.e(TAG, "Error parsing color=$hex: ${ex.message}")
-            }
-        }
-        // Defaults to grey, which represents walking.
-        return Color.GRAY
-    }
-
     /** An [ObaShape] over a [TripLegGeometry] (ported from the legacy DirectionsMapController). */
     private class LegShape(private val geometry: TripLegGeometry) : ObaShape {
         override val length: Int get() = geometry.length
@@ -176,8 +161,6 @@ class DirectionsMapController(private val host: MapHost) {
     }
 
     companion object {
-        private const val TAG = "DirectionsMapController"
-
         // BitmapDescriptorFactory hues for the directions start/end pins (green/red), kept as literals
         // since the map package can't depend on the Google Maps classes.
         private const val HUE_GREEN = 120.0f

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/ItineraryLegStyle.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/ItineraryLegStyle.kt
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.map
+
+import org.onebusaway.android.directions.model.TripLeg
+import org.onebusaway.android.directions.model.TripMode
+import org.onebusaway.android.directions.model.TripVertexType
+import org.onebusaway.android.map.render.ITINERARY_RIDE_WIDTH_PROFILE
+import org.onebusaway.android.map.render.ITINERARY_STREET_WIDTH_PROFILE
+import org.onebusaway.android.map.render.RouteLineDash
+import org.onebusaway.android.map.render.RouteLineWidthProfile
+
+/**
+ * How one trip-plan itinerary leg is stroked on the directions map (#2041).
+ *
+ * Every leg used to be one of two colours — a single green for anything transit, `Color.GRAY` for
+ * everything else — so a walk, an own-bike ride and a bikeshare ride were indistinguishable, and the
+ * route colour the option card and the directions drawer were already showing never reached the map at
+ * all. Here each leg's stroke is decided from its mode, and a ride keeps its own route's hue, rendered by
+ * [mapRouteLineColor] at the same chroma and tone as every other route line on this map — so a leg reads
+ * as one colour whether the rider looks at the map, the drawer beside it or the option card above.
+ *
+ * Pure and free of `android.graphics` (the colour science is Material's own JVM-side HCT), so
+ * `ItineraryLegStyleTest` covers the whole table on the JVM. Parsing the wire hex is the one part that
+ * isn't, so it happens in the caller and arrives here already an ARGB int.
+ */
+internal data class ItineraryLegStyle(
+    val color: Int,
+    val widthProfile: RouteLineWidthProfile,
+    val dash: RouteLineDash,
+    val directional: Boolean
+)
+
+/**
+ * The stroke vocabulary of an itinerary, narrowed from [TripMode] to the distinctions a rider reads off
+ * the map. Notably [BIKESHARE] splits off [BIKE]: both are `TripMode.BICYCLE`, and telling "walk to the
+ * dock, then ride" from "ride your own bike the whole way" is precisely what the flat grey hid.
+ */
+internal enum class ItineraryLegKind { WALK, BIKE, BIKESHARE, CAR, TRANSIT }
+
+/**
+ * Which stroke this leg draws. A bikeshare leg is a `BICYCLE` leg that *starts* at a rental dock, which is
+ * how OTP models one: walk to the dock, ride, dock again. It reads only the near end deliberately — this
+ * asks what the rider is doing for the whole leg, not where its docks are, which is
+ * [DirectionsMapController.bikeStationIdsFromItinerary]'s question (it reads both ends, because a ride has
+ * a station to show at each).
+ */
+internal fun TripLeg.legKind(): ItineraryLegKind = when {
+    mode?.isTransit == true -> ItineraryLegKind.TRANSIT
+    mode == TripMode.CAR -> ItineraryLegKind.CAR
+    mode == TripMode.BICYCLE ->
+        if (from.vertexType == TripVertexType.BIKESHARE) ItineraryLegKind.BIKESHARE else ItineraryLegKind.BIKE
+    // Everything else walks, matching how the drawer's timeline classifies a leg it has no verb for.
+    else -> ItineraryLegKind.WALK
+}
+
+/**
+ * The stroke for a [kind] leg, given its already-parsed GTFS [routeColor] (null for every non-transit
+ * kind, and for a ride whose agency publishes no colour).
+ *
+ * On-street legs are dashed and thinner than the ride they connect to, mirroring the directions
+ * drawer, where a walk is a dashed spine and a ride a solid one. (The MapLibre renderer draws every
+ * line solid, so there the distinction rests on colour and width alone.)
+ *
+ * They also drop the travel-direction chevrons, which a dashed stroke can't carry: the chevron texture
+ * is stamped along the line, so the dash pattern chops it into fragments and the two read as one
+ * confused broken line rather than as either. A ride keeps them — it's solid, and which way along the
+ * corridor you're carried is worth saying.
+ */
+internal fun itineraryLegStyle(kind: ItineraryLegKind, routeColor: Int?): ItineraryLegStyle = when (kind) {
+    ItineraryLegKind.TRANSIT -> ItineraryLegStyle(
+        // The agency's own colour when it has a usable one; otherwise every ride shares the transit
+        // anchor, as they all did before. Giving colourless rides distinct auto-assigned hues (the way
+        // focused-stop adjacency does) is the rest of #2041, not this pass.
+        color = mapRouteLineColorOrNull(routeColor) ?: anchorColor(TRANSIT_HUE_ANCHOR),
+        widthProfile = ITINERARY_RIDE_WIDTH_PROFILE,
+        dash = RouteLineDash.NONE,
+        directional = true
+    )
+
+    ItineraryLegKind.WALK -> street(WALK_HUE_ANCHOR)
+    ItineraryLegKind.BIKE -> street(BIKE_HUE_ANCHOR)
+    ItineraryLegKind.BIKESHARE -> street(BIKESHARE_HUE_ANCHOR)
+    ItineraryLegKind.CAR -> street(CAR_HUE_ANCHOR)
+}
+
+private fun street(hueAnchor: Int) = ItineraryLegStyle(
+    color = anchorColor(hueAnchor),
+    widthProfile = ITINERARY_STREET_WIDTH_PROFILE,
+    dash = RouteLineDash.TRAIL,
+    directional = false
+)
+
+/**
+ * A mode's hue [anchor] rendered at the map's route chroma and tone, so a mode leg carries exactly the
+ * weight a route line does. The elvis stands in for a `!!`: [mapRouteLineColorOrNull] declines only an
+ * achromatic source, and every anchor below is chromatic — which `ItineraryLegStyleTest` holds to, by
+ * asserting every leg kind draws a colour above the achromatic floor.
+ */
+private fun anchorColor(anchor: Int): Int = mapRouteLineColorOrNull(anchor) ?: anchor
+
+// The mode hue anchors. Only each colour's *hue* survives — [mapRouteLineColor] supplies the chroma and
+// tone — so these read as "walking is green", not as literal strokes, and tuning one means moving it
+// around the hue circle. They're spread far apart, and away from the transit anchor, so no two modes of
+// one itinerary read as the same thing.
+private const val WALK_HUE_ANCHOR = 0xFF1D9914.toInt()
+private const val BIKE_HUE_ANCHOR = 0xFF007E8F.toInt()
+
+// Takes its hue from the bikeshare map layer's own colour (`R.color.layer_bikeshare_color`), so a
+// bikeshare leg is drawn in the family of the dock markers at both its ends. A literal rather than a
+// resource read: only the hue is wanted, and this file has no `Context` to resolve one with.
+private const val BIKESHARE_HUE_ANCHOR = 0xFF3A4677.toInt()
+private const val CAR_HUE_ANCHOR = 0xFF8A6D00.toInt()
+
+// The fallback for a ride whose agency publishes no usable colour. It was OTP's green, which walking now
+// owns — a colourless ride takes the terracotta walking vacated rather than sit a few degrees off it.
+private const val TRANSIT_HUE_ANCHOR = 0xFFC4400F.toInt()

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapRouteColors.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapRouteColors.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.map
+
+import android.annotation.SuppressLint
+import com.google.android.material.color.utilities.Hct
+import org.onebusaway.android.util.routeColorHctOrNull
+
+/**
+ * What a route line looks like on the map: one chroma and one tone, whatever the hue and wherever the
+ * hue came from — an agency's GTFS colour ([mapRouteLineColorOrNull]) or one the app assigned itself
+ * ([mapRouteLineColor], which [adjacencyRouteColors] spreads around the circle). A generated line and a
+ * GTFS one therefore differ only in hue, which is the one thing that carries meaning.
+ *
+ * **Every** route line drawn on this map goes through here — the route picker's full-route view, the
+ * ridden segment under a tapped directions leg, focused-stop adjacency, a selected vehicle's trip and its
+ * continuation hint, an itinerary's transit legs, and the badges that label them. Before, a route drawn
+ * from route focus used the agency's raw hex while the same route drawn under adjacency or in an
+ * itinerary used a generated or re-toned colour, so one route changed colour as the user moved between
+ * views of it. The hue still comes from wherever it always did; only the rendering is now shared.
+ *
+ * Deliberately theme-independent, unlike the badge/spine tones in `LineBadge.kt`: those sit on a
+ * Material surface and flip with it, while these sit on a basemap that carries its own light and dark
+ * styles, at a mid tone legible against both. The two policies share only
+ * [routeColorHctOrNull] — reading an agency colour and deciding whether it has a hue worth keeping — so a
+ * route reads as the same *hue* on the map as in the drawer beside it, rendered for its own backdrop.
+ */
+// Hct is Material Components' vendored color-science util (LIBRARY_GROUP); no public equivalent
+// exists, so this is deliberate long-term use, not a migration to track (same as LineBadge).
+@SuppressLint("RestrictedApi")
+internal fun mapRouteLineColor(hue: Double): Int = Hct.from(hue, MAP_ROUTE_CHROMA, MAP_ROUTE_TONE).toInt()
+
+/**
+ * [source]'s hue at the map's route chroma/tone, or null when it is absent or achromatic — grey, black
+ * or white, with no hue to carry over. A caller decides for itself what to draw instead, since the right
+ * substitute depends on what the line is (see `ItineraryLegStyle`).
+ */
+@SuppressLint("RestrictedApi")
+internal fun mapRouteLineColorOrNull(source: Int?): Int? = routeColorHctOrNull(source)?.let { mapRouteLineColor(it.hue) }
+
+private const val MAP_ROUTE_CHROMA = 75.0
+private const val MAP_ROUTE_TONE = 55.0

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
@@ -43,6 +43,7 @@ import org.onebusaway.android.map.render.MapRenderState
 import org.onebusaway.android.map.render.MapVehicles
 import org.onebusaway.android.map.render.ROUTE_LINE_WIDTH_DP
 import org.onebusaway.android.map.render.RouteContinuation
+import org.onebusaway.android.map.render.RouteLineDash
 import org.onebusaway.android.map.render.RouteLineWidthProfile
 import org.onebusaway.android.map.render.RoutePolyline
 import org.onebusaway.android.map.render.VehicleMarker
@@ -474,8 +475,13 @@ class RouteMapController(
         publishMapPresentation()
     }
 
-    /** The shown route's GTFS color (the band tint's basis), or the default when it carries none. */
-    private fun currentRouteColor(): Int = (_loadedRoute.value as? LoadedRoute.Loaded)?.route?.color ?: DEFAULT_ROUTE_LINE_COLOR
+    /**
+     * The shown route's colour as this map draws it (also the band tint's basis): the agency's hue put
+     * through the shared route-line policy, or the default when the route carries no usable colour. This
+     * is what a ridden directions leg's highlighted segment is drawn in, so tapping a leg in the drawer
+     * lands on the same colour the itinerary's own line had.
+     */
+    private fun currentRouteColor(): Int = mapRouteLineColorOrNull((_loadedRoute.value as? LoadedRoute.Loaded)?.route?.color) ?: DEFAULT_ROUTE_LINE_COLOR
 
     /**
      * Resolve (or clear) the selected vehicle's route continuation (#1691); driven by [selectionJob]'s
@@ -521,13 +527,13 @@ class RouteMapController(
         val badgePoint = neighborShape.interpolate(CONTINUATION_LINE_LENGTH_METERS / 2) ?: return null
         val endSeg = neighborShape.segmentIndex(CONTINUATION_LINE_LENGTH_METERS)
         val arrowPoint = neighborShape.interpolate(CONTINUATION_LINE_LENGTH_METERS, endSeg) ?: return null
-        val lineColor = neighbor.routeColor ?: CONTINUATION_FALLBACK_LINE_COLOR
+        val lineColor = mapRouteLineColorOrNull(neighbor.routeColor) ?: CONTINUATION_FALLBACK_LINE_COLOR
         return RouteContinuation(
             polyline = RoutePolyline(
                 color = lineColor,
                 points = listOf(anchor) + tail,
                 widthProfile = CONTINUATION_LINE_WIDTH_PROFILE,
-                dashed = true
+                dash = RouteLineDash.HINT
             ),
             arrow = ContinuationArrow(arrowPoint, neighborShape.bearingAt(endSeg)),
             badge = ContinuationBadge(
@@ -691,6 +697,9 @@ class RouteMapController(
     // state is resolved into plain data first ([selectedTripRenderInput]); the mode-merging policy lives
     // in the pure function, so this stays a plumb-through.
     private fun publishMapPresentation() {
+        // Both the selected trip's fallback and the ridden segment draw in the shown route's colour;
+        // resolve it once so a publish runs the colour policy a single time.
+        val routeColor = currentRouteColor()
         val plan = assembleRouteMapPresentation(
             isActive = isActive,
             emphasizedRoute = routeId?.let { RouteDirectionKey(it, presentationDirectionId) },
@@ -701,14 +710,14 @@ class RouteMapController(
             focusedStops = focusedStops,
             focusedRoutes = focusedRoutes,
             routeColors = _focusedRouteColors.value,
-            selected = selectedTripRenderInput(),
+            selected = selectedTripRenderInput(routeColor),
             projectedFocusStops = {
                 stopFocusSession?.let { projectFocusedStops(it.trips, focusedGeometry, focusedStops) }.orEmpty()
             }
         )
         renderState.setRoutePolylines(
             // Over a highlighted leg segment: thin the full route to context + the ridden span on top.
-            polylines = routePolylinesWithSegment(plan.polylines, highlightedSegment, currentRouteColor()),
+            polylines = routePolylinesWithSegment(plan.polylines, highlightedSegment, routeColor),
             framingPolylines = plan.framingPolylines,
             routeModeScalesStopsWithZoom = plan.routeModeScalesStopsWithZoom
         )
@@ -719,14 +728,15 @@ class RouteMapController(
     /**
      * The selected vehicle's render inputs, or null when no vehicle is selected or its exact shape +
      * schedule haven't both resolved yet. Resolves the IO-backed pieces ([selectedTripPresentation],
-     * the GTFS colour fallback, the direction underlay, the projected stop presentation) so the pure
-     * assembler gets plain data.
+     * the direction underlay, the projected stop presentation) so the pure assembler gets plain data.
+     * [routeColor] is the shown route's drawn colour, passed in rather than re-resolved so one publish
+     * puts the route through the colour policy once.
      */
-    private fun selectedTripRenderInput(): SelectedTripRenderInput? {
+    private fun selectedTripRenderInput(routeColor: Int): SelectedTripRenderInput? {
         val selected = selectedTripPresentation() ?: return null
         return SelectedTripRenderInput(
             presentation = selected,
-            routeColorFallback = currentRouteColor(),
+            routeColorFallback = routeColor,
             // Deferred: the assembler resolves the underlay only when selectedTripStyle keeps it (stop
             // focus inactive) and the stop projection only for a drawable trip, so neither is computed on
             // the branches that skip it.
@@ -926,8 +936,8 @@ class RouteMapController(
     /**
      * The drawn lines for [directionId]'s shape: the selected direction's own travel-ordered shape
      * (with direction arrows), or the whole-route merged shape drawn undirected when [directionId] is
-     * null. Passes the route's raw GTFS color through; the render layer picks the fallback when it's
-     * absent. Uses [focusedRoutePolyline], the same complete line presentation as a route selected
+     * null. Puts the route's GTFS colour through the map's route-line policy; the render layer picks the
+     * fallback when the route has no usable colour of its own. Uses [focusedRoutePolyline], the same complete line presentation as a route selected
      * from focused-stop mode. shapeForDirection pairs the drawn shape with its directionality, so
      * arrows are stamped only when the direction's own travel-ordered shape is used — never on the
      * whole-route merged fallback (a direction that carried no shape on the wire).
@@ -937,12 +947,10 @@ class RouteMapController(
     /** [directionPolylines] against an explicit [route] map — used to draw an interline's extra routes. */
     private fun directionPolylines(route: RouteMap, directionId: Int?): List<RoutePolyline> {
         val shape = route.shapeForDirection(directionId)
+        // One colour for the whole shape — a gapped route draws several polylines, all the same route.
+        val color = mapRouteLineColorOrNull(route.route?.color)
         return shape.polylines.map { points ->
-            focusedRoutePolyline(
-                color = route.route?.color,
-                points = points,
-                directional = shape.directional
-            )
+            focusedRoutePolyline(color = color, points = points, directional = shape.directional)
         }
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteSegmentHighlight.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteSegmentHighlight.kt
@@ -15,7 +15,7 @@
  */
 package org.onebusaway.android.map
 
-import org.onebusaway.android.map.render.ROUTE_LINE_WIDTH_PROFILE
+import org.onebusaway.android.map.render.ITINERARY_RIDE_WIDTH_PROFILE
 import org.onebusaway.android.map.render.RoutePolyline
 import org.onebusaway.android.models.ObaStop
 import org.onebusaway.android.util.GeoPoint
@@ -39,8 +39,13 @@ internal fun List<GeoPoint>.isDrawableSegment() = size >= 2
 
 /**
  * Compose the route's polylines when [segment] is highlighted: the full route [base] de-emphasized
- * (thin, no arrows) under the segment drawn at normal width in [routeColor], last so it sits on top.
+ * (thin, no arrows) under the ridden segment in [routeColor], last so it sits on top.
  * Returns [base] unchanged when there's no drawable segment (plain route focus).
+ *
+ * The segment keeps [ITINERARY_RIDE_WIDTH_PROFILE] — the very weight it had as a leg of the itinerary it
+ * was tapped from — so drilling into a leg thins the route around it without also thinning the ride
+ * itself. It's always a trip-plan leg that gets here, so that is the profile to match, not the ordinary
+ * route line's.
  */
 internal fun routePolylinesWithSegment(
     base: List<RoutePolyline>,
@@ -48,7 +53,7 @@ internal fun routePolylinesWithSegment(
     routeColor: Int?
 ): List<RoutePolyline> {
     val overlay = segment.takeIf { it.isDrawableSegment() }?.let {
-        RoutePolyline(color = routeColor, points = it, widthProfile = ROUTE_LINE_WIDTH_PROFILE, directional = true)
+        RoutePolyline(color = routeColor, points = it, widthProfile = ITINERARY_RIDE_WIDTH_PROFILE, directional = true)
     } ?: return base
     return base.asDeemphasizedRouteUnderlay() + overlay
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteViewGeometry.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteViewGeometry.kt
@@ -67,7 +67,7 @@ internal fun FocusedTripGeometry.toRoutePolylines(
         val emphasized = emphasizedRoute == shape.routeDirection
         val polyline = if (emphasized) {
             focusedRoutePolyline(
-                routeColors[shape.routeDirection] ?: shape.routeColor,
+                routeColors[shape.routeDirection] ?: mapRouteLineColorOrNull(shape.routeColor),
                 shape.points,
                 directional = true
             )
@@ -78,7 +78,7 @@ internal fun FocusedTripGeometry.toRoutePolylines(
                 DEEMPHASIZED_ROUTE_LINE_WIDTH_PROFILE
             }
             RoutePolyline(
-                routeColors[shape.routeDirection] ?: shape.routeColor,
+                routeColors[shape.routeDirection] ?: mapRouteLineColorOrNull(shape.routeColor),
                 shape.points,
                 widthProfile,
                 // Adjacent routes in stop focus are plain thin lines — no direction chevrons — so the
@@ -132,9 +132,12 @@ internal fun FocusedTripGeometry.toRouteBadges(
                 RouteBadge(
                     routeId = spec.key.routeId,
                     routeShortName = spec.name,
+                    // A badge takes its line's colour, so it goes through the same policy — an
+                    // adjacency colour is already in it, an agency's own has to be put through.
                     color = routeColors[spec.key]
-                        ?: spec.shapes.firstNotNullOfOrNull(FocusedTripShape::routeColor)
-                        ?: spec.route.color
+                        ?: mapRouteLineColorOrNull(
+                            spec.shapes.firstNotNullOfOrNull(FocusedTripShape::routeColor) ?: spec.route.color
+                        )
                         ?: DEFAULT_ROUTE_LINE_COLOR,
                     point = placement.point,
                     directionId = spec.key.directionId
@@ -160,15 +163,17 @@ internal data class SelectedTripStyle(val color: Int, val includeUnderlay: Boole
  * isn't among the focused stop's own trips and [routeColors] carries no adjacency entry for it — that
  * combination used to fall back to a whole-route-style underlay (the #1899 regression fixed by #1902),
  * because the underlay decision was proxied off the color lookup instead of the real stop-focus state.
- * A color miss still falls back to [gtfsColor]; only the underlay must not follow it.
+ * A color miss still falls back to [routeColorFallback]; only the underlay must not follow it. Both
+ * inputs are already in the map's route-line colour policy ([mapRouteLineColor]) — this picks between
+ * them, it doesn't render either.
  */
 internal fun selectedTripStyle(
     stopFocusActive: Boolean,
     selectedRouteDirection: RouteDirectionKey,
     routeColors: Map<RouteDirectionKey, Int>,
-    gtfsColor: Int
+    routeColorFallback: Int
 ): SelectedTripStyle = SelectedTripStyle(
-    color = routeColors[selectedRouteDirection] ?: gtfsColor,
+    color = routeColors[selectedRouteDirection] ?: routeColorFallback,
     includeUnderlay = !stopFocusActive
 )
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/DetailZoomRamp.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/DetailZoomRamp.kt
@@ -70,6 +70,24 @@ val DEEMPHASIZED_ROUTE_LINE_WIDTH_PROFILE = ROUTE_LINE_WIDTH_PROFILE.copy(
     thicknessDp = ROUTE_LINE_WIDTH_DP * 0.275f
 )
 
+/**
+ * A trip-plan itinerary's transit legs (#2041). The itinerary is the only thing the directions map is
+ * showing — nothing competes with it — so a ride draws at the focused-route weight, and *is* that
+ * profile rather than a second copy of its multiplier. It carries its own name because the two are read
+ * against different backdrops (route focus sits over sibling routes and nearby stops, directions over a
+ * bare basemap), so directions is the thing to give a value of its own the day they should differ.
+ */
+val ITINERARY_RIDE_WIDTH_PROFILE = FOCUSED_ROUTE_LINE_WIDTH_PROFILE
+
+/**
+ * An itinerary's on-street legs — walking, cycling, bikeshare. Drawn narrower than the ride it connects
+ * to: a sidewalk or bike lane is a thinner thing than a transit corridor, and the step down at each
+ * transition is a second cue (besides colour) for where one mode hands off to the next.
+ */
+val ITINERARY_STREET_WIDTH_PROFILE = ROUTE_LINE_WIDTH_PROFILE.copy(
+    thicknessDp = ROUTE_LINE_WIDTH_DP * 0.9f
+)
+
 /** Route-line scale retained for unprofiled lines and vehicle markers. */
 fun routeLineWidthScale(zoom: Float): Float = ROUTE_LINE_WIDTH_PROFILE.multiplierAt(zoom)
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
@@ -62,6 +62,23 @@ enum class RoutePolylineTransform {
 }
 
 /**
+ * How a line's stroke is broken up. The rhythms are named for what they mean rather than for their
+ * lengths, which are the renderer's to choose:
+ *
+ *  - [NONE] — solid, the ordinary route line.
+ *  - [HINT] — a tight dash for a line that is a preview rather than the thing itself: the
+ *    route-continuation line (#1691), which shouldn't blend into a busy basemap the way a solid stroke
+ *    can, and shouldn't read as a route the rider can board either.
+ *  - [TRAIL] — a long, open stride for travel under the rider's own power (an itinerary's walking and
+ *    cycling legs, #2041), where the breaks say "path, not corridor" without fragmenting into dots.
+ */
+enum class RouteLineDash {
+    NONE,
+    HINT,
+    TRAIL
+}
+
+/**
  * One route/itinerary polyline: an ordered list of points and an optional [color]. A null [color]
  * means "use the [DEFAULT_ROUTE_LINE_COLOR]" — choosing the fallback is a display decision, so producers
  * can pass a route's raw (possibly absent) GTFS color straight through and renderers draw [resolvedColor].
@@ -75,9 +92,9 @@ enum class RoutePolylineTransform {
  * renderer can honor it is flavor-specific (Google stamps a chevron texture; the maplibre classic
  * annotation has no arrow support yet).
  *
- * [dashed] asks the renderer to draw a dashed stroke instead of solid — set it for a preview/hint line
- * that should read as distinct from the primary route shown (the route-continuation line, #1691), so it
- * doesn't blend into a busy basemap the way a plain solid stroke can.
+ * [dash] asks the renderer to break the stroke up rather than draw it solid, in one of the rhythms
+ * [RouteLineDash] names. Whether a renderer honors it is flavor-specific (the maplibre classic
+ * annotation draws every line solid).
  *
  * [transforms] opts this line into renderer-bound geometry processing. Canonical [points] stay intact in
  * [MapRenderState] for framing and other consumers; both native adapters apply the requested transforms
@@ -88,7 +105,7 @@ data class RoutePolyline(
     val points: List<GeoPoint>,
     val widthProfile: RouteLineWidthProfile? = null,
     val directional: Boolean = false,
-    val dashed: Boolean = false,
+    val dash: RouteLineDash = RouteLineDash.NONE,
     val transforms: Set<RoutePolylineTransform> = emptySet()
 ) {
     /** The [color] to draw, applying the [DEFAULT_ROUTE_LINE_COLOR] fallback in one place for every renderer. */

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/LineBadge.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/LineBadge.kt
@@ -58,6 +58,7 @@ import com.google.android.material.color.utilities.Hct
 import kotlin.math.min
 import org.onebusaway.android.ui.compose.theme.ObaTheme
 import org.onebusaway.android.ui.compose.theme.isDarkTheme
+import org.onebusaway.android.util.routeColorHctOrNull
 
 /** Line height as a multiple of the font size, so multi-line badges shrink with the font. */
 private const val LINE_HEIGHT_RATIO = 1.1f
@@ -84,7 +85,6 @@ private const val CHIP_MAX_CHROMA_DARK = 60.0 // saturation cap in dark theme
 
 // (each hue still clamps to its own sRGB gamut limit;
 //  low caps mute vivid hues — e.g. orange → brown)
-private const val ACHROMATIC_CHROMA = 5.0 // below this the source is grey/black/white (no hue)
 
 // Route-*line* tones: the same hue re-derived to sit legibly ON the surface (rather than as a filled
 // chip), for a stroke/marker drawn directly on the background — Material's own accent tones, 40 in
@@ -95,15 +95,15 @@ private const val LINE_TONE_DARK = 80.0
 /**
  * The route's GTFS color re-derived in HCT at [tone]: same hue, chroma capped for the active theme.
  * Null when the source is absent or achromatic (grey/black/white — no hue to keep), which is every
- * caller's cue to fall back to a neutral. The single place the agency-color policy lives, so a chip
- * and a line can't drift apart on which colors count as "grey" or how saturated a route may get.
+ * caller's cue to fall back to a neutral. The single place the *chip and spine* color policy lives, so
+ * those two can't drift apart on how saturated a route may get; reading the agency color and rejecting a
+ * hueless one is [routeColorHctOrNull], shared with the map's own tone policy.
  */
 // Hct is Material Components' vendored color-science util (LIBRARY_GROUP); no public equivalent
 // exists, so this is deliberate long-term use, not a migration to track (same as AdjacencyRouteColors).
 @SuppressLint("RestrictedApi")
 private fun tonedRouteColor(routeColor: Int?, dark: Boolean, tone: Double): Color? {
-    val source = routeColor?.let { Hct.fromInt(it or 0xFF000000.toInt()) } ?: return null
-    if (source.chroma < ACHROMATIC_CHROMA) return null
+    val source = routeColorHctOrNull(routeColor) ?: return null
     val chroma = min(source.chroma, if (dark) CHIP_MAX_CHROMA_DARK else CHIP_MAX_CHROMA_LIGHT)
     return Color(Hct.from(source.hue, chroma, tone).toInt())
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/RouteColors.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/RouteColors.kt
@@ -17,17 +17,45 @@
 
 package org.onebusaway.android.util
 
+import android.annotation.SuppressLint
 import androidx.core.graphics.toColorInt
+import com.google.android.material.color.utilities.Hct
 
 /**
- * Parses an OBA route hex color (a bare hex string like "FDB71A") to an Android ARGB int, or null
- * when absent or malformed. The single canonical parse used by the wire DTO color readers
- * ([org.onebusaway.android.api.colorArgb]).
+ * Parses a route hex color to an Android ARGB int, or null when absent or malformed. The single
+ * canonical parse used by the wire DTO color readers ([org.onebusaway.android.api.colorArgb]).
+ *
+ * OBA hands over a bare hex ("FDB71A") and OTP does too, but not every producer is that disciplined, so
+ * a leading '#' is tolerated here rather than at each call site — this function is the one place that
+ * decides what a route color on the wire may look like, and callers were otherwise obliged to strip the
+ * '#' themselves before handing it over, which several independently did.
  */
 fun parseObaHexColor(hex: String?): Int? = hex?.takeIf { it.isNotEmpty() }?.let {
     try {
-        "#${it.trim()}".toColorInt()
+        "#${it.trim().removePrefix("#")}".toColorInt()
     } catch (e: IllegalArgumentException) {
         null
     }
 }
+
+/**
+ * An agency's color in HCT, ready for a display policy to re-derive from — or null when it is absent or
+ * achromatic (grey/black/white, below [ACHROMATIC_ROUTE_CHROMA]), leaving no hue to carry into a badge, a
+ * spine or a map line. Each policy declines that case and falls back to something of its own; what they
+ * share is this step, so they can't drift apart on which colors count as "grey" or on the opaque-alpha
+ * normalization that precedes the test.
+ *
+ * The callers ([org.onebusaway.android.map.mapRouteLineColorOrNull] and `LineBadge.kt`'s
+ * `tonedRouteColor`) differ only in what they do with the result — the map keeps the hue alone at its own
+ * fixed chroma/tone, the badge caps the source's chroma against a theme.
+ */
+// Hct is Material Components' vendored color-science util (LIBRARY_GROUP); no public equivalent exists,
+// so this is deliberate long-term use, not a migration to track (same as AdjacencyRouteColors).
+@SuppressLint("RestrictedApi")
+fun routeColorHctOrNull(routeColor: Int?): Hct? {
+    val source = routeColor?.let { Hct.fromInt(it or 0xFF000000.toInt()) } ?: return null
+    return source.takeIf { it.chroma >= ACHROMATIC_ROUTE_CHROMA }
+}
+
+/** The chroma floor [routeColorHctOrNull] applies; exposed so a test can assert against the same bar. */
+const val ACHROMATIC_ROUTE_CHROMA = 5.0

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/RouteColors.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/RouteColors.kt
@@ -33,7 +33,9 @@ import com.google.android.material.color.utilities.Hct
 fun parseObaHexColor(hex: String?): Int? = hex?.takeIf { it.isNotEmpty() }?.let {
     try {
         "#${it.trim().removePrefix("#")}".toColorInt()
-    } catch (e: IllegalArgumentException) {
+    } catch (_: IllegalArgumentException) {
+        // A malformed color is the caller's null case, not an error worth reporting: the wire is free to
+        // send nonsense and every consumer already has a fallback for a route with no usable color.
         null
     }
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/ItineraryLegStyleTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/ItineraryLegStyleTest.kt
@@ -1,0 +1,133 @@
+/* Copyright (C) 2026 Open Transit Software Foundation */
+package org.onebusaway.android.map
+
+import android.annotation.SuppressLint
+import com.google.android.material.color.utilities.Hct
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.onebusaway.android.directions.model.TripLeg
+import org.onebusaway.android.directions.model.TripMode
+import org.onebusaway.android.directions.model.TripPlace
+import org.onebusaway.android.directions.model.TripVertexType
+import org.onebusaway.android.map.render.ITINERARY_RIDE_WIDTH_PROFILE
+import org.onebusaway.android.map.render.ITINERARY_STREET_WIDTH_PROFILE
+import org.onebusaway.android.map.render.RouteLineDash
+import org.onebusaway.android.util.ACHROMATIC_ROUTE_CHROMA
+
+/**
+ * The directions map's per-leg stroke policy (#2041). The point of these is the *distinctions*: before
+ * this, every on-street leg was one grey and every ride one green, so the assertions that matter are
+ * that the kinds don't collide and that a ride keeps its agency's hue.
+ */
+@SuppressLint("RestrictedApi") // Hct, Material's vendored color-science util; see AdjacencyRouteColors.kt.
+class ItineraryLegStyleTest {
+
+    private val bikeShareDock = TripPlace(vertexType = TripVertexType.BIKESHARE, bikeShareId = "dock-1")
+
+    @Test
+    fun `a bicycle leg from a rental dock is bikeshare, from anywhere else own-bike`() {
+        assertEquals(
+            ItineraryLegKind.BIKESHARE,
+            TripLeg(mode = TripMode.BICYCLE, from = bikeShareDock).legKind()
+        )
+        assertEquals(
+            ItineraryLegKind.BIKE,
+            TripLeg(mode = TripMode.BICYCLE, from = TripPlace(name = "Home")).legKind()
+        )
+    }
+
+    @Test
+    fun `every transit mode is a ride, and an unknown mode walks`() {
+        listOf(TripMode.BUS, TripMode.RAIL, TripMode.FERRY, TripMode.TRAM, TripMode.SUBWAY).forEach {
+            assertEquals(ItineraryLegKind.TRANSIT, TripLeg(mode = it).legKind())
+        }
+        assertEquals(ItineraryLegKind.WALK, TripLeg(mode = TripMode.WALK).legKind())
+        assertEquals(ItineraryLegKind.CAR, TripLeg(mode = TripMode.CAR).legKind())
+        // A leg OTP left unlabelled is walked, matching how the drawer's timeline classifies it.
+        assertEquals(ItineraryLegKind.WALK, TripLeg(mode = null).legKind())
+    }
+
+    @Test
+    fun `no two leg kinds share a colour`() {
+        val colors = ItineraryLegKind.entries.map { itineraryLegStyle(it, routeColor = null).color }
+        assertEquals(colors.size, colors.toSet().size)
+    }
+
+    @Test
+    fun `on-street legs are dashed and thinner than the ride they connect to`() {
+        val ride = itineraryLegStyle(ItineraryLegKind.TRANSIT, routeColor = null)
+        assertEquals(RouteLineDash.NONE, ride.dash)
+        assertEquals(ITINERARY_RIDE_WIDTH_PROFILE, ride.widthProfile)
+
+        listOf(ItineraryLegKind.WALK, ItineraryLegKind.BIKE, ItineraryLegKind.BIKESHARE, ItineraryLegKind.CAR)
+            .forEach { kind ->
+                val street = itineraryLegStyle(kind, routeColor = null)
+                assertEquals("$kind should be dashed", RouteLineDash.TRAIL, street.dash)
+                assertEquals(ITINERARY_STREET_WIDTH_PROFILE, street.widthProfile)
+            }
+        assertTrue(ITINERARY_STREET_WIDTH_PROFILE.thicknessDp < ITINERARY_RIDE_WIDTH_PROFILE.thicknessDp)
+    }
+
+    @Test
+    fun `no leg both dashes and stamps chevrons`() {
+        // The chevrons are a texture stamped along the stroke, so a dash pattern chops them into
+        // fragments and the two read as one broken line rather than as either.
+        ItineraryLegKind.entries.forEach { kind ->
+            val style = itineraryLegStyle(kind, routeColor = null)
+            assertFalse("$kind dashes and stamps chevrons", style.dash != RouteLineDash.NONE && style.directional)
+        }
+        assertTrue(itineraryLegStyle(ItineraryLegKind.TRANSIT, routeColor = null).directional)
+    }
+
+    @Test
+    fun `a ride keeps its agency's hue, at the map's own chroma and tone`() {
+        // Two reds an agency might publish: one washed out, one nearly black. Only the hue survives, so
+        // the map draws them the same — the hue is the route's identity, the rest is this map's rendering.
+        val pale = Hct.fromInt(itineraryLegStyle(ItineraryLegKind.TRANSIT, Hct.from(25.0, 20.0, 85.0).toInt()).color)
+        val dark = Hct.fromInt(itineraryLegStyle(ItineraryLegKind.TRANSIT, Hct.from(25.0, 90.0, 20.0).toInt()).color)
+
+        assertEquals(25.0, pale.hue, HUE_TOLERANCE_DEGREES)
+        assertEquals(pale.hue, dark.hue, HUE_TOLERANCE_DEGREES)
+
+        // And that rendering is the adjacency lines' own, so the two schemes can't drift apart. Compared
+        // in HCT rather than as ARGB ints: a source hue round-trips through the sRGB gamut with a
+        // fraction of a degree of drift, which moves the packed int without moving the colour.
+        val adjacency = Hct.fromInt(adjacencyRouteColors(listOf("only")).getValue("only"))
+        listOf(pale, dark).forEach {
+            assertEquals(adjacency.chroma, it.chroma, CHANNEL_TOLERANCE)
+            assertEquals(adjacency.tone, it.tone, CHANNEL_TOLERANCE)
+        }
+    }
+
+    @Test
+    fun `a ride whose agency publishes no usable colour falls back rather than going grey`() {
+        val nearBlack = 0xFF101010.toInt() // achromatic: a hue-preserving re-tone has nothing to keep
+
+        listOf(null, nearBlack).forEach { source ->
+            val fallback = itineraryLegStyle(ItineraryLegKind.TRANSIT, source)
+            assertTrue(
+                "fallback for $source was achromatic",
+                Hct.fromInt(fallback.color).chroma > ACHROMATIC_ROUTE_CHROMA
+            )
+        }
+    }
+
+    @Test
+    fun `every leg kind draws a colour with a hue`() {
+        ItineraryLegKind.entries.forEach { kind ->
+            val color = itineraryLegStyle(kind, routeColor = null).color
+            assertTrue("$kind was achromatic", Hct.fromInt(color).chroma > ACHROMATIC_ROUTE_CHROMA)
+        }
+    }
+
+    private companion object {
+        // The re-tone clamps to each hue's own sRGB gamut limit, so a hue can shift a degree or two.
+        const val HUE_TOLERANCE_DEGREES = 3.0
+
+        // Chroma likewise clamps to the gamut: a hue that can't hold the full chroma at this tone lands
+        // slightly under it. Wide enough to absorb that, far too narrow to hide a different policy.
+        const val CHANNEL_TOLERANCE = 2.0
+    }
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteSegmentHighlightTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteSegmentHighlightTest.kt
@@ -20,7 +20,7 @@ import org.junit.Test
 import org.onebusaway.android.api.adapters.ObaStopElement
 import org.onebusaway.android.map.render.DEEMPHASIZED_ROUTE_LINE_WIDTH_PROFILE
 import org.onebusaway.android.map.render.FOCUSED_ROUTE_LINE_WIDTH_PROFILE
-import org.onebusaway.android.map.render.ROUTE_LINE_WIDTH_PROFILE
+import org.onebusaway.android.map.render.ITINERARY_RIDE_WIDTH_PROFILE
 import org.onebusaway.android.map.render.RoutePolyline
 import org.onebusaway.android.util.GeoPoint
 
@@ -55,7 +55,7 @@ class RouteSegmentHighlightTest {
     }
 
     @Test
-    fun routePolylinesWithSegment_deemphasizesBase_andAddsNormalWidthOverlay() {
+    fun routePolylinesWithSegment_deemphasizesBase_andKeepsTheRideAtItsItineraryWeight() {
         val base = listOf(
             RoutePolyline(
                 color = null,
@@ -69,9 +69,10 @@ class RouteSegmentHighlightTest {
         assertEquals(2, result.size)
         // Base is thinned to context (and loses its arrows).
         assertEquals(DEEMPHASIZED_ROUTE_LINE_WIDTH_PROFILE, result.first().widthProfile)
-        // The ridden span rides on top at normal width, in the route colour, directional.
+        // The ridden span rides on top at the weight it had as an itinerary leg, in the route colour,
+        // directional — so drilling in doesn't make the ride itself thinner than it just was.
         val overlay = result.last()
-        assertEquals(ROUTE_LINE_WIDTH_PROFILE, overlay.widthProfile)
+        assertEquals(ITINERARY_RIDE_WIDTH_PROFILE, overlay.widthProfile)
         assertEquals(0xFF00FF00.toInt(), overlay.color)
         assertEquals(true, overlay.directional)
     }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteViewGeometryTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteViewGeometryTest.kt
@@ -31,6 +31,30 @@ class RouteViewGeometryTest {
     }
 
     @Test
+    fun `a route draws the same colour whichever view shows it`() {
+        // The agency's own colour, as it arrives from the wire.
+        val gtfs = 0xFF8B0000.toInt()
+        val shape = FocusedTripShape("shape", "route", gtfs, listOf(GeoPoint(0.0, 0.0), GeoPoint(0.0, 1.0)))
+
+        // Focused-stop geometry (the picker's full-route view goes through the same focusedRoutePolyline).
+        val adjacencyLine = FocusedTripGeometry(listOf(shape)).toRoutePolylines().single().color
+        // The ridden segment under a tapped directions leg, drawn in the shown route's colour.
+        val riddenSegment = routePolylinesWithSegment(
+            base = emptyList(),
+            segment = listOf(GeoPoint(0.0, 0.0), GeoPoint(0.0, 1.0)),
+            routeColor = mapRouteLineColorOrNull(gtfs)
+        ).single().color
+        // The same route ridden as an itinerary leg on the directions map.
+        val itineraryLeg = itineraryLegStyle(ItineraryLegKind.TRANSIT, gtfs).color
+
+        assertEquals(mapRouteLineColorOrNull(gtfs), adjacencyLine)
+        assertEquals(adjacencyLine, riddenSegment)
+        assertEquals(adjacencyLine, itineraryLeg)
+        // And it is not the raw hex: a dark red would otherwise sink into the basemap.
+        assertTrue(adjacencyLine != gtfs)
+    }
+
+    @Test
     fun `focused trip shape uses one thin plain adjacency line without chevrons`() {
         val geometry = FocusedTripGeometry(
             listOf(
@@ -145,26 +169,26 @@ class RouteViewGeometryTest {
         // adjacency map to begin with.
         assertEquals(
             SelectedTripStyle(color = 99, includeUnderlay = true),
-            selectedTripStyle(stopFocusActive = false, direction, routeColors = emptyMap(), gtfsColor = 99)
+            selectedTripStyle(stopFocusActive = false, direction, routeColors = emptyMap(), routeColorFallback = 99)
         )
         // Stop focus, no adjacency entry for this exact direction (e.g. an opposite-direction vehicle
         // whose direction isn't among the focused stop's own trips, #1902): underlay still drops, but
         // the color falls back to GTFS since there's no adjacency color to carry instead.
         assertEquals(
             SelectedTripStyle(color = 99, includeUnderlay = false),
-            selectedTripStyle(stopFocusActive = true, direction, routeColors = emptyMap(), gtfsColor = 99)
+            selectedTripStyle(stopFocusActive = true, direction, routeColors = emptyMap(), routeColorFallback = 99)
         )
         // Whole-route mode with a stray adjacency entry (shouldn't occur in practice, since routeColors
         // is only ever populated during stop focus) still keeps the underlay — it is not proxied off
         // the color lookup.
         assertEquals(
             SelectedTripStyle(color = 10, includeUnderlay = true),
-            selectedTripStyle(stopFocusActive = false, direction, routeColors = withColor, gtfsColor = 99)
+            selectedTripStyle(stopFocusActive = false, direction, routeColors = withColor, routeColorFallback = 99)
         )
         // Stop focus with a matching adjacency entry: the ordinary case — adjacency color, no underlay.
         assertEquals(
             SelectedTripStyle(color = 10, includeUnderlay = false),
-            selectedTripStyle(stopFocusActive = true, direction, routeColors = withColor, gtfsColor = 99)
+            selectedTripStyle(stopFocusActive = true, direction, routeColors = withColor, routeColorFallback = 99)
         )
     }
 


### PR DESCRIPTION
Fixes #2041.

The directions map drew every leg of a trip plan in one of two colours: a single dark green for anything transit, `Color.GRAY` for everything else. A walk to a bikeshare dock, the ride from it, and the walk at the far end were one indistinguishable grey line. And the route colour the option card and the directions drawer were already showing never reached the map at all — `resolveLegColor` returned the green for a transit leg *before* it looked at `leg.routeColor`, so that branch was unreachable for the only legs that could carry a colour.

The legs were also thin, and not by choice: they passed no width profile, and the Google renderer's unprofiled default is **10 raw pixels**, not scaled by density unlike every profiled line. On a 3x phone an itinerary leg drew at ~3dp while an ordinary route line drew at 10dp.

## A colour language for a leg

`ItineraryLegStyle` decides a leg's stroke from what the rider is doing on it — walk, own bike, bikeshare, car, transit. Bikeshare splits off own-bike on the leg's starting vertex, which is how OTP models a rental ride. On-street legs are dashed and a little narrower than the ride they connect to, so each transition steps in colour, weight and rhythm at once. They draw no direction chevrons: the chevron is a texture stamped along the stroke, and a dash pattern shreds it into fragments that read as neither.

| walk | bike | bikeshare | car | ride, no agency colour |
|---|---|---|---|---|
| `#1D9914` | `#0091A4` | `#5579FF` | `#A18000` | `#E55321` |

Only each anchor's *hue* survives; the rendering below supplies the rest, so tuning one means moving it around the hue circle.

## One colouring for every route line on the map

The map had **three** ways to colour a route line, and a route changed colour as the rider moved between views of it:

1. route focus drew the agency's **raw GTFS hex**;
2. focused-stop adjacency **generated** hues at a fixed chroma and tone;
3. badges and the drawer's timeline spine re-toned the GTFS hue for the Material surface they sit on.

`MapRouteColors` makes (1) and (2) one thing. Every route line on the map now renders at one chroma and tone — the picker's full-route view, the ridden segment under a tapped directions leg, adjacency, a selected vehicle's trip and its continuation hint, an itinerary's transit legs, and the badges labelling them. Only the hue varies, and only the hue carries meaning.

(3) stays theme-aware on purpose: a Material surface flips with the theme, a basemap carries its own light and dark styles. What the two policies now share is `routeColorHctOrNull` — the single decision about which agency colours have no hue worth keeping.

## Smaller things that came with it

- **Drilling into a leg no longer makes the ride thinner than it just was.** The ridden segment keeps its itinerary weight while the route thins to context around it.
- **`RoutePolyline.dashed` → `RouteLineDash`.** The two dashed lines here want different rhythms: the route-continuation preview stays tight, an on-street leg strides twice as long so it reads as a path rather than a broken line. The enum names the intent; the renderer owns the pixels.
- **`parseObaHexColor` tolerates a leading `#`.** It re-prepended one unconditionally, so any caller whose input might already carry one had to strip it first — three call sites independently did.
- **`OTPConstants.OTP_TRANSIT_COLOR` is gone**, a display constant with one consumer, which now owns it as the fallback for a ride whose agency publishes no usable colour.

## Testing

`ItineraryLegStyleTest` covers the stroke table on the JVM — no two leg kinds collide, no leg both dashes and stamps chevrons, a ride keeps its agency's hue, a colourless ride doesn't fall back to grey. `RouteViewGeometryTest` pins the unification directly: one agency colour drawn identically by adjacency geometry, by the ridden segment and by the itinerary leg, and not the raw hex it arrived as.

Device-verified on a Pixel 7 Pro across several iterations of tuning. Both flavours compile clean under `-PwarningsAsErrors=true`; full JVM unit suite passes.

## Known gap

MapLibre draws every line solid — it has no dash support in the classic annotation path, as was already the case for the continuation line (#1691). There the modes separate by colour and width alone. Pre-existing, not introduced here.

## Not in this pass

The issue also asks for terminal points at mode transitions and auto-assigned contrasting colours for rides whose agency publishes none (including how to show a leg several interchangeable routes can serve, #2010). Both are follow-ups; the auto-assignment now has a natural home, since `adjacencyRouteColors` and the itinerary legs already render through the same policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consistent, policy-based route-line coloring across maps, itineraries, badges, and highlighted segments.
  * Introduced dash styles (solid, hint, trail) for route polylines and updated continuation/renderer behavior.
  * Added itinerary-leg stroke styling with per-mode colors, width profiles, dashes, and directionality.
  * Improved hex color parsing (trims whitespace, supports leading “#”) with achromatic fallback.
* **Bug Fixes**
  * Fixed inconsistencies when route colors are missing or derived differently across view contexts.
  * Corrected itinerary highlight thickness to match ride weight styling.
* **Tests**
  * Added/updated coverage for itinerary style rules and route color consistency across render contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->