### PR TITLE
Square off short route badges

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/compose/components/RouteBadgeChipRenderTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/compose/components/RouteBadgeChipRenderTest.kt
@@ -27,9 +27,12 @@ import androidx.compose.ui.graphics.toPixelMap
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.captureToImage
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.height
+import androidx.compose.ui.unit.width
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -42,7 +45,8 @@ import org.onebusaway.android.ui.compose.theme.ObaTheme
  * several routes rather than as separate badges, or as one long name:
  *  - its route colors meet **directly**, with none of the surface behind showing through as a gap;
  *  - they meet along a **slash-like diagonal**, not a vertical edge;
- *  - that meeting line is much darker than the routes it separates, and the badge's outline is black.
+ *  - that meeting line is much darker than the routes it separates, and the badge's outline is black;
+ *  - and a short route name is squared off rather than left as a sliver, segment by segment.
  *
  * Rendering assertions, so they live on-device: the badge is drawn over a garish background that must
  * not appear anywhere inside it, and the color boundary is located on a high and a low scan line to
@@ -61,6 +65,35 @@ class RouteBadgeChipRenderTest {
 
     private val link1 = RouteBadge("1 Line", 0xFF00A651.toInt())
     private val link2 = RouteBadge("2 Line", 0xFF0075C4.toInt())
+
+    /**
+     * A one-character route is a roundel, not a sliver: the chip is at least as wide as it is tall, so
+     * "1" and "1 Line" read as the same kind of object at different widths.
+     */
+    @Test
+    fun aShortNameGetsASquareBadge() {
+        renderJoinedBadge(routes = listOf(RouteBadge("1", link1.routeColor)))
+
+        val bounds = composeRule.onNodeWithTag(BADGE).getUnclippedBoundsInRoot()
+
+        assertTrue(
+            "expected a square-or-wider badge, but it was ${bounds.width} × ${bounds.height}",
+            bounds.width >= bounds.height
+        )
+    }
+
+    /** The same squaring inside a joined badge, so one short segment isn't crushed beside a longer one. */
+    @Test
+    fun eachSegmentOfAJoinedBadgeIsSquaredToo() {
+        renderJoinedBadge(routes = listOf(RouteBadge("1", link1.routeColor), RouteBadge("2", link2.routeColor)))
+
+        val bounds = composeRule.onNodeWithTag(BADGE).getUnclippedBoundsInRoot()
+
+        assertTrue(
+            "expected two squared segments, but the badge was ${bounds.width} × ${bounds.height}",
+            bounds.width >= bounds.height * 2
+        )
+    }
 
     private fun renderJoinedBadge(routes: List<RouteBadge> = listOf(link1, link2)) {
         composeRule.setContent {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/RouteBadgeChip.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/RouteBadgeChip.kt
@@ -102,8 +102,12 @@ private val BADGE_VERTICAL_PADDING = 1.dp
  * cards draw glyphs and roundels in one row and size both from a single height, deriving the chip's
  * scale from this rather than hard-coding a number that would silently rot if these metrics changed.
  *
- * Holds at the default font scale. Under a larger accessibility font the sp line box — and the chip —
- * grow while a dp-sized glyph beside it does not, so the two only drift apart in the direction of the
+ * It is also the chip's *minimum width*, which is what makes a short name a square roundel rather than a
+ * lozenge.
+ *
+ * Both hold at the default font scale. Under a larger accessibility font the sp line box — and so the
+ * chip's height — grows while a dp-sized glyph beside it, and this dp minimum width, do not: the chip
+ * comes out taller than it is wide and drifts from a neighbouring glyph, both in the direction of the
  * text being bigger, which is what the setting asked for.
  */
 val ROUTE_BADGE_HEIGHT = 16.dp + BADGE_VERTICAL_PADDING * 2
@@ -147,6 +151,10 @@ private val CHEVRON_LEAN_ALLOWANCE = ROUTE_BADGE_HEIGHT * JOIN_LEAN_RATIO / 2
  * cards), as opposed to the large square [LineBadge]. [scale] enlarges the whole chip (text + padding)
  * proportionally — e.g. the directions board badge uses 1.5×.
  *
+ * The chip is never narrower than it is tall ([ROUTE_BADGE_HEIGHT] at the default font scale), so a
+ * one- or two-character route reads as a roundel of the same family as a longer one rather than as a
+ * sliver next to it. The name centres itself in whatever width that leaves.
+ *
  * [maxWidth] caps the chip and ellipsizes the name past it. Unconstrained by default, since a route
  * short name is a handful of characters; it's for callers that badge a route by its *long* name because
  * it publishes no short one ("Seattle - Bremerton"), which would otherwise blow out a row of roundels.
@@ -167,7 +175,11 @@ fun RouteBadgeChip(
 ) {
     val (container, content) = rememberRouteBadgeColors(routeColor)
     Surface(
-        modifier = modifier.widthIn(max = maxWidth),
+        // A short name still gets a proper roundel rather than a narrow lozenge: at the default font
+        // scale the chip is at least as wide as it is tall, so "8" and "45" read as the same object at
+        // different widths instead of as a sliver beside a badge. [Surface] propagates the minimum to
+        // its content, which centres itself in the room that gives it (see [BadgeContent]).
+        modifier = modifier.widthIn(min = ROUTE_BADGE_HEIGHT * scale, max = maxWidth),
         color = container,
         contentColor = content,
         shape = BADGE_SHAPE
@@ -207,7 +219,12 @@ private fun BadgeContent(
     Row(
         modifier = modifier.padding(horizontal = horizontalPadding, vertical = BADGE_VERTICAL_PADDING * scale),
         verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(BADGE_ICON_GAP * scale)
+        // Centred, not packed at the start: a name narrower than the chip's square minimum has room left
+        // over, and it belongs either side of the name rather than all after it.
+        horizontalArrangement = Arrangement.spacedBy(
+            space = BADGE_ICON_GAP * scale,
+            alignment = Alignment.CenterHorizontally
+        )
     ) {
         if (leadingIcon != null) {
             Icon(
@@ -296,6 +313,9 @@ fun RouteBadgeChip(
                 leadingIconDescription = leadingIconDescription,
                 modifier = Modifier
                     .fillMaxHeight()
+                    // Each segment is squared off the same way the plain chip is, so a one-character
+                    // route inside a joined badge doesn't come out as a sliver beside a wider sibling.
+                    .widthIn(min = ROUTE_BADGE_HEIGHT * scale)
                     // drawWithCache, not drawBehind: the band's Path and the line's geometry depend only
                     // on the segment's size, so they're built once per size change, not per draw pass.
                     .drawWithCache {


### PR DESCRIPTION
Split out of #2072, which didn't work out visually as a whole. This is the badge-shape change from it, on its own — no colour or stripe work rides along.

## What changed

- The mini route badge (`RouteBadgeChip`) is never narrower than it is tall: a square minimum of `ROUTE_BADGE_HEIGHT`, scaled with the chip.
- Each segment of a joined badge gets the same minimum, so a short name inside one isn't crushed beside a longer sibling.
- The badge's content centres itself in the width that leaves, instead of packing at the start and trailing dead space.

## Why

A one- or two-character route came out as a narrow lozenge next to a longer one, so a row of roundels read as objects of different kinds rather than as one badge family at different widths.

The squareness holds at the default font scale. Under a larger accessibility font the sp line box grows past the dp minimum and the chip comes out taller than it is wide — the same direction of drift `ROUTE_BADGE_HEIGHT` already documents, and the direction the setting asked for.

## Validation

- `:onebusaway-android:compileObaGoogleDebugKotlin -PwarningsAsErrors=true`
- `:onebusaway-android:compileObaMaplibreDebugKotlin -PwarningsAsErrors=true`
- `:onebusaway-android:compileObaGoogleDebugAndroidTestKotlin -PwarningsAsErrors=true`
- `spotlessCheck`
- Two new cases in `RouteBadgeChipRenderTest` (plain chip and each segment of a joined one) — instrumented, so they run on CI's emulator rather than locally here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/OneBusAway/codesmith/onebusaway-android/pr/2074"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787943544&installation_model_id=429412&pr_number=2074&repository=OneBusAway%2Fonebusaway-android&return_to=https%3A%2F%2Fgithub.com%2FOneBusAway%2Fonebusaway-android%2Fpull%2F2074&signature=609205e19db1d55d4c653fbcae0a18009b8336a6d6ceac8a1ac25dddd72d0c4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved route badges with short names so they render as properly sized square segments instead of narrow slivers.
  * Updated joined route badges to maintain consistent sizing across all segments.

* **Tests**
  * Added coverage verifying square rendering for single-character and joined route badges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->