### PR TITLE
Replace donation dismiss buttons with "Maybe Later" + "Remind me"

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/home/donation/DonationDismissDialogUiTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/home/donation/DonationDismissDialogUiTest.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.home.donation
+
+import androidx.compose.ui.test.assertIsOff
+import androidx.compose.ui.test.assertIsOn
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.onebusaway.android.R
+import org.onebusaway.android.ui.compose.createUnconfinedComposeRule
+
+/**
+ * The dismiss dialog's outcome mapping: "maybe later" reports [DonationDismissChoice.REMIND_LATER]
+ * while the "remind me" box stays checked, and [DonationDismissChoice.STOP_ASKING] once it's cleared
+ * — the permanent opt-out that replaced the old "I don't want to help" button.
+ *
+ * [DonationOverlay] takes plain booleans and a [DonationCallbacks] holder, so the dialog composes
+ * standalone: no activity, no `DonationsManager` gating, no prefs staging.
+ */
+class DonationDismissDialogUiTest {
+
+    // See createUnconfinedComposeRule for why Unconfined composition is used here (issue #1792).
+    @get:Rule
+    val composeRule = createUnconfinedComposeRule()
+
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext
+    private val remindMe = context.getString(R.string.donation_dismiss_dialog_remind_me_checkbox)
+    private val maybeLater = context.getString(R.string.donation_dismiss_dialog_maybe_later_button)
+    private val back = context.getString(R.string.donation_dismiss_dialog_back_button)
+
+    private fun showDialog(onMaybeLater: (DonationDismissChoice) -> Unit = {}, onCancel: () -> Unit = {}) {
+        composeRule.setContent {
+            DonationOverlay(
+                cardVisible = false,
+                dismissDialogVisible = true,
+                callbacks = DonationCallbacks(
+                    onClose = {},
+                    onLearnMore = {},
+                    onDonate = {},
+                    onMaybeLater = onMaybeLater,
+                    onCancelDismiss = onCancel
+                )
+            )
+        }
+    }
+
+    @Test
+    fun remindMeIsCheckedByDefaultAndMaybeLaterSnoozes() {
+        var choice: DonationDismissChoice? = null
+        showDialog(onMaybeLater = { choice = it })
+
+        composeRule.onNodeWithText(remindMe).assertIsOn()
+        composeRule.onNodeWithText(maybeLater).performClick()
+
+        composeRule.runOnIdle { assertEquals(DonationDismissChoice.REMIND_LATER, choice) }
+    }
+
+    @Test
+    fun clearingRemindMeMakesMaybeLaterStopAsking() {
+        var choice: DonationDismissChoice? = null
+        showDialog(onMaybeLater = { choice = it })
+
+        composeRule.onNodeWithText(remindMe).performClick()
+        composeRule.onNodeWithText(remindMe).assertIsOff()
+        composeRule.onNodeWithText(maybeLater).performClick()
+
+        composeRule.runOnIdle { assertEquals(DonationDismissChoice.STOP_ASKING, choice) }
+    }
+
+    @Test
+    fun backCancelsWithoutChoosing() {
+        var choice: DonationDismissChoice? = null
+        var cancelled = false
+        showDialog(onMaybeLater = { choice = it }, onCancel = { cancelled = true })
+
+        composeRule.onNodeWithText(back).performClick()
+
+        composeRule.runOnIdle {
+            assertEquals(true, cancelled)
+            assertEquals(null, choice)
+        }
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/CheckboxRow.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/CheckboxRow.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.compose.components
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.selection.toggleable
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.unit.dp
+
+/**
+ * A Material 3 [Checkbox] with a trailing [label]; the whole row is the (accessible) toggle target —
+ * the checkbox itself takes a null callback so the row's `toggleable` owns the click and the pair
+ * reads as one control to accessibility services. The checkbox counterpart to [SwitchRow] (leading
+ * control, matching the app's other checkbox rows).
+ *
+ * Unlike [SwitchRow] this wraps its content rather than filling the width, so it can sit inline
+ * beside other content (e.g. next to a dialog button); pass `Modifier.fillMaxWidth()` for a
+ * full-width settings-style row.
+ */
+@Composable
+fun CheckboxRow(
+    label: String,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier
+            .toggleable(value = checked, role = Role.Checkbox, onValueChange = onCheckedChange),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Checkbox(checked = checked, onCheckedChange = null)
+        Text(label, modifier = Modifier.padding(start = 8.dp))
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/donation/DonationCard.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/donation/DonationCard.kt
@@ -15,6 +15,7 @@
  */
 package org.onebusaway.android.ui.home.donation
 
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -28,14 +29,17 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -50,6 +54,7 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.repeatOnLifecycle
 import org.onebusaway.android.R
+import org.onebusaway.android.ui.compose.components.CheckboxRow
 import org.onebusaway.android.util.ExternalIntents
 
 /**
@@ -94,8 +99,7 @@ fun DonationFeature(
             onClose = viewModel::requestDismiss,
             onLearnMore = viewModel::learnMore,
             onDonate = viewModel::donate,
-            onDismissForever = viewModel::dismissForever,
-            onRemindLater = viewModel::remindLater,
+            onMaybeLater = viewModel::maybeLater,
             onCancelDismiss = viewModel::cancelDismiss
         )
     }
@@ -112,8 +116,7 @@ class DonationCallbacks(
     val onClose: () -> Unit,
     val onLearnMore: () -> Unit,
     val onDonate: () -> Unit,
-    val onDismissForever: () -> Unit,
-    val onRemindLater: () -> Unit,
+    val onMaybeLater: (DonationDismissChoice) -> Unit,
     val onCancelDismiss: () -> Unit
 )
 
@@ -141,8 +144,7 @@ fun DonationOverlay(
     }
     if (dismissDialogVisible) {
         DonationDismissDialog(
-            onDismissForever = callbacks.onDismissForever,
-            onRemindLater = callbacks.onRemindLater,
+            onMaybeLater = callbacks.onMaybeLater,
             onCancel = callbacks.onCancelDismiss
         )
     }
@@ -201,15 +203,19 @@ fun DonationCard(
 }
 
 /**
- * Confirmation when the user closes the donation card. Three stacked actions (the Compose idiom for
- * >2 dialog buttons): keep asking later, stop asking, or cancel.
+ * Confirmation when the user closes the donation card. Two outlined action groups: "back", and
+ * "maybe later" + its trailing "remind me" checkbox together (the checkbox chooses between
+ * [DonationDismissChoice.REMIND_LATER] and [DonationDismissChoice.STOP_ASKING], so grouping them in
+ * one outline shows they act as a pair). The checkbox state is local to the dialog, so it starts
+ * opted-in each time the dialog is opened.
  */
 @Composable
 private fun DonationDismissDialog(
-    onDismissForever: () -> Unit,
-    onRemindLater: () -> Unit,
+    onMaybeLater: (DonationDismissChoice) -> Unit,
     onCancel: () -> Unit
 ) {
+    var remindMe by remember { mutableStateOf(true) }
+    val choice = if (remindMe) DonationDismissChoice.REMIND_LATER else DonationDismissChoice.STOP_ASKING
     AlertDialog(
         onDismissRequest = onCancel,
         title = { Text(stringResource(R.string.donation_dismiss_dialog_title)) },
@@ -217,16 +223,33 @@ private fun DonationDismissDialog(
             Text(stringResource(R.string.donation_dismiss_dialog_body, stringResource(R.string.app_name)))
         },
         confirmButton = {
-            Column(horizontalAlignment = Alignment.End) {
-                TextButton(onClick = onRemindLater) {
-                    Text(stringResource(R.string.donation_dismiss_dialog_remind_me_later_button))
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier
+                    // Matches the outline OutlinedButton draws for "back", so the two groups read as peers.
+                    .border(
+                        width = 1.dp,
+                        color = MaterialTheme.colorScheme.outline,
+                        shape = RoundedCornerShape(24.dp)
+                    )
+                    // The group owns its inset off its own curve, so its children stay shape-agnostic
+                    // and reordering them can't break the clearance. Only the trailing edge needs it —
+                    // the leading child is a button, which brings its own content padding.
+                    .padding(end = 16.dp)
+            ) {
+                TextButton(onClick = { onMaybeLater(choice) }) {
+                    Text(stringResource(R.string.donation_dismiss_dialog_maybe_later_button))
                 }
-                TextButton(onClick = onDismissForever) {
-                    Text(stringResource(R.string.donation_dismiss_dialog_dont_want_to_help_button))
-                }
-                TextButton(onClick = onCancel) {
-                    Text(stringResource(R.string.donation_dismiss_dialog_cancel_button))
-                }
+                CheckboxRow(
+                    label = stringResource(R.string.donation_dismiss_dialog_remind_me_checkbox),
+                    checked = remindMe,
+                    onCheckedChange = { remindMe = it }
+                )
+            }
+        },
+        dismissButton = {
+            OutlinedButton(onClick = onCancel) {
+                Text(stringResource(R.string.donation_dismiss_dialog_back_button))
             }
         }
     )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/donation/DonationViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/donation/DonationViewModel.kt
@@ -33,6 +33,9 @@ data class DonationUiState(
     val showDismissDialog: Boolean = false
 )
 
+/** What the user chose in the dismiss dialog's "maybe later" — snooze the card, or stop asking. */
+enum class DonationDismissChoice { REMIND_LATER, STOP_ASKING }
+
 /** One-shot donation navigation the activity carries out (it owns startActivity + the intents). */
 sealed interface DonationEffect {
     object OpenLearnMore : DonationEffect
@@ -78,15 +81,12 @@ class DonationViewModel @Inject constructor(
         _effects.tryEmit(DonationEffect.OpenDonatePage(manager.donateUrl()))
     }
 
-    /** "I don't want to help" — stop asking, hide the dialog, and re-gate the card. */
-    fun dismissForever() {
-        manager.dismissDonationRequests()
-        _state.update { it.copy(showDismissDialog = false, available = manager.shouldShowDonationUI()) }
-    }
-
-    /** "Remind me later" — snooze, hide the dialog, and re-gate the card. */
-    fun remindLater() {
-        manager.remindUserLater()
+    /** "Maybe later" — carry out [choice], then hide the dialog and re-gate the card. */
+    fun maybeLater(choice: DonationDismissChoice) {
+        when (choice) {
+            DonationDismissChoice.REMIND_LATER -> manager.remindUserLater()
+            DonationDismissChoice.STOP_ASKING -> manager.dismissDonationRequests()
+        }
         _state.update { it.copy(showDismissDialog = false, available = manager.shouldShowDonationUI()) }
     }
 }

--- a/onebusaway-android/src/main/res/values-es/strings.xml
+++ b/onebusaway-android/src/main/res/values-es/strings.xml
@@ -1039,9 +1039,9 @@
     <string name="donation_view_donate_now_button">Donar Ahora</string>
     <string name="donation_dismiss_dialog_title">Por favor, no ignores esta solicitud</string>
     <string name="donation_dismiss_dialog_body">%1$s es una organización dirigida por voluntarios con casi ningún financiamiento. Necesitamos tu ayuda para mantener esta aplicación funcionando.</string>
-    <string name="donation_dismiss_dialog_dont_want_to_help_button">No Quiero Ayudar</string>
-    <string name="donation_dismiss_dialog_remind_me_later_button">Recuérdame Más Tarde</string>
-    <string name="donation_dismiss_dialog_cancel_button">Cancelar</string>
+    <string name="donation_dismiss_dialog_remind_me_checkbox">Recuérdame</string>
+    <string name="donation_dismiss_dialog_maybe_later_button">Quizás Más Tarde</string>
+    <string name="donation_dismiss_dialog_back_button">Atrás</string>
     <string name="title_activity_donation_learn_more">Por qué necesitamos tu ayuda</string>
     <!-- "(c)" here is the "501(c)(3)" US tax-code designation, not a copyright symbol. -->
     <string name="donation_learn_more_explanation" tools:ignore="TypographyOther">Tenemos grandes planes para mejorar %1$s, pero no podemos hacerlo sin tu ayuda. Esta aplicación está actualmente desarrollada con un 100%% de trabajo voluntario, y necesitamos que nos ayudes a financiar el desarrollo futuro.\n\nComo un proyecto clave de la Open Transit Software Foundation, una organización sin fines de lucro 501(c)(3), dependemos de la buena voluntad de usuarios como tú para seguir funcionando y mejorando este software.\n\nCada año, solo una pequeña fracción de nuestros usuarios dona, pero cada contribución, grande o pequeña, ayuda a asegurar que %1$s permanezca gratuito, actualizado y accesible para todos. Una pequeña donación, incluso solo el costo de una semana de viaje, $27.50, puede marcar la diferencia.\n\nTu contribución deducible de impuestos asegura que %1$s permanezca libre y accesible para todos. ¡Formemos juntos el futuro del transporte!\n\nGracias,\nEl equipo de %1$s</string>

--- a/onebusaway-android/src/main/res/values-fi/strings.xml
+++ b/onebusaway-android/src/main/res/values-fi/strings.xml
@@ -683,9 +683,9 @@
     <string name="donation_view_donate_now_button">Lahjoita Nyt</string>
     <string name="donation_dismiss_dialog_title">Ole hyvä äläkä hylkää tätä pyyntöä</string>
     <string name="donation_dismiss_dialog_body">%1$s on vapaaehtoisten pyörittämä organisaatio, jolla on lähes ei lainkaan rahoitusta. Tarvitsemme apuasi pitääksemme tämän sovelluksen toiminnassa.</string>
-    <string name="donation_dismiss_dialog_dont_want_to_help_button">En Halua Auttaa</string>
-    <string name="donation_dismiss_dialog_remind_me_later_button">Muistuta Minua Myöhemmin</string>
-    <string name="donation_dismiss_dialog_cancel_button">Peruuta</string>
+    <string name="donation_dismiss_dialog_remind_me_checkbox">Muistuta Minua</string>
+    <string name="donation_dismiss_dialog_maybe_later_button">Ehkä Myöhemmin</string>
+    <string name="donation_dismiss_dialog_back_button">Takaisin</string>
     <string name="title_activity_donation_learn_more">Miksi tarvitsemme apuasi</string>
     <!-- "(c)" here is the "501(c)(3)" US tax-code designation, not a copyright symbol. -->
     <string name="donation_learn_more_explanation" tools:ignore="TypographyOther">Meillä on suuria suunnitelmia %1$sn parantamiseksi, mutta emme voi tehdä sitä ilman apuasi. Tämä sovellus on tällä hetkellä rakennettu 100%% vapaaehtoistyöllä, ja tarvitsemme sinua auttamaan meitä rahoittamaan tulevan kehityksen.\n\nOpen Transit Software Foundationin, 501(c)(3) voittoa tavoittelemattoman järjestön, keskeisenä hankkeena me luotamme käyttäjien, kuten sinun, hyväntahtoisuuteen pysyäksemme toiminnassa ja tehdäksemme tästä ohjelmistosta paremman.\n\nJoka vuosi vain pieni osa käyttäjistämme lahjoittaa, mutta jokainen panos, suuri tai pieni, auttaa varmistamaan, että %1$s pysyy ilmaisena, päivitettynä ja kaikkien saavutettavissa. Pieni lahjoitus, vaikkapa vain yhden viikon työmatkakustannusten verran, 27,50 dollaria, voi tehdä suuren eron.\n\nVerovähennyskelpoinen panoksesi varmistaa, että %1$s pysyy vapaana ja kaikkien saavutettavissa. Muovataan yhdessä joukkoliikenteen tulevaisuutta!\n\nKiitos,\n%1$s-tiimi</string>

--- a/onebusaway-android/src/main/res/values-it/strings.xml
+++ b/onebusaway-android/src/main/res/values-it/strings.xml
@@ -889,9 +889,9 @@
     <string name="donation_view_donate_now_button">Dona Ora</string>
     <string name="donation_dismiss_dialog_title">Per favore, non ignorare questa richiesta</string>
     <string name="donation_dismiss_dialog_body">%1$s è un’organizzazione gestita da volontari con quasi nessun finanziamento. Abbiamo bisogno del tuo aiuto per mantenere questa app in funzione.</string>
-    <string name="donation_dismiss_dialog_dont_want_to_help_button">Non Voglio Aiutare</string>
-    <string name="donation_dismiss_dialog_remind_me_later_button">Ricordamelo Più Tardi</string>
-    <string name="donation_dismiss_dialog_cancel_button">Annulla</string>
+    <string name="donation_dismiss_dialog_remind_me_checkbox">Ricordamelo</string>
+    <string name="donation_dismiss_dialog_maybe_later_button">Forse Più Tardi</string>
+    <string name="donation_dismiss_dialog_back_button">Indietro</string>
     <string name="title_activity_donation_learn_more">Perché abbiamo bisogno del tuo aiuto</string>
     <!-- "(c)" here is the "501(c)(3)" US tax-code designation, not a copyright symbol. -->
     <string name="donation_learn_more_explanation" tools:ignore="TypographyOther">"Abbiamo grandi piani per migliorare %1$s, ma non possiamo farlo senza il tuo aiuto. Questa app è attualmente sviluppata con il 100%% di lavoro volontario, e abbiamo bisogno del tuo aiuto per finanziare lo sviluppo futuro.\n\nCome progetto chiave della Open Transit Software Foundation, un’organizzazione non profit 501(c)(3), ci affidiamo alla buona volontà di utenti come te per continuare a funzionare e migliorare questo software.\n\nOgni anno, solo una piccola frazione dei nostri utenti dona, ma ogni contributo, grande o piccolo, aiuta a garantire che %1$s rimanga gratuito, aggiornato e accessibile a tutti. Una piccola donazione, anche solo il costo di una settimana di pendolarismo, $27.50, può fare tutta la differenza.\n\nIl tuo contributo deducibile dalle tasse assicura che %1$s rimanga libero e accessibile per tutti. Modelliamo insieme il futuro del trasporto pubblico!\n\nGrazie,\nIl Team di %1$s"</string>

--- a/onebusaway-android/src/main/res/values-pl/strings.xml
+++ b/onebusaway-android/src/main/res/values-pl/strings.xml
@@ -799,9 +799,9 @@
     <string name="donation_view_donate_now_button">Wesprzyj Teraz</string>
     <string name="donation_dismiss_dialog_title">Proszę, nie ignoruj tej prośby</string>
     <string name="donation_dismiss_dialog_body">%1$s to organizacja prowadzona przez wolontariuszy, z prawie żadnym finansowaniem. Potrzebujemy twojej pomocy, aby utrzymać tę aplikację przy życiu.</string>
-    <string name="donation_dismiss_dialog_dont_want_to_help_button">Nie chcę pomagać</string>
-    <string name="donation_dismiss_dialog_remind_me_later_button">Przypomnij mi później</string>
-    <string name="donation_dismiss_dialog_cancel_button">Anuluj</string>
+    <string name="donation_dismiss_dialog_remind_me_checkbox">Przypomnij mi</string>
+    <string name="donation_dismiss_dialog_maybe_later_button">Może później</string>
+    <string name="donation_dismiss_dialog_back_button">Wstecz</string>
     <string name="title_activity_donation_learn_more">Dlaczego potrzebujemy Twojej pomocy</string>
     <!-- "(c)" here is the "501(c)(3)" US tax-code designation, not a copyright symbol. -->
     <string name="donation_learn_more_explanation" tools:ignore="TypographyOther">Mamy wielkie plany na ulepszenie %1$s, ale nie możemy tego zrobić bez Twojej pomocy. Ta aplikacja jest obecnie tworzona w 100%% dzięki pracy wolontariuszy, i potrzebujemy Ciebie, abyś pomógł nam sfinansować przyszły rozwój.\n\nJako kluczowy projekt Open Transit Software Foundation, organizacji non-profit 501(c)(3), polegamy na dobrej woli użytkowników takich jak Ty, aby kontynuować działanie i ulepszanie tego oprogramowania.\n\nCo roku tylko mała część naszych użytkowników dokonuje darowizn, ale każdy wkład, duży czy mały, pomaga zapewnić, że %1$s pozostanie darmowe, aktualne i dostępne dla wszystkich. Mała darowizna, nawet tylko koszt tygodniowego dojazdu do pracy, 27,50 dolarów, może zrobić różnicę.\n\nTwoja darowizna odliczalna od podatku zapewnia, że %1$s pozostanie darmowe i dostępne dla każdego. Kształtujmy razem przyszłość transportu publicznego!\n\nDziękujemy,\nZespół %1$s</string>

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -1246,9 +1246,9 @@
     <string name="donation_dismiss_dialog_title">Please don’t dismiss this request</string>
     <!-- Note: %1$s is replaced with app_name for white-label support -->
     <string name="donation_dismiss_dialog_body">%1$s is a volunteer-run organization with almost no funding. We need your help to keep this app running.</string>
-    <string name="donation_dismiss_dialog_dont_want_to_help_button">I Don’t Want to Help</string>
-    <string name="donation_dismiss_dialog_remind_me_later_button">Remind Me Later</string>
-    <string name="donation_dismiss_dialog_cancel_button">Cancel</string>
+    <string name="donation_dismiss_dialog_remind_me_checkbox">Remind me</string>
+    <string name="donation_dismiss_dialog_maybe_later_button">Maybe Later</string>
+    <string name="donation_dismiss_dialog_back_button">Back</string>
     <string name="title_activity_donation_learn_more">Why we need your help</string>
     <!-- Note: %1$s is replaced with app_name for white-label support -->
     <!-- "(c)" here is the "501(c)(3)" US tax-code designation, not a copyright symbol. -->

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/DonationViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/DonationViewModelTest.kt
@@ -32,7 +32,7 @@ import org.onebusaway.android.ui.home.donation.DonationViewModel
 /**
  * Unit tests for [DonationViewModel]'s dialog/effect logic — the parts that don't touch the
  * `DonationsManager` (Application) singleton. The manager-backed paths (refresh / donate /
- * dismissForever / remindLater) are exercised by the on-device verification.
+ * maybeLater) are exercised by the on-device verification.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class DonationViewModelTest {


### PR DESCRIPTION
## What

The donation dismiss confirmation had three stacked actions — **Remind Me Later**, **I Don't Want to Help**, **Cancel**. Closing the card meant either declaring you don't want to help or deferring; the first is a harsh framing for what is really "stop asking me".

This replaces the two outcome buttons with a single **Maybe Later** button and a trailing **Remind me** checkbox, grouped in one outline so they read as acting together, plus an outlined **Back**:

```
Please don't dismiss this request

OneBusAway is a volunteer-run organization with almost
no funding. We need your help to keep this app running.

    ( Back )        ⌜ Maybe Later  [x] Remind me ⌟
```

- **Box checked** (the default) → `remindUserLater()`, the two-week snooze — the old "Remind Me Later".
- **Box cleared** → `dismissDonationRequests()`, stop asking for good — the old "I Don't Want to Help".

Both `DonationsManager` behaviours are unchanged; only the UI that chooses between them moved.

## Changes

- **`DonationCard.kt`** — dismiss dialog rebuilt: `Maybe Later` + `CheckboxRow` in an outlined pill in the confirm slot, `OutlinedButton` "Back" in the dismiss slot. The manual `Column` of stacked `TextButton`s is gone, since with two actions Material3's own `confirmButton`/`dismissButton` pair lays them out.
- **`DonationViewModel.kt`** — `dismissForever()`/`remindLater()` collapse into `maybeLater(DonationDismissChoice)`. The choice is a named enum (`REMIND_LATER` / `STOP_ASKING`) rather than a boolean, so the outcome is explicit at the `onMaybeLater = viewModel::maybeLater` wiring site and the ViewModel branches on an exhaustive `when` — matching the repo's preference for domain types over bare primitives, and keeping parity with the sibling Survey module, which also names its dismiss outcomes.
- **`CheckboxRow.kt`** (new, `ui/compose/components/`) — the label-plus-`Checkbox` row extracted beside the existing `SwitchRow`, so the accessibility idiom (row owns the `toggleable`, control takes a null `onCheckedChange`, `Role.Checkbox`) lives in one place instead of being hand-rolled per call site.
- **Strings** — `..._dont_want_to_help_button` and `..._remind_me_later_button` removed; `..._remind_me_checkbox` and `..._maybe_later_button` added; `..._cancel_button` renamed to `..._back_button` (renamed, not just relabelled, so the key doesn't lie). All four translations (es, it, pl, fi) updated.
- **`DonationDismissDialogUiTest.kt`** (new) — composes `DonationOverlay` standalone under `createUnconfinedComposeRule()` and asserts the outcome mapping through Compose semantics: checked → `REMIND_LATER`, cleared → `STOP_ASKING`, Back → cancel with no choice reported. No activity boot, no `DonationsManager` gating, no prefs staging, so it's fast and device-state independent.

## Verification

- `./gradlew :onebusaway-android:compileObaGoogleDebugKotlin :onebusaway-android:compileObaGoogleDebugAndroidTestKotlin -PwarningsAsErrors=true` — clean (CI's strict gate).
- `./gradlew spotlessApply` — applied.
- `./gradlew :onebusaway-android:testObaGoogleDebugUnitTest` — passing.
- `DonationDismissDialogUiTest` — 3/3 passing on a physical Pixel 7 Pro (API 36).
- Installed and exercised the real dialog on device.

Lint was not run locally (per `CLAUDE.md`, it's left to CI).

## For reviewers

Two judgement calls worth a look:

1. **Clearing the checkbox is now the permanent opt-out**, and it's a quieter affordance than a labelled button was. A rider who unchecks "Remind me" and taps "Maybe Later" gets a "never ask again" that the button text doesn't state. That's the intended trade (the harsh label was the thing being removed), but it is a real change in how discoverable the permanent opt-out is.
2. **iOS now differs.** `Strings+Donations.swift` still has `I Don't Want to Help Right Now` / `Remind Me Later` as two buttons, so the platforms diverge on this dialog until iOS follows.

Also noted but deliberately left out of scope:

- `preferences_reset_donation_timestamps_summary` still describes clearing the *"Remind Me Later"* and *"Don't Bother Me"* timestamps, quoting labels no longer in the UI. Happy to reword it (in all five locales) here or separately.
- `Open311Screen.kt` has two hand-rolled checkbox rows that could now call `CheckboxRow`, and `SwitchRow` hardcodes `fillMaxWidth()` where `CheckboxRow` leaves width to the caller. Both are follow-ups touching unrelated screens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/OneBusAway/codesmith/onebusaway-android/pr/2077"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787964126&installation_model_id=429412&pr_number=2077&repository=OneBusAway%2Fonebusaway-android&return_to=https%3A%2F%2Fgithub.com%2FOneBusAway%2Fonebusaway-android%2Fpull%2F2077&signature=2525ceaaa3bb12d2672d04c0f88d7c4ea8cab2b9177b3c2bcd502576b59433ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned the donation dismissal dialog with a “Remind me” checkbox and “Maybe Later” and “Back” actions.
  * Users can choose whether to be reminded later or stop seeing donation requests.
  * Updated localized text for Spanish, Finnish, Italian, and Polish.

* **Bug Fixes**
  * Improved dismissal behavior when navigating back without selecting an option.

* **Tests**
  * Added coverage for default checkbox state, dismissal choices, and back-button behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->