### PR TITLE
Label an interchangeable ride with every route it may be ridden as

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/map/render/RouteBadgeBitmapTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/map/render/RouteBadgeBitmapTest.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.map.render
+
+import android.graphics.Bitmap
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * The stacked route-label bitmap (#2083): a label naming an interchangeable ride draws one row per route,
+ * each filled with that route's own line colour. Instrumented rather than a JVM test because this is
+ * `Canvas` drawing — the unit-test `android.graphics` stubs draw nothing — so the rows are checked the only
+ * way they can be: by reading the pixels back.
+ */
+@RunWith(AndroidJUnit4::class)
+class RouteBadgeBitmapTest {
+
+    private val blue = 0xFF1050C0.toInt()
+
+    private val green = 0xFF107030.toInt()
+
+    @Test
+    fun oneRoutePerRow_stackedInTheOrderGiven_eachInItsOwnColor() {
+        val single = badge(listOf(BadgedRoute("1 Line", blue)))
+        val stacked = badge(listOf(BadgedRoute("1 Line", blue), BadgedRoute("2 Line", green)))
+
+        // One row per route, all of one height: the stack is exactly as tall as its rows.
+        assertEquals(single.height * 2, stacked.height)
+        // Each row is filled with its own route's colour, in the order the label reads them. Sampled inside
+        // the leading padding — clear of the centred name and of the casing along the edge.
+        assertEquals(blue, stacked.rowFill(row = 0, rows = 2))
+        assertEquals(green, stacked.rowFill(row = 1, rows = 2))
+        // A single-route label is unchanged by all this: still one row in that route's colour.
+        assertEquals(blue, single.rowFill(row = 0, rows = 1))
+    }
+
+    @Test
+    fun everyRowIsAsWideAsTheWidestName() {
+        val stacked = badge(listOf(BadgedRoute("8", blue), BadgedRoute("Seattle - Bremerton", green)))
+        val long = badge(listOf(BadgedRoute("Seattle - Bremerton", green)))
+
+        // Sized to the widest name, and the short row is filled across the whole of that width rather than
+        // ending where its own name does.
+        assertEquals(long.width, stacked.width)
+        assertTrue(stacked.width > badge(listOf(BadgedRoute("8", blue))).width)
+        assertEquals(blue, stacked.getPixel(stacked.width - SAMPLE_INSET_PX, rowCenterY(stacked, row = 0, rows = 2)))
+    }
+
+    private fun badge(routes: List<BadgedRoute>): Bitmap = ContinuationBadgeBitmaps.badge(routes, density = 1f, darkMode = false)
+
+    /** The fill colour of one row, read from inside its leading padding. */
+    private fun Bitmap.rowFill(row: Int, rows: Int): Int = getPixel(SAMPLE_INSET_PX, rowCenterY(this, row, rows))
+
+    private fun rowCenterY(bitmap: Bitmap, row: Int, rows: Int): Int {
+        val rowHeight = bitmap.height / rows
+        return rowHeight * row + rowHeight / 2
+    }
+
+    private companion object {
+        /**
+         * How far in from the badge's edge a fill is sampled: past the casing stroke (2dp at the density
+         * above) and — at a row's vertical centre — past the corner rounding, but well short of the name,
+         * which is centred inside a wider horizontal padding.
+         */
+        const val SAMPLE_INSET_PX = 8
+    }
+}

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
@@ -389,20 +389,12 @@ class GoogleMapRenderer(
         continuationBadgeByMarker[marker] = badge
     }
 
-    private fun routeBadgeIcon(routes: List<BadgedRoute>): BitmapDescriptor = descriptorCache.get(routeBadgeCacheKey(routes)) {
-        ContinuationBadgeBitmaps.badge(
-            routes,
-            density,
-            darkMode = ThemeUtils.isInDarkMode(context)
-        )
+    private fun routeBadgeIcon(routes: List<BadgedRoute>): BitmapDescriptor {
+        val darkMode = ThemeUtils.isInDarkMode(context)
+        return descriptorCache.get(ContinuationBadgeBitmaps.badgeKey(routes, darkMode)) {
+            ContinuationBadgeBitmaps.badge(routes, density, darkMode)
+        }
     }
-
-    /** Every name and colour on the badge, so two labels differing only in a stacked route can't share
-     *  a cached bitmap. */
-    private fun routeBadgeCacheKey(routes: List<BadgedRoute>): String = routes.joinToString(
-        separator = "|",
-        prefix = "route-badge:"
-    ) { "${it.routeShortName}:${it.color}" }
 
     private fun continuationArrowIcon(color: Int): BitmapDescriptor = descriptorCache.get("continuation-arrow:$color") {
         ContinuationBadgeBitmaps.arrow(color)

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
@@ -46,6 +46,7 @@ import org.onebusaway.android.R
 import org.onebusaway.android.map.compose.formatDataAge
 import org.onebusaway.android.map.googlemapsv2.compose.BikeIcons
 import org.onebusaway.android.map.mapRouteLineCaseColor
+import org.onebusaway.android.map.render.BadgedRoute
 import org.onebusaway.android.map.render.BikeBand
 import org.onebusaway.android.map.render.BikeMarker
 import org.onebusaway.android.map.render.ContinuationBadge
@@ -312,7 +313,7 @@ class GoogleMapRenderer(
             val marker = map.addMarkerOrFail(
                 MarkerOptions()
                     .position(badge.point.toLatLng())
-                    .icon(routeBadgeIcon(badge.routeShortName, badge.color))
+                    .icon(routeBadgeIcon(badge.routes))
                     .anchor(0.5f, 0.5f)
                     .zIndex(ROUTE_BADGE_Z_INDEX)
             )
@@ -380,7 +381,7 @@ class GoogleMapRenderer(
         val marker = map.addMarkerOrFail(
             MarkerOptions()
                 .position(badge.point.toLatLng())
-                .icon(routeBadgeIcon(badge.routeShortName, polyline.resolvedColor))
+                .icon(routeBadgeIcon(listOf(BadgedRoute(badge.routeShortName, polyline.resolvedColor))))
                 .anchor(0.5f, 0.5f)
                 .zIndex(ROUTE_BADGE_Z_INDEX)
         )
@@ -388,14 +389,20 @@ class GoogleMapRenderer(
         continuationBadgeByMarker[marker] = badge
     }
 
-    private fun routeBadgeIcon(routeShortName: String, color: Int): BitmapDescriptor = descriptorCache.get("route-badge:$routeShortName:$color") {
+    private fun routeBadgeIcon(routes: List<BadgedRoute>): BitmapDescriptor = descriptorCache.get(routeBadgeCacheKey(routes)) {
         ContinuationBadgeBitmaps.badge(
-            routeShortName,
-            color,
+            routes,
             density,
             darkMode = ThemeUtils.isInDarkMode(context)
         )
     }
+
+    /** Every name and colour on the badge, so two labels differing only in a stacked route can't share
+     *  a cached bitmap. */
+    private fun routeBadgeCacheKey(routes: List<BadgedRoute>): String = routes.joinToString(
+        separator = "|",
+        prefix = "route-badge:"
+    ) { "${it.routeShortName}:${it.color}" }
 
     private fun continuationArrowIcon(color: Int): BitmapDescriptor = descriptorCache.get("continuation-arrow:$color") {
         ContinuationBadgeBitmaps.arrow(color)

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleComposeAdapter.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleComposeAdapter.kt
@@ -388,7 +388,7 @@ private fun routeMarkerTap(
     val routeBadge = renderer.routeBadgeForMarker(marker)
     val routeBadgeTap = routeBadge?.tap
     if (routeBadge != null && routeBadgeTap != null) {
-        cb.onRouteBadgeClick(routeBadgeTap.routeId, routeBadge.routeShortName, routeBadgeTap.directionId)
+        cb.onRouteBadgeClick(routeBadgeTap.routeId, routeBadge.tappedRouteShortName, routeBadgeTap.directionId)
         return true
     }
     // Trip-focus estimate markers + the most-recent-data dot (titled markers): the SDK's default

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/model/Interlines.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/model/Interlines.kt
@@ -13,12 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.onebusaway.android.ui.tripresults
-
-import org.onebusaway.android.directions.model.InterchangeableRoute
-import org.onebusaway.android.directions.model.TripItinerary
-import org.onebusaway.android.directions.model.TripLeg
-import org.onebusaway.android.directions.model.interchangeableRoutes
+package org.onebusaway.android.directions.model
 
 /**
  * Pure interline analysis over a trip's legs (#2000) — no `Context` / OBA-id resolution, so it's
@@ -29,6 +24,10 @@ import org.onebusaway.android.directions.model.interchangeableRoutes
  *    e.g. an inbound 12 that becomes an outbound 12; the rider never acts, so the seam is hidden;
  *  - a **cross-route interline** — the vehicle changes to a *different* route while the rider stays
  *    seated; surfaced as a "stay on board" transition rather than a get-off/get-on pair.
+ *
+ * Lives with the trip-plan model rather than with the results UI that first needed it: the shape of a
+ * ride is a fact about the plan, and the directions map reads it too — it labels an interchangeable ride
+ * with every route it may be ridden as (#2083), which is the [substitutableRoutes] question.
  *
  * Comparing `routeId` across a seam is an exact match on the canonical GTFS route id (not a heuristic):
  * the [TripLeg.interlineWithPreviousLeg] flag is the sanctioned "same vehicle, stay aboard" signal, and

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/DirectionsMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/DirectionsMapController.kt
@@ -91,7 +91,16 @@ class DirectionsMapController(private val host: MapHost) {
         // is already narrowed by what the rest of the plan needs of this leg (a leg of a stay-aboard
         // interline admits no substitute at all, #2000 × #2010), so the label on a line and the badge in the
         // drawer beside it name one ride the same way.
+        //
+        // Its alignment to the legs is stated rather than defended against, in the same terms
+        // [ModeSymbols.forLegs] states it for the same list: a short list read defensively would quietly
+        // label a ride with fewer routes than it can be taken on — the rider is told to wait for the 1 Line
+        // when the 2 Line would also do — and nothing downstream could tell that from a leg that genuinely
+        // has no alternatives. Misalignment is a bug in the analysis, so say so where it is read.
         val substitutes = itinerary.substitutableRoutes()
+        require(substitutes.size == legs.size) {
+            "substitutable routes must be index-aligned to legs (${substitutes.size} vs ${legs.size})"
+        }
 
         // Every leg that has geometry to draw, decoded and styled once: the polylines below stroke it and
         // the route labels are anchored on it, so a label cannot end up a different colour from its own
@@ -103,9 +112,6 @@ class DirectionsMapController(private val host: MapHost) {
             val style = itineraryLegStyle(leg.legKind(), parseObaHexColor(leg.routeColor))
             // The wire hex is parsed here, on the leg and on every route offered in its place, so the
             // styling itself stays free of `android.graphics` (see the [ItineraryLegStyle] file header).
-            // Indexed, not read defensively: `substitutableRoutes` is aligned to these same legs by
-            // construction, so a misalignment is a caller bug worth hearing about rather than a ride
-            // quietly labelled with fewer routes than it can be taken on (as `ModeSymbols.forLegs` argues).
             val interchangeable = substitutes[legIndex].map { route ->
                 ItinerarySubstitute(route, parseObaHexColor(route.routeColor))
             }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/DirectionsMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/DirectionsMapController.kt
@@ -101,10 +101,14 @@ class DirectionsMapController(private val host: MapHost) {
             val shape = LegShape(geometry)
             if (shape.length <= 0) return@mapIndexedNotNull null
             val style = itineraryLegStyle(leg.legKind(), parseObaHexColor(leg.routeColor))
-            // The wire hex is parsed here, on both the leg and its alternatives, so the styling itself stays
-            // free of `android.graphics` (see the [ItineraryLegStyle] file header).
-            val interchangeable = substitutes.getOrElse(legIndex) { emptyList() }
-                .map { route -> interchangeableBadgedRoute(route, parseObaHexColor(route.routeColor)) }
+            // The wire hex is parsed here, on the leg and on every route offered in its place, so the
+            // styling itself stays free of `android.graphics` (see the [ItineraryLegStyle] file header).
+            // Indexed, not read defensively: `substitutableRoutes` is aligned to these same legs by
+            // construction, so a misalignment is a caller bug worth hearing about rather than a ride
+            // quietly labelled with fewer routes than it can be taken on (as `ModeSymbols.forLegs` argues).
+            val interchangeable = substitutes[legIndex].map { route ->
+                ItinerarySubstitute(route, parseObaHexColor(route.routeColor))
+            }
             ItineraryDrawableLeg(legIndex, leg, shape.points, style, interchangeable)
         }
         // Every leg's points run in travel order, so whether it stamps chevrons is the style's call — a

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/DirectionsMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/DirectionsMapController.kt
@@ -21,6 +21,7 @@ import org.onebusaway.android.directions.model.TripLegGeometry
 import org.onebusaway.android.directions.model.TripMode
 import org.onebusaway.android.directions.model.TripVertexType
 import org.onebusaway.android.directions.model.decodedPoints
+import org.onebusaway.android.directions.model.substitutableRoutes
 import org.onebusaway.android.map.render.RoutePolyline
 import org.onebusaway.android.models.ObaShape
 import org.onebusaway.android.util.GeoPoint
@@ -86,6 +87,12 @@ class DirectionsMapController(private val host: MapHost) {
         val endLat = endPlace.lat
         val endLon = endPlace.lon
 
+        // The routes the *drawer* offers for each leg, not the raw interchangeable set: `substitutableRoutes`
+        // is already narrowed by what the rest of the plan needs of this leg (a leg of a stay-aboard
+        // interline admits no substitute at all, #2000 × #2010), so the label on a line and the badge in the
+        // drawer beside it name one ride the same way.
+        val substitutes = itinerary.substitutableRoutes()
+
         // Every leg that has geometry to draw, decoded and styled once: the polylines below stroke it and
         // the route labels are anchored on it, so a label cannot end up a different colour from its own
         // line (a leg without geometry draws neither).
@@ -94,7 +101,11 @@ class DirectionsMapController(private val host: MapHost) {
             val shape = LegShape(geometry)
             if (shape.length <= 0) return@mapIndexedNotNull null
             val style = itineraryLegStyle(leg.legKind(), parseObaHexColor(leg.routeColor))
-            ItineraryDrawableLeg(legIndex, leg, shape.points, style)
+            // The wire hex is parsed here, on both the leg and its alternatives, so the styling itself stays
+            // free of `android.graphics` (see the [ItineraryLegStyle] file header).
+            val interchangeable = substitutes.getOrElse(legIndex) { emptyList() }
+                .map { route -> interchangeableBadgedRoute(route, parseObaHexColor(route.routeColor)) }
+            ItineraryDrawableLeg(legIndex, leg, shape.points, style, interchangeable)
         }
         // Every leg's points run in travel order, so whether it stamps chevrons is the style's call — a
         // dashed on-street stroke declines them (see [itineraryLegStyle]).

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/ItineraryLegStyle.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/ItineraryLegStyle.kt
@@ -140,28 +140,25 @@ internal fun List<ItineraryLegLine>.withLegFocus(focusedLegIndices: Set<Int>): L
 /**
  * One itinerary leg with geometry to draw: its index in the itinerary, the leg itself, its decoded
  * points, the stroke its line and its label share, and the other routes the rider may board in its place
- * (empty for all but an interchangeable ride — see [interchangeableBadgedRoute]).
+ * (empty for all but an interchangeable ride).
  */
 internal data class ItineraryDrawableLeg(
     val index: Int,
     val leg: TripLeg,
     val points: List<GeoPoint>,
     val style: ItineraryLegStyle,
-    val interchangeable: List<BadgedRoute> = emptyList()
+    val interchangeable: List<ItinerarySubstitute> = emptyList()
 )
 
 /**
- * One route the rider may board in place of a leg's planned one (#2010), as a row on that leg's map label:
- * named the way the drawer names it, in the colour this map draws that route's line — the colour its line
- * actually takes when the rider drills into the leg and the whole corridor is drawn (#2063).
- *
- * [routeColor] is the candidate's *already-parsed* GTFS colour, for the reason the file header gives: the
- * wire hex is the caller's to parse, so everything here stays JVM-pure.
+ * A route the rider may board in place of a leg's planned one (#2010), with its GTFS colour *already
+ * parsed* — the one thing the caller has to do for it, since parsing the wire hex needs
+ * `android.graphics` and everything here stays JVM-pure (see the file header). The candidate itself is
+ * carried whole rather than reduced to a name, so a label can group on the route **id** OTP gave it:
+ * two routes may publish the same short name, and a name is only ever an identity of last resort
+ * ([itineraryRouteBadges]).
  */
-internal fun interchangeableBadgedRoute(route: InterchangeableRoute, routeColor: Int?): BadgedRoute = BadgedRoute(
-    routeShortName = route.displayName,
-    color = itineraryLegStyle(ItineraryLegKind.TRANSIT, routeColor).color
-)
+internal data class ItinerarySubstitute(val route: InterchangeableRoute, val routeColor: Int?)
 
 /**
  * One label per route ridden in a drawn itinerary (#2066), so a transit line on the directions map says
@@ -187,8 +184,13 @@ internal fun itineraryRouteBadges(legs: List<ItineraryDrawableLeg>): List<RouteB
         // The alternatives are part of the identity, not just cargo: two legs of one route can be offered
         // different ones (the corridor they share ends), and a single label carrying the union would claim
         // on both segments what is only true of one. When they agree — the ordinary case, and every leg of
-        // an interline chain, which is offered none at all — the legs still share one label.
-        Ride(RideIdentity(drawable.leg.routeId ?: name, drawable.interchangeable.map(BadgedRoute::routeShortName).toSet()), name, drawable)
+        // an interline chain, which is offered none at all — the legs still share one label. They key by
+        // route id, which a candidate always has, so two alternatives that merely read alike stay apart.
+        val identity = RideIdentity(
+            drawable.leg.routeId ?: name,
+            drawable.interchangeable.map { it.route.routeId }.toSet()
+        )
+        Ride(identity, name, drawable)
     }.groupBy(Ride::identity)
     return placeRouteBadges(
         rides.map { (_, ridden) ->
@@ -202,15 +204,24 @@ internal fun itineraryRouteBadges(legs: List<ItineraryDrawableLeg>): List<RouteB
     )
 }
 
-private data class RideIdentity(val route: String, val interchangeableNames: Set<String>)
+private data class RideIdentity(val route: String, val interchangeableRouteIds: Set<String>)
 
 private data class Ride(val identity: RideIdentity, val name: String, val drawable: ItineraryDrawableLeg) {
     /**
      * The routes this label names: the planned one in exactly the colour its own line is stroked with — so
-     * a label and its line can't disagree — joined by whatever is interchangeable with it.
+     * a label and its line can't disagree — joined by whatever is interchangeable with it, each named the
+     * way the drawer names it and drawn in the colour this map gives that route's line, which is the colour
+     * it actually takes when the rider drills into the leg and the whole corridor is drawn (#2063).
      */
-    fun badgedRoutes(): List<BadgedRoute> = (listOf(BadgedRoute(name, drawable.style.color)) + drawable.interchangeable)
-        .inInterchangeableOrder(BadgedRoute::routeShortName)
+    fun badgedRoutes(): List<BadgedRoute> = (
+        listOf(BadgedRoute(name, drawable.style.color)) +
+            drawable.interchangeable.map { substitute ->
+                BadgedRoute(
+                    substitute.route.displayName,
+                    itineraryLegStyle(ItineraryLegKind.TRANSIT, substitute.routeColor).color
+                )
+            }
+        ).inInterchangeableOrder(BadgedRoute::routeShortName)
 }
 
 private fun street(hueAnchor: Int) = ItineraryLegStyle(

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/ItineraryLegStyle.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/ItineraryLegStyle.kt
@@ -15,6 +15,7 @@
  */
 package org.onebusaway.android.map
 
+import org.onebusaway.android.directions.model.InterchangeableRoute
 import org.onebusaway.android.directions.model.TripLeg
 import org.onebusaway.android.directions.model.TripMode
 import org.onebusaway.android.directions.model.TripVertexType
@@ -22,6 +23,7 @@ import org.onebusaway.android.directions.model.routeDisplayLabel
 import org.onebusaway.android.map.layout.RouteBadgePath
 import org.onebusaway.android.map.layout.RouteBadgeRequest
 import org.onebusaway.android.map.layout.placeRouteBadges
+import org.onebusaway.android.map.render.BadgedRoute
 import org.onebusaway.android.map.render.ITINERARY_RIDE_WIDTH_PROFILE
 import org.onebusaway.android.map.render.ITINERARY_STREET_WIDTH_PROFILE
 import org.onebusaway.android.map.render.RouteBadge
@@ -29,6 +31,7 @@ import org.onebusaway.android.map.render.RouteLineDash
 import org.onebusaway.android.map.render.RouteLineWidthProfile
 import org.onebusaway.android.map.render.RoutePolyline
 import org.onebusaway.android.util.GeoPoint
+import org.onebusaway.android.util.inInterchangeableOrder
 
 /**
  * How one trip-plan itinerary leg is stroked on the directions map (#2041).
@@ -136,19 +139,41 @@ internal fun List<ItineraryLegLine>.withLegFocus(focusedLegIndices: Set<Int>): L
 
 /**
  * One itinerary leg with geometry to draw: its index in the itinerary, the leg itself, its decoded
- * points, and the stroke its line and its label share.
+ * points, the stroke its line and its label share, and the other routes the rider may board in its place
+ * (empty for all but an interchangeable ride — see [interchangeableBadgedRoute]).
  */
 internal data class ItineraryDrawableLeg(
     val index: Int,
     val leg: TripLeg,
     val points: List<GeoPoint>,
-    val style: ItineraryLegStyle
+    val style: ItineraryLegStyle,
+    val interchangeable: List<BadgedRoute> = emptyList()
+)
+
+/**
+ * One route the rider may board in place of a leg's planned one (#2010), as a row on that leg's map label:
+ * named the way the drawer names it, in the colour this map draws that route's line — the colour its line
+ * actually takes when the rider drills into the leg and the whole corridor is drawn (#2063).
+ *
+ * [routeColor] is the candidate's *already-parsed* GTFS colour, for the reason the file header gives: the
+ * wire hex is the caller's to parse, so everything here stays JVM-pure.
+ */
+internal fun interchangeableBadgedRoute(route: InterchangeableRoute, routeColor: Int?): BadgedRoute = BadgedRoute(
+    routeShortName = route.displayName,
+    color = itineraryLegStyle(ItineraryLegKind.TRANSIT, routeColor).color
 )
 
 /**
  * One label per route ridden in a drawn itinerary (#2066), so a transit line on the directions map says
  * which route it is without the rider having to match it to the drawer beside it. Two legs of one route
  * — a stay-aboard interline, or a route the itinerary returns to — share a single label.
+ *
+ * A ride the rider may board any of several routes for is labelled with all of them, stacked (#2083):
+ * interchangeability is a fact about the ride, not about which route the planner picked, so the label has
+ * to say the same thing as the drawer's joined badge beside it (`legBadge`) — the same routes, in the same
+ * order ([inInterchangeableOrder]) — rather than naming one route on a line the rider is being told to
+ * board either of two. A leg with no alternatives is labelled with its planned route alone, which is what
+ * an OTP1 plan (no candidates at all) yields for every leg.
  */
 internal fun itineraryRouteBadges(legs: List<ItineraryDrawableLeg>): List<RouteBadge> {
     val rides = legs.mapNotNull { drawable ->
@@ -158,15 +183,18 @@ internal fun itineraryRouteBadges(legs: List<ItineraryDrawableLeg>): List<RouteB
         // Grouped by the wire route id, or — for an OTP1 response, which names a route without
         // identifying it — by the name it displays. That key never leaves this grouping, so a name
         // standing in for an id can't reach anywhere that would treat it as one.
-        Ride(drawable.leg.routeId ?: name, name, drawable)
+        //
+        // The alternatives are part of the identity, not just cargo: two legs of one route can be offered
+        // different ones (the corridor they share ends), and a single label carrying the union would claim
+        // on both segments what is only true of one. When they agree — the ordinary case, and every leg of
+        // an interline chain, which is offered none at all — the legs still share one label.
+        Ride(RideIdentity(drawable.leg.routeId ?: name, drawable.interchangeable.map(BadgedRoute::routeShortName).toSet()), name, drawable)
     }.groupBy(Ride::identity)
     return placeRouteBadges(
         rides.map { (_, ridden) ->
             val ride = ridden.first()
             RouteBadgeRequest(
-                routeShortName = ride.name,
-                // Exactly the colour its own line is stroked with, so a label and its line can't disagree.
-                color = ride.drawable.style.color,
+                routes = ride.badgedRoutes(),
                 paths = ridden.map { RouteBadgePath(it.drawable.points) }
                 // No tap target: see [RouteBadge.tap].
             )
@@ -174,7 +202,16 @@ internal fun itineraryRouteBadges(legs: List<ItineraryDrawableLeg>): List<RouteB
     )
 }
 
-private data class Ride(val identity: String, val name: String, val drawable: ItineraryDrawableLeg)
+private data class RideIdentity(val route: String, val interchangeableNames: Set<String>)
+
+private data class Ride(val identity: RideIdentity, val name: String, val drawable: ItineraryDrawableLeg) {
+    /**
+     * The routes this label names: the planned one in exactly the colour its own line is stroked with — so
+     * a label and its line can't disagree — joined by whatever is interchangeable with it.
+     */
+    fun badgedRoutes(): List<BadgedRoute> = (listOf(BadgedRoute(name, drawable.style.color)) + drawable.interchangeable)
+        .inInterchangeableOrder(BadgedRoute::routeShortName)
+}
 
 private fun street(hueAnchor: Int) = ItineraryLegStyle(
     color = anchorColor(hueAnchor),

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteViewGeometry.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteViewGeometry.kt
@@ -161,21 +161,15 @@ internal fun FocusedTripGeometry.toRouteBadges(
     }
     return placeRouteBadges(
         specs.map { spec ->
+            // A badge takes its line's colour, so it goes through the same policy — an adjacency colour is
+            // already in it, an agency's own has to be put through.
+            val color = routeColors[spec.key]
+                ?: mapRouteLineColorOrNull(spec.shapes.firstNotNullOfOrNull(FocusedTripShape::routeColor) ?: spec.route.color)
+                ?: DEFAULT_ROUTE_LINE_COLOR
             RouteBadgeRequest(
                 // An adjacency label names the one route whose line it sits on; only a directions ride the
                 // rider may board any of several routes for stacks more than one name (#2083).
-                routes = listOf(
-                    BadgedRoute(
-                        routeShortName = spec.name,
-                        // A badge takes its line's colour, so it goes through the same policy — an
-                        // adjacency colour is already in it, an agency's own has to be put through.
-                        color = routeColors[spec.key]
-                            ?: mapRouteLineColorOrNull(
-                                spec.shapes.firstNotNullOfOrNull(FocusedTripShape::routeColor) ?: spec.route.color
-                            )
-                            ?: DEFAULT_ROUTE_LINE_COLOR
-                    )
-                ),
+                routes = listOf(BadgedRoute(spec.name, color)),
                 paths = spec.shapes.map { shape -> RouteBadgePath(shape.points) },
                 // An adjacency label is the way into its route: it names a route the rider hasn't opened.
                 tap = spec.key

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteViewGeometry.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteViewGeometry.kt
@@ -9,6 +9,7 @@ import org.onebusaway.android.map.layout.RouteBadgePath
 import org.onebusaway.android.map.layout.RouteBadgeRequest
 import org.onebusaway.android.map.layout.placeRouteBadges
 import org.onebusaway.android.map.render.ADJACENT_ROUTE_LINE_WIDTH_PROFILE
+import org.onebusaway.android.map.render.BadgedRoute
 import org.onebusaway.android.map.render.DEEMPHASIZED_ROUTE_LINE_WIDTH_PROFILE
 import org.onebusaway.android.map.render.DEFAULT_ROUTE_LINE_COLOR
 import org.onebusaway.android.map.render.FOCUSED_ROUTE_LINE_WIDTH_PROFILE
@@ -161,14 +162,20 @@ internal fun FocusedTripGeometry.toRouteBadges(
     return placeRouteBadges(
         specs.map { spec ->
             RouteBadgeRequest(
-                routeShortName = spec.name,
-                // A badge takes its line's colour, so it goes through the same policy — an
-                // adjacency colour is already in it, an agency's own has to be put through.
-                color = routeColors[spec.key]
-                    ?: mapRouteLineColorOrNull(
-                        spec.shapes.firstNotNullOfOrNull(FocusedTripShape::routeColor) ?: spec.route.color
+                // An adjacency label names the one route whose line it sits on; only a directions ride the
+                // rider may board any of several routes for stacks more than one name (#2083).
+                routes = listOf(
+                    BadgedRoute(
+                        routeShortName = spec.name,
+                        // A badge takes its line's colour, so it goes through the same policy — an
+                        // adjacency colour is already in it, an agency's own has to be put through.
+                        color = routeColors[spec.key]
+                            ?: mapRouteLineColorOrNull(
+                                spec.shapes.firstNotNullOfOrNull(FocusedTripShape::routeColor) ?: spec.route.color
+                            )
+                            ?: DEFAULT_ROUTE_LINE_COLOR
                     )
-                    ?: DEFAULT_ROUTE_LINE_COLOR,
+                ),
                 paths = spec.shapes.map { shape -> RouteBadgePath(shape.points) },
                 // An adjacency label is the way into its route: it names a route the rider hasn't opened.
                 tap = spec.key

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/layout/RouteBadgeLayout.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/layout/RouteBadgeLayout.kt
@@ -19,6 +19,7 @@ import kotlin.math.atan2
 import kotlin.math.cos
 import kotlin.math.sin
 import kotlin.math.sqrt
+import org.onebusaway.android.map.render.BadgedRoute
 import org.onebusaway.android.map.render.RouteBadge
 import org.onebusaway.android.map.render.haversineMeters
 import org.onebusaway.android.models.RouteDirectionKey
@@ -83,13 +84,12 @@ fun <K> layoutRouteBadges(
 }
 
 /**
- * One route label to place: what it reads, the colour of the line it names, where a tap on it navigates
- * (null for an informational label — see [RouteBadge.tap]), and the shapes it may be anchored on. List
- * order is collision priority, as in [layoutRouteBadges].
+ * One route label to place: the route(s) it names (stacked, in reading order — see [RouteBadge.routes]),
+ * where a tap on it navigates (null for an informational label — see [RouteBadge.tap]), and the shapes it
+ * may be anchored on. List order is collision priority, as in [layoutRouteBadges].
  */
 internal data class RouteBadgeRequest(
-    val routeShortName: String,
-    val color: Int,
+    val routes: List<BadgedRoute>,
     val paths: List<RouteBadgePath>,
     val tap: RouteDirectionKey? = null
 )
@@ -108,12 +108,7 @@ internal fun placeRouteBadges(requests: List<RouteBadgeRequest>): List<RouteBadg
     ).associateBy { it.route }
     return requests.mapIndexedNotNull { index, request ->
         placements[index]?.let { placement ->
-            RouteBadge(
-                routeShortName = request.routeShortName,
-                color = request.color,
-                point = placement.point,
-                tap = request.tap
-            )
+            RouteBadge(routes = request.routes, point = placement.point, tap = request.tap)
         }
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/ContinuationBadgeBitmaps.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/ContinuationBadgeBitmaps.kt
@@ -22,12 +22,14 @@ import android.graphics.Paint
 import android.graphics.Path
 import android.graphics.RectF
 import androidx.core.graphics.createBitmap
+import kotlin.math.ceil
 import org.onebusaway.android.util.routeCasingColor
 
 /**
- * Bitmaps for the route-continuation overlay (#1691): the tappable pill badge showing a route short
- * name, and the arrowhead terminating the continuation line. Resource-free and flavor-neutral (like
- * [BikeBitmaps], so a flavor renderer just wraps the [Bitmap] as a marker icon.
+ * Bitmaps for the route-continuation overlay (#1691): the pill badge naming a route, and the arrowhead
+ * terminating the continuation line. The pill is also every route label on the map ([RouteBadge], drawn
+ * by both flavors), which is why [badge] takes a list of routes rather than one name. Resource-free and
+ * flavor-neutral (like [BikeBitmaps], so a flavor renderer just wraps the [Bitmap] as a marker icon.
  *
  * A prototype-quality first pass: legible + tappable, not a final visual design.
  */
@@ -46,21 +48,31 @@ object ContinuationBadgeBitmaps {
     private const val ARROW_STROKE_PX = 4f
 
     /**
-     * The badge bitmap for [routeShortName] — sized to fit the text, a rounded-rect pill filled with
-     * [color] (the continuation line's own color). Text is black or white, whichever contrasts better
-     * with [color], so the badge stays legible across the full range of GTFS route colors.
+     * The badge bitmap naming [routes] — a rounded-rect pill sized to fit the widest name, with one row
+     * per route filled in that route's own line color, stacked top to bottom in the order given. Each
+     * row's text is black or white, whichever contrasts better with the row it sits on, so the badge
+     * stays legible across the full range of GTFS route colors.
+     *
+     * One pill holding several names, rather than several pills, for the reason the directions drawer's
+     * joined chip gives (`RouteBadgeChip`): the routes on it are one ride the rider may board any of
+     * (#2010/#2083), not separate lines that happen to meet here. The stack goes downwards rather than
+     * across because a map label's neighbour is the basemap — a name-per-column pill grows into the
+     * corridor it labels, while rows keep the label roughly as wide as its widest name.
      */
-    fun badge(routeShortName: String, color: Int, density: Float, darkMode: Boolean): Bitmap {
-        val textPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
-            this.color = MarkerRendering.legibleOn(color)
-            textSize = TEXT_SIZE_PX
-            isFakeBoldText = true
-            textAlign = Paint.Align.CENTER
-        }
-        val metrics = textPaint.fontMetrics
-        val textWidth = textPaint.measureText(routeShortName)
-        val width = (textWidth + HORIZONTAL_PADDING_PX * 2).coerceAtLeast(CORNER_RADIUS_PX * 2)
-        val height = (metrics.descent - metrics.ascent) + VERTICAL_PADDING_PX * 2
+    fun badge(routes: List<BadgedRoute>, density: Float, darkMode: Boolean): Bitmap {
+        require(routes.isNotEmpty()) { "a route badge names at least one route" }
+        val rows = routes.map { route -> BadgeRow(route, textPaint(route.color)) }
+        // Every row shares one font size, so one row's metrics size them all — the pill's rows are equal
+        // bands whatever they read.
+        val metrics = rows.first().textPaint.fontMetrics
+        // A whole number of pixels, so the bands are identical and the pill is exactly as tall as its rows
+        // — the row boundaries are also where the dividers are drawn, and a fractional band would drift
+        // away from them down the stack.
+        val rowHeight = ceil((metrics.descent - metrics.ascent) + VERTICAL_PADDING_PX * 2)
+        val width = rows
+            .maxOf { row -> row.textPaint.measureText(row.route.routeShortName) + HORIZONTAL_PADDING_PX * 2 }
+            .coerceAtLeast(CORNER_RADIUS_PX * 2)
+        val height = rowHeight * rows.size
 
         val bitmap = createBitmap(width.toInt(), height.toInt())
         val canvas = Canvas(bitmap)
@@ -71,29 +83,54 @@ object ContinuationBadgeBitmaps {
             width - outlineWidth / 2f,
             height - outlineWidth / 2f
         )
-        canvas.drawRoundRect(
-            badgeBounds,
-            CORNER_RADIUS_PX,
-            CORNER_RADIUS_PX,
-            Paint(Paint.ANTI_ALIAS_FLAG).apply {
-                this.color = Color.rgb(Color.red(color), Color.green(color), Color.blue(color))
-                style = Paint.Style.FILL
-            }
-        )
-        canvas.drawRoundRect(
-            badgeBounds,
-            CORNER_RADIUS_PX,
-            CORNER_RADIUS_PX,
-            Paint(Paint.ANTI_ALIAS_FLAG).apply {
-                this.color = routeBadgeOutlineColor(color, darkMode)
-                style = Paint.Style.STROKE
-                strokeWidth = outlineWidth
-            }
-        )
-        val baseline = height / 2f - (metrics.ascent + metrics.descent) / 2f
-        canvas.drawText(routeShortName, width / 2f, baseline, textPaint)
+        val casing = casingColor(routes, darkMode)
+        // The pill's shape clips the bands, so the outermost ones take its rounded corners and the
+        // interior ones stay square where they meet.
+        canvas.save()
+        canvas.clipPath(Path().apply { addRoundRect(badgeBounds, CORNER_RADIUS_PX, CORNER_RADIUS_PX, Path.Direction.CW) })
+        val band = Paint(Paint.ANTI_ALIAS_FLAG).apply { style = Paint.Style.FILL }
+        rows.forEachIndexed { index, row ->
+            val top = rowHeight * index
+            val color = row.route.color
+            band.color = Color.rgb(Color.red(color), Color.green(color), Color.blue(color))
+            canvas.drawRect(RectF(0f, top, width, top + rowHeight), band)
+            val baseline = top + rowHeight / 2f - (metrics.ascent + metrics.descent) / 2f
+            canvas.drawText(row.route.routeShortName, width / 2f, baseline, row.textPaint)
+        }
+        canvas.restore()
+        val line = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = casing
+            style = Paint.Style.STROKE
+            strokeWidth = outlineWidth
+        }
+        // Where two rows meet, in the same color as the outline around them all — so the badge reads as
+        // one bounded object holding several names, even when its routes share a color or have none.
+        for (index in 1..rows.lastIndex) {
+            val y = rowHeight * index
+            canvas.drawLine(badgeBounds.left, y, badgeBounds.right, y, line)
+        }
+        canvas.drawRoundRect(badgeBounds, CORNER_RADIUS_PX, CORNER_RADIUS_PX, line)
         return bitmap
     }
+
+    private class BadgeRow(val route: BadgedRoute, val textPaint: Paint)
+
+    private fun textPaint(color: Int) = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        this.color = MarkerRendering.legibleOn(color)
+        textSize = TEXT_SIZE_PX
+        isFakeBoldText = true
+        textAlign = Paint.Align.CENTER
+    }
+
+    /**
+     * The color of the badge's outline and of the lines dividing its rows. A badge naming one route cases
+     * itself in that route's own hue ([routeBadgeOutlineColor]); one naming several has no single hue to
+     * case with — picking a row's would say that row is the badge — so it takes the same tone with the hue
+     * dropped, a neutral that reads against every band it encloses.
+     */
+    private fun casingColor(routes: List<BadgedRoute>, darkMode: Boolean): Int = routes.singleOrNull()
+        ?.let { routeBadgeOutlineColor(it.color, darkMode) }
+        ?: neutralBadgeOutlineColor(darkMode)
 
     /**
      * The arrowhead bitmap terminating a continuation line, filled with [color] (the line's own color)
@@ -134,8 +171,14 @@ object ContinuationBadgeBitmaps {
      * [routeCasingColor] with a selected route line's case (#2082); these tones are gentler, since a badge
      * outline sits against the badge's own fill rather than having to hold a hairline off the basemap.
      */
-    internal fun routeBadgeOutlineColor(color: Int, darkMode: Boolean): Int = routeCasingColor(
-        color,
-        if (darkMode) OUTLINE_TONE_DARK else OUTLINE_TONE_LIGHT
-    )
+    internal fun routeBadgeOutlineColor(color: Int, darkMode: Boolean): Int = routeCasingColor(color, outlineTone(darkMode))
+
+    /**
+     * [routeBadgeOutlineColor] with no hue to keep — the casing a badge naming several routes takes (#2083).
+     * Grey through that same shared re-tone, which deliberately doesn't decline a hueless source: it stays
+     * hueless and lands on the theme's tone, which is exactly the answer wanted here.
+     */
+    internal fun neutralBadgeOutlineColor(darkMode: Boolean): Int = routeCasingColor(Color.GRAY, outlineTone(darkMode))
+
+    private fun outlineTone(darkMode: Boolean): Double = if (darkMode) OUTLINE_TONE_DARK else OUTLINE_TONE_LIGHT
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/ContinuationBadgeBitmaps.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/ContinuationBadgeBitmaps.kt
@@ -22,6 +22,7 @@ import android.graphics.Paint
 import android.graphics.Path
 import android.graphics.RectF
 import androidx.core.graphics.createBitmap
+import androidx.core.graphics.withClip
 import kotlin.math.ceil
 import org.onebusaway.android.util.routeCasingColor
 
@@ -60,19 +61,24 @@ object ContinuationBadgeBitmaps {
      * corridor it labels, while rows keep the label roughly as wide as its widest name.
      */
     fun badge(routes: List<BadgedRoute>, density: Float, darkMode: Boolean): Bitmap {
-        require(routes.isNotEmpty()) { "a route badge names at least one route" }
-        val rows = routes.map { route -> BadgeRow(route, textPaint(route.color)) }
-        // Every row shares one font size, so one row's metrics size them all — the pill's rows are equal
-        // bands whatever they read.
-        val metrics = rows.first().textPaint.fontMetrics
+        require(routes.isNotEmpty()) { "a route badge has to name a route to draw one" }
+        // One paint for every row: they share a size and weight, so only the text color changes down the
+        // stack — set per row, exactly as the band's is. That also makes the metrics below the whole pill's:
+        // its rows are equal bands whatever they read.
+        val textPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            textSize = TEXT_SIZE_PX
+            isFakeBoldText = true
+            textAlign = Paint.Align.CENTER
+        }
+        val metrics = textPaint.fontMetrics
         // A whole number of pixels, so the bands are identical and the pill is exactly as tall as its rows
         // — the row boundaries are also where the dividers are drawn, and a fractional band would drift
         // away from them down the stack.
         val rowHeight = ceil((metrics.descent - metrics.ascent) + VERTICAL_PADDING_PX * 2)
-        val width = rows
-            .maxOf { row -> row.textPaint.measureText(row.route.routeShortName) + HORIZONTAL_PADDING_PX * 2 }
+        val width = routes
+            .maxOf { route -> textPaint.measureText(route.routeShortName) + HORIZONTAL_PADDING_PX * 2 }
             .coerceAtLeast(CORNER_RADIUS_PX * 2)
-        val height = rowHeight * rows.size
+        val height = rowHeight * routes.size
 
         val bitmap = createBitmap(width.toInt(), height.toInt())
         val canvas = Canvas(bitmap)
@@ -83,29 +89,28 @@ object ContinuationBadgeBitmaps {
             width - outlineWidth / 2f,
             height - outlineWidth / 2f
         )
-        val casing = casingColor(routes, darkMode)
+        val band = Paint(Paint.ANTI_ALIAS_FLAG).apply { style = Paint.Style.FILL }
         // The pill's shape clips the bands, so the outermost ones take its rounded corners and the
         // interior ones stay square where they meet.
-        canvas.save()
-        canvas.clipPath(Path().apply { addRoundRect(badgeBounds, CORNER_RADIUS_PX, CORNER_RADIUS_PX, Path.Direction.CW) })
-        val band = Paint(Paint.ANTI_ALIAS_FLAG).apply { style = Paint.Style.FILL }
-        rows.forEachIndexed { index, row ->
-            val top = rowHeight * index
-            val color = row.route.color
-            band.color = Color.rgb(Color.red(color), Color.green(color), Color.blue(color))
-            canvas.drawRect(RectF(0f, top, width, top + rowHeight), band)
-            val baseline = top + rowHeight / 2f - (metrics.ascent + metrics.descent) / 2f
-            canvas.drawText(row.route.routeShortName, width / 2f, baseline, row.textPaint)
+        val pill = Path().apply { addRoundRect(badgeBounds, CORNER_RADIUS_PX, CORNER_RADIUS_PX, Path.Direction.CW) }
+        canvas.withClip(pill) {
+            routes.forEachIndexed { index, route ->
+                val top = rowHeight * index
+                band.color = Color.rgb(Color.red(route.color), Color.green(route.color), Color.blue(route.color))
+                drawRect(RectF(0f, top, width, top + rowHeight), band)
+                textPaint.color = MarkerRendering.legibleOn(route.color)
+                val baseline = top + rowHeight / 2f - (metrics.ascent + metrics.descent) / 2f
+                drawText(route.routeShortName, width / 2f, baseline, textPaint)
+            }
         }
-        canvas.restore()
         val line = Paint(Paint.ANTI_ALIAS_FLAG).apply {
-            color = casing
+            color = casingColor(routes, darkMode)
             style = Paint.Style.STROKE
             strokeWidth = outlineWidth
         }
         // Where two rows meet, in the same color as the outline around them all — so the badge reads as
         // one bounded object holding several names, even when its routes share a color or have none.
-        for (index in 1..rows.lastIndex) {
+        for (index in 1..routes.lastIndex) {
             val y = rowHeight * index
             canvas.drawLine(badgeBounds.left, y, badgeBounds.right, y, line)
         }
@@ -113,23 +118,34 @@ object ContinuationBadgeBitmaps {
         return bitmap
     }
 
-    private class BadgeRow(val route: BadgedRoute, val textPaint: Paint)
-
-    private fun textPaint(color: Int) = Paint(Paint.ANTI_ALIAS_FLAG).apply {
-        this.color = MarkerRendering.legibleOn(color)
-        textSize = TEXT_SIZE_PX
-        isFakeBoldText = true
-        textAlign = Paint.Align.CENTER
-    }
+    /**
+     * A stable key identifying the bitmap [badge] draws for these inputs, beside the function itself so the
+     * two can't disagree about which of them the key names (as [VehicleBitmaps.iconKey] is). A renderer
+     * caches one wrapper (a Google `BitmapDescriptor`) per key.
+     *
+     * Every name and color on the badge takes part, so two labels differing only in a stacked route can't
+     * share a bitmap — and so does [darkMode], which the casing reads: the same routes case differently
+     * either side of a light/dark switch, and a key blind to it would serve the pre-switch pill. Density is
+     * fixed for the lifetime of a renderer's cache, so it distinguishes nothing within one.
+     */
+    fun badgeKey(routes: List<BadgedRoute>, darkMode: Boolean): String = routes.joinToString(
+        separator = "|",
+        prefix = "route-badge:$darkMode:"
+    ) { "${it.routeShortName}:${it.color}" }
 
     /**
-     * The color of the badge's outline and of the lines dividing its rows. A badge naming one route cases
-     * itself in that route's own hue ([routeBadgeOutlineColor]); one naming several has no single hue to
-     * case with — picking a row's would say that row is the badge — so it takes the same tone with the hue
-     * dropped, a neutral that reads against every band it encloses.
+     * The color of the badge's outline and of the lines dividing its rows. A badge with one color between
+     * its routes cases itself in that color's own hue ([routeBadgeOutlineColor]) — which is every
+     * single-route label, and equally a pair of colorless routes drawn in the shared transit fallback. Only
+     * a badge that really does hold several colors has no hue to case with — picking one row's would say
+     * that row is the badge — so it takes the same tone with the hue dropped, a neutral that reads against
+     * every band it encloses.
      */
-    private fun casingColor(routes: List<BadgedRoute>, darkMode: Boolean): Int = routes.singleOrNull()
-        ?.let { routeBadgeOutlineColor(it.color, darkMode) }
+    internal fun casingColor(routes: List<BadgedRoute>, darkMode: Boolean): Int = routes
+        .map(BadgedRoute::color)
+        .distinct()
+        .singleOrNull()
+        ?.let { routeBadgeOutlineColor(it, darkMode) }
         ?: neutralBadgeOutlineColor(darkMode)
 
     /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
@@ -214,13 +214,25 @@ data class ContinuationBadge(
 )
 
 /**
- * A label naming one route on the line it is drawn on — in focused-stop adjacency view (#1827), and on
- * a directions itinerary's rides (#2066). Anchored once in geographic space so the map SDK naturally
+ * One route named on a [RouteBadge]: what it reads, and the colour the map draws that route's line in
+ * (already through the map's route-line policy — see [org.onebusaway.android.map.mapRouteLineColor]),
+ * so a name and the line it belongs to can't disagree.
+ */
+data class BadgedRoute(val routeShortName: String, val color: Int)
+
+/**
+ * A label naming the route(s) on the line it is drawn on — in focused-stop adjacency view (#1827), and
+ * on a directions itinerary's rides (#2066). Anchored once in geographic space so the map SDK naturally
  * carries it through pan and zoom. Rendered by both flavors (#1913).
  */
 data class RouteBadge(
-    val routeShortName: String,
-    val color: Int,
+    /**
+     * The routes this label names, in the order it reads them — top to bottom, since a label naming
+     * several routes stacks them (#2083). Usually one; several exactly where the rider may board any of
+     * them for the same ride (interchangeable routes, #2010), which is a fact about the ride, so the
+     * label carries every route rather than whichever one the trip planner picked.
+     */
+    val routes: List<BadgedRoute>,
     val point: GeoPoint,
     /**
      * Where a tap on this label navigates — the route-direction to show, preferring the drawn line's own
@@ -230,7 +242,22 @@ data class RouteBadge(
      * says where it leads, and no producer needs a navigable id it doesn't have.
      */
     val tap: RouteDirectionKey? = null
-)
+) {
+    init {
+        // Both stated rather than trusted: a label with nothing to read is a marker the rider can't
+        // account for, and a navigable label naming several routes would leave the tap handler picking
+        // one of them — the destination has to be as unambiguous as the name. Producer-side invariants
+        // (only adjacency labels navigate, and each names its one route), so a violation is a bug in a
+        // badge builder, which is where the message points.
+        require(routes.isNotEmpty()) { "a route badge names at least one route" }
+        require(tap == null || routes.size == 1) {
+            "a badge naming ${routes.size} routes has no single route to navigate to"
+        }
+    }
+
+    /** The one route a navigable badge names — see the [tap] invariant above. */
+    val tappedRouteShortName: String get() = routes.single().routeShortName
+}
 
 /**
  * The arrowhead terminating a route-continuation line (#1691), at [point] oriented along [bearing]

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/ModeSymbols.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/ModeSymbols.kt
@@ -16,6 +16,7 @@
 package org.onebusaway.android.ui.tripresults
 
 import org.onebusaway.android.directions.model.InterchangeableRoute
+import org.onebusaway.android.directions.model.Interlines
 import org.onebusaway.android.directions.model.TripLeg
 import org.onebusaway.android.directions.model.TripMode
 import org.onebusaway.android.directions.model.TripVertexType

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/RouteBadges.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/RouteBadges.kt
@@ -16,13 +16,14 @@
 package org.onebusaway.android.ui.tripresults
 
 import org.onebusaway.android.directions.model.InterchangeableRoute
+import org.onebusaway.android.directions.model.Interlines
 import org.onebusaway.android.directions.model.TripLeg
 import org.onebusaway.android.directions.model.TripMode
 import org.onebusaway.android.directions.model.routeDisplayLabel
 import org.onebusaway.android.directions.model.routeDisplayShortName
 import org.onebusaway.android.ui.compose.components.RouteBadge
 import org.onebusaway.android.ui.compose.components.RouteBadgeJoin
-import org.onebusaway.android.util.ROUTE_NAME_ORDER
+import org.onebusaway.android.util.inInterchangeableOrder
 import org.onebusaway.android.util.parseObaHexColor
 
 /**
@@ -89,9 +90,7 @@ internal fun legBadge(leg: TripLeg, alternatives: List<InterchangeableRoute>): L
  * an unnameable one is never built. A leg left with no routes renders as its [mode] instead.
  */
 internal fun legBadge(planned: RouteBadge?, alternatives: List<RouteBadge>, mode: TransitMode): LegBadge = LegBadge(
-    (listOfNotNull(planned) + alternatives)
-        .distinctBy { it.shortName }
-        .sortedWith(compareBy(ROUTE_NAME_ORDER) { it.shortName }),
+    (listOfNotNull(planned) + alternatives).inInterchangeableOrder { it.shortName },
     mode,
     RouteBadgeJoin.ANY_OF
 )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripLogBuilder.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripLogBuilder.kt
@@ -16,6 +16,7 @@
 package org.onebusaway.android.ui.tripresults
 
 import org.onebusaway.android.directions.model.Direction
+import org.onebusaway.android.directions.model.Interlines
 import org.onebusaway.android.directions.model.TripLeg
 import org.onebusaway.android.directions.model.decodedPoints
 import org.onebusaway.android.directions.model.routeDisplayName

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsRepository.kt
@@ -22,12 +22,14 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.onebusaway.android.directions.OtpObaIdResolver
 import org.onebusaway.android.directions.model.InterchangeableRoute
+import org.onebusaway.android.directions.model.Interlines
 import org.onebusaway.android.directions.model.TripItinerary
 import org.onebusaway.android.directions.model.TripLeg
 import org.onebusaway.android.directions.model.TripMode
 import org.onebusaway.android.directions.model.TripPlace
 import org.onebusaway.android.directions.model.interchangeableRoutes
 import org.onebusaway.android.directions.model.routeDisplayName
+import org.onebusaway.android.directions.model.substitutableRoutes
 import org.onebusaway.android.directions.util.DirectionsGenerator
 import org.onebusaway.android.map.RouteFocusSegment
 import org.onebusaway.android.util.geoPointOrNull

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/RouteDisplay.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/RouteDisplay.kt
@@ -35,9 +35,12 @@ val ROUTE_NAME_ORDER: Comparator<String> = AlphanumComparator()
  * whichever of them the trip planner picked, and which one it did pick is still on the option card's
  * header line and its ETA strip.
  *
- * Shared by the two places a ride's routes are named: the drawer/picker's joined badge
- * (`legBadge`) and the label on its line on the map (`itineraryRouteBadges`, #2083) — so a rider looking
- * at both at once can't be shown one ride named in two orders.
+ * Shared by the two places a ride's routes are *badged* — the drawer/picker's joined chip (`legBadge`) and
+ * the label on its line on the map (`itineraryRouteBadges`, #2083) — so a rider looking at both at once
+ * can't be shown one ride named in two orders. It is deliberately not what
+ * [org.onebusaway.android.directions.model.interchangeableRoutes] applies when it produces the candidates:
+ * that list is also what the map's route focus loads (#2063), so it sorts by the same order but keeps every
+ * route, name collisions included. Deduplication is a badge's rule, not the plan's.
  */
 fun <T> List<T>.inInterchangeableOrder(name: (T) -> String): List<T> = distinctBy(name).sortedWith(compareBy(ROUTE_NAME_ORDER, name))
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/RouteDisplay.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/RouteDisplay.kt
@@ -30,6 +30,18 @@ data class RouteDisplayNames(val shortName: String, val longName: String?)
 val ROUTE_NAME_ORDER: Comparator<String> = AlphanumComparator()
 
 /**
+ * The routes of one interchangeable ride (#2010) as it is read: deduplicated by [name] and in
+ * [ROUTE_NAME_ORDER], the plan's own choice given no pride of place — "1 Line/2 Line" reads the same
+ * whichever of them the trip planner picked, and which one it did pick is still on the option card's
+ * header line and its ETA strip.
+ *
+ * Shared by the two places a ride's routes are named: the drawer/picker's joined badge
+ * (`legBadge`) and the label on its line on the map (`itineraryRouteBadges`, #2083) — so a rider looking
+ * at both at once can't be shown one ride named in two orders.
+ */
+fun <T> List<T>.inInterchangeableOrder(name: (T) -> String): List<T> = distinctBy(name).sortedWith(compareBy(ROUTE_NAME_ORDER, name))
+
+/**
  * Resolves a route's display names with the same short→long→description fallbacks the legacy
  * UIUtils.setRouteView applied: the short name falls back to the long name, and the secondary
  * line is the long name (or the description when the long name is missing or equals the short

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
@@ -39,6 +39,7 @@ import org.maplibre.android.maps.Style
 import org.onebusaway.android.R
 import org.onebusaway.android.map.compose.formatDataAge
 import org.onebusaway.android.map.mapRouteLineCaseColor
+import org.onebusaway.android.map.render.BadgedRoute
 import org.onebusaway.android.map.render.BikeBand
 import org.onebusaway.android.map.render.BikeBitmaps
 import org.onebusaway.android.map.render.BikeMarker
@@ -254,7 +255,7 @@ class MapLibreRenderer(
             val marker = map.addMarker(
                 MarkerOptions()
                     .position(badge.point.toLatLng())
-                    .icon(routeBadgeIcon(badge.routeShortName, badge.color))
+                    .icon(routeBadgeIcon(badge.routes))
             )
             staticAnnotations.add(marker)
             // Only a label that leads somewhere becomes a tap target (see [RouteBadge.tap]); an
@@ -263,10 +264,9 @@ class MapLibreRenderer(
         }
     }
 
-    private fun routeBadgeIcon(routeShortName: String, color: Int): Icon = iconFactory.fromBitmap(
+    private fun routeBadgeIcon(routes: List<BadgedRoute>): Icon = iconFactory.fromBitmap(
         ContinuationBadgeBitmaps.badge(
-            routeShortName,
-            color,
+            routes,
             density,
             darkMode = ThemeUtils.isInDarkMode(context)
         )

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreComposeAdapter.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreComposeAdapter.kt
@@ -331,7 +331,7 @@ private fun wireClicks(
         val routeBadge = renderer.routeBadgeForMarker(marker)
         val routeBadgeTap = routeBadge?.tap
         if (routeBadge != null && routeBadgeTap != null) {
-            callbacks.onRouteBadgeClick(routeBadgeTap.routeId, routeBadge.routeShortName, routeBadgeTap.directionId)
+            callbacks.onRouteBadgeClick(routeBadgeTap.routeId, routeBadge.tappedRouteShortName, routeBadgeTap.directionId)
             return@setOnMarkerClickListener true
         }
         // Titled markers (the trip-focus estimate markers + the most-recent-data dot) fall through to

--- a/onebusaway-android/src/test/java/org/onebusaway/android/directions/model/InterlinesTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/directions/model/InterlinesTest.kt
@@ -13,15 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.onebusaway.android.ui.tripresults
+package org.onebusaway.android.directions.model
 
 import org.junit.Assert.assertEquals
 import org.junit.Test
-import org.onebusaway.android.directions.model.TripItinerary
-import org.onebusaway.android.directions.model.TripLeg
-import org.onebusaway.android.directions.model.TripLegAlternative
-import org.onebusaway.android.directions.model.TripMode
-import org.onebusaway.android.directions.model.TripPlace
 
 /**
  * JVM tests for [Interlines]: the pure analysis that folds a self-interline seam away and keeps a

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/ItineraryRouteBadgesTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/ItineraryRouteBadgesTest.kt
@@ -144,13 +144,36 @@ class ItineraryRouteBadgesTest {
         assertEquals(listOf(listOf("1 Line", "2 Line"), listOf("2 Line")), badges.map(::names))
     }
 
+    @Test
+    fun `substitutes that merely read alike are different offers`() {
+        // Two legs of the 2 Line, each offered a different route that happens to publish the same name. The
+        // labels group on the candidates' route ids, so the two rides stay apart; grouping on the name would
+        // fold them into one label covering both corridors.
+        val first = TripLeg(mode = TripMode.RAIL, routeId = "route-2", routeShortName = "2 Line")
+        val second = TripLeg(mode = TripMode.RAIL, routeId = "route-2", routeShortName = "2 Line")
+
+        val badges = itineraryRouteBadges(
+            listOf(
+                drawable(0, first, eastward, interchangeable = listOf(interchangeable("1 Line", routeId = "route-1a"))),
+                drawable(1, second, northward, interchangeable = listOf(interchangeable("1 Line", routeId = "route-1b")))
+            )
+        )
+
+        assertEquals(listOf(listOf("1 Line", "2 Line"), listOf("1 Line", "2 Line")), badges.map(::names))
+    }
+
     private fun names(badge: RouteBadge) = badge.routes.map(BadgedRoute::routeShortName)
 
-    /** An interchangeable route as the controller hands it over: named, and already colour-parsed. */
-    private fun interchangeable(displayName: String, routeColor: Int? = null) = interchangeableBadgedRoute(
+    /** A route offered in a leg's place, as the controller hands it over: the candidate plus its parsed colour. */
+    private fun interchangeable(
+        displayName: String,
+        routeColor: Int? = null,
+        routeId: String = "route-for-$displayName"
+    ) = ItinerarySubstitute(
         InterchangeableRoute(
-            routeId = "route-for-$displayName",
+            routeId = routeId,
             displayName = displayName,
+            // The colour reaches the label already parsed, so the wire field plays no part here.
             routeColor = null,
             agencyId = null,
             agencyName = null,
@@ -164,6 +187,6 @@ class ItineraryRouteBadgesTest {
         leg: TripLeg,
         points: List<GeoPoint>,
         kind: ItineraryLegKind = ItineraryLegKind.TRANSIT,
-        interchangeable: List<BadgedRoute> = emptyList()
+        interchangeable: List<ItinerarySubstitute> = emptyList()
     ) = ItineraryDrawableLeg(index, leg, points, itineraryLegStyle(kind, routeColor = null), interchangeable)
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/ItineraryRouteBadgesTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/ItineraryRouteBadgesTest.kt
@@ -5,14 +5,18 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
+import org.onebusaway.android.directions.model.InterchangeableRoute
 import org.onebusaway.android.directions.model.TripLeg
 import org.onebusaway.android.directions.model.TripMode
+import org.onebusaway.android.map.render.BadgedRoute
+import org.onebusaway.android.map.render.RouteBadge
 import org.onebusaway.android.util.GeoPoint
 
 /**
  * The route labels drawn on a directions itinerary's transit lines (#2066). The point of these is that a
- * label names *a ride* — one per route, however many legs it spans — takes the colour of the line it
- * names, and never becomes a tap target that would navigate away from the trip being read.
+ * label names *a ride* — one per route, however many legs it spans, and every route the rider may board
+ * for it (#2083) — takes the colour of the line it names, and never becomes a tap target that would
+ * navigate away from the trip being read.
  */
 class ItineraryRouteBadgesTest {
 
@@ -32,10 +36,9 @@ class ItineraryRouteBadgesTest {
             )
         ).single()
 
-        assertEquals("45", badge.routeShortName)
-        assertEquals(GeoPoint(0.0, 0.5), badge.point)
         // Exactly the colour its own line is stroked with, so a label and its line can't disagree.
-        assertEquals(rideStyle.color, badge.color)
+        assertEquals(listOf(BadgedRoute("45", rideStyle.color)), badge.routes)
+        assertEquals(GeoPoint(0.0, 0.5), badge.point)
         // No tap target at all, so there is nothing for a stray tap to navigate to.
         assertNull(badge.tap)
     }
@@ -49,7 +52,7 @@ class ItineraryRouteBadgesTest {
             listOf(drawable(0, first, eastward), drawable(2, second, northward))
         )
 
-        assertEquals(listOf("5"), badges.map { it.routeShortName })
+        assertEquals(listOf(listOf("5")), badges.map(::names))
     }
 
     @Test
@@ -61,7 +64,7 @@ class ItineraryRouteBadgesTest {
             )
         )
 
-        assertEquals(listOf("A", "B"), badges.map { it.routeShortName })
+        assertEquals(listOf(listOf("A"), listOf("B")), badges.map(::names))
         assertNotEquals(badges[0].point, badges[1].point)
     }
 
@@ -76,7 +79,7 @@ class ItineraryRouteBadgesTest {
             )
         )
 
-        assertEquals(listOf("45"), badges.map { it.routeShortName })
+        assertEquals(listOf(listOf("45")), badges.map(::names))
     }
 
     @Test
@@ -91,13 +94,76 @@ class ItineraryRouteBadgesTest {
             )
         )
 
-        assertEquals(emptyList<String>(), badges.map { it.routeShortName })
+        assertEquals(emptyList<List<String>>(), badges.map(::names))
     }
+
+    @Test
+    fun `an interchangeable ride is labelled with every route it may be ridden as, in name order`() {
+        // The planner picked the 2 Line; the label gives it no pride of place, exactly as the drawer's
+        // joined badge doesn't — the routes are interchangeable, so the label reads the same either way.
+        val ride = TripLeg(mode = TripMode.RAIL, routeId = "route-2", routeShortName = "2 Line")
+
+        val badge = itineraryRouteBadges(
+            listOf(drawable(0, ride, eastward, interchangeable = listOf(interchangeable("1 Line"))))
+        ).single()
+
+        assertEquals(listOf("1 Line", "2 Line"), names(badge))
+        // Still informational: naming several routes doesn't turn the label into a navigation target.
+        assertNull(badge.tap)
+    }
+
+    @Test
+    fun `an interchangeable route is coloured as the map would draw its own line`() {
+        val ride = TripLeg(mode = TripMode.RAIL, routeId = "route-2", routeShortName = "2 Line")
+        val alternative = interchangeable("1 Line", routeColor = 0xFF0000FF.toInt())
+
+        val badge = itineraryRouteBadges(
+            listOf(drawable(0, ride, eastward, interchangeable = listOf(alternative)))
+        ).single()
+
+        assertEquals(
+            itineraryLegStyle(ItineraryLegKind.TRANSIT, routeColor = 0xFF0000FF.toInt()).color,
+            badge.routes.single { it.routeShortName == "1 Line" }.color
+        )
+    }
+
+    @Test
+    fun `two legs of one route offered different substitutes are labelled separately`() {
+        // The first leg shares its corridor with the 1 Line; the second doesn't. One shared label would
+        // claim on both segments what is only true of one, so the ride is labelled where it is true.
+        val first = TripLeg(mode = TripMode.RAIL, routeId = "route-2", routeShortName = "2 Line")
+        val second = TripLeg(mode = TripMode.RAIL, routeId = "route-2", routeShortName = "2 Line")
+
+        val badges = itineraryRouteBadges(
+            listOf(
+                drawable(0, first, eastward, interchangeable = listOf(interchangeable("1 Line"))),
+                drawable(1, second, northward)
+            )
+        )
+
+        assertEquals(listOf(listOf("1 Line", "2 Line"), listOf("2 Line")), badges.map(::names))
+    }
+
+    private fun names(badge: RouteBadge) = badge.routes.map(BadgedRoute::routeShortName)
+
+    /** An interchangeable route as the controller hands it over: named, and already colour-parsed. */
+    private fun interchangeable(displayName: String, routeColor: Int? = null) = interchangeableBadgedRoute(
+        InterchangeableRoute(
+            routeId = "route-for-$displayName",
+            displayName = displayName,
+            routeColor = null,
+            agencyId = null,
+            agencyName = null,
+            headsign = null
+        ),
+        routeColor
+    )
 
     private fun drawable(
         index: Int,
         leg: TripLeg,
         points: List<GeoPoint>,
-        kind: ItineraryLegKind = ItineraryLegKind.TRANSIT
-    ) = ItineraryDrawableLeg(index, leg, points, itineraryLegStyle(kind, routeColor = null))
+        kind: ItineraryLegKind = ItineraryLegKind.TRANSIT,
+        interchangeable: List<BadgedRoute> = emptyList()
+    ) = ItineraryDrawableLeg(index, leg, points, itineraryLegStyle(kind, routeColor = null), interchangeable)
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteViewGeometryTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteViewGeometryTest.kt
@@ -278,8 +278,10 @@ class RouteViewGeometryTest {
         )
 
         assertEquals(listOf("route-b", "route-a", "route-a"), badges.map { it.tap?.routeId })
-        assertEquals(listOf("B", "A", "A"), badges.map { it.routeShortName })
-        assertEquals(listOf(20, 10, 30), badges.map { it.color })
+        // An adjacency label names its one route: only a directions ride the rider may board any of
+        // several routes for stacks more than one name (#2083).
+        assertEquals(listOf("B", "A", "A"), badges.map { it.routes.single().routeShortName })
+        assertEquals(listOf(20, 10, 30), badges.map { it.routes.single().color })
         assertEquals(listOf(1, 0, 1), badges.map { it.tap?.directionId })
         assertEquals(GeoPoint(0.0, 0.5), badges[0].point)
         assertTrue(haversineMeters(badges[0].point, badges[1].point) >= 299.9)

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/render/ContinuationBadgeBitmapsTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/render/ContinuationBadgeBitmapsTest.kt
@@ -18,7 +18,9 @@ package org.onebusaway.android.map.render
 import android.annotation.SuppressLint
 import com.google.android.material.color.utilities.Hct
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.onebusaway.android.util.ACHROMATIC_ROUTE_CHROMA
 
 @SuppressLint("RestrictedApi")
 class ContinuationBadgeBitmapsTest {
@@ -31,5 +33,20 @@ class ContinuationBadgeBitmapsTest {
 
         assertEquals(35.0, Hct.fromInt(lightOutline).tone, 1.0)
         assertEquals(85.0, Hct.fromInt(darkOutline).tone, 1.0)
+    }
+
+    @Test
+    fun `a badge naming several routes cases itself in a neutral of the same tone`() {
+        // A stacked badge (#2083) has no single hue to case with, so it keeps the theme tone and drops the
+        // hue — the outline and the lines between its rows read against every band they enclose.
+        val light = ContinuationBadgeBitmaps.neutralBadgeOutlineColor(darkMode = false)
+        val dark = ContinuationBadgeBitmaps.neutralBadgeOutlineColor(darkMode = true)
+
+        assertEquals(35.0, Hct.fromInt(light).tone, 1.0)
+        assertEquals(85.0, Hct.fromInt(dark).tone, 1.0)
+        // Grey to the same threshold the app uses to declare a route colour hueless, rather than exactly
+        // zero: the tone is quantized into sRGB on the way out and lands a hair off achromatic.
+        assertTrue(Hct.fromInt(light).chroma < ACHROMATIC_ROUTE_CHROMA)
+        assertTrue(Hct.fromInt(dark).chroma < ACHROMATIC_ROUTE_CHROMA)
     }
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/render/ContinuationBadgeBitmapsTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/render/ContinuationBadgeBitmapsTest.kt
@@ -49,4 +49,24 @@ class ContinuationBadgeBitmapsTest {
         assertTrue(Hct.fromInt(light).chroma < ACHROMATIC_ROUTE_CHROMA)
         assertTrue(Hct.fromInt(dark).chroma < ACHROMATIC_ROUTE_CHROMA)
     }
+
+    @Test
+    fun `casing follows the colours on the badge, not how many routes it names`() {
+        val blue = Hct.from(210.0, 75.0, 55.0).toInt()
+        val green = Hct.from(140.0, 75.0, 55.0).toInt()
+        val hued = ContinuationBadgeBitmaps.routeBadgeOutlineColor(blue, darkMode = false)
+
+        // One route: its own hue, as it always has been.
+        assertEquals(hued, casing(listOf(BadgedRoute("1 Line", blue))))
+        // Two routes drawn in one colour — a pair whose agency publishes none, both taking the shared
+        // transit fallback — is a single-colour pill, so it cases like one rather than going grey.
+        assertEquals(hued, casing(listOf(BadgedRoute("1 Line", blue), BadgedRoute("2 Line", blue))))
+        // Only a badge that really holds several colours has no hue to case with.
+        assertEquals(
+            ContinuationBadgeBitmaps.neutralBadgeOutlineColor(darkMode = false),
+            casing(listOf(BadgedRoute("1 Line", blue), BadgedRoute("2 Line", green)))
+        )
+    }
+
+    private fun casing(routes: List<BadgedRoute>) = ContinuationBadgeBitmaps.casingColor(routes, darkMode = false)
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/render/RouteBadgeInvariantsTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/render/RouteBadgeInvariantsTest.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.map.render
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+import org.onebusaway.android.models.RouteDirectionKey
+import org.onebusaway.android.util.GeoPoint
+
+/**
+ * The two invariants [RouteBadge] states about what a map label may be (#2083): it names at least one
+ * route, and a navigable one names exactly one. Both are producer-side — only adjacency labels navigate,
+ * and each names its own route — so these pin the contract a badge builder has to keep rather than
+ * behaviour a rider sees.
+ */
+class RouteBadgeInvariantsTest {
+
+    private val point = GeoPoint(47.6, -122.3)
+
+    private val oneLine = BadgedRoute("1 Line", 0xFF1050C0.toInt())
+
+    private val twoLine = BadgedRoute("2 Line", 0xFF107030.toInt())
+
+    @Test
+    fun `a label with nothing to read is rejected`() {
+        assertThrows(IllegalArgumentException::class.java) { RouteBadge(routes = emptyList(), point = point) }
+    }
+
+    @Test
+    fun `a navigable label naming several routes is rejected`() {
+        // Where would the tap lead? A label that stacks routes is informational for exactly this reason.
+        assertThrows(IllegalArgumentException::class.java) {
+            RouteBadge(routes = listOf(oneLine, twoLine), point = point, tap = RouteDirectionKey("route-1", 0))
+        }
+    }
+
+    @Test
+    fun `an informational label may name several routes, in the order given`() {
+        val badge = RouteBadge(routes = listOf(oneLine, twoLine), point = point)
+
+        assertEquals(listOf(oneLine, twoLine), badge.routes)
+        assertEquals(null, badge.tap)
+    }
+
+    @Test
+    fun `a navigable label names its one route`() {
+        val tap = RouteDirectionKey("route-1", 0)
+        val badge = RouteBadge(routes = listOf(oneLine), point = point, tap = tap)
+
+        assertEquals(tap, badge.tap)
+        assertEquals("1 Line", badge.tappedRouteShortName)
+    }
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/RouteBadgesTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/RouteBadgesTest.kt
@@ -21,6 +21,7 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.onebusaway.android.directions.model.InterchangeableRoute
+import org.onebusaway.android.directions.model.Interlines
 import org.onebusaway.android.directions.model.TripLeg
 import org.onebusaway.android.directions.model.TripMode
 import org.onebusaway.android.ui.compose.components.RouteBadge


### PR DESCRIPTION
Fixes #2083.

A directions-map label named one route per ridden line — the one OTP happened to plan — while the drawer beside it badged "1 Line/2 Line" for the same ride. On an interleaved corridor the two disagreed about what the rider may board, and the map was the one that was wrong: interchangeability (#2010) is a fact about the ride, not about which route the planner picked.

## What changed

- **A map label is a stack of routes, not one name.** `RouteBadge` carries `routes: List<BadgedRoute>` — read top to bottom — and the pill draws a band per route in that route's own line colour: one bounded object holding several names, for the reason the drawer's joined chip already gives (these are one ride, not separate lines that happen to meet here). The stack goes down rather than across because a map label's neighbour is the basemap, and a name-per-column pill grows into the corridor it labels.
- **A single-route label is unchanged.** Focused-stop adjacency (#1827) and the continuation badge (#1691) still draw exactly as before, including their route-hued casing. Only a badge naming *several* routes has no single hue to case with, so it keeps the casing tone and drops the hue — a neutral that reads against every band it encloses.
- **Two invariants the model states rather than trusts:** a label names at least one route, and a navigable one names exactly one — so a tap can't be left picking which of several names it meant. (An itinerary label stays informational; naming more routes doesn't make it a navigation target.)
- **The routes, and their order, come from the drawer.** A label carries `substitutableRoutes` — the interchangeable set already narrowed by what the rest of the plan needs of the leg, so a leg of a stay-aboard interline admits no substitute at all (#2000 × #2010) — sorted by one shared `inInterchangeableOrder` that `legBadge` now uses too. The plan's own choice gets no pride of place, exactly as in the drawer.
- **The alternatives key the label.** Two legs of one route offered different substitutes are labelled separately: a single shared label would claim on both segments what is only true of one. When they agree — the ordinary case, and every leg of an interline chain — the legs still share one label.
- **`Interlines` moves to `directions/model`**, alongside `interchangeableRoutes`, so the map reads a fact about the plan instead of importing from the trip-results UI. Pure move — no behaviour change, and its test moves with it.

No new heuristics: every route on a label is one OTP named, and its colour goes through the map's existing route-line policy.

## Verification

- `obaGoogle` + `obaMaplibre` compile clean under `-PwarningsAsErrors=true`; full `:test` suite and `spotlessCheck` green; androidTest sources compile.
- New JVM coverage in `ItineraryRouteBadgesTest` (stacking, name order, per-route colour, the split-label case) and the neutral-casing rule in `ContinuationBadgeBitmapsTest`.
- New instrumented `RouteBadgeBitmapTest` reads the drawn pixels back to confirm one row per route, stacked in order, each in its own colour — the only way `Canvas` drawing can be checked here. **Not yet run locally**; CI's instrumented leg will be its first execution.
- Checked by hand on a device: an interleaved corridor's label now names both lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/OneBusAway/codesmith/onebusaway-android/pr/2088"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787973660&installation_model_id=429412&pr_number=2088&repository=OneBusAway%2Fonebusaway-android&return_to=https%3A%2F%2Fgithub.com%2FOneBusAway%2Fonebusaway-android%2Fpull%2F2088&signature=0f976db033f717a75738173774369923e083204b20c036ab0bea9f04bb69e9e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Route badges can now show stacked, color-coded labels for multiple interchangeable route options.
  * Badge ordering and label grouping reflect the set of available alternatives consistently across map views.

* **Bug Fixes**
  * Badge rendering and outline behavior updated for multi-route stacks (including neutral outline when routes span multiple tones).
  * Badge tap now targets the specific route represented by the tapped badge.

* **Tests**
  * Added and updated coverage for stacked badge layout, dimensions, colors, ordering, and interchangeable-route labeling/tap behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->