### PR TITLE
Match directions badges to contrasting map colors

### DIFF
--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
@@ -310,7 +310,7 @@ class GoogleMapRenderer(
                     .zIndex(ROUTE_BADGE_Z_INDEX)
             )!!
             staticMarkers += marker
-            routeBadgeByMarker[marker] = badge
+            if (badge.interactive) routeBadgeByMarker[marker] = badge
         }
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/DirectionsMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/DirectionsMapController.kt
@@ -21,8 +21,15 @@ import org.onebusaway.android.directions.model.TripLegGeometry
 import org.onebusaway.android.directions.model.TripMode
 import org.onebusaway.android.directions.model.TripVertexType
 import org.onebusaway.android.directions.model.decodedPoints
+import org.onebusaway.android.directions.model.interchangeableRoutes
+import org.onebusaway.android.directions.model.routeDisplayLabel
+import org.onebusaway.android.map.layout.RouteBadgeLayoutInput
+import org.onebusaway.android.map.layout.RouteBadgePath
+import org.onebusaway.android.map.layout.layoutRouteBadges
+import org.onebusaway.android.map.render.RouteBadge
 import org.onebusaway.android.map.render.RoutePolyline
 import org.onebusaway.android.models.ObaShape
+import org.onebusaway.android.models.RouteDirectionKey
 import org.onebusaway.android.util.GeoPoint
 import org.onebusaway.android.util.parseObaHexColor
 
