### PR TITLE
Badge an interlined ride as the ride it is, not as a transfer (#2049)

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/DirectionRowAlternativeRoutesTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/DirectionRowAlternativeRoutesTest.kt
@@ -27,6 +27,7 @@ import org.onebusaway.android.directions.model.TripLeg
 import org.onebusaway.android.directions.model.TripMode
 import org.onebusaway.android.time.ServerTime
 import org.onebusaway.android.ui.compose.components.RouteBadge
+import org.onebusaway.android.ui.compose.components.RouteBadgeJoin
 import org.onebusaway.android.ui.compose.createUnconfinedComposeRule
 import org.onebusaway.android.util.GeoPoint
 
@@ -69,7 +70,8 @@ class DirectionRowAlternativeRoutesTest {
                 RouteBadge("1 Line", 0xFF00A651.toInt()),
                 RouteBadge("2 Line", 0xFF0075C4.toInt())
             ),
-            TransitMode.RAIL
+            TransitMode.RAIL,
+            RouteBadgeJoin.ANY_OF
         )
     )
 
@@ -126,7 +128,7 @@ class DirectionRowAlternativeRoutesTest {
     fun rideWithoutInterchangeableRoutesBadgesOnlyItsOwnRoute() {
         val soloRef = interlinedLegRef.copy(
             alternatives = emptyList(),
-            badge = LegBadge(listOf(RouteBadge("2 Line", 0xFF0075C4.toInt())), TransitMode.RAIL)
+            badge = LegBadge(listOf(RouteBadge("2 Line", 0xFF0075C4.toInt())), TransitMode.RAIL, RouteBadgeJoin.ANY_OF)
         )
         composeRule.setContent { TripResultsList(state = state(soloRef)) }
 

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/DirectionRowFocusTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/DirectionRowFocusTest.kt
@@ -27,6 +27,7 @@ import org.junit.Test
 import org.onebusaway.android.R
 import org.onebusaway.android.time.ServerTime
 import org.onebusaway.android.ui.compose.components.RouteBadge
+import org.onebusaway.android.ui.compose.components.RouteBadgeJoin
 import org.onebusaway.android.ui.compose.createUnconfinedComposeRule
 import org.onebusaway.android.util.GeoPoint
 
@@ -95,7 +96,7 @@ class DirectionRowFocusTest {
     private fun state(directions: List<TripLogEntry>) = TripResultsUiState.Success(
         options = listOf(
             ItineraryOption(
-                symbols = listOf(ModeSymbol.Transit(LegBadge(listOf(RouteBadge("8", routeColor = null)), TransitMode.BUS))),
+                symbols = listOf(ModeSymbol.Transit(LegBadge(listOf(RouteBadge("8", routeColor = null)), TransitMode.BUS, RouteBadgeJoin.ANY_OF))),
                 durationMinutes = 32L,
                 startTime = ServerTime(0L),
                 endTime = ServerTime(32 * 60_000L)

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/DirectionRowInterlineBadgeTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/DirectionRowInterlineBadgeTest.kt
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.tripresults
+
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Rule
+import org.junit.Test
+import org.onebusaway.android.R
+import org.onebusaway.android.time.ServerTime
+import org.onebusaway.android.ui.compose.components.RouteBadge
+import org.onebusaway.android.ui.compose.components.RouteBadgeJoin
+import org.onebusaway.android.ui.compose.createUnconfinedComposeRule
+import org.onebusaway.android.util.GeoPoint
+
+/**
+ * Verifies that a ride the vehicle changes route during (#2000) is badged as what it is in both places a
+ * ride is drawn — the itinerary option card at the top and the ride's own badge in the trip log: one
+ * roundel naming every route ridden, "5 > 12" (#2049). The badge used to name only the route boarded,
+ * leaving the picker promising a 5 all the way while the log's own "stay on board" row said otherwise.
+ *
+ * The instruction it must *not* pick up is the interchangeable one: a chevron badge is one vehicle, so
+ * "whichever comes first" (see [DirectionRowAlternativeRoutesTest]) would tell the rider to board a 12
+ * that is the same bus they are already on.
+ */
+class DirectionRowInterlineBadgeTest {
+
+    // See createUnconfinedComposeRule for why Unconfined composition is used here (issue #1792).
+    @get:Rule
+    val composeRule = createUnconfinedComposeRule()
+
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext
+
+    private val boardPoint = GeoPoint(47.6062, -122.3321)
+    private val seamPoint = GeoPoint(47.5764, -122.2977)
+    private val alightPoint = GeoPoint(47.5301, -122.2688)
+
+    /** The 5 becoming the 12 at the seam stop, with the rider aboard for both. */
+    private val interlinedBadge = LegBadge(
+        listOf(
+            RouteBadge("5", 0xFF1B6EF3.toInt()),
+            RouteBadge("12", 0xFFD62828.toInt())
+        ),
+        TransitMode.BUS,
+        RouteBadgeJoin.THEN
+    )
+
+    private val transition = InterlineTransition(
+        routeLabel = "12",
+        headsign = "Interlaken Park",
+        stop = RouteStopRef("1_550", "550", "Mount Baker Transit Center", seamPoint)
+    )
+
+    private val interlinedLegRef = RouteLegRef(
+        routeId = "1_100",
+        headsign = "Rainier Beach",
+        board = RouteStopRef("1_500", "500", "3rd Ave & Pine St", boardPoint),
+        alight = RouteStopRef("1_600", "600", "Rainier Ave S & S Alaska St", alightPoint),
+        interlineTransitions = mapOf(1 to transition),
+        badge = interlinedBadge
+    )
+
+    private val ride = TripLogEntry.Transit(
+        routeShortName = "5",
+        routeDisplayName = "5",
+        mode = TransitMode.BUS,
+        routeColorHex = "1B6EF3",
+        headsign = "Rainier Beach",
+        boardTime = ServerTime(2 * 60_000L),
+        exitTime = ServerTime(32 * 60_000L),
+        durationMinutes = 30,
+        realtime = RealtimeState.Unknown,
+        rideEvents = listOf(RideEvent.Transition(transition)),
+        routeLeg = interlinedLegRef,
+        legPoints = listOf(boardPoint, seamPoint, alightPoint)
+    )
+
+    private val state = TripResultsUiState.Success(
+        options = listOf(
+            ItineraryOption(
+                symbols = listOf(ModeSymbol.Transit(interlinedBadge)),
+                durationMinutes = 32L,
+                startTime = ServerTime(0L),
+                endTime = ServerTime(32 * 60_000L)
+            )
+        ),
+        selectedIndex = 0,
+        directions = listOf(ride)
+    )
+
+    /** Both roundels — the option card's and the ride's — name the route boarded and the one it becomes. */
+    @Test
+    fun anInterlinedRideBadgesEveryRouteItRunsAsInThePickerAndTheLog() {
+        composeRule.setContent { TripResultsList(state = state) }
+
+        // One node per route in each of the two badges: the option card's and the ride's.
+        composeRule.onAllNodesWithText("5").assertCountEquals(2)
+        composeRule.onAllNodesWithText("12").assertCountEquals(2)
+    }
+
+    /** The badge and the narrative tell one story: the 12 is where the ride goes, not a bus to board. */
+    @Test
+    fun theRideStillSaysToStayOnBoardAndNeverToTakeWhicheverComesFirst() {
+        composeRule.setContent { TripResultsList(state = state) }
+
+        composeRule
+            .onNodeWithText(
+                context.getString(
+                    R.string.step_by_step_transit_interline,
+                    "12 ${context.getString(R.string.step_by_step_transit_connector_headsign)} Interlaken Park"
+                )
+            )
+            .assertExists()
+        composeRule
+            .onAllNodesWithText(context.getString(R.string.directions_whichever_comes_first))
+            .assertCountEquals(0)
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/RouteBadgeChip.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/RouteBadgeChip.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -47,6 +48,28 @@ import androidx.compose.ui.unit.dp
 /** One route on a badge: its short name and (nullable) GTFS color as an ARGB int. */
 data class RouteBadge(val shortName: String, val routeColor: Int?)
 
+/**
+ * How the routes sharing one badge relate to each other — and so what shape divides them. A badge is one
+ * or the other, never a mix: the two facts arise on different legs (see `TripItinerary.substitutableRoutes`,
+ * which drops the alternatives on an interlined ride), so nothing has to draw a slash and a chevron in the
+ * same chip.
+ */
+enum class RouteBadgeJoin {
+
+    /**
+     * Interchangeable routes (#2010) — any one of them will do, so the rider takes whichever comes
+     * first. Divided by a slash, the way a corridor's lines are written down: `1 Line / 2 Line`.
+     */
+    ANY_OF,
+
+    /**
+     * The routes one vehicle runs as in turn, ridden without alighting — a stay-aboard interline
+     * (#2000). Divided by a chevron, because the order is the whole point: `5 > 12` is one ride that
+     * changes its name at a seam, not a choice and not a transfer (#2049).
+     */
+    THEN
+}
+
 /** The badge's corner rounding — barely rounded, matching the roundels elsewhere in the app. */
 private val BADGE_SHAPE = RoundedCornerShape(1.dp)
 
@@ -54,8 +77,11 @@ private val BADGE_SHAPE = RoundedCornerShape(1.dp)
  * How far the divider between two routes leans, as a fraction of the badge's height: it sits at the
  * segment edge at mid-height and shifts by half this either way, so it reads as a "/" between the names
  * rather than as a vertical seam.
+ *
+ * The chevron ([RouteBadgeJoin.THEN]) is the same lean folded at mid-height — one constant for both, so
+ * the two joins are visibly the same badge family and only their *shape* says which relation they mean.
  */
-private const val SLASH_SLANT_RATIO = 0.5f
+private const val JOIN_LEAN_RATIO = 0.5f
 
 /** The width of the badge's outline and of the line where two routes meet inside it. */
 private val BADGE_LINE_WIDTH = 1.dp
@@ -89,6 +115,30 @@ val ROUTE_BADGE_HEIGHT = 16.dp + BADGE_VERTICAL_PADDING * 2
  * color (or have none) from running together into one name.
  */
 private val BADGE_LINE_COLOR = Color.Black
+
+/**
+ * How much room a name gets either side of it inside a joined badge, before allowing for the divider.
+ * Wider than the plain chip's padding, since the divider leans through the segment edges and the name has
+ * to stay clear of it. Scales with the chip.
+ */
+private val JOINED_SEGMENT_PADDING = 5.dp
+
+/**
+ * How far a chevron's point reaches past the segment edge, at [scale][RouteBadgeChip] 1 — the drawn lean
+ * ([JOIN_LEAN_RATIO] of the chip's height, halved) restated in layout units, so the padding can *allow*
+ * for it instead of guessing at a number that would rot if the lean changed.
+ *
+ * A notched segment adds this to its leading padding and nothing to its trailing one. That's the whole
+ * correction: the boundary is slanted, so a name's tightest clearance is not at mid-height (where the
+ * notch is deepest) but where the edge crosses the segment's nominal edge, a quarter of the way down —
+ * which for a notch is a full lean in from where the padding starts, and for a point is exactly at it.
+ * Without this the name sits a half-lean left of centre in the band a rider actually sees, with the slack
+ * left over as dead space after it.
+ *
+ * Exact at the default font scale. Above it the sp-driven chip grows while this dp allowance does not, so
+ * the clearance tightens a little — the same direction of drift [ROUTE_BADGE_HEIGHT] already notes.
+ */
+private val CHEVRON_LEAN_ALLOWANCE = ROUTE_BADGE_HEIGHT * JOIN_LEAN_RATIO / 2
 
 /**
  * A small route roundel — the route's short name on a chip tinted from its GTFS color (via
@@ -126,7 +176,8 @@ fun RouteBadgeChip(
             name = shortName,
             contentColor = content,
             scale = scale,
-            horizontalPadding = 3.dp * scale,
+            startPadding = 3.dp * scale,
+            endPadding = 3.dp * scale,
             leadingIcon = leadingIcon,
             leadingIconDescription = leadingIconDescription
         )
@@ -140,7 +191,8 @@ private fun BadgeContent(
     name: String,
     contentColor: Color,
     scale: Float,
-    horizontalPadding: Dp,
+    startPadding: Dp,
+    endPadding: Dp,
     leadingIcon: Int?,
     leadingIconDescription: String?,
     modifier: Modifier = Modifier
@@ -155,7 +207,7 @@ private fun BadgeContent(
         letterSpacing = base.letterSpacing * scale
     )
     Row(
-        modifier = modifier.padding(horizontal = horizontalPadding, vertical = BADGE_VERTICAL_PADDING * scale),
+        modifier = modifier.padding(start = startPadding, end = endPadding, top = BADGE_VERTICAL_PADDING * scale, bottom = BADGE_VERTICAL_PADDING * scale),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(BADGE_ICON_GAP * scale)
     ) {
@@ -179,26 +231,36 @@ private fun BadgeContent(
 }
 
 /**
- * The same roundel for a set of routes that are ridden interchangeably (#2010) — "1 Line/2 Line" for a
- * pair of lines sharing the same track between two stops. One chip, not several: the names sit side by
- * side on a single background divided by a slash-like diagonal, each half in its own route color, so
- * the badge reads as one choice of several routes rather than as a sequence of separate legs.
+ * The same roundel for a set of routes ridden as one leg — "1 Line/2 Line" for a pair of lines sharing
+ * the same track between two stops ([RouteBadgeJoin.ANY_OF], #2010), or "5 > 12" for a bus that becomes
+ * another route with the rider still aboard ([RouteBadgeJoin.THEN], #2000/#2049). One chip, not several:
+ * the names sit side by side on a single background, each in its own route color, divided by the shape
+ * [join] calls for — so the badge reads as *one* ride however many routes it names, rather than as
+ * separate legs the rider gets off and on between.
  *
  * Each segment paints its own band, overhanging its neighbours by half the lean; siblings paint left to
  * right, so each band's left edge cleanly overwrites the previous band's overhang and the colors meet
- * exactly on the diagonal. A [BADGE_LINE_COLOR] hairline is then drawn along that meeting line, and the
+ * exactly on the divider. A [BADGE_LINE_COLOR] hairline is then drawn along that meeting line, and the
  * whole chip is outlined in the same color — so the badge reads as one bounded object holding two
  * names, even when its routes share a color or have none. The chip is clipped to [BADGE_SHAPE], which
  * trims the outermost bands' overhang back to the badge's own edges.
  *
+ * [routes] is in the order the badge reads. For [RouteBadgeJoin.THEN] that order *is* the information —
+ * `5 > 12` and `12 > 5` are different rides — so the caller sorts an [RouteBadgeJoin.ANY_OF] badge into
+ * natural name order and leaves a [RouteBadgeJoin.THEN] one in ride order (see `RouteBadges`).
+ *
  * A single-route list is the plain chip above, outlined to match: these badges sit side by side in the
- * trip planner (`[2] [1 Line/2 Line]`), so they have to be bounded the same way. The plain chip's other
- * callers keep their un-outlined roundel. [scale] enlarges everything proportionally, as on the plain
- * chip.
+ * trip planner (`[2] [1 Line/2 Line]`), so they have to be bounded the same way. It has no divider, so
+ * [join] doesn't reach it. The plain chip's other callers keep their un-outlined roundel. [scale]
+ * enlarges everything proportionally, as on the plain chip.
  *
  * [maxWidth] applies only to that single-route case — see the note at the joined `Row` below.
- * [leadingIcon] heads the whole badge rather than each name in it: interchangeable routes are one ride
- * on one mode, so a glyph per segment would read as several legs.
+ * [leadingIcon] heads the whole badge rather than each name in it: however its routes are joined, a badge
+ * is one ride on one mode, so a glyph per segment would read as several legs.
+ *
+ * The bands are laid out by a `Row` (which an RTL layout would reverse) but painted in raw draw-space
+ * offsets (which it would not), so a joined badge assumes an LTR reading order — as it has since #2010,
+ * and as the app does throughout, shipping no RTL locale.
  */
 @Composable
 fun RouteBadgeChip(
@@ -206,6 +268,7 @@ fun RouteBadgeChip(
     modifier: Modifier = Modifier,
     scale: Float = 1f,
     maxWidth: Dp = Dp.Unspecified,
+    join: RouteBadgeJoin = RouteBadgeJoin.ANY_OF,
     leadingIcon: Int? = null,
     leadingIconDescription: String? = null
 ) {
@@ -217,9 +280,9 @@ fun RouteBadgeChip(
     }
     // Deliberately uncapped, unlike the plain chip: this Row's children are unweighted, so a bounded max
     // would be consumed by the first segment and leave the later ones measured at zero width — a route
-    // silently missing from a badge that means "any of these will do" is far worse than a wide chip, and
-    // the option-card row it sits in already scrolls horizontally. [maxWidth] therefore only reaches the
-    // single-route delegation above, which is the case it exists for.
+    // silently missing from a badge whose whole point is naming every route on the ride is far worse than
+    // a wide chip, and the option-card row it sits in already scrolls horizontally. [maxWidth] therefore
+    // only reaches the single-route delegation above, which is the case it exists for.
     Row(outlined.clip(BADGE_SHAPE).height(IntrinsicSize.Min)) {
         routes.forEachIndexed { index, route ->
             val (container, content) = rememberRouteBadgeColors(route.routeColor)
@@ -227,11 +290,12 @@ fun RouteBadgeChip(
                 name = route.shortName,
                 contentColor = content,
                 scale = scale,
-                // Wider than the plain chip's padding: the meeting line leans through the segment edges,
-                // so the extra breathing room keeps a name clear of it and of the neighbouring color.
-                horizontalPadding = 5.dp * scale,
-                // The glyph heads the badge, not each name in it: these routes are interchangeable, so
-                // they are one ride on one mode, and a glyph per segment would read as several.
+                // Wider than the plain chip's, plus room for a chevron's notch where there is one, so
+                // every name sits centred in the band the rider sees — see the two constants.
+                startPadding = (JOINED_SEGMENT_PADDING + notchAllowance(join, index)) * scale,
+                endPadding = JOINED_SEGMENT_PADDING * scale,
+                // The glyph heads the badge, not each name in it: these routes are one ride on one mode,
+                // and a glyph per segment would read as several.
                 leadingIcon = leadingIcon.takeIf { index == 0 },
                 leadingIconDescription = leadingIconDescription,
                 modifier = Modifier
@@ -239,25 +303,19 @@ fun RouteBadgeChip(
                     // drawWithCache, not drawBehind: the band's Path and the line's geometry depend only
                     // on the segment's size, so they're built once per size change, not per draw pass.
                     .drawWithCache {
-                        val band = slantedBandPath(
+                        val band = bandPath(
+                            join = join,
                             extendStart = index == 0,
                             extendEnd = index == routes.lastIndex
                         )
-                        val lean = leanPx()
-                        val lineWidth = BADGE_LINE_WIDTH.toPx()
+                        val divider = dividerPath(join)
+                        val line = Stroke(BADGE_LINE_WIDTH.toPx())
                         onDrawBehind {
                             drawPath(band, container)
                             // Only the leading edge, and never on the first segment: each segment draws
                             // its line after its band, so it lands on top of the neighbouring band this
                             // one just overwrote.
-                            if (index > 0) {
-                                drawLine(
-                                    color = BADGE_LINE_COLOR,
-                                    start = Offset(lean, 0f),
-                                    end = Offset(-lean, size.height),
-                                    strokeWidth = lineWidth
-                                )
-                            }
+                            if (index > 0) drawPath(divider, BADGE_LINE_COLOR, style = line)
                         }
                     }
             )
@@ -265,24 +323,57 @@ fun RouteBadgeChip(
     }
 }
 
+/** The leading padding a segment adds for the notch cut into it — a chevron's, and only where there is a
+ *  segment before it to be notched by. Zero for the first segment and for every slashed one. */
+private fun notchAllowance(join: RouteBadgeJoin, index: Int): Dp = if (join == RouteBadgeJoin.THEN && index > 0) CHEVRON_LEAN_ALLOWANCE else 0.dp
+
 /**
- * This segment's background as a parallelogram: vertical at the badge's outer edges
- * ([extendStart]/[extendEnd] push those past the clip so no sliver of background shows through), and
- * leaning by [SLASH_SLANT_RATIO] of the height where it meets a neighbour. The lean is symmetric about
- * mid-height, so the divider crosses the segment edge exactly where the layout puts it.
+ * Where two of the badge's routes meet, as a top-to-bottom polyline in offsets from the segment edge: a
+ * "/" for [RouteBadgeJoin.ANY_OF], a ">" for [RouteBadgeJoin.THEN]. Both are symmetric about the edge, so
+ * whichever shape divides them, the names sit where the layout put them and neither is pushed off centre.
+ *
+ * The single definition of the join's geometry: the hairline is drawn along it and the bands either side
+ * are cut by it ([bandPath]), so a band cannot drift away from the line dividing it.
  */
-private fun CacheDrawScope.slantedBandPath(extendStart: Boolean, extendEnd: Boolean): Path {
+private fun CacheDrawScope.joinEdge(join: RouteBadgeJoin): List<Offset> {
     val lean = leanPx()
+    return when (join) {
+        RouteBadgeJoin.ANY_OF -> listOf(Offset(lean, 0f), Offset(-lean, size.height))
+        // A chevron pointing the way the row is read: the same lean, folded at mid-height.
+        RouteBadgeJoin.THEN -> listOf(Offset(-lean, 0f), Offset(lean, size.height / 2f), Offset(-lean, size.height))
+    }
+}
+
+/**
+ * This segment's background: cut by [joinEdge] where it meets a neighbour, and vertical at the badge's
+ * outer edges — [extendStart]/[extendEnd] push those well past the clip so no sliver of background shows
+ * through. Since both a segment's trailing edge and its neighbour's leading edge are the same [joinEdge],
+ * consecutive bands meet exactly along it with no gap and no double-painted overlap.
+ */
+private fun CacheDrawScope.bandPath(join: RouteBadgeJoin, extendStart: Boolean, extendEnd: Boolean): Path {
     // Overhang the neighbouring segment far enough that an outer edge is always covered after clipping.
     val outer = size.height
+    fun straightEdge(x: Float) = listOf(Offset(x, 0f), Offset(x, size.height))
+    val edge = joinEdge(join)
+    val leading = if (extendStart) straightEdge(-outer) else edge
+    val trailing = if (extendEnd) straightEdge(size.width + outer) else edge.map { Offset(it.x + size.width, it.y) }
     return Path().apply {
-        moveTo(if (extendStart) -outer else lean, 0f)
-        lineTo(if (extendEnd) size.width + outer else size.width + lean, 0f)
-        lineTo(if (extendEnd) size.width + outer else size.width - lean, size.height)
-        lineTo(if (extendStart) -outer else -lean, size.height)
+        // Around the band: from the leading top corner across the top, down the trailing edge, back
+        // across the bottom, then up the leading edge.
+        moveTo(leading.first().x, leading.first().y)
+        (trailing + leading.asReversed()).forEach { lineTo(it.x, it.y) }
         close()
     }
 }
 
+/** The hairline where this segment meets the one before it, along its leading [joinEdge]. */
+private fun CacheDrawScope.dividerPath(join: RouteBadgeJoin): Path {
+    val edge = joinEdge(join)
+    return Path().apply {
+        moveTo(edge.first().x, edge.first().y)
+        edge.drop(1).forEach { lineTo(it.x, it.y) }
+    }
+}
+
 /** Half the lean, in px: how far the meeting line shifts either side of the segment edge. */
-private fun CacheDrawScope.leanPx(): Float = size.height * SLASH_SLANT_RATIO / 2f
+private fun CacheDrawScope.leanPx(): Float = size.height * JOIN_LEAN_RATIO / 2f

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/RouteBadgeChip.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/RouteBadgeChip.kt
@@ -176,8 +176,7 @@ fun RouteBadgeChip(
             name = shortName,
             contentColor = content,
             scale = scale,
-            startPadding = 3.dp * scale,
-            endPadding = 3.dp * scale,
+            horizontalPadding = 3.dp * scale,
             leadingIcon = leadingIcon,
             leadingIconDescription = leadingIconDescription
         )
@@ -191,8 +190,7 @@ private fun BadgeContent(
     name: String,
     contentColor: Color,
     scale: Float,
-    startPadding: Dp,
-    endPadding: Dp,
+    horizontalPadding: Dp,
     leadingIcon: Int?,
     leadingIconDescription: String?,
     modifier: Modifier = Modifier
@@ -207,7 +205,7 @@ private fun BadgeContent(
         letterSpacing = base.letterSpacing * scale
     )
     Row(
-        modifier = modifier.padding(start = startPadding, end = endPadding, top = BADGE_VERTICAL_PADDING * scale, bottom = BADGE_VERTICAL_PADDING * scale),
+        modifier = modifier.padding(horizontal = horizontalPadding, vertical = BADGE_VERTICAL_PADDING * scale),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(BADGE_ICON_GAP * scale)
     ) {
@@ -290,10 +288,8 @@ fun RouteBadgeChip(
                 name = route.shortName,
                 contentColor = content,
                 scale = scale,
-                // Wider than the plain chip's, plus room for a chevron's notch where there is one, so
-                // every name sits centred in the band the rider sees — see the two constants.
-                startPadding = (JOINED_SEGMENT_PADDING + notchAllowance(join, index)) * scale,
-                endPadding = JOINED_SEGMENT_PADDING * scale,
+                // Wider than the plain chip's, since the divider leans through the segment edges.
+                horizontalPadding = JOINED_SEGMENT_PADDING * scale,
                 // The glyph heads the badge, not each name in it: these routes are one ride on one mode,
                 // and a glyph per segment would read as several.
                 leadingIcon = leadingIcon.takeIf { index == 0 },
@@ -303,29 +299,46 @@ fun RouteBadgeChip(
                     // drawWithCache, not drawBehind: the band's Path and the line's geometry depend only
                     // on the segment's size, so they're built once per size change, not per draw pass.
                     .drawWithCache {
+                        // One edge per segment, shared by the band it cuts and the line drawn along it —
+                        // the geometry is defined once (see [joinEdge]) and computed once too.
+                        val edge = joinEdge(join)
                         val band = bandPath(
-                            join = join,
+                            edge = edge,
                             extendStart = index == 0,
                             extendEnd = index == routes.lastIndex
                         )
-                        val divider = dividerPath(join)
+                        // Only the leading edge, and never on the first segment: each segment draws its
+                        // line after its band, so it lands on top of the neighbouring band this one just
+                        // overwrote. The first segment has no neighbour, so it builds no line at all.
+                        val divider = if (index > 0) edge.toPath() else null
                         val line = Stroke(BADGE_LINE_WIDTH.toPx())
                         onDrawBehind {
                             drawPath(band, container)
-                            // Only the leading edge, and never on the first segment: each segment draws
-                            // its line after its band, so it lands on top of the neighbouring band this
-                            // one just overwrote.
-                            if (index > 0) drawPath(divider, BADGE_LINE_COLOR, style = line)
+                            divider?.let { drawPath(it, BADGE_LINE_COLOR, style = line) }
                         }
                     }
+                    // Room for the notch the previous segment's divider cuts into this one, so the name
+                    // stays centred in the band the rider sees. Applied after the draw modifier, which
+                    // therefore still sizes the band to the whole segment.
+                    .padding(start = join.leadingInset(index) * scale)
             )
         }
     }
 }
 
-/** The leading padding a segment adds for the notch cut into it — a chevron's, and only where there is a
- *  segment before it to be notched by. Zero for the first segment and for every slashed one. */
-private fun notchAllowance(join: RouteBadgeJoin, index: Int): Dp = if (join == RouteBadgeJoin.THEN && index > 0) CHEVRON_LEAN_ALLOWANCE else 0.dp
+/**
+ * How much room this join's divider needs on the leading edge of the segment at [index] — nothing on the
+ * first segment, which has no neighbour to be cut by. Stated as a `when` over the join rather than as a
+ * test for one of them, so a third join shape has to answer the question instead of silently reserving
+ * nothing and drawing its name into its own divider.
+ */
+private fun RouteBadgeJoin.leadingInset(index: Int): Dp = when {
+    index == 0 -> 0.dp
+    // A slash sits at the segment edge at mid-height, where the name's ink is, and leans away above and
+    // below it — so [JOINED_SEGMENT_PADDING] already clears it. Only a chevron's notch reaches inwards.
+    this == RouteBadgeJoin.ANY_OF -> 0.dp
+    else -> CHEVRON_LEAN_ALLOWANCE
+}
 
 /**
  * Where two of the badge's routes meet, as a top-to-bottom polyline in offsets from the segment edge: a
@@ -344,34 +357,30 @@ private fun CacheDrawScope.joinEdge(join: RouteBadgeJoin): List<Offset> {
     }
 }
 
+/** This polyline as an open `Path` — the one walk from a list of points to something drawable, shared by
+ *  the divider hairline and by the band edges it cuts. */
+private fun List<Offset>.toPath(): Path = Path().apply {
+    moveTo(first().x, first().y)
+    for (i in 1..lastIndex) lineTo(this@toPath[i].x, this@toPath[i].y)
+}
+
 /**
- * This segment's background: cut by [joinEdge] where it meets a neighbour, and vertical at the badge's
- * outer edges — [extendStart]/[extendEnd] push those well past the clip so no sliver of background shows
- * through. Since both a segment's trailing edge and its neighbour's leading edge are the same [joinEdge],
+ * This segment's background: cut by [edge] where it meets a neighbour, and vertical at the badge's outer
+ * edges — [extendStart]/[extendEnd] push those well past the clip so no sliver of background shows
+ * through. Since a segment's trailing edge and its neighbour's leading edge are that same [edge],
  * consecutive bands meet exactly along it with no gap and no double-painted overlap.
  */
-private fun CacheDrawScope.bandPath(join: RouteBadgeJoin, extendStart: Boolean, extendEnd: Boolean): Path {
+private fun CacheDrawScope.bandPath(edge: List<Offset>, extendStart: Boolean, extendEnd: Boolean): Path {
     // Overhang the neighbouring segment far enough that an outer edge is always covered after clipping.
     val outer = size.height
     fun straightEdge(x: Float) = listOf(Offset(x, 0f), Offset(x, size.height))
-    val edge = joinEdge(join)
     val leading = if (extendStart) straightEdge(-outer) else edge
     val trailing = if (extendEnd) straightEdge(size.width + outer) else edge.map { Offset(it.x + size.width, it.y) }
-    return Path().apply {
-        // Around the band: from the leading top corner across the top, down the trailing edge, back
-        // across the bottom, then up the leading edge.
-        moveTo(leading.first().x, leading.first().y)
-        (trailing + leading.asReversed()).forEach { lineTo(it.x, it.y) }
+    // Around the band: down the leading edge, across the bottom, back up the trailing edge, and closed
+    // across the top.
+    return leading.toPath().apply {
+        for (i in trailing.lastIndex downTo 0) lineTo(trailing[i].x, trailing[i].y)
         close()
-    }
-}
-
-/** The hairline where this segment meets the one before it, along its leading [joinEdge]. */
-private fun CacheDrawScope.dividerPath(join: RouteBadgeJoin): Path {
-    val edge = joinEdge(join)
-    return Path().apply {
-        moveTo(edge.first().x, edge.first().y)
-        edge.drop(1).forEach { lineTo(it.x, it.y) }
     }
 }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/Interlines.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/Interlines.kt
@@ -47,7 +47,15 @@ internal object Interlines {
         val leaderIndex: Int,
         val alightIndex: Int,
         val transitionLegIndices: List<Int>
-    )
+    ) {
+        /**
+         * The legs whose route the rider is told about, in travel order: the one boarded, plus every leg
+         * the vehicle changes route at. A self-interlined continuation is in neither, so a 12 reversing
+         * onto itself names one route. This is what a ride's badge and its symbol are built from — the
+         * routes ridden, rather than the legs OTP happened to split the ride into.
+         */
+        val riddenLegIndices: List<Int> get() = listOf(leaderIndex) + transitionLegIndices
+    }
 
     /**
      * The transit chains in leg order. A chain leader is a transit leg that is not itself an interlined

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/ModeSymbols.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/ModeSymbols.kt
@@ -29,7 +29,7 @@ import org.onebusaway.android.directions.model.TripVertexType
  * means a walking option and the walk *inside* a transit option are the same symbol, and a card says
  * how a rider gets to the bus rather than only which bus it is.
  *
- * Pure (no `Context`), like [Interlines] and [legBadge], so `ModeSymbolsTest` covers the sequencing
+ * Pure (no `Context`), like [Interlines] and [rideBadge], so `ModeSymbolsTest` covers the sequencing
  * directly.
  */
 internal object ModeSymbols {
@@ -53,8 +53,10 @@ internal object ModeSymbols {
      * and supplies each transit leg's interchangeable routes (#2010), exactly as
      * [TripResultsRepository][DefaultTripResultsRepository] hands them to the drawer's badges.
      *
-     * A stay-aboard interline (#2000) contributes one symbol per *route* the vehicle runs as, not one
-     * per leg — the continuation legs the rider never acts on fold away — by reading the same
+     * A stay-aboard interline (#2000) is **one** symbol, not one per leg and not one per route: the
+     * rider boards once, so the card draws one roundel, and the routes the vehicle runs as are joined
+     * inside it by chevrons — `[5 > 12]` (#2049). Drawing them as separate roundels made an interline
+     * read exactly like a transfer, which is the one thing it isn't. It reads the same
      * [Interlines.chains] the directions do, so the card and the drawer can't disagree about how many
      * rides a trip has. Pseudo-legs (`BOARDING`/`ALIGHTING`/`TRANSFER`) are not travel and draw
      * nothing.
@@ -67,14 +69,14 @@ internal object ModeSymbols {
         require(substitutable.size == legs.size) {
             "substitutable must be index-aligned to legs (${substitutable.size} vs ${legs.size})"
         }
-        // The legs that badge a ride: each chain's leader, plus every leg the vehicle changes route at.
-        // A self-interlined continuation is in neither, so a 12 reversing onto itself badges once.
-        val ridden = Interlines.chains(legs)
-            .flatMap { chain -> listOf(chain.leaderIndex) + chain.transitionLegIndices }
-            .toSet()
+        // One badge per ride, at the leg it's boarded at; every other transit leg is a continuation the
+        // rider never acts on, and is already named inside its leader's badge.
+        val rides = Interlines.chains(legs).associate { chain ->
+            chain.leaderIndex to rideBadge(legs, chain, substitutable[chain.leaderIndex])
+        }
         val symbols = legs.mapIndexedNotNull { i, leg ->
             when {
-                leg.mode?.isTransit == true -> if (i in ridden) ModeSymbol.Transit(legBadge(leg, substitutable[i])) else null
+                leg.mode?.isTransit == true -> rides[i]?.let { ModeSymbol.Transit(it) }
                 leg.mode?.isOnStreetNonTransit == true -> leg.streetSymbolOrNull()
                 else -> null
             }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/RouteBadges.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/RouteBadges.kt
@@ -42,8 +42,13 @@ import org.onebusaway.android.util.parseObaHexColor
  *    promises a 5 all the way and the drawer's own "stay on board" row contradicts it;
  *  - any other ride badges its planned route joined by whatever is interchangeable with it (#2010).
  *
- * The two can't both apply: [substitutableRoutes] empties the alternatives of every leg in a chain
- * longer than one leg, since a substitute vehicle would put the rider off at the seam.
+ * The two can't both apply, and this says so rather than trusting it: [substitutableRoutes] empties the
+ * alternatives of every leg in a chain longer than one leg, since a substitute vehicle would put the
+ * rider off at the seam. Stated as a `require` because the alternative is a silent drop — the chevron
+ * branch has no way to render an alternative, so a caller passing raw [interchangeableRoutes] instead
+ * would lose them with nothing downstream able to tell that from a ride that genuinely had none. Both
+ * call sites are wrapped in `runCatchingCancellable`, so a violation surfaces as a failed load, loudly,
+ * rather than as a badge quietly missing a route.
  */
 internal fun rideBadge(
     legs: List<TripLeg>,
@@ -52,6 +57,9 @@ internal fun rideBadge(
 ): LegBadge = if (chain.transitionLegIndices.isEmpty()) {
     legBadge(legs[chain.leaderIndex], alternatives)
 } else {
+    require(alternatives.isEmpty()) {
+        "a ride that changes route mid-vehicle admits no substitutes (leg ${chain.leaderIndex}, ${alternatives.size} offered)"
+    }
     LegBadge(
         // In travel order and *not* deduplicated: consecutive entries are legs OTP gave different route
         // ids, so two that read alike are two routes that publish the same name — a real change the

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/RouteBadges.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/RouteBadges.kt
@@ -20,17 +20,49 @@ import org.onebusaway.android.directions.model.TripLeg
 import org.onebusaway.android.directions.model.TripMode
 import org.onebusaway.android.directions.model.routeDisplayLabel
 import org.onebusaway.android.ui.compose.components.RouteBadge
+import org.onebusaway.android.ui.compose.components.RouteBadgeJoin
 import org.onebusaway.android.util.ROUTE_NAME_ORDER
 import org.onebusaway.android.util.parseObaHexColor
 
 /**
- * Builds the [LegBadge] a transit leg draws — the planned route plus whatever else the rider may ride
- * for that leg (#2010). Both places a leg's routes appear (the itinerary option cards and the
- * directions drawer) are fed from here by [TripResultsRepository], so the two can't name or order a
- * corridor's routes differently.
+ * Builds the [LegBadge] a ride draws — the planned route, plus whatever else the rider may ride for that
+ * leg (#2010) or whatever the vehicle goes on to become under them (#2000/#2049). Both places a ride's
+ * routes appear (the itinerary option cards and the directions drawer) are fed from here by
+ * [TripResultsRepository], so the two can't name, order, or join a ride's routes differently.
  *
  * Pure (no `Context`), so `RouteBadgesTest` covers the naming, ordering and color parsing directly.
  */
+
+/**
+ * The badge for one **ride** — a whole [Interlines.Chain] rather than a leg, because a stay-aboard
+ * interline is one ride the rider is never asked to act on. Which of the two joins it takes is decided
+ * here, once, for both places a ride is badged:
+ *  - a ride the vehicle changes route during badges those routes in travel order, joined by chevrons
+ *    (`5 > 12`, #2049) — the seam is a fact about the ride, so the badge has to carry it, or the picker
+ *    promises a 5 all the way and the drawer's own "stay on board" row contradicts it;
+ *  - any other ride badges its planned route joined by whatever is interchangeable with it (#2010).
+ *
+ * The two can't both apply: [substitutableRoutes] empties the alternatives of every leg in a chain
+ * longer than one leg, since a substitute vehicle would put the rider off at the seam.
+ */
+internal fun rideBadge(
+    legs: List<TripLeg>,
+    chain: Interlines.Chain,
+    alternatives: List<InterchangeableRoute>
+): LegBadge = if (chain.transitionLegIndices.isEmpty()) {
+    legBadge(legs[chain.leaderIndex], alternatives)
+} else {
+    LegBadge(
+        // In travel order and *not* deduplicated: consecutive entries are legs OTP gave different route
+        // ids, so two that read alike are two routes that publish the same name — a real change the
+        // drawer's transition row announces too, and hiding it here would leave the two disagreeing.
+        // A leg whose route names itself in no way at all (a null badge) drops out rather than leaving a
+        // blank segment; the ride still names every route that can be named.
+        routes = chain.riddenLegIndices.mapNotNull { legs[it].plannedBadge() },
+        mode = legs[chain.leaderIndex].mode.transitMode(),
+        join = RouteBadgeJoin.THEN
+    )
+}
 
 /** The badge for one transit leg: its planned route joined by the routes ruled interchangeable with
  *  it ([org.onebusaway.android.directions.model.interchangeableRoutes]). */
@@ -49,7 +81,8 @@ internal fun legBadge(planned: RouteBadge?, alternatives: List<RouteBadge>, mode
     (listOfNotNull(planned) + alternatives)
         .distinctBy { it.shortName }
         .sortedWith(compareBy(ROUTE_NAME_ORDER) { it.shortName }),
-    mode
+    mode,
+    RouteBadgeJoin.ANY_OF
 )
 
 /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsRepository.kt
@@ -140,8 +140,9 @@ class DefaultTripResultsRepository @Inject constructor(
                 extraSegments = extraSegments,
                 alternatives = alternatives.map { it.resolve() },
                 // Built here, alongside the option cards' badges, so the drawer renders one rather than
-                // deriving it per row (#2010).
-                badge = legBadge(leader, alternatives)
+                // deriving it per row (#2010) — and so a ride that changes route under the rider is
+                // badged the same "5 > 12" in both places (#2049).
+                badge = rideBadge(legs, chain, alternatives)
             )
         }
         return refs

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
@@ -1144,7 +1144,7 @@ private fun ColumnScope.BoardContent(
         // arrive. Each one's own ETA strip sits under the board stop below (#2010). A chevron badge is
         // the opposite instruction — board this one and stay on it — and says so in its own row further
         // down the ride (TransitionContent), so it must not pick this caption up.
-        if (entry.routeLeg.badge?.isInterchangeable == true) {
+        if (joined?.isInterchangeable == true) {
             Text(
                 text = stringResource(R.string.directions_whichever_comes_first),
                 style = MaterialTheme.typography.bodyMedium,
@@ -1349,7 +1349,8 @@ private fun TripResultsPreview() {
                                     RouteBadge("1 Line", 0xFF00A651.toInt()),
                                     RouteBadge("2 Line", 0xFF0075C4.toInt())
                                 ),
-                                TransitMode.RAIL
+                                TransitMode.RAIL,
+                                RouteBadgeJoin.ANY_OF
                             )
                         ),
                         ModeSymbol.Street(StreetMode.WALK)
@@ -1363,9 +1364,9 @@ private fun TripResultsPreview() {
                     // The second leg is a ferry, which publishes no route short name — so it badges its
                     // long name, capped and ellipsized.
                     symbols = listOf(
-                        ModeSymbol.Transit(LegBadge(listOf(RouteBadge("48", null)), TransitMode.BUS)),
+                        ModeSymbol.Transit(LegBadge(listOf(RouteBadge("48", null)), TransitMode.BUS, RouteBadgeJoin.ANY_OF)),
                         ModeSymbol.Street(StreetMode.WALK),
-                        ModeSymbol.Transit(LegBadge(listOf(RouteBadge("Seattle - Bremerton", null)), TransitMode.FERRY))
+                        ModeSymbol.Transit(LegBadge(listOf(RouteBadge("Seattle - Bremerton", null)), TransitMode.FERRY, RouteBadgeJoin.ANY_OF))
                     ),
                     durationMinutes = 41,
                     startTime = ServerTime(0L),

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
@@ -98,6 +98,7 @@ import org.onebusaway.android.ui.compose.components.LoadingContent
 import org.onebusaway.android.ui.compose.components.ROUTE_BADGE_HEIGHT
 import org.onebusaway.android.ui.compose.components.RouteBadge
 import org.onebusaway.android.ui.compose.components.RouteBadgeChip
+import org.onebusaway.android.ui.compose.components.RouteBadgeJoin
 import org.onebusaway.android.ui.compose.components.RouteLineColors
 import org.onebusaway.android.ui.compose.components.ScrollChevronGutter
 import org.onebusaway.android.ui.compose.components.routeLineColors
@@ -277,6 +278,7 @@ private fun OptionCard(
                                     badge.routes,
                                     scale = SYMBOL_BADGE_SCALE,
                                     maxWidth = OPTION_BADGE_MAX_WIDTH,
+                                    join = badge.join,
                                     leadingIcon = glyph,
                                     leadingIconDescription = glyphLabel
                                 )
@@ -1105,14 +1107,16 @@ private fun ColumnScope.BoardContent(
             .defaultMinSize(minHeight = ROW_MIN_TOUCH_HEIGHT)
             .clickable(onClick = onFocus)
     ) {
-        // A ride the rider may take on more than one route (#2010) badges them all as one joined
-        // roundel; an ordinary ride badges its own route exactly as before. A route that publishes no
-        // short name gets no roundel and leads with its long name — see routeDisplayShortName.
-        val joined = entry.routeLeg.badge?.takeIf { it.isInterchangeable }
+        // A ride naming more than one route badges them all as one joined roundel — the routes it may be
+        // taken on ("1 Line/2 Line", #2010) or the ones the vehicle becomes under the rider ("5 > 12",
+        // #2049), the badge's own join saying which. An ordinary ride badges its own route exactly as
+        // before. A route that publishes no short name gets no roundel and leads with its long name —
+        // see routeDisplayShortName.
+        val joined = entry.routeLeg.badge?.takeIf { it.isJoined }
         val title = entry.routeDisplayName?.takeIf { it != entry.routeShortName }
         Row(verticalAlignment = Alignment.CenterVertically) {
             when {
-                joined != null -> RouteBadgeChip(joined.routes, scale = 1.5f)
+                joined != null -> RouteBadgeChip(joined.routes, scale = 1.5f, join = joined.join)
                 entry.routeShortName != null ->
                     RouteBadgeChip(entry.routeShortName, routeColorInt(entry.routeColorHex), scale = 1.5f)
             }
@@ -1136,9 +1140,11 @@ private fun ColumnScope.BoardContent(
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
         }
-        // What the joined badge means: any of those routes will do, so board the first to arrive. Each
-        // one's own ETA strip sits under the board stop below (#2010).
-        if (joined != null) {
+        // What an interchangeable badge means: any of those routes will do, so board the first to
+        // arrive. Each one's own ETA strip sits under the board stop below (#2010). A chevron badge is
+        // the opposite instruction — board this one and stay on it — and says so in its own row further
+        // down the ride (TransitionContent), so it must not pick this caption up.
+        if (entry.routeLeg.badge?.isInterchangeable == true) {
             Text(
                 text = stringResource(R.string.directions_whichever_comes_first),
                 style = MaterialTheme.typography.bodyMedium,
@@ -1322,11 +1328,21 @@ private fun TripResultsPreview() {
         val state = TripResultsUiState.Success(
             options = listOf(
                 ItineraryOption(
-                    // Walk, a bus leg, then an interchangeable rail pair drawn as one joined badge
-                    // (#2010) — the transfer between them being too short to draw a glyph for (#2047).
+                    // Both joined badges side by side: a bus that becomes the 12 with the rider aboard,
+                    // chevroned (#2049), then an interchangeable rail pair, slashed (#2010) — the
+                    // transfer between them being too short to draw a glyph for (#2047).
                     symbols = listOf(
                         ModeSymbol.Street(StreetMode.WALK),
-                        ModeSymbol.Transit(LegBadge(listOf(RouteBadge("8", 0xFF1B6EF3.toInt())), TransitMode.BUS)),
+                        ModeSymbol.Transit(
+                            LegBadge(
+                                listOf(
+                                    RouteBadge("8", 0xFF1B6EF3.toInt()),
+                                    RouteBadge("12", 0xFFD62828.toInt())
+                                ),
+                                TransitMode.BUS,
+                                RouteBadgeJoin.THEN
+                            )
+                        ),
                         ModeSymbol.Transit(
                             LegBadge(
                                 listOf(
@@ -1393,16 +1409,33 @@ private fun TripResultsPreview() {
                     exitTime = ServerTime(20 * 60_000L),
                     durationMinutes = 16,
                     realtime = RealtimeState.OnTime,
+                    // The same ride the first option's chevron badge stands for: boarded once as the 8,
+                    // becoming the 12 at Mount Baker without the rider getting off (#2000/#2049).
                     rideEvents = listOf(
                         RideEvent.Stop(LogStop("Capitol Hill Station")),
                         RideEvent.Stop(LogStop("23rd Ave & E Union St")),
-                        RideEvent.Stop(LogStop("Mount Baker Transit Center"))
+                        RideEvent.Transition(
+                            InterlineTransition(
+                                routeLabel = "12",
+                                headsign = "Interlaken Park",
+                                stop = RouteStopRef("1_550", "550", "Mount Baker Transit Center", null)
+                            )
+                        ),
+                        RideEvent.Stop(LogStop("Rainier Ave S & S McClellan St"))
                     ),
                     routeLeg = RouteLegRef(
                         routeId = "1_100",
                         headsign = "Rainier Beach",
                         board = RouteStopRef("1_500", "500", "Pine St & 3rd Ave", null),
-                        alight = RouteStopRef("1_600", "600", "Rainier & Alaska", null)
+                        alight = RouteStopRef("1_600", "600", "Rainier & Alaska", null),
+                        badge = LegBadge(
+                            listOf(
+                                RouteBadge("8", 0xFF1B6EF3.toInt()),
+                                RouteBadge("12", 0xFFD62828.toInt())
+                            ),
+                            TransitMode.BUS,
+                            RouteBadgeJoin.THEN
+                        )
                     )
                 ),
                 // A Washington State Ferries run: no route short name, so no badge — the long name is

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
@@ -79,9 +79,12 @@ sealed interface ModeSymbol {
 data class LegBadge(
     val routes: List<RouteBadge>,
     val mode: TransitMode,
-    // Moot for the single-route badge that most rides get, hence a default: with nothing to divide,
-    // there is no relation to name. It matters only once a second route joins the chip.
-    val join: RouteBadgeJoin = RouteBadgeJoin.ANY_OF
+    // Stated at every construction, with no default. It is moot for the single-route badge most rides
+    // get — nothing to divide, so no relation to name — but a *joined* badge that forgot to say would
+    // take a default silently, and the join is not merely a divider shape: [isInterchangeable] reads it
+    // to decide whether the drawer tells the rider to board whichever route comes first. Getting that by
+    // omission is a wrong instruction, not a wrong pixel.
+    val join: RouteBadgeJoin
 ) {
     /** Whether this ride has more than one route on its badge, i.e. the chip is a joined/multicolor one. */
     val isJoined: Boolean get() = routes.size > 1

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
@@ -19,6 +19,7 @@ import org.onebusaway.android.directions.model.TripMode
 import org.onebusaway.android.map.RiddenSegment
 import org.onebusaway.android.time.ServerTime
 import org.onebusaway.android.ui.compose.components.RouteBadge
+import org.onebusaway.android.ui.compose.components.RouteBadgeJoin
 import org.onebusaway.android.util.GeoPoint
 
 /**
@@ -54,29 +55,42 @@ sealed interface ModeSymbol {
      */
     data class Street(val mode: StreetMode) : ModeSymbol
 
-    /** A transit leg, drawn as its route roundel — which names every route the leg can be ridden on
-     *  (see [LegBadge]), or falls back to the mode glyph for a leg that names no route. */
+    /** A ride, drawn as one route roundel — which names every route it can be taken on, or becomes
+     *  along the way (see [LegBadge]), and falls back to the mode glyph for a ride that names no
+     *  route. One symbol per *boarding*, so a stay-aboard interline is one roundel, not two. */
     data class Transit(val badge: LegBadge) : ModeSymbol
 }
 
 /**
- * One transit leg's roundel: every route the leg can be ridden on — the planned route plus any
- * interchangeable ones (#2010) — as a single joined chip, each route in its own color ("1 Line/2 Line"
- * for the Lynnwood–downtown pair). An ordinary leg holds exactly one route and draws as the plain
- * one-color chip it always did.
+ * One ride's roundel: every route the rider is on for it, as a single joined chip with each route in its
+ * own color. A ride names more than one route two ways, and [join] says which — the routes are
+ * interchangeable and any will do ("1 Line/2 Line" for the Lynnwood–downtown pair, #2010), or one vehicle
+ * runs as each in turn and the rider never gets off ("5 > 12", a stay-aboard interline, #2000/#2049). An
+ * ordinary ride holds exactly one route and draws as the plain one-color chip it always did.
  *
- * [routes] is in natural route-name order rather than plan order, so a corridor reads the same way
- * whichever of its lines the planner happened to pick.
+ * [routes] is in the order the badge reads, which [join] decides: natural route-name order for
+ * interchangeable routes, so a corridor reads the same way whichever of its lines the planner picked, and
+ * **ride order** for an interline, where the order is the information ("5 > 12" is not "12 > 5").
  *
- * [routes] is **empty** for a leg whose route publishes no short name — there is no roundel to draw, so
- * the option card falls back to the leg's [mode] glyph rather than an empty chip or a silently missing
+ * [routes] is **empty** for a ride whose route publishes no short name — there is no roundel to draw, so
+ * the option card falls back to the ride's [mode] glyph rather than an empty chip or a silently missing
  * leg (a ferry ride still has to appear on the card).
  */
-data class LegBadge(val routes: List<RouteBadge>, val mode: TransitMode) {
-    /** Whether this leg has more than one route to ride, i.e. the chip is a joined/multicolor one. */
-    val isInterchangeable: Boolean get() = routes.size > 1
+data class LegBadge(
+    val routes: List<RouteBadge>,
+    val mode: TransitMode,
+    // Moot for the single-route badge that most rides get, hence a default: with nothing to divide,
+    // there is no relation to name. It matters only once a second route joins the chip.
+    val join: RouteBadgeJoin = RouteBadgeJoin.ANY_OF
+) {
+    /** Whether this ride has more than one route on its badge, i.e. the chip is a joined/multicolor one. */
+    val isJoined: Boolean get() = routes.size > 1
 
-    /** True when the leg names no route at all, and can only be shown as its mode. */
+    /** Whether the badge offers a *choice* of routes — as opposed to naming a ride that becomes another
+     *  route under the rider ([RouteBadgeJoin.THEN]), which is one route to board, not several. */
+    val isInterchangeable: Boolean get() = isJoined && join == RouteBadgeJoin.ANY_OF
+
+    /** True when the ride names no route at all, and can only be shown as its mode. */
     val isUnnamed: Boolean get() = routes.isEmpty()
 }
 

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/ModeSymbolsTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/ModeSymbolsTest.kt
@@ -16,12 +16,14 @@
 package org.onebusaway.android.ui.tripresults
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Test
 import org.onebusaway.android.directions.model.InterchangeableRoute
 import org.onebusaway.android.directions.model.TripLeg
 import org.onebusaway.android.directions.model.TripMode
 import org.onebusaway.android.directions.model.TripPlace
 import org.onebusaway.android.directions.model.TripVertexType
+import org.onebusaway.android.ui.compose.components.RouteBadgeJoin
 
 /**
  * JVM tests for [ModeSymbols]: an itinerary read as one left-to-right symbol sequence — the on-street
@@ -133,11 +135,44 @@ class ModeSymbolsTest {
         assertEquals(listOf(StreetMode.WALK, listOf("8")), symbolsOf(listOf(longWalk, longWalk, transit("8"))))
     }
 
-    /** Straight off [Interlines.chains]: a self-interline is one ride, a cross-route one is two. */
+    /**
+     * Straight off [Interlines.chains]: a self-interline is one ride on one route, a cross-route one is
+     * one ride on two. One symbol either way — the rider boards once, so the card draws one roundel, and
+     * the routes ridden are named inside it (#2049).
+     */
     @Test
-    fun interlinedRidesBadgeTheRoutesActuallyRidden() {
+    fun anInterlinedRideIsOneSymbolNamingEveryRouteItRunsAs() {
         assertEquals(listOf(listOf("12")), symbolsOf(listOf(transit("12"), transit("12", interline = true))))
-        assertEquals(listOf(listOf("10"), listOf("12")), symbolsOf(listOf(transit("10"), transit("12", interline = true))))
+        assertEquals(listOf(listOf("10", "12")), symbolsOf(listOf(transit("10"), transit("12", interline = true))))
+    }
+
+    /**
+     * …and those routes read in ride order, chevroned. Deliberately a pair that natural name order would
+     * reverse: an interline's order is the information ("12 > 10" is a different ride from "10 > 12"),
+     * unlike an interchangeable pair, which is sorted so a corridor reads the same either way.
+     */
+    @Test
+    fun anInterlinedRidesRoutesReadInRideOrderNotNameOrder() {
+        val legs = listOf(transit("12"), transit("10", interline = true))
+
+        val badge = ModeSymbols.forLegs(legs, legs.map { emptyList() })
+            .filterIsInstance<ModeSymbol.Transit>()
+            .single()
+            .badge
+
+        assertEquals(listOf("12", "10"), badge.routes.map { it.shortName })
+        assertEquals(RouteBadgeJoin.THEN, badge.join)
+        // The rider has one route to board, not a choice of two — the card must not offer the 10.
+        assertFalse(badge.isInterchangeable)
+    }
+
+    /** A transfer stays two symbols: two boardings, so two roundels with a walk (or a gap) between. */
+    @Test
+    fun aTransferBetweenTwoRidesStaysTwoSymbols() {
+        assertEquals(
+            listOf(listOf("10"), listOf("12")),
+            symbolsOf(listOf(transit("10"), transit("12")))
+        )
     }
 
     /** A ride's badge names the routes it can be taken on, not just the planned one (#2010). */

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/ModeSymbolsTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/ModeSymbolsTest.kt
@@ -16,14 +16,12 @@
 package org.onebusaway.android.ui.tripresults
 
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Test
 import org.onebusaway.android.directions.model.InterchangeableRoute
 import org.onebusaway.android.directions.model.TripLeg
 import org.onebusaway.android.directions.model.TripMode
 import org.onebusaway.android.directions.model.TripPlace
 import org.onebusaway.android.directions.model.TripVertexType
-import org.onebusaway.android.ui.compose.components.RouteBadgeJoin
 
 /**
  * JVM tests for [ModeSymbols]: an itinerary read as one left-to-right symbol sequence — the on-street
@@ -143,27 +141,11 @@ class ModeSymbolsTest {
     @Test
     fun anInterlinedRideIsOneSymbolNamingEveryRouteItRunsAs() {
         assertEquals(listOf(listOf("12")), symbolsOf(listOf(transit("12"), transit("12", interline = true))))
-        assertEquals(listOf(listOf("10", "12")), symbolsOf(listOf(transit("10"), transit("12", interline = true))))
-    }
-
-    /**
-     * …and those routes read in ride order, chevroned. Deliberately a pair that natural name order would
-     * reverse: an interline's order is the information ("12 > 10" is a different ride from "10 > 12"),
-     * unlike an interchangeable pair, which is sorted so a corridor reads the same either way.
-     */
-    @Test
-    fun anInterlinedRidesRoutesReadInRideOrderNotNameOrder() {
-        val legs = listOf(transit("12"), transit("10", interline = true))
-
-        val badge = ModeSymbols.forLegs(legs, legs.map { emptyList() })
-            .filterIsInstance<ModeSymbol.Transit>()
-            .single()
-            .badge
-
-        assertEquals(listOf("12", "10"), badge.routes.map { it.shortName })
-        assertEquals(RouteBadgeJoin.THEN, badge.join)
-        // The rider has one route to board, not a choice of two — the card must not offer the 10.
-        assertFalse(badge.isInterchangeable)
+        // Deliberately a pair that natural name order would reverse, so this also pins that the ride
+        // order survives the trip through the badge builder. What that order *means*, and that the badge
+        // chevrons rather than offers a choice, is `RouteBadgesTest`'s to assert — `rideBadge` owns the
+        // rule and this only checks that a card is handed the whole of it.
+        assertEquals(listOf(listOf("12", "10")), symbolsOf(listOf(transit("12"), transit("10", interline = true))))
     }
 
     /** A transfer stays two symbols: two boardings, so two roundels with a walk (or a gap) between. */

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/RouteBadgesTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/RouteBadgesTest.kt
@@ -24,10 +24,12 @@ import org.onebusaway.android.directions.model.InterchangeableRoute
 import org.onebusaway.android.directions.model.TripLeg
 import org.onebusaway.android.directions.model.TripMode
 import org.onebusaway.android.ui.compose.components.RouteBadge
+import org.onebusaway.android.ui.compose.components.RouteBadgeJoin
 
 /**
- * JVM tests for the joined route badge a transit leg draws (#2010) — the planned route plus whatever
- * else the leg can be ridden on, shared by the itinerary option cards and the directions drawer.
+ * JVM tests for the joined route badge a ride draws — the planned route plus whatever else the leg can be
+ * ridden on (#2010), or plus whatever the vehicle becomes under the rider (#2049) — shared by the
+ * itinerary option cards and the directions drawer.
  */
 class RouteBadgesTest {
 
@@ -153,6 +155,73 @@ class RouteBadgesTest {
     fun interchangeableRouteBadgesItsDisplayName() {
         assertEquals("1 Line", interchangeableRoute("1 Line").badge().shortName)
         assertEquals("Seattle - Bremerton", interchangeableRoute("Seattle - Bremerton").badge().shortName)
+    }
+
+    /**
+     * A ride the vehicle changes route during badges every route it runs as, in ride order and joined by
+     * chevrons (#2049) — the picker used to promise a 5 all the way while the drawer's own "stay on
+     * board" row said the vehicle becomes the 12.
+     *
+     * Ride order, again on a pair natural name order would reverse: what the rider boards comes first.
+     */
+    @Test
+    fun rideBadgeChevronsTheRoutesAnInterlinedVehicleRunsAs() {
+        val badge = rideBadgeOf(transitLeg("12"), transitLeg("10", interline = true))
+
+        assertEquals(listOf("12", "10"), badge.routes.map { it.shortName })
+        assertEquals(RouteBadgeJoin.THEN, badge.join)
+        assertTrue(badge.isJoined)
+        // "Board either one" is the wrong instruction here: there is one vehicle, and it becomes the 10.
+        assertFalse(badge.isInterchangeable)
+    }
+
+    /** A self-interline is invisible to the rider — same route, same vehicle — so it badges once. */
+    @Test
+    fun rideBadgeOfASelfInterlineNamesTheRouteOnce() {
+        val badge = rideBadgeOf(transitLeg("12"), transitLeg("12", interline = true))
+
+        assertEquals(listOf("12"), badge.routes.map { it.shortName })
+        assertFalse(badge.isJoined)
+    }
+
+    /** A ride with no route change is the leg's own badge: its interchangeable routes, slashed. */
+    @Test
+    fun rideBadgeOfAnOrdinaryRideOffersItsInterchangeableRoutes() {
+        val legs = listOf(transitLeg("2 Line"))
+
+        val badge = rideBadge(legs, Interlines.chains(legs).single(), listOf(interchangeableRoute("1 Line")))
+
+        assertEquals(listOf("1 Line", "2 Line"), badge.routes.map { it.shortName })
+        assertEquals(RouteBadgeJoin.ANY_OF, badge.join)
+        assertTrue(badge.isInterchangeable)
+    }
+
+    /**
+     * A continuation whose route names itself in no way at all drops out of the badge rather than
+     * leaving it a blank segment; the ride still names every route that can be named, and the drawer's
+     * transition row still announces the change (falling back to the headsign).
+     */
+    @Test
+    fun rideBadgeDropsAContinuationThatNamesNoRoute() {
+        val unnamed = TripLeg(mode = TripMode.BUS, routeId = "1_999", interlineWithPreviousLeg = true)
+
+        val badge = rideBadgeOf(transitLeg("12"), unnamed)
+
+        assertEquals(listOf("12"), badge.routes.map { it.shortName })
+        assertEquals(TransitMode.BUS, badge.mode)
+    }
+
+    private fun transitLeg(shortName: String, interline: Boolean = false) = TripLeg(
+        mode = TripMode.BUS,
+        routeId = "1_$shortName",
+        routeShortName = shortName,
+        interlineWithPreviousLeg = interline
+    )
+
+    /** The badge for the single ride [legs] describe, with nothing interchangeable. */
+    private fun rideBadgeOf(vararg legs: TripLeg): LegBadge {
+        val ride = legs.toList()
+        return rideBadge(ride, Interlines.chains(ride).single(), emptyList())
     }
 
     private fun interchangeableRoute(displayName: String) = InterchangeableRoute(

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/TripResultsViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/TripResultsViewModelTest.kt
@@ -29,6 +29,7 @@ import org.onebusaway.android.directions.model.TripItinerary
 import org.onebusaway.android.testing.MainDispatcherRule
 import org.onebusaway.android.time.ServerTime
 import org.onebusaway.android.ui.compose.components.RouteBadge
+import org.onebusaway.android.ui.compose.components.RouteBadgeJoin
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class TripResultsViewModelTest {
@@ -42,7 +43,7 @@ class TripResultsViewModelTest {
     )
 
     private fun option(shortName: String) = ItineraryOption(
-        symbols = listOf(ModeSymbol.Transit(LegBadge(listOf(RouteBadge(shortName, routeColor = null)), TransitMode.BUS))),
+        symbols = listOf(ModeSymbol.Transit(LegBadge(listOf(RouteBadge(shortName, routeColor = null)), TransitMode.BUS, RouteBadgeJoin.ANY_OF))),
         durationMinutes = 30,
         startTime = ServerTime(0L),
         endTime = ServerTime(30 * 60_000L)


### PR DESCRIPTION
Closes #2049.

A stay-aboard interline (#2000) was drawn as two different things at once, and both were misleading:

- The **option card** put the routes in separate roundels, `[5] ▸ [12]` — which is exactly how it draws a *transfer*. The one ride the rider never gets off looked like two rides they do.
- The **drawer** went the other way and badged only the route boarded, `[5]`, while the ride's own "Stay on board — the vehicle becomes 12" row said otherwise a few lines below.

Both now badge the ride: one roundel naming every route the vehicle runs as, in travel order, divided by a chevron — `[5 > 12]`.

## How

The chip is the one #2010 built for interchangeable routes. What's new is that a badge now says **how** its routes relate. `RouteBadgeJoin` is `ANY_OF` (a slash: take whichever comes first) or `THEN` (a chevron: this becomes that under you). The two can't collide — `substitutableRoutes()` already drops the alternatives on an interlined ride, since a substitute vehicle would put the rider off at the seam — and `rideBadge()` now `require`s that rather than trusting it.

The chevron is the slash's own lean folded at mid-height, one constant for both, so the joins read as one family of badges and only their shape says which relation they mean. Each join defines its divider once as a polyline; the bands either side are cut by that same polyline, so a band can't drift off the line dividing it.

Both badges are built by one `rideBadge()`, which takes a whole `Interlines.Chain` rather than a leg, so the picker and the drawer can't disagree about what a ride is. `ModeSymbols` now emits one symbol per *boarding* rather than per ridden leg. Ride order is preserved (not name-sorted — `5 > 12` is not `12 > 5`) and not deduplicated: two segments that read alike are two routes publishing the same name, a real change the drawer announces too.

"Whichever comes first" keys off the join rather than off the badge merely having two routes — on a chevron badge it would tell the rider to board a 12 that is the bus they're already sitting on.

## A note on the padding

A chevron's notch bites deepest at mid-height, which is where the name is, so a notched segment pads its leading edge by the lean and its trailing edge not at all. The boundary is slanted, so a name's tightest clearance isn't at mid-height but a quarter of the way down, where the edge crosses the segment's nominal edge — a full lean in for a notch, exactly at it for a point. Without the correction the name sits half a lean left of centre in the band a rider actually sees, with the slack left over as dead space after it. This was caught by capturing the rendered badge on-device at both drawn scales; the numbers alone looked fine.

## Testing

- New JVM coverage in `RouteBadgesTest` (chevron ordering/join, self-interline, unnameable continuation) and `ModeSymbolsTest` (one symbol per boarding, transfer still two).
- New instrumented `DirectionRowInterlineBadgeTest`: both badges name `5` and `12`, the "stay on board" row is present, and "whichever comes first" is absent.
- Ran on a physical Pixel 7 Pro (API 36): 6/6 instrumented tests pass alongside the existing `DirectionRowAlternativeRoutesTest`, confirming the slash badge is unregressed.
- Full `testObaGoogleDebugUnitTest`, `-PwarningsAsErrors=true` compile, and `spotlessCheck` clean.

## Not done here

- **TalkBack doesn't get the divider's meaning** — it reads "5, 12" for either join. Pre-existing since #2010; closing it needs `clearAndSetSemantics` on the chip, which would break the text-based UI tests, so it deserves its own issue.
- **The joined chip is LTR-only** — bands are laid out by a `Row` (which RTL reverses) but painted in raw draw-space offsets (which it doesn't). Also pre-existing; the assumption is now documented at the composable rather than silently extended. The app ships no RTL locale today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved route badges for rides that continue across multiple routes.
  * Route badges now distinguish between interchangeable routes and routes traveled in sequence.
  * Interlined rides display route names consistently in itinerary cards, ride logs, and step-by-step directions.
  * Updated guidance clarifies when riders should remain onboard versus choose any available route.

* **Bug Fixes**
  * Corrected route badge rendering and transit symbol behavior for interlined rides and transfers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->