### PR TITLE
Wrap the route picker's summary line and rule it off from the stats (#2081)

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/OptionCardSummaryTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/OptionCardSummaryTest.kt
@@ -17,11 +17,14 @@ package org.onebusaway.android.ui.tripresults
 
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.width
+import androidx.test.platform.app.InstrumentationRegistry
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -31,6 +34,7 @@ import org.onebusaway.android.ui.compose.components.RouteBadge
 import org.onebusaway.android.ui.compose.components.RouteBadgeJoin
 import org.onebusaway.android.ui.compose.createUnconfinedComposeRule
 import org.onebusaway.android.ui.compose.theme.ObaTheme
+import org.onebusaway.android.util.DisplayFormat
 
 /**
  * Layout coverage for an option card's summary line — the row of mode glyphs and route roundels that
@@ -52,6 +56,8 @@ class OptionCardSummaryTest {
     // See createUnconfinedComposeRule for why Unconfined composition is used here (issue #1792).
     @get:Rule
     val composeRule = createUnconfinedComposeRule()
+
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext
 
     @Test
     fun aSummaryTooWideForTheCardWrapsOntoAnotherLine() {
@@ -84,6 +90,34 @@ class OptionCardSummaryTest {
         assertTrue(
             "expected the one-leg card to be narrower: ${short.width} vs ${long.width}",
             short.width < long.width
+        )
+    }
+
+    /**
+     * The point of the wrap being bounded: a card whose summary took two lines used to push its own
+     * stats a line below its neighbours', so the row could not be read across.
+     *
+     * The two options are given identical stats, so the only thing that differs is how many lines their
+     * summaries take — and so that no category is won by one card alone, since a winner's outline insets
+     * its own value by a padding that has nothing to do with what is under test here.
+     */
+    @Test
+    fun everyCardsStatsStartAtTheSameHeight() {
+        show(
+            option(bus("Q1")),
+            option(walk(), bus("R1"), walk(), bus("R2"), walk(), bus("R3"), walk())
+        )
+
+        val durations = composeRule.onAllNodesWithText(
+            DisplayFormat.formatEtaParts(context, DURATION_MINUTES).joinToString(separator = "") { it.text },
+            useUnmergedTree = true
+        )
+        durations.assertCountEquals(2)
+
+        assertEquals(
+            "expected both cards' durations on the same line",
+            durations[0].getUnclippedBoundsInRoot().top,
+            durations[1].getUnclippedBoundsInRoot().top
         )
     }
 
