### PR TITLE
Make the directions sheet a real Material bottom sheet

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/DragHandle.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/DragHandle.kt
@@ -16,10 +16,12 @@
 package org.onebusaway.android.ui.compose.components
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.unit.dp
@@ -31,6 +33,13 @@ import org.onebusaway.android.R
 val DRAG_HANDLE_BAR_HEIGHT = 4.dp
 val DRAG_HANDLE_VERTICAL_PADDING = 9.dp
 val DRAG_HANDLE_HEIGHT = DRAG_HANDLE_BAR_HEIGHT + DRAG_HANDLE_VERTICAL_PADDING * 2
+
+// The same bar in a full 48dp band — Android's minimum touch-target size, which is also the geometry
+// Material 3 gives `BottomSheetDefaults.DragHandle`. Used by [SheetDragHandle] for a sheet that collapses
+// to a handle-only peek, where the band is all that separates a tap from the system gesture area; the
+// tighter band above is for handles sitting atop content that is already on screen.
+val DRAG_HANDLE_TOUCH_TARGET_PADDING = 22.dp
+val DRAG_HANDLE_TOUCH_TARGET_HEIGHT = DRAG_HANDLE_BAR_HEIGHT + DRAG_HANDLE_TOUCH_TARGET_PADDING * 2
 
 /**
  * The short tinted grab-bar pill drawn inside a bottom-sheet drag handle — a muted grey matching the
@@ -45,5 +54,22 @@ fun DragHandleBar(modifier: Modifier = Modifier) {
         shape = RoundedCornerShape(percent = 50)
     ) {
         Box(Modifier.size(width = 32.dp, height = DRAG_HANDLE_BAR_HEIGHT))
+    }
+}
+
+/**
+ * [DragHandleBar] centred in a full 48dp touch-target band ([DRAG_HANDLE_TOUCH_TARGET_HEIGHT]) — the
+ * handle to hand a Material `BottomSheetScaffold` as its `sheetDragHandle`. The scaffold wraps whatever
+ * it's given with the sheet's tap-to-toggle and expand/collapse accessibility actions, so this only has
+ * to supply the geometry; sizing the band here (rather than using `BottomSheetDefaults.DragHandle`) keeps
+ * a handle-only peek height computable from an app-owned constant instead of one of M3's private ones.
+ */
+@Composable
+fun SheetDragHandle(modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier.padding(vertical = DRAG_HANDLE_TOUCH_TARGET_PADDING),
+        contentAlignment = Alignment.Center
+    ) {
+        DragHandleBar()
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -56,7 +56,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.boundsInWindow
 import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalResources
@@ -758,9 +757,11 @@ fun HomeScreen(
                                                     }
                                                 )
                                             },
