### PR TITLE
Highlight category winners in route picker

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/ItineraryWinnerHighlightTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/ItineraryWinnerHighlightTest.kt
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.tripresults
+
+import androidx.compose.ui.test.hasStateDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.onebusaway.android.R
+import org.onebusaway.android.directions.util.ConversionUtils
+import org.onebusaway.android.time.ServerTime
+import org.onebusaway.android.ui.compose.components.RouteBadge
+import org.onebusaway.android.ui.compose.components.RouteBadgeJoin
+import org.onebusaway.android.ui.compose.createUnconfinedComposeRule
+
+/** Semantic coverage for the category emphasis in the itinerary option picker (#2054). */
+class ItineraryWinnerHighlightTest {
+
+    @get:Rule
+    val composeRule = createUnconfinedComposeRule()
+
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext
+
+    private fun option(
+        route: String,
+        durationMinutes: Long,
+        walkMeters: Double,
+        departureMinutes: Long,
+        arrivalMinutes: Long
+    ) = ItineraryOption(
+        symbols = listOf(
+            ModeSymbol.Transit(
+                LegBadge(
+                    listOf(RouteBadge(route, routeColor = null)),
+                    TransitMode.BUS,
+                    RouteBadgeJoin.ANY_OF
+                )
+            )
+        ),
+        durationMinutes = durationMinutes,
+        startTime = ServerTime(departureMinutes * 60_000L),
+        endTime = ServerTime(arrivalMinutes * 60_000L),
+        walkDistanceMeters = walkMeters
+    )
+
+    private val state = TripResultsUiState.Success(
+        options = listOf(
+            option("8", durationMinutes = 10, walkMeters = 0.0, departureMinutes = 0, arrivalMinutes = 10),
+            option("48", durationMinutes = 20, walkMeters = 500.0, departureMinutes = 0, arrivalMinutes = 20)
+        ),
+        selectedIndex = 0,
+        directions = emptyList()
+    )
+
+    @Test
+    fun winningValuesAnnounceTheirCategories() {
+        composeRule.setContent {
+            TripResultsHeader(
+                state,
+                onSelectOption = {},
+                scheduleWinnerMode = ScheduleWinnerMode.EARLIEST_ARRIVAL
+            )
+        }
+
+        val description = listOf(
+            R.string.trip_plan_winner_shortest_travel_time,
+            R.string.trip_plan_winner_least_walking,
+            R.string.trip_plan_winner_earliest_arrival
+        ).joinToString { context.getString(it) }
+        composeRule.onNode(hasStateDescription(description)).assertExists()
+    }
+
+    @Test
+    fun aZeroDistanceWinnerStillShowsItsWalkingValue() {
+        composeRule.setContent {
+            TripResultsHeader(
+                state,
+                onSelectOption = {},
+                scheduleWinnerMode = ScheduleWinnerMode.EARLIEST_ARRIVAL
+            )
+        }
+
+        val zeroDistance = ConversionUtils.getFormattedDistanceParts(0.0, context)
+            .joinToString(separator = "") { it.text }
+        composeRule.onNodeWithText(zeroDistance).assertExists()
+    }
+
+    @Test
+    fun highlightingDoesNotChangeCardSelection() {
+        var selected = -1
+        composeRule.setContent {
+            TripResultsHeader(
+                state,
+                onSelectOption = { selected = it },
+                scheduleWinnerMode = ScheduleWinnerMode.EARLIEST_ARRIVAL
+            )
+        }
+
+        composeRule.onNodeWithText("48").performClick()
+
+        assertEquals(1, selected)
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/ItineraryWinners.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/ItineraryWinners.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.tripresults
+
+/** A comparison an itinerary option can win in the route picker. */
+enum class WinnerCategory {
+    SHORTEST_TRAVEL_TIME,
+    LEAST_WALKING,
+    EARLIEST_ARRIVAL,
+    LATEST_DEPARTURE
+}
+
+/** Which clock-time comparison is useful for the request that produced the options. */
+enum class ScheduleWinnerMode {
+    EARLIEST_ARRIVAL,
+    LATEST_DEPARTURE,
+    BOTH
+}
+
+/**
+ * Finds the best option(s) in each useful category. Results are index-aligned with [options]. A
+ * category that cannot distinguish the choices is deliberately omitted: calling every card a winner
+ * communicates nothing, as does decorating the only card in a one-option result.
+ *
+ * Duration and clock times use the precision printed on the card. That prevents two equal-looking
+ * values from receiving different emphasis because their hidden seconds differ.
+ */
+fun itineraryWinnerCategories(
+    options: List<ItineraryOption>,
+    scheduleMode: ScheduleWinnerMode
+): List<Set<WinnerCategory>> {
+    val winners = List(options.size) { mutableSetOf<WinnerCategory>() }
+    if (options.size < 2) return winners
+
+    fun <T : Comparable<T>> award(
+        category: WinnerCategory,
+        values: List<T>,
+        best: (List<T>) -> T
+    ) {
+        if (values.distinct().size < 2) return
+        val winningValue = best(values)
+        values.forEachIndexed { index, value ->
+            if (value == winningValue) winners[index].add(category)
+        }
+    }
+
+    award(WinnerCategory.SHORTEST_TRAVEL_TIME, options.map { it.durationMinutes }) { it.min() }
+
+    // A non-finite distance is not comparable enough to declare a winner for the whole result set.
+    val walks = options.map { it.walkDistanceMeters }
+    if (walks.all(Double::isFinite)) {
+        award(WinnerCategory.LEAST_WALKING, walks) { it.min() }
+    }
+
+    if (scheduleMode == ScheduleWinnerMode.EARLIEST_ARRIVAL || scheduleMode == ScheduleWinnerMode.BOTH) {
+        award(
+            WinnerCategory.EARLIEST_ARRIVAL,
+            options.map { Math.floorDiv(it.endTime.epochMs, MILLIS_PER_MINUTE) }
+        ) { it.min() }
+    }
+    if (scheduleMode == ScheduleWinnerMode.LATEST_DEPARTURE || scheduleMode == ScheduleWinnerMode.BOTH) {
+        award(
+            WinnerCategory.LATEST_DEPARTURE,
+            options.map { Math.floorDiv(it.startTime.epochMs, MILLIS_PER_MINUTE) }
+        ) { it.max() }
+    }
+
+    return winners
+}
+
+private const val MILLIS_PER_MINUTE = 60_000L

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
@@ -77,6 +77,8 @@ import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -120,9 +122,13 @@ import org.onebusaway.android.util.parseObaHexColor
 @Composable
 fun TripResultsHeader(
     state: TripResultsUiState,
-    onSelectOption: (Int) -> Unit
+    onSelectOption: (Int) -> Unit,
+    scheduleWinnerMode: ScheduleWinnerMode = ScheduleWinnerMode.BOTH
 ) {
     val success = state as? TripResultsUiState.Success ?: return
+    val winners = remember(success.options, scheduleWinnerMode) {
+        itineraryWinnerCategories(success.options, scheduleWinnerMode)
+    }
     // Side-scrollable so options never get squished: each card sizes to its own content (route/lines,
     // duration, walk distance, time) and the row scrolls horizontally when they overflow the width.
     // Flanked by the same overflow chevrons as the ETA strip (ScrollChevronGutter) so the user can see
@@ -159,6 +165,7 @@ fun TripResultsHeader(
             success.options.forEachIndexed { index, option ->
                 OptionCard(
                     option = option,
+                    winners = winners[index],
                     selected = index == success.selectedIndex,
                     onClick = { onSelectOption(index) }
                 )
@@ -213,9 +220,15 @@ private const val SYMBOL_SEPARATOR_ALPHA = 0.6f
 
 private val SYMBOL_GAP = 4.dp
 
+/** A quiet keyline around a winning metric: enough separation to survive the selected card's tint. */
+private val WINNER_OUTLINE_WIDTH = 1.5.dp
+private val WINNER_OUTLINE_RADIUS = 4.dp
+private const val WINNER_OUTLINE_ALPHA = 0.60f
+
 @Composable
 private fun OptionCard(
     option: ItineraryOption,
+    winners: Set<WinnerCategory>,
     selected: Boolean,
     onClick: () -> Unit
 ) {
@@ -226,6 +239,17 @@ private fun OptionCard(
         if (selected) R.color.trip_plan_header_text_selected else R.color.trip_plan_header_text
     )
     val context = LocalContext.current
+    val winnerOutlineColor = MaterialTheme.colorScheme.outline.copy(alpha = WINNER_OUTLINE_ALPHA)
+    val shortestTravelTime = WinnerCategory.SHORTEST_TRAVEL_TIME in winners
+    val leastWalking = WinnerCategory.LEAST_WALKING in winners
+    val earliestArrival = WinnerCategory.EARLIEST_ARRIVAL in winners
+    val latestDeparture = WinnerCategory.LATEST_DEPARTURE in winners
+    val winnerDescriptions = buildList {
+        if (shortestTravelTime) add(stringResource(R.string.trip_plan_winner_shortest_travel_time))
+        if (leastWalking) add(stringResource(R.string.trip_plan_winner_least_walking))
+        if (earliestArrival) add(stringResource(R.string.trip_plan_winner_earliest_arrival))
+        if (latestDeparture) add(stringResource(R.string.trip_plan_winner_latest_departure))
+    }
     Surface(
         color = background,
         contentColor = textColor,
@@ -234,6 +258,11 @@ private fun OptionCard(
         modifier = Modifier
             .widthIn(min = 104.dp)
             .clickable(onClick = onClick)
+            .semantics {
+                if (winnerDescriptions.isNotEmpty()) {
+                    stateDescription = winnerDescriptions.joinToString()
+                }
+            }
     ) {
         Column(
             modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
@@ -291,28 +320,38 @@ private fun OptionCard(
             // card's other lines.
             Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
                 // Duration — a leading hourglass + the ETA-pill-formatted trip length.
-                MetricRow(R.drawable.hourglass_24, contentDescription = null) {
+                MetricRow(
+                    R.drawable.hourglass_24,
+                    contentDescription = null,
+                    winner = shortestTravelTime,
+                    outlineColor = winnerOutlineColor
+                ) {
                     EtaDurationText(minutes = option.durationMinutes)
                 }
                 // Total walking for the trip — a leading walk glyph mirroring the duration row's hourglass,
                 // with the distance styled like the duration (bold value + smaller unit). In the user's units
                 // (miles/km, or feet/meters for short walks). Hidden when the trip has no walking.
-                if (option.walkDistanceMeters > 0.0) {
+                if (option.walkDistanceMeters > 0.0 || leastWalking) {
                     MetricRow(
                         R.drawable.ic_directions_walk,
-                        contentDescription = stringResource(R.string.step_by_step_non_transit_mode_walk_action)
+                        contentDescription = stringResource(R.string.step_by_step_non_transit_mode_walk_action),
+                        winner = leastWalking,
+                        outlineColor = winnerOutlineColor
                     ) {
-                        EtaPartsText(ConversionUtils.getFormattedDistanceParts(option.walkDistanceMeters, context))
+                        EtaPartsText(
+                            ConversionUtils.getFormattedDistanceParts(option.walkDistanceMeters, context)
+                        )
                     }
                 }
             }
             // The device-localized departure–arrival range (unwrap the server clock only here).
-            Text(
-                text = "${DisplayFormat.formatTime(context, option.startTime.epochMs)} – " +
-                    DisplayFormat.formatTime(context, option.endTime.epochMs),
-                style = MaterialTheme.typography.bodySmall,
-                maxLines = 1
-            )
+            val startText = DisplayFormat.formatTime(context, option.startTime.epochMs)
+            val endText = DisplayFormat.formatTime(context, option.endTime.epochMs)
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                ScheduleMetric(startText, winner = latestDeparture, outlineColor = winnerOutlineColor)
+                Text(" – ", style = MaterialTheme.typography.bodySmall, maxLines = 1)
+                ScheduleMetric(endText, winner = earliestArrival, outlineColor = winnerOutlineColor)
+            }
         }
     }
 }
@@ -322,8 +361,15 @@ private fun OptionCard(
  * duration and walk-distance rows so their icon size and spacing stay in lockstep.
  */
 @Composable
-private fun MetricRow(iconRes: Int, contentDescription: String?, content: @Composable () -> Unit) {
+private fun MetricRow(
+    iconRes: Int,
+    contentDescription: String?,
+    winner: Boolean,
+    outlineColor: Color,
+    content: @Composable () -> Unit
+) {
     Row(
+        modifier = winnerOutline(winner, outlineColor),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(4.dp)
     ) {
@@ -334,6 +380,26 @@ private fun MetricRow(iconRes: Int, contentDescription: String?, content: @Compo
         )
         content()
     }
+}
+
+/** One endpoint of the option's time range, outlined independently when it wins its schedule category. */
+@Composable
+private fun ScheduleMetric(text: String, winner: Boolean, outlineColor: Color) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.bodySmall,
+        maxLines = 1,
+        modifier = winnerOutline(winner, outlineColor)
+    )
+}
+
+/** Adds no layout or drawing when [winner] is false, preserving the existing ordinary metric rows. */
+private fun winnerOutline(winner: Boolean, color: Color): Modifier = if (winner) {
+    Modifier
+        .border(WINNER_OUTLINE_WIDTH, color, RoundedCornerShape(WINNER_OUTLINE_RADIUS))
+        .padding(horizontal = 3.dp, vertical = 1.dp)
+} else {
+    Modifier
 }
 
 /**
@@ -347,6 +413,7 @@ fun TripResultsList(
     state: TripResultsUiState,
     modifier: Modifier = Modifier,
     bottomInset: Dp = 0.dp,
+    scheduleWinnerMode: ScheduleWinnerMode = ScheduleWinnerMode.BOTH,
     onSelectOption: (Int) -> Unit = {},
     onFocusRouteLeg: (RouteLegRef, FocusedLeg) -> Unit = { _, _ -> },
     onFocusLeg: (FocusedLeg) -> Unit = {},
@@ -373,6 +440,7 @@ fun TripResultsList(
             is TripResultsUiState.Success -> TripLogList(
                 state = state,
                 bottomInset = bottomInset,
+                scheduleWinnerMode = scheduleWinnerMode,
                 onSelectOption = onSelectOption,
                 onFocusRouteLeg = onFocusRouteLeg,
                 onFocusLeg = onFocusLeg,
@@ -438,6 +506,11 @@ fun TripResultsSheet(
         state = state,
         modifier = modifier.fillMaxSize(),
         bottomInset = listBottomInset,
+        scheduleWinnerMode = when (params?.arriving) {
+            true -> ScheduleWinnerMode.LATEST_DEPARTURE
+            false -> ScheduleWinnerMode.EARLIEST_ARRIVAL
+            null -> ScheduleWinnerMode.BOTH
+        },
         onSelectOption = resultsViewModel::selectOption,
         onFocusRouteLeg = onFocusRouteLeg,
         onFocusLeg = onFocusLeg,
@@ -516,6 +589,7 @@ private fun railSplit(): Dp = RAIL_SPLIT * timelineScale()
 private fun TripLogList(
     state: TripResultsUiState.Success,
     bottomInset: Dp,
+    scheduleWinnerMode: ScheduleWinnerMode,
     onSelectOption: (Int) -> Unit,
     onFocusRouteLeg: (RouteLegRef, FocusedLeg) -> Unit,
     onFocusLeg: (FocusedLeg) -> Unit,
@@ -551,7 +625,7 @@ private fun TripLogList(
     ) {
         // The picker scrolls with the steps (not pinned), so it recedes as you read down the list.
         item {
-            TripResultsHeader(state, onSelectOption)
+            TripResultsHeader(state, onSelectOption, scheduleWinnerMode)
             HorizontalDivider()
             Spacer(Modifier.height(LOG_EDGE_GAP))
         }

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -950,6 +950,11 @@
     <!-- Content descriptions for the chevrons that hint the itinerary-option picker can scroll sideways -->
     <string name="trip_plan_options_scroll_previous">Show previous options</string>
     <string name="trip_plan_options_scroll_more">Show more options</string>
+    <!-- Accessibility announcements for values emphasized as the best among the itinerary options. -->
+    <string name="trip_plan_winner_shortest_travel_time">Shortest travel time</string>
+    <string name="trip_plan_winner_least_walking">Least walking</string>
+    <string name="trip_plan_winner_earliest_arrival">Earliest arrival</string>
+    <string name="trip_plan_winner_latest_departure">Latest departure</string>
     <!-- Content descriptions for the control that expands/collapses a leg's minor events (walk steps / stops) in the trip-log directions -->
     <string name="trip_plan_expand_leg">Show steps</string>
     <string name="trip_plan_collapse_leg">Hide steps</string>

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/ItineraryWinnersTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/ItineraryWinnersTest.kt
@@ -1,0 +1,136 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.tripresults
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.onebusaway.android.time.ServerTime
+
+class ItineraryWinnersTest {
+
+    private fun option(
+        durationMinutes: Long,
+        walkMeters: Double,
+        departureMinutes: Long,
+        arrivalMinutes: Long
+    ) = ItineraryOption(
+        symbols = emptyList(),
+        durationMinutes = durationMinutes,
+        startTime = ServerTime(departureMinutes * 60_000L),
+        endTime = ServerTime(arrivalMinutes * 60_000L),
+        walkDistanceMeters = walkMeters
+    )
+
+    @Test
+    fun `shortest travel time is duration, not earliest arrival`() {
+        val options = listOf(
+            option(durationMinutes = 10, walkMeters = 500.0, departureMinutes = 30, arrivalMinutes = 40),
+            option(durationMinutes = 20, walkMeters = 300.0, departureMinutes = 0, arrivalMinutes = 20)
+        )
+
+        val winners = itineraryWinnerCategories(options, ScheduleWinnerMode.EARLIEST_ARRIVAL)
+
+        assertEquals(setOf(WinnerCategory.SHORTEST_TRAVEL_TIME), winners[0])
+        assertEquals(
+            setOf(WinnerCategory.LEAST_WALKING, WinnerCategory.EARLIEST_ARRIVAL),
+            winners[1]
+        )
+    }
+
+    @Test
+    fun `ties award every best option while all-equal categories are suppressed`() {
+        val options = listOf(
+            option(20, 100.0, 0, 30),
+            option(20, 200.0, 5, 30),
+            option(30, 300.0, 10, 30)
+        )
+
+        val winners = itineraryWinnerCategories(options, ScheduleWinnerMode.EARLIEST_ARRIVAL)
+
+        assertTrue(WinnerCategory.SHORTEST_TRAVEL_TIME in winners[0])
+        assertTrue(WinnerCategory.SHORTEST_TRAVEL_TIME in winners[1])
+        assertTrue(winners.none { WinnerCategory.EARLIEST_ARRIVAL in it })
+        assertEquals(setOf(WinnerCategory.LEAST_WALKING, WinnerCategory.SHORTEST_TRAVEL_TIME), winners[0])
+    }
+
+    @Test
+    fun `a single option has no winners`() {
+        val winners = itineraryWinnerCategories(
+            listOf(option(20, 0.0, 0, 20)),
+            ScheduleWinnerMode.BOTH
+        )
+
+        assertEquals(listOf(emptySet<WinnerCategory>()), winners)
+    }
+
+    @Test
+    fun `schedule mode chooses the useful endpoint`() {
+        val options = listOf(
+            option(20, 100.0, 0, 20),
+            option(20, 100.0, 10, 30)
+        )
+
+        val leaveAt = itineraryWinnerCategories(options, ScheduleWinnerMode.EARLIEST_ARRIVAL)
+        val arriveBy = itineraryWinnerCategories(options, ScheduleWinnerMode.LATEST_DEPARTURE)
+        val restored = itineraryWinnerCategories(options, ScheduleWinnerMode.BOTH)
+
+        assertEquals(setOf(WinnerCategory.EARLIEST_ARRIVAL), leaveAt[0])
+        assertEquals(setOf(WinnerCategory.LATEST_DEPARTURE), arriveBy[1])
+        assertEquals(setOf(WinnerCategory.EARLIEST_ARRIVAL), restored[0])
+        assertEquals(setOf(WinnerCategory.LATEST_DEPARTURE), restored[1])
+    }
+
+    @Test
+    fun `clock-time ties use the minute precision shown on the card`() {
+        val options = listOf(
+            option(20, 100.0, 0, 20).copy(endTime = ServerTime(20 * 60_000L + 1_000L)),
+            option(20, 100.0, 0, 20).copy(endTime = ServerTime(20 * 60_000L + 59_000L)),
+            option(20, 100.0, 0, 21)
+        )
+
+        val winners = itineraryWinnerCategories(options, ScheduleWinnerMode.EARLIEST_ARRIVAL)
+
+        assertTrue(WinnerCategory.EARLIEST_ARRIVAL in winners[0])
+        assertTrue(WinnerCategory.EARLIEST_ARRIVAL in winners[1])
+        assertTrue(WinnerCategory.EARLIEST_ARRIVAL !in winners[2])
+    }
+
+    @Test
+    fun `zero walking wins against positive distances`() {
+        val options = listOf(
+            option(20, 0.0, 0, 20),
+            option(20, 250.0, 0, 20)
+        )
+
+        val winners = itineraryWinnerCategories(options, ScheduleWinnerMode.BOTH)
+
+        assertEquals(setOf(WinnerCategory.LEAST_WALKING), winners[0])
+        assertTrue(winners[1].isEmpty())
+    }
+
+    @Test
+    fun `non-finite walking distance suppresses that category`() {
+        val options = listOf(
+            option(20, Double.NaN, 0, 20),
+            option(30, 250.0, 0, 30)
+        )
+
+        val winners = itineraryWinnerCategories(options, ScheduleWinnerMode.EARLIEST_ARRIVAL)
+
+        assertTrue(winners.none { WinnerCategory.LEAST_WALKING in it })
+    }
+}


### PR DESCRIPTION
## Summary

- outline the shortest travel time and least-walking metrics in the itinerary picker
- outline the earliest arrival for leave-at plans and latest departure for arrive-by plans
- award exact ties while suppressing categories that do not distinguish the available options
- announce winning categories through accessibility semantics

## Why

Route options already show duration, walking distance, and schedule times, but riders have to compare the values themselves. A subtle 1.5 dp neutral outline makes the best values scannable without competing with the selected-card treatment or relying on color.

The shortest-travel-time category is based specifically on time en route, independent of departure and arrival clock times.

## Validation

- `spotlessCheck`
- trip-results JVM unit tests
- Android test source compilation
- `assembleObaGoogleDebug`
- `lintObaGoogleDebug`
- iterative manual review and testing on the shared physical phone

Closes #2054

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/OneBusAway/codesmith/onebusaway-android/pr/2069"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787901117&installation_model_id=429412&pr_number=2069&repository=OneBusAway%2Fonebusaway-android&return_to=https%3A%2F%2Fgithub.com%2FOneBusAway%2Fonebusaway-android%2Fpull%2F2069&signature=46e28a8f297bde08f4b2d3be72d223c3a90d52cfa943bdbfe7c788f4a25cb6fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Trip results now highlight itinerary options with the shortest travel time, least walking, earliest arrival, or latest departure.
  * Tied options are highlighted together, while categories without meaningful differences remain unmarked.
  * Highlights adapt to whether the trip is planned for arrival, departure, or both.
  * Accessibility announcements now describe each highlighted category.
  * Zero-distance walking results and card selection behavior are handled consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->