@@ -123,9 +157,9 @@ class OptionCardSummaryTest {
 
     private fun option(vararg symbols: ModeSymbol) = ItineraryOption(
         symbols = symbols.toList(),
-        durationMinutes = 30,
+        durationMinutes = DURATION_MINUTES,
         startTime = ServerTime(0L),
-        endTime = ServerTime(30 * 60_000L),
+        endTime = ServerTime(DURATION_MINUTES * 60_000L),
         walkDistanceMeters = 400.0
     )
 
@@ -153,6 +187,9 @@ class OptionCardSummaryTest {
     /** The whole card holding [name]: `clickable` merges the card's descendants into one node. */
     private fun card(name: String) = composeRule.onNodeWithText(name).getUnclippedBoundsInRoot()
 }
+
+/** Every fixture option runs the same length, so no card wins a category its neighbour doesn't. */
+private const val DURATION_MINUTES = 30L
 
 /** Pinned so text measurement — and so where the summary wraps — is the same on every screen. */
 private const val DENSITY = 2f

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/OptionCardSummaryTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/OptionCardSummaryTest.kt
@@ -1,0 +1,161 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.tripresults
+
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.width
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.onebusaway.android.time.ServerTime
+import org.onebusaway.android.ui.compose.components.RouteBadge
+import org.onebusaway.android.ui.compose.components.RouteBadgeJoin
+import org.onebusaway.android.ui.compose.createUnconfinedComposeRule
+import org.onebusaway.android.ui.compose.theme.ObaTheme
+
+/**
+ * Layout coverage for an option card's summary line — the row of mode glyphs and route roundels that
+ * says what the trip is (#2081):
+ *  - a trip with too many legs to fit the card's width **wraps** rather than drawing one long card that
+ *    pushes every other option off the picker;
+ *  - the wrap is a ceiling, not a floor: a short trip still gets a card sized to itself (the keyline
+ *    under the summary spans the card, and a `fillMaxWidth` one would otherwise blow every card out to
+ *    the same width under the picker's horizontal scroll);
+ *  - and a badge that is *itself* wider than the wrap — several interchangeable routes on one ride —
+ *    keeps every route it names, instead of being measured into the space that's left and losing its
+ *    last segments to a zero width.
+ *
+ * A layout test, so it runs on-device against real text measurement, with the density pinned so the
+ * numbers don't depend on the screen it lands on.
+ */
+class OptionCardSummaryTest {
+
+    // See createUnconfinedComposeRule for why Unconfined composition is used here (issue #1792).
+    @get:Rule
+    val composeRule = createUnconfinedComposeRule()
+
+    @Test
+    fun aSummaryTooWideForTheCardWrapsOntoAnotherLine() {
+        show(option(walk(), bus("R1"), walk(), bus("R2"), walk(), bus("R3"), walk()))
+
+        val first = symbol("R1")
+        val last = symbol("R3")
+
+        assertTrue(
+            "expected the summary to wrap: R1 at $first, R3 at $last",
+            last.top >= first.bottom
+        )
+        // And to wrap where the width genuinely runs out, not a symbol early. The card takes its width
+        // from what the summary reports it needs; if measuring it again at that width broke the lines
+        // anywhere else, the card would carry an extra line and a strip of dead space (see [SymbolFlow]
+        // on stable packing).
+        assertEquals("expected R2 to still share R1's line", first.top, symbol("R2").top)
+    }
+
+    @Test
+    fun aShortSummaryKeepsItsCardNarrowerThanALongOne() {
+        show(
+            option(bus("Q1")),
+            option(walk(), bus("R1"), walk(), bus("R2"), walk(), bus("R3"), walk())
+        )
+
+        val short = card("Q1")
+        val long = card("R1")
+
+        assertTrue(
+            "expected the one-leg card to be narrower: ${short.width} vs ${long.width}",
+            short.width < long.width
+        )
+    }
+
+    /**
+     * The names are all three digits, so any two segments of the badge that were measured the same come
+     * out the same width — which makes an unequal one exactly the failure this guards: a segment that
+     * was handed what width was left over rather than the width it asked for.
+     */
+    @Test
+    fun anOversizedBadgeKeepsEveryRouteItNames() {
+        val names = listOf("111", "112", "113", "114", "115", "116")
+        show(option(walk(), interchangeable(names), walk()))
+
+        val segments = names.map { symbol(it) }
+
+        assertTrue(
+            "expected every route to be drawn, but the segments were ${segments.map { it.width }}",
+            segments.all { it.width > 0.dp }
+        )
+        val widest = segments.maxOf { it.width }
+        val narrowest = segments.minOf { it.width }
+        assertTrue(
+            "expected equal-width segments, but they ran $narrowest–$widest",
+            widest - narrowest <= SEGMENT_WIDTH_TOLERANCE
+        )
+    }
+
+    // ---- fixtures -------------------------------------------------------------------------------
+
+    private fun walk() = ModeSymbol.Street(StreetMode.WALK)
+
+    private fun bus(name: String) = interchangeable(listOf(name))
+
+    private fun interchangeable(names: List<String>) = ModeSymbol.Transit(
+        LegBadge(names.map { RouteBadge(it, routeColor = null) }, TransitMode.BUS, RouteBadgeJoin.ANY_OF)
+    )
+
+    private fun option(vararg symbols: ModeSymbol) = ItineraryOption(
+        symbols = symbols.toList(),
+        durationMinutes = 30,
+        startTime = ServerTime(0L),
+        endTime = ServerTime(30 * 60_000L),
+        walkDistanceMeters = 400.0
+    )
+
+    private fun show(vararg options: ItineraryOption) {
+        composeRule.setContent {
+            CompositionLocalProvider(LocalDensity provides Density(DENSITY)) {
+                ObaTheme {
+                    TripResultsHeader(
+                        TripResultsUiState.Success(
+                            options = options.toList(),
+                            selectedIndex = 0,
+                            directions = emptyList()
+                        ),
+                        onSelectOption = {}
+                    )
+                }
+            }
+        }
+        composeRule.waitForIdle()
+    }
+
+    /** One route name inside a card — the unmerged tree, since the card itself merges its symbols. */
+    private fun symbol(name: String) = composeRule.onNodeWithText(name, useUnmergedTree = true).getUnclippedBoundsInRoot()
+
+    /** The whole card holding [name]: `clickable` merges the card's descendants into one node. */
+    private fun card(name: String) = composeRule.onNodeWithText(name).getUnclippedBoundsInRoot()
+}
+
+/** Pinned so text measurement — and so where the summary wraps — is the same on every screen. */
+private const val DENSITY = 2f
+
+/** Room for the odd rounding of a segment's width to a whole pixel, and nothing more. */
+private val SEGMENT_WIDTH_TOLERANCE = 1.dp

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/OptionCardSummaryTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/OptionCardSummaryTest.kt
@@ -37,9 +37,9 @@ import org.onebusaway.android.ui.compose.theme.ObaTheme
  * says what the trip is (#2081):
  *  - a trip with too many legs to fit the card's width **wraps** rather than drawing one long card that
  *    pushes every other option off the picker;
- *  - the wrap is a ceiling, not a floor: a short trip still gets a card sized to itself (the keyline
- *    under the summary spans the card, and a `fillMaxWidth` one would otherwise blow every card out to
- *    the same width under the picker's horizontal scroll);
+ *  - the wrap is a ceiling, not a floor: a short trip still gets a card sized to itself (the summary's
+ *    tinted band fills the card, and a `fillMaxWidth` that measured against the picker's unbounded
+ *    horizontal scroll would otherwise blow every card out to the same width);
  *  - and a badge that is *itself* wider than the wrap — several interchangeable routes on one ride —
  *    keeps every route it names, instead of being measured into the space that's left and losing its
  *    last segments to a zero width.

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
@@ -224,8 +224,9 @@ private val OPTION_CARD_MAX_WIDTH = 200.dp
 
 /**
  * The padding around each of the card's two sections. Applied per section rather than to the card, so
- * the keyline between them can span the card edge to edge — which also means the gap either side of that
- * keyline is twice this. One value, so the two sections' content cannot drift out of alignment.
+ * the summary's band can be filled edge to edge — the padding is inside the tint, which is what makes it
+ * read as a header rather than as a stripe behind some glyphs. One value, so the two sections' content
+ * cannot drift out of alignment.
  */
 private val CARD_PADDING_HORIZONTAL = 12.dp
 private val CARD_PADDING_VERTICAL = 8.dp
@@ -236,12 +237,21 @@ private val CARD_SECTION_PADDING =
 private val SUMMARY_WRAP_WIDTH = OPTION_CARD_MAX_WIDTH - CARD_PADDING_HORIZONTAL * 2
 
 /**
- * The keyline separating a card's summary line from its stats (#2081). Faded from the card's *own*
- * content colour for the same reason [SymbolSeparator] is: the card is tinted, and differently again
- * when selected, so a theme grey lands on it as an off-hue smudge. Quiet enough to divide the two halves
- * without drawing a box around either.
+ * How far the summary's band is tinted off the card behind it, to set the trip itself on its own surface
+ * above the stats (#2081).
+ *
+ * A veil of the card's *own* content colour rather than a second background colour, for the reason
+ * [SymbolSeparator] is faded the same way: the card is tinted, and differently again when selected, so a
+ * theme surface token lands on one of those two states as an off-hue patch — and the selected card's
+ * `secondaryContainer` has no "one step up" token to reach for at all. Veiling toward the content colour
+ * moves both states the way Material's own container ramp moves: darker on a light theme, lighter on a
+ * dark one.
+ *
+ * Set a little above one step of that ramp (which is ~0.03–0.05 here), since this band has to do on its
+ * own the separating a rule between the sections would otherwise share. This is the knob to turn if the
+ * header reads too loud or too faint.
  */
-private const val CARD_DIVIDER_ALPHA = 0.2f
+private const val CARD_HEADER_TINT_ALPHA = 0.06f
 
 /**
  * The chevron between two of a card's mode symbols, and the gap on either side of it. Deliberately
@@ -318,10 +328,10 @@ private fun OptionCard(
                 }
             }
     ) {
-        // Sized to the widest thing on it, so the summary's keyline has a card width to span: under the
-        // picker's horizontal scroll the incoming width is unbounded, where a `fillMaxWidth` divider
-        // measures to nothing. The intrinsic pass asks the summary how wide it lands *after* wrapping,
-        // which is stable — see [SymbolFlow].
+        // Sized to the widest thing on it, so the summary's band has a card width to fill: under the
+        // picker's horizontal scroll the incoming width is unbounded, where `fillMaxWidth` measures to
+        // nothing. The intrinsic pass asks the summary how wide it lands *after* wrapping — see
+        // [SymbolFlow].
         Column(Modifier.width(IntrinsicSize.Max)) {
             // The trip in travel order, as one symbol sequence: a glyph per on-street leg and a roundel
             // per ride, chevron-separated (#2047). The gap between symbols is deliberately wide, so
@@ -335,12 +345,15 @@ private fun OptionCard(
             val drawn = remember(option.symbols) {
                 option.symbols.filter { it !is ModeSymbol.Street || streetModeIcon(it.mode) != null }
             }
-            // A trip with nothing drawable to say (see above) gets no summary at all — a lone keyline
-            // over an empty strip would be worse than the card simply starting at its stats.
+            // A trip with nothing drawable to say (see above) gets no summary at all — an empty tinted
+            // strip would be worse than the card simply starting at its stats.
             if (drawn.isNotEmpty()) {
                 SymbolFlow(
                     wrapAt = SUMMARY_WRAP_WIDTH,
-                    modifier = Modifier.padding(CARD_SECTION_PADDING)
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(LocalContentColor.current.copy(alpha = CARD_HEADER_TINT_ALPHA))
+                        .padding(CARD_SECTION_PADDING)
                 ) {
                     drawn.forEachIndexed { index, symbol ->
                         // A symbol travels with the chevron that follows it, as one unbreakable unit:
@@ -355,7 +368,6 @@ private fun OptionCard(
                         }
                     }
                 }
-                HorizontalDivider(color = LocalContentColor.current.copy(alpha = CARD_DIVIDER_ALPHA))
             }
             StatsColumn(option, winners)
         }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
@@ -76,8 +76,13 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.clipRect
+import androidx.compose.ui.layout.IntrinsicMeasurable
+import androidx.compose.ui.layout.IntrinsicMeasureScope
 import androidx.compose.ui.layout.Layout
-import androidx.compose.ui.layout.Placeable
+import androidx.compose.ui.layout.Measurable
+import androidx.compose.ui.layout.MeasurePolicy
+import androidx.compose.ui.layout.MeasureResult
+import androidx.compose.ui.layout.MeasureScope
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLocale
@@ -210,17 +215,25 @@ private val OPTION_BADGE_MAX_WIDTH = 110.dp
  * costs more than a card two lines tall. Chosen to keep the *next* card in view on a narrow (320dp)
  * screen; tune here.
  *
- * A ceiling on the *wrap*, not a clip: see [SymbolFlow] for the one case a card still exceeds it.
+ * It governs the **summary line**, which is what makes a card wide, and it governs where that line
+ * *breaks* rather than clipping it. So it is not quite a maximum on the card: the card still exceeds it
+ * for a single symbol too wide to break (see [SymbolFlow]), and it says nothing about the stats below,
+ * which are short enough not to need it.
  */
 private val OPTION_CARD_MAX_WIDTH = 200.dp
 
-/** The card's own padding — named because [OPTION_CARD_MAX_WIDTH] has to be net of it to bite. */
+/**
+ * The padding around each of the card's two sections. Applied per section rather than to the card, so
+ * the keyline between them can span the card edge to edge — which also means the gap either side of that
+ * keyline is twice this. One value, so the two sections' content cannot drift out of alignment.
+ */
 private val CARD_PADDING_HORIZONTAL = 12.dp
 private val CARD_PADDING_VERTICAL = 8.dp
+private val CARD_SECTION_PADDING =
+    PaddingValues(horizontal = CARD_PADDING_HORIZONTAL, vertical = CARD_PADDING_VERTICAL)
 
-/** The gap between two wrapped lines of the summary — matched to [SYMBOL_GAP] so the wrap reads as one
- *  evenly-spaced field of symbols rather than as two stacked rows. */
-private val SYMBOL_LINE_GAP = 4.dp
+/** Where the summary line breaks: the card's width, net of the padding it is drawn inside. */
+private val SUMMARY_WRAP_WIDTH = OPTION_CARD_MAX_WIDTH - CARD_PADDING_HORIZONTAL * 2
 
 /**
  * The keyline separating a card's summary line from its stats (#2081). Faded from the card's *own*
@@ -261,6 +274,10 @@ private const val SYMBOL_SEPARATOR_ALPHA = 0.6f
 
 private val SYMBOL_GAP = 4.dp
 
+/** The gap between two wrapped lines of the summary — [SYMBOL_GAP] itself, so the wrap reads as one
+ *  evenly-spaced field of symbols rather than as two stacked rows, and stays so if that gap is retuned. */
+private val SYMBOL_LINE_GAP = SYMBOL_GAP
+
 /** A quiet keyline around a winning metric: enough separation to survive the selected card's tint. */
 private val WINNER_OUTLINE_WIDTH = 1.5.dp
 private val WINNER_OUTLINE_RADIUS = 4.dp
@@ -279,16 +296,11 @@ private fun OptionCard(
     val textColor = colorResource(
         if (selected) R.color.trip_plan_header_text_selected else R.color.trip_plan_header_text
     )
-    val winnerOutlineColor = MaterialTheme.colorScheme.outline.copy(alpha = WINNER_OUTLINE_ALPHA)
-    val shortestTravelTime = WinnerCategory.SHORTEST_TRAVEL_TIME in winners
-    val leastWalking = WinnerCategory.LEAST_WALKING in winners
-    val earliestArrival = WinnerCategory.EARLIEST_ARRIVAL in winners
-    val latestDeparture = WinnerCategory.LATEST_DEPARTURE in winners
     val winnerDescriptions = buildList {
-        if (shortestTravelTime) add(stringResource(R.string.trip_plan_winner_shortest_travel_time))
-        if (leastWalking) add(stringResource(R.string.trip_plan_winner_least_walking))
-        if (earliestArrival) add(stringResource(R.string.trip_plan_winner_earliest_arrival))
-        if (latestDeparture) add(stringResource(R.string.trip_plan_winner_latest_departure))
+        if (WinnerCategory.SHORTEST_TRAVEL_TIME in winners) add(stringResource(R.string.trip_plan_winner_shortest_travel_time))
+        if (WinnerCategory.LEAST_WALKING in winners) add(stringResource(R.string.trip_plan_winner_least_walking))
+        if (WinnerCategory.EARLIEST_ARRIVAL in winners) add(stringResource(R.string.trip_plan_winner_earliest_arrival))
+        if (WinnerCategory.LATEST_DEPARTURE in winners) add(stringResource(R.string.trip_plan_winner_latest_departure))
     }
     Surface(
         color = background,
@@ -327,13 +339,8 @@ private fun OptionCard(
             // over an empty strip would be worse than the card simply starting at its stats.
             if (drawn.isNotEmpty()) {
                 SymbolFlow(
-                    wrapAt = OPTION_CARD_MAX_WIDTH - CARD_PADDING_HORIZONTAL * 2,
-                    horizontalGap = SYMBOL_GAP,
-                    verticalGap = SYMBOL_LINE_GAP,
-                    modifier = Modifier.padding(
-                        horizontal = CARD_PADDING_HORIZONTAL,
-                        vertical = CARD_PADDING_VERTICAL
-                    )
+                    wrapAt = SUMMARY_WRAP_WIDTH,
+                    modifier = Modifier.padding(CARD_SECTION_PADDING)
                 ) {
                     drawn.forEachIndexed { index, symbol ->
                         // A symbol travels with the chevron that follows it, as one unbreakable unit:
@@ -350,14 +357,7 @@ private fun OptionCard(
                 }
                 HorizontalDivider(color = LocalContentColor.current.copy(alpha = CARD_DIVIDER_ALPHA))
             }
-            StatsColumn(
-                option = option,
-                shortestTravelTime = shortestTravelTime,
-                leastWalking = leastWalking,
-                earliestArrival = earliestArrival,
-                latestDeparture = latestDeparture,
-                winnerOutlineColor = winnerOutlineColor
-            )
+            StatsColumn(option, winners)
         }
     }
 }
@@ -374,48 +374,41 @@ private fun OptionCard(
  * lose a route off the end of its own badge. [wrapAt] is therefore where the line *breaks*, not a width
  * the card is cut to.
  *
- * The packing is stable under re-measurement, which is what lets the card take its width from this
- * layout's intrinsic one ([OptionCard]): every line fits inside the width reported here, so packing
- * again at exactly that width breaks the lines in the same places.
+ * The card takes its width from this layout's intrinsic one ([OptionCard]), which [SymbolFlowPolicy]
+ * answers from the same packing the measure pass performs — so the two cannot disagree and leave the
+ * card carrying a line it then refuses to fill.
  */
 @Composable
-private fun SymbolFlow(
-    wrapAt: Dp,
-    horizontalGap: Dp,
-    verticalGap: Dp,
-    modifier: Modifier = Modifier,
-    content: @Composable () -> Unit
-) {
-    Layout(content, modifier) { measurables, constraints ->
-        val gapX = horizontalGap.roundToPx()
-        val gapY = verticalGap.roundToPx()
+private fun SymbolFlow(wrapAt: Dp, modifier: Modifier = Modifier, content: @Composable () -> Unit) {
+    Layout(content, modifier, remember(wrapAt) { SymbolFlowPolicy(wrapAt) })
+}
+
+/**
+ * [SymbolFlow]'s measurement. A policy object rather than a measure lambda so the layout can state its
+ * own **intrinsic** width: the card is sized by asking for it ([OptionCard]), and the default intrinsic
+ * a lambda inherits re-runs the whole measure block at an unbounded width and hopes the answer matches.
+ * Here both paths break the lines with the same [packLines] call, so the width the card takes is the
+ * width this layout then packs into, by construction rather than by argument.
+ */
+private class SymbolFlowPolicy(private val wrapAt: Dp) : MeasurePolicy {
+
+    override fun MeasureScope.measure(measurables: List<Measurable>, constraints: Constraints): MeasureResult {
+        val gapX = SYMBOL_GAP.roundToPx()
+        val gapY = SYMBOL_LINE_GAP.roundToPx()
+        // Measured unbounded — the point of the whole layout, see [SymbolFlow].
+        val placeables = measurables.map { it.measure(Constraints()) }
+        val widths = placeables.map { it.width }
         // Whichever binds first: the line we chose, or a genuinely narrower parent.
-        val limit = minOf(constraints.maxWidth, wrapAt.roundToPx())
-        val lines = mutableListOf<MutableList<Placeable>>()
-        var lineWidth = 0
-        measurables.forEach { measurable ->
-            val placeable = measurable.measure(Constraints())
-            val line = lines.lastOrNull()
-            if (line == null || lineWidth + gapX + placeable.width > limit) {
-                lines += mutableListOf(placeable)
-                lineWidth = placeable.width
-            } else {
-                line += placeable
-                lineWidth += gapX + placeable.width
-            }
-        }
-        val lineHeights = lines.map { line -> line.maxOf { it.height } }
-        val width = constraints.constrainWidth(
-            lines.maxOfOrNull { line -> line.sumOf { it.width } + gapX * (line.size - 1) } ?: 0
-        )
-        val height = constraints.constrainHeight(
-            lineHeights.sum() + gapY * (lines.size - 1).coerceAtLeast(0)
-        )
-        layout(width, height) {
+        val lines = packLines(widths, minOf(constraints.maxWidth, wrapAt.roundToPx()), gapX)
+        val lineHeights = lines.map { line -> line.maxOf { placeables[it].height } }
+        val width = constraints.constrainWidth(lines.maxOfOrNull { lineWidth(widths, it, gapX) } ?: 0)
+        val height = constraints.constrainHeight(lineHeights.sum() + gapY * (lines.size - 1))
+        return layout(width, height) {
             var y = 0
             lines.forEachIndexed { index, line ->
                 var x = 0
-                line.forEach { placeable ->
+                line.forEach {
+                    val placeable = placeables[it]
                     // Centred in its line, as the symbols were in the single row they used to share: a
                     // chevron is half a glyph tall, and belongs level with what it joins.
                     placeable.placeRelative(x, y + (lineHeights[index] - placeable.height) / 2)
@@ -425,7 +418,46 @@ private fun SymbolFlow(
             }
         }
     }
+
+    /** The width [measure] will report when nothing narrower is imposed — the same packing, asked early. */
+    override fun IntrinsicMeasureScope.maxIntrinsicWidth(measurables: List<IntrinsicMeasurable>, height: Int): Int {
+        val gapX = SYMBOL_GAP.roundToPx()
+        val widths = measurables.map { it.maxIntrinsicWidth(Constraints.Infinity) }
+        return packLines(widths, wrapAt.roundToPx(), gapX).maxOfOrNull { lineWidth(widths, it, gapX) } ?: 0
+    }
 }
+
+/**
+ * Greedy line breaking: which symbols land on each line, given their [widths] and the [gap] between two
+ * of them. A symbol wider than [limit] all the same opens — and keeps — a line of its own, which is what
+ * widens the card rather than cutting the symbol down (see [SymbolFlow]).
+ *
+ * Every line comes out no wider than the widest, so packing again at that width breaks the lines in the
+ * same places: a line stopped where the *next* symbol would have passed [limit], and [limit] can only
+ * have shrunk to a width this same line already fitted.
+ */
+private fun packLines(widths: List<Int>, limit: Int, gap: Int): List<IntRange> {
+    val lines = mutableListOf<IntRange>()
+    var start = 0
+    var packed = 0
+    widths.forEachIndexed { index, width ->
+        when {
+            // The first symbol on a line takes it whatever its width — nothing is ever cut to fit.
+            index == start -> packed = width
+            packed + gap + width <= limit -> packed += gap + width
+            else -> {
+                lines += start until index
+                start = index
+                packed = width
+            }
+        }
+    }
+    if (widths.isNotEmpty()) lines += start until widths.size
+    return lines
+}
+
+/** How wide one of [packLines]' lines is: its symbols, plus a [gap] between each neighbouring pair. */
+private fun lineWidth(widths: List<Int>, line: IntRange, gap: Int): Int = line.sumOf { widths[it] } + gap * (line.last - line.first)
 
 /** One symbol of a card's summary line: a bare mode glyph, or the ride's route roundel. */
 @Composable
@@ -459,19 +491,18 @@ private fun ModeSymbolContent(symbol: ModeSymbol) {
     }
 }
 
-/** The lower half of an option card: what the trip costs (duration, walking) and when it runs. */
+/**
+ * The lower half of an option card: what the trip costs (duration, walking) and when it runs, each metric
+ * outlined where it wins its category. Takes the [winners] set itself rather than a flag per category, so
+ * a new [WinnerCategory] is one line here and nothing at the call site.
+ */
 @Composable
-private fun StatsColumn(
-    option: ItineraryOption,
-    shortestTravelTime: Boolean,
-    leastWalking: Boolean,
-    earliestArrival: Boolean,
-    latestDeparture: Boolean,
-    winnerOutlineColor: Color
-) {
+private fun StatsColumn(option: ItineraryOption, winners: Set<WinnerCategory>) {
     val context = LocalContext.current
+    val leastWalking = WinnerCategory.LEAST_WALKING in winners
+    val winnerOutlineColor = MaterialTheme.colorScheme.outline.copy(alpha = WINNER_OUTLINE_ALPHA)
     Column(
-        modifier = Modifier.padding(horizontal = CARD_PADDING_HORIZONTAL, vertical = CARD_PADDING_VERTICAL),
+        modifier = Modifier.padding(CARD_SECTION_PADDING),
         verticalArrangement = Arrangement.spacedBy(4.dp)
     ) {
         // Duration + walk distance read as one stat group, so they sit tighter together than the
@@ -481,7 +512,7 @@ private fun StatsColumn(
             MetricRow(
                 MetricGlyph.DURATION,
                 contentDescription = null,
-                winner = shortestTravelTime,
+                winner = WinnerCategory.SHORTEST_TRAVEL_TIME in winners,
                 outlineColor = winnerOutlineColor
             ) {
                 EtaDurationText(
@@ -514,9 +545,9 @@ private fun StatsColumn(
         val startText = DisplayFormat.formatTime(context, option.startTime.epochMs)
         val endText = DisplayFormat.formatTime(context, option.endTime.epochMs)
         Row(verticalAlignment = Alignment.CenterVertically) {
-            ScheduleMetric(startText, winner = latestDeparture, outlineColor = winnerOutlineColor)
+            ScheduleMetric(startText, winner = WinnerCategory.LATEST_DEPARTURE in winners, outlineColor = winnerOutlineColor)
             Text(" – ", style = MaterialTheme.typography.bodySmall, maxLines = 1)
-            ScheduleMetric(endText, winner = earliestArrival, outlineColor = winnerOutlineColor)
+            ScheduleMetric(endText, winner = WinnerCategory.EARLIEST_ARRIVAL in winners, outlineColor = winnerOutlineColor)
         }
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
@@ -57,12 +57,15 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.Stable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateSetOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -148,6 +151,9 @@ fun TripResultsHeader(
     val winners = remember(success.options, scheduleWinnerMode) {
         itineraryWinnerCategories(success.options, scheduleWinnerMode)
     }
+    // Every card's summary reserves the tallest one's height, so a trip whose summary wraps doesn't push
+    // its own stats a line below its neighbours' and leave the row unreadable across (#2081).
+    val summaryHeights = remember(success.options) { SummaryHeights() }
     // Side-scrollable so options never get squished: each card sizes to its own content (route/lines,
     // duration, walk distance, time) and the row scrolls horizontally when they overflow the width.
     // Flanked by the same overflow chevrons as the ETA strip (ScrollChevronGutter) so the user can see
@@ -186,6 +192,7 @@ fun TripResultsHeader(
                     option = option,
                     winners = winners[index],
                     selected = index == success.selectedIndex,
+                    summaryHeights = summaryHeights,
                     onClick = { onSelectOption(index) }
                 )
             }
@@ -302,11 +309,35 @@ private val WINNER_OUTLINE_WIDTH = 1.5.dp
 private val WINNER_OUTLINE_RADIUS = 4.dp
 private const val WINNER_OUTLINE_ALPHA = 0.60f
 
+/**
+ * The tallest summary band across a picker row's cards, which every card in it then reserves — so the
+ * stats below start at the same y on each card and can be read across the row, whether or not a
+ * particular trip's summary wrapped (#2081).
+ *
+ * Filled in from layout rather than known up front: where a summary wraps depends on measured text, so
+ * the tallest is only knowable once the cards have been measured. The first layout pass reports it and a
+ * second settles every card on the result — [tallest] only ever grows within one set of options, so it
+ * converges rather than oscillating, and the whole holder is re-created when the options change (a new
+ * plan whose summaries all fit on one line must not inherit an old plan's taller band).
+ */
+@Stable
+private class SummaryHeights {
+
+    /** The tallest natural summary height reported so far, in pixels. */
+    var tallest by mutableIntStateOf(0)
+        private set
+
+    fun report(height: Int) {
+        if (height > tallest) tallest = height
+    }
+}
+
 @Composable
 private fun OptionCard(
     option: ItineraryOption,
     winners: Set<WinnerCategory>,
     selected: Boolean,
+    summaryHeights: SummaryHeights,
     onClick: () -> Unit
 ) {
     val background = colorResource(
@@ -359,6 +390,8 @@ private fun OptionCard(
             if (drawn.isNotEmpty()) {
                 SymbolFlow(
                     wrapAt = SUMMARY_WRAP_WIDTH,
+                    minHeight = summaryHeights.tallest,
+                    onNaturalHeight = summaryHeights::report,
                     modifier = Modifier
                         .fillMaxWidth()
                         .background(MaterialTheme.colorScheme.primary.copy(alpha = CARD_HEADER_TINT_ALPHA))
@@ -400,8 +433,17 @@ private fun OptionCard(
  * card carrying a line it then refuses to fill.
  */
 @Composable
-private fun SymbolFlow(wrapAt: Dp, modifier: Modifier = Modifier, content: @Composable () -> Unit) {
-    Layout(content, modifier, remember(wrapAt) { SymbolFlowPolicy(wrapAt) })
+private fun SymbolFlow(
+    wrapAt: Dp,
+    minHeight: Int,
+    onNaturalHeight: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit
+) {
+    // Held through rememberUpdatedState so the reporting callback can be re-created every recomposition
+    // without re-creating the policy — only [wrapAt] and [minHeight] change what this layout does.
+    val report by rememberUpdatedState(onNaturalHeight)
+    Layout(content, modifier, remember(wrapAt, minHeight) { SymbolFlowPolicy(wrapAt, minHeight) { report(it) } })
 }
 
 /**
@@ -411,7 +453,11 @@ private fun SymbolFlow(wrapAt: Dp, modifier: Modifier = Modifier, content: @Comp
  * Here both paths break the lines with the same [packLines] call, so the width the card takes is the
  * width this layout then packs into, by construction rather than by argument.
  */
-private class SymbolFlowPolicy(private val wrapAt: Dp) : MeasurePolicy {
+private class SymbolFlowPolicy(
+    private val wrapAt: Dp,
+    private val minHeight: Int,
+    private val onNaturalHeight: (Int) -> Unit
+) : MeasurePolicy {
 
     override fun MeasureScope.measure(measurables: List<Measurable>, constraints: Constraints): MeasureResult {
         val gapX = SYMBOL_GAP.roundToPx()
@@ -423,8 +469,16 @@ private class SymbolFlowPolicy(private val wrapAt: Dp) : MeasurePolicy {
         val lines = packLines(widths, minOf(constraints.maxWidth, wrapAt.roundToPx()), gapX)
         val lineHeights = lines.map { line -> line.maxOf { placeables[it].height } }
         val width = constraints.constrainWidth(lines.maxOfOrNull { lineWidth(widths, it, gapX) } ?: 0)
-        val height = constraints.constrainHeight(lineHeights.sum() + gapY * (lines.size - 1))
+        // The height these lines want, and the height they are given: a card whose summary wraps to fewer
+        // lines than its neighbours' still reserves theirs, so every card's stats start at the same y.
+        // The lines are laid from the top, so the reserved room falls below them rather than centring
+        // them in it.
+        val natural = lineHeights.sum() + gapY * (lines.size - 1)
+        val height = constraints.constrainHeight(maxOf(natural, minHeight))
         return layout(width, height) {
+            // Reported from placement, not from measure: writing the row's shared state is a change to
+            // someone else's layout, and placement is where that is safe to do.
+            onNaturalHeight(natural)
             var y = 0
             lines.forEachIndexed { index, line ->
                 var x = 0

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
@@ -240,18 +240,27 @@ private val SUMMARY_WRAP_WIDTH = OPTION_CARD_MAX_WIDTH - CARD_PADDING_HORIZONTAL
  * How far the summary's band is tinted off the card behind it, to set the trip itself on its own surface
  * above the stats (#2081).
  *
- * A veil of the card's *own* content colour rather than a second background colour, for the reason
- * [SymbolSeparator] is faded the same way: the card is tinted, and differently again when selected, so a
- * theme surface token lands on one of those two states as an off-hue patch — and the selected card's
- * `secondaryContainer` has no "one step up" token to reach for at all. Veiling toward the content colour
- * moves both states the way Material's own container ramp moves: darker on a light theme, lighter on a
- * dark one.
+ * A veil of the **brand green** (`MaterialTheme.colorScheme.primary`) rather than a neutral step up the
+ * container ramp: the band is the app's colour showing through the card, not a second grey. `primary` is
+ * the token to veil with because it flips ends between the themes exactly as the ramp does — a deep green
+ * over a light card darkens it, a pale green over a dark card lightens it — so one alpha serves both, and
+ * a white-label brand re-tints these headers by overriding the one colour it already overrides.
  *
- * Set a little above one step of that ramp (which is ~0.03–0.05 here), since this band has to do on its
- * own the separating a rule between the sections would otherwise share. This is the knob to turn if the
- * header reads too loud or too faint.
+ * The value is chosen to land the same lightness step the neutral veil it replaced did (−7.4 on a light
+ * card, +9.0 on a dark one, in CIE L*), so this changed the hue and not the weight; it holds within about
+ * one unit of that across all four card states. That weight is itself set well above one step of the
+ * container ramp (~0.03–0.05 here), since the band does on its own the separating a rule between the
+ * sections would otherwise share — at a single step the two halves of the card barely read as two.
+ *
+ * Tried louder, too: a band inverted into the dark range (the card's own opposite, carrying light
+ * glyphs) reads as a slab in a picker of small cards, at any strength. The header stays light and merely
+ * offset; this is the knob for how far.
+ *
+ * Note the selected card is *already* green ([R.color.trip_plan_card_background_selected]), so on that
+ * one the veil reads as darkening rather than as a hue change — which is what keeps a selected card
+ * looking like the same object as its neighbours rather than a differently-tinted one.
  */
-private const val CARD_HEADER_TINT_ALPHA = 0.06f
+private const val CARD_HEADER_TINT_ALPHA = 0.13f
 
 /**
  * The chevron between two of a card's mode symbols, and the gap on either side of it. Deliberately
@@ -352,7 +361,7 @@ private fun OptionCard(
                     wrapAt = SUMMARY_WRAP_WIDTH,
                     modifier = Modifier
                         .fillMaxWidth()
-                        .background(LocalContentColor.current.copy(alpha = CARD_HEADER_TINT_ALPHA))
+                        .background(MaterialTheme.colorScheme.primary.copy(alpha = CARD_HEADER_TINT_ALPHA))
                         .padding(CARD_SECTION_PADDING)
                 ) {
                     drawn.forEachIndexed { index, symbol ->

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
@@ -75,6 +76,8 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.clipRect
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.layout.Placeable
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLocale
@@ -88,9 +91,12 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.constrainHeight
+import androidx.compose.ui.unit.constrainWidth
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -198,6 +204,33 @@ fun TripResultsHeader(
 private val OPTION_BADGE_MAX_WIDTH = 110.dp
 
 /**
+ * How wide an option card is allowed to grow before its summary line wraps onto another line (#2081).
+ * Without it a four-leg trip drew one long card that pushed every other option off the row — the picker
+ * scrolls, but the rider can only compare what is on screen at once, so a card that runs off the edge
+ * costs more than a card two lines tall. Chosen to keep the *next* card in view on a narrow (320dp)
+ * screen; tune here.
+ *
+ * A ceiling on the *wrap*, not a clip: see [SymbolFlow] for the one case a card still exceeds it.
+ */
+private val OPTION_CARD_MAX_WIDTH = 200.dp
+
+/** The card's own padding — named because [OPTION_CARD_MAX_WIDTH] has to be net of it to bite. */
+private val CARD_PADDING_HORIZONTAL = 12.dp
+private val CARD_PADDING_VERTICAL = 8.dp
+
+/** The gap between two wrapped lines of the summary — matched to [SYMBOL_GAP] so the wrap reads as one
+ *  evenly-spaced field of symbols rather than as two stacked rows. */
+private val SYMBOL_LINE_GAP = 4.dp
+
+/**
+ * The keyline separating a card's summary line from its stats (#2081). Faded from the card's *own*
+ * content colour for the same reason [SymbolSeparator] is: the card is tinted, and differently again
+ * when selected, so a theme grey lands on it as an off-hue smudge. Quiet enough to divide the two halves
+ * without drawing a box around either.
+ */
+private const val CARD_DIVIDER_ALPHA = 0.2f
+
+/**
  * The chevron between two of a card's mode symbols, and the gap on either side of it. Deliberately
  * small and quiet: it is punctuation saying "then", not a step of the trip, so it must not compete
  * with the glyphs and roundels it joins — hence a height well under [ModeGlyph]'s 20dp and a faded
@@ -246,7 +279,6 @@ private fun OptionCard(
     val textColor = colorResource(
         if (selected) R.color.trip_plan_header_text_selected else R.color.trip_plan_header_text
     )
-    val context = LocalContext.current
     val winnerOutlineColor = MaterialTheme.colorScheme.outline.copy(alpha = WINNER_OUTLINE_ALPHA)
     val shortestTravelTime = WinnerCategory.SHORTEST_TRAVEL_TIME in winners
     val leastWalking = WinnerCategory.LEAST_WALKING in winners
@@ -263,6 +295,8 @@ private fun OptionCard(
         contentColor = textColor,
         shape = MaterialTheme.shapes.small,
         // Wrap to the content width (a sensible floor so short options aren't tiny); the row scrolls.
+        // The ceiling is the summary line's own — it wraps at [OPTION_CARD_MAX_WIDTH] rather than the
+        // card being cut to it (see [SymbolFlow]).
         modifier = Modifier
             .widthIn(min = 104.dp)
             .clickable(onClick = onClick)
@@ -272,10 +306,11 @@ private fun OptionCard(
                 }
             }
     ) {
-        Column(
-            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
-            verticalArrangement = Arrangement.spacedBy(4.dp)
-        ) {
+        // Sized to the widest thing on it, so the summary's keyline has a card width to span: under the
+        // picker's horizontal scroll the incoming width is unbounded, where a `fillMaxWidth` divider
+        // measures to nothing. The intrinsic pass asks the summary how wide it lands *after* wrapping,
+        // which is stable — see [SymbolFlow].
+        Column(Modifier.width(IntrinsicSize.Max)) {
             // The trip in travel order, as one symbol sequence: a glyph per on-street leg and a roundel
             // per ride, chevron-separated (#2047). The gap between symbols is deliberately wide, so
             // "two legs" and "one leg, two interchangeable routes" (which is one seamless chip) can't
@@ -288,86 +323,200 @@ private fun OptionCard(
             val drawn = remember(option.symbols) {
                 option.symbols.filter { it !is ModeSymbol.Street || streetModeIcon(it.mode) != null }
             }
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(SYMBOL_GAP),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                drawn.forEachIndexed { index, symbol ->
-                    if (index > 0) SymbolSeparator()
-                    when (symbol) {
-                        // A glyph alone — there is nothing to name about a walk.
-                        is ModeSymbol.Street -> streetModeIcon(symbol.mode)?.let { glyph ->
-                            ModeGlyph(glyph, stringResource(streetModeLabel(symbol.mode)))
-                        }
-                        // Every badge leads with the mode it's ridden on, which a route number never says
-                        // on its own. A route publishing no short name badges its long name, capped to
-                        // [OPTION_BADGE_MAX_WIDTH] and ellipsized so one wordy name can't crowd the
-                        // other legs off the card; only a route that names itself in no way at all is
-                        // left with the bare glyph.
-                        is ModeSymbol.Transit -> {
-                            val badge = symbol.badge
-                            val glyph = transitModeIcon(badge.mode)
-                            val glyphLabel = stringResource(transitModeLabel(badge.mode))
-                            if (badge.isUnnamed) {
-                                ModeGlyph(glyph, glyphLabel)
-                            } else {
-                                RouteBadgeChip(
-                                    badge.routes,
-                                    scale = SYMBOL_BADGE_SCALE,
-                                    maxWidth = OPTION_BADGE_MAX_WIDTH,
-                                    join = badge.join,
-                                    leadingIcon = glyph,
-                                    leadingIconDescription = glyphLabel
-                                )
-                            }
+            // A trip with nothing drawable to say (see above) gets no summary at all — a lone keyline
+            // over an empty strip would be worse than the card simply starting at its stats.
+            if (drawn.isNotEmpty()) {
+                SymbolFlow(
+                    wrapAt = OPTION_CARD_MAX_WIDTH - CARD_PADDING_HORIZONTAL * 2,
+                    horizontalGap = SYMBOL_GAP,
+                    verticalGap = SYMBOL_LINE_GAP,
+                    modifier = Modifier.padding(
+                        horizontal = CARD_PADDING_HORIZONTAL,
+                        vertical = CARD_PADDING_VERTICAL
+                    )
+                ) {
+                    drawn.forEachIndexed { index, symbol ->
+                        // A symbol travels with the chevron that follows it, as one unbreakable unit:
+                        // the wrap then never opens a line with a chevron pointing at the symbol above
+                        // it, and a broken line ends on the "and then" that carries the eye down.
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(SYMBOL_GAP),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            ModeSymbolContent(symbol)
+                            if (index < drawn.lastIndex) SymbolSeparator()
                         }
                     }
                 }
+                HorizontalDivider(color = LocalContentColor.current.copy(alpha = CARD_DIVIDER_ALPHA))
             }
-            // Duration + walk distance read as one stat group, so they sit tighter together than the
-            // card's other lines.
-            Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
-                // Duration — a leading hourglass + the ETA-pill-formatted trip length.
+            StatsColumn(
+                option = option,
+                shortestTravelTime = shortestTravelTime,
+                leastWalking = leastWalking,
+                earliestArrival = earliestArrival,
+                latestDeparture = latestDeparture,
+                winnerOutlineColor = winnerOutlineColor
+            )
+        }
+    }
+}
+
+/**
+ * The summary line's layout: its symbols packed left to right, wrapping onto the next line as soon as
+ * the following one would carry the line past [wrapAt] (#2081).
+ *
+ * Not a `FlowRow`, for one reason: every child here is measured **unbounded**, so a symbol that is by
+ * itself wider than [wrapAt] takes a line of its own and widens the card rather than being measured into
+ * whatever width is left. That case is real — a badge joining several interchangeable routes is
+ * deliberately uncapped (see [RouteBadgeChip]) — and the alternative is the failure that badge exists to
+ * avoid: a `Row` handed too little width measures its later segments at zero, so the ride would quietly
+ * lose a route off the end of its own badge. [wrapAt] is therefore where the line *breaks*, not a width
+ * the card is cut to.
+ *
+ * The packing is stable under re-measurement, which is what lets the card take its width from this
+ * layout's intrinsic one ([OptionCard]): every line fits inside the width reported here, so packing
+ * again at exactly that width breaks the lines in the same places.
+ */
+@Composable
+private fun SymbolFlow(
+    wrapAt: Dp,
+    horizontalGap: Dp,
+    verticalGap: Dp,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit
+) {
+    Layout(content, modifier) { measurables, constraints ->
+        val gapX = horizontalGap.roundToPx()
+        val gapY = verticalGap.roundToPx()
+        // Whichever binds first: the line we chose, or a genuinely narrower parent.
+        val limit = minOf(constraints.maxWidth, wrapAt.roundToPx())
+        val lines = mutableListOf<MutableList<Placeable>>()
+        var lineWidth = 0
+        measurables.forEach { measurable ->
+            val placeable = measurable.measure(Constraints())
+            val line = lines.lastOrNull()
+            if (line == null || lineWidth + gapX + placeable.width > limit) {
+                lines += mutableListOf(placeable)
+                lineWidth = placeable.width
+            } else {
+                line += placeable
+                lineWidth += gapX + placeable.width
+            }
+        }
+        val lineHeights = lines.map { line -> line.maxOf { it.height } }
+        val width = constraints.constrainWidth(
+            lines.maxOfOrNull { line -> line.sumOf { it.width } + gapX * (line.size - 1) } ?: 0
+        )
+        val height = constraints.constrainHeight(
+            lineHeights.sum() + gapY * (lines.size - 1).coerceAtLeast(0)
+        )
+        layout(width, height) {
+            var y = 0
+            lines.forEachIndexed { index, line ->
+                var x = 0
+                line.forEach { placeable ->
+                    // Centred in its line, as the symbols were in the single row they used to share: a
+                    // chevron is half a glyph tall, and belongs level with what it joins.
+                    placeable.placeRelative(x, y + (lineHeights[index] - placeable.height) / 2)
+                    x += placeable.width + gapX
+                }
+                y += lineHeights[index] + gapY
+            }
+        }
+    }
+}
+
+/** One symbol of a card's summary line: a bare mode glyph, or the ride's route roundel. */
+@Composable
+private fun ModeSymbolContent(symbol: ModeSymbol) {
+    when (symbol) {
+        // A glyph alone — there is nothing to name about a walk.
+        is ModeSymbol.Street -> streetModeIcon(symbol.mode)?.let { glyph ->
+            ModeGlyph(glyph, stringResource(streetModeLabel(symbol.mode)))
+        }
+        // Every badge leads with the mode it's ridden on, which a route number never says on its own. A
+        // route publishing no short name badges its long name, capped to [OPTION_BADGE_MAX_WIDTH] and
+        // ellipsized so one wordy name can't crowd the other legs off the card; only a route that names
+        // itself in no way at all is left with the bare glyph.
+        is ModeSymbol.Transit -> {
+            val badge = symbol.badge
+            val glyph = transitModeIcon(badge.mode)
+            val glyphLabel = stringResource(transitModeLabel(badge.mode))
+            if (badge.isUnnamed) {
+                ModeGlyph(glyph, glyphLabel)
+            } else {
+                RouteBadgeChip(
+                    badge.routes,
+                    scale = SYMBOL_BADGE_SCALE,
+                    maxWidth = OPTION_BADGE_MAX_WIDTH,
+                    join = badge.join,
+                    leadingIcon = glyph,
+                    leadingIconDescription = glyphLabel
+                )
+            }
+        }
+    }
+}
+
+/** The lower half of an option card: what the trip costs (duration, walking) and when it runs. */
+@Composable
+private fun StatsColumn(
+    option: ItineraryOption,
+    shortestTravelTime: Boolean,
+    leastWalking: Boolean,
+    earliestArrival: Boolean,
+    latestDeparture: Boolean,
+    winnerOutlineColor: Color
+) {
+    val context = LocalContext.current
+    Column(
+        modifier = Modifier.padding(horizontal = CARD_PADDING_HORIZONTAL, vertical = CARD_PADDING_VERTICAL),
+        verticalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
+        // Duration + walk distance read as one stat group, so they sit tighter together than the
+        // card's other lines.
+        Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+            // Duration — a leading hourglass + the ETA-pill-formatted trip length.
+            MetricRow(
+                MetricGlyph.DURATION,
+                contentDescription = null,
+                winner = shortestTravelTime,
+                outlineColor = winnerOutlineColor
+            ) {
+                EtaDurationText(
+                    minutes = option.durationMinutes,
+                    modifier = Modifier.alignByBaseline(),
+                    numberSize = METRIC_NUMBER_SIZE,
+                    unitSize = METRIC_UNIT_SIZE
+                )
+            }
+            // Total walking for the trip — a leading walk glyph mirroring the duration row's hourglass,
+            // with the distance styled like the duration (bold value + smaller unit). In the user's units
+            // (miles/km, or feet/meters for short walks). Hidden when the trip has no walking.
+            if (option.walkDistanceMeters > 0.0 || leastWalking) {
                 MetricRow(
-                    MetricGlyph.DURATION,
-                    contentDescription = null,
-                    winner = shortestTravelTime,
+                    MetricGlyph.WALK,
+                    contentDescription = stringResource(R.string.step_by_step_non_transit_mode_walk_action),
+                    winner = leastWalking,
                     outlineColor = winnerOutlineColor
                 ) {
-                    EtaDurationText(
-                        minutes = option.durationMinutes,
+                    EtaPartsText(
+                        ConversionUtils.getFormattedDistanceParts(option.walkDistanceMeters, context),
                         modifier = Modifier.alignByBaseline(),
                         numberSize = METRIC_NUMBER_SIZE,
                         unitSize = METRIC_UNIT_SIZE
                     )
                 }
-                // Total walking for the trip — a leading walk glyph mirroring the duration row's hourglass,
-                // with the distance styled like the duration (bold value + smaller unit). In the user's units
-                // (miles/km, or feet/meters for short walks). Hidden when the trip has no walking.
-                if (option.walkDistanceMeters > 0.0 || leastWalking) {
-                    MetricRow(
-                        MetricGlyph.WALK,
-                        contentDescription = stringResource(R.string.step_by_step_non_transit_mode_walk_action),
-                        winner = leastWalking,
-                        outlineColor = winnerOutlineColor
-                    ) {
-                        EtaPartsText(
-                            ConversionUtils.getFormattedDistanceParts(option.walkDistanceMeters, context),
-                            modifier = Modifier.alignByBaseline(),
-                            numberSize = METRIC_NUMBER_SIZE,
-                            unitSize = METRIC_UNIT_SIZE
-                        )
-                    }
-                }
             }
-            // The device-localized departure–arrival range (unwrap the server clock only here).
-            val startText = DisplayFormat.formatTime(context, option.startTime.epochMs)
-            val endText = DisplayFormat.formatTime(context, option.endTime.epochMs)
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                ScheduleMetric(startText, winner = latestDeparture, outlineColor = winnerOutlineColor)
-                Text(" – ", style = MaterialTheme.typography.bodySmall, maxLines = 1)
-                ScheduleMetric(endText, winner = earliestArrival, outlineColor = winnerOutlineColor)
-            }
+        }
+        // The device-localized departure–arrival range (unwrap the server clock only here).
+        val startText = DisplayFormat.formatTime(context, option.startTime.epochMs)
+        val endText = DisplayFormat.formatTime(context, option.endTime.epochMs)
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            ScheduleMetric(startText, winner = latestDeparture, outlineColor = winnerOutlineColor)
+            Text(" – ", style = MaterialTheme.typography.bodySmall, maxLines = 1)
+            ScheduleMetric(endText, winner = earliestArrival, outlineColor = winnerOutlineColor)
         }
     }
 }


### PR DESCRIPTION
Closes #2081.

An option card sized itself to whatever its summary line asked for, so a four-leg trip drew one card wide enough to push every other option off the picker — which scrolls, but a rider can only compare what is on screen at once. The issue asked for two refinements; a third fell out of the first.

## 1. A max width, and the summary wraps at it

`OPTION_CARD_MAX_WIDTH = 200.dp`, chosen to keep the *next* card in view on a narrow (320dp) screen.

The row became `SymbolFlow`, a small custom layout rather than a `FlowRow`, for one reason: it measures every symbol **unbounded**, so a badge that is itself wider than the wrap — several interchangeable routes on one ride, which `RouteBadgeChip` deliberately leaves uncapped — takes a line of its own and widens the card. A `FlowRow` would measure it into the width that's left, and an unweighted `Row` handed too little width measures its later segments at zero: the ride would quietly lose a route off the end of the badge whose whole point is naming every route on it. So the wrap is a ceiling on the *line*, not a clip on the card.

Each symbol travels with the chevron that follows it as one unbreakable unit, so a wrap never opens a line with a chevron pointing at the symbol above it, and a broken line ends on the "and then" that carries the eye down.

The card takes its width from the layout's own intrinsic width, which `SymbolFlowPolicy` answers from the same `packLines` call the measure pass uses — so the two can't disagree and leave the card carrying a line it then refuses to fill. This is also what gives the band below a width to span: under the picker's horizontal scroll the incoming constraint is unbounded, where `fillMaxWidth` measures to nothing.

## 2. The summary sits on its own surface

The issue suggested "initially try a full width horizontal divider", and that's where this started. Two iterations on the phone later:

- a keyline worked but drew a line across a card only two sections tall;
- a band **inverted into the dark range** (the card's opposite, carrying light glyphs) reads as a slab in a picker of cards this small, at any strength — that's recorded at the constant so it doesn't get re-tried;
- what landed is a band veiled with the **brand green** (`colorScheme.primary`) at `0.13`, so the header carries the app's colour rather than a second grey.

`primary` is the token to veil with because it flips ends between the themes the way Material's container ramp does — a deep green over a light card darkens it, a pale green over a dark card lightens it — so one alpha serves both, and a white-label brand re-tints these headers through a colour it already overrides. The value lands the same lightness step the earlier neutral veil did (−7.4 on a light card, +9.0 on a dark one, in CIE L\*), holding within about one unit across all four card states, so the last iteration changed the hue and not the weight.

## 3. Levelling the bands, so the stats line up

Wrapping created its own problem: a card whose summary took two lines pushed its own stats a line below its neighbours', so the durations, walk distances and times no longer sat on shared rows — and reading across is most of what a row of options is for.

Every card now reserves the tallest summary in its row, symbols laid from the top so the reserved room falls below them. The height comes from layout rather than up front, since where a summary wraps depends on measured text: `SymbolFlow` reports the height its lines wanted and the row keeps the maximum. It converges rather than oscillating (the maximum only grows), it's reset with the options (a new plan of short summaries can't inherit an old plan's taller band), and the report is made from placement rather than measure, since it changes another card's layout.

## Testing

`OptionCardSummaryTest` (new, on-device, density pinned) covers four properties:

- a too-wide summary wraps — and wraps where the width genuinely runs out, not a symbol early, which is what pins the intrinsic width against the measured one;
- a one-leg card still sizes to itself rather than to the max;
- an oversized joined badge keeps every route it names, all six segments equal width;
- every card's stats start at the same height, whatever its summary did.

That last one was checked against a forced regression (reservation set to zero → fails by 22dp) rather than just observed green. All 23 `ui.tripresults` instrumented tests pass on a Pixel 7 Pro (API 36); `spotlessCheck`, unit tests, and `-PwarningsAsErrors=true` are clean. The result has been looked at on a real device at each step.

## For the reviewer

Everything tunable is a single documented constant: `OPTION_CARD_MAX_WIDTH` (where the line breaks), `CARD_HEADER_TINT_ALPHA` (how far the band is veiled), `CARD_SECTION_PADDING` (which the wrap width is derived from, so the two can't drift).

A `/simplify` pass over the diff is folded in as its own commit: the intrinsic width tied to its own packing, `StatsColumn` taking the `WinnerCategory` set instead of a Boolean per category plus a colour, and the card padding stated once instead of three times. Two findings were deliberately skipped as outside this diff — the `ItineraryOption` test fixtures duplicated across six test files, and splitting the 1900-line `TripResultsScreen.kt` into its picker and timeline halves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