-                                            modifier = Modifier
-                                                .align(Alignment.BottomCenter)
-                                                .onSizeChanged { directionsSheetHeightPx = it.height }
+                                            // Its own settled height (peek vs expanded), not a measured
+                                            // size: the sheet now hosts a full-screen scaffold over the
+                                            // map, so the composable's own bounds are the whole screen.
+                                            onSheetHeightPx = { directionsSheetHeightPx = it },
+                                            modifier = Modifier.fillMaxSize()
                                         )
                                         directionsError != null -> DirectionsErrorSnackbar(
                                             error = directionsError,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
@@ -19,11 +19,7 @@ import android.content.Context
 import android.text.format.DateFormat
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
-import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.gestures.Orientation
-import androidx.compose.foundation.gestures.draggable
-import androidx.compose.foundation.gestures.rememberDraggableState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
@@ -42,6 +38,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.BottomSheetScaffold
 import androidx.compose.material3.Button
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -52,19 +49,23 @@ import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberBottomSheetScaffoldState
+import androidx.compose.material3.rememberStandardBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalWindowInfo
@@ -97,10 +98,9 @@ import org.onebusaway.android.ui.arrivals.ArrivalsViewModel
 import org.onebusaway.android.ui.arrivals.RouteRowGroup
 import org.onebusaway.android.ui.arrivals.components.EtaStrip
 import org.onebusaway.android.ui.arrivals.rememberArrivalRowCallbacks
-import org.onebusaway.android.ui.compose.components.DRAG_HANDLE_HEIGHT
-import org.onebusaway.android.ui.compose.components.DRAG_HANDLE_VERTICAL_PADDING
-import org.onebusaway.android.ui.compose.components.DragHandleBar
+import org.onebusaway.android.ui.compose.components.DRAG_HANDLE_TOUCH_TARGET_HEIGHT
 import org.onebusaway.android.ui.compose.components.RouteBadgeChip
+import org.onebusaway.android.ui.compose.components.SheetDragHandle
 import org.onebusaway.android.ui.compose.components.SwitchRow
 import org.onebusaway.android.ui.compose.findActivity
 import org.onebusaway.android.ui.compose.navigationBarBottomPadding
@@ -261,17 +261,23 @@ private fun pickTripTime(activity: AppCompatActivity, viewModel: TripPlanViewMod
     picker.show(activity.supportFragmentManager, "TIME_PICKER")
 }
 
-/** Collapsed height of the directions sheet content — just the drag handle peeking above the map. */
-private val DIRECTIONS_SHEET_PEEK = DRAG_HANDLE_HEIGHT
-
-/** Net drag (px per gesture event) on the handle past which the sheet snaps collapsed/expanded. */
-private const val DIRECTIONS_SHEET_DRAG_THRESHOLD = 8f
+/** The expanded directions sheet's share of the window height (the collapsed peek is handle-only). */
+private const val DIRECTIONS_SHEET_HEIGHT_FRACTION = 0.4f
 
 /**
- * The bottom directions sheet: option cards + the step-by-step list, over the map. Collapsible via the
- * drag handle at its top — tap or drag it down to collapse to just the handle (revealing the map), up to
- * restore the full ~40%-height sheet.
+ * The bottom directions sheet: option cards + the step-by-step list, over the map. A standard Material 3
+ * persistent bottom sheet — [BottomSheetScaffold]'s sheet slot — so it gets the real sheet gesture:
+ * the sheet tracks the finger, settles on velocity, and drags from anywhere on it (including a
+ * nested-scroll handoff, so pulling down at the top of the step list collapses the sheet). Collapsed it
+ * rests at a handle-only peek revealing the map; expanded it fills [DIRECTIONS_SHEET_HEIGHT_FRACTION]
+ * of the window. Tapping the handle still toggles, and screen readers get M3's expand/collapse actions.
+ *
+ * The scaffold hosts *only* the sheet: its body is empty and its container transparent, so the map that
+ * the caller drew underneath shows through and keeps receiving its own gestures (M3 builds the scaffold
+ * root from a plain `Box`, not a touch-intercepting `Surface`). [onSheetHeightPx] reports the sheet's
+ * settled on-screen height for the map's bottom inset.
  */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DirectionsResultsSheet(
     resultsViewModel: TripResultsViewModel,
@@ -282,30 +288,47 @@ fun DirectionsResultsSheet(
     onFocusLeg: (FocusedLeg) -> Unit,
     onFocusPoint: (GeoPoint) -> Unit,
     stopEtaStrip: @Composable (RouteLegRef, RouteStopRef, List<GeoPoint>) -> Unit,
+    onSheetHeightPx: (Int) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    // The system nav-bar inset: the surface reaches the bottom edge (continuous background), but its
+    // The system nav-bar inset: the sheet reaches the bottom edge (continuous background), but its
     // content is padded above the nav chrome so the collapsed handle (and the last list row) aren't
-    // stranded under the gesture pill / 3-button bar. Collapsed height includes it so the handle fits.
+    // stranded under the gesture pill / 3-button bar. The peek includes it so the handle clears it.
     val navBottom = navigationBarBottomPadding()
     // containerSize (px), not Configuration.screenHeightDp (lint-flagged as unreliable across insets).
     val fullHeight = with(LocalDensity.current) {
-        (LocalWindowInfo.current.containerSize.height * 0.4f).toDp()
+        (LocalWindowInfo.current.containerSize.height * DIRECTIONS_SHEET_HEIGHT_FRACTION).toDp()
     }
-    var collapsed by rememberSaveable { mutableStateOf(false) }
-    val sheetHeight by animateDpAsState(
-        targetValue = if (collapsed) DIRECTIONS_SHEET_PEEK + navBottom else fullHeight,
-        label = "directionsSheetHeight"
-    )
-    Surface(
-        modifier = modifier.fillMaxWidth().height(sheetHeight),
-        shape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp),
-        color = MaterialTheme.colorScheme.surface,
-        tonalElevation = 2.dp,
-        shadowElevation = 8.dp
-    ) {
-        Column(Modifier.fillMaxWidth().navigationBarsPadding()) {
-            DirectionsSheetHandle(collapsed = collapsed, onSetCollapsed = { collapsed = it })
+    val peekHeight = DRAG_HANDLE_TOUCH_TARGET_HEIGHT + navBottom
+    val sheetState = rememberStandardBottomSheetState(initialValue = SheetValue.Expanded)
+    val scaffoldState = rememberBottomSheetScaffoldState(bottomSheetState = sheetState)
+
+    // The map's bottom inset follows the *settled* sheet, not the live drag — a per-frame inset would
+    // re-frame the map on every gesture event. Both resting heights are known up front, so this needs no
+    // measurement: expanded is the sheet's own height, collapsed is the peek. Keyed on the heights too,
+    // so a late nav-bar inset (or a rotation) re-emits rather than sticking at the stale value.
+    val density = LocalDensity.current
+    LaunchedEffect(sheetState, fullHeight, peekHeight) {
+        snapshotFlow { sheetState.currentValue }.collect { value ->
+            val resting = if (value == SheetValue.Expanded) fullHeight else peekHeight
+            onSheetHeightPx(with(density) { resting.roundToPx() })
+        }
+    }
+
+    BottomSheetScaffold(
+        modifier = modifier,
+        scaffoldState = scaffoldState,
+        sheetPeekHeight = peekHeight,
+        sheetShape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp),
+        sheetContainerColor = MaterialTheme.colorScheme.surface,
+        sheetTonalElevation = 2.dp,
+        sheetShadowElevation = 8.dp,
+        // The scaffold supplies the drag gesture and the tap/accessibility actions around whatever handle
+        // it's given, so this is the app's own bar — the same one the arrivals sheet shows — in the 48dp
+        // band [DRAG_HANDLE_TOUCH_TARGET_HEIGHT] measures for the peek above.
+        sheetDragHandle = { SheetDragHandle() },
+        sheetContent = {
+            // Sized so handle + content == fullHeight, which is what sets the sheet's expanded anchor.
             TripResultsSheet(
                 itineraries = itineraries,
                 params = params,
@@ -315,41 +338,18 @@ fun DirectionsResultsSheet(
                 onFocusLeg = onFocusLeg,
                 onFocusPoint = onFocusPoint,
                 stopEtaStrip = stopEtaStrip,
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(fullHeight - DRAG_HANDLE_TOUCH_TARGET_HEIGHT)
+                    .navigationBarsPadding()
             )
-        }
-    }
-}
-
-/** The drag handle atop [DirectionsResultsSheet]: tap toggles collapse; drag up/down sets it. */
-@Composable
-private fun DirectionsSheetHandle(collapsed: Boolean, onSetCollapsed: (Boolean) -> Unit) {
-    // draggable() reports per-frame deltas, so accumulate them — a slow drag would never cross the
-    // threshold on any single frame. Reset once a threshold crossing snaps the sheet, and at drag end.
-    var dragAccumulated by remember { mutableFloatStateOf(0f) }
-    Box(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clickable { onSetCollapsed(!collapsed) }
-            .draggable(
-                orientation = Orientation.Vertical,
-                state = rememberDraggableState { delta ->
-                    dragAccumulated += delta
-                    if (dragAccumulated > DIRECTIONS_SHEET_DRAG_THRESHOLD) {
-                        onSetCollapsed(true)
-                        dragAccumulated = 0f
-                    } else if (dragAccumulated < -DIRECTIONS_SHEET_DRAG_THRESHOLD) {
-                        onSetCollapsed(false)
-                        dragAccumulated = 0f
-                    }
-                },
-                onDragStopped = { dragAccumulated = 0f }
-            )
-            .padding(vertical = DRAG_HANDLE_VERTICAL_PADDING),
-        contentAlignment = Alignment.Center
-    ) {
-        DragHandleBar()
-    }
+        },
+        // Sheet-only host: no snackbar (the caller owns one), no body, and a transparent container so
+        // the caller's map stays visible and interactive behind it.
+        snackbarHost = {},
+        containerColor = Color.Transparent,
+        content = {}
+    )
 }
 
 /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
@@ -295,11 +295,18 @@ fun DirectionsResultsSheet(
     // content is padded above the nav chrome so the collapsed handle (and the last list row) aren't
     // stranded under the gesture pill / 3-button bar. The peek includes it so the handle clears it.
     val navBottom = navigationBarBottomPadding()
+    val peekHeight = DRAG_HANDLE_TOUCH_TARGET_HEIGHT + navBottom
     // containerSize (px), not Configuration.screenHeightDp (lint-flagged as unreliable across insets).
+    //
+    // Floored at the peek, because a sheet shorter than its own peek inverts the two states: M3 anchors
+    // PartiallyExpanded at (layoutHeight - peek) and Expanded at (layoutHeight - sheetHeight), so the
+    // collapsed sheet would sit *above* the expanded one. Reachable in a freeform window near Android's
+    // 220dp resizable minimum alongside a 48dp 3-button bar, where the fraction lands under the peek. At
+    // the floor M3 drops the Expanded anchor outright (it skips it when sheet height == peek) and the
+    // sheet just rests at the handle — the honest outcome for a window with no room to open into.
     val fullHeight = with(LocalDensity.current) {
         (LocalWindowInfo.current.containerSize.height * DIRECTIONS_SHEET_HEIGHT_FRACTION).toDp()
-    }
-    val peekHeight = DRAG_HANDLE_TOUCH_TARGET_HEIGHT + navBottom
+    }.coerceAtLeast(peekHeight)
     val sheetState = rememberStandardBottomSheetState(initialValue = SheetValue.Expanded)
     val scaffoldState = rememberBottomSheetScaffoldState(bottomSheetState = sheetState)
 
@@ -329,6 +336,8 @@ fun DirectionsResultsSheet(
         sheetDragHandle = { SheetDragHandle() },
         sheetContent = {
             // Sized so handle + content == fullHeight, which is what sets the sheet's expanded anchor.
+            // Non-negative by construction: fullHeight is floored at the peek, which is this same
+            // handle band plus navBottom, so the subtraction leaves at least the nav padding below.
             TripResultsSheet(
                 itineraries = itineraries,
                 params = params,


### PR DESCRIPTION
## Problem

The directions results sheet's drag handle wasn't a drag handle — it was a button. Under the hood it was a `clickable` Box plus a `draggable()` that accumulated per-frame deltas and snapped the sheet the instant the gesture crossed 8px. The sheet never tracked the finger, so the only interaction that really worked was a tap.

It also sat in a 22dp band directly above the system gesture inset. Collapsed, that band *is* the whole sheet, so a tap aimed slightly low fell through to the navigation chrome and minimized the app.

## Change

Host the sheet in Material 3's `BottomSheetScaffold`, so the gesture comes from `StandardBottomSheet` rather than from hand-rolled threshold logic:

- the sheet tracks the finger and settles on velocity
- it drags from anywhere on the sheet, not just the handle
- `nestedScroll` hands off — pulling down at the top of the step list collapses the sheet, dragging up expands it before the list starts scrolling
- tap-to-toggle still works, and the sheet now gets M3's expand/collapse accessibility actions, which the hand-rolled handle never had

The scaffold hosts **only** the sheet: empty body, no snackbar host, transparent container. The caller's map still shows through and keeps its own gestures — which works because M3 builds the scaffold root from a plain `Box` rather than a touch-intercepting `Surface` (their source comments call this out explicitly). The arrivals sheet, the screen's other `BottomSheetScaffold`, is gated on `CurrentFocus.Stop` and so rests at a 0dp peek whenever directions is active; the two never contend.

### Handle geometry

The handle is the app's own `DragHandleBar` — the same pill the arrivals sheet shows, 32×4dp, identical to M3's own tokens — centred in a **48dp** touch-target band. That's Android's minimum touch target, and also the geometry `BottomSheetDefaults.DragHandle` uses.

Sizing the band from an app-owned constant instead of calling M3's handle is deliberate: a handle-only peek height has to be known before layout, and M3 exposes its `DragHandleVerticalPadding` (22dp) only as a private constant. Mirroring a private value would rot silently on a library bump — a mis-sized peek and a map inset that no longer matches the screen, with no compile break. The scaffold wraps whatever handle it's given with the tap and a11y actions, so nothing is lost by supplying our own.

### Map inset

The map's bottom inset now follows the sheet's *settled* resting height rather than the composable's measured size, since the scaffold spans the whole screen. Both resting heights are known up front, so no measurement is needed. This is also less work than before: the old `onSizeChanged` on an `animateDpAsState`-sized Surface fired every frame of the expand/collapse tween, where this fires twice per toggle.

## State retention

Unchanged from before. The old `rememberSaveable` boolean is gone, but M3's own sheet state is saveable in exactly the same way: `rememberStandardBottomSheetState` → `rememberSheetState` → `rememberSaveable(…, SheetState.Saver)`, and that saver stores `currentValue` — a `SheetValue`, an enum, so `java.lang.Enum`'s `Serializable` carries it into the Bundle. The collapsed/expanded position survives recomposition and configuration changes as it did before; nothing was dropped by moving to the scaffold.

Neither the old code nor this one restores the position after *process* death in practice, because the sheet composes only while `TripPlanViewModel.planState` is a non-empty `Success` — a plain `MutableStateFlow(Idle)` with no `SavedStateHandle` behind it. The plan is gone before the saved position could be read, so the saved value is simply never claimed.

## Testing

Compiles clean under `-PwarningsAsErrors=true` and passes `spotlessCheck`; installed on a Pixel 7 Pro. The gesture feel itself is unverified — the nested-scroll handoff from the middle of the step list is the part most worth exercising, along with confirming the map still pans behind the collapsed sheet.

## Follow-up (not in this PR)

The home screen now runs two independent sheet states. Folding directions into the existing arrivals scaffold's sheet slot would be the deeper fix, and would also give directions the back-press collapse and FAB-inset behavior arrivals has. It's a real refactor, though — the arrivals sheet carries a lot of specific machinery (no `Hidden` anchor, show/hide via animated peek, measured cap-and-shrink, `openSettled` sequencing) that doesn't map onto directions' fixed-fraction peek, so it belongs in its own change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a standardized drag handle with a larger, more accessible touch target for interacting with the directions sheet.
  * Updated directions results to use a persistent Material bottom sheet with distinct handle/peek and expanded states.
* **Improvements**
  * Map content now repositions using the directions sheet’s settled height for more accurate insets.
  * Sheet styling remains transparent so the map can remain visible and interactive where appropriate.
  * Added safer height handling to prevent inconsistent sheet anchor behavior on smaller screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
