### PR TITLE
Keep the rest of the trip on the map when a leg is focused (#2048)

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/DirectionRowFocusTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/DirectionRowFocusTest.kt
@@ -63,7 +63,8 @@ class DirectionRowFocusTest {
         isTransfer = false,
         steps = listOf(LogStep("Turn left onto Pike St", point = stepPoint)),
         legPoints = walkLegPoints,
-        focusPoint = walkLegPoints.first()
+        focusPoint = walkLegPoints.first(),
+        legIndices = setOf(0)
     )
 
     private val routeLeg = RouteLegRef(
@@ -87,7 +88,8 @@ class DirectionRowFocusTest {
         realtime = RealtimeState.OnTime,
         rideEvents = listOf(RideEvent.Stop(LogStop("Capitol Hill Station", stopMidPoint))),
         routeLeg = routeLeg,
-        legPoints = transitLegPoints
+        legPoints = transitLegPoints,
+        legIndices = setOf(1)
     )
 
     private val arrive = TripLogEntry.Terminal(TerminalKind.ARRIVE, ServerTime(32 * 60_000L), "Alaska Junction", alightPoint)
@@ -117,7 +119,7 @@ class DirectionRowFocusTest {
 
     @Test
     fun tappingWalkHeader_framesTheLeg_withoutRevealingItsSteps() {
-        var framed: List<GeoPoint>? = null
+        var framed: FocusedLeg? = null
         var focused: GeoPoint? = null
         composeRule.setContent {
             TripResultsList(state = walkOnlyState, onFocusLeg = { framed = it }, onFocusPoint = { focused = it })
@@ -129,7 +131,9 @@ class DirectionRowFocusTest {
         // Tapping the walk header frames the leg but does not reveal its steps (#2040) — that's the
         // chevron's job, checked separately below.
         composeRule.onNodeWithText(walkAction).performClick()
-        assertEquals(walkLegPoints, framed)
+        // The focus carries which itinerary leg it is, so the map can recede the rest of the trip
+        // around it rather than drawing this leg alone (#2048).
+        assertEquals(FocusedLeg(walkLegPoints, setOf(0)), framed)
         composeRule.onNodeWithText(walk.steps.single().text).assertDoesNotExist()
 
         // Tapping the chevron reveals the steps without re-framing the leg.
@@ -146,12 +150,12 @@ class DirectionRowFocusTest {
 
     @Test
     fun tappingTransitHeader_highlightsRoute_withoutRevealingIntermediateStops() {
-        var captured: Pair<RouteLegRef, List<GeoPoint>>? = null
+        var captured: Pair<RouteLegRef, FocusedLeg>? = null
         var focused: GeoPoint? = null
         composeRule.setContent {
             TripResultsList(
                 state = transitOnlyState,
-                onFocusRouteLeg = { rl, pts -> captured = rl to pts },
+                onFocusRouteLeg = { rl, leg -> captured = rl to leg },
                 onFocusPoint = { focused = it }
             )
         }
@@ -162,7 +166,7 @@ class DirectionRowFocusTest {
         // Tapping the transit header highlights the route but does not reveal the stops (#2040).
         composeRule.onNodeWithText(transitTitle).performClick()
         assertEquals("1_100", captured?.first?.routeId)
-        assertEquals(transitLegPoints, captured?.second)
+        assertEquals(FocusedLeg(transitLegPoints, setOf(1)), captured?.second)
         composeRule.onNodeWithText(midStopName).assertDoesNotExist()
 
         // Tapping the chevron reveals the stops without re-highlighting the route.
@@ -241,7 +245,7 @@ class DirectionRowFocusTest {
     @Test
     fun walkLegWithoutPolyline_fallsBackToFocusingItsPoint() {
         val noGeometry = walk.copy(legPoints = emptyList(), focusPoint = boardPoint, steps = emptyList())
-        var framed: List<GeoPoint>? = null
+        var framed: FocusedLeg? = null
         var focused: GeoPoint? = null
         composeRule.setContent {
             TripResultsList(
@@ -260,7 +264,7 @@ class DirectionRowFocusTest {
     @Test
     fun walkLegWithNeitherPolylineNorPoint_movesTheMapNowhere() {
         val inert = walk.copy(legPoints = emptyList(), focusPoint = null, steps = emptyList())
-        var framed: List<GeoPoint>? = null
+        var framed: FocusedLeg? = null
         var focused: GeoPoint? = null
         composeRule.setContent {
             TripResultsList(

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/DirectionsMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/DirectionsMapController.kt
@@ -33,14 +33,23 @@ import org.onebusaway.android.util.parseObaHexColor
  * just writes polylines + markers and dispatches the framing camera command.
  *
  * [start] draws an itinerary; [frameDirections] (re-appliable, since the [start]-time camera command
- * is lost before the adapter subscribes) fits it; [clear] removes its start/end pins. The leg
- * polylines are cleared generically by the owner (they share the render state's polyline list).
+ * is lost before the adapter subscribes) fits it; [focusLegs] recedes all but the leg the rider is
+ * reading; [clear] removes its start/end pins and forgets the itinerary. In directions mode the drawn
+ * itinerary *is* the render state's whole polyline list (the owner clears it before each [start]), so
+ * republishing here replaces it wholesale.
  * [setEndpoints] additionally draws standalone From/To pins as the endpoints resolve, before an
  * itinerary exists (superseded by the itinerary's own start/end pins once [start] runs).
  */
 class DirectionsMapController(private val host: MapHost) {
 
     private val directionsMarkerIds = HashSet<Int>()
+
+    // The drawn itinerary, retained so a leg focus can recompose it without rebuilding from the
+    // itinerary, and so a leg's route sub-focus can take it as context (see [contextPolylines]).
+    private var legLines: List<ItineraryLegLine> = emptyList()
+
+    // Which legs the rider is currently reading; empty is the itinerary overview (every leg full weight).
+    private var focusedLegIndices: Set<Int> = emptySet()
 
     // The directions framing intent, kept so [frameDirections] can (re)apply it once the map is ready
     // (the one-shot camera command dispatched at start time is lost before the adapter subscribes).
@@ -76,29 +85,32 @@ class DirectionsMapController(private val host: MapHost) {
         val endLat = endPlace.lat
         val endLon = endPlace.lon
 
-        // Build every leg's polyline (each in its own mode/route style), then append them in one write —
-        // matching the legacy per-leg append but without rebuilding the polyline list n times.
-        val legPolylines = legs.mapNotNull { leg ->
-            val geometry = leg.legGeometry ?: return@mapNotNull null
+        // Build every leg's polyline (each in its own mode/route style), keeping each one's leg index so
+        // a later focus can name legs rather than drawn positions (a leg without geometry draws nothing).
+        legLines = legs.mapIndexedNotNull { legIndex, leg ->
+            val geometry = leg.legGeometry ?: return@mapIndexedNotNull null
             val shape = LegShape(geometry)
             if (shape.length > 0) {
                 val style = itineraryLegStyle(leg.legKind(), parseObaHexColor(leg.routeColor))
                 // Every leg's points run in travel order, so whether it stamps chevrons is the style's
                 // call — a dashed on-street stroke declines them (see [itineraryLegStyle]).
-                RoutePolyline(
-                    style.color,
-                    shape.points,
-                    widthProfile = style.widthProfile,
-                    directional = style.directional,
-                    dash = style.dash
+                ItineraryLegLine(
+                    legIndex,
+                    RoutePolyline(
+                        style.color,
+                        shape.points,
+                        widthProfile = style.widthProfile,
+                        directional = style.directional,
+                        dash = style.dash
+                    )
                 )
             } else {
                 null
             }
         }
-        if (legPolylines.isNotEmpty()) {
-            host.renderState.setRoutePolylines(host.renderState.getRoutePolylines() + legPolylines)
-        }
+        // A freshly drawn itinerary is the overview: every leg at full weight until one is focused.
+        focusedLegIndices = emptySet()
+        publishLegs()
 
         if (startLat != null && startLon != null) {
             directionsMarkerIds.add(host.addMarker(startLat, startLon, HUE_GREEN))
@@ -107,9 +119,32 @@ class DirectionsMapController(private val host: MapHost) {
             directionsMarkerIds.add(host.addMarker(endLat, endLon, HUE_RED))
         }
 
-        directionsHasRoute = legPolylines.isNotEmpty()
+        directionsHasRoute = legLines.isNotEmpty()
         directionsStart = if (startLat != null && startLon != null) GeoPoint(startLat, startLon) else null
         frameDirections()
+    }
+
+    /**
+     * Recede all but [legIndices] — the leg (or folded interline chain) the rider has just focused —
+     * leaving the rest of the trip on the map as faint context instead of erasing it (#2048). An empty
+     * set restores the overview. A no-op when no itinerary is drawn.
+     */
+    fun focusLegs(legIndices: Set<Int>) {
+        if (legLines.isEmpty() || focusedLegIndices == legIndices) return
+        focusedLegIndices = legIndices
+        publishLegs()
+    }
+
+    /**
+     * The whole drawn itinerary thinned to context, for a transit leg's route sub-focus to keep beneath
+     * the route it drills into (#2048). Every leg is thinned — including the focused one, whose ridden
+     * segment the route view redraws at full weight directly over its own faint copy — so this needs no
+     * notion of which leg is focused and can't disagree with one.
+     */
+    fun contextPolylines(): List<RoutePolyline> = legLines.map { it.line }.asDeemphasizedRouteUnderlay()
+
+    private fun publishLegs() {
+        host.renderState.setRoutePolylines(legLines.withLegFocus(focusedLegIndices))
     }
 
     /**
@@ -127,10 +162,16 @@ class DirectionsMapController(private val host: MapHost) {
         }
     }
 
-    /** Remove the start/end pins (the owner clears the leg polylines via the shared polyline list). */
+    /**
+     * Forget the drawn itinerary: remove the start/end pins and drop the retained legs (the owner clears
+     * the leg polylines themselves via the shared polyline list). Called on every transition that leaves
+     * the trip behind — a leg's route sub-focus deliberately doesn't, so [contextPolylines] survives into it.
+     */
     fun clear() {
         directionsMarkerIds.forEach { host.removeMarker(it) }
         directionsMarkerIds.clear()
+        legLines = emptyList()
+        focusedLegIndices = emptySet()
     }
 
     /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/DirectionsMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/DirectionsMapController.kt
@@ -136,12 +136,12 @@ class DirectionsMapController(private val host: MapHost) {
     }
 
     /**
-     * The whole drawn itinerary thinned to context, for a transit leg's route sub-focus to keep beneath
-     * the route it drills into (#2048). Every leg is thinned — including the focused one, whose ridden
-     * segment the route view redraws at full weight directly over its own faint copy — so this needs no
-     * notion of which leg is focused and can't disagree with one.
+     * The whole drawn itinerary reduced to journey context, for a transit leg's route sub-focus (#2048).
+     * It remains stronger than the unused remainder of that route, since these are legs the rider will
+     * actually travel. Every leg is included — even the focused one, whose ridden segment the route view
+     * redraws at full weight over its context copy — so this needs no notion of the current focus.
      */
-    fun contextPolylines(): List<RoutePolyline> = legLines.map { it.line }.asDeemphasizedRouteUnderlay()
+    fun contextPolylines(): List<RoutePolyline> = legLines.map { it.line }.asItineraryContext()
 
     private fun publishLegs() {
         host.renderState.setRoutePolylines(legLines.withLegFocus(focusedLegIndices))

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/ItineraryLegStyle.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/ItineraryLegStyle.kt
@@ -22,6 +22,7 @@ import org.onebusaway.android.map.render.ITINERARY_RIDE_WIDTH_PROFILE
 import org.onebusaway.android.map.render.ITINERARY_STREET_WIDTH_PROFILE
 import org.onebusaway.android.map.render.RouteLineDash
 import org.onebusaway.android.map.render.RouteLineWidthProfile
+import org.onebusaway.android.map.render.RoutePolyline
 
 /**
  * How one trip-plan itinerary leg is stroked on the directions map (#2041).
@@ -95,6 +96,32 @@ internal fun itineraryLegStyle(kind: ItineraryLegKind, routeColor: Int?): Itiner
     ItineraryLegKind.BIKE -> street(BIKE_HUE_ANCHOR)
     ItineraryLegKind.BIKESHARE -> street(BIKESHARE_HUE_ANCHOR)
     ItineraryLegKind.CAR -> street(CAR_HUE_ANCHOR)
+}
+
+/**
+ * One drawn itinerary leg, paired with its index in the itinerary. The pairing is what lets a focus be
+ * expressed in *leg* terms: a leg that carries no geometry draws no line, so a position in the drawn
+ * list is not a leg index.
+ */
+internal data class ItineraryLegLine(val legIndex: Int, val line: RoutePolyline)
+
+/**
+ * The drawn itinerary composed around a leg focus (#2048): every leg the rider isn't looking at thinned
+ * to the same faint context weight a route takes under its ridden segment, and the focused leg(s)
+ * re-appended last so they draw at full weight on top. Focusing a leg therefore *recedes* the rest of
+ * the trip rather than erasing it — the rider keeps where this leg sits in the whole journey, which is
+ * exactly what a leg drawn alone can't say.
+ *
+ * [focusedLegIndices] is a set of leg indices rather than one index because a folded interline chain
+ * (#2000) is several itinerary legs the rider reads — and taps — as a single ride.
+ *
+ * Returns the lines unchanged when nothing is focused (the itinerary overview), and when the focus names
+ * no drawn leg (a leg that carried no geometry): there is nothing to raise, so nothing is lowered.
+ */
+internal fun List<ItineraryLegLine>.withLegFocus(focusedLegIndices: Set<Int>): List<RoutePolyline> {
+    val (focused, rest) = partition { it.legIndex in focusedLegIndices }
+    if (focused.isEmpty()) return map { it.line }
+    return rest.map { it.line }.asDeemphasizedRouteUnderlay() + focused.map { it.line }
 }
 
 private fun street(hueAnchor: Int) = ItineraryLegStyle(

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
@@ -308,11 +308,14 @@ class MapViewModel @Inject constructor(
         preserveStopFocus: Boolean = false,
         highlightedSegment: List<GeoPoint> = emptyList(),
         extraSegments: List<RiddenSegment> = emptyList(),
-        itineraryContext: List<RoutePolyline> = emptyList()
+        itineraryContext: List<RoutePolyline> = emptyList(),
+        preserveItinerary: Boolean = false
     ) {
         // A leg's route sub-focus keeps the trip it came from (its context lines were read by the caller
         // before this teardown, and its start/end pins are left standing); every other entry drops it.
-        leaveCurrentView(clearStopFocus = !preserveStopFocus, keepItinerary = itineraryContext.isNotEmpty())
+        // Preserve based on the transition's origin rather than the context list: an itinerary whose
+        // legs have no drawable geometry still has start/end pins and retained controller state to keep.
+        leaveCurrentView(clearStopFocus = !preserveStopFocus, keepItinerary = preserveItinerary)
         persistRoute(routeId, directionStopId, initialDirectionId)
         routeController.start(
             routeId,
@@ -480,7 +483,8 @@ class MapViewModel @Inject constructor(
                 extraSegments = request.extraSegments,
                 // Read before entering: the transition tears the drawn itinerary down, and this is what
                 // survives it.
-                itineraryContext = if (withinDirections) directionsController.contextPolylines() else emptyList()
+                itineraryContext = if (withinDirections) directionsController.contextPolylines() else emptyList(),
+                preserveItinerary = withinDirections
             )
         }
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
@@ -39,6 +39,7 @@ import org.onebusaway.android.map.render.CameraCommand
 import org.onebusaway.android.map.render.CameraSnapshot
 import org.onebusaway.android.map.render.MapRenderState
 import org.onebusaway.android.map.render.MapViewport
+import org.onebusaway.android.map.render.RoutePolyline
 import org.onebusaway.android.map.render.WALK_LEG_MIN_FRAMING_SPAN_DEG
 import org.onebusaway.android.map.render.viewport
 import org.onebusaway.android.models.FocusedTrip
@@ -306,9 +307,12 @@ class MapViewModel @Inject constructor(
         focusTripId: String? = null,
         preserveStopFocus: Boolean = false,
         highlightedSegment: List<GeoPoint> = emptyList(),
-        extraSegments: List<RiddenSegment> = emptyList()
+        extraSegments: List<RiddenSegment> = emptyList(),
+        itineraryContext: List<RoutePolyline> = emptyList()
     ) {
-        leaveCurrentView(clearStopFocus = !preserveStopFocus)
+        // A leg's route sub-focus keeps the trip it came from (its context lines were read by the caller
+        // before this teardown, and its start/end pins are left standing); every other entry drops it.
+        leaveCurrentView(clearStopFocus = !preserveStopFocus, keepItinerary = itineraryContext.isNotEmpty())
         persistRoute(routeId, directionStopId, initialDirectionId)
         routeController.start(
             routeId,
@@ -317,7 +321,8 @@ class MapViewModel @Inject constructor(
             initialDirectionId,
             focusTripId,
             highlightedSegment,
-            extraSegments
+            extraSegments,
+            itineraryContext
         )
         bikeController.start(directions = false, selectedBikeStationIds = null)
     }
@@ -341,18 +346,22 @@ class MapViewModel @Inject constructor(
     /**
      * Tears down whatever the map is currently showing: stops the loaders (each controller clears its
      * own overlays) and drops the accumulated stops (keeping the focused one). Shared by the transitions
-     * above.
+     * above. [keepItinerary] is the one exception — a trip-plan leg drilling into its route, which hands
+     * the drawn trip forward as context rather than leaving it behind (#2048).
      */
-    private fun leaveCurrentView(clearStopFocus: Boolean) {
+    private fun leaveCurrentView(clearStopFocus: Boolean, keepItinerary: Boolean = false) {
         if (clearStopFocus) routeController.clearStopFocus()
         // Endpoint pins belong only to the directions-before-a-plan state; drop them on any transition
         // out (they can exist without [directionsActive], which is only set once an itinerary draws).
         directionsController.clearEndpoints()
         if (directionsActive) {
-            directionsController.clear()
             renderState.clearRoutePolylines()
             directionsActive = false
         }
+        // The drawn trip (its start/end pins and the legs a route sub-focus takes as context, #2048)
+        // survives only into that sub-focus. Unconditional otherwise, since by then [directionsActive] is
+        // already false — the sub-focus is what turned it off — and the pins would otherwise be stranded.
+        if (!keepItinerary) directionsController.clear()
         stopsController.stop()
         routeController.stop()
         bikeController.stop()
@@ -436,11 +445,16 @@ class MapViewModel @Inject constructor(
      * that trip's live vehicle together with the originating stop instead of framing the whole route, and
      * raises the "vehicle isn't on the map" toast when no live vehicle is running that trip. A plain row
      * tap carries no [ShowRouteRequest.focusTripId] and just frames the whole route.
+     *
+     * [withinDirections] marks the one caller that drills in from a *trip plan* — a leg (or its inline
+     * ETA pill) tapped in the directions drawer. That entry keeps the drawn trip beneath the route as
+     * de-emphasized context (#2048) instead of clearing it; every other caller arrives with no trip to keep.
      */
     fun toRoute(
         request: ShowRouteRequest,
         stopScoped: Boolean = false,
-        frameRoute: Boolean = true
+        frameRoute: Boolean = true,
+        withinDirections: Boolean = false
     ) {
         // Same route AND same direction anchor: a plain re-tap (no focus) just reframes (the recent-routes
         // re-tap); an ETA-pill focus instead fits the vehicle+stop against the already-loaded vehicles (or
@@ -463,7 +477,10 @@ class MapViewModel @Inject constructor(
                 focusTripId = request.focusTripId,
                 preserveStopFocus = stopScoped,
                 highlightedSegment = request.highlightedSegment,
-                extraSegments = request.extraSegments
+                extraSegments = request.extraSegments,
+                // Read before entering: the transition tears the drawn itinerary down, and this is what
+                // survives it.
+                itineraryContext = if (withinDirections) directionsController.contextPolylines() else emptyList()
             )
         }
     }
@@ -473,7 +490,8 @@ class MapViewModel @Inject constructor(
      * session. The first call leaves the current view (dropping
      * stop/route focus + nearby stops) and enters directions mode; later calls (a different option
      * selected) just redraw the legs/pins. Deliberately does not restart the nearby-stops loader —
-     * directions hides nearby stops. Exiting (any other transition → [leaveCurrentView]) tears it down.
+     * directions hides nearby stops. Exiting (any other transition → [leaveCurrentView]) tears it down,
+     * except a leg's route sub-focus, which carries the trip on as context (#2048).
      */
     fun showItinerary(itinerary: TripItinerary) {
         if (!directionsActive) {
@@ -507,12 +525,15 @@ class MapViewModel @Inject constructor(
     }
 
     /**
-     * Frame a whole tapped itinerary leg: fit its polyline within the map's content padding, so the leg
-     * lands in the visible band above the directions results sheet. Guarded on an active directions
-     * session (like [focusItineraryPoint]); an empty point list is a no-op.
+     * Focus a whole tapped itinerary leg: recede the rest of the trip to context (#2048) and fit the
+     * leg's polyline within the map's content padding, so it lands in the visible band above the
+     * directions results sheet. [legIndices] names the itinerary legs the tapped row covers — more than
+     * one for a folded interline chain. Guarded on an active directions session (like
+     * [focusItineraryPoint]); an empty point list is a no-op.
      */
-    fun focusItineraryLeg(points: List<GeoPoint>) {
+    fun focusItineraryLeg(points: List<GeoPoint>, legIndices: Set<Int>) {
         if (!directionsActive || points.isEmpty()) return
+        directionsController.focusLegs(legIndices)
         // A short walking leg (crossing a street) frames to a block-level floor rather than the default
         // minimum, so the user doesn't have to zoom in further to read it.
         mapHost.frameItineraryLeg(points, WALK_LEG_MIN_FRAMING_SPAN_DEG)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
@@ -113,6 +113,12 @@ class RouteMapController(
     // publishMapPresentation so it survives re-publishes (vehicle polls, direction changes).
     private var highlightedSegment: List<GeoPoint> = emptyList()
 
+    // The trip whose leg was drilled into, already thinned to context (#2048) — drawn beneath everything
+    // this controller publishes so the rest of the journey stays on the map around the ridden segment,
+    // rather than the route arriving on an otherwise empty map. Empty for every non-directions launch.
+    // Set in start(); cleared in stop(), since the trip doesn't outlive the view that drilled into it.
+    private var itineraryContext: List<RoutePolyline> = emptyList()
+
     // The additional ridden legs of a stay-aboard interline (#2000) drilled into route focus, beyond the
     // leader route/direction: each names a route continued onto (the same route in another direction for
     // a self-interline, or a different route to load for a cross-route interline) and its seam stop. The
@@ -259,12 +265,14 @@ class RouteMapController(
         initialDirectionId: Int? = null,
         focusTripId: String? = null,
         highlightedSegment: List<GeoPoint> = emptyList(),
-        extraSegments: List<RiddenSegment> = emptyList()
+        extraSegments: List<RiddenSegment> = emptyList(),
+        itineraryContext: List<RoutePolyline> = emptyList()
     ) {
         this.routeId = routeId
         this.directionStopId = directionStopId
         this.highlightedSegment = highlightedSegment
         this.extraSegments = extraSegments
+        this.itineraryContext = itineraryContext
         // (Re)built as the extra routes load / poll in onRouteLoaded + startVehiclePolling; cleared here
         // so a prior focus's routes/polls can't leak into this one during the load window.
         this.extraRouteMaps = emptyMap()
@@ -568,6 +576,7 @@ class RouteMapController(
         directionStopId = null
         highlightedSegment = emptyList()
         extraSegments = emptyList()
+        itineraryContext = emptyList()
         extraRouteMaps = emptyMap()
         extraPolls = emptyMap()
         initialDirectionOverride = null
@@ -716,8 +725,12 @@ class RouteMapController(
             }
         )
         renderState.setRoutePolylines(
-            // Over a highlighted leg segment: thin the full route to context + the ridden span on top.
-            polylines = routePolylinesWithSegment(plan.polylines, highlightedSegment, routeColor),
+            // Over a highlighted leg segment: thin the full route to context + the ridden span on top,
+            // all of it above the rest of the trip this leg belongs to (already thinned, #2048).
+            // The trip is context only, so it stays out of [framingPolylines] — drilling into a leg
+            // frames that leg, not the whole journey again.
+            polylines = itineraryContext +
+                routePolylinesWithSegment(plan.polylines, highlightedSegment, routeColor),
             framingPolylines = plan.framingPolylines,
             routeModeScalesStopsWithZoom = plan.routeModeScalesStopsWithZoom
         )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
@@ -113,10 +113,10 @@ class RouteMapController(
     // publishMapPresentation so it survives re-publishes (vehicle polls, direction changes).
     private var highlightedSegment: List<GeoPoint> = emptyList()
 
-    // The trip whose leg was drilled into, already thinned to context (#2048) — drawn beneath everything
-    // this controller publishes so the rest of the journey stays on the map around the ridden segment,
-    // rather than the route arriving on an otherwise empty map. Empty for every non-directions launch.
-    // Set in start(); cleared in stop(), since the trip doesn't outlive the view that drilled into it.
+    // The trip whose leg was drilled into, already reduced to its middle journey-context weight (#2048).
+    // It draws above unused route geometry but below the ridden segment, keeping the rest of the journey
+    // visible around the selected leg. Empty for every non-directions launch. Set in start(); cleared in
+    // stop(), since the trip doesn't outlive the view that drilled into it.
     private var itineraryContext: List<RoutePolyline> = emptyList()
 
     // The additional ridden legs of a stay-aboard interline (#2000) drilled into route focus, beyond the
@@ -725,12 +725,15 @@ class RouteMapController(
             }
         )
         renderState.setRoutePolylines(
-            // Over a highlighted leg segment: thin the full route to context + the ridden span on top,
-            // all of it above the rest of the trip this leg belongs to (already thinned, #2048).
-            // The trip is context only, so it stays out of [framingPolylines] — drilling into a leg
-            // frames that leg, not the whole journey again.
-            polylines = itineraryContext +
-                routePolylinesWithSegment(plan.polylines, highlightedSegment, routeColor),
+            // Over a highlighted leg segment: unused route first, the rider's remaining itinerary at a
+            // middle weight, then the ridden span on top (#2048). The trip stays out of
+            // [framingPolylines] — drilling into a leg frames that leg, not the whole journey again.
+            polylines = routePolylinesWithSegment(
+                plan.polylines,
+                highlightedSegment,
+                routeColor,
+                itineraryContext
+            ),
             framingPolylines = plan.framingPolylines,
             routeModeScalesStopsWithZoom = plan.routeModeScalesStopsWithZoom
         )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteSegmentHighlight.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteSegmentHighlight.kt
@@ -39,8 +39,10 @@ internal fun List<GeoPoint>.isDrawableSegment() = size >= 2
 
 /**
  * Compose the route's polylines when [segment] is highlighted: the full route [base] de-emphasized
- * (thin, no arrows) under the ridden segment in [routeColor], last so it sits on top.
- * Returns [base] unchanged when there's no drawable segment (plain route focus).
+ * (thin, no arrows), then the rider's [itineraryContext], then the ridden segment in [routeColor]. This
+ * order makes the visual hierarchy match the semantics: unused route, committed journey, current leg.
+ * Without a drawable segment, retains the ordinary plain-route ordering: itinerary context beneath
+ * [base], with no route deemphasis or selected overlay.
  *
  * The segment keeps [ITINERARY_RIDE_WIDTH_PROFILE] — the very weight it had as a leg of the itinerary it
  * was tapped from — so drilling into a leg thins the route around it without also thinning the ride
@@ -50,12 +52,13 @@ internal fun List<GeoPoint>.isDrawableSegment() = size >= 2
 internal fun routePolylinesWithSegment(
     base: List<RoutePolyline>,
     segment: List<GeoPoint>,
-    routeColor: Int?
+    routeColor: Int?,
+    itineraryContext: List<RoutePolyline> = emptyList()
 ): List<RoutePolyline> {
     val overlay = segment.takeIf { it.isDrawableSegment() }?.let {
         RoutePolyline(color = routeColor, points = it, widthProfile = ITINERARY_RIDE_WIDTH_PROFILE, directional = true)
-    } ?: return base
-    return base.asDeemphasizedRouteUnderlay() + overlay
+    } ?: return itineraryContext + base
+    return base.asUntraveledRouteUnderlay() + itineraryContext + overlay
 }
 
 /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteViewGeometry.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteViewGeometry.kt
@@ -12,9 +12,12 @@ import org.onebusaway.android.map.render.ADJACENT_ROUTE_LINE_WIDTH_PROFILE
 import org.onebusaway.android.map.render.DEEMPHASIZED_ROUTE_LINE_WIDTH_PROFILE
 import org.onebusaway.android.map.render.DEFAULT_ROUTE_LINE_COLOR
 import org.onebusaway.android.map.render.FOCUSED_ROUTE_LINE_WIDTH_PROFILE
+import org.onebusaway.android.map.render.ITINERARY_CONTEXT_WIDTH_PROFILE
 import org.onebusaway.android.map.render.RouteBadge
+import org.onebusaway.android.map.render.RouteLineDash
 import org.onebusaway.android.map.render.RoutePolyline
 import org.onebusaway.android.map.render.RoutePolylineTransform
+import org.onebusaway.android.map.render.UNTRAVELED_ROUTE_LINE_WIDTH_PROFILE
 import org.onebusaway.android.models.FocusedTrip
 import org.onebusaway.android.models.ObaRoute
 import org.onebusaway.android.models.RouteDirectionKey
@@ -43,6 +46,27 @@ internal fun focusedRoutePolyline(
 internal fun List<RoutePolyline>.asDeemphasizedRouteUnderlay(): List<RoutePolyline> = map { line ->
     line.copy(
         widthProfile = DEEMPHASIZED_ROUTE_LINE_WIDTH_PROFILE,
+        directional = false
+    )
+}
+
+/** The unused remainder of a route retained as the faintest reference beneath a ridden segment. */
+internal fun List<RoutePolyline>.asUntraveledRouteUnderlay(): List<RoutePolyline> = map { line ->
+    line.copy(
+        widthProfile = UNTRAVELED_ROUTE_LINE_WIDTH_PROFILE,
+        directional = false,
+        dash = RouteLineDash.HINT
+    )
+}
+
+/**
+ * The rider's committed journey retained around a focused transit leg. It keeps each leg's mode/route
+ * colour and dash, but drops chevrons and takes a middle weight: stronger than unused route geometry,
+ * weaker than the selected ridden segment.
+ */
+internal fun List<RoutePolyline>.asItineraryContext(): List<RoutePolyline> = map { line ->
+    line.copy(
+        widthProfile = ITINERARY_CONTEXT_WIDTH_PROFILE,
         directional = false
     )
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/DetailZoomRamp.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/DetailZoomRamp.kt
@@ -71,6 +71,26 @@ val DEEMPHASIZED_ROUTE_LINE_WIDTH_PROFILE = ROUTE_LINE_WIDTH_PROFILE.copy(
 )
 
 /**
+ * The portion of a transit route outside the segment the rider will travel. It is only geographic
+ * reference beneath a focused itinerary leg, so it takes the faintest route weight on the map.
+ */
+val UNTRAVELED_ROUTE_LINE_WIDTH_PROFILE = ROUTE_LINE_WIDTH_PROFILE.copy(
+    thicknessDp = 2f
+)
+
+/**
+ * The rest of a rider's itinerary retained around a focused transit leg. It sits between the selected
+ * ridden segment and the thinner, untraveled remainder of that transit route: still visibly part of the
+ * journey, but no longer competing with the leg being read.
+ *
+ * This deliberately has its own semantic profile even though it currently shares the adjacent-route
+ * value. The two presentations describe different things and can be tuned independently later.
+ */
+val ITINERARY_CONTEXT_WIDTH_PROFILE = ROUTE_LINE_WIDTH_PROFILE.copy(
+    thicknessDp = ROUTE_LINE_WIDTH_DP * 0.5f
+)
+
+/**
  * A trip-plan itinerary's transit legs (#2041). The itinerary is the only thing the directions map is
  * showing — nothing competes with it — so a ride draws at the focused-route weight, and *is* that
  * profile rather than a second copy of its multiplier. It carries its own name because the two are read

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -734,9 +734,7 @@ fun HomeScreen(
                                             itineraries = directionsResults.itineraries,
                                             params = directionsResults.params,
                                             showItinerary = homeViewModel::showItineraryOnMap,
-                                            onFocusRouteLeg = { routeLeg, legPoints ->
-                                                homeViewModel.focusItineraryRouteLeg(routeLeg, legPoints)
-                                            },
+                                            onFocusRouteLeg = homeViewModel::focusItineraryRouteLeg,
                                             onFocusLeg = homeViewModel::focusItineraryLegOnMap,
                                             onFocusPoint = homeViewModel::focusItineraryPointOnMap,
                                             // Each transit leg's Board/Alight row shows that stop's live ETA strip inline.

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
@@ -43,6 +43,7 @@ import org.onebusaway.android.models.RouteDirectionKey
 import org.onebusaway.android.region.Region
 import org.onebusaway.android.region.RegionRepository
 import org.onebusaway.android.region.RegionStatus
+import org.onebusaway.android.ui.tripresults.FocusedLeg
 import org.onebusaway.android.ui.tripresults.RouteLegRef
 import org.onebusaway.android.util.GeoPoint
 import org.onebusaway.android.util.toGeoPoint
@@ -598,25 +599,28 @@ class HomeViewModel @Inject constructor(
     /** Recenter the map on a tapped itinerary step's point (only while in [CurrentFocus.Directions]). */
     fun focusItineraryPointOnMap(point: GeoPoint) = emitMapDirective(MapDirective.FocusItineraryPoint(point))
 
-    /** Frame a whole tapped itinerary leg on the map (only while in [CurrentFocus.Directions]). */
-    fun focusItineraryLegOnMap(points: List<GeoPoint>) {
+    /**
+     * Focus a whole tapped itinerary leg on the map (only while in [CurrentFocus.Directions]): frame it,
+     * with the rest of the trip receding to context around it (#2048).
+     */
+    fun focusItineraryLegOnMap(leg: FocusedLeg) {
         // If a transit leg's route is in focus, drop back to the itinerary overview and redraw it first —
         // otherwise the framing would no-op in route mode (directionsActive is false).
         if (popRouteFocus()) shownItinerary?.let { emitMapDirective(MapDirective.ShowItinerary(it)) }
-        emitMapDirective(MapDirective.FocusItineraryLeg(points))
+        emitMapDirective(MapDirective.FocusItineraryLeg(leg.points, leg.legIndices))
     }
 
     /**
      * Tap a transit leg from the directions overview: highlight its route on the map (the whole route +
-     * the traveled [fallbackLegPoints] drawn thick), recording the overview as the back target so a
+     * the traveled [fallbackLeg] drawn thick), recording the overview as the back target so a
      * map-background tap (or Back) returns to the itinerary. [routeLeg]'s ids are already OBA-format
      * (resolved at build time); an unresolved route degrades to framing the leg. The per-stop ETAs are
      * shown inline in the drawer's Board/Alight rows, not here.
      */
-    fun focusItineraryRouteLeg(routeLeg: RouteLegRef, fallbackLegPoints: List<GeoPoint>) {
+    fun focusItineraryRouteLeg(routeLeg: RouteLegRef, fallbackLeg: FocusedLeg) {
         val routeId = routeLeg.routeId
         if (routeId == null) {
-            focusItineraryLegOnMap(fallbackLegPoints)
+            focusItineraryLegOnMap(fallbackLeg)
             return
         }
         // Anchor to the boarding stop so the route shows only the ridden direction. A folded interline
@@ -624,7 +628,7 @@ class HomeViewModel @Inject constructor(
         // the shared vehicle across them; empty for an ordinary leg (plain single-route focus).
         focusItineraryRouteLegOnMap(
             routeId,
-            segment = fallbackLegPoints,
+            segment = fallbackLeg.points,
             directionStopId = routeLeg.board?.stopId,
             extraSegments = routeLeg.extraSegments
         )
@@ -675,7 +679,9 @@ class HomeViewModel @Inject constructor(
         undoViewport: MapViewport? = null
     ) {
         pushFocus(CurrentFocus.Directions(DirectionsRouteFocus(request)), undoViewport)
-        emitMapDirective(MapDirective.ShowRoute(request, stopScoped = false))
+        // withinDirections: this route is drilled into *from* a trip plan, so the map keeps the rest of
+        // the trip beneath it as de-emphasized context (#2048).
+        emitMapDirective(MapDirective.ShowRoute(request, stopScoped = false, withinDirections = true))
     }
 
     /** Clear the drawn itinerary while staying in directions (the plan became unsubmittable). */
@@ -778,12 +784,14 @@ class HomeViewModel @Inject constructor(
                 is CurrentFocus.Directions -> {
                     val routeFocus = target.routeFocus
                     if (routeFocus != null) {
-                        // Back into a route sub-focus: re-show that leg's route on the map.
+                        // Back into a route sub-focus: re-show that leg's route on the map, over the trip
+                        // it belongs to (still drawn, or restored by the sheet's own reconcile).
                         emitMapDirective(
                             MapDirective.ShowRoute(
                                 routeFocus.request,
                                 stopScoped = false,
-                                frameRoute = frameFocus
+                                frameRoute = frameFocus,
+                                withinDirections = true
                             )
                         )
                     } else {
@@ -870,11 +878,16 @@ sealed interface MapDirective {
     /** Animate the camera to recenter on the currently focused stop (sheet expanded). */
     data class RecenterOnFocusedStop(val point: GeoPoint) : MapDirective
 
-    /** Enter route mode for [request]'s route (the "show vehicles on map" action). */
+    /**
+     * Enter route mode for [request]'s route (the "show vehicles on map" action). [withinDirections]
+     * marks a drill-in from a trip plan's leg, which keeps the rest of the trip drawn beneath the route
+     * as de-emphasized context (#2048).
+     */
     data class ShowRoute(
         val request: ShowRouteRequest,
         val stopScoped: Boolean,
-        val frameRoute: Boolean = true
+        val frameRoute: Boolean = true,
+        val withinDirections: Boolean = false
     ) : MapDirective
 
     /** Restore the camera paired with an undone semantic action. */
@@ -918,8 +931,11 @@ sealed interface MapDirective {
     /** Recenter the map on a tapped itinerary step's point (recenter + zoom to street level). */
     data class FocusItineraryPoint(val point: GeoPoint) : MapDirective
 
-    /** Frame a whole tapped itinerary leg (fit its polyline within the map's content padding). */
-    data class FocusItineraryLeg(val points: List<GeoPoint>) : MapDirective
+    /**
+     * Focus a whole tapped itinerary leg: fit its polyline within the map's content padding, and recede
+     * the trip's other legs — everything outside [legIndices] — to context (#2048).
+     */
+    data class FocusItineraryLeg(val points: List<GeoPoint>, val legIndices: Set<Int>) : MapDirective
 
     /** Clear the drawn itinerary but stay in directions mode (the plan became unsubmittable). */
     data object ClearItinerary : MapDirective

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
@@ -121,6 +121,7 @@ import org.onebusaway.android.ui.tripplan.TripPlanParams
 import org.onebusaway.android.ui.tripplan.TripPlanViewModel
 import org.onebusaway.android.ui.tripplan.VehicleMode
 import org.onebusaway.android.ui.tripplan.WalkPreference
+import org.onebusaway.android.ui.tripresults.FocusedLeg
 import org.onebusaway.android.ui.tripresults.RouteLegRef
 import org.onebusaway.android.ui.tripresults.RouteStopRef
 import org.onebusaway.android.ui.tripresults.TripResultsSheet
@@ -277,8 +278,8 @@ fun DirectionsResultsSheet(
     itineraries: List<TripItinerary>,
     params: TripPlanParams?,
     showItinerary: (TripItinerary) -> Unit,
-    onFocusRouteLeg: (RouteLegRef, List<GeoPoint>) -> Unit,
-    onFocusLeg: (List<GeoPoint>) -> Unit,
+    onFocusRouteLeg: (RouteLegRef, FocusedLeg) -> Unit,
+    onFocusLeg: (FocusedLeg) -> Unit,
     onFocusPoint: (GeoPoint) -> Unit,
     stopEtaStrip: @Composable (RouteLegRef, RouteStopRef, List<GeoPoint>) -> Unit,
     modifier: Modifier = Modifier

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
@@ -267,7 +267,8 @@ fun MapFeature(
                     mapViewModel.toRoute(
                         directive.request,
                         directive.stopScoped,
-                        directive.frameRoute
+                        directive.frameRoute,
+                        directive.withinDirections
                     )
                 is MapDirective.RestoreViewport ->
                     mapViewModel.restoreViewport(directive.viewport)
@@ -294,7 +295,7 @@ fun MapFeature(
                 is MapDirective.FocusItineraryPoint ->
                     mapViewModel.focusItineraryPoint(directive.point)
                 is MapDirective.FocusItineraryLeg ->
-                    mapViewModel.focusItineraryLeg(directive.points)
+                    mapViewModel.focusItineraryLeg(directive.points, directive.legIndices)
                 MapDirective.ClearItinerary -> mapViewModel.clearShownItinerary()
                 is MapDirective.SetDirectionsEndpoints ->
                     mapViewModel.setDirectionsEndpoints(directive.from, directive.to)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripLogBuilder.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripLogBuilder.kt
@@ -81,7 +81,7 @@ object TripLogBuilder {
             val legPoints = leg.legGeometry?.decodedPoints().orEmpty()
             if (leg.mode?.isOnStreetNonTransit == true) {
                 val walk = flatDirections.getOrNull(cursor++) ?: return@forEachIndexed
-                entries += walkEntry(leg, walk, legPoints, isTransfer = legs.isTransferAt(legIndex))
+                entries += walkEntry(leg, walk, legPoints, legIndex, isTransfer = legs.isTransferAt(legIndex))
             } else {
                 val board = flatDirections.getOrNull(cursor++) ?: return@forEachIndexed
                 // Consume the generator's "get off" direction to keep the cursor aligned; the Board/Exit
@@ -92,9 +92,9 @@ object TripLogBuilder {
                     // chain leader's ride to this leg's destination/time and geometry rather than starting a
                     // new entry; the leader's routeLeg already carries the chain alight (built span-aware
                     // in TripResultsRepository).
-                    foldIntoLeader(entries, leg, board, legPoints, transitionByLeg[legIndex])
+                    foldIntoLeader(entries, leg, board, legPoints, legIndex, transitionByLeg[legIndex])
                 } else {
-                    entries += transitEntry(leg, board, legPoints, routeLegRefs.getOrNull(legIndex))
+                    entries += transitEntry(leg, board, legPoints, legIndex, routeLegRefs.getOrNull(legIndex))
                 }
             }
         }
@@ -113,6 +113,7 @@ object TripLogBuilder {
         leg: TripLeg,
         walk: Direction,
         legPoints: List<GeoPoint>,
+        legIndex: Int,
         isTransfer: Boolean
     ) = TripLogEntry.Walk(
         mode = leg.streetMode(),
@@ -125,7 +126,8 @@ object TripLogBuilder {
             LogStep(sub.directionText.str(), leg.steps.getOrNull(i)?.distance ?: 0.0, sub.focusPoint())
         },
         legPoints = legPoints,
-        focusPoint = walk.focusPoint()
+        focusPoint = walk.focusPoint(),
+        legIndices = setOf(legIndex)
     )
 
     /**
@@ -143,6 +145,7 @@ object TripLogBuilder {
         leg: TripLeg,
         board: Direction,
         legPoints: List<GeoPoint>,
+        legIndex: Int,
         transition: InterlineTransition?
     ) {
         val idx = entries.indexOfLast { it is TripLogEntry.Transit }
@@ -154,7 +157,9 @@ object TripLogBuilder {
             rideEvents = leader.rideEvents +
                 listOfNotNull(transition?.let { RideEvent.Transition(it) }) +
                 stopEvents(board),
-            legPoints = leader.legPoints + legPoints
+            legPoints = leader.legPoints + legPoints,
+            // The rider stays aboard across the seam, so the whole chain is one focus target.
+            legIndices = leader.legIndices + legIndex
         )
     }
 
@@ -162,6 +167,7 @@ object TripLogBuilder {
         leg: TripLeg,
         board: Direction,
         legPoints: List<GeoPoint>,
+        legIndex: Int,
         ref: RouteLegRef?
     ): TripLogEntry.Transit {
         val routeLeg = ref ?: fallbackRouteLeg(leg)
@@ -178,7 +184,8 @@ object TripLogBuilder {
             // Only this leg's own stops; a folded chain's later legs append theirs after their seam.
             rideEvents = stopEvents(board),
             routeLeg = routeLeg,
-            legPoints = legPoints
+            legPoints = legPoints,
+            legIndices = setOf(legIndex)
         )
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
@@ -346,8 +346,8 @@ fun TripResultsList(
     modifier: Modifier = Modifier,
     bottomInset: Dp = 0.dp,
     onSelectOption: (Int) -> Unit = {},
-    onFocusRouteLeg: (RouteLegRef, List<GeoPoint>) -> Unit = { _, _ -> },
-    onFocusLeg: (List<GeoPoint>) -> Unit = {},
+    onFocusRouteLeg: (RouteLegRef, FocusedLeg) -> Unit = { _, _ -> },
+    onFocusLeg: (FocusedLeg) -> Unit = {},
     onFocusPoint: (GeoPoint) -> Unit = {},
     stopEtaStrip: @Composable (RouteLegRef, RouteStopRef, List<GeoPoint>) -> Unit = { _, _, _ -> }
 ) {
@@ -398,8 +398,8 @@ fun TripResultsSheet(
     params: TripPlanParams?,
     resultsViewModel: TripResultsViewModel,
     showItinerary: (TripItinerary) -> Unit,
-    onFocusRouteLeg: (RouteLegRef, List<GeoPoint>) -> Unit,
-    onFocusLeg: (List<GeoPoint>) -> Unit,
+    onFocusRouteLeg: (RouteLegRef, FocusedLeg) -> Unit,
+    onFocusLeg: (FocusedLeg) -> Unit,
     onFocusPoint: (GeoPoint) -> Unit,
     stopEtaStrip: @Composable (RouteLegRef, RouteStopRef, List<GeoPoint>) -> Unit,
     modifier: Modifier = Modifier,
@@ -515,8 +515,8 @@ private fun TripLogList(
     state: TripResultsUiState.Success,
     bottomInset: Dp,
     onSelectOption: (Int) -> Unit,
-    onFocusRouteLeg: (RouteLegRef, List<GeoPoint>) -> Unit,
-    onFocusLeg: (List<GeoPoint>) -> Unit,
+    onFocusRouteLeg: (RouteLegRef, FocusedLeg) -> Unit,
+    onFocusLeg: (FocusedLeg) -> Unit,
     onFocusPoint: (GeoPoint) -> Unit,
     stopEtaStrip: @Composable (RouteLegRef, RouteStopRef, List<GeoPoint>) -> Unit
 ) {
@@ -566,8 +566,8 @@ private fun TripLogList(
 private fun LogRow(
     model: LogRowModel,
     onToggle: (Int) -> Unit,
-    onFocusRouteLeg: (RouteLegRef, List<GeoPoint>) -> Unit,
-    onFocusLeg: (List<GeoPoint>) -> Unit,
+    onFocusRouteLeg: (RouteLegRef, FocusedLeg) -> Unit,
+    onFocusLeg: (FocusedLeg) -> Unit,
     onFocusPoint: (GeoPoint) -> Unit,
     stopEtaStrip: @Composable (RouteLegRef, RouteStopRef, List<GeoPoint>) -> Unit
 ) {
@@ -585,7 +585,7 @@ private fun LogRow(
             LogRowScaffold(
                 model = model,
                 onClick = {
-                    if (walk.legPoints.isNotEmpty()) onFocusLeg(walk.legPoints) else walk.focusPoint?.let(onFocusPoint)
+                    if (walk.legPoints.isNotEmpty()) onFocusLeg(walk.focus) else walk.focusPoint?.let(onFocusPoint)
                 },
                 onToggleExpand = { onToggle(i) }
             ) { WalkHeaderContent(walk) }
@@ -647,14 +647,14 @@ private fun expandLabel(model: LogRowModel): String? = when {
  */
 private fun focusTransit(
     entry: TripLogEntry.Transit,
-    onFocusRouteLeg: (RouteLegRef, List<GeoPoint>) -> Unit,
-    onFocusLeg: (List<GeoPoint>) -> Unit,
+    onFocusRouteLeg: (RouteLegRef, FocusedLeg) -> Unit,
+    onFocusLeg: (FocusedLeg) -> Unit,
     onFocusPoint: (GeoPoint) -> Unit
 ) {
     val routeLeg = entry.routeLeg.takeIf { it.routeId != null }
     when {
-        routeLeg != null -> onFocusRouteLeg(routeLeg, entry.legPoints)
-        entry.legPoints.isNotEmpty() -> onFocusLeg(entry.legPoints)
+        routeLeg != null -> onFocusRouteLeg(routeLeg, entry.focus)
+        entry.legPoints.isNotEmpty() -> onFocusLeg(entry.focus)
         else -> entry.routeLeg.board?.point?.let(onFocusPoint)
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
@@ -81,6 +81,16 @@ data class LegBadge(val routes: List<RouteBadge>, val mode: TransitMode) {
 }
 
 /**
+ * A leg the rider has tapped, as the map needs it: the geometry to frame, plus [legIndices] — which of
+ * the itinerary's legs the tapped row actually covers. The indices are what let the map hold the *rest*
+ * of the trip as de-emphasized context around the focus (#2048) instead of drawing the leg alone.
+ *
+ * It's a set rather than one index because a folded interline chain (#2000) is several itinerary legs
+ * the rider reads — and taps — as a single ride, and every leg of it is part of what they focused.
+ */
+data class FocusedLeg(val points: List<GeoPoint>, val legIndices: Set<Int>)
+
+/**
  * One entry in the trip **log** — the directions rendered as a single transit timeline the user reads
  * top-to-bottom, each event on a shared vertical spine next to its clock time (see [TripResultsList]).
  * The list is the trip in order: a [Terminal] Start, then one [Walk] or [Transit] per leg, then a
@@ -124,8 +134,12 @@ sealed interface TripLogEntry {
         val isTransfer: Boolean,
         val steps: List<LogStep>,
         val legPoints: List<GeoPoint> = emptyList(),
-        val focusPoint: GeoPoint? = null
-    ) : TripLogEntry
+        val focusPoint: GeoPoint? = null,
+        val legIndices: Set<Int> = emptySet()
+    ) : TripLogEntry {
+        /** This leg as the map's focus target — see [FocusedLeg]. */
+        val focus: FocusedLeg get() = FocusedLeg(legPoints, legIndices)
+    }
 
     /**
      * A transit leg — a Board node and an Exit node uniting the ride, its solid route-coloured segment
@@ -153,8 +167,12 @@ sealed interface TripLogEntry {
         val realtime: RealtimeState,
         val rideEvents: List<RideEvent>,
         val routeLeg: RouteLegRef,
-        val legPoints: List<GeoPoint> = emptyList()
+        val legPoints: List<GeoPoint> = emptyList(),
+        val legIndices: Set<Int> = emptySet()
     ) : TripLogEntry {
+        /** This ride as the map's focus target — every leg of a folded chain; see [FocusedLeg]. */
+        val focus: FocusedLeg get() = FocusedLeg(legPoints, legIndices)
+
         /**
          * How many intermediate stops the ride passes — derived from [rideEvents] rather than stored, so
          * the "N stops" summary can't disagree with the list the leg expands to (it did when a folded

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/ItineraryLegStyleTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/ItineraryLegStyleTest.kt
@@ -11,10 +11,13 @@ import org.onebusaway.android.directions.model.TripLeg
 import org.onebusaway.android.directions.model.TripMode
 import org.onebusaway.android.directions.model.TripPlace
 import org.onebusaway.android.directions.model.TripVertexType
+import org.onebusaway.android.map.render.DEEMPHASIZED_ROUTE_LINE_WIDTH_PROFILE
 import org.onebusaway.android.map.render.ITINERARY_RIDE_WIDTH_PROFILE
 import org.onebusaway.android.map.render.ITINERARY_STREET_WIDTH_PROFILE
 import org.onebusaway.android.map.render.RouteLineDash
+import org.onebusaway.android.map.render.RoutePolyline
 import org.onebusaway.android.util.ACHROMATIC_ROUTE_CHROMA
+import org.onebusaway.android.util.GeoPoint
 
 /**
  * The directions map's per-leg stroke policy (#2041). The point of these is the *distinctions*: before
@@ -120,6 +123,64 @@ class ItineraryLegStyleTest {
             val color = itineraryLegStyle(kind, routeColor = null).color
             assertTrue("$kind was achromatic", Hct.fromInt(color).chroma > ACHROMATIC_ROUTE_CHROMA)
         }
+    }
+
+    @Test
+    fun `focusing a leg recedes the rest of the trip instead of erasing it`() {
+        val lines = tripOf(walk = 0, ride = 1, walk2 = 2)
+
+        val focused = lines.withLegFocus(setOf(1))
+
+        // Nothing is dropped — the whole trip is still drawn, just no longer all at one weight.
+        assertEquals(lines.size, focused.size)
+        // The two on-street legs recede; the ride keeps the weight it had.
+        val (context, ride) = focused.partition { it.widthProfile == DEEMPHASIZED_ROUTE_LINE_WIDTH_PROFILE }
+        assertEquals(2, context.size)
+        assertEquals(listOf(ITINERARY_RIDE_WIDTH_PROFILE), ride.map { it.widthProfile })
+        // The focused leg is last, so it draws over the context rather than under it.
+        assertEquals(ride.single(), focused.last())
+        // Only the weight changes: a leg keeps its mode/route colour, so the trip is still legible.
+        assertEquals(lines.map { it.line.color }.toSet(), focused.map { it.color }.toSet())
+    }
+
+    @Test
+    fun `a folded interline chain focuses as one ride, not as its first leg`() {
+        // #2000: several itinerary legs the rider stays aboard through, read (and tapped) as one ride.
+        val focused = tripOf(walk = 0, ride = 1, walk2 = 2).withLegFocus(setOf(1, 2))
+
+        assertEquals(1, focused.count { it.widthProfile == DEEMPHASIZED_ROUTE_LINE_WIDTH_PROFILE })
+    }
+
+    @Test
+    fun `the overview draws every leg at its own weight`() {
+        val lines = tripOf(walk = 0, ride = 1, walk2 = 2)
+
+        // No focus at all, and a focus naming a leg that carried no geometry, are the same case: there
+        // is nothing to raise, so nothing is lowered.
+        listOf(emptySet<Int>(), setOf(7)).forEach { focus ->
+            assertEquals(lines.map { it.line }, lines.withLegFocus(focus))
+        }
+    }
+
+    /** A walk → ride → walk trip as drawn lines, at the given leg indices. */
+    private fun tripOf(walk: Int, ride: Int, walk2: Int) = listOf(
+        legLine(walk, ItineraryLegKind.WALK),
+        legLine(ride, ItineraryLegKind.TRANSIT),
+        legLine(walk2, ItineraryLegKind.BIKE)
+    )
+
+    private fun legLine(legIndex: Int, kind: ItineraryLegKind): ItineraryLegLine {
+        val style = itineraryLegStyle(kind, routeColor = null)
+        return ItineraryLegLine(
+            legIndex,
+            RoutePolyline(
+                style.color,
+                listOf(GeoPoint(47.6, -122.3), GeoPoint(47.7, -122.4)),
+                widthProfile = style.widthProfile,
+                directional = style.directional,
+                dash = style.dash
+            )
+        )
     }
 
     private companion object {

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteSegmentHighlightTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteSegmentHighlightTest.kt
@@ -18,10 +18,12 @@ package org.onebusaway.android.map
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.onebusaway.android.api.adapters.ObaStopElement
-import org.onebusaway.android.map.render.DEEMPHASIZED_ROUTE_LINE_WIDTH_PROFILE
 import org.onebusaway.android.map.render.FOCUSED_ROUTE_LINE_WIDTH_PROFILE
+import org.onebusaway.android.map.render.ITINERARY_CONTEXT_WIDTH_PROFILE
 import org.onebusaway.android.map.render.ITINERARY_RIDE_WIDTH_PROFILE
+import org.onebusaway.android.map.render.RouteLineDash
 import org.onebusaway.android.map.render.RoutePolyline
+import org.onebusaway.android.map.render.UNTRAVELED_ROUTE_LINE_WIDTH_PROFILE
 import org.onebusaway.android.util.GeoPoint
 
 /** JVM tests for the pure trip-plan-leg segment highlighting helpers ([onSegment], [routePolylinesWithSegment]). */
@@ -68,12 +70,35 @@ class RouteSegmentHighlightTest {
 
         assertEquals(2, result.size)
         // Base is thinned to context (and loses its arrows).
-        assertEquals(DEEMPHASIZED_ROUTE_LINE_WIDTH_PROFILE, result.first().widthProfile)
+        assertEquals(UNTRAVELED_ROUTE_LINE_WIDTH_PROFILE, result.first().widthProfile)
+        assertEquals(RouteLineDash.HINT, result.first().dash)
         // The ridden span rides on top at the weight it had as an itinerary leg, in the route colour,
         // directional — so drilling in doesn't make the ride itself thinner than it just was.
         val overlay = result.last()
         assertEquals(ITINERARY_RIDE_WIDTH_PROFILE, overlay.widthProfile)
         assertEquals(0xFF00FF00.toInt(), overlay.color)
         assertEquals(true, overlay.directional)
+    }
+
+    @Test
+    fun routePolylinesWithSegment_layersUnusedRoute_thenJourneyContext_thenSelectedRide() {
+        val base = listOf(RoutePolyline(color = 1, points = segment, directional = true))
+        val journey = listOf(
+            RoutePolyline(
+                color = 2,
+                points = segment.reversed(),
+                widthProfile = ITINERARY_CONTEXT_WIDTH_PROFILE,
+                dash = RouteLineDash.TRAIL
+            )
+        )
+
+        val result = routePolylinesWithSegment(base, segment, routeColor = 3, itineraryContext = journey)
+
+        assertEquals(listOf(1, 2, 3), result.map { it.color })
+        assertEquals(UNTRAVELED_ROUTE_LINE_WIDTH_PROFILE, result[0].widthProfile)
+        assertEquals(RouteLineDash.HINT, result[0].dash)
+        assertEquals(ITINERARY_CONTEXT_WIDTH_PROFILE, result[1].widthProfile)
+        assertEquals(RouteLineDash.TRAIL, result[1].dash)
+        assertEquals(ITINERARY_RIDE_WIDTH_PROFILE, result[2].widthProfile)
     }
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteViewGeometryTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteViewGeometryTest.kt
@@ -8,7 +8,9 @@ import org.junit.Test
 import org.onebusaway.android.map.render.ADJACENT_ROUTE_LINE_WIDTH_PROFILE
 import org.onebusaway.android.map.render.DEEMPHASIZED_ROUTE_LINE_WIDTH_PROFILE
 import org.onebusaway.android.map.render.FOCUSED_ROUTE_LINE_WIDTH_PROFILE
+import org.onebusaway.android.map.render.ITINERARY_CONTEXT_WIDTH_PROFILE
 import org.onebusaway.android.map.render.ROUTE_LINE_WIDTH_PROFILE
+import org.onebusaway.android.map.render.RouteLineDash
 import org.onebusaway.android.map.render.RoutePolyline
 import org.onebusaway.android.map.render.RoutePolylineTransform
 import org.onebusaway.android.map.render.haversineMeters
@@ -18,6 +20,26 @@ import org.onebusaway.android.models.RouteDirectionKey
 import org.onebusaway.android.util.GeoPoint
 
 class RouteViewGeometryTest {
+
+    @Test
+    fun `itinerary context keeps leg identity at a middle plain weight`() {
+        val line = RoutePolyline(
+            color = 0xFF123456.toInt(),
+            points = listOf(GeoPoint(0.0, 0.0), GeoPoint(0.0, 1.0)),
+            widthProfile = FOCUSED_ROUTE_LINE_WIDTH_PROFILE,
+            directional = true,
+            dash = RouteLineDash.TRAIL,
+            transforms = setOf(RoutePolylineTransform.ZOOM_SIMPLIFY)
+        )
+
+        val context = listOf(line).asItineraryContext().single()
+
+        assertEquals(ITINERARY_CONTEXT_WIDTH_PROFILE, context.widthProfile)
+        assertEquals(line.color, context.color)
+        assertEquals(line.dash, context.dash)
+        assertEquals(line.transforms, context.transforms)
+        assertEquals(false, context.directional)
+    }
 
     @Test
     fun `single route view and focused-stop route share the focused width profile`() {

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/render/RouteLineWidthProfileTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/render/RouteLineWidthProfileTest.kt
@@ -51,4 +51,11 @@ class RouteLineWidthProfileTest {
         assertEquals(2.5f, ADJACENT_ROUTE_LINE_WIDTH_PROFILE.thicknessAt(10f), 0f)
         assertEquals(5f, ADJACENT_ROUTE_LINE_WIDTH_PROFILE.thicknessAt(16f), 0f)
     }
+
+    @Test
+    fun `focused ride journey context and unused route form three distinct weights`() {
+        assertEquals(15f, ITINERARY_RIDE_WIDTH_PROFILE.thicknessDp, 0f)
+        assertEquals(5f, ITINERARY_CONTEXT_WIDTH_PROFILE.thicknessDp, 0f)
+        assertEquals(2f, UNTRAVELED_ROUTE_LINE_WIDTH_PROFILE.thicknessDp, 0f)
+    }
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/TripLogBuilderTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/TripLogBuilderTest.kt
@@ -337,6 +337,32 @@ class TripLogBuilderTest {
     }
 
     /**
+     * Every leg row knows which itinerary leg(s) it is, so tapping it can tell the map what to keep as
+     * context around the focus (#2048) — and a folded chain claims every leg the rider stays aboard for,
+     * not just the leader's.
+     */
+    @Test
+    fun everyLegRowNamesTheItineraryLegsItCovers() {
+        val entries = TripLogBuilder.build(
+            legs = listOf(walkLeg, transitLeg, walkLeg),
+            flatDirections = listOf(walkDir, boardDir, alightDir, walkDir),
+            routeLegRefs = listOf(null, transitRef, null)
+        )
+        assertEquals(
+            listOf(setOf(0), setOf(2)),
+            entries.filterIsInstance<TripLogEntry.Walk>().map { it.legIndices }
+        )
+        assertEquals(setOf(1), entries.filterIsInstance<TripLogEntry.Transit>().single().legIndices)
+
+        val chained = TripLogBuilder.build(
+            legs = listOf(transitLeg, transitLeg.copy(interlineWithPreviousLeg = true)),
+            flatDirections = listOf(boardDir, alightDir, continuationBoardDir, alightDir),
+            routeLegRefs = listOf(transitRef, null)
+        ).filterIsInstance<TripLogEntry.Transit>().single()
+        assertEquals(setOf(0, 1), chained.legIndices)
+    }
+
+    /**
      * A ferry leg reaches the renderer as a ferry. The leg's mode used to stop here — the timeline drew
      * a bus for every ride — so a Washington State Ferries crossing was a bus on a boat's schedule.
      */


### PR DESCRIPTION
Closes #2048.

Tapping a leg in the directions drawer used to draw that leg alone. The rider got the leg they asked for and lost everything else — where it sits in the journey, what comes before and after it. This keeps the whole trip drawn and *recedes* the legs the rider isn't reading to the same faint context weight a route already takes under its ridden segment, then re-draws the focused leg on top.

### A focus is a set of legs, not one

A folded interline chain (#2000) is several itinerary legs the rider reads — and taps — as a single ride. So the focus is a `Set<Int>` of leg indices: `TripLogBuilder` stamps every leg a row covers (the chain leader unions in each leg it folds), and the row hands the map a `FocusedLeg` (geometry + indices) instead of bare points.

The indices name *itinerary* legs, not drawn positions — a leg without geometry draws nothing, so the two lists don't line up. `DirectionsMapController` retains each drawn line paired with its leg index (`ItineraryLegLine`) and recomposes the itinerary around the focus in `withLegFocus`.

### The context crosses into route focus

Tapping a transit leg drills into that route's own view, which is a different map mode — the transition tears the itinerary down. The trip now survives that crossing: `ShowRoute` carries `withinDirections`, `MapViewModel` reads `directionsController.contextPolylines()` *before* the teardown, and `RouteMapController` draws it beneath everything it publishes. It stays out of `framingPolylines` — drilling into a leg frames that leg, not the whole journey again.

`contextPolylines()` thins every leg, including the focused one, whose ridden segment the route view redraws at full weight directly over its own faint copy. That way it needs no notion of which leg is focused and can't disagree with one.

### Tests

- `ItineraryLegStyleTest` — focusing recedes rather than drops (same line count, colours preserved, focused leg last so it draws on top); a folded chain focuses as one ride; the overview and a focus naming a geometry-less leg are the same no-op case.
- `TripLogBuilderTest` — every row names the itinerary legs it covers, and a chain claims all of them.
- `DirectionRowFocusTest` — the existing row-tap assertions now check the leg identity travels with the focus.

Device-checked on a Pixel 7 Pro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved itinerary leg highlighting: tapping walk/transit legs now preserves the full trip while emphasizing the selected segment and de-emphasizing the rest.
  * Route “within directions” drilling now keeps itinerary context visible during sub-focus navigation.
  * Supports focusing folded/interlined transit chains as one continuous ride.
* **Bug Fixes**
  * More robust handling for itinerary legs with missing/empty map geometry, avoiding incorrect framing/styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->