### PR TITLE
Label directions-map transit lines with their route

### DIFF
--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
@@ -310,7 +310,9 @@ class GoogleMapRenderer(
                     .zIndex(ROUTE_BADGE_Z_INDEX)
             )!!
             staticMarkers += marker
-            routeBadgeByMarker[marker] = badge
+            // Only an interactive label becomes a tap target; a directions label is informational, and
+            // an unregistered marker's tap falls through to the map like any other unclaimed one.
+            if (badge.interactive) routeBadgeByMarker[marker] = badge
         }
     }
 

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
@@ -310,9 +310,9 @@ class GoogleMapRenderer(
                     .zIndex(ROUTE_BADGE_Z_INDEX)
             )!!
             staticMarkers += marker
-            // Only an interactive label becomes a tap target; a directions label is informational, and
-            // an unregistered marker's tap falls through to the map like any other unclaimed one.
-            if (badge.interactive) routeBadgeByMarker[marker] = badge
+            // Only a label that leads somewhere becomes a tap target (see [RouteBadge.tap]); an
+            // unregistered marker's tap falls through to the map like any other unclaimed one.
+            if (badge.tap != null) routeBadgeByMarker[marker] = badge
         }
     }
 

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleComposeAdapter.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleComposeAdapter.kt
@@ -386,8 +386,9 @@ private fun routeMarkerTap(
         return true
     }
     val routeBadge = renderer.routeBadgeForMarker(marker)
