### PR TITLE
Draw circular bulbs at transit leg endpoints

### DIFF
--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
@@ -355,7 +355,7 @@ class GoogleMapRenderer(
         return map.addPolyline(options)
     }
 
-    /** A circle 1.3x the stroke width, scaled by Maps together with the line at every zoom. */
+    /** A circle 2x the stroke width, scaled by Maps together with the line at every zoom. */
     private fun endpointBulbCap(color: Int): CustomCap {
         val descriptor = descriptorCache.get("route-endpoint-bulb:$color") {
             val bitmap = createBitmap(ENDPOINT_BULB_BITMAP_PX, ENDPOINT_BULB_BITMAP_PX)
@@ -823,7 +823,7 @@ class GoogleMapRenderer(
     fun vehicleMarkerForTripId(tripId: String): Marker? = vehicleMarkersByTripId[tripId]
 
     companion object {
-        private const val ENDPOINT_BULB_BITMAP_PX = 26
+        private const val ENDPOINT_BULB_BITMAP_PX = 40
         private const val ENDPOINT_BULB_REFERENCE_WIDTH_PX = 20f
 
         // gms polyline/marker dimensions are in screen pixels.

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
@@ -19,6 +19,7 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.Color
+import android.graphics.Paint
 import androidx.core.content.ContextCompat
 import androidx.core.graphics.createBitmap
 import com.google.android.gms.maps.GoogleMap
@@ -26,6 +27,7 @@ import com.google.android.gms.maps.model.BitmapDescriptor
 import com.google.android.gms.maps.model.BitmapDescriptorFactory
 import com.google.android.gms.maps.model.Circle
 import com.google.android.gms.maps.model.CircleOptions
+import com.google.android.gms.maps.model.CustomCap
 import com.google.android.gms.maps.model.Dash
 import com.google.android.gms.maps.model.Gap
 import com.google.android.gms.maps.model.LatLng
@@ -333,6 +335,10 @@ class GoogleMapRenderer(
             .width(widthPx)
             .addPoints(polyline.points)
             .applyDashPattern(polyline)
+        if (polyline.roundCaps) {
+            val bulb = endpointBulbCap(polyline.resolvedColor)
+            options.startCap(bulb).endCap(bulb)
+        }
         if (polyline.directional) {
             // Advanced spans are substantially more expensive for Maps to retessellate while
             // zooming. Reserve that path for the lines that actually need repeated chevrons.
@@ -346,6 +352,21 @@ class GoogleMapRenderer(
             options.color(polyline.resolvedColor)
         }
         return map.addPolyline(options)
+    }
+
+    /** A circle 1.5x the stroke width, scaled by Maps together with the line at every zoom. */
+    private fun endpointBulbCap(color: Int): CustomCap {
+        val descriptor = descriptorCache.get("route-endpoint-bulb:$color") {
+            val bitmap = createBitmap(ENDPOINT_BULB_BITMAP_PX, ENDPOINT_BULB_BITMAP_PX)
+            Canvas(bitmap).drawCircle(
+                ENDPOINT_BULB_BITMAP_PX / 2f,
+                ENDPOINT_BULB_BITMAP_PX / 2f,
+                ENDPOINT_BULB_BITMAP_PX / 2f,
+                Paint(Paint.ANTI_ALIAS_FLAG).apply { this.color = color }
+            )
+            bitmap
+        }
+        return CustomCap(descriptor, ENDPOINT_BULB_REFERENCE_WIDTH_PX)
     }
 
     /**
@@ -801,6 +822,9 @@ class GoogleMapRenderer(
     fun vehicleMarkerForTripId(tripId: String): Marker? = vehicleMarkersByTripId[tripId]
 
     companion object {
+        private const val ENDPOINT_BULB_BITMAP_PX = 24
+        private const val ENDPOINT_BULB_REFERENCE_WIDTH_PX = 16f
+
         // gms polyline/marker dimensions are in screen pixels.
         private const val DEFAULT_ROUTE_WIDTH_PX = 10f
         private const val TRIP_BAND_WIDTH_PX = 44f

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
@@ -335,9 +335,10 @@ class GoogleMapRenderer(
             .width(widthPx)
             .addPoints(polyline.points)
             .applyDashPattern(polyline)
-        if (polyline.roundCaps) {
+        if (polyline.roundStartCap || polyline.roundEndCap) {
             val bulb = endpointBulbCap(polyline.resolvedColor)
-            options.startCap(bulb).endCap(bulb)
+            if (polyline.roundStartCap) options.startCap(bulb)
+            if (polyline.roundEndCap) options.endCap(bulb)
         }
         if (polyline.directional) {
             // Advanced spans are substantially more expensive for Maps to retessellate while
@@ -354,7 +355,7 @@ class GoogleMapRenderer(
         return map.addPolyline(options)
     }
 
-    /** A circle 1.5x the stroke width, scaled by Maps together with the line at every zoom. */
+    /** A circle 1.3x the stroke width, scaled by Maps together with the line at every zoom. */
     private fun endpointBulbCap(color: Int): CustomCap {
         val descriptor = descriptorCache.get("route-endpoint-bulb:$color") {
             val bitmap = createBitmap(ENDPOINT_BULB_BITMAP_PX, ENDPOINT_BULB_BITMAP_PX)
@@ -822,8 +823,8 @@ class GoogleMapRenderer(
     fun vehicleMarkerForTripId(tripId: String): Marker? = vehicleMarkersByTripId[tripId]
 
     companion object {
-        private const val ENDPOINT_BULB_BITMAP_PX = 24
-        private const val ENDPOINT_BULB_REFERENCE_WIDTH_PX = 16f
+        private const val ENDPOINT_BULB_BITMAP_PX = 26
+        private const val ENDPOINT_BULB_REFERENCE_WIDTH_PX = 20f
 
         // gms polyline/marker dimensions are in screen pixels.
         private const val DEFAULT_ROUTE_WIDTH_PX = 10f

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/DirectionsMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/DirectionsMapController.kt
@@ -99,6 +99,7 @@ class DirectionsMapController(private val host: MapHost) {
         // Every leg's points run in travel order, so whether it stamps chevrons is the style's call — a
         // dashed on-street stroke declines them (see [itineraryLegStyle]).
         legLines = drawableLegs.map { (legIndex, _, points, style) ->
+            val caps = itineraryLegCaps(legs, legIndex)
             ItineraryLegLine(
                 legIndex,
                 RoutePolyline(
@@ -107,7 +108,8 @@ class DirectionsMapController(private val host: MapHost) {
                     widthProfile = style.widthProfile,
                     directional = style.directional,
                     dash = style.dash,
-                    roundCaps = style.roundCaps
+                    roundStartCap = style.roundCaps && caps.start,
+                    roundEndCap = style.roundCaps && caps.end
                 )
             )
         }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/DirectionsMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/DirectionsMapController.kt
@@ -106,7 +106,8 @@ class DirectionsMapController(private val host: MapHost) {
                     points,
                     widthProfile = style.widthProfile,
                     directional = style.directional,
-                    dash = style.dash
+                    dash = style.dash,
+                    roundCaps = style.roundCaps
                 )
             )
         }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/ItineraryLegStyle.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/ItineraryLegStyle.kt
@@ -113,6 +113,19 @@ internal fun itineraryLegStyle(kind: ItineraryLegKind, routeColor: Int?): Itiner
  */
 internal data class ItineraryLegLine(val legIndex: Int, val line: RoutePolyline)
 
+/** Bulb-bearing ends of one itinerary leg; an interline continuation has no visible internal seam. */
+internal data class ItineraryLegCaps(val start: Boolean, val end: Boolean)
+
+internal fun itineraryLegCaps(legs: List<TripLeg>, index: Int): ItineraryLegCaps {
+    val leg = legs[index]
+    val transit = leg.mode?.isTransit == true
+    val continuesPrevious = transit && leg.interlineWithPreviousLeg &&
+        legs.getOrNull(index - 1)?.mode?.isTransit == true
+    val next = legs.getOrNull(index + 1)
+    val continuesIntoNext = transit && next?.mode?.isTransit == true && next.interlineWithPreviousLeg
+    return ItineraryLegCaps(start = !continuesPrevious, end = !continuesIntoNext)
+}
+
 /**
  * The drawn itinerary composed around a leg focus (#2048): the focused leg(s) cased ([withCase]) and
  * re-appended last so they draw on top. Focusing a leg therefore *marks* it within the whole journey rather

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/ItineraryLegStyle.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/ItineraryLegStyle.kt
@@ -48,7 +48,8 @@ internal data class ItineraryLegStyle(
     val color: Int,
     val widthProfile: RouteLineWidthProfile,
     val dash: RouteLineDash,
-    val directional: Boolean
+    val directional: Boolean,
+    val roundCaps: Boolean
 )
 
 /**
@@ -95,7 +96,8 @@ internal fun itineraryLegStyle(kind: ItineraryLegKind, routeColor: Int?): Itiner
         color = mapRouteLineColorOrNull(routeColor) ?: anchorColor(TRANSIT_HUE_ANCHOR),
         widthProfile = ITINERARY_RIDE_WIDTH_PROFILE,
         dash = RouteLineDash.NONE,
-        directional = true
+        directional = true,
+        roundCaps = true
     )
 
     ItineraryLegKind.WALK -> street(WALK_HUE_ANCHOR)
@@ -180,7 +182,8 @@ private fun street(hueAnchor: Int) = ItineraryLegStyle(
     color = anchorColor(hueAnchor),
     widthProfile = ITINERARY_STREET_WIDTH_PROFILE,
     dash = RouteLineDash.TRAIL,
-    directional = false
+    directional = false,
+    roundCaps = false
 )
 
 /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/ItineraryLegStyle.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/ItineraryLegStyle.kt
@@ -119,7 +119,8 @@ internal data class ItineraryLegCaps(val start: Boolean, val end: Boolean)
 internal fun itineraryLegCaps(legs: List<TripLeg>, index: Int): ItineraryLegCaps {
     val leg = legs[index]
     val transit = leg.mode?.isTransit == true
-    val continuesPrevious = transit && leg.interlineWithPreviousLeg &&
+    val continuesPrevious = transit &&
+        leg.interlineWithPreviousLeg &&
         legs.getOrNull(index - 1)?.mode?.isTransit == true
     val next = legs.getOrNull(index + 1)
     val continuesIntoNext = transit && next?.mode?.isTransit == true && next.interlineWithPreviousLeg

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
@@ -107,6 +107,11 @@ enum class RouteLineDash {
  * basemap flips with the theme, so its colour is the one route colour that has to be resolved against the
  * current theme at draw time (`mapRouteLineCaseColor`) rather than when the line is produced.
  *
+ * [roundCaps] asks the renderer to finish both ends with a circle rather than a flat cut. Directions
+ * transit legs use these endpoint bulbs so consecutive rides remain visibly segmented even when their
+ * agencies publish the same GTFS color. It is deliberately independent of [directional]: the cap says
+ * where a leg starts and stops, while the repeated chevrons say which way it travels.
+ *
  * [transforms] opts this line into renderer-bound geometry processing. Canonical [points] stay intact in
  * [MapRenderState] for framing and other consumers; both native adapters apply the requested transforms
  * only to the list they render. An empty set is a strict pass-through.
@@ -118,6 +123,7 @@ data class RoutePolyline(
     val directional: Boolean = false,
     val dash: RouteLineDash = RouteLineDash.NONE,
     val cased: Boolean = false,
+    val roundCaps: Boolean = false,
     val transforms: Set<RoutePolylineTransform> = emptySet()
 ) {
     /** The [color] to draw, applying the [DEFAULT_ROUTE_LINE_COLOR] fallback in one place for every renderer. */

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
@@ -107,10 +107,10 @@ enum class RouteLineDash {
  * basemap flips with the theme, so its colour is the one route colour that has to be resolved against the
  * current theme at draw time (`mapRouteLineCaseColor`) rather than when the line is produced.
  *
- * [roundCaps] asks the renderer to finish both ends with a circle rather than a flat cut. Directions
- * transit legs use these endpoint bulbs so consecutive rides remain visibly segmented even when their
- * agencies publish the same GTFS color. It is deliberately independent of [directional]: the cap says
- * where a leg starts and stops, while the repeated chevrons say which way it travels.
+ * [roundStartCap] and [roundEndCap] ask the renderer to finish that end with a circle rather than a
+ * flat cut. Directions transit legs use these endpoint bulbs so consecutive rides remain visibly
+ * segmented even when their agencies publish the same GTFS color. Separate ends let a stay-aboard
+ * interline hide its internal seam while retaining bulbs at the beginning and end of the combined ride.
  *
  * [transforms] opts this line into renderer-bound geometry processing. Canonical [points] stay intact in
  * [MapRenderState] for framing and other consumers; both native adapters apply the requested transforms
@@ -123,7 +123,8 @@ data class RoutePolyline(
     val directional: Boolean = false,
     val dash: RouteLineDash = RouteLineDash.NONE,
     val cased: Boolean = false,
-    val roundCaps: Boolean = false,
+    val roundStartCap: Boolean = false,
+    val roundEndCap: Boolean = false,
     val transforms: Set<RoutePolylineTransform> = emptySet()
 ) {
     /** The [color] to draw, applying the [DEFAULT_ROUTE_LINE_COLOR] fallback in one place for every renderer. */

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
@@ -99,6 +99,7 @@ class MapLibreRenderer(
     private val renderState: MapRenderState
 ) : PingTarget {
     private val stopMarkerLayer = MapLibreStopMarkerLayer(map, context)
+    private val routeEndpointBulbLayer = MapLibreRouteEndpointBulbLayer(mapStyle)
     private val bikeByMarker = HashMap<Marker, BikeMarker>()
 
     private val vehicleByMarker = HashMap<Marker, VehicleMarker>()
@@ -274,7 +275,9 @@ class MapLibreRenderer(
 
     /** Reconcile the independently collected route layer, retaining equal native polylines. */
     fun renderRoutePolylines(next: List<RoutePolyline> = renderState.snapshot.value.routePolylines) {
-        routePolylineReconciler.reconcile(next, map.cameraPosition.zoom.toFloat())
+        val zoom = map.cameraPosition.zoom.toFloat()
+        routePolylineReconciler.reconcile(next, zoom)
+        routeEndpointBulbLayer.render(next) { routeWidth(it, zoom) }
     }
 
     private fun PolylineOptions.addPoints(points: List<GeoPoint>): PolylineOptions {
@@ -284,6 +287,7 @@ class MapLibreRenderer(
 
     fun onCameraSettled(zoom: Float) {
         routePolylineReconciler.resyncWidths(zoom)
+        routeEndpointBulbLayer.render(renderState.snapshot.value.routePolylines) { routeWidth(it, zoom) }
         val detailScale = routeLineWidthScale(zoom)
         updateVehicleScale(detailScale)
     }
@@ -308,6 +312,7 @@ class MapLibreRenderer(
         clearPing()
         stopMarkerLayer.dispose()
         routeStopCircleLayer.dispose()
+        routeEndpointBulbLayer.dispose()
         // Clear the route lines first (removes them from the map), then mass-remove the rest.
         routePolylineReconciler.clear()
         map.removeAnnotations()

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRouteEndpointBulbLayer.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRouteEndpointBulbLayer.kt
@@ -1,0 +1,63 @@
+/* Copyright (C) 2026 Open Transit Software Foundation */
+package org.onebusaway.android.map.maplibre
+
+import org.maplibre.android.maps.Style
+import org.maplibre.android.style.expressions.Expression.get
+import org.maplibre.android.style.expressions.Expression.toColor
+import org.maplibre.android.style.layers.CircleLayer
+import org.maplibre.android.style.layers.PropertyFactory.circleColor
+import org.maplibre.android.style.layers.PropertyFactory.circleRadius
+import org.maplibre.android.style.sources.GeoJsonSource
+import org.maplibre.geojson.Feature
+import org.maplibre.geojson.FeatureCollection
+import org.maplibre.geojson.Point
+import org.onebusaway.android.map.render.RoutePolyline
+
+/** Draws screen-sized circular caps that MapLibre's classic polyline annotation cannot configure. */
+internal class MapLibreRouteEndpointBulbLayer(private val style: Style) {
+    private val source = GeoJsonSource(SOURCE_ID, FeatureCollection.fromFeatures(emptyList<Feature>()))
+
+    init {
+        style.addSource(source)
+        style.addLayer(
+            CircleLayer(LAYER_ID, SOURCE_ID).withProperties(
+                circleRadius(get(RADIUS_PROPERTY)),
+                circleColor(toColor(get(COLOR_PROPERTY)))
+            )
+        )
+    }
+
+    fun render(polylines: List<RoutePolyline>, widthOf: (RoutePolyline) -> Float) {
+        val features = polylines.flatMap { line ->
+            if (!line.roundCaps || line.points.isEmpty()) return@flatMap emptyList()
+            listOf(line.points.first(), line.points.last()).distinct().map { point ->
+                Feature.fromGeometry(Point.fromLngLat(point.longitude, point.latitude)).apply {
+                    addNumberProperty(RADIUS_PROPERTY, widthOf(line) * ENDPOINT_BULB_RADIUS_SCALE)
+                    addStringProperty(COLOR_PROPERTY, line.resolvedColor.toMapLibreColor())
+                }
+            }
+        }
+        source.setGeoJson(FeatureCollection.fromFeatures(features))
+    }
+
+    fun dispose() {
+        style.removeLayer(LAYER_ID)
+        style.removeSource(SOURCE_ID)
+    }
+
+    private fun Int.toMapLibreColor(): String {
+        val red = this shr 16 and 0xFF
+        val green = this shr 8 and 0xFF
+        val blue = this and 0xFF
+        val alpha = (this ushr 24) / 255f
+        return "rgba($red, $green, $blue, $alpha)"
+    }
+
+    private companion object {
+        const val SOURCE_ID = "oba-route-endpoint-bulbs-source"
+        const val LAYER_ID = "oba-route-endpoint-bulbs-layer"
+        const val RADIUS_PROPERTY = "radius"
+        const val COLOR_PROPERTY = "color"
+        const val ENDPOINT_BULB_RADIUS_SCALE = 0.75f
+    }
+}

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRouteEndpointBulbLayer.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRouteEndpointBulbLayer.kt
@@ -61,6 +61,6 @@ internal class MapLibreRouteEndpointBulbLayer(private val style: Style) {
         const val LAYER_ID = "oba-route-endpoint-bulbs-layer"
         const val RADIUS_PROPERTY = "radius"
         const val COLOR_PROPERTY = "color"
-        const val ENDPOINT_BULB_RADIUS_SCALE = 0.65f
+        const val ENDPOINT_BULB_RADIUS_SCALE = 1f
     }
 }

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRouteEndpointBulbLayer.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRouteEndpointBulbLayer.kt
@@ -29,8 +29,11 @@ internal class MapLibreRouteEndpointBulbLayer(private val style: Style) {
 
     fun render(polylines: List<RoutePolyline>, widthOf: (RoutePolyline) -> Float) {
         val features = polylines.flatMap { line ->
-            if (!line.roundCaps || line.points.isEmpty()) return@flatMap emptyList()
-            listOf(line.points.first(), line.points.last()).distinct().map { point ->
+            if ((!line.roundStartCap && !line.roundEndCap) || line.points.isEmpty()) return@flatMap emptyList()
+            buildList {
+                if (line.roundStartCap) add(line.points.first())
+                if (line.roundEndCap) add(line.points.last())
+            }.distinct().map { point ->
                 Feature.fromGeometry(Point.fromLngLat(point.longitude, point.latitude)).apply {
                     addNumberProperty(RADIUS_PROPERTY, widthOf(line) * ENDPOINT_BULB_RADIUS_SCALE)
                     addStringProperty(COLOR_PROPERTY, line.resolvedColor.toMapLibreColor())
@@ -58,6 +61,6 @@ internal class MapLibreRouteEndpointBulbLayer(private val style: Style) {
         const val LAYER_ID = "oba-route-endpoint-bulbs-layer"
         const val RADIUS_PROPERTY = "radius"
         const val COLOR_PROPERTY = "color"
-        const val ENDPOINT_BULB_RADIUS_SCALE = 0.75f
+        const val ENDPOINT_BULB_RADIUS_SCALE = 0.65f
     }
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/ItineraryLegStyleTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/ItineraryLegStyleTest.kt
@@ -84,6 +84,14 @@ class ItineraryLegStyleTest {
     }
 
     @Test
+    fun `only transit legs draw circular endpoint bulbs`() {
+        assertTrue(itineraryLegStyle(ItineraryLegKind.TRANSIT, routeColor = null).roundCaps)
+        ItineraryLegKind.entries.filterNot { it == ItineraryLegKind.TRANSIT }.forEach { kind ->
+            assertFalse("$kind should keep flat endpoints", itineraryLegStyle(kind, routeColor = null).roundCaps)
+        }
+    }
+
+    @Test
     fun `a ride keeps its agency's hue, at the map's own chroma and tone`() {
         // Two reds an agency might publish: one washed out, one nearly black. Only the hue survives, so
         // the map draws them the same — the hue is the route's identity, the rest is this map's rendering.
@@ -214,7 +222,8 @@ class ItineraryLegStyleTest {
                 listOf(GeoPoint(47.6, -122.3), GeoPoint(47.7, -122.4)),
                 widthProfile = style.widthProfile,
                 directional = style.directional,
-                dash = style.dash
+                dash = style.dash,
+                roundCaps = style.roundCaps
             )
         )
     }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/ItineraryLegStyleTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/ItineraryLegStyleTest.kt
@@ -92,6 +92,18 @@ class ItineraryLegStyleTest {
     }
 
     @Test
+    fun `an interline hides only the shared bulbs`() {
+        val first = TripLeg(mode = TripMode.BUS)
+        val continuation = TripLeg(mode = TripMode.RAIL, interlineWithPreviousLeg = true)
+        val walk = TripLeg(mode = TripMode.WALK)
+        val legs = listOf(first, continuation, walk)
+
+        assertEquals(ItineraryLegCaps(start = true, end = false), itineraryLegCaps(legs, 0))
+        assertEquals(ItineraryLegCaps(start = false, end = true), itineraryLegCaps(legs, 1))
+        assertEquals(ItineraryLegCaps(start = true, end = true), itineraryLegCaps(legs, 2))
+    }
+
+    @Test
     fun `a ride keeps its agency's hue, at the map's own chroma and tone`() {
         // Two reds an agency might publish: one washed out, one nearly black. Only the hue survives, so
         // the map draws them the same — the hue is the route's identity, the rest is this map's rendering.
@@ -223,7 +235,8 @@ class ItineraryLegStyleTest {
                 widthProfile = style.widthProfile,
                 directional = style.directional,
                 dash = style.dash,
-                roundCaps = style.roundCaps
+                roundStartCap = style.roundCaps,
+                roundEndCap = style.roundCaps
             )
         )
     }


### PR DESCRIPTION
## Summary

- mark transit itinerary polylines for circular endpoint bulbs
- render 1.5x stroke-width bulbs with scalable custom caps on Google Maps
- render matching zoom-aware endpoint circles on MapLibre
- leave walking, cycling, bikeshare, and car legs unchanged

## Why

Adjacent transit legs can share the same published GTFS color, causing their boundary to disappear on the directions map. Circular endpoint bulbs make each boarding and alighting boundary visible without changing the route's identity color.

Closes #2084.

## Validation

- `:onebusaway-android:testObaGoogleDebugUnitTest --tests org.onebusaway.android.map.ItineraryLegStyleTest`
- `:onebusaway-android:testObaMaplibreDebugUnitTest --tests org.onebusaway.android.map.ItineraryLegStyleTest`
- `:onebusaway-android:compileObaGoogleDebugKotlin`
- `:onebusaway-android:compileObaMaplibreDebugKotlin`
- `spotlessKotlinCheck`
- `git diff --check`

No shared-phone install or on-device test was performed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/OneBusAway/codesmith/onebusaway-android/pr/2089"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787978389&installation_model_id=429412&pr_number=2089&repository=OneBusAway%2Fonebusaway-android&return_to=https%3A%2F%2Fgithub.com%2FOneBusAway%2Fonebusaway-android%2Fpull%2F2089&signature=ceee34ddd38ce99e1ac597795f6cd73b8c7353b9d5683fe15e32e8b165bc9b12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Transit route lines now display rounded endpoint bulbs, making individual transit legs easier to distinguish.
  * Rounded endpoints are supported consistently across Google Maps and MapLibre.
  * Walking, biking, ridesharing, and driving route lines retain their existing endpoint styling.

* **Tests**
  * Added coverage verifying that rounded endpoint bulbs appear only on transit legs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->