### PR TITLE
Replace the out-of-range dialog with a map banner

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapEffect.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapEffect.kt
@@ -23,13 +23,10 @@ import org.onebusaway.android.api.ObaApiException
  * A one-shot map event that needs an Activity to carry out (so it can't be plain state). [MapHost]
  * emits these on [MapHost.effects] (re-exposed by the map view models); the hosting Activity collects
  * them while STARTED and shows the corresponding UI (the dialog/toast bodies are the ones that used to
- * live in the flavor host's `showOutOfRangeDialog` / `showNoLocationDialog` /
- * `showLocationPermissionDialog` / the my-location toast + the permission-launcher relay).
+ * live in the flavor host's `showNoLocationDialog` / `showLocationPermissionDialog` / the my-location
+ * toast + the permission-launcher relay).
  */
 sealed interface MapEffect {
-
-    /** The viewport (or the device) is outside the current region — prompt the user to switch regions. */
-    object OutOfRange : MapEffect
 
     /** Location services are off — show the "enable location" dialog (with its never-ask-again opt-out). */
     object NoLocation : MapEffect

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapHost.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapHost.kt
@@ -60,6 +60,9 @@ sealed interface StopsBanner {
 
     /** A load failed with cached stops on screen (offline, #1754): the map is showing saved stops. */
     data object ShowingSavedStops : StopsBanner
+
+    /** The viewport is outside the current region; offer to frame its service area. */
+    data object OutsideRegion : StopsBanner
 }
 
 /**
@@ -171,9 +174,10 @@ class MapHost(
 
     /**
      * The informational strip across the top of the nearby-stops map: prompt to zoom in when the load
-     * was truncated ([StopsBanner.MoreStopsAvailable]), or a "showing saved stops" notice when a load
-     * failed with cached stops on screen ([StopsBanner.ShowingSavedStops], #1754). Set by the stop
-     * loader on each load; cleared when leaving the nearby-stops view.
+     * was truncated ([StopsBanner.MoreStopsAvailable]), a "showing saved stops" notice when a load
+     * failed with cached stops on screen ([StopsBanner.ShowingSavedStops], #1754), or an action to
+     * return to the service area when the viewport is out of range ([StopsBanner.OutsideRegion]). Set
+     * by the stop loader on each load; cleared when leaving the nearby-stops view.
      */
     val stopsBanner: StateFlow<StopsBanner> = _stopsBanner.asStateFlow()
 
@@ -313,8 +317,11 @@ class MapHost(
 
     fun zoomOut() = dispatchGesture(CameraCommand.ZoomOut)
 
-    /** Frame the current region's bounds (the out-of-range dialog's "take me there"). */
-    fun zoomToRegion() = frame(FramingIntent.Region)
+    /** Clear the out-of-range banner and frame the current region's bounds. */
+    fun zoomToRegion() {
+        setStopsBanner(StopsBanner.None)
+        frame(FramingIntent.Region)
+    }
 
     // ----- Generic markers -----
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
@@ -594,7 +594,7 @@ class MapViewModel @Inject constructor(
 
     fun zoomOut() = mapHost.zoomOut()
 
-    /** Frame the current region's bounds (the out-of-range dialog's "take me there"). */
+    /** Clear the out-of-range banner and frame the current region's bounds. */
     fun zoomToRegion() = mapHost.zoomToRegion()
 
     // ----- Lifecycle (the owner forwards onPause/onResume) -----

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/StopsMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/StopsMapController.kt
@@ -336,7 +336,7 @@ class StopsMapController(
             return
         }
         if (nearby.outOfRange) {
-            notifyOutOfRange()
+            host.setStopsBanner(StopsBanner.OutsideRegion)
             return
         }
 
@@ -361,7 +361,7 @@ class StopsMapController(
             }
             if (!inRegion && nearby.stops.isEmpty()) {
                 Log.d(TAG, "Device location is outside region range, notifying...")
-                notifyOutOfRange()
+                host.setStopsBanner(StopsBanner.OutsideRegion)
                 return
             }
         }
@@ -373,11 +373,6 @@ class StopsMapController(
         val complete = !nearby.limitExceeded
         if (!complete) host.setStopsBanner(StopsBanner.MoreStopsAvailable)
         showStops(nearby.stops, nearby.routes, viewport = snapshot, complete = complete)
-    }
-
-    private fun notifyOutOfRange() {
-        host.setStopsBanner(StopsBanner.None)
-        host.emitEffect(MapEffect.OutOfRange)
     }
 
     // ----- Focus -----

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
@@ -31,10 +31,13 @@ import androidx.compose.animation.scaleOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBars
@@ -109,7 +112,7 @@ private const val SHOW_DEBUG_ZOOM_INDICATOR = false
 /**
  * The self-wiring map feature module: renders [ObaMap] and owns everything that used to be map glue
  * in HomeActivity — the tap callbacks (focus -> the map view model + the home focused stop +
- * analytics; info-window taps -> navigation), the one-shot effects (the out-of-range / no-location /
+ * analytics; info-window taps -> navigation), the one-shot effects (the no-location /
  * permission-rationale dialogs + the my-location toast + the permission request, now Compose-native),
  * the eager first-launch permission prompt, and the resume/pause lifecycle. The visibility gates are a
  * self-wired [MapChromeViewModel]; the loading bar reads [MapViewModel.progress] directly. Mirrors the
@@ -307,7 +310,6 @@ fun MapFeature(
     LaunchedEffect(mapViewModel) {
         mapViewModel.effects.collect { effect ->
             when (effect) {
-                MapEffect.OutOfRange,
                 MapEffect.NoLocation,
                 MapEffect.ShowPermissionRationale -> dialog = effect
                 MapEffect.RequestLocationPermission ->
@@ -348,14 +350,6 @@ fun MapFeature(
     }
 
     when (dialog) {
-        MapEffect.OutOfRange -> OutOfRangeDialog(
-            regionName = mapViewModel.currentRegionName.orEmpty(),
-            onConfirm = {
-                mapViewModel.zoomToRegion()
-                dialog = null
-            },
-            onDismiss = { dialog = null }
-        )
         MapEffect.NoLocation -> NoLocationDialog(
             onEnable = {
                 context.startActivity(Intent(Settings.ACTION_LOCATION_SOURCE_SETTINGS))
@@ -411,6 +405,8 @@ fun MapFeature(
     ) {
         StopsInfoBanner(
             banner = stopsBanner.forFocus(currentFocus),
+            regionName = mapViewModel.currentRegionName.orEmpty(),
+            onViewServiceArea = mapViewModel::zoomToRegion,
             modifier = Modifier.align(Alignment.TopCenter)
         )
         if (BuildConfig.DEBUG && SHOW_DEBUG_ZOOM_INDICATOR) {
@@ -495,25 +491,32 @@ fun MapFeature(
 internal fun StopsBanner.forFocus(focus: CurrentFocus): StopsBanner = if (this == StopsBanner.MoreStopsAvailable && focus is CurrentFocus.Stop) StopsBanner.None else this
 
 /**
- * The nearby-stops info notice: an extended-FAB-style pill (leading icon + text) at the top-center of the
- * map that slides down to appear and up to disappear. Shows either "zoom in to see more stops" (a
- * truncated load) or "showing saved stops" (a failed load with cached stops on screen, #1754); hidden on
- * [StopsBanner.None]. Purely state-driven and informational — no dismiss button, and no action on tap.
- * The caller applies the status-bar inset and the slide clipping (clipToBounds).
+ * The nearby-stops notice: a pill at the top-center of the map. Shows "zoom in to see more stops" (a
+ * truncated load), "showing saved stops" (a failed load with cached stops on screen, #1754), or an
+ * out-of-region message with an action that frames the service area. Hidden on [StopsBanner.None].
  */
 @Composable
-private fun StopsInfoBanner(banner: StopsBanner, modifier: Modifier = Modifier) {
+private fun StopsInfoBanner(
+    banner: StopsBanner,
+    regionName: String,
+    onViewServiceArea: () -> Unit,
+    modifier: Modifier = Modifier
+) {
     // Retain the last shown banner so its label stays put during the slide-out (when banner -> None),
     // instead of blanking mid-animation. Seeded with the more-stops case; only ever set to a real one.
     var lastShown by remember { mutableStateOf<StopsBanner>(StopsBanner.MoreStopsAvailable) }
     if (banner != StopsBanner.None) lastShown = banner
-    val (labelRes, iconRes) = when (lastShown) {
-        StopsBanner.ShowingSavedStops -> R.string.map_showing_cached_stops to R.drawable.history_24
-        else -> R.string.map_zoom_in_for_more_stops to R.drawable.ic_zoom_in
+    val iconRes = when (lastShown) {
+        StopsBanner.None,
+        StopsBanner.MoreStopsAvailable -> R.drawable.ic_zoom_in
+        StopsBanner.ShowingSavedStops -> R.drawable.history_24
+        StopsBanner.OutsideRegion -> R.drawable.ic_action_location_map
     }
     AnimatedVisibility(
         visible = banner != StopsBanner.None,
-        modifier = modifier,
+        // The actionable banner is wider than the informational pills, so place it below the
+        // top-right weather chip instead of letting that sibling obscure its action.
+        modifier = modifier.padding(top = if (lastShown == StopsBanner.OutsideRegion) 56.dp else 0.dp),
         // Pop into place (scale up from ~80% with a little spring), rather than sliding down from the edge.
         enter = scaleIn(
             initialScale = 0.8f,
@@ -542,29 +545,33 @@ private fun StopsInfoBanner(banner: StopsBanner, modifier: Modifier = Modifier) 
                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.size(20.dp)
             )
-            Text(
-                text = stringResource(labelRes),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
+            if (lastShown == StopsBanner.OutsideRegion) {
+                Column(modifier = Modifier.padding(horizontal = 4.dp, vertical = 2.dp)) {
+                    Text(
+                        text = stringResource(R.string.map_outside_service_area, regionName),
+                        style = MaterialTheme.typography.titleSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    TextButton(
+                        onClick = onViewServiceArea,
+                        contentPadding = PaddingValues(0.dp),
+                        modifier = Modifier.height(36.dp)
+                    ) {
+                        Text(stringResource(R.string.map_view_service_area))
+                    }
+                }
+            } else {
+                Text(
+                    text = when (lastShown) {
+                        StopsBanner.ShowingSavedStops -> stringResource(R.string.map_showing_cached_stops)
+                        else -> stringResource(R.string.map_zoom_in_for_more_stops)
+                    },
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
         }
     }
-}
-
-/** The viewport (or device) is outside the current region (ported from GoogleMapHost.showOutOfRange). */
-@Composable
-private fun OutOfRangeDialog(regionName: String, onConfirm: () -> Unit, onDismiss: () -> Unit) {
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = { Text(stringResource(R.string.main_outofrange_title)) },
-        text = { Text(stringResource(R.string.main_outofrange, regionName)) },
-        confirmButton = {
-            TextButton(onClick = onConfirm) { Text(stringResource(R.string.main_outofrange_yes)) }
-        },
-        dismissButton = {
-            TextButton(onClick = onDismiss) { Text(stringResource(R.string.main_outofrange_no)) }
-        }
-    )
 }
 
 /** Location services are off (ported from GoogleMapHost.showNoLocationDialog + its never-ask opt-out). */

--- a/onebusaway-android/src/main/res/values-es/strings.xml
+++ b/onebusaway-android/src/main/res/values-es/strings.xml
@@ -120,12 +120,6 @@
     <string name="main_changelocationmode_title">Cambiar modo de ubicación</string>
     <string name="main_waiting_for_location">Tratando de establecer tú ubicación&#8230;</string>
     <string name="no_location_permission">No se puede obtener tú ubicación.</string>
-    <string name="main_outofrange_title">Fuera de alcance</string>
-    <string name="main_outofrange">Usted esta fuera del área de servicio %1$s.\n\n¿Mover
-        el mapa a %1$s ahora?
-    </string>
-    <string name="main_outofrange_yes">Llévame allí</string>
-    <string name="main_outofrange_no">Quedarme donde estoy</string>
 
     <string name="bus_options_menu_add_star">Adicionar la ruta a favoritos</string>
     <string name="bus_options_menu_remove_star">Remover la ruta de favoritos</string>

--- a/onebusaway-android/src/main/res/values-fi/strings.xml
+++ b/onebusaway-android/src/main/res/values-fi/strings.xml
@@ -118,10 +118,6 @@
     <string name="main_changelocationmode_title">Korkean tarkkuuden sijainti ei ole käytössä</string>
     <string name="main_changelocationmode">Laitteesi nykyinen “Sijaintimenetelmä”-asetus ei välttämättä ilmoita sinulle määränpäähän lähestymisestä epätarkan sijaintitiedon vuoksi. Haluatko muuttaa laitteesi “Sijaintimenetelmän” asetukseksi “Korkea tarkkuus” nyt?</string>
     <string name="no_location_permission">Sijaintiasi ei pystytty määrittämään.</string>
-    <string name="main_outofrange_title">Ulkona alueelta</string>
-    <string name="main_outofrange">Olet ulkona %1$s palvelualueelta.\n\nHaluatko siirtyä sinne?</string>
-    <string name="main_outofrange_yes">Siirry</string>
-    <string name="main_outofrange_no">Pysy täällä</string>
 
     <string name="bus_options_menu_add_star">Lisää reitti suosikiksi</string>
     <string name="bus_options_menu_remove_star">Poista reitti suosikeista</string>

--- a/onebusaway-android/src/main/res/values-it/strings.xml
+++ b/onebusaway-android/src/main/res/values-it/strings.xml
@@ -81,10 +81,6 @@
 
     <string name="main_waiting_for_location">Ricerca della posizione…</string>
     <string name="no_location_permission">Impossibile individuare la posizione. Fornisci all’app l’accesso alla posizione nelle impostazioni di sistema.</string>
-    <string name="main_outofrange_title">Fuori portata</string>
-    <string name="main_outofrange">Il servizio di trasporti di %1$s non copre il luogo in cui ti trovi.\n\nSpostare mappa su %1$s?</string>
-    <string name="main_outofrange_yes">Portami lì</string>
-    <string name="main_outofrange_no">Resta qui</string>
 
     <string name="bus_options_menu_add_star">Aggiungi linea ai preferiti</string>
     <string name="bus_options_menu_remove_star">Rimuovi linea dai preferiti</string>

--- a/onebusaway-android/src/main/res/values-pl/strings.xml
+++ b/onebusaway-android/src/main/res/values-pl/strings.xml
@@ -90,10 +90,6 @@
     <string name="main_never_show_again">Nigdy nie pokazuj ponownie</string>
     <string name="no_location_permission">Nie można uzyskać Twojej lokalizacji. Przyznaj aplikacji uprawnienia do lokalizacji w ustawieniach systemowych.</string>
     <string name="main_waiting_for_location">Próba naprawienia Twojej lokacji&#8230;</string>
-    <string name="main_outofrange_title">Poza zasięgiem</string>
-    <string name="main_outofrange">Jesteś poza zasięgiem organizatora %1$s.\n\nIść tam teraz?</string>
-    <string name="main_outofrange_yes">Zabierz mnie tam</string>
-    <string name="main_outofrange_no">Zostań, gdzie jestem.</string>
 
     <string name="bus_options_menu_add_star">Dodaj trasę do ulubionych</string>
     <string name="bus_options_menu_remove_star">Usuń linię z ulubionych</string>

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -127,12 +127,8 @@
 
     <string name="main_waiting_for_location">Trying to get a fix on your location&#8230;</string>
     <string name="no_location_permission">Unable to get your location.  Please give app location permissions via system settings.</string>
-    <string name="main_outofrange_title">Out of range</string>
-    <string name="main_outofrange">You’re looking at a place outside the %1$s service area.\n\nMove
-        map to %1$s now?
-    </string>
-    <string name="main_outofrange_yes">Take me there</string>
-    <string name="main_outofrange_no">Stay where I am</string>
+    <string name="map_outside_service_area">Outside %1$s service area</string>
+    <string name="map_view_service_area">View service area</string>
 
     <string name="bus_options_menu_add_star">Add star to route</string>
     <string name="bus_options_menu_remove_star">Remove star from route</string>

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/map/MapStopsBannerTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/map/MapStopsBannerTest.kt
@@ -37,6 +37,11 @@ class MapStopsBannerTest {
     }
 
     @Test
+    fun `stop focus preserves the outside-region banner`() {
+        assertEquals(StopsBanner.OutsideRegion, StopsBanner.OutsideRegion.forFocus(stopFocus))
+    }
+
+    @Test
     fun `nearby mode preserves the zoom-in banner`() {
         assertEquals(
             StopsBanner.MoreStopsAvailable,


### PR DESCRIPTION
## Summary

- replace the blocking out-of-range dialog with a non-modal map banner
- clarify that the currently viewed map area is outside the active service area
- offer a compact **View service area** action while leaving the map interactive
- remove the obsolete dialog effect and localized dialog strings
- preserve the banner while a stop is focused

## Why

The previous **Take me there** / **Stay where I am** choices were ambiguous because “where I am” could mean either the map viewport or the rider’s physical location. The new banner names the service area explicitly and makes the resulting map action clear.

## User impact

Riders can continue panning and inspecting the map when it is outside the active region. Choosing **View service area** dismisses the banner and frames the active region’s bounds.

## Validation

- `./gradlew spotlessCheck`
- `./gradlew :onebusaway-android:testObaGoogleDebugUnitTest`
- `./gradlew :onebusaway-android:lintObaGoogleDebug` — no issues
- verified the banner layout and semantics on the shared physical phone

Closes #1986


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an in-map notice when the map is outside the current service area.
  - Added an option to view the service area, which repositions the map to the correct region.
  - Replaced the previous out-of-range dialog flow with an actionable map banner.

- **Bug Fixes**
  - When repositioning the map, the service-area notice is cleared and the map is framed to the region.

- **Tests**
  - Added coverage to ensure the outside-service-area banner state is preserved when focusing on a stop.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->