### PR TITLE
Split an interlined ride into segments in the directions drawer

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/DirectionRowInterlineBadgeTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/DirectionRowInterlineBadgeTest.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 import org.onebusaway.android.R
@@ -29,14 +30,18 @@ import org.onebusaway.android.ui.compose.createUnconfinedComposeRule
 import org.onebusaway.android.util.GeoPoint
 
 /**
- * Verifies that a ride the vehicle changes route during (#2000) is badged as what it is in both places a
- * ride is drawn — the itinerary option card at the top and the ride's own badge in the trip log: one
- * roundel naming every route ridden, "5 > 12" (#2049). The badge used to name only the route boarded,
- * leaving the picker promising a 5 all the way while the log's own "stay on board" row said otherwise.
+ * Verifies that a ride the vehicle changes route during (#2000) names every route it runs as, in the two
+ * places a ride is drawn — and names them in the form each place can carry:
+ *  - the itinerary option card has one line to stand for the whole ride, so it joins them into one
+ *    roundel, "5 > 12" (#2049). The card used to name only the route boarded, leaving the picker
+ *    promising a 5 all the way while the drawer's own "stay on board" row said otherwise;
+ *  - the trip log has a row per segment, so it splits them (#2071): the header badges the 5 the rider
+ *    boards, and the 12 appears at the seam row, where the rider is told to stay aboard for it. The
+ *    header used to carry the joined roundel too, promising a 12 several stops before it existed.
  *
- * The instruction it must *not* pick up is the interchangeable one: a chevron badge is one vehicle, so
- * "whichever comes first" (see [DirectionRowAlternativeRoutesTest]) would tell the rider to board a 12
- * that is the same bus they are already on.
+ * The instruction the seam must *not* pick up is the interchangeable one: an interlined ride is one
+ * vehicle, so "whichever comes first" (see [DirectionRowAlternativeRoutesTest]) would tell the rider to
+ * board a 12 that is the same bus they are already on.
  */
 class DirectionRowInterlineBadgeTest {
 
@@ -61,7 +66,8 @@ class DirectionRowInterlineBadgeTest {
     )
 
     private val transition = InterlineTransition(
-        routeLabel = "12",
+        badge = RouteBadge("12", 0xFFD62828.toInt()),
+        routeDisplayName = "12",
         headsign = "Interlaken Park",
         stop = RouteStopRef("1_550", "550", "Mount Baker Transit Center", seamPoint)
     )
@@ -103,14 +109,36 @@ class DirectionRowInterlineBadgeTest {
         directions = listOf(ride)
     )
 
-    /** Both roundels — the option card's and the ride's — name the route boarded and the one it becomes. */
+    /** Every route the ride runs as is named twice over: once on the option card, once in the log. */
     @Test
-    fun anInterlinedRideBadgesEveryRouteItRunsAsInThePickerAndTheLog() {
+    fun anInterlinedRideNamesEveryRouteItRunsAsInThePickerAndTheLog() {
         composeRule.setContent { TripResultsList(state = state) }
 
-        // One node per route in each of the two badges: the option card's and the ride's.
         composeRule.onAllNodesWithText("5").assertCountEquals(2)
         composeRule.onAllNodesWithText("12").assertCountEquals(2)
+    }
+
+    /**
+     * …but the log names them where the rider reaches them (#2071): the 12 is drawn *below* the board
+     * stop, at its seam, and never beside the route the rider is boarding. Anchored on the board stop's
+     * own row rather than on node order, so it fails for the reason it is named — the header carrying a
+     * "5 > 12" roundel would put a 12 above that line, and no 5 may appear below it.
+     */
+    @Test
+    fun theLogBadgesTheRouteBoardedAtTheHeaderAndTheOneItBecomesAtTheSeam() {
+        composeRule.setContent { TripResultsList(state = state) }
+
+        val boardStopBottom = composeRule
+            .onNodeWithText("3rd Ave & Pine St")
+            .fetchSemanticsNode()
+            .boundsInRoot
+            .bottom
+        fun topsOf(name: String) = composeRule.onAllNodesWithText(name)
+            .fetchSemanticsNodes()
+            .map { it.boundsInRoot.top }
+
+        assertEquals("one 12 below the board stop — the seam's", 1, topsOf("12").count { it > boardStopBottom })
+        assertEquals("no 5 below the board stop", 0, topsOf("5").count { it > boardStopBottom })
     }
 
     /** The badge and the narrative tell one story: the 12 is where the ride goes, not a bus to board. */
@@ -119,13 +147,9 @@ class DirectionRowInterlineBadgeTest {
         composeRule.setContent { TripResultsList(state = state) }
 
         composeRule
-            .onNodeWithText(
-                context.getString(
-                    R.string.step_by_step_transit_interline,
-                    "12 ${context.getString(R.string.step_by_step_transit_connector_headsign)} Interlaken Park"
-                )
-            )
+            .onNodeWithText(context.getString(R.string.step_by_step_transit_stay_on_board))
             .assertExists()
+        composeRule.onNodeWithText("Interlaken Park").assertExists()
         composeRule
             .onAllNodesWithText(context.getString(R.string.directions_whichever_comes_first))
             .assertCountEquals(0)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/Interlines.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/Interlines.kt
@@ -19,7 +19,6 @@ import org.onebusaway.android.directions.model.InterchangeableRoute
 import org.onebusaway.android.directions.model.TripItinerary
 import org.onebusaway.android.directions.model.TripLeg
 import org.onebusaway.android.directions.model.interchangeableRoutes
-import org.onebusaway.android.directions.model.routeDisplayLabel
 
 /**
  * Pure interline analysis over a trip's legs (#2000) — no `Context` / OBA-id resolution, so it's
@@ -84,16 +83,6 @@ internal object Interlines {
         }
         return chains
     }
-
-    /**
-     * How a stay-aboard transition names the route the vehicle becomes ("stay on board for X"). The
-     * prose label rather than the badge name — the sentence needs a name even where a badge would be
-     * omitted — so a route with only a long name reads "stay on board for Seattle - Bremerton".
-     *
-     * Null when the route names itself in no way at all, so the renderer can reach for the headsign (or
-     * a generic) rather than building a sentence around a blank.
-     */
-    fun transitionRouteLabel(leg: TripLeg): String? = leg.routeDisplayLabel()
 }
 
 /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/RouteBadges.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/RouteBadges.kt
@@ -19,6 +19,7 @@ import org.onebusaway.android.directions.model.InterchangeableRoute
 import org.onebusaway.android.directions.model.TripLeg
 import org.onebusaway.android.directions.model.TripMode
 import org.onebusaway.android.directions.model.routeDisplayLabel
+import org.onebusaway.android.directions.model.routeDisplayShortName
 import org.onebusaway.android.ui.compose.components.RouteBadge
 import org.onebusaway.android.ui.compose.components.RouteBadgeJoin
 import org.onebusaway.android.util.ROUTE_NAME_ORDER
@@ -38,8 +39,10 @@ import org.onebusaway.android.util.parseObaHexColor
  * interline is one ride the rider is never asked to act on. Which of the two joins it takes is decided
  * here, once, for both places a ride is badged:
  *  - a ride the vehicle changes route during badges those routes in travel order, joined by chevrons
- *    (`5 > 12`, #2049) — the seam is a fact about the ride, so the badge has to carry it, or the picker
- *    promises a 5 all the way and the drawer's own "stay on board" row contradicts it;
+ *    (`5 > 12`, #2049) — the seam is a fact about the ride, so a badge standing for the *whole* ride has
+ *    to carry it, or the picker promises a 5 all the way and the drawer's own "stay on board" row
+ *    contradicts it. (The drawer itself no longer draws this form: it has a row per segment, so it
+ *    badges each segment where the rider reaches it — #2071. It still builds it, for the picker.)
  *  - any other ride badges its planned route joined by whatever is interchangeable with it (#2010).
  *
  * The two can't both apply, and this says so rather than trusting it: [substitutableRoutes] empties the
@@ -92,6 +95,18 @@ internal fun legBadge(planned: RouteBadge?, alternatives: List<RouteBadge>, mode
     mode,
     RouteBadgeJoin.ANY_OF
 )
+
+/**
+ * The transit leg's roundel as the **directions drawer** draws one: its short name and parsed GTFS
+ * color, and *no* badge at all for a route publishing no short name.
+ *
+ * The narrower rule the drawer has always applied to a board row's roundel ([TripLogEntry.Transit
+ * .routeShortName]), lifted out so a seam row can badge the route continued onto by the same rule
+ * (#2071) — the two rows name a route the same way or the ride reads as two different kinds of thing.
+ * The wider [plannedBadge] rule (long name in the roundel) belongs to the option cards, which have no
+ * room to print a long name any other way.
+ */
+internal fun TripLeg.shortNameBadge(): RouteBadge? = routeDisplayShortName()?.let { RouteBadge(it, badgeColor(routeColor)) }
 
 /**
  * The transit leg's own roundel: its badge name and parsed GTFS color; null when it names itself in no

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsRepository.kt
@@ -143,8 +143,12 @@ class DefaultTripResultsRepository @Inject constructor(
                 extraSegments = extraSegments,
                 alternatives = alternatives.map { it.resolve() },
                 // Built here, alongside the option cards' badges, so the drawer renders one rather than
-                // deriving it per row (#2010) — and so a ride that changes route under the rider is
-                // badged the same "5 > 12" in both places (#2049).
+                // deriving it per row (#2010). The drawer's board row draws only the interchangeable
+                // form; on an interlined ride it names each segment at its own row instead (#2071), so
+                // the "5 > 12" this returns for one of those is drawn on the option card alone. Still
+                // built by the shared [rideBadge] rather than short-cut to the interchangeable case —
+                // that is where the two forms are held apart, invariant check and all, and the card's
+                // badge would otherwise be the only thing keeping it honest.
                 badge = rideBadge(legs, chain, alternatives)
             )
         }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsRepository.kt
@@ -27,6 +27,7 @@ import org.onebusaway.android.directions.model.TripLeg
 import org.onebusaway.android.directions.model.TripMode
 import org.onebusaway.android.directions.model.TripPlace
 import org.onebusaway.android.directions.model.interchangeableRoutes
+import org.onebusaway.android.directions.model.routeDisplayName
 import org.onebusaway.android.directions.util.DirectionsGenerator
 import org.onebusaway.android.map.RouteFocusSegment
 import org.onebusaway.android.util.geoPointOrNull
@@ -113,7 +114,8 @@ class DefaultTripResultsRepository @Inject constructor(
             val leader = legs[chain.leaderIndex]
             val transitions = chain.transitionLegIndices.associateWith { j ->
                 InterlineTransition(
-                    routeLabel = Interlines.transitionRouteLabel(legs[j]),
+                    badge = legs[j].shortNameBadge(),
+                    routeDisplayName = legs[j].routeDisplayName(),
                     headsign = legs[j].headsign,
                     stop = legs[j].from.resolveStop(legs[j])
                 )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
@@ -1196,12 +1196,15 @@ private fun ColumnScope.BoardContent(
             .defaultMinSize(minHeight = ROW_MIN_TOUCH_HEIGHT)
             .clickable(onClick = onFocus)
     ) {
-        // A ride naming more than one route badges them all as one joined roundel — the routes it may be
-        // taken on ("1 Line/2 Line", #2010) or the ones the vehicle becomes under the rider ("5 > 12",
-        // #2049), the badge's own join saying which. An ordinary ride badges its own route exactly as
-        // before. A route that publishes no short name gets no roundel and leads with its long name —
-        // see routeDisplayShortName.
-        val joined = entry.routeLeg.badge?.takeIf { it.isJoined }
+        // A ride the rider may take on any of several routes badges them all as one joined roundel
+        // ("1 Line/2 Line", #2010). A ride the *vehicle* changes route during does not (#2071): the
+        // drawer draws a row per segment, so the header badges only the route boarded and each route the
+        // vehicle becomes is badged at the seam the rider reaches it at (TransitionContent) — the
+        // header's roundel says what to board, not everything the ride will eventually be called. The
+        // option card above still joins them ("5 > 12", #2049); it has one line for the whole ride.
+        // A route that publishes no short name gets no roundel and leads with its long name — see
+        // routeDisplayShortName.
+        val joined = entry.routeLeg.badge?.takeIf { it.isInterchangeable }
         val title = entry.routeDisplayName?.takeIf { it != entry.routeShortName }
         Row(verticalAlignment = Alignment.CenterVertically) {
             when {
@@ -1230,10 +1233,11 @@ private fun ColumnScope.BoardContent(
             )
         }
         // What an interchangeable badge means: any of those routes will do, so board the first to
-        // arrive. Each one's own ETA strip sits under the board stop below (#2010). A chevron badge is
-        // the opposite instruction — board this one and stay on it — and says so in its own row further
-        // down the ride (TransitionContent), so it must not pick this caption up.
-        if (joined?.isInterchangeable == true) {
+        // arrive. Each one's own ETA strip sits under the board stop below (#2010). A ride that changes
+        // route under the rider carries the opposite instruction — board this one and stay on it — and
+        // gives it in its own row further down the ride (TransitionContent); its badge never reaches
+        // this header, so it cannot pick this caption up.
+        if (joined != null) {
             Text(
                 text = stringResource(R.string.directions_whichever_comes_first),
                 style = MaterialTheme.typography.bodyMedium,
@@ -1274,23 +1278,57 @@ private fun ColumnScope.StopContent(stop: LogStop) {
 
 /**
  * A stay-aboard interline (#2000): the vehicle keeps going but its route changes, so the rider is told
- * to stay on board — never to get off and reboard. Shows the new route label (short name + "to headsign")
- * and the seam stop where the change happens.
+ * to stay on board — never to get off and reboard.
+ *
+ * Laid out as the board row of the ride's *next segment* (#2071) — badge, fuller name, headsign, by the
+ * same rules a board row uses — since that is what the seam is: the header above named the route
+ * boarded, and this names the route the rider goes on to ride, at the point they reach it. The
+ * instruction and the seam stop follow, so a route with no long name reads
+ * `[12] / Interlaken Park / Stay on board / At Mount Baker Transit Center`.
+ *
+ * With nothing at all to name the new route by — no badge, no name, no headsign — the instruction says
+ * so itself rather than standing over a blank.
  */
 @Composable
 private fun ColumnScope.TransitionContent(transition: InterlineTransition) {
     val headsign = transition.headsign?.takeIf { it.isNotEmpty() }
-    // "the vehicle becomes <X>" needs a subject. With a route name, X is that name (plus "to
-    // <headsign>" when there is one). With no name the headsign stands in alone — never behind the "to"
-    // connector, which would read "becomes to Bremerton" — and with neither, the sentence drops the
-    // subject entirely rather than trailing off into a blank.
-    val becomes = when (val route = transition.routeLabel) {
-        null -> headsign
-        else -> headsign?.let { "$route ${stringResource(R.string.step_by_step_transit_connector_headsign)} $it" } ?: route
+    // Dropped when it merely repeats the badge beside it, exactly as a board row's title is.
+    val title = transition.routeDisplayName?.takeIf { it != transition.badge?.shortName }
+    if (transition.badge != null || title != null) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            transition.badge?.let {
+                RouteBadgeChip(it.shortName, it.routeColor, scale = 1.5f)
+                Spacer(Modifier.width(8.dp))
+            }
+            if (title != null) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.bodyLarge,
+                    fontWeight = FontWeight.Medium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    modifier = Modifier.weight(1f)
+                )
+            } else {
+                Spacer(Modifier.weight(1f))
+            }
+        }
     }
+    headsign?.let {
+        Text(
+            text = it,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+    val named = transition.badge != null || title != null || headsign != null
     Text(
-        text = becomes?.let { stringResource(R.string.step_by_step_transit_interline, it) }
-            ?: stringResource(R.string.step_by_step_transit_interline_unknown_route),
+        text = stringResource(
+            if (named) {
+                R.string.step_by_step_transit_stay_on_board
+            } else {
+                R.string.step_by_step_transit_interline_unknown_route
+            }
+        ),
         style = MaterialTheme.typography.bodyMedium,
         fontWeight = FontWeight.SemiBold,
         color = MaterialTheme.colorScheme.onSurface
@@ -1503,13 +1541,15 @@ private fun TripResultsPreview() {
                     durationMinutes = 16,
                     realtime = RealtimeState.OnTime,
                     // The same ride the first option's chevron badge stands for: boarded once as the 8,
-                    // becoming the 12 at Mount Baker without the rider getting off (#2000/#2049).
+                    // becoming the 12 at Mount Baker without the rider getting off (#2000/#2049). Here
+                    // the header badges only the 8 and the 12 arrives at its own seam row (#2071).
                     rideEvents = listOf(
                         RideEvent.Stop(LogStop("Capitol Hill Station")),
                         RideEvent.Stop(LogStop("23rd Ave & E Union St")),
                         RideEvent.Transition(
                             InterlineTransition(
-                                routeLabel = "12",
+                                badge = RouteBadge("12", 0xFFD62828.toInt()),
+                                routeDisplayName = "Route 12",
                                 headsign = "Interlaken Park",
                                 stop = RouteStopRef("1_550", "550", "Mount Baker Transit Center", null)
                             )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
@@ -578,6 +578,9 @@ private val ROW_MIN_TOUCH_HEIGHT = 48.dp
 /** The gap between the option-card header and the log, and below the log's last row. */
 private val LOG_EDGE_GAP = 4.dp
 
+/** How much the drawer enlarges a route roundel over its default size — see [SegmentIdentity]. */
+private const val BADGE_SCALE = 1.5f
+
 /**
  * How far the timeline's fixed metrics stretch with the user's font scale, capped at the platform's 2×
  * ceiling so a large text size can't crowd the content off a narrow screen. [TIME_WIDTH] is sized for
@@ -1038,8 +1041,11 @@ private fun BoxScope.LogNode(content: RowContent, nodeColors: RouteLineColors) {
             FilledNode(26.dp, nodeColor, transitModeIcon(content.entry.mode), onNode, 16.dp, shape = RoundedCornerShape(8.dp))
         is RowContent.ExitNode -> RingNode(22.dp, 3.dp, nodeColor)
         is RowContent.Stop -> RingNode(11.dp, 2.dp, nodeColor)
+        // A seam's arrow points *down* the rail, the way the ride carries on. It used to borrow the walk
+        // maneuver's ic_continue, whose arrow points up — that glyph means "keep going straight ahead"
+        // on a compass-oriented turn list, and read as travel back up the timeline on a vertical one.
         is RowContent.Transition ->
-            FilledNode(22.dp, nodeColor, R.drawable.ic_continue, onNode, 14.dp)
+            FilledNode(22.dp, nodeColor, R.drawable.ic_arrow_downward, onNode, 14.dp)
         is RowContent.Step -> RingNode(8.dp, 2.dp, muted.copy(alpha = 0.7f))
         // The between-steps distance is an interval, not an event — the spine runs through unbroken.
         is RowContent.StepDistance -> Unit
@@ -1205,33 +1211,16 @@ private fun ColumnScope.BoardContent(
         // A route that publishes no short name gets no roundel and leads with its long name — see
         // routeDisplayShortName.
         val joined = entry.routeLeg.badge?.takeIf { it.isInterchangeable }
-        val title = entry.routeDisplayName?.takeIf { it != entry.routeShortName }
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            when {
-                joined != null -> RouteBadgeChip(joined.routes, scale = 1.5f, join = joined.join)
+        SegmentIdentity(
+            title = entry.routeDisplayName?.takeIf { it != entry.routeShortName },
+            headsign = entry.headsign,
+            roundel = when {
+                joined != null -> ({ RouteBadgeChip(joined.routes, scale = BADGE_SCALE, join = joined.join) })
                 entry.routeShortName != null ->
-                    RouteBadgeChip(entry.routeShortName, routeColorInt(entry.routeColorHex), scale = 1.5f)
+                    ({ RouteBadgeChip(entry.routeShortName, routeColorInt(entry.routeColorHex), scale = BADGE_SCALE) })
+                else -> null
             }
-            if (joined != null || entry.routeShortName != null) Spacer(Modifier.width(8.dp))
-            if (title != null) {
-                Text(
-                    text = title,
-                    style = MaterialTheme.typography.bodyLarge,
-                    fontWeight = FontWeight.Medium,
-                    color = MaterialTheme.colorScheme.onSurface,
-                    modifier = Modifier.weight(1f)
-                )
-            } else {
-                Spacer(Modifier.weight(1f))
-            }
-        }
-        entry.headsign?.let {
-            Text(
-                text = it,
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-        }
+        )
         // What an interchangeable badge means: any of those routes will do, so board the first to
         // arrive. Each one's own ETA strip sits under the board stop below (#2010). A ride that changes
         // route under the rider carries the opposite instruction — board this one and stay on it — and
@@ -1292,42 +1281,18 @@ private fun ColumnScope.StopContent(stop: LogStop) {
 @Composable
 private fun ColumnScope.TransitionContent(transition: InterlineTransition) {
     val headsign = transition.headsign?.takeIf { it.isNotEmpty() }
-    // Dropped when it merely repeats the badge beside it, exactly as a board row's title is.
     val title = transition.routeDisplayName?.takeIf { it != transition.badge?.shortName }
-    if (transition.badge != null || title != null) {
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            transition.badge?.let {
-                RouteBadgeChip(it.shortName, it.routeColor, scale = 1.5f)
-                Spacer(Modifier.width(8.dp))
-            }
-            if (title != null) {
-                Text(
-                    text = title,
-                    style = MaterialTheme.typography.bodyLarge,
-                    fontWeight = FontWeight.Medium,
-                    color = MaterialTheme.colorScheme.onSurface,
-                    modifier = Modifier.weight(1f)
-                )
-            } else {
-                Spacer(Modifier.weight(1f))
-            }
+    SegmentIdentity(
+        title = title,
+        headsign = headsign,
+        roundel = transition.badge?.let { badge ->
+            { RouteBadgeChip(badge.shortName, badge.routeColor, scale = BADGE_SCALE) }
         }
-    }
-    headsign?.let {
-        Text(
-            text = it,
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
-        )
-    }
+    )
     val named = transition.badge != null || title != null || headsign != null
     Text(
         text = stringResource(
-            if (named) {
-                R.string.step_by_step_transit_stay_on_board
-            } else {
-                R.string.step_by_step_transit_interline_unknown_route
-            }
+            if (named) R.string.step_by_step_transit_stay_on_board else R.string.step_by_step_transit_interline_unknown_route
         ),
         style = MaterialTheme.typography.bodyMedium,
         fontWeight = FontWeight.SemiBold,
@@ -1336,6 +1301,49 @@ private fun ColumnScope.TransitionContent(transition: InterlineTransition) {
     transition.stop.name?.let { name ->
         Text(
             text = "${stringResource(R.string.step_by_step_transit_connector_stop_name)} $name",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+/**
+ * How a row names the route the rider is about to be on: its [roundel], the fuller name beside it, and
+ * the [headsign] under both.
+ *
+ * One composable rather than two so the ride's segments can't drift apart (#2071). The rider boards a
+ * segment at the board row and reaches every later one at a seam row, and those are the same act — a
+ * padding or type tweak landing on one of them and not the other would make one ride read as two
+ * different kinds of thing.
+ *
+ * [roundel] is a slot rather than a badge value because the two rows draw genuinely different chips: a
+ * board row may draw the joined "1 Line/2 Line" roundel, which is outlined, where a seam always draws
+ * the plain single one. Null draws none — and takes its spacing with it — for a route publishing no
+ * short name. [title] is null when the name would merely repeat the roundel, and the weight falls to a
+ * spacer, so whatever follows is laid out the same either way.
+ */
+@Composable
+private fun SegmentIdentity(title: String?, headsign: String?, roundel: (@Composable () -> Unit)?) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        if (roundel != null) {
+            roundel()
+            Spacer(Modifier.width(8.dp))
+        }
+        if (title != null) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.Medium,
+                color = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.weight(1f)
+            )
+        } else {
+            Spacer(Modifier.weight(1f))
+        }
+    }
+    headsign?.let {
+        Text(
+            text = it,
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant
         )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
@@ -91,7 +91,9 @@ data class LegBadge(
     val isJoined: Boolean get() = routes.size > 1
 
     /** Whether the badge offers a *choice* of routes — as opposed to naming a ride that becomes another
-     *  route under the rider ([RouteBadgeJoin.THEN]), which is one route to board, not several. */
+     *  route under the rider ([RouteBadgeJoin.THEN]), which is one route to board, not several. The
+     *  drawer's board row draws only this form: the other names routes the rider does not reach until
+     *  later in the ride, and it has a row down there to name each of them at (#2071). */
     val isInterchangeable: Boolean get() = isJoined && join == RouteBadgeJoin.ANY_OF
 
     /** True when the ride names no route at all, and can only be shown as its mode. */
@@ -334,16 +336,23 @@ data class RouteLegRef(
 
 /**
  * A stay-aboard interline onto a **different** route within one continuous vehicle ride (#2000): at
- * [stop] the vehicle changes to route [routeLabel] (heading to [headsign]) and the passenger stays
- * seated. Rendered as a distinct row between Board and Alight so the directions never tell the rider to
- * get off and reboard. Self-interlines (same route reversing onto itself) produce no transition — the
- * seam vanishes entirely.
+ * [stop] the vehicle changes route (heading to [headsign]) and the passenger stays seated. Rendered as a
+ * distinct row between Board and Alight so the directions never tell the rider to get off and reboard.
+ * Self-interlines (same route reversing onto itself) produce no transition — the seam vanishes entirely.
  *
- * [routeLabel] is the prose label ([Interlines.transitionRouteLabel]), not the badge name: this row is a
- * sentence, so it names a short-name-less route by its long name rather than saying nothing.
+ * The row identifies the route continued onto exactly as a board row identifies the route boarded
+ * (#2071) — that is the point of the seam row: the ride's second segment starts here, so it is named
+ * here rather than folded into the header's badge:
+ *  - [badge] is the roundel, so a route's number arrives in its own colour beside the instruction. Null
+ *    for a route that publishes no short name — like a board row, the seam draws no roundel for one and
+ *    leans on [routeDisplayName] instead, rather than putting a long name in a roundel.
+ *  - [routeDisplayName] is the fuller name for the row's title line (long name, else the short one), so
+ *    a route with both reads `[550] Bellevue - Seattle`. The renderer drops it when it merely repeats
+ *    the badge.
  */
 data class InterlineTransition(
-    val routeLabel: String?,
+    val badge: RouteBadge?,
+    val routeDisplayName: String?,
     val headsign: String?,
     val stop: RouteStopRef
 )

--- a/onebusaway-android/src/main/res/drawable/ic_arrow_downward.xml
+++ b/onebusaway-android/src/main/res/drawable/ic_arrow_downward.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M11,4V16.18L5.4,10.58L4,12l8,8l8,-8L18.6,10.58L13,16.18V4H11Z"/>
+</vector>

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -1060,8 +1060,9 @@
     <string name="step_by_step_transit_get_on">Get on</string>
     <string name="step_by_step_transit_get_off">Get off</string>
     <!-- Shown when the trip stays aboard the same vehicle but its route changes (a stay-aboard
-         interline, #2000); %1$s is the new route label, e.g. "12 to Downtown". -->
-    <string name="step_by_step_transit_interline">Stay on board — the vehicle becomes %1$s</string>
+         interline, #2000). The route the vehicle becomes is named beside this instruction — its badge,
+         name and headsign — so the instruction itself only has to give the action (#2071). -->
+    <string name="step_by_step_transit_stay_on_board">Stay on board</string>
     <!-- The same stay-aboard interline where the new route publishes neither a name nor a headsign, so
          there is nothing to name it by. The instruction still has to be given. -->
     <string name="step_by_step_transit_interline_unknown_route">Stay on board — the vehicle continues on another route</string>

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/InterlinesTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/InterlinesTest.kt
@@ -16,7 +16,6 @@
 package org.onebusaway.android.ui.tripresults
 
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
 import org.junit.Test
 import org.onebusaway.android.directions.model.TripItinerary
 import org.onebusaway.android.directions.model.TripLeg
@@ -94,23 +93,6 @@ class InterlinesTest {
     fun aLeadingInterlineFlagWithNoPredecessor_leadsNoChain() {
         // Malformed input (nothing precedes it to stay aboard from): it must not become a chain leader.
         assertEquals(emptyList<Interlines.Chain>(), Interlines.chains(listOf(transit("12", interline = true))))
-    }
-
-    /**
-     * The transition sentence names the route the vehicle becomes: by its short name, else its long one
-     * — and null, not blank, when it has neither, so the renderer can say "continues on another route"
-     * rather than "the vehicle becomes ".
-     */
-    @Test
-    fun transitionRouteLabel_prefersShortNameThenLongNameThenNothing() {
-        assertEquals("12", Interlines.transitionRouteLabel(transit("12")))
-        assertEquals(
-            "Seattle - Bremerton",
-            Interlines.transitionRouteLabel(
-                TripLeg(mode = TripMode.FERRY, routeId = "95:74", routeLongName = "Seattle - Bremerton")
-            )
-        )
-        assertNull(Interlines.transitionRouteLabel(TripLeg(mode = TripMode.FERRY, routeId = "95:74")))
     }
 
     /**

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/RouteBadgesTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/RouteBadgesTest.kt
@@ -128,6 +128,21 @@ class RouteBadgesTest {
         assertEquals(TransitMode.FERRY, badge.mode)
     }
 
+    /**
+     * The drawer's narrower rule (#2071): a short name roundels, a long name never does. The two board
+     * and seam rows both use it, and each has room to print a long name as the row's title instead — so
+     * a ferry that reaches the drawer draws no roundel where an option card would draw a wide one.
+     */
+    @Test
+    fun shortNameBadgeRoundelsOnlyAShortName() {
+        val bus = TripLeg(mode = TripMode.BUS, routeId = "1_100", routeShortName = "8", routeLongName = "Rainier Ave")
+        val ferry = TripLeg(mode = TripMode.FERRY, routeId = "95:74", routeLongName = "Seattle - Bremerton")
+
+        assertEquals("8", bus.shortNameBadge()?.shortName)
+        assertEquals("Seattle - Bremerton", ferry.plannedBadge()?.shortName)
+        assertNull(ferry.shortNameBadge())
+    }
+
     /** OTP1 legs carry a flat display string instead of a short name; it still badges. */
     @Test
     fun legBadgeUsesTheOtp1FlatRouteStringWhenThereIsNoShortName() {

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/TripLogBuilderTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/TripLogBuilderTest.kt
@@ -30,6 +30,7 @@ import org.onebusaway.android.directions.model.TripPlace
 import org.onebusaway.android.directions.model.TripStep
 import org.onebusaway.android.directions.model.TripVertexType
 import org.onebusaway.android.time.ServerTime
+import org.onebusaway.android.ui.compose.components.RouteBadge
 import org.onebusaway.android.util.GeoPoint
 
 /**
@@ -287,7 +288,12 @@ class TripLogBuilderTest {
             alight = RouteStopRef("1_700", "700", "Final Dest", alightTo),
             // Keyed by the leg the change happens at — leg 1, the continuation.
             interlineTransitions = mapOf(
-                1 to InterlineTransition("49", "Downtown", RouteStopRef("1_600", "600", "Seam Stop", alightTo))
+                1 to InterlineTransition(
+                    badge = RouteBadge("49", null),
+                    routeDisplayName = "49",
+                    headsign = "Downtown",
+                    stop = RouteStopRef("1_600", "600", "Seam Stop", alightTo)
+                )
             )
         )
 
@@ -310,7 +316,7 @@ class TripLogBuilderTest {
             transit.rideEvents.map {
                 when (it) {
                     is RideEvent.Stop -> "stop:${it.stop.name}"
-                    is RideEvent.Transition -> "transition:${it.transition.routeLabel}"
+                    is RideEvent.Transition -> "transition:${it.transition.badge?.shortName}"
                 }
             }
         )

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/TripLogRowsTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/TripLogRowsTest.kt
@@ -22,6 +22,7 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.onebusaway.android.time.ServerTime
+import org.onebusaway.android.ui.compose.components.RouteBadge
 import org.onebusaway.android.ui.compose.components.RouteLineColors
 
 /**
@@ -52,7 +53,12 @@ class TripLogRowsTest {
         )
     )
 
-    private val seam = InterlineTransition("49", "Downtown", RouteStopRef("1_600", "600", "Seam Stop", null))
+    private val seam = InterlineTransition(
+        badge = RouteBadge("49", null),
+        routeDisplayName = "49",
+        headsign = "Downtown",
+        stop = RouteStopRef("1_600", "600", "Seam Stop", null)
+    )
 
     private fun transit(events: List<RideEvent>) = TripLogEntry.Transit(
         routeShortName = "8",
@@ -105,7 +111,7 @@ class TripLogRowsTest {
             )
         )
 
-        // Collapsed: the stops hide, but the "stay on board — it becomes route 49" instruction does not.
+        // Collapsed: the stops hide, but the "stay on board for the 49" instruction does not.
         assertEquals(
             listOf("BoardHeader", "Transition", "ExitNode"),
             flatten(listOf(chain)).kinds()


### PR DESCRIPTION
Fixes #2071.

An interlined ride — one vehicle that changes route under the rider — was badged in the directions drawer's board row as the whole ride's chevron roundel, `67 > 65`. That promised the 65 several stops before the vehicle became one, while the row that actually tells the rider about the change sat further down the rail with no badge at all.

The drawer has a row per segment, so it now names each route where the rider reaches it:

- the **board header** badges only the route boarded;
- the **stay-aboard seam row** is laid out as the next segment's board row — roundel, fuller name, headsign — followed by the instruction and the seam stop:

```
[67]  Rainier Beach                 ← board header
      Get on  3rd Ave & Pine St
      …
[65]  Interlaken Park               ← seam row
      Stay on board
      At Mount Baker Transit Center
```

The **itinerary option card** at the top still shows the joined `67 > 65` roundel — it has one line to stand for the whole ride, which is why #2049 put the seam in the badge there in the first place.

### Changes

- `InterlineTransition` carries the new route's `badge` + `routeDisplayName` instead of a prose `routeLabel`. The badge comes from a new `TripLeg.shortNameBadge()`, the short-name-only rule the board row's roundel has always used — so a route publishing no short name (Washington State Ferries' "Seattle - Bremerton") draws no roundel in either row and leads with its long name, exactly as before. `Interlines.transitionRouteLabel` is gone.
- `BoardContent` takes the joined roundel only when it is the *interchangeable* kind (`isInterchangeable` rather than `isJoined`), so a chevron badge no longer reaches the header. The repository still builds it via the shared `rideBadge` — that is where the two badge forms are held apart, invariant check and all.
- The instruction line drops the route name it no longer has to carry ("Stay on board"); the existing unknown-route wording stays for a seam with nothing at all to name. The retired `%1$s` string had no translations, so no locale files change.
- The board and seam rows now share one `SegmentIdentity` composable, with the roundel as a slot (a board row may draw the joined, outlined chip; a seam always draws the plain one).
- The seam node's glyph is its own `ic_arrow_downward` vector. It used to borrow `ic_continue`, the walk maneuver's *up* arrow — right for "keep going straight ahead" on a compass-oriented turn list, wrong on a vertical timeline, where it read as travel back up the rail. `ic_continue` is untouched for the walk steps that still want it.

### Known follow-up

The rail and node colour stay the boarded route's for the whole chain, so the seam's roundel is (say) the 65's red sitting on a rail that is still the 67's blue. Recolouring below the seam means threading a per-segment colour through `flattenLog`'s band/edge logic — a real structural change to `LogRowModel`/`RailSeg` — so it is deliberately not in this PR.

### Testing

- `DirectionRowInterlineBadgeTest` rewritten to actually discriminate the new layout: it anchors on the board stop's bounds and asserts exactly one "12" below it and no "5" below it, so the old joined header would fail it.
- JVM coverage for the drawer's badge rule added to `RouteBadgesTest`; `InterlinesTest` / `TripLogBuilderTest` / `TripLogRowsTest` updated for the new `InterlineTransition` shape.
- `test`, `spotlessCheck` and a `-PwarningsAsErrors=true` compile all clean; verified on a Pixel 7 Pro.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/OneBusAway/codesmith/onebusaway-android/pr/2080"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787968814&installation_model_id=429412&pr_number=2080&repository=OneBusAway%2Fonebusaway-android&return_to=https%3A%2F%2Fgithub.com%2FOneBusAway%2Fonebusaway-android%2Fpull%2F2080&signature=3d2b6a6cadf7d7683d6542c27965c8fc9dea080d40ac7f25debc9802b1f5f096"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->