-    if (routeBadge != null) {
-        cb.onRouteBadgeClick(routeBadge.routeId, routeBadge.routeShortName, routeBadge.directionId)
+    val routeBadgeTap = routeBadge?.tap
+    if (routeBadge != null && routeBadgeTap != null) {
+        cb.onRouteBadgeClick(routeBadgeTap.routeId, routeBadge.routeShortName, routeBadgeTap.directionId)
         return true
     }
     // Trip-focus estimate markers + the most-recent-data dot (titled markers): the SDK's default

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/DirectionsMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/DirectionsMapController.kt
@@ -21,14 +21,8 @@ import org.onebusaway.android.directions.model.TripLegGeometry
 import org.onebusaway.android.directions.model.TripMode
 import org.onebusaway.android.directions.model.TripVertexType
 import org.onebusaway.android.directions.model.decodedPoints
-import org.onebusaway.android.directions.model.routeDisplayLabel
-import org.onebusaway.android.map.layout.RouteBadgeLayoutInput
-import org.onebusaway.android.map.layout.RouteBadgePath
-import org.onebusaway.android.map.layout.layoutRouteBadges
-import org.onebusaway.android.map.render.RouteBadge
 import org.onebusaway.android.map.render.RoutePolyline
 import org.onebusaway.android.models.ObaShape
-import org.onebusaway.android.models.RouteDirectionKey
 import org.onebusaway.android.util.GeoPoint
 import org.onebusaway.android.util.parseObaHexColor
 
@@ -102,23 +96,20 @@ class DirectionsMapController(private val host: MapHost) {
             val style = itineraryLegStyle(leg.legKind(), parseObaHexColor(leg.routeColor))
             ItineraryDrawableLeg(legIndex, leg, shape.points, style)
         }
-        // Build every leg's polyline (each in its own mode/route style), keeping each one's leg index so
-        // a later focus can name legs rather than drawn positions.
-        legLines = drawableLegs.map { drawable ->
-            // Every leg's points run in travel order, so whether it stamps chevrons is the style's
-            // call — a dashed on-street stroke declines them (see [itineraryLegStyle]).
+        // Every leg's points run in travel order, so whether it stamps chevrons is the style's call — a
+        // dashed on-street stroke declines them (see [itineraryLegStyle]).
+        legLines = drawableLegs.map { (legIndex, _, points, style) ->
             ItineraryLegLine(
-                drawable.index,
+                legIndex,
                 RoutePolyline(
-                    drawable.style.color,
-                    drawable.points,
-                    widthProfile = drawable.style.widthProfile,
-                    directional = drawable.style.directional,
-                    dash = drawable.style.dash
+                    style.color,
+                    points,
+                    widthProfile = style.widthProfile,
+                    directional = style.directional,
+                    dash = style.dash
                 )
             )
         }
-        host.renderState.setRouteBadges(itineraryRouteBadges(drawableLegs))
         // A freshly drawn itinerary is the overview: every leg at full weight until one is focused.
         focusedLegIndices = emptySet()
         publishLegs()
@@ -129,6 +120,9 @@ class DirectionsMapController(private val host: MapHost) {
         if (endLat != null && endLon != null) {
             directionsMarkerIds.add(host.addMarker(endLat, endLon, HUE_RED))
         }
+        // Published after the pins, since the static layer is redrawn wholesale on each emission that
+        // reaches it: badges written first would be built again for every pin added after them.
+        host.renderState.setRouteBadges(itineraryRouteBadges(drawableLegs))
 
         directionsHasRoute = legLines.isNotEmpty()
         directionsStart = if (startLat != null && startLon != null) GeoPoint(startLat, startLon) else null
@@ -240,63 +234,3 @@ class DirectionsMapController(private val host: MapHost) {
         }
     }
 }
-
-/**
- * One itinerary leg that has geometry to draw: its index in the itinerary, the leg itself, its decoded
- * points, and the stroke they're drawn in — resolved once, so the line and its label share it.
- */
-internal data class ItineraryDrawableLeg(
-    val index: Int,
-    val leg: TripLeg,
-    val points: List<GeoPoint>,
-    val style: ItineraryLegStyle
-)
-
-/**
- * One route label per ride in a drawn itinerary, so a line on the directions map says which route it
- * is without the rider having to match it to the drawer beside it. Non-interactive: they name legs of
- * the trip already being read, so a tap must not navigate away into a single route's map.
- *
- * Anchored by the shared [layoutRouteBadges] used by focused-stop adjacency, so labels sit at stable
- * distance midpoints and stagger apart when two ridden corridors overlap. Each label takes the colour
- * its own line is stroked with ([itineraryLegStyle]), so the two can't disagree.
- */
-internal fun itineraryRouteBadges(legs: List<ItineraryDrawableLeg>): List<RouteBadge> {
-    val rides = legs.asSequence()
-        .filter { it.leg.mode?.isTransit == true }
-        .mapNotNull { drawable ->
-            // A route that names itself in no way at all has nothing to label the line with.
-            val name = drawable.leg.routeDisplayLabel() ?: return@mapNotNull null
-            // Grouped by the wire route id, or — for an OTP1 response, which names a route without
-            // identifying it — by that name. So two legs of one route (a stay-aboard interline, or a
-            // route the itinerary returns to) share a single label rather than each getting their own.
-            RideLabel(drawable.leg.routeId ?: name, name, drawable.style.color, drawable.points)
-        }
-        .groupBy(RideLabel::identity)
-    val placements = layoutRouteBadges(
-        rides.map { (identity, ridden) ->
-            // Direction is the adjacency view's axis, not an itinerary's: a ride is already one
-            // direction along its route, so every leg of it shares one label.
-            RouteBadgeLayoutInput(RouteDirectionKey(identity, null), ridden.map { RouteBadgePath(it.points) })
-        }
-    ).associateBy { it.route.routeId }
-    return rides.mapNotNull { (identity, ridden) ->
-        // A ride whose every leg is too short to measure gets no anchor, and so no label.
-        val point = placements[identity]?.point ?: return@mapNotNull null
-        RouteBadge(
-            routeId = identity,
-            routeShortName = ridden.first().name,
-            color = ridden.first().color,
-            point = point,
-            directionId = null,
-            interactive = false
-        )
-    }
-}
-
-private data class RideLabel(
-    val identity: String,
-    val name: String,
-    val color: Int,
-    val points: List<GeoPoint>
-)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/DirectionsMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/DirectionsMapController.kt
@@ -21,14 +21,21 @@ import org.onebusaway.android.directions.model.TripLegGeometry
 import org.onebusaway.android.directions.model.TripMode
 import org.onebusaway.android.directions.model.TripVertexType
 import org.onebusaway.android.directions.model.decodedPoints
+import org.onebusaway.android.directions.model.routeDisplayLabel
+import org.onebusaway.android.map.layout.RouteBadgeLayoutInput
+import org.onebusaway.android.map.layout.RouteBadgePath
+import org.onebusaway.android.map.layout.layoutRouteBadges
+import org.onebusaway.android.map.render.RouteBadge
 import org.onebusaway.android.map.render.RoutePolyline
 import org.onebusaway.android.models.ObaShape
+import org.onebusaway.android.models.RouteDirectionKey
 import org.onebusaway.android.util.GeoPoint
 import org.onebusaway.android.util.parseObaHexColor
 
 /**
  * The trip-plan directions use case (the legacy `DirectionsMapController`): draws an itinerary's legs
- * (each polyline styled by [itineraryLegStyle]) plus start/end pins, and frames the whole itinerary. A
+ * (each polyline styled by [itineraryLegStyle], each ride labelled by [itineraryRouteBadges]) plus
+ * start/end pins, and frames the whole itinerary. A
  * synchronous driver over [MapHost] — it has no loader of its own (the itinerary is handed in), so it
  * just writes polylines + markers and dispatches the framing camera command.
  *
@@ -85,29 +92,33 @@ class DirectionsMapController(private val host: MapHost) {
         val endLat = endPlace.lat
         val endLon = endPlace.lon
 
-        // Build every leg's polyline (each in its own mode/route style), keeping each one's leg index so
-        // a later focus can name legs rather than drawn positions (a leg without geometry draws nothing).
-        legLines = legs.mapIndexedNotNull { legIndex, leg ->
+        // Every leg that has geometry to draw, decoded and styled once: the polylines below stroke it and
+        // the route labels are anchored on it, so a label cannot end up a different colour from its own
+        // line (a leg without geometry draws neither).
+        val drawableLegs = legs.mapIndexedNotNull { legIndex, leg ->
             val geometry = leg.legGeometry ?: return@mapIndexedNotNull null
             val shape = LegShape(geometry)
-            if (shape.length > 0) {
-                val style = itineraryLegStyle(leg.legKind(), parseObaHexColor(leg.routeColor))
-                // Every leg's points run in travel order, so whether it stamps chevrons is the style's
-                // call — a dashed on-street stroke declines them (see [itineraryLegStyle]).
-                ItineraryLegLine(
-                    legIndex,
-                    RoutePolyline(
-                        style.color,
-                        shape.points,
-                        widthProfile = style.widthProfile,
-                        directional = style.directional,
-                        dash = style.dash
-                    )
-                )
-            } else {
-                null
-            }
+            if (shape.length <= 0) return@mapIndexedNotNull null
+            val style = itineraryLegStyle(leg.legKind(), parseObaHexColor(leg.routeColor))
+            ItineraryDrawableLeg(legIndex, leg, shape.points, style)
         }
+        // Build every leg's polyline (each in its own mode/route style), keeping each one's leg index so
+        // a later focus can name legs rather than drawn positions.
+        legLines = drawableLegs.map { drawable ->
+            // Every leg's points run in travel order, so whether it stamps chevrons is the style's
+            // call — a dashed on-street stroke declines them (see [itineraryLegStyle]).
+            ItineraryLegLine(
+                drawable.index,
+                RoutePolyline(
+                    drawable.style.color,
+                    drawable.points,
+                    widthProfile = drawable.style.widthProfile,
+                    directional = drawable.style.directional,
+                    dash = drawable.style.dash
+                )
+            )
+        }
+        host.renderState.setRouteBadges(itineraryRouteBadges(drawableLegs))
         // A freshly drawn itinerary is the overview: every leg at full weight until one is focused.
         focusedLegIndices = emptySet()
         publishLegs()
@@ -172,6 +183,7 @@ class DirectionsMapController(private val host: MapHost) {
         directionsMarkerIds.clear()
         legLines = emptyList()
         focusedLegIndices = emptySet()
+        host.renderState.setRouteBadges(emptyList())
     }
 
     /**
@@ -228,3 +240,63 @@ class DirectionsMapController(private val host: MapHost) {
         }
     }
 }
+
+/**
+ * One itinerary leg that has geometry to draw: its index in the itinerary, the leg itself, its decoded
+ * points, and the stroke they're drawn in — resolved once, so the line and its label share it.
+ */
+internal data class ItineraryDrawableLeg(
+    val index: Int,
+    val leg: TripLeg,
+    val points: List<GeoPoint>,
+    val style: ItineraryLegStyle
+)
+
+/**
+ * One route label per ride in a drawn itinerary, so a line on the directions map says which route it
+ * is without the rider having to match it to the drawer beside it. Non-interactive: they name legs of
+ * the trip already being read, so a tap must not navigate away into a single route's map.
+ *
+ * Anchored by the shared [layoutRouteBadges] used by focused-stop adjacency, so labels sit at stable
+ * distance midpoints and stagger apart when two ridden corridors overlap. Each label takes the colour
+ * its own line is stroked with ([itineraryLegStyle]), so the two can't disagree.
+ */
+internal fun itineraryRouteBadges(legs: List<ItineraryDrawableLeg>): List<RouteBadge> {
+    val rides = legs.asSequence()
+        .filter { it.leg.mode?.isTransit == true }
+        .mapNotNull { drawable ->
+            // A route that names itself in no way at all has nothing to label the line with.
+            val name = drawable.leg.routeDisplayLabel() ?: return@mapNotNull null
+            // Grouped by the wire route id, or — for an OTP1 response, which names a route without
+            // identifying it — by that name. So two legs of one route (a stay-aboard interline, or a
+            // route the itinerary returns to) share a single label rather than each getting their own.
+            RideLabel(drawable.leg.routeId ?: name, name, drawable.style.color, drawable.points)
+        }
+        .groupBy(RideLabel::identity)
+    val placements = layoutRouteBadges(
+        rides.map { (identity, ridden) ->
+            // Direction is the adjacency view's axis, not an itinerary's: a ride is already one
+            // direction along its route, so every leg of it shares one label.
+            RouteBadgeLayoutInput(RouteDirectionKey(identity, null), ridden.map { RouteBadgePath(it.points) })
+        }
+    ).associateBy { it.route.routeId }
+    return rides.mapNotNull { (identity, ridden) ->
+        // A ride whose every leg is too short to measure gets no anchor, and so no label.
+        val point = placements[identity]?.point ?: return@mapNotNull null
+        RouteBadge(
+            routeId = identity,
+            routeShortName = ridden.first().name,
+            color = ridden.first().color,
+            point = point,
+            directionId = null,
+            interactive = false
+        )
+    }
+}
+
+private data class RideLabel(
+    val identity: String,
+    val name: String,
+    val color: Int,
+    val points: List<GeoPoint>
+)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/ItineraryLegStyle.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/ItineraryLegStyle.kt
@@ -18,11 +18,17 @@ package org.onebusaway.android.map
 import org.onebusaway.android.directions.model.TripLeg
 import org.onebusaway.android.directions.model.TripMode
 import org.onebusaway.android.directions.model.TripVertexType
+import org.onebusaway.android.directions.model.routeDisplayLabel
+import org.onebusaway.android.map.layout.RouteBadgePath
+import org.onebusaway.android.map.layout.RouteBadgeRequest
+import org.onebusaway.android.map.layout.placeRouteBadges
 import org.onebusaway.android.map.render.ITINERARY_RIDE_WIDTH_PROFILE
 import org.onebusaway.android.map.render.ITINERARY_STREET_WIDTH_PROFILE
+import org.onebusaway.android.map.render.RouteBadge
 import org.onebusaway.android.map.render.RouteLineDash
 import org.onebusaway.android.map.render.RouteLineWidthProfile
 import org.onebusaway.android.map.render.RoutePolyline
+import org.onebusaway.android.util.GeoPoint
 
 /**
  * How one trip-plan itinerary leg is stroked on the directions map (#2041).
@@ -123,6 +129,48 @@ internal fun List<ItineraryLegLine>.withLegFocus(focusedLegIndices: Set<Int>): L
     if (focused.isEmpty()) return map { it.line }
     return rest.map { it.line }.asDeemphasizedRouteUnderlay() + focused.map { it.line }
 }
+
+/**
+ * One itinerary leg with geometry to draw: its index in the itinerary, the leg itself, its decoded
+ * points, and the stroke its line and its label share.
+ */
+internal data class ItineraryDrawableLeg(
+    val index: Int,
+    val leg: TripLeg,
+    val points: List<GeoPoint>,
+    val style: ItineraryLegStyle
+)
+
+/**
+ * One label per route ridden in a drawn itinerary (#2066), so a transit line on the directions map says
+ * which route it is without the rider having to match it to the drawer beside it. Two legs of one route
+ * — a stay-aboard interline, or a route the itinerary returns to — share a single label.
+ */
+internal fun itineraryRouteBadges(legs: List<ItineraryDrawableLeg>): List<RouteBadge> {
+    val rides = legs.mapNotNull { drawable ->
+        if (drawable.leg.mode?.isTransit != true) return@mapNotNull null
+        // A route that names itself in no way at all has nothing to label the line with.
+        val name = drawable.leg.routeDisplayLabel() ?: return@mapNotNull null
+        // Grouped by the wire route id, or — for an OTP1 response, which names a route without
+        // identifying it — by the name it displays. That key never leaves this grouping, so a name
+        // standing in for an id can't reach anywhere that would treat it as one.
+        Ride(drawable.leg.routeId ?: name, name, drawable)
+    }.groupBy(Ride::identity)
+    return placeRouteBadges(
+        rides.map { (_, ridden) ->
+            val ride = ridden.first()
+            RouteBadgeRequest(
+                routeShortName = ride.name,
+                // Exactly the colour its own line is stroked with, so a label and its line can't disagree.
+                color = ride.drawable.style.color,
+                paths = ridden.map { RouteBadgePath(it.drawable.points) }
+                // No tap target: see [RouteBadge.tap].
+            )
+        }
+    )
+}
+
+private data class Ride(val identity: String, val name: String, val drawable: ItineraryDrawableLeg)
 
 private fun street(hueAnchor: Int) = ItineraryLegStyle(
     color = anchorColor(hueAnchor),

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteViewGeometry.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteViewGeometry.kt
@@ -5,9 +5,9 @@
  */
 package org.onebusaway.android.map
 
-import org.onebusaway.android.map.layout.RouteBadgeLayoutInput
 import org.onebusaway.android.map.layout.RouteBadgePath
-import org.onebusaway.android.map.layout.layoutRouteBadges
+import org.onebusaway.android.map.layout.RouteBadgeRequest
+import org.onebusaway.android.map.layout.placeRouteBadges
 import org.onebusaway.android.map.render.ADJACENT_ROUTE_LINE_WIDTH_PROFILE
 import org.onebusaway.android.map.render.DEEMPHASIZED_ROUTE_LINE_WIDTH_PROFILE
 import org.onebusaway.android.map.render.DEFAULT_ROUTE_LINE_COLOR
@@ -141,34 +141,23 @@ internal fun FocusedTripGeometry.toRouteBadges(
         val name = getRouteDisplayName(route).takeIf(String::isNotBlank) ?: return@mapNotNull null
         RouteBadgeSpec(key, route, name, routeShapes)
     }
-    val placements = layoutRouteBadges(
+    return placeRouteBadges(
         specs.map { spec ->
-            RouteBadgeLayoutInput(
-                spec.key,
-                spec.shapes.map { shape -> RouteBadgePath(shape.points) }
+            RouteBadgeRequest(
+                routeShortName = spec.name,
+                // A badge takes its line's colour, so it goes through the same policy — an
+                // adjacency colour is already in it, an agency's own has to be put through.
+                color = routeColors[spec.key]
+                    ?: mapRouteLineColorOrNull(
+                        spec.shapes.firstNotNullOfOrNull(FocusedTripShape::routeColor) ?: spec.route.color
+                    )
+                    ?: DEFAULT_ROUTE_LINE_COLOR,
+                paths = spec.shapes.map { shape -> RouteBadgePath(shape.points) },
+                // An adjacency label is the way into its route: it names a route the rider hasn't opened.
+                tap = spec.key
             )
         }
-    ).associateBy { it.route }
-    return buildList {
-        for (spec in specs) {
-            val placement = placements[spec.key] ?: continue
-            add(
-                RouteBadge(
-                    routeId = spec.key.routeId,
-                    routeShortName = spec.name,
-                    // A badge takes its line's colour, so it goes through the same policy — an
-                    // adjacency colour is already in it, an agency's own has to be put through.
-                    color = routeColors[spec.key]
-                        ?: mapRouteLineColorOrNull(
-                            spec.shapes.firstNotNullOfOrNull(FocusedTripShape::routeColor) ?: spec.route.color
-                        )
-                        ?: DEFAULT_ROUTE_LINE_COLOR,
-                    point = placement.point,
-                    directionId = spec.key.directionId
-                )
-            )
-        }
-    }
+    )
 }
 
 private data class RouteBadgeSpec(

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/layout/RouteBadgeLayout.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/layout/RouteBadgeLayout.kt
@@ -19,39 +19,45 @@ import kotlin.math.atan2
 import kotlin.math.cos
 import kotlin.math.sin
 import kotlin.math.sqrt
+import org.onebusaway.android.map.render.RouteBadge
 import org.onebusaway.android.map.render.haversineMeters
 import org.onebusaway.android.models.RouteDirectionKey
 import org.onebusaway.android.util.EARTH_RADIUS_METERS
 import org.onebusaway.android.util.GeoPoint
 
-/** One shape on which a route-direction badge may be anchored. */
+/** One shape on which a route badge may be anchored. */
 data class RouteBadgePath(val points: List<GeoPoint>)
 
-/** One route-direction identity and the geographic shapes on which its badge may be anchored. */
-data class RouteBadgeLayoutInput(
-    val route: RouteDirectionKey,
+/**
+ * One badge identity and the geographic shapes on which it may be anchored. [route] is an opaque token
+ * — the layout never reads it, only echoes it back on the placement — so a caller keys by whatever
+ * identifies a badge in its own view: adjacency by [RouteDirectionKey], an itinerary (which has no
+ * direction axis) by something else entirely.
+ */
+data class RouteBadgeLayoutInput<K>(
+    val route: K,
     val paths: List<RouteBadgePath>
 )
 
 /** A stable geographic badge anchor. Input order determines collision priority. */
-data class RouteBadgePlacement(
-    val route: RouteDirectionKey,
+data class RouteBadgePlacement<K>(
+    val route: K,
     val point: GeoPoint,
     val overlaps: Boolean
 )
 
 /**
- * Places one badge per route-direction identity in geographic space, following the line-center
+ * Places one badge per input identity in geographic space, following the line-center
  * convention used for road shields. The midpoint by distance of the route's longest shape is
  * preferred. When that is too close to an earlier route's badge, candidates alternate upstream and
  * downstream by a fixed geographic distance; if none clears [minimumSeparationMeters], the least-conflicting candidate
  * wins. The result is computed only when route geometry changes and remains fixed across pan/zoom.
  */
-fun layoutRouteBadges(
-    inputs: List<RouteBadgeLayoutInput>,
+fun <K> layoutRouteBadges(
+    inputs: List<RouteBadgeLayoutInput<K>>,
     minimumSeparationMeters: Double = DEFAULT_BADGE_SEPARATION_METERS,
     maxStaggerSteps: Int = DEFAULT_MAX_STAGGER_STEPS
-): List<RouteBadgePlacement> {
+): List<RouteBadgePlacement<K>> {
     val separation = minimumSeparationMeters.coerceAtLeast(0.0)
     val occupied = mutableListOf<GeoPoint>()
     return buildList {
@@ -72,6 +78,42 @@ fun layoutRouteBadges(
             val overlaps = clear == null && occupied.isNotEmpty()
             occupied += point
             add(RouteBadgePlacement(input.route, point, overlaps))
+        }
+    }
+}
+
+/**
+ * One route label to place: what it reads, the colour of the line it names, where a tap on it navigates
+ * (null for an informational label — see [RouteBadge.tap]), and the shapes it may be anchored on. List
+ * order is collision priority, as in [layoutRouteBadges].
+ */
+internal data class RouteBadgeRequest(
+    val routeShortName: String,
+    val color: Int,
+    val paths: List<RouteBadgePath>,
+    val tap: RouteDirectionKey? = null
+)
+
+/**
+ * The shared tail behind every route label on the map — focused-stop adjacency (#1827) and a directions
+ * itinerary's rides (#2066): anchor each request via [layoutRouteBadges], preserve the caller's order,
+ * and drop a request the layout couldn't measure (no anchor, so no label). Callers differ only in how
+ * they group geometry into requests, which is the half that is actually view-specific.
+ */
+internal fun placeRouteBadges(requests: List<RouteBadgeRequest>): List<RouteBadge> {
+    // A request's own position is its layout key: unique by construction, and since the layout only
+    // echoes the key back, neither caller has to invent an identity it would never read.
+    val placements = layoutRouteBadges(
+        requests.mapIndexed { index, request -> RouteBadgeLayoutInput(index, request.paths) }
+    ).associateBy { it.route }
+    return requests.mapIndexedNotNull { index, request ->
+        placements[index]?.let { placement ->
+            RouteBadge(
+                routeShortName = request.routeShortName,
+                color = request.color,
+                point = placement.point,
+                tap = request.tap
+            )
         }
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
@@ -202,15 +202,22 @@ data class ContinuationBadge(
 )
 
 /**
- * A tappable label for one route in focused-stop adjacency view (#1827), anchored once in geographic
- * space so the map SDK naturally carries it through pan and zoom. Rendered by both flavors (#1913).
+ * A label naming one route on the line it is drawn on — in focused-stop adjacency view (#1827), and on
+ * a directions itinerary's rides (#2066). Anchored once in geographic space so the map SDK naturally
+ * carries it through pan and zoom. Rendered by both flavors (#1913).
  */
 data class RouteBadge(
     val routeId: String,
     val routeShortName: String,
     val color: Int,
     val point: GeoPoint,
-    val directionId: Int?
+    val directionId: Int?,
+    /**
+     * Whether tapping this label navigates the map to its route. Adjacency labels do; a directions
+     * itinerary's labels don't — they name legs of a trip the rider is already reading, so a stray tap
+     * would drop the whole itinerary for a single route's map.
+     */
+    val interactive: Boolean = true
 )
 
 /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
@@ -207,17 +207,17 @@ data class ContinuationBadge(
  * carries it through pan and zoom. Rendered by both flavors (#1913).
  */
 data class RouteBadge(
-    val routeId: String,
     val routeShortName: String,
     val color: Int,
     val point: GeoPoint,
-    val directionId: Int?,
     /**
-     * Whether tapping this label navigates the map to its route. Adjacency labels do; a directions
-     * itinerary's labels don't — they name legs of a trip the rider is already reading, so a stray tap
-     * would drop the whole itinerary for a single route's map.
+     * Where a tap on this label navigates — the route-direction to show, preferring the drawn line's own
+     * direction over the route's default. Null makes the label informational: a directions itinerary's
+     * labels name legs of a trip the rider is already reading, so a stray tap must not drop the whole
+     * itinerary for a single route's map. Null is also the default, so a label is inert until a producer
+     * says where it leads, and no producer needs a navigable id it doesn't have.
      */
-    val interactive: Boolean = true
+    val tap: RouteDirectionKey? = null
 )
 
 /**

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
@@ -250,9 +250,9 @@ class MapLibreRenderer(
                     .icon(routeBadgeIcon(badge.routeShortName, badge.color))
             )
             staticAnnotations.add(marker)
-            // Only an interactive label becomes a tap target; a directions label is informational, and
-            // an unregistered marker's tap falls through to the map like any other unclaimed one.
-            if (badge.interactive) routeBadgeByMarker[marker] = badge
+            // Only a label that leads somewhere becomes a tap target (see [RouteBadge.tap]); an
+            // unregistered marker's tap falls through to the map like any other unclaimed one.
+            if (badge.tap != null) routeBadgeByMarker[marker] = badge
         }
     }
 

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
@@ -250,7 +250,9 @@ class MapLibreRenderer(
                     .icon(routeBadgeIcon(badge.routeShortName, badge.color))
             )
             staticAnnotations.add(marker)
-            routeBadgeByMarker[marker] = badge
+            // Only an interactive label becomes a tap target; a directions label is informational, and
+            // an unregistered marker's tap falls through to the map like any other unclaimed one.
+            if (badge.interactive) routeBadgeByMarker[marker] = badge
         }
     }
 

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreComposeAdapter.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreComposeAdapter.kt
@@ -329,8 +329,9 @@ private fun wireClicks(
             return@setOnMarkerClickListener true
         }
         val routeBadge = renderer.routeBadgeForMarker(marker)
-        if (routeBadge != null) {
-            callbacks.onRouteBadgeClick(routeBadge.routeId, routeBadge.routeShortName, routeBadge.directionId)
+        val routeBadgeTap = routeBadge?.tap
+        if (routeBadge != null && routeBadgeTap != null) {
+            callbacks.onRouteBadgeClick(routeBadgeTap.routeId, routeBadge.routeShortName, routeBadgeTap.directionId)
             return@setOnMarkerClickListener true
         }
         // Titled markers (the trip-focus estimate markers + the most-recent-data dot) fall through to

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/ItineraryRouteBadgesTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/ItineraryRouteBadgesTest.kt
@@ -1,0 +1,99 @@
+/* Copyright (C) 2026 Open Transit Software Foundation */
+package org.onebusaway.android.map
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+import org.onebusaway.android.directions.model.TripLeg
+import org.onebusaway.android.directions.model.TripMode
+import org.onebusaway.android.util.GeoPoint
+
+/**
+ * The route labels drawn on a directions itinerary's transit lines (#2066). The point of these is that a
+ * label names *a ride* — one per route, however many legs it spans — takes the colour of the line it
+ * names, and never becomes a tap target that would navigate away from the trip being read.
+ */
+class ItineraryRouteBadgesTest {
+
+    private val eastward = listOf(GeoPoint(0.0, 0.0), GeoPoint(0.0, 1.0))
+
+    private val northward = listOf(GeoPoint(0.0, 0.0), GeoPoint(1.0, 0.0))
+
+    @Test
+    fun `each ridden route is labelled at its midpoint, in its own line colour, and is not tappable`() {
+        val ride = TripLeg(mode = TripMode.BUS, routeId = "route-45", routeShortName = "45")
+        val rideStyle = itineraryLegStyle(ItineraryLegKind.TRANSIT, routeColor = 0xFF0000FF.toInt())
+
+        val badge = itineraryRouteBadges(
+            listOf(
+                drawable(0, TripLeg(mode = TripMode.WALK), northward, ItineraryLegKind.WALK),
+                ItineraryDrawableLeg(1, ride, eastward, rideStyle)
+            )
+        ).single()
+
+        assertEquals("45", badge.routeShortName)
+        assertEquals("route-45", badge.routeId)
+        assertEquals(GeoPoint(0.0, 0.5), badge.point)
+        // Exactly the colour its own line is stroked with, so a label and its line can't disagree.
+        assertEquals(rideStyle.color, badge.color)
+        assertFalse(badge.interactive)
+    }
+
+    @Test
+    fun `two legs of one route share a single label`() {
+        val first = TripLeg(mode = TripMode.BUS, routeId = "route-5", routeShortName = "5")
+        val second = TripLeg(mode = TripMode.BUS, routeId = "route-5", routeShortName = "5")
+
+        val badges = itineraryRouteBadges(
+            listOf(drawable(0, first, eastward), drawable(2, second, northward))
+        )
+
+        assertEquals(listOf("route-5"), badges.map { it.routeId })
+    }
+
+    @Test
+    fun `two routes ridden along the same corridor are labelled apart`() {
+        val badges = itineraryRouteBadges(
+            listOf(
+                drawable(0, TripLeg(mode = TripMode.BUS, routeId = "a", routeShortName = "A"), eastward),
+                drawable(1, TripLeg(mode = TripMode.RAIL, routeId = "b", routeShortName = "B"), eastward)
+            )
+        )
+
+        assertEquals(listOf("A", "B"), badges.map { it.routeShortName })
+        assertNotEquals(badges[0].point, badges[1].point)
+    }
+
+    @Test
+    fun `an OTP1 leg, which identifies no route, is identified by the name it displays`() {
+        val badge = itineraryRouteBadges(
+            listOf(drawable(0, TripLeg(mode = TripMode.BUS, routeId = null, route = "45"), eastward))
+        ).single()
+
+        assertEquals("45", badge.routeId)
+        assertEquals("45", badge.routeShortName)
+    }
+
+    @Test
+    fun `a route that names itself in no way, and a line too short to anchor on, are left unlabelled`() {
+        val nameless = TripLeg(mode = TripMode.BUS, routeId = "route-x")
+        val degenerate = TripLeg(mode = TripMode.BUS, routeId = "route-y", routeShortName = "Y")
+
+        val badges = itineraryRouteBadges(
+            listOf(
+                drawable(0, nameless, eastward),
+                drawable(1, degenerate, listOf(GeoPoint(0.0, 0.0)))
+            )
+        )
+
+        assertEquals(emptyList<String>(), badges.map { it.routeId })
+    }
+
+    private fun drawable(
+        index: Int,
+        leg: TripLeg,
+        points: List<GeoPoint>,
+        kind: ItineraryLegKind = ItineraryLegKind.TRANSIT
+    ) = ItineraryDrawableLeg(index, leg, points, itineraryLegStyle(kind, routeColor = null))
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/ItineraryRouteBadgesTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/ItineraryRouteBadgesTest.kt
@@ -2,8 +2,8 @@
 package org.onebusaway.android.map
 
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 import org.onebusaway.android.directions.model.TripLeg
 import org.onebusaway.android.directions.model.TripMode
@@ -33,11 +33,11 @@ class ItineraryRouteBadgesTest {
         ).single()
 
         assertEquals("45", badge.routeShortName)
-        assertEquals("route-45", badge.routeId)
         assertEquals(GeoPoint(0.0, 0.5), badge.point)
         // Exactly the colour its own line is stroked with, so a label and its line can't disagree.
         assertEquals(rideStyle.color, badge.color)
-        assertFalse(badge.interactive)
+        // No tap target at all, so there is nothing for a stray tap to navigate to.
+        assertNull(badge.tap)
     }
 
     @Test
@@ -49,7 +49,7 @@ class ItineraryRouteBadgesTest {
             listOf(drawable(0, first, eastward), drawable(2, second, northward))
         )
 
-        assertEquals(listOf("route-5"), badges.map { it.routeId })
+        assertEquals(listOf("5"), badges.map { it.routeShortName })
     }
 
     @Test
@@ -66,13 +66,17 @@ class ItineraryRouteBadgesTest {
     }
 
     @Test
-    fun `an OTP1 leg, which identifies no route, is identified by the name it displays`() {
-        val badge = itineraryRouteBadges(
-            listOf(drawable(0, TripLeg(mode = TripMode.BUS, routeId = null, route = "45"), eastward))
-        ).single()
+    fun `OTP1 legs, which identify no route, are grouped by the name they display`() {
+        // An OTP1 response names a route without identifying it, so the displayed name is all these two
+        // legs have to be recognized as one ride by — they still get a single shared label.
+        val badges = itineraryRouteBadges(
+            listOf(
+                drawable(0, TripLeg(mode = TripMode.BUS, routeId = null, route = "45"), eastward),
+                drawable(1, TripLeg(mode = TripMode.BUS, routeId = null, route = "45"), northward)
+            )
+        )
 
-        assertEquals("45", badge.routeId)
-        assertEquals("45", badge.routeShortName)
+        assertEquals(listOf("45"), badges.map { it.routeShortName })
     }
 
     @Test
@@ -87,7 +91,7 @@ class ItineraryRouteBadgesTest {
             )
         )
 
-        assertEquals(emptyList<String>(), badges.map { it.routeId })
+        assertEquals(emptyList<String>(), badges.map { it.routeShortName })
     }
 
     private fun drawable(

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteMapPresentationPlanTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteMapPresentationPlanTest.kt
@@ -144,7 +144,7 @@ class RouteMapPresentationPlanTest {
         )
 
         // No emphasized route -> route badges are emitted, and there's no active base route to frame to.
-        assertEquals(listOf("79"), plan.badges.map { it.routeId })
+        assertEquals(listOf("79"), plan.badges.map { it.tap?.routeId })
         assertEquals(emptyList<RoutePolyline>(), plan.framingPolylines)
         assertEquals(1, plan.polylines.size)
     }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteViewGeometryTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteViewGeometryTest.kt
@@ -277,10 +277,10 @@ class RouteViewGeometryTest {
             )
         )
 
-        assertEquals(listOf("route-b", "route-a", "route-a"), badges.map { it.routeId })
+        assertEquals(listOf("route-b", "route-a", "route-a"), badges.map { it.tap?.routeId })
         assertEquals(listOf("B", "A", "A"), badges.map { it.routeShortName })
         assertEquals(listOf(20, 10, 30), badges.map { it.color })
-        assertEquals(listOf(1, 0, 1), badges.map { it.directionId })
+        assertEquals(listOf(1, 0, 1), badges.map { it.tap?.directionId })
         assertEquals(GeoPoint(0.0, 0.5), badges[0].point)
         assertTrue(haversineMeters(badges[0].point, badges[1].point) >= 299.9)
     }
@@ -300,7 +300,7 @@ class RouteViewGeometryTest {
             listOf(route("known-route", "Known"), route("degenerate-route", "Degenerate"))
         )
 
-        assertEquals(listOf("known-route"), badges.map { it.routeId })
+        assertEquals(listOf("known-route"), badges.map { it.tap?.routeId })
     }
 
     private fun route(id: String, shortName: String, routeColor: Int? = null) = object : ObaRoute {


### PR DESCRIPTION
Split out of #2072, which didn't work out visually as a whole. This is the map-label half of #2066, on its own and without the colour-stripe work.

## What changed

- Draw one non-interactive route label per ride on the directions map's transit lines, using the shared route-badge layout and both flavors' existing badge renderer.
- Resolve each leg's stroke once and share it between the leg's polyline and its label, so a label can't end up a different colour from the line it names.
- Give `RouteBadge` an `interactive` flag; both renderers register only an interactive label as a tap target.

## Why

A drawn itinerary's transit lines said nothing about which route they were — the rider had to match a colour on the map to a badge in the drawer beside it. The focused-stop adjacency view already solved this with anchored route labels, so the same layout is reused here: labels sit at stable distance midpoints and stagger apart when two ridden corridors overlap.

The labels are informational rather than tappable. Adjacency labels navigate to their route, but a directions label names a leg of the trip the rider is already reading, so a stray tap must not drop the whole itinerary for a single route's map.

Legs of one route share a single label, keyed by wire route id — or, on an OTP1 response, which names a route without identifying it, by the name the leg displays. A route that names itself in no way at all, and a line too short to anchor on, are simply left unlabelled.

This PR deliberately does **not** change any leg's colour: a ride still keeps its agency's hue via `itineraryLegStyle`. The contrasting-colour policy and the badge colour stripes from #2072 are left out.

## Validation

- `:onebusaway-android:compileObaGoogleDebugKotlin -PwarningsAsErrors=true`
- `:onebusaway-android:compileObaMaplibreDebugKotlin -PwarningsAsErrors=true`
- `:onebusaway-android:testObaGoogleDebugUnitTest` (new `ItineraryRouteBadgesTest`)
- `spotlessCheck`, `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/OneBusAway/codesmith/onebusaway-android/pr/2073"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787943261&installation_model_id=429412&pr_number=2073&repository=OneBusAway%2Fonebusaway-android&return_to=https%3A%2F%2Fgithub.com%2FOneBusAway%2Fonebusaway-android%2Fpull%2F2073&signature=28be3845938499cc39e0f92c715d190c36a6526ec180b136ec768f8d35491b66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Directions maps now display route labels along rideable itinerary legs, using each route’s color and geometry.
  * Multiple itinerary legs on the same route share a single label.
* **Bug Fixes**
  * Informational itinerary labels are no longer incorrectly tappable.
  * Route labels are cleared when directions are reset.
  * Improved handling ensures labels only appear when sufficient route info is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->