### PR TITLE
Return to the trip overview when tapping or backing out of any leg (#2075)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
@@ -543,6 +543,18 @@ class MapViewModel @Inject constructor(
         mapHost.frameItineraryLeg(points, WALK_LEG_MIN_FRAMING_SPAN_DEG)
     }
 
+    /**
+     * Drop a [focusItineraryLeg] focus: restore every leg of the drawn trip to full weight and reframe the
+     * whole itinerary — the map returning from a leg the rider was reading to the trip overview. The
+     * itinerary is still drawn (a leg focus only restyles it), so no redraw is needed. Guarded on an active
+     * directions session, like the focus it undoes.
+     */
+    fun clearItineraryLegFocus() {
+        if (!directionsActive) return
+        directionsController.focusLegs(emptySet())
+        directionsController.frameDirections()
+    }
+
     /** Clear the drawn itinerary while staying in directions mode (e.g. the plan became unsubmittable). */
     fun clearShownItinerary() {
         if (!directionsActive) return

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/CurrentFocus.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/CurrentFocus.kt
@@ -63,6 +63,15 @@ sealed interface DirectionsSubFocus {
     data class Leg(val leg: FocusedLeg) : DirectionsSubFocus
 }
 
+/**
+ * Whether the drawn itinerary survives in this focus: the overview and an on-street leg focus both keep it
+ * (the leg focus just restyles it), while a leg's route sub-focus recontextualizes the map onto that route
+ * — and any focus outside directions tears the trip down altogether. So returning to a trip *from* a focus
+ * that doesn't keep it has to redraw it first.
+ */
+internal val CurrentFocus.keepsDrawnItinerary: Boolean
+    get() = this is CurrentFocus.Directions && subFocus !is DirectionsSubFocus.Route
+
 val CurrentFocus.focusedStop: FocusedStop?
     get() = (this as? CurrentFocus.Stop)?.stop
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/CurrentFocus.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/CurrentFocus.kt
@@ -17,6 +17,7 @@ package org.onebusaway.android.ui.home
 
 import org.onebusaway.android.map.ShowRouteRequest
 import org.onebusaway.android.models.RouteDirectionKey
+import org.onebusaway.android.ui.tripresults.FocusedLeg
 
 /** The one mutually-exclusive focus rendered by HOME. */
 sealed interface CurrentFocus {
@@ -31,23 +32,36 @@ sealed interface CurrentFocus {
     /**
      * Trip-plan directions mode. The itinerary/plan identity still lives in
      * `TripPlanViewModel`/`TripResultsViewModel` (persisted via their own SavedStateHandle), so this
-     * does not duplicate "which itinerary". [routeFocus] is the one sub-state it does own: the transit
-     * leg the user drilled into to examine its route (map recontextualized to that route + the
-     * departing stop's arrivals board), mirroring the route-subordinate-to-stop focus. Null is the
-     * plain itinerary overview.
+     * does not duplicate "which itinerary". [subFocus] is the one sub-state it does own: the leg the
+     * user drilled into from the overview. Null is the plain itinerary overview.
      */
-    data class Directions(val routeFocus: DirectionsRouteFocus? = null) : CurrentFocus
+    data class Directions(val subFocus: DirectionsSubFocus? = null) : CurrentFocus
 }
 
 /**
- * A transit leg the user tapped from the directions overview — the route-subordinate-to-directions
- * focus. Recontextualizes the map onto a route with the traveled board→alight segment drawn thick over
- * it. Holds the exact [ShowRouteRequest] that produced this focus (route id, the boarding stop the
- * direction is narrowed to, the ridden `highlightedSegment`, and — for a followed vehicle — its
- * `focusTripId`) so restoring after a back-press replays it faithfully. (Each stop's live ETAs are
- * shown inline in the drawer's Board/Alight rows, not here.)
+ * A leg the user tapped from the directions overview — the leg-subordinate-to-directions focus, one
+ * attention level below the whole trip (mirroring the route-subordinate-to-stop focus). Being its own
+ * level is what makes a background tap, or Back, drop to the itinerary overview rather than out of
+ * directions, for every kind of leg alike (#2075).
  */
-data class DirectionsRouteFocus(val request: ShowRouteRequest)
+sealed interface DirectionsSubFocus {
+
+    /**
+     * A transit leg examined as its route: the map recontextualized onto that route with the traveled
+     * board→alight segment drawn thick over it. Holds the exact [ShowRouteRequest] that produced this
+     * focus (route id, the boarding stop the direction is narrowed to, the ridden `highlightedSegment`,
+     * and — for a followed vehicle — its `focusTripId`) so restoring after a back-press replays it
+     * faithfully. (Each stop's live ETAs are shown inline in the drawer's Board/Alight rows, not here.)
+     */
+    data class Route(val request: ShowRouteRequest) : DirectionsSubFocus
+
+    /**
+     * An on-street (walk/bike) leg framed on its own, with the rest of the trip receding to context
+     * around it (#2048) — the itinerary stays drawn, so only [leg]'s geometry + leg indices are needed
+     * to re-apply the focus.
+     */
+    data class Leg(val leg: FocusedLeg) : DirectionsSubFocus
+}
 
 val CurrentFocus.focusedStop: FocusedStop?
     get() = (this as? CurrentFocus.Stop)?.stop

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/CurrentFocusPersistence.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/CurrentFocusPersistence.kt
@@ -53,7 +53,7 @@ internal object CurrentFocusPersistence {
             FOCUS_ROUTE -> readRouteTarget(state)?.let { CurrentFocus.Route(it) } ?: CurrentFocus.None
             FOCUS_BIKE -> state.get<String>(KEY_BIKE_STATION)?.let { CurrentFocus.BikeStation(it) }
                 ?: CurrentFocus.None
-            // A restored directions focus returns to the itinerary overview; the transient route
+            // A restored directions focus returns to the itinerary overview; the transient leg
             // sub-focus isn't persisted.
             FOCUS_DIRECTIONS -> CurrentFocus.Directions()
             FOCUS_NONE -> CurrentFocus.None

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -614,9 +614,17 @@ fun HomeScreen(
                                     if (showResultsSheet) directionsSheetHeightPx else 0
                                 )
                             }
-                            // Back cancels an in-progress map pick, else exits directions focus (to nearby stops).
+                            // Back cancels an in-progress map pick, then steps out of a drilled-into leg to
+                            // the whole trip, and only from the itinerary overview exits directions focus
+                            // (to nearby stops). This handler composes inside the undo one above, so it
+                            // registers later and wins every back press while directions is active — the
+                            // one-level walk it delegates to is what keeps that from stranding the trip.
                             BackHandler(enabled = directionsActive) {
-                                if (pickTarget != null) pickTarget = null else homeViewModel.exitDirections()
+                                if (pickTarget != null) {
+                                    pickTarget = null
+                                } else {
+                                    homeViewModel.navigateBackInDirections()
+                                }
                             }
 
                             // Lift the FABs above the whole collapsed sheet peek; the target changes only on settle

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
@@ -564,14 +564,6 @@ class HomeViewModel @Inject constructor(
         shownItinerary?.let { MapDirective.ShowItinerary(it) }
     }
 
-    /**
-     * Whether the drawn itinerary survives in this focus: the overview and an on-street leg focus both
-     * keep it (the leg focus just restyles it), while a leg's route sub-focus recontextualizes the map onto
-     * that route — and any focus outside directions tears the trip down altogether.
-     */
-    private val CurrentFocus.keepsDrawnItinerary: Boolean
-        get() = this is CurrentFocus.Directions && subFocus !is DirectionsSubFocus.Route
-
     /** Clears the complete focus hierarchy. Used by the focus banner's explicit close control. */
     fun clearMapFocus() {
         if (_currentFocus.value == CurrentFocus.None) return
@@ -605,7 +597,9 @@ class HomeViewModel @Inject constructor(
      */
     fun showItineraryOnMap(itinerary: TripItinerary) {
         shownItinerary = itinerary
-        popLegFocus() // the ShowItinerary below is the redraw
+        // Showing the whole trip drops any leg sub-focus; the ShowItinerary below is the redraw. Guarded so
+        // a call from outside directions can't push a directions focus.
+        if (directionsSubFocus != null) pushFocus(CurrentFocus.Directions())
         emitMapDirective(MapDirective.ShowItinerary(itinerary))
     }
 
@@ -613,29 +607,30 @@ class HomeViewModel @Inject constructor(
     private val directionsSubFocus: DirectionsSubFocus?
         get() = (_currentFocus.value as? CurrentFocus.Directions)?.subFocus
 
-    /** Drop a leg sub-focus back to the itinerary overview, if one is active. */
-    private fun popLegFocus() {
-        if (directionsSubFocus == null) return
-        pushFocus(CurrentFocus.Directions())
-    }
-
     /** Recenter the map on a tapped itinerary step's point (only while in [CurrentFocus.Directions]). */
     fun focusItineraryPointOnMap(point: GeoPoint) = emitMapDirective(MapDirective.FocusItineraryPoint(point))
 
     /**
-     * Focus a whole tapped itinerary leg on the map (only while in [CurrentFocus.Directions]): frame it,
-     * with the rest of the trip receding to context around it (#2048). Recorded as the overview's
-     * [DirectionsSubFocus.Leg], so tapping the map background (or Back) returns to the whole trip exactly
-     * as it does from a transit leg's route focus, instead of leaving directions (#2075).
+     * Focus a whole tapped itinerary leg on the map: frame it, with the rest of the trip receding to context
+     * around it (#2048). Recorded as the overview's [DirectionsSubFocus.Leg], so tapping the map background
+     * (or Back) returns to the whole trip exactly as it does from a transit leg's route focus, instead of
+     * leaving directions (#2075). Only the directions drawer offers leg taps, so anywhere else there is no
+     * trip to focus into and this is a no-op.
      */
     fun focusItineraryLegOnMap(leg: FocusedLeg) {
-        if (_currentFocus.value is CurrentFocus.Directions) {
-            // If a transit leg's route is in focus, redraw the itinerary it tore down first — otherwise
-            // the framing would no-op in route mode (directionsActive is false).
-            if (directionsSubFocus is DirectionsSubFocus.Route) {
-                shownItinerary?.let { emitMapDirective(MapDirective.ShowItinerary(it)) }
-            }
-            pushFocus(CurrentFocus.Directions(DirectionsSubFocus.Leg(leg)))
+        val from = _currentFocus.value as? CurrentFocus.Directions ?: return
+        pushFocus(CurrentFocus.Directions(DirectionsSubFocus.Leg(leg)))
+        applyLegFocus(leg, from)
+    }
+
+    /**
+     * Recede the trip's other legs around [leg] and frame it — redrawing the itinerary first when the focus
+     * we come from ([from]) tore it down, since the framing would otherwise no-op in route mode
+     * (directionsActive is false). Shared by the drawer's leg tap and the back-restore of one.
+     */
+    private fun applyLegFocus(leg: FocusedLeg, from: CurrentFocus) {
+        if (!from.keepsDrawnItinerary) {
+            shownItinerary?.let { emitMapDirective(MapDirective.ShowItinerary(it)) }
         }
         emitMapDirective(MapDirective.FocusItineraryLeg(leg.points, leg.legIndices))
     }
@@ -732,8 +727,10 @@ class HomeViewModel @Inject constructor(
     /** Show the resolved From/To endpoints as green/red pins (before a plan); a null endpoint drops it. */
     fun setDirectionsEndpointsOnMap(from: GeoPoint?, to: GeoPoint?) = emitMapDirective(MapDirective.SetDirectionsEndpoints(from, to))
 
-    /** Leave directions focus, returning the map to nearby stops. */
-    fun exitDirections() = clearMapFocus()
+    // Leave directions focus, returning the map to nearby stops. Private: the only way out is
+    // [navigateBackInDirections]'s last step, so a control can't jump straight out of a focused leg —
+    // exactly the behaviour #2075 removed.
+    private fun exitDirections() = clearMapFocus()
 
     /**
      * The system Back gesture while in directions. A leg the user drilled into — its route, or an
@@ -849,16 +846,8 @@ class HomeViewModel @Inject constructor(
                             withinDirections = true
                         )
                     )
-                    // Back into an on-street leg focus: redraw the trip first if whatever we're returning
-                    // from tore it down, then recede its other legs around the leg again.
-                    is DirectionsSubFocus.Leg -> {
-                        if (!from.keepsDrawnItinerary) {
-                            shownItinerary?.let { emitMapDirective(MapDirective.ShowItinerary(it)) }
-                        }
-                        emitMapDirective(
-                            MapDirective.FocusItineraryLeg(subFocus.leg.points, subFocus.leg.legIndices)
-                        )
-                    }
+                    // Back into an on-street leg focus: re-apply it exactly as the drawer's tap does.
+                    is DirectionsSubFocus.Leg -> applyLegFocus(subFocus.leg, from)
                     // Back to the itinerary overview: restore it over whatever the leg focus did (the
                     // sheet's own remount reconcile covers a fresh entry, where shownItinerary is null).
                     null -> emitMapDirective(itineraryOverviewDirective(from) ?: MapDirective.ClearFocus)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
@@ -518,18 +518,21 @@ class HomeViewModel @Inject constructor(
     }
 
     /**
-     * A background-map tap drops one attention layer: route-over-stop becomes the plain stop; any
-     * plain stop, standalone route, or bike focus returns to the unfocused root.
+     * A background-map tap drops one attention layer: route-over-stop becomes the plain stop; a focused
+     * itinerary leg becomes the plain itinerary overview; any plain stop, standalone route, or bike focus
+     * returns to the unfocused root.
      */
     fun unfocusMapOneLevel() {
-        val target = when (val focus = _currentFocus.value) {
+        val focus = _currentFocus.value
+        val target = when (focus) {
             is CurrentFocus.Stop -> if (focus.selectedRoute == null) {
                 CurrentFocus.None
             } else {
                 CurrentFocus.Stop(focus.stop)
             }
-            // Route-over-directions becomes the plain itinerary overview; a plain overview exits.
-            is CurrentFocus.Directions -> if (focus.routeFocus == null) {
+            // A focused leg — its route, or an on-street leg framed on its own — becomes the plain
+            // itinerary overview; a plain overview exits.
+            is CurrentFocus.Directions -> if (focus.subFocus == null) {
                 CurrentFocus.None
             } else {
                 CurrentFocus.Directions()
@@ -540,15 +543,34 @@ class HomeViewModel @Inject constructor(
         pushFocus(target)
         when {
             target is CurrentFocus.Stop -> emitMapDirective(MapDirective.ClearSelectedRoute)
-            // Popped a route sub-focus back to the overview: redraw the itinerary over the route.
+            // Popped a leg sub-focus back to the whole trip.
             target is CurrentFocus.Directions ->
-                shownItinerary?.let { emitMapDirective(MapDirective.ShowItinerary(it)) }
+                itineraryOverviewDirective(focus)?.let { emitMapDirective(it) }
             else -> {
                 presentedRoutes = emptySet()
                 emitMapDirective(MapDirective.ClearFocus)
             }
         }
     }
+
+    /**
+     * How the map returns to the itinerary overview from [from]: with the trip still drawn (an on-street
+     * leg focus only receded its other legs) restoring their weight and reframing the trip is enough;
+     * otherwise it has to be redrawn — null when there is none to redraw (a fresh entry).
+     */
+    private fun itineraryOverviewDirective(from: CurrentFocus): MapDirective? = if (from.keepsDrawnItinerary) {
+        MapDirective.ClearItineraryLegFocus
+    } else {
+        shownItinerary?.let { MapDirective.ShowItinerary(it) }
+    }
+
+    /**
+     * Whether the drawn itinerary survives in this focus: the overview and an on-street leg focus both
+     * keep it (the leg focus just restyles it), while a leg's route sub-focus recontextualizes the map onto
+     * that route — and any focus outside directions tears the trip down altogether.
+     */
+    private val CurrentFocus.keepsDrawnItinerary: Boolean
+        get() = this is CurrentFocus.Directions && subFocus !is DirectionsSubFocus.Route
 
     /** Clears the complete focus hierarchy. Used by the focus banner's explicit close control. */
     fun clearMapFocus() {
@@ -583,18 +605,18 @@ class HomeViewModel @Inject constructor(
      */
     fun showItineraryOnMap(itinerary: TripItinerary) {
         shownItinerary = itinerary
-        popRouteFocus() // the ShowItinerary below is the redraw
+        popLegFocus() // the ShowItinerary below is the redraw
         emitMapDirective(MapDirective.ShowItinerary(itinerary))
     }
 
-    /**
-     * Drop a leg's route sub-focus back to the itinerary overview, if one is active; returns whether it
-     * did (so the caller can redraw the itinerary the route mode tore down).
-     */
-    private fun popRouteFocus(): Boolean {
-        if ((_currentFocus.value as? CurrentFocus.Directions)?.routeFocus == null) return false
+    /** The leg the user has drilled into from the itinerary overview, if any. */
+    private val directionsSubFocus: DirectionsSubFocus?
+        get() = (_currentFocus.value as? CurrentFocus.Directions)?.subFocus
+
+    /** Drop a leg sub-focus back to the itinerary overview, if one is active. */
+    private fun popLegFocus() {
+        if (directionsSubFocus == null) return
         pushFocus(CurrentFocus.Directions())
-        return true
     }
 
     /** Recenter the map on a tapped itinerary step's point (only while in [CurrentFocus.Directions]). */
@@ -602,12 +624,19 @@ class HomeViewModel @Inject constructor(
 
     /**
      * Focus a whole tapped itinerary leg on the map (only while in [CurrentFocus.Directions]): frame it,
-     * with the rest of the trip receding to context around it (#2048).
+     * with the rest of the trip receding to context around it (#2048). Recorded as the overview's
+     * [DirectionsSubFocus.Leg], so tapping the map background (or Back) returns to the whole trip exactly
+     * as it does from a transit leg's route focus, instead of leaving directions (#2075).
      */
     fun focusItineraryLegOnMap(leg: FocusedLeg) {
-        // If a transit leg's route is in focus, drop back to the itinerary overview and redraw it first —
-        // otherwise the framing would no-op in route mode (directionsActive is false).
-        if (popRouteFocus()) shownItinerary?.let { emitMapDirective(MapDirective.ShowItinerary(it)) }
+        if (_currentFocus.value is CurrentFocus.Directions) {
+            // If a transit leg's route is in focus, redraw the itinerary it tore down first — otherwise
+            // the framing would no-op in route mode (directionsActive is false).
+            if (directionsSubFocus is DirectionsSubFocus.Route) {
+                shownItinerary?.let { emitMapDirective(MapDirective.ShowItinerary(it)) }
+            }
+            pushFocus(CurrentFocus.Directions(DirectionsSubFocus.Leg(leg)))
+        }
         emitMapDirective(MapDirective.FocusItineraryLeg(leg.points, leg.legIndices))
     }
 
@@ -691,7 +720,7 @@ class HomeViewModel @Inject constructor(
         request: ShowRouteRequest,
         undoViewport: MapViewport? = null
     ) {
-        pushFocus(CurrentFocus.Directions(DirectionsRouteFocus(request)), undoViewport)
+        pushFocus(CurrentFocus.Directions(DirectionsSubFocus.Route(request)), undoViewport)
         // withinDirections: this route is drilled into *from* a trip plan, so the map keeps the rest of
         // the trip beneath it as de-emphasized context (#2048).
         emitMapDirective(MapDirective.ShowRoute(request, stopScoped = false, withinDirections = true))
@@ -794,25 +823,30 @@ class HomeViewModel @Inject constructor(
                         )
                     )
                 }
-                is CurrentFocus.Directions -> {
-                    val routeFocus = target.routeFocus
-                    if (routeFocus != null) {
-                        // Back into a route sub-focus: re-show that leg's route on the map, over the trip
-                        // it belongs to (still drawn, or restored by the sheet's own reconcile).
-                        emitMapDirective(
-                            MapDirective.ShowRoute(
-                                routeFocus.request,
-                                stopScoped = false,
-                                frameRoute = frameFocus,
-                                withinDirections = true
-                            )
+                is CurrentFocus.Directions -> when (val subFocus = target.subFocus) {
+                    // Back into a route sub-focus: re-show that leg's route on the map, over the trip
+                    // it belongs to (still drawn, or restored by the sheet's own reconcile).
+                    is DirectionsSubFocus.Route -> emitMapDirective(
+                        MapDirective.ShowRoute(
+                            subFocus.request,
+                            stopScoped = false,
+                            frameRoute = frameFocus,
+                            withinDirections = true
                         )
-                    } else {
-                        // Back to the itinerary overview: redraw it over any route (the sheet's own
-                        // remount reconcile also covers a fresh entry, where shownItinerary is null).
-                        shownItinerary?.let { emitMapDirective(MapDirective.ShowItinerary(it)) }
-                            ?: emitMapDirective(MapDirective.ClearFocus)
+                    )
+                    // Back into an on-street leg focus: redraw the trip first if whatever we're returning
+                    // from tore it down, then recede its other legs around the leg again.
+                    is DirectionsSubFocus.Leg -> {
+                        if (!from.keepsDrawnItinerary) {
+                            shownItinerary?.let { emitMapDirective(MapDirective.ShowItinerary(it)) }
+                        }
+                        emitMapDirective(
+                            MapDirective.FocusItineraryLeg(subFocus.leg.points, subFocus.leg.legIndices)
+                        )
                     }
+                    // Back to the itinerary overview: restore it over whatever the leg focus did (the
+                    // sheet's own remount reconcile covers a fresh entry, where shownItinerary is null).
+                    null -> emitMapDirective(itineraryOverviewDirective(from) ?: MapDirective.ClearFocus)
                 }
                 CurrentFocus.None, is CurrentFocus.BikeStation ->
                     emitMapDirective(MapDirective.ClearFocus)
@@ -949,6 +983,13 @@ sealed interface MapDirective {
      * the trip's other legs — everything outside [legIndices] — to context (#2048).
      */
     data class FocusItineraryLeg(val points: List<GeoPoint>, val legIndices: Set<Int>) : MapDirective
+
+    /**
+     * Drop a [FocusItineraryLeg] focus back to the itinerary overview: every leg to full weight again and
+     * the whole trip reframed. The lighter counterpart to redrawing via [ShowItinerary], which a leg focus
+     * doesn't need — it never tore the trip down (unlike a leg's route sub-focus).
+     */
+    data object ClearItineraryLegFocus : MapDirective
 
     /** Clear the drawn itinerary but stay in directions mode (the plan became unsubmittable). */
     data object ClearItinerary : MapDirective

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
@@ -735,6 +735,21 @@ class HomeViewModel @Inject constructor(
     /** Leave directions focus, returning the map to nearby stops. */
     fun exitDirections() = clearMapFocus()
 
+    /**
+     * The system Back gesture while in directions. A leg the user drilled into — its route, or an
+     * on-street leg framed on its own — steps back out of that leg first, so Back reverses the drill-in
+     * (restoring the camera it moved) instead of leaving the trip behind (#2075); only from the plain
+     * itinerary overview does Back exit directions. The map-background tap drops a level the same way,
+     * but jumps straight to the overview, while Back walks the legs the user visited in order — matching
+     * how a stop's route focus already behaves under each gesture.
+     */
+    fun navigateBackInDirections() {
+        // The false guard is belt-and-braces: reaching a leg sub-focus always pushed the overview it was
+        // entered from, so there is history to pop.
+        if (directionsSubFocus != null && navigateBackFocus()) return
+        exitDirections()
+    }
+
     /** Reframe the focused route as one undoable camera action. */
     fun reframeFocusedRoute(undoViewport: MapViewport?) {
         if (_currentFocus.value !is CurrentFocus.Route) return

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
@@ -544,8 +544,7 @@ class HomeViewModel @Inject constructor(
         when {
             target is CurrentFocus.Stop -> emitMapDirective(MapDirective.ClearSelectedRoute)
             // Popped a leg sub-focus back to the whole trip.
-            target is CurrentFocus.Directions ->
-                itineraryOverviewDirective(focus)?.let { emitMapDirective(it) }
+            target is CurrentFocus.Directions -> emitMapDirective(itineraryOverviewDirective(focus))
             else -> {
                 presentedRoutes = emptySet()
                 emitMapDirective(MapDirective.ClearFocus)
@@ -556,12 +555,14 @@ class HomeViewModel @Inject constructor(
     /**
      * How the map returns to the itinerary overview from [from]: with the trip still drawn (an on-street
      * leg focus only receded its other legs) restoring their weight and reframing the trip is enough;
-     * otherwise it has to be redrawn — null when there is none to redraw (a fresh entry).
+     * otherwise it has to be redrawn — and where there is nothing to redraw (a fresh entry, before any
+     * itinerary was shown) the map is cleared rather than left in whatever the sub-focus made of it; the
+     * sheet's own remount reconcile draws the selected trip back.
      */
-    private fun itineraryOverviewDirective(from: CurrentFocus): MapDirective? = if (from.keepsDrawnItinerary) {
+    private fun itineraryOverviewDirective(from: CurrentFocus): MapDirective = if (from.keepsDrawnItinerary) {
         MapDirective.ClearItineraryLegFocus
     } else {
-        shownItinerary?.let { MapDirective.ShowItinerary(it) }
+        shownItinerary?.let { MapDirective.ShowItinerary(it) } ?: MapDirective.ClearFocus
     }
 
     /** Clears the complete focus hierarchy. Used by the focus banner's explicit close control. */
@@ -848,9 +849,8 @@ class HomeViewModel @Inject constructor(
                     )
                     // Back into an on-street leg focus: re-apply it exactly as the drawer's tap does.
                     is DirectionsSubFocus.Leg -> applyLegFocus(subFocus.leg, from)
-                    // Back to the itinerary overview: restore it over whatever the leg focus did (the
-                    // sheet's own remount reconcile covers a fresh entry, where shownItinerary is null).
-                    null -> emitMapDirective(itineraryOverviewDirective(from) ?: MapDirective.ClearFocus)
+                    // Back to the itinerary overview: restore it over whatever the leg focus did.
+                    null -> emitMapDirective(itineraryOverviewDirective(from))
                 }
                 CurrentFocus.None, is CurrentFocus.BikeStation ->
                     emitMapDirective(MapDirective.ClearFocus)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
@@ -299,6 +299,7 @@ fun MapFeature(
                     mapViewModel.focusItineraryPoint(directive.point)
                 is MapDirective.FocusItineraryLeg ->
                     mapViewModel.focusItineraryLeg(directive.points, directive.legIndices)
+                MapDirective.ClearItineraryLegFocus -> mapViewModel.clearItineraryLegFocus()
                 MapDirective.ClearItinerary -> mapViewModel.clearShownItinerary()
                 is MapDirective.SetDirectionsEndpoints ->
                     mapViewModel.setDirectionsEndpoints(directive.from, directive.to)

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
@@ -203,6 +203,78 @@ class HomeViewModelTest {
     }
 
     @Test
+    fun `back steps out of a focused on-street leg before leaving directions`() = runTest {
+        val vm = viewModel()
+        val map = MapDirectiveRecorder(vm)
+        val job = launch { map.collect() }
+        advanceUntilIdle()
+        vm.enterDirections()
+        vm.showItineraryOnMap(TripItinerary())
+        vm.focusItineraryLegOnMap(FocusedLeg(listOf(GeoPoint(47.6, -122.3), GeoPoint(47.61, -122.31)), setOf(0)))
+        advanceUntilIdle()
+        map.sent.clear()
+
+        // Back reverses the drill-in rather than leaving the trip behind.
+        vm.navigateBackInDirections()
+        advanceUntilIdle()
+        assertEquals(CurrentFocus.Directions(), vm.currentFocus.value)
+        assertEquals(listOf(MapDirective.ClearItineraryLegFocus), map.sent)
+
+        // From the plain overview it exits directions.
+        vm.navigateBackInDirections()
+        advanceUntilIdle()
+        assertEquals(CurrentFocus.None, vm.currentFocus.value)
+        assertEquals(1, map.clearFocusCount)
+        job.cancel()
+    }
+
+    @Test
+    fun `back walks the focused legs the user visited in order`() = runTest {
+        val vm = viewModel()
+        val map = MapDirectiveRecorder(vm)
+        val job = launch { map.collect() }
+        advanceUntilIdle()
+        vm.enterDirections()
+        vm.showItineraryOnMap(TripItinerary())
+        val first = FocusedLeg(listOf(GeoPoint(47.6, -122.3), GeoPoint(47.61, -122.31)), setOf(0))
+        val second = FocusedLeg(listOf(GeoPoint(47.62, -122.32), GeoPoint(47.63, -122.33)), setOf(2))
+        vm.focusItineraryLegOnMap(first)
+        vm.focusItineraryLegOnMap(second)
+        advanceUntilIdle()
+
+        // Unlike the map-background tap (which jumps to the overview), Back retraces each leg.
+        vm.navigateBackInDirections()
+        assertEquals(CurrentFocus.Directions(DirectionsSubFocus.Leg(first)), vm.currentFocus.value)
+        vm.navigateBackInDirections()
+        assertEquals(CurrentFocus.Directions(), vm.currentFocus.value)
+        vm.navigateBackInDirections()
+        assertEquals(CurrentFocus.None, vm.currentFocus.value)
+        job.cancel()
+    }
+
+    @Test
+    fun `back steps out of a transit leg's route focus to the itinerary overview`() = runTest {
+        val vm = viewModel()
+        val map = MapDirectiveRecorder(vm)
+        val job = launch { map.collect() }
+        advanceUntilIdle()
+        vm.enterDirections()
+        val itinerary = TripItinerary()
+        vm.showItineraryOnMap(itinerary)
+        vm.focusItineraryRouteLegOnMap("65")
+        advanceUntilIdle()
+        map.sent.clear()
+
+        vm.navigateBackInDirections()
+        advanceUntilIdle()
+
+        // Route mode tore the trip down, so returning to the overview redraws it.
+        assertEquals(CurrentFocus.Directions(), vm.currentFocus.value)
+        assertEquals(listOf(MapDirective.ShowItinerary(itinerary)), map.sent)
+        job.cancel()
+    }
+
+    @Test
     fun `focusing an on-street leg from a route focus redraws the trip first`() = runTest {
         val vm = viewModel()
         val map = MapDirectiveRecorder(vm)

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
@@ -26,6 +26,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.onebusaway.android.api.adapters.ObaStopElement
+import org.onebusaway.android.directions.model.TripItinerary
 import org.onebusaway.android.location.FakeLocationRepository
 import org.onebusaway.android.map.RouteFocusRelationship
 import org.onebusaway.android.map.RouteFocusSegment
@@ -144,6 +145,90 @@ class HomeViewModelTest {
             ),
             map.routeRequests.single()
         )
+        job.cancel()
+    }
+
+    @Test
+    fun `tapping off a focused on-street leg returns to the itinerary overview`() = runTest {
+        val vm = viewModel()
+        val map = MapDirectiveRecorder(vm)
+        val job = launch { map.collect() }
+        advanceUntilIdle()
+        vm.enterDirections()
+        vm.showItineraryOnMap(TripItinerary())
+        val walk = FocusedLeg(listOf(GeoPoint(47.6, -122.3), GeoPoint(47.61, -122.31)), setOf(0))
+
+        vm.focusItineraryLegOnMap(walk)
+        advanceUntilIdle()
+        assertEquals(CurrentFocus.Directions(DirectionsSubFocus.Leg(walk)), vm.currentFocus.value)
+        map.sent.clear()
+
+        // The first background tap drops the leg, not directions: the trip's legs return to full weight.
+        vm.unfocusMapOneLevel()
+        advanceUntilIdle()
+        assertEquals(CurrentFocus.Directions(), vm.currentFocus.value)
+        assertEquals(listOf(MapDirective.ClearItineraryLegFocus), map.sent)
+
+        // Only the second tap leaves directions.
+        vm.unfocusMapOneLevel()
+        advanceUntilIdle()
+        assertEquals(CurrentFocus.None, vm.currentFocus.value)
+        assertEquals(1, map.clearFocusCount)
+        job.cancel()
+    }
+
+    @Test
+    fun `back after tapping off an on-street leg refocuses it`() = runTest {
+        val vm = viewModel()
+        val map = MapDirectiveRecorder(vm)
+        val job = launch { map.collect() }
+        advanceUntilIdle()
+        vm.enterDirections()
+        vm.showItineraryOnMap(TripItinerary())
+        val walk = FocusedLeg(listOf(GeoPoint(47.6, -122.3), GeoPoint(47.61, -122.31)), setOf(2))
+        vm.focusItineraryLegOnMap(walk)
+        vm.unfocusMapOneLevel()
+        advanceUntilIdle()
+        map.sent.clear()
+
+        assertTrue(vm.navigateBackFocus())
+        advanceUntilIdle()
+
+        assertEquals(CurrentFocus.Directions(DirectionsSubFocus.Leg(walk)), vm.currentFocus.value)
+        assertEquals(
+            listOf(MapDirective.FocusItineraryLeg(walk.points, walk.legIndices)),
+            map.sent
+        )
+        job.cancel()
+    }
+
+    @Test
+    fun `focusing an on-street leg from a route focus redraws the trip first`() = runTest {
+        val vm = viewModel()
+        val map = MapDirectiveRecorder(vm)
+        val job = launch { map.collect() }
+        advanceUntilIdle()
+        vm.enterDirections()
+        val itinerary = TripItinerary()
+        vm.showItineraryOnMap(itinerary)
+        vm.focusItineraryRouteLegOnMap("65")
+        advanceUntilIdle()
+        map.sent.clear()
+        val walk = FocusedLeg(listOf(GeoPoint(47.6, -122.3), GeoPoint(47.61, -122.31)), setOf(1))
+
+        vm.focusItineraryLegOnMap(walk)
+        advanceUntilIdle()
+
+        // Route mode tore the itinerary down, so it is redrawn before the leg framing (which would
+        // otherwise no-op), and the leg — not the route — is now the focus.
+        assertEquals(
+            listOf(
+                MapDirective.ShowItinerary(itinerary),
+                MapDirective.FocusItineraryLeg(walk.points, walk.legIndices)
+            ),
+            map.sent
+        )
+        assertEquals(CurrentFocus.Directions(DirectionsSubFocus.Leg(walk)), vm.currentFocus.value)
         job.cancel()
     }
 

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
@@ -148,29 +148,42 @@ class HomeViewModelTest {
         job.cancel()
     }
 
-    @Test
-    fun `tapping off a focused on-street leg returns to the itinerary overview`() = runTest {
+    // A tapped on-street leg. Only [legIndices] distinguishes one from another to the focus model, so the
+    // geometry is shared; [walkLeg] gives each test the leg it needs without restating the coordinates.
+    private fun walkLeg(vararg legIndices: Int) = FocusedLeg(listOf(GeoPoint(47.6, -122.3), GeoPoint(47.61, -122.31)), legIndices.toSet())
+
+    /** Directions focus with [itinerary] drawn — the state every leg-focus test starts from. */
+    private fun HomeViewModel.enterDirectionsShowing(itinerary: TripItinerary = TripItinerary()) = itinerary.also {
+        enterDirections()
+        showItineraryOnMap(it)
+    }
+
+    /**
+     * A background tap and Back both drop a focused on-street leg to the itinerary overview before leaving
+     * directions — the same two steps, so both gestures ([dropOneLevel]) are held to one script. Where they
+     * differ is which state they drop *to* with several legs visited; that's the walk test below.
+     */
+    private fun assertDropsLegThenExitsDirections(dropOneLevel: HomeViewModel.() -> Unit) = runTest {
         val vm = viewModel()
         val map = MapDirectiveRecorder(vm)
         val job = launch { map.collect() }
         advanceUntilIdle()
-        vm.enterDirections()
-        vm.showItineraryOnMap(TripItinerary())
-        val walk = FocusedLeg(listOf(GeoPoint(47.6, -122.3), GeoPoint(47.61, -122.31)), setOf(0))
+        vm.enterDirectionsShowing()
+        val walk = walkLeg(0)
 
         vm.focusItineraryLegOnMap(walk)
         advanceUntilIdle()
         assertEquals(CurrentFocus.Directions(DirectionsSubFocus.Leg(walk)), vm.currentFocus.value)
         map.sent.clear()
 
-        // The first background tap drops the leg, not directions: the trip's legs return to full weight.
-        vm.unfocusMapOneLevel()
+        // The first gesture drops the leg, not directions: the trip's legs return to full weight.
+        vm.dropOneLevel()
         advanceUntilIdle()
         assertEquals(CurrentFocus.Directions(), vm.currentFocus.value)
         assertEquals(listOf(MapDirective.ClearItineraryLegFocus), map.sent)
 
-        // Only the second tap leaves directions.
-        vm.unfocusMapOneLevel()
+        // Only the second one leaves directions.
+        vm.dropOneLevel()
         advanceUntilIdle()
         assertEquals(CurrentFocus.None, vm.currentFocus.value)
         assertEquals(1, map.clearFocusCount)
@@ -178,14 +191,19 @@ class HomeViewModelTest {
     }
 
     @Test
+    fun `tapping off a focused on-street leg returns to the itinerary overview`() = assertDropsLegThenExitsDirections(HomeViewModel::unfocusMapOneLevel)
+
+    @Test
+    fun `back steps out of a focused on-street leg before leaving directions`() = assertDropsLegThenExitsDirections(HomeViewModel::navigateBackInDirections)
+
+    @Test
     fun `back after tapping off an on-street leg refocuses it`() = runTest {
         val vm = viewModel()
         val map = MapDirectiveRecorder(vm)
         val job = launch { map.collect() }
         advanceUntilIdle()
-        vm.enterDirections()
-        vm.showItineraryOnMap(TripItinerary())
-        val walk = FocusedLeg(listOf(GeoPoint(47.6, -122.3), GeoPoint(47.61, -122.31)), setOf(2))
+        vm.enterDirectionsShowing()
+        val walk = walkLeg(2)
         vm.focusItineraryLegOnMap(walk)
         vm.unfocusMapOneLevel()
         advanceUntilIdle()
@@ -203,53 +221,18 @@ class HomeViewModelTest {
     }
 
     @Test
-    fun `back steps out of a focused on-street leg before leaving directions`() = runTest {
-        val vm = viewModel()
-        val map = MapDirectiveRecorder(vm)
-        val job = launch { map.collect() }
-        advanceUntilIdle()
-        vm.enterDirections()
-        vm.showItineraryOnMap(TripItinerary())
-        vm.focusItineraryLegOnMap(FocusedLeg(listOf(GeoPoint(47.6, -122.3), GeoPoint(47.61, -122.31)), setOf(0)))
-        advanceUntilIdle()
-        map.sent.clear()
-
-        // Back reverses the drill-in rather than leaving the trip behind.
-        vm.navigateBackInDirections()
-        advanceUntilIdle()
-        assertEquals(CurrentFocus.Directions(), vm.currentFocus.value)
-        assertEquals(listOf(MapDirective.ClearItineraryLegFocus), map.sent)
-
-        // From the plain overview it exits directions.
-        vm.navigateBackInDirections()
-        advanceUntilIdle()
-        assertEquals(CurrentFocus.None, vm.currentFocus.value)
-        assertEquals(1, map.clearFocusCount)
-        job.cancel()
-    }
-
-    @Test
     fun `back walks the focused legs the user visited in order`() = runTest {
         val vm = viewModel()
-        val map = MapDirectiveRecorder(vm)
-        val job = launch { map.collect() }
-        advanceUntilIdle()
-        vm.enterDirections()
-        vm.showItineraryOnMap(TripItinerary())
-        val first = FocusedLeg(listOf(GeoPoint(47.6, -122.3), GeoPoint(47.61, -122.31)), setOf(0))
-        val second = FocusedLeg(listOf(GeoPoint(47.62, -122.32), GeoPoint(47.63, -122.33)), setOf(2))
+        vm.enterDirectionsShowing()
+        val first = walkLeg(0)
         vm.focusItineraryLegOnMap(first)
-        vm.focusItineraryLegOnMap(second)
-        advanceUntilIdle()
+        vm.focusItineraryLegOnMap(walkLeg(2))
 
-        // Unlike the map-background tap (which jumps to the overview), Back retraces each leg.
+        // Unlike the map-background tap (which jumps straight to the overview), Back retraces each leg.
         vm.navigateBackInDirections()
         assertEquals(CurrentFocus.Directions(DirectionsSubFocus.Leg(first)), vm.currentFocus.value)
         vm.navigateBackInDirections()
         assertEquals(CurrentFocus.Directions(), vm.currentFocus.value)
-        vm.navigateBackInDirections()
-        assertEquals(CurrentFocus.None, vm.currentFocus.value)
-        job.cancel()
     }
 
     @Test
@@ -258,9 +241,7 @@ class HomeViewModelTest {
         val map = MapDirectiveRecorder(vm)
         val job = launch { map.collect() }
         advanceUntilIdle()
-        vm.enterDirections()
-        val itinerary = TripItinerary()
-        vm.showItineraryOnMap(itinerary)
+        val itinerary = vm.enterDirectionsShowing()
         vm.focusItineraryRouteLegOnMap("65")
         advanceUntilIdle()
         map.sent.clear()
@@ -280,13 +261,11 @@ class HomeViewModelTest {
         val map = MapDirectiveRecorder(vm)
         val job = launch { map.collect() }
         advanceUntilIdle()
-        vm.enterDirections()
-        val itinerary = TripItinerary()
-        vm.showItineraryOnMap(itinerary)
+        val itinerary = vm.enterDirectionsShowing()
         vm.focusItineraryRouteLegOnMap("65")
         advanceUntilIdle()
         map.sent.clear()
-        val walk = FocusedLeg(listOf(GeoPoint(47.6, -122.3), GeoPoint(47.61, -122.31)), setOf(1))
+        val walk = walkLeg(1)
 
         vm.focusItineraryLegOnMap(walk)
         advanceUntilIdle()

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
@@ -255,6 +255,35 @@ class HomeViewModelTest {
         job.cancel()
     }
 
+    /**
+     * A route sub-focus entered before any itinerary was drawn has nothing to redraw on the way back, so
+     * both gestures clear the map rather than emitting nothing and leaving it in route mode while the focus
+     * already reads as the plain overview.
+     */
+    private fun assertClearsMapWithNoDrawnItinerary(dropOneLevel: HomeViewModel.() -> Unit) = runTest {
+        val vm = viewModel()
+        val map = MapDirectiveRecorder(vm)
+        val job = launch { map.collect() }
+        advanceUntilIdle()
+        vm.enterDirections()
+        vm.focusItineraryRouteLegOnMap("65")
+        advanceUntilIdle()
+        map.sent.clear()
+
+        vm.dropOneLevel()
+        advanceUntilIdle()
+
+        assertEquals(CurrentFocus.Directions(), vm.currentFocus.value)
+        assertEquals(listOf(MapDirective.ClearFocus), map.sent)
+        job.cancel()
+    }
+
+    @Test
+    fun `tapping off a route focus with no drawn itinerary clears the map`() = assertClearsMapWithNoDrawnItinerary(HomeViewModel::unfocusMapOneLevel)
+
+    @Test
+    fun `back out of a route focus with no drawn itinerary clears the map`() = assertClearsMapWithNoDrawnItinerary(HomeViewModel::navigateBackInDirections)
+
     @Test
     fun `focusing an on-street leg from a route focus redraws the trip first`() = runTest {
         val vm = viewModel()


### PR DESCRIPTION
Fixes #2075.

In directions, tapping the map background out of a focused **transit** leg dropped one attention level, back to the whole itinerary. Doing the same out of a focused **walk or bike** leg left directions entirely, back to nearby stops.

## Why

Only the transit path recorded a focus *level*. A transit leg pushed `CurrentFocus.Directions(routeFocus = …)`, so `unfocusMapOneLevel` had something to pop. An on-street leg focus lived only in `DirectionsMapController.focusedLegIndices` — render state the focus model couldn't see — so focus stayed at the plain overview and the background tap took the "plain overview exits" branch.

## What changed

- **`CurrentFocus.Directions` now holds a sealed `DirectionsSubFocus`** — `Route(request)` (the former `DirectionsRouteFocus`) or `Leg(FocusedLeg)`. Both drill-ins are the same level of one hierarchy, so the background tap and the undo history treat every kind of leg alike.
- **New `MapDirective.ClearItineraryLegFocus`** → `MapViewModel.clearItineraryLegFocus()`. Popping a leg focus doesn't need the route path's full `ShowItinerary` redraw — the trip is still drawn, only restyled — so this just restores every leg to full weight and reframes the trip. That also avoids `showItinerary`'s per-tap polyline re-decode, marker churn, and bike-station reload.
- **Back now pops one level too** (second commit). `navigateBackFocus` had a single caller — the undo `BackHandler` — and the directions `BackHandler` composes inside it, so it registers later and wins every back press while directions is active, going straight to `exitDirections()`. It now routes through `HomeViewModel.navigateBackInDirections()`: with a leg drilled into, Back reverses the drill-in through the existing undo history (restoring the camera it moved); only from the plain overview does it exit directions. This covers the route sub-focus as well, which had the same problem.

The two gestures stay deliberately distinct, matching how a stop's route focus already behaves: the background tap jumps to the overview, while Back retraces the legs the rider visited.

## Notes for review

- **A judgment call worth a look:** Back retracing each visited leg (leg B → leg A → overview) rather than jumping to the overview. `back walks the focused legs the user visited in order` pins it; switching to `unfocusMapOneLevel()` would make Back jump, at the cost of no longer restoring the camera the drill-in moved.
- **Known latent staleness, not introduced here:** `DirectionsSubFocus.Leg` records the leg's geometry, so an undo entry can outlive the itinerary it came from (focus a leg on option A, switch to option B, leave directions, then walk back through history → A's geometry replayed over B's trip). `Route` has carried the same shape via `highlightedSegment` all along. The deeper fix is to record leg *identity* only (`legIndices`) and resolve points from the map controller's retained legs; happy to do that here or as a follow-up.
- The sub-focus is still not persisted across process death — a restore lands on the overview, as it already did for route focus.

## Testing

- `:onebusaway-android:testObaGoogleDebugUnitTest` — 64 tests in `HomeViewModelTest`, 0 failures, 6 new covering: tap-off and Back each dropping the leg then exiting (one shared script, two gestures), Back refocusing a leg, the multi-leg Back walk, Back out of a route focus redrawing the trip, and focusing an on-street leg out of a route focus.
- `obaGoogle` + `obaMaplibre` compile clean under `-PwarningsAsErrors=true`; `spotlessCheck` passes. Lint left to CI.
- Verified by hand on a physical device: the walk-leg tap-off returns to the whole itinerary with the results sheet intact. The Back gesture is worth a manual pass by a reviewer — there's no semantic handle to drive a map-background tap or a system Back in an instrumented test, which is why the coverage sits at the ViewModel.

Third commit is a `/simplify` pass over the first two (one shared `applyLegFocus` step, predicate moved beside its siblings in `CurrentFocus.kt`, shared test fixtures) — net −23 lines, no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/OneBusAway/codesmith/onebusaway-android/pr/2078"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787965635&installation_model_id=429412&pr_number=2078&repository=OneBusAway%2Fonebusaway-android&return_to=https%3A%2F%2Fgithub.com%2FOneBusAway%2Fonebusaway-android%2Fpull%2F2078&signature=8f432dbb437b7ff02af5680c0a7ba39779d0420ea96c2a8c90d9949b17c072c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved directions navigation with step-by-step Back behavior.
  * Users can clear a focused itinerary leg and return to the full trip overview.
  * Added support for focusing transit routes and on-street legs independently.
  * Directions state is restored more accurately after navigating back or undoing actions.
* **Tests**
  * Added coverage for leg focus, route focus, itinerary restoration, and back navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->