@@ -87,27 +94,35 @@ class DirectionsMapController(private val host: MapHost) {
 
         // Build every leg's polyline (each in its own mode/route style), keeping each one's leg index so
         // a later focus can name legs rather than drawn positions (a leg without geometry draws nothing).
-        legLines = legs.mapIndexedNotNull { legIndex, leg ->
+        val drawableLegs = legs.mapIndexedNotNull { legIndex, leg ->
             val geometry = leg.legGeometry ?: return@mapIndexedNotNull null
             val shape = LegShape(geometry)
-            if (shape.length > 0) {
-                val style = itineraryLegStyle(leg.legKind(), parseObaHexColor(leg.routeColor))
-                // Every leg's points run in travel order, so whether it stamps chevrons is the style's
-                // call — a dashed on-street stroke declines them (see [itineraryLegStyle]).
-                ItineraryLegLine(
-                    legIndex,
-                    RoutePolyline(
-                        style.color,
-                        shape.points,
-                        widthProfile = style.widthProfile,
-                        directional = style.directional,
-                        dash = style.dash
-                    )
-                )
-            } else {
-                null
-            }
+            shape.points.takeIf { shape.length > 0 && it.size >= 2 }
+                ?.let { ItineraryDrawableLeg(legIndex, leg, it) }
         }
+        val interchangeable = itinerary.interchangeableRoutes()
+        val transitColors = itineraryTransitColors(
+            legs,
+            interchangeable.flatten().map { it.routeId }
+        )
+        legLines = drawableLegs.map { drawable ->
+            val leg = drawable.leg
+            val style = itineraryLegStyle(
+                leg.legKind(),
+                transitColors[leg.itineraryRouteIdentity()] ?: parseObaHexColor(leg.routeColor)
+            )
+            ItineraryLegLine(
+                drawable.index,
+                RoutePolyline(
+                    style.color,
+                    drawable.points,
+                    widthProfile = style.widthProfile,
+                    directional = style.directional,
+                    dash = style.dash
+                )
+            )
+        }
+        host.renderState.setRouteBadges(itineraryRouteBadges(drawableLegs, transitColors))
         // A freshly drawn itinerary is the overview: every leg at full weight until one is focused.
         focusedLegIndices = emptySet()
         publishLegs()
@@ -172,6 +187,7 @@ class DirectionsMapController(private val host: MapHost) {
         directionsMarkerIds.clear()
         legLines = emptyList()
         focusedLegIndices = emptySet()
+        host.renderState.setRouteBadges(emptyList())
     }
 
     /**
@@ -226,5 +242,66 @@ class DirectionsMapController(private val host: MapHost) {
             }
             return ids
         }
+    }
+}
+
+internal data class ItineraryDrawableLeg(
+    val index: Int,
+    val leg: TripLeg,
+    val points: List<GeoPoint>
+)
+
+/** Stable directions-map identity: prefer the wire route id, with its display name as the OTP1 fallback. */
+internal fun TripLeg.itineraryRouteIdentity(): String? = routeId ?: routeDisplayLabel()?.takeIf(String::isNotBlank)
+
+/**
+ * Assign every distinct transit route in a drawn itinerary an evenly separated map hue. This is the
+ * same policy as focused-stop adjacency: agency colors don't get to make two simultaneously visible
+ * routes indistinguishable, and a colorless route no longer collapses onto a shared fallback.
+ */
+internal fun itineraryTransitColors(
+    legs: List<TripLeg>,
+    additionalRouteIdentities: List<String> = emptyList()
+): Map<String, Int> = adjacencyRouteColors(
+    legs.asSequence()
+        .filter { it.mode?.isTransit == true }
+        .mapNotNull(TripLeg::itineraryRouteIdentity)
+        .plus(additionalRouteIdentities.asSequence())
+        .asIterable()
+)
+
+/**
+ * One non-interactive line label per transit route in the itinerary. The stop-focus badge layout is
+ * reused so labels sit at stable distance midpoints and stagger when two ridden corridors overlap.
+ */
+internal fun itineraryRouteBadges(
+    legs: List<ItineraryDrawableLeg>,
+    colors: Map<String, Int>
+): List<RouteBadge> {
+    val specs = legs.asSequence()
+        .filter { it.leg.mode?.isTransit == true }
+        .mapNotNull { drawable ->
+            val identity = drawable.leg.itineraryRouteIdentity() ?: return@mapNotNull null
+            val name = drawable.leg.routeDisplayLabel()?.takeIf(String::isNotBlank) ?: return@mapNotNull null
+            Triple(identity, name, drawable.points)
+        }
+        .groupBy { it.first }
+    val inputs = specs.map { (identity, entries) ->
+        RouteBadgeLayoutInput(
+            RouteDirectionKey(identity, null),
+            entries.map { RouteBadgePath(it.third) }
+        )
+    }
+    val placements = layoutRouteBadges(inputs).associateBy { it.route.routeId }
+    return specs.mapNotNull { (identity, entries) ->
+        val point = placements[identity]?.point ?: return@mapNotNull null
+        RouteBadge(
+            routeId = identity,
+            routeShortName = entries.first().second,
+            color = colors.getValue(identity),
+            point = point,
+            directionId = null,
+            interactive = false
+        )
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
@@ -210,7 +210,9 @@ data class RouteBadge(
     val routeShortName: String,
     val color: Int,
     val point: GeoPoint,
-    val directionId: Int?
+    val directionId: Int?,
+    /** Whether tapping this label enters route focus. Directions labels are informational only. */
+    val interactive: Boolean = true
 )
 
 /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/LineBadge.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/LineBadge.kt
@@ -70,7 +70,7 @@ private const val SHRINK_STEP = 0.9f
 private val CHIP_SHAPE = RoundedCornerShape(8.dp)
 private val CHIP_H_PADDING = 8.dp
 private val CHIP_V_PADDING = 2.dp
-private const val CHIP_END_COLOR_FRACTION = 0.2f
+private val CHIP_END_COLOR_WIDTH = 9.dp
 
 // Route-badge color tokens. We take only the *hue* of the agency's GTFS color and re-derive the chip
 // in HCT (a perceptual space) at a fixed tone + capped chroma, so the agency can't hand us an
@@ -170,7 +170,7 @@ fun rememberRouteBadgeColors(routeColor: Int?): Pair<Color, Color> {
  * [color] defaults to [Color.Unspecified] so the badge inherits the ambient content color. Pass a
  * [containerColor] (e.g. from [rememberRouteBadgeColors]) to draw the name on a rounded colored chip
  * filling the fixed-width slot; leave it unspecified for the bare-text badge. [endContainerColor]
- * optionally replaces the rightmost fifth of that background (the arrivals drawer uses this to key
+ * optionally replaces the rightmost 9dp of that background (the arrivals drawer uses this to key
  * the GTFS-colored badge to its stop-focus map color). Set [square] to make the chip a [width]×[width]
  * square tile (a route roundel) with the text shrunk to fit inside it.
  *
@@ -262,7 +262,7 @@ fun LineBadge(
                     Modifier
                         .drawWithContent {
                             if (endContainerColor.isSpecified) {
-                                val endWidth = size.width * CHIP_END_COLOR_FRACTION
+                                val endWidth = CHIP_END_COLOR_WIDTH.toPx().coerceAtMost(size.width)
                                 drawRect(
                                     color = endContainerColor,
                                     topLeft = Offset(size.width - endWidth, 0f),

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/RouteBadgeChip.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/RouteBadgeChip.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.draw.CacheDrawScope
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.drawscope.Stroke
@@ -45,8 +46,10 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
-/** One route on a badge: its short name and (nullable) GTFS color as an ARGB int. */
-data class RouteBadge(val shortName: String, val routeColor: Int?)
+/** One route on a badge: its name, GTFS chip color, and optional map-line color for the end stripe. */
+data class RouteBadge(val shortName: String, val routeColor: Int?, val mapRouteColor: Int? = null)
+
+private val MAP_COLOR_STRIPE_WIDTH = 9.dp
 
 /**
  * How the routes sharing one badge relate to each other — and so what shape divides them. A badge is one
@@ -163,11 +166,12 @@ fun RouteBadgeChip(
     scale: Float = 1f,
     maxWidth: Dp = Dp.Unspecified,
     leadingIcon: Int? = null,
-    leadingIconDescription: String? = null
+    leadingIconDescription: String? = null,
+    mapRouteColor: Int? = null
 ) {
     val (container, content) = rememberRouteBadgeColors(routeColor)
     Surface(
-        modifier = modifier.widthIn(max = maxWidth),
+        modifier = modifier.widthIn(min = ROUTE_BADGE_HEIGHT * scale, max = maxWidth),
         color = container,
         contentColor = content,
         shape = BADGE_SHAPE
@@ -178,7 +182,8 @@ fun RouteBadgeChip(
             scale = scale,
             horizontalPadding = 3.dp * scale,
             leadingIcon = leadingIcon,
-            leadingIconDescription = leadingIconDescription
+            leadingIconDescription = leadingIconDescription,
+            modifier = Modifier.mapColorStripe(mapRouteColor)
         )
     }
 }
@@ -207,7 +212,10 @@ private fun BadgeContent(
     Row(
         modifier = modifier.padding(horizontal = horizontalPadding, vertical = BADGE_VERTICAL_PADDING * scale),
         verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(BADGE_ICON_GAP * scale)
+        horizontalArrangement = Arrangement.spacedBy(
+            space = BADGE_ICON_GAP * scale,
+            alignment = Alignment.CenterHorizontally
+        )
     ) {
         if (leadingIcon != null) {
             Icon(
@@ -273,7 +281,16 @@ fun RouteBadgeChip(
     val outlined = modifier.border(BADGE_LINE_WIDTH, BADGE_LINE_COLOR, BADGE_SHAPE)
     if (routes.size == 1) {
         val route = routes.first()
-        RouteBadgeChip(route.shortName, route.routeColor, outlined, scale, maxWidth, leadingIcon, leadingIconDescription)
+        RouteBadgeChip(
+            route.shortName,
+            route.routeColor,
+            outlined,
+            scale,
+            maxWidth,
+            leadingIcon,
+            leadingIconDescription,
+            route.mapRouteColor
+        )
         return
     }
     // Deliberately uncapped, unlike the plain chip: this Row's children are unweighted, so a bounded max
@@ -296,6 +313,9 @@ fun RouteBadgeChip(
                 leadingIconDescription = leadingIconDescription,
                 modifier = Modifier
                     .fillMaxHeight()
+                    // A one-character route still gets a proper roundel rather than a narrow lozenge:
+                    // at the default font scale each segment is at least as wide as the badge is tall.
+                    .widthIn(min = ROUTE_BADGE_HEIGHT * scale)
                     // drawWithCache, not drawBehind: the band's Path and the line's geometry depend only
                     // on the segment's size, so they're built once per size change, not per draw pass.
                     .drawWithCache {
@@ -307,6 +327,16 @@ fun RouteBadgeChip(
                             extendStart = index == 0,
                             extendEnd = index == routes.lastIndex
                         )
+                        // Keep the stripe's leading edge vertical and overdraw its trailing edge beneath
+                        // the next segment. That sibling's band then clips the overdraw to the actual
+                        // slash/chevron divider, filling cleanly into its geometry without bending the
+                        // stripe itself.
+                        val stripe = route.mapRouteColor?.let {
+                            endStripePath(
+                                extendEnd = index == routes.lastIndex,
+                                width = MAP_COLOR_STRIPE_WIDTH.toPx()
+                            ) to Color(it)
+                        }
                         // Only the leading edge, and never on the first segment: each segment draws its
                         // line after its band, so it lands on top of the neighbouring band this one just
                         // overwrote. The first segment has no neighbour, so it builds no line at all.
@@ -314,6 +344,7 @@ fun RouteBadgeChip(
                         val line = Stroke(BADGE_LINE_WIDTH.toPx())
                         onDrawBehind {
                             drawPath(band, container)
+                            stripe?.let { (path, color) -> drawPath(path, color) }
                             divider?.let { drawPath(it, BADGE_LINE_COLOR, style = line) }
                         }
                     }
@@ -322,6 +353,19 @@ fun RouteBadgeChip(
                     // therefore still sizes the band to the whole segment.
                     .padding(start = join.leadingInset(index) * scale)
             )
+        }
+    }
+}
+
+/** Paint the same exact-map-color 9dp end stripe used by the arrivals drawer's large line badge. */
+private fun Modifier.mapColorStripe(mapRouteColor: Int?): Modifier = if (mapRouteColor == null) {
+    this
+} else {
+    drawWithCache {
+        val stripe = Color(mapRouteColor)
+        onDrawBehind {
+            val width = MAP_COLOR_STRIPE_WIDTH.toPx().coerceAtMost(size.width)
+            drawRect(stripe, Offset(size.width - width, 0f), Size(width, size.height))
         }
     }
 }
@@ -380,6 +424,22 @@ private fun CacheDrawScope.bandPath(edge: List<Offset>, extendStart: Boolean, ex
     // across the top.
     return leading.toPath().apply {
         for (i in trailing.lastIndex downTo 0) lineTo(trailing[i].x, trailing[i].y)
+        close()
+    }
+}
+
+/**
+ * A vertical fixed-width strip that overdraws beneath a following segment. Siblings paint left to
+ * right, so that following band erases the overdraw exactly along its slash/chevron leading edge.
+ */
+private fun CacheDrawScope.endStripePath(extendEnd: Boolean, width: Float): Path {
+    val left = size.width - width.coerceAtMost(size.width)
+    val right = size.width + if (extendEnd) 0f else leanPx()
+    return Path().apply {
+        moveTo(left, 0f)
+        lineTo(right, 0f)
+        lineTo(right, size.height)
+        lineTo(left, size.height)
         close()
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
@@ -426,7 +426,11 @@ fun DirectionStopEtaStrip(
                 modifier = rowPadding,
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                RouteBadgeChip(alternative.shortName, alternative.routeColor)
+                RouteBadgeChip(
+                    alternative.shortName,
+                    alternative.routeColor,
+                    mapRouteColor = alternative.mapRouteColor
+                )
                 Spacer(Modifier.width(8.dp))
                 EtaStrip(
                     trips = group.trips,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/ModeSymbols.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/ModeSymbols.kt
@@ -19,6 +19,7 @@ import org.onebusaway.android.directions.model.InterchangeableRoute
 import org.onebusaway.android.directions.model.TripLeg
 import org.onebusaway.android.directions.model.TripMode
 import org.onebusaway.android.directions.model.TripVertexType
+import org.onebusaway.android.map.itineraryTransitColors
 
 /**
  * Builds the [ModeSymbol] sequence an itinerary option card shows (#2047) — the whole trip in travel
@@ -69,10 +70,19 @@ internal object ModeSymbols {
         require(substitutable.size == legs.size) {
             "substitutable must be index-aligned to legs (${substitutable.size} vs ${legs.size})"
         }
+        val mapRouteColors = itineraryTransitColors(
+            legs,
+            substitutable.flatten().map(InterchangeableRoute::routeId)
+        )
         // One badge per ride, at the leg it's boarded at; every other transit leg is a continuation the
         // rider never acts on, and is already named inside its leader's badge.
         val rides = Interlines.chains(legs).associate { chain ->
-            chain.leaderIndex to rideBadge(legs, chain, substitutable[chain.leaderIndex])
+            chain.leaderIndex to rideBadge(
+                legs,
+                chain,
+                substitutable[chain.leaderIndex],
+                mapRouteColors
+            )
         }
         val symbols = legs.mapIndexedNotNull { i, leg ->
             when {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/RouteBadges.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/RouteBadges.kt
@@ -19,6 +19,7 @@ import org.onebusaway.android.directions.model.InterchangeableRoute
 import org.onebusaway.android.directions.model.TripLeg
 import org.onebusaway.android.directions.model.TripMode
 import org.onebusaway.android.directions.model.routeDisplayLabel
+import org.onebusaway.android.map.itineraryRouteIdentity
 import org.onebusaway.android.ui.compose.components.RouteBadge
 import org.onebusaway.android.ui.compose.components.RouteBadgeJoin
 import org.onebusaway.android.util.ROUTE_NAME_ORDER
@@ -53,9 +54,10 @@ import org.onebusaway.android.util.parseObaHexColor
 internal fun rideBadge(
     legs: List<TripLeg>,
     chain: Interlines.Chain,
-    alternatives: List<InterchangeableRoute>
+    alternatives: List<InterchangeableRoute>,
+    mapRouteColors: Map<String, Int> = emptyMap()
 ): LegBadge = if (chain.transitionLegIndices.isEmpty()) {
-    legBadge(legs[chain.leaderIndex], alternatives)
+    legBadge(legs[chain.leaderIndex], alternatives, mapRouteColors)
 } else {
     require(alternatives.isEmpty()) {
         "a ride that changes route mid-vehicle admits no substitutes (leg ${chain.leaderIndex}, ${alternatives.size} offered)"
@@ -66,7 +68,7 @@ internal fun rideBadge(
         // drawer's transition row announces too, and hiding it here would leave the two disagreeing.
         // A leg whose route names itself in no way at all (a null badge) drops out rather than leaving a
         // blank segment; the ride still names every route that can be named.
-        routes = chain.riddenLegIndices.mapNotNull { legs[it].plannedBadge() },
+        routes = chain.riddenLegIndices.mapNotNull { legs[it].plannedBadge(mapRouteColors) },
         mode = legs[chain.leaderIndex].mode.transitMode(),
         join = RouteBadgeJoin.THEN
     )
@@ -74,7 +76,15 @@ internal fun rideBadge(
 
 /** The badge for one transit leg: its planned route joined by the routes ruled interchangeable with
  *  it ([org.onebusaway.android.directions.model.interchangeableRoutes]). */
-internal fun legBadge(leg: TripLeg, alternatives: List<InterchangeableRoute>): LegBadge = legBadge(leg.plannedBadge(), alternatives.map { it.badge() }, leg.mode.transitMode())
+internal fun legBadge(
+    leg: TripLeg,
+    alternatives: List<InterchangeableRoute>,
+    mapRouteColors: Map<String, Int> = emptyMap()
+): LegBadge = legBadge(
+    leg.plannedBadge(mapRouteColors),
+    alternatives.map { it.badge(mapRouteColors) },
+    leg.mode.transitMode()
+)
 
 /**
  * The leg's badge: [planned] joined by [alternatives], in natural name order. The plan's own choice
@@ -103,10 +113,12 @@ internal fun legBadge(planned: RouteBadge?, alternatives: List<RouteBadge>, mode
  * directions pane still draws no roundel for such a route: it has room to print the long name in full as
  * the row's title, and doesn't reach for this badge to do it.
  */
-internal fun TripLeg.plannedBadge(): RouteBadge? = routeDisplayLabel()?.let { RouteBadge(it, badgeColor(routeColor)) }
+internal fun TripLeg.plannedBadge(mapRouteColors: Map<String, Int> = emptyMap()): RouteBadge? = routeDisplayLabel()?.let {
+    RouteBadge(it, badgeColor(routeColor), itineraryRouteIdentity()?.let(mapRouteColors::get))
+}
 
 /** An interchangeable route's roundel, alongside [plannedBadge] in the same leg's badge. */
-internal fun InterchangeableRoute.badge(): RouteBadge = RouteBadge(displayName, badgeColor(routeColor))
+internal fun InterchangeableRoute.badge(mapRouteColors: Map<String, Int> = emptyMap()): RouteBadge = RouteBadge(displayName, badgeColor(routeColor), mapRouteColors[routeId])
 
 /** A wire route color as a badge color: OTP hands over a bare hex, but tolerate a leading '#'. */
 private fun badgeColor(wireHex: String?): Int? = parseObaHexColor(wireHex?.removePrefix("#"))

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsRepository.kt
@@ -29,6 +29,7 @@ import org.onebusaway.android.directions.model.TripPlace
 import org.onebusaway.android.directions.model.interchangeableRoutes
 import org.onebusaway.android.directions.util.DirectionsGenerator
 import org.onebusaway.android.map.RouteFocusSegment
+import org.onebusaway.android.map.itineraryTransitColors
 import org.onebusaway.android.util.geoPointOrNull
 import org.onebusaway.android.util.runCatchingCancellable
 
@@ -88,7 +89,12 @@ class DefaultTripResultsRepository @Inject constructor(
             // One RouteLegRef per transit chain (a stay-aboard interline folds its continuation legs into
             // the chain leader, #2000); the builder folds the same continuation legs into the leader's
             // Transit entry so the two agree.
-            val routeLegRefs = resolveRouteLegRefs(itinerary.legs, itinerary.substitutableRoutes())
+            val substitutable = itinerary.substitutableRoutes()
+            val mapRouteColors = itineraryTransitColors(
+                itinerary.legs,
+                substitutable.flatten().map(InterchangeableRoute::routeId)
+            )
+            val routeLegRefs = resolveRouteLegRefs(itinerary.legs, substitutable, mapRouteColors)
             TripLogBuilder.build(itinerary.legs, flat, routeLegRefs)
         }
     }
@@ -106,7 +112,8 @@ class DefaultTripResultsRepository @Inject constructor(
      */
     private suspend fun resolveRouteLegRefs(
         legs: List<TripLeg>,
-        substitutable: List<List<InterchangeableRoute>>
+        substitutable: List<List<InterchangeableRoute>>,
+        mapRouteColors: Map<String, Int>
     ): List<RouteLegRef?> {
         val refs = MutableList<RouteLegRef?>(legs.size) { null }
         for (chain in Interlines.chains(legs)) {
@@ -139,24 +146,25 @@ class DefaultTripResultsRepository @Inject constructor(
                 alight = legs[chain.alightIndex].to.resolveStop(legs[chain.alightIndex]),
                 interlineTransitions = transitions,
                 extraSegments = extraSegments,
-                alternatives = alternatives.map { it.resolve() },
+                alternatives = alternatives.map { it.resolve(mapRouteColors) },
                 // Built here, alongside the option cards' badges, so the drawer renders one rather than
                 // deriving it per row (#2010) — and so a ride that changes route under the rider is
                 // badged the same "5 > 12" in both places (#2049).
-                badge = rideBadge(legs, chain, alternatives)
+                badge = rideBadge(legs, chain, alternatives, mapRouteColors)
             )
         }
         return refs
     }
 
     /** The same OTP-route-id → OBA-route-id resolution the planned route gets, for an alternative. */
-    private suspend fun InterchangeableRoute.resolve(): AlternativeRouteRef {
-        val badge = badge()
+    private suspend fun InterchangeableRoute.resolve(mapRouteColors: Map<String, Int>): AlternativeRouteRef {
+        val badge = badge(mapRouteColors)
         return AlternativeRouteRef(
             routeId = otpObaIdResolver.obaRouteId(routeId, agencyId, agencyName),
             headsign = headsign,
             shortName = badge.shortName,
-            routeColor = badge.routeColor
+            routeColor = badge.routeColor,
+            mapRouteColor = badge.mapRouteColor
         )
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
@@ -1113,12 +1113,18 @@ private fun ColumnScope.BoardContent(
         // before. A route that publishes no short name gets no roundel and leads with its long name —
         // see routeDisplayShortName.
         val joined = entry.routeLeg.badge?.takeIf { it.isJoined }
+        val singleMapRouteColor = entry.routeLeg.badge?.routes?.singleOrNull()?.mapRouteColor
         val title = entry.routeDisplayName?.takeIf { it != entry.routeShortName }
         Row(verticalAlignment = Alignment.CenterVertically) {
             when {
                 joined != null -> RouteBadgeChip(joined.routes, scale = 1.5f, join = joined.join)
                 entry.routeShortName != null ->
-                    RouteBadgeChip(entry.routeShortName, routeColorInt(entry.routeColorHex), scale = 1.5f)
+                    RouteBadgeChip(
+                        entry.routeShortName,
+                        routeColorInt(entry.routeColorHex),
+                        scale = 1.5f,
+                        mapRouteColor = singleMapRouteColor
+                    )
             }
             if (joined != null || entry.routeShortName != null) Spacer(Modifier.width(8.dp))
             if (title != null) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
@@ -359,7 +359,8 @@ data class AlternativeRouteRef(
     val routeId: String?,
     val headsign: String?,
     val shortName: String,
-    val routeColor: Int?
+    val routeColor: Int?,
+    val mapRouteColor: Int? = null
 )
 
 /** A transit stop reached on a leg — its OBA id (for arrivals), display name, code, and location. */

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
@@ -250,7 +250,7 @@ class MapLibreRenderer(
                     .icon(routeBadgeIcon(badge.routeShortName, badge.color))
             )
             staticAnnotations.add(marker)
-            routeBadgeByMarker[marker] = badge
+            if (badge.interactive) routeBadgeByMarker[marker] = badge
         }
     }
 

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/ItineraryLegStyleTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/ItineraryLegStyleTest.kt
@@ -5,6 +5,7 @@ import android.annotation.SuppressLint
 import com.google.android.material.color.utilities.Hct
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.onebusaway.android.directions.model.TripLeg
@@ -115,6 +116,69 @@ class ItineraryLegStyleTest {
                 Hct.fromInt(fallback.color).chroma > ACHROMATIC_ROUTE_CHROMA
             )
         }
+    }
+
+    @Test
+    fun `itinerary transit routes get contrasting colors independent of agency colors`() {
+        val legs = listOf(
+            TripLeg(mode = TripMode.BUS, routeId = "route-a", routeShortName = "A", routeColor = "FF0000"),
+            TripLeg(mode = TripMode.RAIL, routeId = "route-b", routeShortName = "B", routeColor = "FF0000"),
+            // A later leg on the same route retains the first leg's identity and color.
+            TripLeg(mode = TripMode.BUS, routeId = "route-a", routeShortName = "A", routeColor = null),
+            TripLeg(mode = TripMode.WALK, routeId = "not-a-route", routeShortName = "Walk")
+        )
+
+        val colors = itineraryTransitColors(legs, additionalRouteIdentities = listOf("route-c"))
+
+        assertEquals(setOf("route-a", "route-b", "route-c"), colors.keys)
+        assertEquals(3, colors.values.toSet().size)
+        assertEquals(
+            colors.getValue("route-a"),
+            itineraryLegStyle(ItineraryLegKind.TRANSIT, colors.getValue("route-a")).color
+        )
+    }
+
+    @Test
+    fun `OTP1 route display name is the fallback color identity`() {
+        val leg = TripLeg(mode = TripMode.BUS, routeId = null, route = "45")
+
+        assertEquals("45", leg.itineraryRouteIdentity())
+        assertEquals(setOf("45"), itineraryTransitColors(listOf(leg)).keys)
+    }
+
+    @Test
+    fun `directions route badge matches its assigned line color and midpoint`() {
+        val route = TripLeg(mode = TripMode.BUS, routeId = "route-45", routeShortName = "45")
+        val walk = TripLeg(mode = TripMode.WALK)
+        val path = listOf(GeoPoint(0.0, 0.0), GeoPoint(0.0, 1.0))
+        val color = itineraryTransitColors(listOf(route)).getValue("route-45")
+
+        val badge = itineraryRouteBadges(
+            listOf(
+                ItineraryDrawableLeg(0, route, path),
+                ItineraryDrawableLeg(1, walk, path)
+            ),
+            mapOf("route-45" to color)
+        ).single()
+
+        assertEquals("45", badge.routeShortName)
+        assertEquals(color, badge.color)
+        assertEquals(GeoPoint(0.0, 0.5), badge.point)
+        assertFalse(badge.interactive)
+    }
+
+    @Test
+    fun `a transit leg without geometry still reserves its palette position`() {
+        val hidden = TripLeg(mode = TripMode.BUS, routeId = "hidden", routeShortName = "H")
+        val drawn = TripLeg(mode = TripMode.BUS, routeId = "drawn", routeShortName = "D")
+
+        val fullPalette = itineraryTransitColors(listOf(hidden, drawn))
+
+        assertEquals(listOf("hidden", "drawn"), fullPalette.keys.toList())
+        assertNotEquals(
+            fullPalette.getValue("drawn"),
+            itineraryTransitColors(listOf(drawn)).getValue("drawn")
+        )
     }
 
     @Test

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/RouteBadgesTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/RouteBadgesTest.kt
@@ -97,6 +97,23 @@ class RouteBadgesTest {
         assertEquals("8", badge?.shortName)
     }
 
+    @Test
+    fun plannedAndAlternativeBadgesCarryTheirMapStripeColors() {
+        val leg = transitLeg("8")
+        val alternative = interchangeableRoute("7")
+
+        val badge = legBadge(
+            leg,
+            listOf(alternative),
+            mapOf(leg.routeId!! to 0xFF112233.toInt(), alternative.routeId to 0xFF445566.toInt())
+        )
+
+        assertEquals(
+            mapOf("7" to 0xFF445566.toInt(), "8" to 0xFF112233.toInt()),
+            badge.routes.associate { it.shortName to it.mapRouteColor }
+        )
+    }
+
     /**
      * A route that publishes no short name badges its long name — never its GTFS id, which is an
      * identifier and not a name. Washington State Ferries' "Seattle - Bremerton" is the real case: it


### PR DESCRIPTION
Fixes #2066.

## What changed

- Assign every transit route in a trip itinerary a stable, contrasting map color using the same hue-distribution policy as stop-focus adjacency.
- Draw non-interactive midpoint route labels on directions-map transit lines using the shared map badge layout and renderer in both Google Maps and MapLibre.
- Carry each assigned map color into route-picker and directions-drawer microbadges as a 9dp trailing orientation stripe.
- Apply the stripe to every segment of interchangeable and stay-aboard interline badges, extending it beneath the slash/chevron so the divider clips the color cleanly.
- Give microbadges a square minimum footprint and center their icon/name content within the available width.
- Keep directions-map labels informational so tapping one cannot accidentally enter stop-focused route navigation.
- Use the same fixed 9dp stripe width on the arrivals drawer's larger line badges for consistency.

## Why

Directions-map transit legs previously preferred agency colors and sent every colorless route to one fallback hue. Simultaneously visible routes could therefore be indistinguishable, and the map had no labels tying those lines back to the route names in the picker and drawer. The existing stop-focus view already solved both problems with contrasting colors and route badges.

The picker and drawer also used theme-retinted GTFS badge colors, which intentionally differ from colors drawn on a basemap. The trailing stripe preserves the badge's readable Material treatment while showing the exact map-line color as an orientation key.

## Review notes

A convergence review found and fixed a palette-order mismatch: the map initially derived colors only from drawable legs while the UI used all transit legs. A missing or degenerate earlier geometry could rotate later colors and make a stripe disagree with its line. Palette assignment now always uses the complete itinerary, including eligible interchangeable routes.

## Validation

- `:onebusaway-android:compileObaGoogleDebugKotlin -PwarningsAsErrors=true`
- `:onebusaway-android:compileObaMaplibreDebugKotlin -PwarningsAsErrors=true`
- `:onebusaway-android:testObaGoogleDebugUnitTest -PwarningsAsErrors=true`
- `spotlessCheck`
- `git diff --check`
- Iteratively installed and visually reviewed on the shared physical test phone.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/OneBusAway/codesmith/onebusaway-android/pr/2072"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787904052&installation_model_id=429412&pr_number=2072&repository=OneBusAway%2Fonebusaway-android&return_to=https%3A%2F%2Fgithub.com%2FOneBusAway%2Fonebusaway-android%2Fpull%2F2072&signature=82866e18def9dfab27968e519fe27eb9430ee2d2e7a36a3014c86629de7c3263"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Transit routes now use consistent, distinct colors across map directions and trip results.
  * Route badges display map-specific color stripes, including for alternative routes.
  * Map route labels can be interactive or display-only.
* **Bug Fixes**
  * Improved badge sizing and segment rendering for short route names.
  * Non-interactive map labels no longer respond to taps.
* **Tests**
  * Added coverage for route color consistency, badge placement, and alternative-route styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->