### PR TITLE
Draw the directions map's rides in their route badges' own colours

### DIFF
--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
@@ -61,7 +61,6 @@ import org.onebusaway.android.map.render.MapRenderState
 import org.onebusaway.android.map.render.MapVehicles
 import org.onebusaway.android.map.render.MarkerRendering
 import org.onebusaway.android.map.render.PingTarget
-import org.onebusaway.android.map.render.ROUTE_LINE_CASE_EXTRA_DP
 import org.onebusaway.android.map.render.RouteBadge
 import org.onebusaway.android.map.render.RouteContinuation
 import org.onebusaway.android.map.render.RouteLineDash
@@ -154,7 +153,7 @@ class GoogleMapRenderer(
         // theme, because the basemap it separates its line from does (see [mapRouteLineCaseColor]).
         caseColorOf = { mapRouteLineCaseColor(it.resolvedColor, ThemeUtils.isInDarkMode(context)) },
         // Read from context rather than the [density] field, which is declared below this initializer.
-        caseExtraWidth = ROUTE_LINE_CASE_EXTRA_DP * context.resources.displayMetrics.density
+        caseExtraWidth = { it.case.extraWidthDp * context.resources.displayMetrics.density }
     )
 
     // The dynamic layer, tracked by identity so [renderDynamic] can move markers in place: route vehicles

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
@@ -152,8 +152,7 @@ class GoogleMapRenderer(
         // Resolved per line rather than once, and here rather than by the producer: a case's colour follows the
         // theme, because the basemap it separates its line from does (see [mapRouteLineCaseColor]).
         caseColorOf = { mapRouteLineCaseColor(it.resolvedColor, ThemeUtils.isInDarkMode(context)) },
-        // Read from context rather than the [density] field, which is declared below this initializer.
-        caseExtraWidth = { it.case.extraWidthDp * context.resources.displayMetrics.density }
+        caseExtraWidth = { it.case.extraWidthDp * density }
     )
 
     // The dynamic layer, tracked by identity so [renderDynamic] can move markers in place: route vehicles

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/DirectionsMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/DirectionsMapController.kt
@@ -132,7 +132,6 @@ class DirectionsMapController(private val host: MapHost) {
                     style.color,
                     points,
                     widthProfile = style.widthProfile,
-                    directional = style.directional,
                     dash = style.dash,
                     case = style.case,
                     roundStartCap = style.roundCaps && caps.start,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/DirectionsMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/DirectionsMapController.kt
@@ -69,8 +69,13 @@ class DirectionsMapController(private val host: MapHost) {
 
     private class EndpointMarker(val point: GeoPoint, val id: Int)
 
-    /** Draw [itinerary]'s leg polylines + start/end pins and frame it. */
-    fun start(itinerary: TripItinerary) {
+    /**
+     * Draw [itinerary]'s leg polylines + start/end pins and frame it, stroking every leg through
+     * [palette] — the directions view's own, which is the theme-aware colour the drawer badges this leg
+     * with (see [directionsRouteLinePalette]). Passed per draw rather than held, so the palette that
+     * resolved the current theme is the one this itinerary was drawn with.
+     */
+    fun start(itinerary: TripItinerary, palette: RouteLinePalette) {
         val legs = itinerary.legs
         if (legs.isEmpty()) {
             return
@@ -109,7 +114,7 @@ class DirectionsMapController(private val host: MapHost) {
             val geometry = leg.legGeometry ?: return@mapIndexedNotNull null
             val shape = LegShape(geometry)
             if (shape.length <= 0) return@mapIndexedNotNull null
-            val style = itineraryLegStyle(leg.legKind(), parseObaHexColor(leg.routeColor))
+            val style = itineraryLegStyle(leg.legKind(), parseObaHexColor(leg.routeColor), palette)
             // The wire hex is parsed here, on the leg and on every route offered in its place, so the
             // styling itself stays free of `android.graphics` (see the [ItineraryLegStyle] file header).
             val interchangeable = substitutes[legIndex].map { route ->
@@ -117,8 +122,8 @@ class DirectionsMapController(private val host: MapHost) {
             }
             ItineraryDrawableLeg(legIndex, leg, shape.points, style, interchangeable)
         }
-        // Every leg's points run in travel order, so whether it stamps chevrons is the style's call — a
-        // dashed on-street stroke declines them (see [itineraryLegStyle]).
+        // Every leg's points run in travel order, but no itinerary leg stamps chevrons any more — see
+        // [itineraryLegStyle], which also decides the hairline case a ride wears.
         legLines = drawableLegs.map { (legIndex, _, points, style) ->
             val caps = itineraryLegCaps(legs, legIndex)
             ItineraryLegLine(
@@ -129,6 +134,7 @@ class DirectionsMapController(private val host: MapHost) {
                     widthProfile = style.widthProfile,
                     directional = style.directional,
                     dash = style.dash,
+                    case = style.case,
                     roundStartCap = style.roundCaps && caps.start,
                     roundEndCap = style.roundCaps && caps.end
                 )
@@ -146,7 +152,7 @@ class DirectionsMapController(private val host: MapHost) {
         }
         // Published after the pins, since the static layer is redrawn wholesale on each emission that
         // reaches it: badges written first would be built again for every pin added after them.
-        host.renderState.setRouteBadges(itineraryRouteBadges(drawableLegs))
+        host.renderState.setRouteBadges(itineraryRouteBadges(drawableLegs, palette))
 
         directionsHasRoute = legLines.isNotEmpty()
         directionsStart = if (startLat != null && startLon != null) GeoPoint(startLat, startLon) else null

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/ItineraryLegStyle.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/ItineraryLegStyle.kt
@@ -27,11 +27,13 @@ import org.onebusaway.android.map.render.BadgedRoute
 import org.onebusaway.android.map.render.ITINERARY_RIDE_WIDTH_PROFILE
 import org.onebusaway.android.map.render.ITINERARY_STREET_WIDTH_PROFILE
 import org.onebusaway.android.map.render.RouteBadge
+import org.onebusaway.android.map.render.RouteLineCase
 import org.onebusaway.android.map.render.RouteLineDash
 import org.onebusaway.android.map.render.RouteLineWidthProfile
 import org.onebusaway.android.map.render.RoutePolyline
 import org.onebusaway.android.util.GeoPoint
 import org.onebusaway.android.util.inInterchangeableOrder
+import org.onebusaway.android.util.routeColorHctOrNull
 
 /**
  * How one trip-plan itinerary leg is stroked on the directions map (#2041).
@@ -40,8 +42,9 @@ import org.onebusaway.android.util.inInterchangeableOrder
  * everything else — so a walk, an own-bike ride and a bikeshare ride were indistinguishable, and the
  * route colour the option card and the directions drawer were already showing never reached the map at
  * all. Here each leg's stroke is decided from its mode, and a ride keeps its own route's hue, rendered by
- * [mapRouteLineColor] at the same chroma and tone as every other route line on this map — so a leg reads
- * as one colour whether the rider looks at the map, the drawer beside it or the option card above.
+ * the [RouteLinePalette] the caller hands in — [directionsRouteLinePalette] for every line the directions
+ * view draws, which is the badge's own colour, so a leg is literally the same colour as the badge naming it
+ * in the drawer beside it and on the option card above.
  *
  * Pure and free of `android.graphics` (the colour science is Material's own JVM-side HCT), so
  * `ItineraryLegStyleTest` covers the whole table on the JVM. Parsing the wire hex is the one part that
@@ -52,7 +55,8 @@ internal data class ItineraryLegStyle(
     val widthProfile: RouteLineWidthProfile,
     val dash: RouteLineDash,
     val directional: Boolean,
-    val roundCaps: Boolean
+    val roundCaps: Boolean,
+    val case: RouteLineCase
 )
 
 /**
@@ -80,29 +84,49 @@ internal fun TripLeg.legKind(): ItineraryLegKind = when {
 
 /**
  * The stroke for a [kind] leg, given its already-parsed GTFS [routeColor] (null for every non-transit
- * kind, and for a ride whose agency publishes no colour).
+ * kind, and for a ride whose agency publishes no colour), rendered by [palette].
+ *
+ * [palette] reaches the **ride** only. A ride is faded to the badge's own colour because it is read against
+ * the badge that names it (see [directionsRouteLinePalette]); an on-street leg has no badge — the drawer
+ * marks it with a mode glyph, not a route roundel — so there is no parity to keep, and nothing to buy for
+ * the contrast it would cost. Every mode leg therefore keeps [BASEMAP_ROUTE_LINE_PALETTE], which is what
+ * every other line on this map is drawn with.
+ *
+ * So the palette is now one more way the two kinds of leg differ, alongside width, dash and chevrons: a
+ * ride carries its route's identity and is toned to match how that identity is written elsewhere, while a
+ * mode leg only has to read as "you walk here" against the basemap.
  *
  * On-street legs are dashed and thinner than the ride they connect to, mirroring the directions
  * drawer, where a walk is a dashed spine and a ride a solid one. (The MapLibre renderer draws every
  * line solid, so there the distinction rests on colour and width alone.)
  *
- * They also drop the travel-direction chevrons, which a dashed stroke can't carry: the chevron texture
- * is stamped along the line, so the dash pattern chops it into fragments and the two read as one
- * confused broken line rather than as either. A ride keeps them — it's solid, and which way along the
- * corridor you're carried is worth saying.
+ * **No itinerary leg stamps travel-direction chevrons.** A dashed on-street stroke never could — the chevron
+ * texture is stamped along the line, so the dash chops it into fragments and the two read as one confused
+ * broken line rather than as either. A ride dropped them with the badge palette: it is drawn in a faded,
+ * badge-toned colour now and wears a hairline case to hold that colour off the basemap, and an arrow texture
+ * under a hairline edge is noise rather than direction. Which way the rider is carried is read from the
+ * drawer's ordered rows and from the leg's endpoint bulbs instead.
+ *
+ * A ride also carries [RouteLineCase.OUTLINE] for that reason — every ride, so the edge says nothing about
+ * selection; the rider's selected leg steps up to [RouteLineCase.SELECTION] ([withCase]). A mode leg has no
+ * case, as it has no fading to compensate for.
  */
-internal fun itineraryLegStyle(kind: ItineraryLegKind, routeColor: Int?): ItineraryLegStyle = when (kind) {
+internal fun itineraryLegStyle(
+    kind: ItineraryLegKind,
+    routeColor: Int?,
+    palette: RouteLinePalette
+): ItineraryLegStyle = when (kind) {
     ItineraryLegKind.TRANSIT -> ItineraryLegStyle(
-        // The agency's own colour when it has a usable one; otherwise every ride shares the transit
-        // anchor, as they all did before. Giving colourless rides distinct auto-assigned hues (the way
-        // focused-stop adjacency does) is the rest of #2041, not this pass.
-        color = mapRouteLineColorOrNull(routeColor) ?: anchorColor(TRANSIT_HUE_ANCHOR),
+        color = anchorColor(riddenRouteHue(routeColor), palette),
         widthProfile = ITINERARY_RIDE_WIDTH_PROFILE,
         dash = RouteLineDash.NONE,
-        directional = true,
-        roundCaps = true
+        directional = false,
+        roundCaps = true,
+        case = RouteLineCase.OUTLINE
     )
 
+    // Deliberately not [palette]: see the note above — a mode leg has no badge to match, so it stays on
+    // the map's own rendering rather than being faded for a parity that doesn't exist.
     ItineraryLegKind.WALK -> street(WALK_HUE_ANCHOR)
     ItineraryLegKind.BIKE -> street(BIKE_HUE_ANCHOR)
     ItineraryLegKind.BIKESHARE -> street(BIKESHARE_HUE_ANCHOR)
@@ -188,7 +212,10 @@ internal data class ItinerarySubstitute(val route: InterchangeableRoute, val rou
  * board either of two. A leg with no alternatives is labelled with its planned route alone, which is what
  * an OTP1 plan (no candidates at all) yields for every leg.
  */
-internal fun itineraryRouteBadges(legs: List<ItineraryDrawableLeg>): List<RouteBadge> {
+internal fun itineraryRouteBadges(
+    legs: List<ItineraryDrawableLeg>,
+    palette: RouteLinePalette
+): List<RouteBadge> {
     val rides = legs.mapNotNull { drawable ->
         if (drawable.leg.mode?.isTransit != true) return@mapNotNull null
         // A route that names itself in no way at all has nothing to label the line with.
@@ -212,7 +239,7 @@ internal fun itineraryRouteBadges(legs: List<ItineraryDrawableLeg>): List<RouteB
         rides.map { (_, ridden) ->
             val ride = ridden.first()
             RouteBadgeRequest(
-                routes = ride.badgedRoutes(),
+                routes = ride.badgedRoutes(palette),
                 paths = ridden.map { RouteBadgePath(it.drawable.points) }
                 // No tap target: see [RouteBadge.tap].
             )
@@ -229,36 +256,56 @@ private data class Ride(val identity: RideIdentity, val name: String, val drawab
      * way the drawer names it and drawn in the colour this map gives that route's line, which is the colour
      * it actually takes when the rider drills into the leg and the whole corridor is drawn (#2063).
      */
-    fun badgedRoutes(): List<BadgedRoute> = (
+    fun badgedRoutes(palette: RouteLinePalette): List<BadgedRoute> = (
         listOf(BadgedRoute(name, drawable.style.color)) +
             drawable.interchangeable.map { substitute ->
                 BadgedRoute(
                     substitute.route.displayName,
-                    itineraryLegStyle(ItineraryLegKind.TRANSIT, substitute.routeColor).color
+                    itineraryLegStyle(ItineraryLegKind.TRANSIT, substitute.routeColor, palette).color
                 )
             }
         ).inInterchangeableOrder(BadgedRoute::routeShortName)
 }
 
 private fun street(hueAnchor: Int) = ItineraryLegStyle(
-    color = anchorColor(hueAnchor),
+    color = anchorColor(hueAnchor, BASEMAP_ROUTE_LINE_PALETTE),
     widthProfile = ITINERARY_STREET_WIDTH_PROFILE,
     dash = RouteLineDash.TRAIL,
     directional = false,
-    roundCaps = false
+    roundCaps = false,
+    case = RouteLineCase.NONE
 )
 
 /**
- * A mode's hue [anchor] rendered at the map's route chroma and tone, so a mode leg carries exactly the
- * weight a route line does. The elvis stands in for a `!!`: [mapRouteLineColorOrNull] declines only an
+ * The hue a ride is *presented* in, wherever it is presented: the agency's own [routeColor] when it has a
+ * usable one, else [COLOURLESS_RIDE_HUE_ANCHOR]. A hue source, not a rendered colour — each surface still
+ * renders it through its own policy (the map line and the drawer badge through the badge tone, the drawer's
+ * leg spine through its on-surface tone), which is what lets this be shared by a Compose surface and a
+ * `Context`-free map controller alike.
+ *
+ * It exists because that fallback is the one thing the surfaces cannot each decide for themselves. They
+ * did: a WSF ferry (every WSF route publishes an empty colour) drew a coral line on the map, since the map
+ * substituted the anchor, beside a neutral grey badge in the drawer, since a badge substituted the theme's
+ * `surfaceVariant`. Same route, same wire field, same policy — and two different colours, because "no
+ * colour published" was answered twice.
+ *
+ * Giving *distinct* auto-assigned hues to the colourless rides of one itinerary (the way focused-stop
+ * adjacency does) is still the rest of #2041; when that lands it replaces this function's fallback, and
+ * every surface follows because they all read it here.
+ */
+internal fun riddenRouteHue(routeColor: Int?): Int = routeColor?.takeIf { routeColorHctOrNull(it) != null } ?: COLOURLESS_RIDE_HUE_ANCHOR
+
+/**
+ * A mode's hue [anchor] rendered by [palette] exactly as a route's own colour is, so a mode leg carries
+ * exactly the weight a route line does. The elvis stands in for a `!!`: a palette declines only an
  * achromatic source, and every anchor below is chromatic — which `ItineraryLegStyleTest` holds to, by
  * asserting every leg kind draws a colour above the achromatic floor.
  */
-private fun anchorColor(anchor: Int): Int = mapRouteLineColorOrNull(anchor) ?: anchor
+private fun anchorColor(anchor: Int, palette: RouteLinePalette): Int = palette.lineColor(anchor) ?: anchor
 
-// The mode hue anchors. Only each colour's *hue* survives — [mapRouteLineColor] supplies the chroma and
-// tone — so these read as "walking is green", not as literal strokes, and tuning one means moving it
-// around the hue circle. They're spread far apart, and away from the transit anchor, so no two modes of
+// The mode hue anchors. Only each colour's *hue* survives — [BASEMAP_ROUTE_LINE_PALETTE] supplies the
+// chroma and tone — so these read as "walking is green", not as literal strokes, and tuning one means moving
+// it around the hue circle. They're spread far apart, and away from the transit anchor, so no two modes of
 // one itinerary read as the same thing.
 private const val WALK_HUE_ANCHOR = 0xFF1D9914.toInt()
 private const val BIKE_HUE_ANCHOR = 0xFF007E8F.toInt()
@@ -269,6 +316,10 @@ private const val BIKE_HUE_ANCHOR = 0xFF007E8F.toInt()
 private const val BIKESHARE_HUE_ANCHOR = 0xFF3A4677.toInt()
 private const val CAR_HUE_ANCHOR = 0xFF8A6D00.toInt()
 
-// The fallback for a ride whose agency publishes no usable colour. It was OTP's green, which walking now
-// owns — a colourless ride takes the terracotta walking vacated rather than sit a few degrees off it.
-private const val TRANSIT_HUE_ANCHOR = 0xFFC4400F.toInt()
+/**
+ * The hue a ride whose agency publishes no usable colour is presented in — read through [riddenRouteHue],
+ * which is the one place that substitution happens, so the map line, the drawer badge and the leg spine
+ * cannot answer "no colour published" differently. It was OTP's green, which walking now owns; a colourless
+ * ride takes the terracotta walking vacated rather than sit a few degrees off it.
+ */
+internal const val COLOURLESS_RIDE_HUE_ANCHOR = 0xFFC4400F.toInt()

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/ItineraryLegStyle.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/ItineraryLegStyle.kt
@@ -31,9 +31,10 @@ import org.onebusaway.android.map.render.RouteLineCase
 import org.onebusaway.android.map.render.RouteLineDash
 import org.onebusaway.android.map.render.RouteLineWidthProfile
 import org.onebusaway.android.map.render.RoutePolyline
+import org.onebusaway.android.util.COLOURLESS_RIDE_HUE_ANCHOR
 import org.onebusaway.android.util.GeoPoint
 import org.onebusaway.android.util.inInterchangeableOrder
-import org.onebusaway.android.util.routeColorHctOrNull
+import org.onebusaway.android.util.riddenRouteHue
 
 /**
  * How one trip-plan itinerary leg is stroked on the directions map (#2041).
@@ -54,7 +55,6 @@ internal data class ItineraryLegStyle(
     val color: Int,
     val widthProfile: RouteLineWidthProfile,
     val dash: RouteLineDash,
-    val directional: Boolean,
     val roundCaps: Boolean,
     val case: RouteLineCase
 )
@@ -100,12 +100,13 @@ internal fun TripLeg.legKind(): ItineraryLegKind = when {
  * drawer, where a walk is a dashed spine and a ride a solid one. (The MapLibre renderer draws every
  * line solid, so there the distinction rests on colour and width alone.)
  *
- * **No itinerary leg stamps travel-direction chevrons.** A dashed on-street stroke never could — the chevron
- * texture is stamped along the line, so the dash chops it into fragments and the two read as one confused
- * broken line rather than as either. A ride dropped them with the badge palette: it is drawn in a faded,
- * badge-toned colour now and wears a hairline case to hold that colour off the basemap, and an arrow texture
- * under a hairline edge is noise rather than direction. Which way the rider is carried is read from the
- * drawer's ordered rows and from the leg's endpoint bulbs instead.
+ * **No itinerary leg stamps travel-direction chevrons**, which is why this table names no `directional` at
+ * all — [RoutePolyline] defaults it off and nothing here turns it on. A dashed on-street stroke never could
+ * carry them: the chevron texture is stamped along the line, so the dash chops it into fragments and the two
+ * read as one confused broken line rather than as either. A ride dropped them with the badge palette — it is
+ * drawn in a faded, badge-toned colour now and wears a hairline case to hold that colour off the basemap, and
+ * an arrow texture under a hairline edge is noise rather than direction. Which way the rider is carried is
+ * read from the drawer's ordered rows and from the leg's endpoint bulbs instead.
  *
  * A ride also carries [RouteLineCase.OUTLINE] for that reason — every ride, so the edge says nothing about
  * selection; the rider's selected leg steps up to [RouteLineCase.SELECTION] ([withCase]). A mode leg has no
@@ -120,7 +121,6 @@ internal fun itineraryLegStyle(
         color = anchorColor(riddenRouteHue(routeColor), palette),
         widthProfile = ITINERARY_RIDE_WIDTH_PROFILE,
         dash = RouteLineDash.NONE,
-        directional = false,
         roundCaps = true,
         case = RouteLineCase.OUTLINE
     )
@@ -271,29 +271,9 @@ private fun street(hueAnchor: Int) = ItineraryLegStyle(
     color = anchorColor(hueAnchor, BASEMAP_ROUTE_LINE_PALETTE),
     widthProfile = ITINERARY_STREET_WIDTH_PROFILE,
     dash = RouteLineDash.TRAIL,
-    directional = false,
     roundCaps = false,
     case = RouteLineCase.NONE
 )
-
-/**
- * The hue a ride is *presented* in, wherever it is presented: the agency's own [routeColor] when it has a
- * usable one, else [COLOURLESS_RIDE_HUE_ANCHOR]. A hue source, not a rendered colour — each surface still
- * renders it through its own policy (the map line and the drawer badge through the badge tone, the drawer's
- * leg spine through its on-surface tone), which is what lets this be shared by a Compose surface and a
- * `Context`-free map controller alike.
- *
- * It exists because that fallback is the one thing the surfaces cannot each decide for themselves. They
- * did: a WSF ferry (every WSF route publishes an empty colour) drew a coral line on the map, since the map
- * substituted the anchor, beside a neutral grey badge in the drawer, since a badge substituted the theme's
- * `surfaceVariant`. Same route, same wire field, same policy — and two different colours, because "no
- * colour published" was answered twice.
- *
- * Giving *distinct* auto-assigned hues to the colourless rides of one itinerary (the way focused-stop
- * adjacency does) is still the rest of #2041; when that lands it replaces this function's fallback, and
- * every surface follows because they all read it here.
- */
-internal fun riddenRouteHue(routeColor: Int?): Int = routeColor?.takeIf { routeColorHctOrNull(it) != null } ?: COLOURLESS_RIDE_HUE_ANCHOR
 
 /**
  * A mode's hue [anchor] rendered by [palette] exactly as a route's own colour is, so a mode leg carries
@@ -315,11 +295,3 @@ private const val BIKE_HUE_ANCHOR = 0xFF007E8F.toInt()
 // resource read: only the hue is wanted, and this file has no `Context` to resolve one with.
 private const val BIKESHARE_HUE_ANCHOR = 0xFF3A4677.toInt()
 private const val CAR_HUE_ANCHOR = 0xFF8A6D00.toInt()
-
-/**
- * The hue a ride whose agency publishes no usable colour is presented in — read through [riddenRouteHue],
- * which is the one place that substitution happens, so the map line, the drawer badge and the leg spine
- * cannot answer "no colour published" differently. It was OTP's green, which walking now owns; a colourless
- * ride takes the terracotta walking vacated rather than sit a few degrees off it.
- */
-internal const val COLOURLESS_RIDE_HUE_ANCHOR = 0xFFC4400F.toInt()

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapRouteColors.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapRouteColors.kt
@@ -17,6 +17,7 @@ package org.onebusaway.android.map
 
 import android.annotation.SuppressLint
 import com.google.android.material.color.utilities.Hct
+import org.onebusaway.android.util.routeBadgeChipColor
 import org.onebusaway.android.util.routeCasingColor
 import org.onebusaway.android.util.routeColorHctOrNull
 
@@ -39,9 +40,15 @@ import org.onebusaway.android.util.routeColorHctOrNull
  * [routeColorHctOrNull] — reading an agency colour and deciding whether it has a hue worth keeping — so a
  * route reads as the same *hue* on the map as in the drawer beside it, rendered for its own backdrop.
  *
- * [mapRouteLineCaseColor] is the one deliberate exception, and for the reason that proves the rule: a case
- * exists to hold its line apart from the basemap, so it is the one route colour whose job is defined against
- * a backdrop that flips. It follows the theme — contrasting with it — so the line it wraps doesn't have to.
+ * Two deliberate exceptions, each for a reason that proves the rule:
+ *
+ *  - [mapRouteLineCaseColor]: a case exists to hold its line apart from the basemap, so it is the one route
+ *    colour whose job is defined against a backdrop that flips. It follows the theme — contrasting with it —
+ *    so the line it wraps doesn't have to.
+ *  - [directionsRouteLinePalette]: in the directions view a line is read *against the drawer beside it*, a
+ *    Material surface full of route badges naming those very legs, so there the line takes the badge's own
+ *    theme-aware colour rather than this map's. Which of the two policies a line draws through is the
+ *    [RouteLinePalette] its producer was handed.
  */
 // Hct is Material Components' vendored color-science util (LIBRARY_GROUP); no public equivalent
 // exists, so this is deliberate long-term use, not a migration to track (same as LineBadge).
@@ -87,6 +94,50 @@ internal fun mapRouteLineCaseColor(lineColor: Int, darkMode: Boolean): Int = rou
     lineColor,
     if (darkMode) MAP_ROUTE_CASE_TONE_LIGHT else MAP_ROUTE_CASE_TONE_DARK
 )
+
+/**
+ * Which policy renders a route line's colour, handed to whatever produces the lines rather than read from
+ * ambient state — so a pure geometry helper still says, in its own signature, that a colour decision was
+ * made somewhere.
+ *
+ * Two exist: [BASEMAP_ROUTE_LINE_PALETTE] for every line drawn against the basemap alone, and
+ * [directionsRouteLinePalette] for the directions view, where the line is read next to the badges in the
+ * drawer. A third would be a third answer to "what does a route line look like here", so add one only with
+ * a backdrop that genuinely differs — not to tweak a single view.
+ */
+// Public, unlike the rest of this file: a palette is handed to the controllers' own entry points
+// ([DirectionsMapController.start], [RouteMapController.start]), so it is part of their signature. What it
+// renders *with* stays internal.
+fun interface RouteLinePalette {
+
+    /** [source]'s hue rendered by this palette, or null when it is absent or achromatic. */
+    fun lineColor(source: Int?): Int?
+}
+
+/**
+ * The map's own palette: one chroma and one tone whatever the hue, theme-independent (see the file
+ * header). Every route line outside the directions view.
+ */
+val BASEMAP_ROUTE_LINE_PALETTE = RouteLinePalette { mapRouteLineColorOrNull(it) }
+
+/**
+ * The directions view's palette: a line takes the exact colour of the route badge that names it
+ * ([routeBadgeChipColor]) — the agency's hue at the badge's capped chroma and light tone, flipping with the
+ * theme as the badge does.
+ *
+ * The trade this makes, deliberately: these are *faded* colours, chosen to sit on a Material surface, so a
+ * directions line carries less contrast against the light basemap than a [BASEMAP_ROUTE_LINE_PALETTE] line
+ * would. That is the point — in directions the map is read together with the drawer's badges and spines, and
+ * a leg being the same colour as its badge is worth more there than maximum contrast with the basemap. The
+ * selected leg still separates itself with a case ([mapRouteLineCaseColor]), which is a tonal contrast and so
+ * unaffected.
+ *
+ * [dark] is resolved when the lines are produced (the drawn itinerary is rebuilt on every plan, leg focus and
+ * drill-in), not when they are drawn. A theme flipped while a plan is on screen therefore leaves the lines as
+ * they were until the next redraw — the same as the case colour, which the renderer resolves once per created
+ * line. The two themes' badge tones sit close together, so a stale line is a shade off, never illegible.
+ */
+fun directionsRouteLinePalette(dark: Boolean) = RouteLinePalette { routeBadgeChipColor(it, dark) }
 
 private const val MAP_ROUTE_CHROMA = 75.0
 private const val MAP_ROUTE_TONE = 55.0

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
@@ -53,6 +53,7 @@ import org.onebusaway.android.region.RegionRepository
 import org.onebusaway.android.util.GeoPoint
 import org.onebusaway.android.util.LayerUtils
 import org.onebusaway.android.util.MyTextUtils
+import org.onebusaway.android.util.ThemeUtils
 import org.onebusaway.android.util.getRouteDescription
 import org.onebusaway.android.util.getRouteDisplayName
 
@@ -228,6 +229,16 @@ class MapViewModel @Inject constructor(
     private val directionsController = DirectionsMapController(mapHost)
     private var directionsActive = false
 
+    /**
+     * The palette every line the directions view draws is stroked with — the route badge's own theme-aware
+     * colour (see [directionsRouteLinePalette]), so a leg on the map, its badge in the drawer and its spine
+     * in the option card are one colour.
+     *
+     * Read per draw rather than held: the theme can change between one plan and the next, and this is the
+     * boundary where the app's `Context` — and so the current night mode — is available at all.
+     */
+    private fun directionsPalette(): RouteLinePalette = directionsRouteLinePalette(ThemeUtils.isInDarkMode(context))
+
     // Keeps vehicle markers clear of whichever top control anchors route focus: the standalone route
     // banner or, for a route selected within stop focus, the always-visible search field.
     private val focusBannerMarkerPaddingPx =
@@ -309,7 +320,8 @@ class MapViewModel @Inject constructor(
         highlightedSegment: List<GeoPoint> = emptyList(),
         extraSegments: List<RouteFocusSegment> = emptyList(),
         itineraryContext: List<RoutePolyline> = emptyList(),
-        preserveItinerary: Boolean = false
+        preserveItinerary: Boolean = false,
+        palette: RouteLinePalette = BASEMAP_ROUTE_LINE_PALETTE
     ) {
         // A leg's route sub-focus keeps the trip it came from (its context lines were read by the caller
         // before this teardown, and its start/end pins are left standing); every other entry drops it.
@@ -325,7 +337,8 @@ class MapViewModel @Inject constructor(
             focusTripId,
             highlightedSegment,
             extraSegments,
-            itineraryContext
+            itineraryContext,
+            palette
         )
         bikeController.start(directions = false, selectedBikeStationIds = null)
     }
@@ -484,7 +497,10 @@ class MapViewModel @Inject constructor(
                 // Read before entering: the transition tears the drawn itinerary down, and this is what
                 // survives it.
                 itineraryContext = if (withinDirections) directionsController.contextPolylines() else emptyList(),
-                preserveItinerary = withinDirections
+                preserveItinerary = withinDirections,
+                // A leg drilled into keeps the directions view's colours: the corridor it belongs to is drawn
+                // in the same badge colour the leg had in the itinerary, rather than shifting palette on tap.
+                palette = if (withinDirections) directionsPalette() else BASEMAP_ROUTE_LINE_PALETTE
             )
         }
     }
@@ -506,7 +522,7 @@ class MapViewModel @Inject constructor(
         directionsController.clear()
         directionsController.clearEndpoints()
         renderState.clearRoutePolylines()
-        directionsController.start(itinerary)
+        directionsController.start(itinerary, directionsPalette())
         bikeController.start(
             directions = true,
             selectedBikeStationIds = DirectionsMapController.bikeStationIdsFromItinerary(itinerary)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
@@ -113,6 +113,11 @@ class RouteMapController(
     // publishMapPresentation so it survives re-publishes (vehicle polls, direction changes).
     private var highlightedSegment: List<GeoPoint> = emptyList()
 
+    // How this session's route colours are rendered: the basemap palette for an ordinary route launch, the
+    // directions one for a leg drilled into from a trip plan, so the corridor keeps the leg's badge colour.
+    // Set in start(); restored to the default in stop(), since a palette belongs to the view that asked for it.
+    private var palette: RouteLinePalette = BASEMAP_ROUTE_LINE_PALETTE
+
     // The trip whose leg was drilled into, already reduced to its middle journey-context weight (#2048).
     // It draws above unused route geometry but below the ridden segment, keeping the rest of the journey
     // visible around the selected leg. Empty for every non-directions launch. Set in start(); cleared in
@@ -272,6 +277,11 @@ class RouteMapController(
      * originating [directionStopId] once the vehicle appears; the on-load framing is deferred until that
      * decision so a successful vehicle+stop fit isn't first yanked out to the whole-route extent, and a
      * route frame is the fallback when no such vehicle exists.
+     *
+     * [palette] renders this session's route colours. It is the one thing a drill-in from the directions
+     * drawer changes about how the route is drawn: the leg the rider tapped keeps the badge colour it had in
+     * the itinerary, so the whole corridor it belongs to is drawn in that colour too rather than shifting to
+     * the basemap palette the moment the rider drills in.
      */
     fun start(
         routeId: String,
@@ -281,13 +291,15 @@ class RouteMapController(
         focusTripId: String? = null,
         highlightedSegment: List<GeoPoint> = emptyList(),
         extraSegments: List<RouteFocusSegment> = emptyList(),
-        itineraryContext: List<RoutePolyline> = emptyList()
+        itineraryContext: List<RoutePolyline> = emptyList(),
+        palette: RouteLinePalette = BASEMAP_ROUTE_LINE_PALETTE
     ) {
         this.routeId = routeId
         this.directionStopId = directionStopId
         this.highlightedSegment = highlightedSegment
         this.extraSegments = extraSegments
         this.itineraryContext = itineraryContext
+        this.palette = palette
         // (Re)built as the extra routes load / poll in onRouteLoaded + startVehiclePolling; cleared here
         // so a prior focus's routes/polls can't leak into this one during the load window.
         this.extraRouteMaps = emptyMap()
@@ -520,11 +532,11 @@ class RouteMapController(
 
     /**
      * The shown route's colour as this map draws it (also the band tint's basis): the agency's hue put
-     * through the shared route-line policy, or the default when the route carries no usable colour. This
-     * is what a ridden directions leg's highlighted segment is drawn in, so tapping a leg in the drawer
-     * lands on the same colour the itinerary's own line had.
+     * through this session's [palette], or the default when the route carries no usable colour. This is what
+     * a ridden directions leg's highlighted segment is drawn in, so tapping a leg in the drawer lands on the
+     * same colour the itinerary's own line had — which is why the palette travels with the drill-in.
      */
-    private fun currentRouteColor(): Int = mapRouteLineColorOrNull((_loadedRoute.value as? LoadedRoute.Loaded)?.route?.color) ?: DEFAULT_ROUTE_LINE_COLOR
+    private fun currentRouteColor(): Int = palette.lineColor((_loadedRoute.value as? LoadedRoute.Loaded)?.route?.color) ?: DEFAULT_ROUTE_LINE_COLOR
 
     /**
      * Resolve (or clear) the selected vehicle's route continuation (#1691); driven by [selectionJob]'s
@@ -570,7 +582,7 @@ class RouteMapController(
         val badgePoint = neighborShape.interpolate(CONTINUATION_LINE_LENGTH_METERS / 2) ?: return null
         val endSeg = neighborShape.segmentIndex(CONTINUATION_LINE_LENGTH_METERS)
         val arrowPoint = neighborShape.interpolate(CONTINUATION_LINE_LENGTH_METERS, endSeg) ?: return null
-        val lineColor = mapRouteLineColorOrNull(neighbor.routeColor) ?: CONTINUATION_FALLBACK_LINE_COLOR
+        val lineColor = palette.lineColor(neighbor.routeColor) ?: CONTINUATION_FALLBACK_LINE_COLOR
         return RouteContinuation(
             polyline = RoutePolyline(
                 color = lineColor,
@@ -612,6 +624,7 @@ class RouteMapController(
         highlightedSegment = emptyList()
         extraSegments = emptyList()
         itineraryContext = emptyList()
+        palette = BASEMAP_ROUTE_LINE_PALETTE
         extraRouteMaps = emptyMap()
         focusedVehiclePathsByRoute = emptyMap()
         extraPolls = emptyMap()
@@ -987,7 +1000,7 @@ class RouteMapController(
     /**
      * The drawn lines for [directionId]'s shape: the selected direction's own travel-ordered shape
      * (with direction arrows), or the whole-route merged shape drawn undirected when [directionId] is
-     * null. Puts the route's GTFS colour through the map's route-line policy; the render layer picks the
+     * null. Puts the route's GTFS colour through this session's [palette]; the render layer picks the
      * fallback when the route has no usable colour of its own. Uses [focusedRoutePolyline], the same complete line presentation as a route selected
      * from focused-stop mode. shapeForDirection pairs the drawn shape with its directionality, so
      * arrows are stamped only when the direction's own travel-ordered shape is used — never on the
@@ -999,7 +1012,7 @@ class RouteMapController(
     private fun directionPolylines(route: RouteMap, directionId: Int?): List<RoutePolyline> {
         val shape = route.shapeForDirection(directionId)
         // One colour for the whole shape — a gapped route draws several polylines, all the same route.
-        val color = mapRouteLineColorOrNull(route.route?.color)
+        val color = palette.lineColor(route.route?.color)
         return shape.polylines.map { points ->
             focusedRoutePolyline(color = color, points = points, directional = shape.directional)
         }
@@ -1182,7 +1195,7 @@ class RouteMapController(
         // drawn color and passes through, while an agency's GTFS color goes through the map's route-line
         // policy (#2041) first. Skipping that policy here would put the disc on the raw agency color
         // while its line drew the normalized one — the disagreement this resolution exists to prevent.
-        return assigned ?: mapRouteLineColorOrNull(response.route(trip.routeId)?.color)
+        return assigned ?: palette.lineColor(response.route(trip.routeId)?.color)
     }
 }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
@@ -292,7 +292,7 @@ class RouteMapController(
         highlightedSegment: List<GeoPoint> = emptyList(),
         extraSegments: List<RouteFocusSegment> = emptyList(),
         itineraryContext: List<RoutePolyline> = emptyList(),
-        palette: RouteLinePalette = BASEMAP_ROUTE_LINE_PALETTE
+        palette: RouteLinePalette
     ) {
         this.routeId = routeId
         this.directionStopId = directionStopId

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteViewGeometry.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteViewGeometry.kt
@@ -16,6 +16,7 @@ import org.onebusaway.android.map.render.FOCUSED_ROUTE_LINE_WIDTH_PROFILE
 import org.onebusaway.android.map.render.ITINERARY_APPROACH_WIDTH_PROFILE
 import org.onebusaway.android.map.render.ITINERARY_CONTEXT_WIDTH_PROFILE
 import org.onebusaway.android.map.render.RouteBadge
+import org.onebusaway.android.map.render.RouteLineCase
 import org.onebusaway.android.map.render.RouteLineDash
 import org.onebusaway.android.map.render.RoutePolyline
 import org.onebusaway.android.map.render.RoutePolylineTransform
@@ -52,13 +53,17 @@ internal fun List<RoutePolyline>.asDeemphasizedRouteUnderlay(): List<RoutePolyli
 }
 
 /**
- * The line the rider has selected, wrapped in a case (halo) — the map's one way of saying "this is the one
- * you're looking at" (#2082). Selection deliberately changes nothing else: a leg keeps the weight, colour,
- * dash and chevrons that say what *kind* of line it is, so drilling into it doesn't restyle the trip around
- * it. The case's colour is the renderer's to resolve, since it depends on the current theme (see
- * [mapRouteLineCaseColor]).
+ * The line the rider has selected, wrapped in the heavier [RouteLineCase.SELECTION] case — the map's one way
+ * of saying "this is the one you're looking at" (#2082). Selection deliberately changes nothing else: a leg
+ * keeps the weight, colour and dash that say what *kind* of line it is, so drilling into it doesn't restyle
+ * the trip around it.
+ *
+ * It overwrites whatever case the line already carried, which for a directions ride is the hairline
+ * [RouteLineCase.OUTLINE] every ride wears: selection is the *step up* in edge weight, so a line that already
+ * has an edge simply gets a heavier one. The case's colour is the renderer's to resolve, since it depends on
+ * the current theme (see [mapRouteLineCaseColor]).
  */
-internal fun RoutePolyline.withCase(): RoutePolyline = copy(cased = true)
+internal fun RoutePolyline.withCase(): RoutePolyline = copy(case = RouteLineCase.SELECTION)
 
 /**
  * The selected transit route upstream of the boarding point — where the vehicle is coming from — drawn as

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/DetailZoomRamp.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/DetailZoomRamp.kt
@@ -72,7 +72,7 @@ val DEEMPHASIZED_ROUTE_LINE_WIDTH_PROFILE = ROUTE_LINE_WIDTH_PROFILE.copy(
 
 /**
  * The selected transit route upstream of where the rider boards it — where the bus is coming from. It is the
- * same route as the ridden segment, so it is cased like it (see [RoutePolyline.cased]) and steps down in width
+ * same route as the ridden segment, so it is cased like it (see [RoutePolyline.case]) and steps down in width
  * at the boarding point.
  *
  * The thinnest of the itinerary weights, because it is the least committed geometry on the map: the rider
@@ -115,22 +115,6 @@ val ITINERARY_RIDE_WIDTH_PROFILE = FOCUSED_ROUTE_LINE_WIDTH_PROFILE
 val ITINERARY_STREET_WIDTH_PROFILE = ROUTE_LINE_WIDTH_PROFILE.copy(
     thicknessDp = ROUTE_LINE_WIDTH_DP * 0.9f
 )
-
-/**
- * How far a case (halo) extends beyond its line on each side — see [RoutePolyline.cased]. Deliberately *not*
- * on the zoom ramp: a case is an outline, and an outline that thins with its line stops separating it from the
- * basemap at exactly the zoom where the line is hardest to pick out.
- *
- * Kept fine enough to read as an edge on the line rather than as a second line under it — a case's job is to
- * separate, and past a hairline the extra width only adds visual weight the selection didn't ask for.
- */
-const val ROUTE_LINE_CASE_DP = 1.5f
-
-/**
- * What [ROUTE_LINE_CASE_DP] adds to a line's *total* width — both sides. Derived here rather than at each width
- * computation, so nothing has to remember that the constant above is per-side.
- */
-const val ROUTE_LINE_CASE_EXTRA_DP = 2f * ROUTE_LINE_CASE_DP
 
 /** Route-line scale retained for unprofiled lines and vehicle markers. */
 fun routeLineWidthScale(zoom: Float): Float = ROUTE_LINE_WIDTH_PROFILE.multiplierAt(zoom)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
@@ -79,6 +79,32 @@ enum class RouteLineDash {
 }
 
 /**
+ * Whether a line is outlined, and how heavily. Named for what each weight *means*, since that is what
+ * decides which one a producer asks for:
+ *
+ *  - [NONE] — no case, the ordinary route line.
+ *  - [OUTLINE] — a hairline edge that holds a directions ride off the basemap. Every ride in a drawn
+ *    itinerary carries it, so it says nothing about selection; it is there because a faded, badge-toned
+ *    line has less of its own contrast to spend against the map than a full-strength one does.
+ *  - [SELECTION] — the heavier case marking the line the rider has selected (#2082). Selection used to be
+ *    said with a width, but the map already spends width on what a line *is* (a ride, an on-street leg,
+ *    route context), so saying two things with one channel left neither legible. It stays legible against
+ *    [OUTLINE] because it is twice the weight of it — selection is now a *heavier* edge, not the only edge.
+ *
+ * The widths are deliberately *not* on the zoom ramp: a case is an outline, and an outline that thins with
+ * its line stops separating it from the basemap at exactly the zoom where the line is hardest to pick out.
+ */
+enum class RouteLineCase(val widthDp: Float) {
+    NONE(0f),
+    OUTLINE(0.75f),
+    SELECTION(1.5f);
+
+    /** What this case adds to its line's *total* width — both sides. Derived here so no caller has to
+     *  remember that [widthDp] is per-side. */
+    val extraWidthDp: Float get() = widthDp * 2f
+}
+
+/**
  * One route/itinerary polyline: an ordered list of points and an optional [color]. A null [color]
  * means "use the [DEFAULT_ROUTE_LINE_COLOR]" — choosing the fallback is a display decision, so producers
  * can pass a route's raw (possibly absent) GTFS color straight through and renderers draw [resolvedColor].
@@ -96,12 +122,10 @@ enum class RouteLineDash {
  * [RouteLineDash] names. Whether a renderer honors it is flavor-specific (the maplibre classic
  * annotation draws every line solid).
  *
- * [cased] asks the renderer to draw a *case* (halo) beneath this line: the same geometry stroked
- * [ROUTE_LINE_CASE_DP] wider on each side, immediately under the line itself. It marks the line the rider
- * has selected (#2082) — selection used to be said with a width, but the map already spends width on what a
- * line *is* (a ride, an on-street leg, route context), so saying two things with one channel left neither
- * legible. Renderers draw the pair as a unit; the case never carries chevrons, and follows the line's own
- * [dash] so a broken line's case breaks with it.
+ * [case] asks the renderer to draw a *case* (halo) beneath this line: the same geometry stroked
+ * [RouteLineCase.widthDp] wider on each side, immediately under the line itself. Renderers draw the pair as
+ * a unit; the case never carries chevrons, and follows the line's own [dash] so a broken line's case breaks
+ * with it.
  *
  * Only the *request* lives here, not a colour: a case works by separating its line from the basemap, and the
  * basemap flips with the theme, so its colour is the one route colour that has to be resolved against the
@@ -122,7 +146,7 @@ data class RoutePolyline(
     val widthProfile: RouteLineWidthProfile? = null,
     val directional: Boolean = false,
     val dash: RouteLineDash = RouteLineDash.NONE,
-    val cased: Boolean = false,
+    val case: RouteLineCase = RouteLineCase.NONE,
     val roundStartCap: Boolean = false,
     val roundEndCap: Boolean = false,
     val transforms: Set<RoutePolylineTransform> = emptySet()

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/RoutePolylineReconciler.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/RoutePolylineReconciler.kt
@@ -23,7 +23,7 @@ package org.onebusaway.android.map.render
  * against the last-drawn widths, the native width patch, the three-field state update, and the
  * camera-settle width resync all live here once.
  *
- * It also owns the *case* pairing (#2082): a [RoutePolyline] that asks to be [RoutePolyline.cased] draws as two
+ * It also owns the *case* pairing (#2082): a [RoutePolyline] that asks for a [RouteLineCase] draws as two
  * native lines — the case beneath its own stroke — and "create both, remove both, resize both, case underneath"
  * is the same species of bookkeeping as everything above, so it belongs here rather than in each flavor.
  *
@@ -31,8 +31,9 @@ package org.onebusaway.android.map.render
  * type: how to resolve a line's pixel width at a zoom ([widthOf]), how to create a native line
  * ([createLine]), how to remove a batch of them ([removeLines]), how to patch a live line's width
  * ([setWidth]), what colour a case draws in ([caseColorOf] — theme-dependent, so it needs the flavor's
- * `Context`), and how much wider a case is stroked ([caseExtraWidth], in whatever width unit that flavor's
- * [widthOf] returns). Everything else — the bookkeeping the fixes were about — is shared.
+ * `Context`), and how much wider a given line's case is stroked ([caseExtraWidth] — per line, since the two
+ * case weights differ, in whatever width unit that flavor's [widthOf] returns). Everything else — the
+ * bookkeeping the fixes were about — is shared.
  *
  * Not thread-safe: every method mutates native map state and must run on the map's main thread, which
  * is where both renderers already call it.
@@ -43,13 +44,13 @@ class RoutePolylineReconciler<NativeLine>(
     private val removeLines: (List<NativeLine>) -> Unit,
     private val setWidth: (NativeLine, Float) -> Unit,
     private val caseColorOf: (RoutePolyline) -> Int,
-    private val caseExtraWidth: Float
+    private val caseExtraWidth: (RoutePolyline) -> Float
 ) {
     /**
      * One drawn line: its stroke, plus the wider case (halo) stroke beneath it when the line asked for one.
      * Held as a pair so a case cannot outlive its line or drift out of sync with its width.
      */
-    private class Drawn<NativeLine>(val case: NativeLine?, val line: NativeLine) {
+    private class Drawn<NativeLine>(val case: NativeLine?, val line: NativeLine, val caseExtraWidth: Float) {
         /** Both strokes, case first — the order they were added, and so the order they draw. */
         val natives: List<NativeLine> get() = listOfNotNull(case, line)
     }
@@ -119,10 +120,16 @@ class RoutePolylineReconciler<NativeLine>(
      * order they were added, which is the same thing that layers the polyline list itself, so creating the case
      * ahead of its own stroke is what puts it underneath.
      */
-    private fun create(polyline: RoutePolyline, width: Float): Drawn<NativeLine> = Drawn(
-        case = if (polyline.cased) createLine(polyline.asCase(caseColorOf(polyline)), width + caseExtraWidth) else null,
-        line = createLine(polyline, width)
-    )
+    private fun create(polyline: RoutePolyline, width: Float): Drawn<NativeLine> {
+        val extra = caseExtraWidth(polyline)
+        return Drawn(
+            case = if (polyline.case != RouteLineCase.NONE) createLine(polyline.asCase(caseColorOf(polyline)), width + extra) else null,
+            line = createLine(polyline, width),
+            // Retained with the pair: a width resync patches the case from the line's new width, and the
+            // amount to add is a property of the case that was drawn, not of the reconcile doing the patching.
+            caseExtraWidth = extra
+        )
+    }
 
     private fun Drawn<NativeLine>.applyWidth(width: Float) {
         setWidth(line, width)
@@ -137,4 +144,4 @@ class RoutePolylineReconciler<NativeLine>(
  * (its dash rhythm, and on gms the cheap solid-colour draw path a non-directional line takes) rather than each
  * flavor rebuilding a parallel one that has to be kept in step.
  */
-private fun RoutePolyline.asCase(color: Int) = copy(color = color, directional = false, cased = false)
+private fun RoutePolyline.asCase(color: Int) = copy(color = color, directional = false, case = RouteLineCase.NONE)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/LineBadge.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/LineBadge.kt
@@ -78,17 +78,6 @@ private const val LINE_TONE_LIGHT = 40.0
 private const val LINE_TONE_DARK = 80.0
 
 /**
- * The route's GTFS color re-derived in HCT at [tone] as a Compose [Color] — same hue, chroma capped for
- * the active theme. Null when the source is absent or achromatic (grey/black/white — no hue to keep),
- * which is every caller's cue to fall back to a neutral.
- *
- * The policy itself is [routeColorAtTone], which the directions map's route lines also draw through, so
- * the chip and the line naming the same ride can't drift apart on how saturated a route may get. This is
- * only the Compose wrapper.
- */
-private fun tonedRouteColor(routeColor: Int?, dark: Boolean, tone: Double): Color? = routeColorAtTone(routeColor, dark, tone)?.let { Color(it) }
-
-/**
  * A route color for drawing straight **on the surface** — a spine, stroke or filled marker — paired
  * with the color for a glyph placed on top of it. Returned together (as [rememberRouteBadgeColors]
  * does for its chip) so the contrast is guaranteed by construction rather than by a comment, on the
@@ -105,8 +94,8 @@ data class RouteLineColors(val line: Color, val onLine: Color)
  * An achromatic or absent route color yields [fallback] unchanged, glyph included.
  */
 fun routeLineColors(routeColor: Int?, dark: Boolean, fallback: RouteLineColors): RouteLineColors {
-    val line = tonedRouteColor(routeColor, dark, if (dark) LINE_TONE_DARK else LINE_TONE_LIGHT)
-        ?: return fallback
+    val line = routeColorAtTone(routeColor, dark, if (dark) LINE_TONE_DARK else LINE_TONE_LIGHT)
+        ?.let { Color(it) } ?: return fallback
     return RouteLineColors(line, if (dark) Color.Black else Color.White)
 }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/LineBadge.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/LineBadge.kt
@@ -15,7 +15,6 @@
  */
 package org.onebusaway.android.ui.compose.components
 
-import android.annotation.SuppressLint
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -54,11 +53,11 @@ import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.isSpecified
 import androidx.compose.ui.unit.sp
-import com.google.android.material.color.utilities.Hct
-import kotlin.math.min
 import org.onebusaway.android.ui.compose.theme.ObaTheme
 import org.onebusaway.android.ui.compose.theme.isDarkTheme
-import org.onebusaway.android.util.routeColorHctOrNull
+import org.onebusaway.android.util.routeBadgeChipColor
+import org.onebusaway.android.util.routeBadgeChipTextColor
+import org.onebusaway.android.util.routeColorAtTone
 
 /** Line height as a multiple of the font size, so multi-line badges shrink with the font. */
 private const val LINE_HEIGHT_RATIO = 1.1f
@@ -72,20 +71,6 @@ private val CHIP_H_PADDING = 8.dp
 private val CHIP_V_PADDING = 2.dp
 private const val CHIP_END_COLOR_FRACTION = 0.2f
 
-// Route-badge color tokens. We take only the *hue* of the agency's GTFS color and re-derive the chip
-// in HCT (a perceptual space) at a fixed tone + capped chroma, so the agency can't hand us an
-// over-saturated or too-dark/too-light color — every chip lands at a consistent, legible brightness,
-// and the tone flips lighter for dark theme. Fidget with these to taste.
-private const val CHIP_TONE_LIGHT = 80.0 // container tone in light theme (0=black … 100=white)
-private const val CHIP_TONE_DARK = 78.0 // container tone for dark theme
-private const val CHIP_ON_TONE_LIGHT = 30.0 // text tone on the light-theme (pastel) chip (→ dark)
-private const val CHIP_ON_TONE_DARK = 20.0 // text tone on the dark-theme chip (→ near-black)
-private const val CHIP_MAX_CHROMA_LIGHT = 30.0 // saturation cap in light theme (soft pastel)
-private const val CHIP_MAX_CHROMA_DARK = 60.0 // saturation cap in dark theme
-
-// (each hue still clamps to its own sRGB gamut limit;
-//  low caps mute vivid hues — e.g. orange → brown)
-
 // Route-*line* tones: the same hue re-derived to sit legibly ON the surface (rather than as a filled
 // chip), for a stroke/marker drawn directly on the background — Material's own accent tones, 40 in
 // light and 80 in dark.
@@ -93,20 +78,15 @@ private const val LINE_TONE_LIGHT = 40.0
 private const val LINE_TONE_DARK = 80.0
 
 /**
- * The route's GTFS color re-derived in HCT at [tone]: same hue, chroma capped for the active theme.
- * Null when the source is absent or achromatic (grey/black/white — no hue to keep), which is every
- * caller's cue to fall back to a neutral. The single place the *chip and spine* color policy lives, so
- * those two can't drift apart on how saturated a route may get; reading the agency color and rejecting a
- * hueless one is [routeColorHctOrNull], shared with the map's own tone policy.
+ * The route's GTFS color re-derived in HCT at [tone] as a Compose [Color] — same hue, chroma capped for
+ * the active theme. Null when the source is absent or achromatic (grey/black/white — no hue to keep),
+ * which is every caller's cue to fall back to a neutral.
+ *
+ * The policy itself is [routeColorAtTone], which the directions map's route lines also draw through, so
+ * the chip and the line naming the same ride can't drift apart on how saturated a route may get. This is
+ * only the Compose wrapper.
  */
-// Hct is Material Components' vendored color-science util (LIBRARY_GROUP); no public equivalent
-// exists, so this is deliberate long-term use, not a migration to track (same as AdjacencyRouteColors).
-@SuppressLint("RestrictedApi")
-private fun tonedRouteColor(routeColor: Int?, dark: Boolean, tone: Double): Color? {
-    val source = routeColorHctOrNull(routeColor) ?: return null
-    val chroma = min(source.chroma, if (dark) CHIP_MAX_CHROMA_DARK else CHIP_MAX_CHROMA_LIGHT)
-    return Color(Hct.from(source.hue, chroma, tone).toInt())
-}
+private fun tonedRouteColor(routeColor: Int?, dark: Boolean, tone: Double): Color? = routeColorAtTone(routeColor, dark, tone)?.let { Color(it) }
 
 /**
  * A route color for drawing straight **on the surface** — a spine, stroke or filled marker — paired
@@ -132,23 +112,23 @@ fun routeLineColors(routeColor: Int?, dark: Boolean, fallback: RouteLineColors):
 
 /**
  * Resolves the (container, content) colors for a route-badge chip from the route's GTFS color. We keep
- * only its hue and regenerate the chip at a fixed HCT tone + capped chroma (see the tokens above), so
- * the result is a consistent brightness in the active theme regardless of what the agency picked; the
- * text tone is paired to the container for guaranteed contrast. An achromatic source (grey/black/white)
+ * only its hue and regenerate the chip at a fixed HCT tone + capped chroma ([routeBadgeChipColor], paired
+ * with [routeBadgeChipTextColor]), so the result is a consistent brightness in the active theme regardless
+ * of what the agency picked, and the text tone moves with the container it has to contrast with. An achromatic source (grey/black/white)
  * or a route with no color falls back to a neutral theme chip. Callers pass the pair straight to
  * [LineBadge]'s `containerColor` / `color`.
+ *
+ * The container color is also what the directions map strokes that route's line with, so the two are read
+ * from one definition rather than kept in step by hand.
  */
-// Hct is Material Components' vendored color-science util (LIBRARY_GROUP); no public equivalent
-// exists, so this is deliberate long-term use, not a migration to track (same as AdjacencyRouteColors).
-@SuppressLint("RestrictedApi")
 @Composable
 fun rememberRouteBadgeColors(routeColor: Int?): Pair<Color, Color> {
     val neutralContainer = MaterialTheme.colorScheme.surfaceVariant
     val neutralContent = MaterialTheme.colorScheme.onSurfaceVariant
     val dark = MaterialTheme.colorScheme.isDarkTheme()
     return remember(routeColor, dark, neutralContainer, neutralContent) {
-        val container = tonedRouteColor(routeColor, dark, if (dark) CHIP_TONE_DARK else CHIP_TONE_LIGHT)
-        val content = tonedRouteColor(routeColor, dark, if (dark) CHIP_ON_TONE_DARK else CHIP_ON_TONE_LIGHT)
+        val container = routeBadgeChipColor(routeColor, dark)?.let { Color(it) }
+        val content = routeBadgeChipTextColor(routeColor, dark)?.let { Color(it) }
         // Both tones come from the same source, so they are null together — an achromatic or absent
         // route color takes the neutral theme chip.
         if (container == null || content == null) neutralContainer to neutralContent else container to content

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/RouteBadges.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/RouteBadges.kt
@@ -21,11 +21,11 @@ import org.onebusaway.android.directions.model.TripLeg
 import org.onebusaway.android.directions.model.TripMode
 import org.onebusaway.android.directions.model.routeDisplayLabel
 import org.onebusaway.android.directions.model.routeDisplayShortName
-import org.onebusaway.android.map.riddenRouteHue
 import org.onebusaway.android.ui.compose.components.RouteBadge
 import org.onebusaway.android.ui.compose.components.RouteBadgeJoin
 import org.onebusaway.android.util.inInterchangeableOrder
 import org.onebusaway.android.util.parseObaHexColor
+import org.onebusaway.android.util.riddenRouteHue
 
 /**
  * Builds the [LegBadge] a ride draws — the planned route, plus whatever else the rider may ride for that
@@ -106,7 +106,7 @@ internal fun legBadge(planned: RouteBadge?, alternatives: List<RouteBadge>, mode
  * The wider [plannedBadge] rule (long name in the roundel) belongs to the option cards, which have no
  * room to print a long name any other way.
  */
-internal fun TripLeg.shortNameBadge(): RouteBadge? = routeDisplayShortName()?.let { RouteBadge(it, badgeColor(routeColor)) }
+internal fun TripLeg.shortNameBadge(): RouteBadge? = routeDisplayShortName()?.let { RouteBadge(it, ridePresentationColor(routeColor)) }
 
 /**
  * The transit leg's own roundel: its badge name and parsed GTFS color; null when it names itself in no
@@ -118,18 +118,22 @@ internal fun TripLeg.shortNameBadge(): RouteBadge? = routeDisplayShortName()?.le
  * directions pane still draws no roundel for such a route: it has room to print the long name in full as
  * the row's title, and doesn't reach for this badge to do it.
  */
-internal fun TripLeg.plannedBadge(): RouteBadge? = routeDisplayLabel()?.let { RouteBadge(it, badgeColor(routeColor)) }
+internal fun TripLeg.plannedBadge(): RouteBadge? = routeDisplayLabel()?.let { RouteBadge(it, ridePresentationColor(routeColor)) }
 
 /** An interchangeable route's roundel, alongside [plannedBadge] in the same leg's badge. */
-internal fun InterchangeableRoute.badge(): RouteBadge = RouteBadge(displayName, badgeColor(routeColor))
+internal fun InterchangeableRoute.badge(): RouteBadge = RouteBadge(displayName, ridePresentationColor(routeColor))
 
 /**
- * A wire route color as a badge color: OTP hands over a bare hex, but tolerate a leading '#'.
+ * A ride's wire route colour as the colour that ride is *presented* in — by its badge here, by its spine and
+ * roundel in the drawer, and by its line on the map.
  *
- * A route publishing nothing usable takes the colourless-ride hue rather than leaving the badge to fall
- * back on its own, because the map draws that ride's line in exactly that hue ([riddenRouteHue]) — and a
- * badge picking the neutral theme chip instead is how a WSF ferry came to sit as a grey roundel beside its
- * own coral line. The hue, not a rendered colour: the chip still re-tones it for the active theme, which is
- * the one thing this pure, `Context`-free layer can't do.
+ * A route publishing nothing usable takes the colourless-ride hue ([riddenRouteHue]) rather than leaving
+ * each surface to fall back on its own: a badge picking the neutral theme chip instead is how a WSF ferry
+ * came to sit as a grey roundel beside its own coral line. The hue, not a rendered colour — the chip and the
+ * spine still re-tone it for the active theme, which is the one thing this pure, `Context`-free layer can't
+ * do.
+ *
+ * `internal` so the drawer's composables share this one spelling rather than re-deriving it: the same
+ * substitution written twice is the same defect waiting to reappear one surface over.
  */
-private fun badgeColor(wireHex: String?): Int = riddenRouteHue(parseObaHexColor(wireHex?.removePrefix("#")))
+internal fun ridePresentationColor(wireHex: String?): Int = riddenRouteHue(parseObaHexColor(wireHex))

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/RouteBadges.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/RouteBadges.kt
@@ -21,6 +21,7 @@ import org.onebusaway.android.directions.model.TripLeg
 import org.onebusaway.android.directions.model.TripMode
 import org.onebusaway.android.directions.model.routeDisplayLabel
 import org.onebusaway.android.directions.model.routeDisplayShortName
+import org.onebusaway.android.map.riddenRouteHue
 import org.onebusaway.android.ui.compose.components.RouteBadge
 import org.onebusaway.android.ui.compose.components.RouteBadgeJoin
 import org.onebusaway.android.util.inInterchangeableOrder
@@ -122,5 +123,13 @@ internal fun TripLeg.plannedBadge(): RouteBadge? = routeDisplayLabel()?.let { Ro
 /** An interchangeable route's roundel, alongside [plannedBadge] in the same leg's badge. */
 internal fun InterchangeableRoute.badge(): RouteBadge = RouteBadge(displayName, badgeColor(routeColor))
 
-/** A wire route color as a badge color: OTP hands over a bare hex, but tolerate a leading '#'. */
-private fun badgeColor(wireHex: String?): Int? = parseObaHexColor(wireHex?.removePrefix("#"))
+/**
+ * A wire route color as a badge color: OTP hands over a bare hex, but tolerate a leading '#'.
+ *
+ * A route publishing nothing usable takes the colourless-ride hue rather than leaving the badge to fall
+ * back on its own, because the map draws that ride's line in exactly that hue ([riddenRouteHue]) — and a
+ * badge picking the neutral theme chip instead is how a WSF ferry came to sit as a grey roundel beside its
+ * own coral line. The hue, not a rendered colour: the chip still re-tones it for the active theme, which is
+ * the one thing this pure, `Context`-free layer can't do.
+ */
+private fun badgeColor(wireHex: String?): Int = riddenRouteHue(parseObaHexColor(wireHex?.removePrefix("#")))

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
@@ -115,7 +115,6 @@ import org.onebusaway.android.directions.model.TripItinerary
 import org.onebusaway.android.directions.realtime.TripPlanMonitor
 import org.onebusaway.android.directions.realtime.TripPlanNotifications
 import org.onebusaway.android.directions.util.ConversionUtils
-import org.onebusaway.android.map.riddenRouteHue
 import org.onebusaway.android.time.ServerTime
 import org.onebusaway.android.ui.compose.components.EtaDurationText
 import org.onebusaway.android.ui.compose.components.EtaPartsText
@@ -991,9 +990,10 @@ private fun TripLogList(
             neutral = neutral,
             // The agency's GTFS colour re-toned to stay legible on this theme's surface, so a near-black
             // or near-white route can't hand us an invisible spine. Same system as the leg's route badge —
-            // including its answer for a route that publishes no colour at all ([riddenRouteHue]), so a
-            // ferry's spine, its badge and its line on the map are one hue rather than three fallbacks.
-            rideColors = { routeLineColors(riddenRouteHue(routeColorInt(it.routeColorHex)), dark, neutral) }
+            // including its answer for a route that publishes no colour at all
+            // ([ridePresentationColor]), so a ferry's spine, its roundel and its line on the map are one
+            // hue rather than three fallbacks.
+            rideColors = { routeLineColors(ridePresentationColor(it.routeColorHex), dark, neutral) }
         )
     }
 
@@ -1115,9 +1115,6 @@ private fun focusTransit(
         else -> entry.routeLeg.board?.point?.let(onFocusPoint)
     }
 }
-
-/** The GTFS colour as the nullable ARGB int the route-colour helpers want (null → their fallback). */
-private fun routeColorInt(hex: String?): Int? = parseObaHexColor(hex?.removePrefix("#"))
 
 /**
  * One timeline row: the time column, the spine cell (drawn from [LogRowModel.top]/[bottom] with the node
@@ -1580,7 +1577,7 @@ private fun ColumnScope.BoardContent(
             roundel = when {
                 joined != null -> ({ RouteBadgeChip(joined.routes, scale = BADGE_SCALE, join = joined.join) })
                 entry.routeShortName != null ->
-                    ({ RouteBadgeChip(entry.routeShortName, routeColorInt(entry.routeColorHex), scale = BADGE_SCALE) })
+                    ({ RouteBadgeChip(entry.routeShortName, ridePresentationColor(entry.routeColorHex), scale = BADGE_SCALE) })
                 else -> null
             }
         )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
@@ -115,6 +115,7 @@ import org.onebusaway.android.directions.model.TripItinerary
 import org.onebusaway.android.directions.realtime.TripPlanMonitor
 import org.onebusaway.android.directions.realtime.TripPlanNotifications
 import org.onebusaway.android.directions.util.ConversionUtils
+import org.onebusaway.android.map.riddenRouteHue
 import org.onebusaway.android.time.ServerTime
 import org.onebusaway.android.ui.compose.components.EtaDurationText
 import org.onebusaway.android.ui.compose.components.EtaPartsText
@@ -989,8 +990,10 @@ private fun TripLogList(
             expandedEntries = expandedEntries,
             neutral = neutral,
             // The agency's GTFS colour re-toned to stay legible on this theme's surface, so a near-black
-            // or near-white route can't hand us an invisible spine. Same system as the leg's route badge.
-            rideColors = { routeLineColors(routeColorInt(it.routeColorHex), dark, neutral) }
+            // or near-white route can't hand us an invisible spine. Same system as the leg's route badge —
+            // including its answer for a route that publishes no colour at all ([riddenRouteHue]), so a
+            // ferry's spine, its badge and its line on the map are one hue rather than three fallbacks.
+            rideColors = { routeLineColors(riddenRouteHue(routeColorInt(it.routeColorHex)), dark, neutral) }
         )
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/RouteColors.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/RouteColors.kt
@@ -113,6 +113,37 @@ fun routeBadgeChipColor(routeColor: Int?, dark: Boolean): Int? = routeColorAtTon
  */
 fun routeBadgeChipTextColor(routeColor: Int?, dark: Boolean): Int? = routeColorAtTone(routeColor, dark, if (dark) BADGE_CHIP_TEXT_TONE_DARK else BADGE_CHIP_TEXT_TONE_LIGHT)
 
+/**
+ * The hue a ride is *presented* in, wherever it is presented: the agency's own [routeColor] when it has a
+ * usable one, else [COLOURLESS_RIDE_HUE_ANCHOR]. A hue source, not a rendered colour — each surface still
+ * renders it through its own policy (the map line and the drawer badge through the badge tone, the drawer's
+ * leg spine through its on-surface tone), which is what lets this be shared by a Compose surface and a
+ * `Context`-free map controller alike.
+ *
+ * It exists because that fallback is the one thing the surfaces cannot each decide for themselves. They
+ * did: a WSF ferry (every WSF route publishes an empty colour) drew a coral line on the map, since the map
+ * substituted the anchor, beside a neutral grey badge in the drawer, since a badge substituted the theme's
+ * `surfaceVariant`. Same route, same wire field, same policy — and two different colours, because "no
+ * colour published" was answered twice.
+ *
+ * Giving *distinct* auto-assigned hues to the colourless rides of one itinerary (the way focused-stop
+ * adjacency does) is still the rest of #2041; when that lands it replaces this function's fallback, and
+ * every surface follows because they all read it here.
+ *
+ * Lives beside [routeBadgeChipColor] rather than with the map's leg styling, for the reason that put the
+ * chip's tonal policy here: the surfaces sharing it are a `Context`-free map controller and two Compose
+ * files, which cannot reach each other. This file is where they meet.
+ */
+internal fun riddenRouteHue(routeColor: Int?): Int = routeColor?.takeIf { routeColorHctOrNull(it) != null } ?: COLOURLESS_RIDE_HUE_ANCHOR
+
+/**
+ * The hue a ride whose agency publishes no usable colour is presented in — read through [riddenRouteHue],
+ * which is the one place that substitution happens, so the map line, the drawer badge and the leg spine
+ * cannot answer "no colour published" differently. It was OTP's green, which walking now owns; a colourless
+ * ride takes the terracotta walking vacated rather than sit a few degrees off it.
+ */
+internal const val COLOURLESS_RIDE_HUE_ANCHOR = 0xFFC4400F.toInt()
+
 // The saturation ceiling a re-derived route colour may reach, per theme, and the badge chip's tones
 // (0=black … 100=white). Together these decide how *pastel* a route reads: chroma is how much of the
 // agency's colour survives, tone how light the result sits. Each hue still clamps to its own sRGB gamut

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/RouteColors.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/RouteColors.kt
@@ -18,6 +18,7 @@ package org.onebusaway.android.util
 import android.annotation.SuppressLint
 import androidx.core.graphics.toColorInt
 import com.google.android.material.color.utilities.Hct
+import kotlin.math.min
 
 /**
  * Parses a route hex color to an Android ARGB int, or null when absent or malformed. The single
@@ -45,9 +46,9 @@ fun parseObaHexColor(hex: String?): Int? = hex?.takeIf { it.isNotEmpty() }?.let 
  * share is this step, so they can't drift apart on which colors count as "grey" or on the opaque-alpha
  * normalization that precedes the test.
  *
- * The callers ([org.onebusaway.android.map.mapRouteLineColorOrNull] and `LineBadge.kt`'s
- * `tonedRouteColor`) differ only in what they do with the result — the map keeps the hue alone at its own
- * fixed chroma/tone, the badge caps the source's chroma against a theme.
+ * The callers ([org.onebusaway.android.map.mapRouteLineColorOrNull] and [routeColorAtTone]) differ only in
+ * what they do with the result — the map keeps the hue alone at its own fixed chroma/tone, the badge caps
+ * the source's chroma against a theme.
  */
 // Hct is Material Components' vendored color-science util (LIBRARY_GROUP); no public equivalent exists,
 // so this is deliberate long-term use, not a migration to track (same as AdjacencyRouteColors).
@@ -59,6 +60,82 @@ fun routeColorHctOrNull(routeColor: Int?): Hct? {
 
 /** The chroma floor [routeColorHctOrNull] applies; exposed so a test can assert against the same bar. */
 const val ACHROMATIC_ROUTE_CHROMA = 5.0
+
+/**
+ * [routeColor]'s hue re-derived in HCT at [tone], with its chroma capped for the active theme — the
+ * theme-aware route colour policy, as opposed to the map's basemap-neutral one
+ * ([org.onebusaway.android.map.mapRouteLineColorOrNull]). Null when the source is absent or achromatic
+ * (grey/black/white — no hue to keep), which is every caller's cue to fall back to a neutral.
+ *
+ * Capping rather than replacing the chroma is what makes these colours read as *faded*: an agency handing
+ * over a fully saturated hue is muted to the theme's ceiling, while one that publishes an already-soft
+ * colour keeps it. [tone] stays the caller's decision, because the same hue is wanted at different
+ * lightnesses depending on what is drawn — a filled chip, the glyph on it, a spine on the surface
+ * ([org.onebusaway.android.ui.compose.components.routeLineColors]) — and it is the one channel each of
+ * those has to choose for itself.
+ *
+ * Lives here, in ARGB ints, rather than in `LineBadge.kt` where it grew: the directions map draws its
+ * route lines in exactly [routeBadgeChipColor] so a line matches the badge naming it, and the map package
+ * can't reach a Compose component (nor wants Compose's `Color` in its render state).
+ */
+// Hct is Material Components' vendored color-science util (LIBRARY_GROUP); no public equivalent exists,
+// so this is deliberate long-term use, not a migration to track (same as AdjacencyRouteColors).
+@SuppressLint("RestrictedApi")
+fun routeColorAtTone(routeColor: Int?, dark: Boolean, tone: Double): Int? {
+    val source = routeColorHctOrNull(routeColor) ?: return null
+    val chroma = min(source.chroma, if (dark) ROUTE_CHROMA_CAP_DARK else ROUTE_CHROMA_CAP_LIGHT)
+    return Hct.from(source.hue, chroma, tone).toInt()
+}
+
+/**
+ * The route badge chip's own fill: [routeColor] at the badge tone for the active theme. The single
+ * definition of that colour, shared by the chip itself
+ * ([org.onebusaway.android.ui.compose.components.rememberRouteBadgeColors]) and by the directions map's
+ * route lines, so a ride's line and the badge that names it are the same colour rather than two policies
+ * that happen to agree today.
+ *
+ * Null for an absent or achromatic source, as [routeColorAtTone] is — the chip takes a neutral theme
+ * container and a map line falls back to whatever its own kind calls for.
+ */
+fun routeBadgeChipColor(routeColor: Int?, dark: Boolean): Int? = routeColorAtTone(routeColor, dark, if (dark) BADGE_CHIP_TONE_DARK else BADGE_CHIP_TONE_LIGHT)
+
+/**
+ * The text drawn on a [routeBadgeChipColor] fill: the same route colour taken to a deep tone, so the name
+ * reads as part of its badge rather than as black ink dropped on it.
+ *
+ * Paired with the fill deliberately, and in the same file: the two tones are only correct *together* — the
+ * chip's legibility is the contrast between them, which `RouteColorsTest` holds to 4.5:1 — so a fill tone
+ * can't be darkened for a less-pastel badge without its text following. Kept as a colour rather than a
+ * per-fill luminance test because the tone is fixed by the theme, so the answer is too.
+ *
+ * Null for an absent or achromatic source, exactly when the fill is: the chip then takes the neutral theme
+ * container/content pair instead.
+ */
+fun routeBadgeChipTextColor(routeColor: Int?, dark: Boolean): Int? = routeColorAtTone(routeColor, dark, if (dark) BADGE_CHIP_TEXT_TONE_DARK else BADGE_CHIP_TEXT_TONE_LIGHT)
+
+// The saturation ceiling a re-derived route colour may reach, per theme, and the badge chip's tones
+// (0=black … 100=white). Together these decide how *pastel* a route reads: chroma is how much of the
+// agency's colour survives, tone how light the result sits. Each hue still clamps to its own sRGB gamut
+// limit, so a low cap mutes vivid hues — orange → brown.
+//
+// Deliberately tuned away from pastel: a route's colour is identity, and washed-out fills made two nearby
+// hues hard to tell apart — on the chip, and more so on the directions map, where the same colours are
+// stroked over a basemap. So the caps sit well above a pastel's, while staying under the map's own chroma
+// (75) — this is still the *faded* rendering, just not a wash.
+//
+// The light theme is the one that had the problem, and its tone is why: a light fill can hold little chroma
+// before leaving the sRGB gamut, so most light hues were clamped well under their cap and came out pale
+// whatever the cap said. Its fill therefore sits lower than the dark theme's — the opposite of what a
+// "lighter theme, lighter chip" reading would suggest — with the text tone darkened in step to hold the
+// contrast. The dark theme needed neither move.
+private const val ROUTE_CHROMA_CAP_LIGHT = 48.0
+private const val ROUTE_CHROMA_CAP_DARK = 70.0
+
+private const val BADGE_CHIP_TONE_LIGHT = 73.0
+private const val BADGE_CHIP_TONE_DARK = 74.0
+
+private const val BADGE_CHIP_TEXT_TONE_LIGHT = 25.0
+private const val BADGE_CHIP_TEXT_TONE_DARK = 20.0
 
 /**
  * [color] re-toned to [tone], keeping its hue and chroma — the casing step, shared by the two things on the

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
@@ -50,7 +50,6 @@ import org.onebusaway.android.map.render.MapRenderSnapshot
 import org.onebusaway.android.map.render.MapRenderState
 import org.onebusaway.android.map.render.MapVehicles
 import org.onebusaway.android.map.render.PingTarget
-import org.onebusaway.android.map.render.ROUTE_LINE_CASE_EXTRA_DP
 import org.onebusaway.android.map.render.RouteBadge
 import org.onebusaway.android.map.render.RoutePolyline
 import org.onebusaway.android.map.render.RoutePolylineReconciler
@@ -134,7 +133,7 @@ class MapLibreRenderer(
         // theme, because the basemap it separates its line from does.
         caseColorOf = { mapRouteLineCaseColor(it.resolvedColor, ThemeUtils.isInDarkMode(context)) },
         // maplibre annotation widths are already in dp, so no density conversion is involved.
-        caseExtraWidth = ROUTE_LINE_CASE_EXTRA_DP
+        caseExtraWidth = { it.case.extraWidthDp }
     )
 
     // The dynamic layer, tracked by identity so [renderDynamic] can move markers in place: route

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/ItineraryLegStyleTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/ItineraryLegStyleTest.kt
@@ -5,6 +5,7 @@ import android.annotation.SuppressLint
 import com.google.android.material.color.utilities.Hct
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.onebusaway.android.directions.model.TripLeg
@@ -13,10 +14,12 @@ import org.onebusaway.android.directions.model.TripPlace
 import org.onebusaway.android.directions.model.TripVertexType
 import org.onebusaway.android.map.render.ITINERARY_RIDE_WIDTH_PROFILE
 import org.onebusaway.android.map.render.ITINERARY_STREET_WIDTH_PROFILE
+import org.onebusaway.android.map.render.RouteLineCase
 import org.onebusaway.android.map.render.RouteLineDash
 import org.onebusaway.android.map.render.RoutePolyline
 import org.onebusaway.android.util.ACHROMATIC_ROUTE_CHROMA
 import org.onebusaway.android.util.GeoPoint
+import org.onebusaway.android.util.routeBadgeChipColor
 
 /**
  * The directions map's per-leg stroke policy (#2041). The point of these is the *distinctions*: before
@@ -53,19 +56,19 @@ class ItineraryLegStyleTest {
 
     @Test
     fun `no two leg kinds share a colour`() {
-        val colors = ItineraryLegKind.entries.map { itineraryLegStyle(it, routeColor = null).color }
+        val colors = ItineraryLegKind.entries.map { itineraryLegStyle(it, routeColor = null, palette = DIRECTIONS).color }
         assertEquals(colors.size, colors.toSet().size)
     }
 
     @Test
     fun `on-street legs are dashed and thinner than the ride they connect to`() {
-        val ride = itineraryLegStyle(ItineraryLegKind.TRANSIT, routeColor = null)
+        val ride = itineraryLegStyle(ItineraryLegKind.TRANSIT, routeColor = null, palette = DIRECTIONS)
         assertEquals(RouteLineDash.NONE, ride.dash)
         assertEquals(ITINERARY_RIDE_WIDTH_PROFILE, ride.widthProfile)
 
         listOf(ItineraryLegKind.WALK, ItineraryLegKind.BIKE, ItineraryLegKind.BIKESHARE, ItineraryLegKind.CAR)
             .forEach { kind ->
-                val street = itineraryLegStyle(kind, routeColor = null)
+                val street = itineraryLegStyle(kind, routeColor = null, palette = DIRECTIONS)
                 assertEquals("$kind should be dashed", RouteLineDash.TRAIL, street.dash)
                 assertEquals(ITINERARY_STREET_WIDTH_PROFILE, street.widthProfile)
             }
@@ -73,21 +76,32 @@ class ItineraryLegStyleTest {
     }
 
     @Test
-    fun `no leg both dashes and stamps chevrons`() {
-        // The chevrons are a texture stamped along the stroke, so a dash pattern chops them into
-        // fragments and the two read as one broken line rather than as either.
+    fun `no itinerary leg stamps travel-direction chevrons`() {
+        // An on-street leg never could: the chevrons are a texture stamped along the stroke, so its dash
+        // chops them into fragments. A ride dropped them with the badge palette — a faded line under a
+        // hairline case reads as noise with an arrow texture on it, and the trip's direction is already read
+        // from the drawer's ordered rows and the leg's endpoint bulbs.
         ItineraryLegKind.entries.forEach { kind ->
-            val style = itineraryLegStyle(kind, routeColor = null)
-            assertFalse("$kind dashes and stamps chevrons", style.dash != RouteLineDash.NONE && style.directional)
+            assertFalse("$kind stamps chevrons", itineraryLegStyle(kind, routeColor = null, palette = DIRECTIONS).directional)
         }
-        assertTrue(itineraryLegStyle(ItineraryLegKind.TRANSIT, routeColor = null).directional)
+    }
+
+    @Test
+    fun `every ride is outlined and no mode leg is, so the outline can't be read as selection`() {
+        assertEquals(RouteLineCase.OUTLINE, itineraryLegStyle(ItineraryLegKind.TRANSIT, routeColor = null, palette = DIRECTIONS).case)
+        ItineraryLegKind.entries.filterNot { it == ItineraryLegKind.TRANSIT }.forEach { kind ->
+            assertEquals("$kind should carry no case", RouteLineCase.NONE, itineraryLegStyle(kind, routeColor = null, palette = DIRECTIONS).case)
+        }
+        // The selection case is a *heavier* edge than the one every ride already wears — that difference is
+        // the whole selection signal now, so it has to be a real one.
+        assertTrue(RouteLineCase.OUTLINE.widthDp < RouteLineCase.SELECTION.widthDp)
     }
 
     @Test
     fun `only transit legs draw circular endpoint bulbs`() {
-        assertTrue(itineraryLegStyle(ItineraryLegKind.TRANSIT, routeColor = null).roundCaps)
+        assertTrue(itineraryLegStyle(ItineraryLegKind.TRANSIT, routeColor = null, palette = DIRECTIONS).roundCaps)
         ItineraryLegKind.entries.filterNot { it == ItineraryLegKind.TRANSIT }.forEach { kind ->
-            assertFalse("$kind should keep flat endpoints", itineraryLegStyle(kind, routeColor = null).roundCaps)
+            assertFalse("$kind should keep flat endpoints", itineraryLegStyle(kind, routeColor = null, palette = DIRECTIONS).roundCaps)
         }
     }
 
@@ -104,11 +118,11 @@ class ItineraryLegStyleTest {
     }
 
     @Test
-    fun `a ride keeps its agency's hue, at the map's own chroma and tone`() {
+    fun `on the basemap palette a ride keeps its agency's hue, at the map's own chroma and tone`() {
         // Two reds an agency might publish: one washed out, one nearly black. Only the hue survives, so
         // the map draws them the same — the hue is the route's identity, the rest is this map's rendering.
-        val pale = Hct.fromInt(itineraryLegStyle(ItineraryLegKind.TRANSIT, Hct.from(25.0, 20.0, 85.0).toInt()).color)
-        val dark = Hct.fromInt(itineraryLegStyle(ItineraryLegKind.TRANSIT, Hct.from(25.0, 90.0, 20.0).toInt()).color)
+        val pale = Hct.fromInt(itineraryLegStyle(ItineraryLegKind.TRANSIT, Hct.from(25.0, 20.0, 85.0).toInt(), BASEMAP).color)
+        val dark = Hct.fromInt(itineraryLegStyle(ItineraryLegKind.TRANSIT, Hct.from(25.0, 90.0, 20.0).toInt(), BASEMAP).color)
 
         assertEquals(25.0, pale.hue, HUE_TOLERANCE_DEGREES)
         assertEquals(pale.hue, dark.hue, HUE_TOLERANCE_DEGREES)
@@ -124,11 +138,91 @@ class ItineraryLegStyleTest {
     }
 
     @Test
+    fun `the palette reaches the ride and leaves every mode leg on the map's own rendering`() {
+        // A ride is faded to its badge's colour because it is read beside that badge. A walk, bike or car
+        // leg has no badge at all — the drawer marks it with a mode glyph — so it keeps the basemap
+        // rendering every other line on this map uses, and the palette must not touch it.
+        val streets = ItineraryLegKind.entries.filterNot { it == ItineraryLegKind.TRANSIT }
+        streets.forEach { kind ->
+            val palettes = listOf(BASEMAP, DIRECTIONS, directionsRouteLinePalette(dark = true))
+                .map { itineraryLegStyle(kind, routeColor = null, palette = it).color }
+            assertEquals("$kind should be palette-invariant", 1, palettes.toSet().size)
+        }
+
+        // And the ride is not: it is the whole point of handing a palette in.
+        val ride = { palette: RouteLinePalette -> itineraryLegStyle(ItineraryLegKind.TRANSIT, routeColor = null, palette = palette).color }
+        assertNotEquals(ride(BASEMAP), ride(DIRECTIONS))
+    }
+
+    @Test
+    fun `a ride in the directions view is drawn in exactly its route badge's colour`() {
+        // The whole point of the directions palette: the line under a ride and the badge naming it in the
+        // drawer are one colour, not two policies that happen to land near each other. Asserted against
+        // [routeBadgeChipColor] itself — the chip reads the same function — so a change to the badge's tone
+        // or chroma cap moves the map line with it or fails here.
+        val agencyRed = Hct.from(25.0, 90.0, 45.0).toInt()
+
+        listOf(false, true).forEach { dark ->
+            assertEquals(
+                "ride colour (dark=$dark)",
+                routeBadgeChipColor(agencyRed, dark),
+                itineraryLegStyle(ItineraryLegKind.TRANSIT, agencyRed, directionsRouteLinePalette(dark)).color
+            )
+        }
+    }
+
+    @Test
+    fun `the directions palette is faded and theme-aware where the basemap one is neither`() {
+        // An agency's vivid hue is muted to the badge's soft chroma cap and taken to its light tone, and the
+        // two themes differ — none of which is true of the basemap palette, which renders one chroma and one
+        // tone whatever the theme (the basemap carries its own light/dark styles).
+        val agencyRed = Hct.from(25.0, 90.0, 45.0).toInt()
+        fun ride(palette: RouteLinePalette) = Hct.fromInt(itineraryLegStyle(ItineraryLegKind.TRANSIT, agencyRed, palette).color)
+
+        val basemap = ride(BASEMAP)
+        val light = ride(directionsRouteLinePalette(dark = false))
+        val night = ride(directionsRouteLinePalette(dark = true))
+
+        // Same route, so the hue is the same in all three: only the rendering changed.
+        listOf(light, night).forEach { assertEquals(basemap.hue, it.hue, HUE_TOLERANCE_DEGREES) }
+        // Faded: less saturated and lighter than the basemap line.
+        listOf(light, night).forEach {
+            assertTrue("chroma ${it.chroma} should be under the basemap's ${basemap.chroma}", it.chroma < basemap.chroma)
+            assertTrue("tone ${it.tone} should be above the basemap's ${basemap.tone}", it.tone > basemap.tone)
+        }
+        // Theme-aware: the two themes render the same route differently. Deliberately not asserted as
+        // "the dark theme is more saturated" — each theme's chroma ceiling is its own *cap* (which
+        // `RouteColorsTest` pins at a shared tone), but what a hue can actually hold is decided by the sRGB
+        // gamut at that theme's fill tone, so which theme comes out more saturated varies by hue.
+        assertNotEquals(light.toInt(), night.toInt())
+    }
+
+    @Test
+    fun `a colourless ride's line is the colour a badge gives that ride, not a fallback of its own`() {
+        // The WSF case: every WSF route publishes an empty colour, and the two surfaces each substituted
+        // something — the map the colourless-ride anchor, the badge the theme's neutral chip — so a ferry
+        // drew a coral line beside a grey roundel. Both now read [riddenRouteHue], and this is the assertion
+        // that fails if either grows a private fallback again.
+        val greyPublished = 0xFF808080.toInt() // achromatic: published, but no hue to keep
+
+        listOf(false, true).forEach { dark ->
+            val badge = routeBadgeChipColor(riddenRouteHue(routeColor = null), dark)
+            listOf(null, greyPublished).forEach { source ->
+                assertEquals(
+                    "colourless ride line for $source (dark=$dark)",
+                    badge,
+                    itineraryLegStyle(ItineraryLegKind.TRANSIT, source, directionsRouteLinePalette(dark)).color
+                )
+            }
+        }
+    }
+
+    @Test
     fun `a ride whose agency publishes no usable colour falls back rather than going grey`() {
         val nearBlack = 0xFF101010.toInt() // achromatic: a hue-preserving re-tone has nothing to keep
 
         listOf(null, nearBlack).forEach { source ->
-            val fallback = itineraryLegStyle(ItineraryLegKind.TRANSIT, source)
+            val fallback = itineraryLegStyle(ItineraryLegKind.TRANSIT, source, DIRECTIONS)
             assertTrue(
                 "fallback for $source was achromatic",
                 Hct.fromInt(fallback.color).chroma > ACHROMATIC_ROUTE_CHROMA
@@ -139,7 +233,7 @@ class ItineraryLegStyleTest {
     @Test
     fun `every leg kind draws a colour with a hue`() {
         ItineraryLegKind.entries.forEach { kind ->
-            val color = itineraryLegStyle(kind, routeColor = null).color
+            val color = itineraryLegStyle(kind, routeColor = null, palette = DIRECTIONS).color
             assertTrue("$kind was achromatic", Hct.fromInt(color).chroma > ACHROMATIC_ROUTE_CHROMA)
         }
     }
@@ -152,15 +246,21 @@ class ItineraryLegStyleTest {
 
         // Nothing is dropped — the whole trip is still drawn.
         assertEquals(lines.size, focused.size)
-        // Exactly the focused leg is cased; that case *is* the selection signal (#2082).
-        val (cased, plain) = focused.partition { it.cased }
+        // Exactly the focused leg takes the selection case; that step up in edge weight *is* the selection
+        // signal (#2082) — every ride already wears the hairline outline.
+        val (cased, plain) = focused.partition { it.case == RouteLineCase.SELECTION }
         assertEquals(listOf(ITINERARY_RIDE_WIDTH_PROFILE), cased.map { it.widthProfile })
         // The focused leg is last, so its case and stroke draw over the legs around it.
         assertEquals(cased.single(), focused.last())
         // Nothing but the case changes: every leg keeps the weight, colour and dash that say what kind of
         // leg it is, so width is free to mean only that. Compared as sets — focusing reorders the list, which
         // is how the focused leg comes to draw last.
-        assertEquals(lines.map { it.line }.toSet(), focused.map { it.copy(cased = false) }.toSet())
+        assertEquals(
+            lines.map { it.line }.toSet(),
+            // Undo only the selection step: a ride drops back to the outline it always wore, and the mode
+            // legs beside it are compared exactly as they were drawn.
+            focused.map { if (it.case == RouteLineCase.SELECTION) it.copy(case = RouteLineCase.OUTLINE) else it }.toSet()
+        )
         assertEquals(2, plain.size)
     }
 
@@ -174,7 +274,7 @@ class ItineraryLegStyleTest {
         // colour — a deliberate trade for contrast. What must survive is the *hue*, so the trace of colour
         // that's left is its own line's and not a neighbouring one's.
         ItineraryLegKind.entries.forEach { kind ->
-            val line = Hct.fromInt(itineraryLegStyle(kind, routeColor = null).color)
+            val line = Hct.fromInt(itineraryLegStyle(kind, routeColor = null, palette = DIRECTIONS).color)
 
             listOf(false to 10.0, true to 90.0).forEach { (darkMode, expectedTone) ->
                 val case = Hct.fromInt(mapRouteLineCaseColor(line.toInt(), darkMode))
@@ -202,7 +302,7 @@ class ItineraryLegStyleTest {
         // #2000: several itinerary legs the rider stays aboard through, read (and tapped) as one ride.
         val focused = tripOf(walk = 0, ride = 1, walk2 = 2).withLegFocus(setOf(1, 2))
 
-        assertEquals(2, focused.count { it.cased })
+        assertEquals(2, focused.count { it.case == RouteLineCase.SELECTION })
     }
 
     @Test
@@ -226,7 +326,7 @@ class ItineraryLegStyleTest {
     )
 
     private fun legLine(legIndex: Int, kind: ItineraryLegKind): ItineraryLegLine {
-        val style = itineraryLegStyle(kind, routeColor = null)
+        val style = itineraryLegStyle(kind, routeColor = null, palette = DIRECTIONS)
         return ItineraryLegLine(
             legIndex,
             RoutePolyline(
@@ -235,6 +335,7 @@ class ItineraryLegStyleTest {
                 widthProfile = style.widthProfile,
                 directional = style.directional,
                 dash = style.dash,
+                case = style.case,
                 roundStartCap = style.roundCaps,
                 roundEndCap = style.roundCaps
             )
@@ -242,6 +343,13 @@ class ItineraryLegStyleTest {
     }
 
     private companion object {
+        // The palette the directions view actually draws with, and the one every other view does. Most cases
+        // here are about a leg's *shape* rather than its colour, and take the directions palette because that
+        // is the only palette an itinerary leg is ever stroked with.
+        val DIRECTIONS: RouteLinePalette = directionsRouteLinePalette(dark = false)
+
+        val BASEMAP: RouteLinePalette = BASEMAP_ROUTE_LINE_PALETTE
+
         // The re-tone clamps to each hue's own sRGB gamut limit, so a hue can shift a degree or two.
         const val HUE_TOLERANCE_DEGREES = 3.0
 

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/ItineraryLegStyleTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/ItineraryLegStyleTest.kt
@@ -19,6 +19,7 @@ import org.onebusaway.android.map.render.RouteLineDash
 import org.onebusaway.android.map.render.RoutePolyline
 import org.onebusaway.android.util.ACHROMATIC_ROUTE_CHROMA
 import org.onebusaway.android.util.GeoPoint
+import org.onebusaway.android.util.riddenRouteHue
 import org.onebusaway.android.util.routeBadgeChipColor
 
 /**
@@ -76,25 +77,11 @@ class ItineraryLegStyleTest {
     }
 
     @Test
-    fun `no itinerary leg stamps travel-direction chevrons`() {
-        // An on-street leg never could: the chevrons are a texture stamped along the stroke, so its dash
-        // chops them into fragments. A ride dropped them with the badge palette — a faded line under a
-        // hairline case reads as noise with an arrow texture on it, and the trip's direction is already read
-        // from the drawer's ordered rows and the leg's endpoint bulbs.
-        ItineraryLegKind.entries.forEach { kind ->
-            assertFalse("$kind stamps chevrons", itineraryLegStyle(kind, routeColor = null, palette = DIRECTIONS).directional)
-        }
-    }
-
-    @Test
     fun `every ride is outlined and no mode leg is, so the outline can't be read as selection`() {
         assertEquals(RouteLineCase.OUTLINE, itineraryLegStyle(ItineraryLegKind.TRANSIT, routeColor = null, palette = DIRECTIONS).case)
         ItineraryLegKind.entries.filterNot { it == ItineraryLegKind.TRANSIT }.forEach { kind ->
             assertEquals("$kind should carry no case", RouteLineCase.NONE, itineraryLegStyle(kind, routeColor = null, palette = DIRECTIONS).case)
         }
-        // The selection case is a *heavier* edge than the one every ride already wears — that difference is
-        // the whole selection signal now, so it has to be a real one.
-        assertTrue(RouteLineCase.OUTLINE.widthDp < RouteLineCase.SELECTION.widthDp)
     }
 
     @Test
@@ -325,6 +312,16 @@ class ItineraryLegStyleTest {
         legLine(walk2, ItineraryLegKind.BIKE)
     )
 
+    @Test
+    fun `no itinerary leg stamps travel-direction chevrons`() {
+        // An on-street leg never could: the chevrons are a texture stamped along the stroke, so its dash
+        // chops them into fragments. A ride dropped them with the badge palette — a faded line under a
+        // hairline case reads as noise with an arrow texture on it, and the trip's direction is already read
+        // from the drawer's ordered rows and the leg's endpoint bulbs. Asserted on the drawn line, since the
+        // style table deliberately names no `directional` for anything to get wrong.
+        assertTrue(tripOf(walk = 0, ride = 1, walk2 = 2).none { it.line.directional })
+    }
+
     private fun legLine(legIndex: Int, kind: ItineraryLegKind): ItineraryLegLine {
         val style = itineraryLegStyle(kind, routeColor = null, palette = DIRECTIONS)
         return ItineraryLegLine(
@@ -333,7 +330,6 @@ class ItineraryLegStyleTest {
                 style.color,
                 listOf(GeoPoint(47.6, -122.3), GeoPoint(47.7, -122.4)),
                 widthProfile = style.widthProfile,
-                directional = style.directional,
                 dash = style.dash,
                 case = style.case,
                 roundStartCap = style.roundCaps,

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/ItineraryRouteBadgesTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/ItineraryRouteBadgesTest.kt
@@ -27,9 +27,9 @@ class ItineraryRouteBadgesTest {
     @Test
     fun `each ridden route is labelled at its midpoint, in its own line colour, and is not tappable`() {
         val ride = TripLeg(mode = TripMode.BUS, routeId = "route-45", routeShortName = "45")
-        val rideStyle = itineraryLegStyle(ItineraryLegKind.TRANSIT, routeColor = 0xFF0000FF.toInt())
+        val rideStyle = itineraryLegStyle(ItineraryLegKind.TRANSIT, routeColor = 0xFF0000FF.toInt(), palette = PALETTE)
 
-        val badge = itineraryRouteBadges(
+        val badge = labelsFor(
             listOf(
                 drawable(0, TripLeg(mode = TripMode.WALK), northward, ItineraryLegKind.WALK),
                 ItineraryDrawableLeg(1, ride, eastward, rideStyle)
@@ -48,7 +48,7 @@ class ItineraryRouteBadgesTest {
         val first = TripLeg(mode = TripMode.BUS, routeId = "route-5", routeShortName = "5")
         val second = TripLeg(mode = TripMode.BUS, routeId = "route-5", routeShortName = "5")
 
-        val badges = itineraryRouteBadges(
+        val badges = labelsFor(
             listOf(drawable(0, first, eastward), drawable(2, second, northward))
         )
 
@@ -57,7 +57,7 @@ class ItineraryRouteBadgesTest {
 
     @Test
     fun `two routes ridden along the same corridor are labelled apart`() {
-        val badges = itineraryRouteBadges(
+        val badges = labelsFor(
             listOf(
                 drawable(0, TripLeg(mode = TripMode.BUS, routeId = "a", routeShortName = "A"), eastward),
                 drawable(1, TripLeg(mode = TripMode.RAIL, routeId = "b", routeShortName = "B"), eastward)
@@ -72,7 +72,7 @@ class ItineraryRouteBadgesTest {
     fun `OTP1 legs, which identify no route, are grouped by the name they display`() {
         // An OTP1 response names a route without identifying it, so the displayed name is all these two
         // legs have to be recognized as one ride by — they still get a single shared label.
-        val badges = itineraryRouteBadges(
+        val badges = labelsFor(
             listOf(
                 drawable(0, TripLeg(mode = TripMode.BUS, routeId = null, route = "45"), eastward),
                 drawable(1, TripLeg(mode = TripMode.BUS, routeId = null, route = "45"), northward)
@@ -87,7 +87,7 @@ class ItineraryRouteBadgesTest {
         val nameless = TripLeg(mode = TripMode.BUS, routeId = "route-x")
         val degenerate = TripLeg(mode = TripMode.BUS, routeId = "route-y", routeShortName = "Y")
 
-        val badges = itineraryRouteBadges(
+        val badges = labelsFor(
             listOf(
                 drawable(0, nameless, eastward),
                 drawable(1, degenerate, listOf(GeoPoint(0.0, 0.0)))
@@ -103,7 +103,7 @@ class ItineraryRouteBadgesTest {
         // joined badge doesn't — the routes are interchangeable, so the label reads the same either way.
         val ride = TripLeg(mode = TripMode.RAIL, routeId = "route-2", routeShortName = "2 Line")
 
-        val badge = itineraryRouteBadges(
+        val badge = labelsFor(
             listOf(drawable(0, ride, eastward, interchangeable = listOf(interchangeable("1 Line"))))
         ).single()
 
@@ -117,12 +117,12 @@ class ItineraryRouteBadgesTest {
         val ride = TripLeg(mode = TripMode.RAIL, routeId = "route-2", routeShortName = "2 Line")
         val alternative = interchangeable("1 Line", routeColor = 0xFF0000FF.toInt())
 
-        val badge = itineraryRouteBadges(
+        val badge = labelsFor(
             listOf(drawable(0, ride, eastward, interchangeable = listOf(alternative)))
         ).single()
 
         assertEquals(
-            itineraryLegStyle(ItineraryLegKind.TRANSIT, routeColor = 0xFF0000FF.toInt()).color,
+            itineraryLegStyle(ItineraryLegKind.TRANSIT, routeColor = 0xFF0000FF.toInt(), palette = PALETTE).color,
             badge.routes.single { it.routeShortName == "1 Line" }.color
         )
     }
@@ -134,7 +134,7 @@ class ItineraryRouteBadgesTest {
         val first = TripLeg(mode = TripMode.RAIL, routeId = "route-2", routeShortName = "2 Line")
         val second = TripLeg(mode = TripMode.RAIL, routeId = "route-2", routeShortName = "2 Line")
 
-        val badges = itineraryRouteBadges(
+        val badges = labelsFor(
             listOf(
                 drawable(0, first, eastward, interchangeable = listOf(interchangeable("1 Line"))),
                 drawable(1, second, northward)
@@ -152,7 +152,7 @@ class ItineraryRouteBadgesTest {
         val first = TripLeg(mode = TripMode.RAIL, routeId = "route-2", routeShortName = "2 Line")
         val second = TripLeg(mode = TripMode.RAIL, routeId = "route-2", routeShortName = "2 Line")
 
-        val badges = itineraryRouteBadges(
+        val badges = labelsFor(
             listOf(
                 drawable(0, first, eastward, interchangeable = listOf(interchangeable("1 Line", routeId = "route-1a"))),
                 drawable(1, second, northward, interchangeable = listOf(interchangeable("1 Line", routeId = "route-1b")))
@@ -161,6 +161,9 @@ class ItineraryRouteBadgesTest {
 
         assertEquals(listOf(listOf("1 Line", "2 Line"), listOf("1 Line", "2 Line")), badges.map(::names))
     }
+
+    /** The labels [legs] would be drawn with, through the palette the directions view itself uses. */
+    private fun labelsFor(legs: List<ItineraryDrawableLeg>) = itineraryRouteBadges(legs, PALETTE)
 
     private fun names(badge: RouteBadge) = badge.routes.map(BadgedRoute::routeShortName)
 
@@ -188,5 +191,9 @@ class ItineraryRouteBadgesTest {
         points: List<GeoPoint>,
         kind: ItineraryLegKind = ItineraryLegKind.TRANSIT,
         interchangeable: List<ItinerarySubstitute> = emptyList()
-    ) = ItineraryDrawableLeg(index, leg, points, itineraryLegStyle(kind, routeColor = null), interchangeable)
+    ) = ItineraryDrawableLeg(index, leg, points, itineraryLegStyle(kind, routeColor = null, palette = PALETTE), interchangeable)
+
+    private companion object {
+        val PALETTE: RouteLinePalette = directionsRouteLinePalette(dark = false)
+    }
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteSegmentHighlightTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteSegmentHighlightTest.kt
@@ -17,6 +17,7 @@ package org.onebusaway.android.map
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.onebusaway.android.api.adapters.ObaStopElement
@@ -24,6 +25,7 @@ import org.onebusaway.android.map.render.FOCUSED_ROUTE_LINE_WIDTH_PROFILE
 import org.onebusaway.android.map.render.ITINERARY_APPROACH_WIDTH_PROFILE
 import org.onebusaway.android.map.render.ITINERARY_CONTEXT_WIDTH_PROFILE
 import org.onebusaway.android.map.render.ITINERARY_RIDE_WIDTH_PROFILE
+import org.onebusaway.android.map.render.RouteLineCase
 import org.onebusaway.android.map.render.RouteLineDash
 import org.onebusaway.android.map.render.RoutePolyline
 import org.onebusaway.android.util.GeoPoint
@@ -85,8 +87,8 @@ class RouteSegmentHighlightTest {
         assertEquals(true, overlay.directional)
         // Both halves of the selected route carry a case, so the approach and the ride read as one line
         // rather than as two things that happen to meet.
-        assertTrue(approach.cased)
-        assertTrue(overlay.cased)
+        assertEquals(RouteLineCase.SELECTION, approach.case)
+        assertEquals(RouteLineCase.SELECTION, overlay.case)
     }
 
     @Test
@@ -110,9 +112,9 @@ class RouteSegmentHighlightTest {
         assertEquals(RouteLineDash.TRAIL, result[1].dash)
         assertEquals(ITINERARY_RIDE_WIDTH_PROFILE, result[2].widthProfile)
         // Only the selected route is cased: the rest of the rider's journey is context, not selection.
-        assertFalse(result[1].cased)
-        assertTrue(result[0].cased)
-        assertTrue(result[2].cased)
+        assertNotEquals(RouteLineCase.SELECTION, result[1].case)
+        assertEquals(RouteLineCase.SELECTION, result[0].case)
+        assertEquals(RouteLineCase.SELECTION, result[2].case)
     }
 
     @Test

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteViewGeometryTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteViewGeometryTest.kt
@@ -1,8 +1,6 @@
 /* Copyright (C) 2026 Open Transit Software Foundation */
 package org.onebusaway.android.map
 
-import android.annotation.SuppressLint
-import com.google.android.material.color.utilities.Hct
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
@@ -21,7 +19,6 @@ import org.onebusaway.android.models.ObaRoute
 import org.onebusaway.android.models.RouteDirectionKey
 import org.onebusaway.android.util.GeoPoint
 
-@SuppressLint("RestrictedApi") // Hct, Material's vendored color-science util; see AdjacencyRouteColors.kt.
 class RouteViewGeometryTest {
 
     @Test
@@ -74,21 +71,8 @@ class RouteViewGeometryTest {
         assertEquals(adjacencyLine, riddenSegment)
         // And it is not the raw hex: a dark red would otherwise sink into the basemap.
         assertTrue(adjacencyLine != gtfs)
-    }
-
-    @Test
-    fun `the directions view redraws the same route in its own palette, keeping the hue`() {
-        // The one deliberate divergence from the invariant above: in directions a line is read beside the
-        // drawer's badges, so it takes the badge's faded theme-aware colour instead of the basemap one. What
-        // has to survive is the route's identity — its hue — so the leg is recognisably the same route as the
-        // picker draws, just rendered for a different backdrop.
-        val gtfs = 0xFF8B0000.toInt()
-        val basemap = itineraryLegStyle(ItineraryLegKind.TRANSIT, gtfs, BASEMAP_ROUTE_LINE_PALETTE).color
-        val directions = itineraryLegStyle(ItineraryLegKind.TRANSIT, gtfs, directionsRouteLinePalette(dark = false)).color
-
-        assertEquals(mapRouteLineColorOrNull(gtfs), basemap)
-        assertTrue(directions != basemap)
-        assertEquals(Hct.fromInt(basemap).hue, Hct.fromInt(directions).hue, HUE_TOLERANCE_DEGREES)
+        // The directions view is the one deliberate exception — same hue, its own rendering. That is
+        // asserted where the exception lives, in ItineraryLegStyleTest.
     }
 
     @Test
@@ -330,10 +314,5 @@ class RouteViewGeometryTest {
         override val color = routeColor
         override val textColor: Int? = null
         override val agencyId = "agency"
-    }
-
-    private companion object {
-        // The re-tone clamps to each hue's own sRGB gamut limit, so a hue can shift a degree or two.
-        const val HUE_TOLERANCE_DEGREES = 3.0
     }
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteViewGeometryTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteViewGeometryTest.kt
@@ -1,6 +1,8 @@
 /* Copyright (C) 2026 Open Transit Software Foundation */
 package org.onebusaway.android.map
 
+import android.annotation.SuppressLint
+import com.google.android.material.color.utilities.Hct
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
@@ -19,6 +21,7 @@ import org.onebusaway.android.models.ObaRoute
 import org.onebusaway.android.models.RouteDirectionKey
 import org.onebusaway.android.util.GeoPoint
 
+@SuppressLint("RestrictedApi") // Hct, Material's vendored color-science util; see AdjacencyRouteColors.kt.
 class RouteViewGeometryTest {
 
     @Test
@@ -53,27 +56,39 @@ class RouteViewGeometryTest {
     }
 
     @Test
-    fun `a route draws the same colour whichever view shows it`() {
+    fun `a route draws one colour across every view that shares its backdrop`() {
         // The agency's own colour, as it arrives from the wire.
         val gtfs = 0xFF8B0000.toInt()
         val shape = FocusedTripShape("shape", "route", gtfs, listOf(GeoPoint(0.0, 0.0), GeoPoint(0.0, 1.0)))
 
         // Focused-stop geometry (the picker's full-route view goes through the same focusedRoutePolyline).
         val adjacencyLine = FocusedTripGeometry(listOf(shape)).toRoutePolylines().single().color
-        // The ridden segment under a tapped directions leg, drawn in the shown route's colour.
+        // The ridden segment under a tapped route, drawn in the shown route's colour.
         val riddenSegment = routePolylinesWithSegment(
             base = emptyList(),
             segment = listOf(GeoPoint(0.0, 0.0), GeoPoint(0.0, 1.0)),
             routeColor = mapRouteLineColorOrNull(gtfs)
         ).single().color
-        // The same route ridden as an itinerary leg on the directions map.
-        val itineraryLeg = itineraryLegStyle(ItineraryLegKind.TRANSIT, gtfs).color
 
         assertEquals(mapRouteLineColorOrNull(gtfs), adjacencyLine)
         assertEquals(adjacencyLine, riddenSegment)
-        assertEquals(adjacencyLine, itineraryLeg)
         // And it is not the raw hex: a dark red would otherwise sink into the basemap.
         assertTrue(adjacencyLine != gtfs)
+    }
+
+    @Test
+    fun `the directions view redraws the same route in its own palette, keeping the hue`() {
+        // The one deliberate divergence from the invariant above: in directions a line is read beside the
+        // drawer's badges, so it takes the badge's faded theme-aware colour instead of the basemap one. What
+        // has to survive is the route's identity — its hue — so the leg is recognisably the same route as the
+        // picker draws, just rendered for a different backdrop.
+        val gtfs = 0xFF8B0000.toInt()
+        val basemap = itineraryLegStyle(ItineraryLegKind.TRANSIT, gtfs, BASEMAP_ROUTE_LINE_PALETTE).color
+        val directions = itineraryLegStyle(ItineraryLegKind.TRANSIT, gtfs, directionsRouteLinePalette(dark = false)).color
+
+        assertEquals(mapRouteLineColorOrNull(gtfs), basemap)
+        assertTrue(directions != basemap)
+        assertEquals(Hct.fromInt(basemap).hue, Hct.fromInt(directions).hue, HUE_TOLERANCE_DEGREES)
     }
 
     @Test
@@ -315,5 +330,10 @@ class RouteViewGeometryTest {
         override val color = routeColor
         override val textColor: Int? = null
         override val agencyId = "agency"
+    }
+
+    private companion object {
+        // The re-tone clamps to each hue's own sRGB gamut limit, so a hue can shift a degree or two.
+        const val HUE_TOLERANCE_DEGREES = 3.0
     }
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/render/RouteLineWidthProfileTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/render/RouteLineWidthProfileTest.kt
@@ -75,9 +75,13 @@ class RouteLineWidthProfileTest {
     fun `a case reads as an outline at every zoom, so it stays off the width ramp`() {
         // The case is a fixed dp inset on each side, deliberately not scaled by the line's zoom multiplier: a
         // halo that thinned with its line would stop separating it from the basemap exactly when zoomed out.
-        assertEquals(1.5f, ROUTE_LINE_CASE_DP, 0f)
-        // And it stays finer than the thinnest line it can wrap, so a case reads as that line's edge rather
-        // than as a second line under it.
-        assertTrue(ROUTE_LINE_CASE_EXTRA_DP < ITINERARY_APPROACH_WIDTH_PROFILE.thicknessDp)
+        assertEquals(1.5f, RouteLineCase.SELECTION.widthDp, 0f)
+        assertEquals(0.75f, RouteLineCase.OUTLINE.widthDp, 0f)
+        // Selection is the heavier edge, which is what lets it still mean "selected" now that every
+        // directions ride wears an outline.
+        assertTrue(RouteLineCase.OUTLINE.widthDp < RouteLineCase.SELECTION.widthDp)
+        // And both stay finer than the thinnest line they can wrap, so a case reads as that line's edge
+        // rather than as a second line under it.
+        assertTrue(RouteLineCase.SELECTION.extraWidthDp < ITINERARY_APPROACH_WIDTH_PROFILE.thicknessDp)
     }
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/render/RouteLineWidthProfileTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/render/RouteLineWidthProfileTest.kt
@@ -76,10 +76,9 @@ class RouteLineWidthProfileTest {
         // The case is a fixed dp inset on each side, deliberately not scaled by the line's zoom multiplier: a
         // halo that thinned with its line would stop separating it from the basemap exactly when zoomed out.
         assertEquals(1.5f, RouteLineCase.SELECTION.widthDp, 0f)
+        // The lighter edge every directions ride wears; selection stays legible against it by being the
+        // heavier of the two, which is what lets it still mean "selected".
         assertEquals(0.75f, RouteLineCase.OUTLINE.widthDp, 0f)
-        // Selection is the heavier edge, which is what lets it still mean "selected" now that every
-        // directions ride wears an outline.
-        assertTrue(RouteLineCase.OUTLINE.widthDp < RouteLineCase.SELECTION.widthDp)
         // And both stay finer than the thinnest line they can wrap, so a case reads as that line's edge
         // rather than as a second line under it.
         assertTrue(RouteLineCase.SELECTION.extraWidthDp < ITINERARY_APPROACH_WIDTH_PROFILE.thicknessDp)

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/render/RoutePolylineReconcilerTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/render/RoutePolylineReconcilerTest.kt
@@ -47,7 +47,7 @@ class RoutePolylineReconcilerTest {
                 line.width = width
             },
             caseColorOf = { CASE_COLOR },
-            caseExtraWidth = CASE_EXTRA_WIDTH
+            caseExtraWidth = { it.case.extraWidthDp }
         )
 
         /** The lines still on the map — created minus removed (creation order, not draw order). */
@@ -192,15 +192,33 @@ class RoutePolylineReconcilerTest {
     fun `a cased line draws its case first, wider, and without chevrons`() {
         val h = Harness()
 
-        h.reconciler.reconcile(listOf(line(1, 0.0).copy(cased = true, directional = true)), zoom = 4f)
+        h.reconciler.reconcile(listOf(line(1, 0.0).copy(case = RouteLineCase.SELECTION, directional = true)), zoom = 4f)
 
         // Created case-first, which is what puts it under its own stroke in both SDKs' add-order draw.
         assertEquals(listOf(CASE_COLOR, 1), h.created.map { it.polyline.color })
-        assertEquals(4f + CASE_EXTRA_WIDTH, h.cases().single().width, 0f)
+        assertEquals(4f + SELECTION_CASE_EXTRA, h.cases().single().width, 0f)
         assertEquals(4f, h.strokes().single().width, 0f)
         // The stroke keeps its chevrons; the case must not double them.
         assertTrue(h.strokes().single().polyline.directional)
         assertFalse(h.cases().single().polyline.directional)
+    }
+
+    @Test
+    fun `an outline case draws thinner than a selection case, so selection still reads as the heavier edge`() {
+        val h = Harness()
+
+        h.reconciler.reconcile(
+            listOf(line(1, 0.0).copy(case = RouteLineCase.OUTLINE), line(2, 1.0).copy(case = RouteLineCase.SELECTION)),
+            zoom = 4f
+        )
+
+        val (outline, selection) = h.cases()
+        assertTrue(
+            "outline ${outline.width} should be thinner than selection ${selection.width}",
+            outline.width < selection.width
+        )
+        // Both are still wider than the stroke they wrap, or they wouldn't show at all.
+        assertTrue(outline.width > 4f)
     }
 
     @Test
@@ -217,7 +235,7 @@ class RoutePolylineReconcilerTest {
     fun `a case keeps its line's dash so a broken line's case breaks with it`() {
         val h = Harness()
 
-        h.reconciler.reconcile(listOf(line(1, 0.0).copy(cased = true, dash = RouteLineDash.TRAIL)), zoom = 4f)
+        h.reconciler.reconcile(listOf(line(1, 0.0).copy(case = RouteLineCase.SELECTION, dash = RouteLineDash.TRAIL)), zoom = 4f)
 
         assertEquals(RouteLineDash.TRAIL, h.cases().single().polyline.dash)
     }
@@ -225,18 +243,18 @@ class RoutePolylineReconcilerTest {
     @Test
     fun `a case is re-widened with its line, staying the wider of the two`() {
         val h = Harness()
-        h.reconciler.reconcile(listOf(line(1, 0.0).copy(cased = true)), zoom = 4f)
+        h.reconciler.reconcile(listOf(line(1, 0.0).copy(case = RouteLineCase.SELECTION)), zoom = 4f)
 
         h.reconciler.resyncWidths(zoom = 10f)
 
-        assertEquals(10f + CASE_EXTRA_WIDTH, h.cases().single().width, 0f)
+        assertEquals(10f + SELECTION_CASE_EXTRA, h.cases().single().width, 0f)
         assertEquals(10f, h.strokes().single().width, 0f)
     }
 
     @Test
     fun `removing a cased line removes its case too`() {
         val h = Harness()
-        h.reconciler.reconcile(listOf(line(1, 0.0).copy(cased = true)), zoom = 4f)
+        h.reconciler.reconcile(listOf(line(1, 0.0).copy(case = RouteLineCase.SELECTION)), zoom = 4f)
 
         // A wholly different line: the cased one goes away, so its case must not be stranded on the map.
         h.reconciler.reconcile(listOf(line(2, 1.0)), zoom = 4f)
@@ -248,7 +266,7 @@ class RoutePolylineReconcilerTest {
     @Test
     fun `clear removes cases as well as strokes`() {
         val h = Harness()
-        h.reconciler.reconcile(listOf(line(1, 0.0).copy(cased = true), line(2, 1.0)), zoom = 4f)
+        h.reconciler.reconcile(listOf(line(1, 0.0).copy(case = RouteLineCase.SELECTION), line(2, 1.0)), zoom = 4f)
 
         h.reconciler.clear()
 
@@ -259,6 +277,8 @@ class RoutePolylineReconcilerTest {
         // The fake's case colour, distinct from every line colour used here so a test can tell the two apart.
         const val CASE_COLOR = -424242
 
-        const val CASE_EXTRA_WIDTH = 3f
+        // The width a SELECTION case adds, read from the enum rather than restated: the harness feeds the
+        // reconciler the same per-line lambda the renderers do, so these assertions follow a retuned case.
+        val SELECTION_CASE_EXTRA = RouteLineCase.SELECTION.extraWidthDp
     }
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/RouteBadgesTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/RouteBadgesTest.kt
@@ -24,9 +24,9 @@ import org.onebusaway.android.directions.model.InterchangeableRoute
 import org.onebusaway.android.directions.model.Interlines
 import org.onebusaway.android.directions.model.TripLeg
 import org.onebusaway.android.directions.model.TripMode
-import org.onebusaway.android.map.COLOURLESS_RIDE_HUE_ANCHOR
 import org.onebusaway.android.ui.compose.components.RouteBadge
 import org.onebusaway.android.ui.compose.components.RouteBadgeJoin
+import org.onebusaway.android.util.COLOURLESS_RIDE_HUE_ANCHOR
 
 /**
  * JVM tests for the joined route badge a ride draws — the planned route plus whatever else the leg can be

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/RouteBadgesTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/RouteBadgesTest.kt
@@ -24,6 +24,7 @@ import org.onebusaway.android.directions.model.InterchangeableRoute
 import org.onebusaway.android.directions.model.Interlines
 import org.onebusaway.android.directions.model.TripLeg
 import org.onebusaway.android.directions.model.TripMode
+import org.onebusaway.android.map.COLOURLESS_RIDE_HUE_ANCHOR
 import org.onebusaway.android.ui.compose.components.RouteBadge
 import org.onebusaway.android.ui.compose.components.RouteBadgeJoin
 
@@ -82,6 +83,18 @@ class RouteBadgesTest {
         val badge = legBadge(RouteBadge("8", null), listOf(RouteBadge("8", null), RouteBadge("7", null)), TransitMode.BUS)
 
         assertEquals(listOf("7", "8"), badge.routes.map { it.shortName })
+    }
+
+    /**
+     * A leg whose route publishes no colour — every WSF ferry — badges the colourless-ride hue, which is
+     * what the map draws that ride's line in. It used to carry no colour at all and the chip fell back to
+     * the theme's neutral container, so the ferry's roundel came out grey beside its own coral line.
+     */
+    @Test
+    fun aColourlessRouteBadgesTheColourlessRideHue() {
+        val ferry = TripLeg(mode = TripMode.FERRY, routeId = "95_128", routeLongName = "Kingston - Edmonds")
+
+        assertEquals(COLOURLESS_RIDE_HUE_ANCHOR, ferry.plannedBadge()?.routeColor)
     }
 
     /** A leg badges its route's short name. (Parsing the GTFS color needs the Android graphics stack,

--- a/onebusaway-android/src/test/java/org/onebusaway/android/util/RouteColorsTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/util/RouteColorsTest.kt
@@ -1,0 +1,135 @@
+/* Copyright (C) 2026 Open Transit Software Foundation */
+package org.onebusaway.android.util
+
+import android.annotation.SuppressLint
+import com.google.android.material.color.utilities.Hct
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The theme-aware route colour policy — the faded re-tone a route badge chip is filled with, and now also
+ * what the directions map strokes that route's line with. It sits here, shared, precisely so those two
+ * can't drift apart; these assertions pin the properties each of them depends on.
+ */
+@SuppressLint("RestrictedApi") // Hct, Material's vendored color-science util; see AdjacencyRouteColors.kt.
+class RouteColorsTest {
+
+    // A vivid red and a muted one, as two agencies might publish the same route colour.
+    private val vivid = Hct.from(25.0, 90.0, 45.0).toInt()
+
+    private val muted = Hct.from(25.0, 20.0, 45.0).toInt()
+
+    @Test
+    fun `a re-toned colour keeps the agency's hue and takes the requested tone`() {
+        listOf(false, true).forEach { dark ->
+            val toned = Hct.fromInt(routeColorAtTone(vivid, dark, tone = 60.0)!!)
+            assertEquals("hue (dark=$dark)", 25.0, toned.hue, HUE_TOLERANCE_DEGREES)
+            assertEquals("tone (dark=$dark)", 60.0, toned.tone, CHANNEL_TOLERANCE)
+        }
+    }
+
+    @Test
+    fun `saturation is capped, not replaced`() {
+        // This is what makes these colours read as *faded*: a vivid hue is muted to the theme's ceiling,
+        // while an agency that already publishes something soft keeps it rather than being pushed up to the
+        // cap. Both themes cap, and the dark one lets more through.
+        listOf(false, true).forEach { dark ->
+            val cappedVivid = Hct.fromInt(routeColorAtTone(vivid, dark, tone = 60.0)!!).chroma
+            val keptMuted = Hct.fromInt(routeColorAtTone(muted, dark, tone = 60.0)!!).chroma
+
+            assertTrue("vivid should be muted (dark=$dark)", cappedVivid < Hct.fromInt(vivid).chroma)
+            assertEquals("muted should pass through (dark=$dark)", Hct.fromInt(muted).chroma, keptMuted, CHANNEL_TOLERANCE)
+            assertTrue("muted should stay under the cap (dark=$dark)", keptMuted < cappedVivid)
+        }
+    }
+
+    @Test
+    fun `the dark theme lets more of the agency's saturation through`() {
+        val light = Hct.fromInt(routeColorAtTone(vivid, dark = false, tone = 60.0)!!).chroma
+        val night = Hct.fromInt(routeColorAtTone(vivid, dark = true, tone = 60.0)!!).chroma
+
+        assertTrue("dark chroma $night should exceed light's $light", night > light)
+    }
+
+    @Test
+    fun `a colourless or hueless route is declined, leaving the fallback to the caller`() {
+        // Grey, black and white carry no hue to re-tone, so there is nothing to render — the chip takes a
+        // neutral theme container and a map line falls back to whatever its own kind calls for.
+        listOf(null, 0xFF808080.toInt(), 0xFF000000.toInt(), 0xFFFFFFFF.toInt()).forEach { source ->
+            listOf(false, true).forEach { dark ->
+                assertNull("$source (dark=$dark)", routeColorAtTone(source, dark, tone = 60.0))
+                assertNull("$source (dark=$dark)", routeBadgeChipColor(source, dark))
+            }
+        }
+    }
+
+    @Test
+    fun `the badge chip's fill and text differ by theme, and the fill stays the lighter of the two`() {
+        val light = Hct.fromInt(routeBadgeChipColor(vivid, dark = false)!!)
+        val night = Hct.fromInt(routeBadgeChipColor(vivid, dark = true)!!)
+
+        // The chip is a light fill carrying dark text in both themes — which is also what makes the same
+        // colour read as the faded rendering when it's stroked as a map line.
+        listOf(light, night).forEach { fill ->
+            assertTrue("fill tone ${fill.tone} should be light", fill.tone > 60.0)
+        }
+        listOf(false, true).forEach { dark ->
+            val fill = Hct.fromInt(routeBadgeChipColor(vivid, dark)!!).tone
+            val text = Hct.fromInt(routeBadgeChipTextColor(vivid, dark)!!).tone
+            assertTrue("text tone $text should be darker than fill $fill (dark=$dark)", text < fill)
+        }
+        // But not the same colour: the theme decides how much saturation the fill holds and how light it sits.
+        assertNotEquals(routeBadgeChipColor(vivid, dark = false), routeBadgeChipColor(vivid, dark = true))
+    }
+
+    @Test
+    fun `a badge's text clears 4point5 to 1 against its own fill, in both themes`() {
+        // The one hard constraint on how un-pastel a chip may get: the fill tone and the text tone are only
+        // correct together, so darkening the fill for a stronger colour has to darken the text with it. This
+        // is the assertion that fails if a future tuning pass moves one and forgets the other.
+        //
+        // Computed from HCT tone, which *is* CIE L*, so relative luminance follows from it exactly and no
+        // per-channel sRGB round-trip is needed.
+        val agencyColors = listOf(
+            0xFF00A651.toInt(), // a green
+            0xFF0076CE.toInt(), // a blue
+            0xFF6F2C91.toInt(), // a purple
+            0xFFC8102E.toInt(), // a red — the hue that clamps hardest at a light tone
+            0xFFF6871F.toInt() // an orange
+        )
+        agencyColors.forEach { source ->
+            listOf(false, true).forEach { dark ->
+                val fill = Hct.fromInt(routeBadgeChipColor(source, dark)!!).tone
+                val text = Hct.fromInt(routeBadgeChipTextColor(source, dark)!!).tone
+                val ratio = contrastRatio(fill, text)
+                assertTrue(
+                    "contrast %.2f:1 for %06X (dark=%b)".format(ratio, source and 0xFFFFFF, dark),
+                    ratio >= MIN_TEXT_CONTRAST
+                )
+            }
+        }
+    }
+
+    /** WCAG contrast between two HCT tones, via the relative luminance each one is defined by. */
+    private fun contrastRatio(oneTone: Double, otherTone: Double): Double {
+        fun luminance(tone: Double) = if (tone > 8.0) Math.pow((tone + 16.0) / 116.0, 3.0) else tone / 903.3
+        val lighter = luminance(maxOf(oneTone, otherTone))
+        val darker = luminance(minOf(oneTone, otherTone))
+        return (lighter + 0.05) / (darker + 0.05)
+    }
+
+    private companion object {
+        // The re-tone clamps to each hue's own sRGB gamut limit, so a hue can shift a degree or two.
+        const val HUE_TOLERANCE_DEGREES = 3.0
+
+        // Chroma/tone likewise clamp to the gamut. Wide enough to absorb that, far too narrow to hide a
+        // different policy.
+        const val CHANNEL_TOLERANCE = 2.0
+
+        // WCAG AA for normal-size text, which a route name on a chip is (bold, but small).
+        const val MIN_TEXT_CONTRAST = 4.5
+    }
+}


### PR DESCRIPTION
A ride's line on the directions map was rendered by the map's basemap-neutral policy (chroma 75 / tone 55, theme-independent) while the badge naming that same ride in the drawer beside it was rendered by the badge's theme-aware one. Same route, two colours, inches apart.

The map policy is right for a line read against the basemap alone. In directions the line is read against a Material surface full of badges for those very legs, so there it takes the badge's.

## What changed

**The chip's tonal policy moved out of `LineBadge.kt` into `util/RouteColors.kt`** — `routeColorAtTone` / `routeBadgeChipColor` / `routeBadgeChipTextColor`, in ARGB ints so the map package can reach it without depending on a Compose component. The chip and the line now read one definition instead of two kept in step by hand.

**Which policy a line draws through is an explicit `RouteLinePalette`** handed to the producers rather than ambient state: `BASEMAP_ROUTE_LINE_PALETTE` everywhere else, `directionsRouteLinePalette(dark)` for the directions view. It reaches the drawn itinerary's rides and the corridor a tapped leg drills into, so a leg doesn't change colour on drill-in. The route picker and stop adjacency are untouched.

**Light theme tuned away from pastel** — chroma cap 30 → 48, chip fill tone 80 → 73, chip text tone 30 → 25. The fill tone, not the cap, was binding: at tone 80 the sRGB gamut clamped most hues well under their cap (RapidRide red reached only 37.5). Text contrast against the fill improves to ~5.3:1 across real agency colours. Dark theme unchanged.

| | chroma before | chroma now | fill | contrast |
|---|---|---|---|---|
| KCM green | 45.3 | 47.9 | `#70C583` | 5.28:1 |
| Link blue | 42.9 | 47.3 | `#7DB6FF` | 5.29:1 |
| ST purple | 45.1 | 48.2 | `#D89DF2` | 5.33:1 |
| RapidRide red | 37.5 | 43.9 | `#FF9694` | 5.34:1 |

**"This route publishes no colour" is answered once**, in `riddenRouteHue`. Every WSF ferry route publishes an empty colour (verified against the live Puget Sound API), and each surface had been substituting its own thing: the map the colourless-ride anchor, the badge the theme's neutral chip, the drawer spine `colorScheme.outline`. A ferry drew a coral line beside a grey roundel. It's a hue source rather than a rendered colour, so each surface still renders it through its own tone policy.

**Chevrons dropped from itinerary legs, and every ride wears a hairline case.** That needed `RoutePolyline.cased` (a Boolean) to become `RouteLineCase`: with every ride cased, the selection case (#2082) would have stopped meaning anything, so selection is now the heavier edge (1.5dp) over the outline every ride wears (0.75dp) rather than the only edge. The reconciler's `caseExtraWidth` became per line.

Mode legs (walk, bike, bikeshare, car) keep the basemap palette and take no case: a ride is faded because it is read beside its badge, and an on-street leg has no badge — the drawer marks it with a mode glyph — so there is no parity to buy and no fading to compensate for.

## Testing

- New `RouteColorsTest` pins the shared policy: hue kept, chroma capped rather than replaced, achromatic declined, and the chip's fill/text pairing held to 4.5:1 across five real agency hues in both themes — the two tones are only correct together, so a future tuning pass can't darken one and forget the other.
- Regression tests for the colourless fallback in both `ItineraryLegStyleTest` and `RouteBadgesTest`, so neither side can grow a private fallback again.
- `RouteViewGeometryTest`'s "one colour whichever view shows it" invariant is now scoped to views sharing a backdrop, with the directions divergence asserted where it lives.
- Full JVM suite green; both flavors and androidTest compile clean under `-PwarningsAsErrors=true`; Spotless applied. Exercised on a Pixel 7 Pro in both themes.

## Follow-ups deliberately not in scope

- Giving the colourless rides of one itinerary *distinct* auto-assigned hues, the way focused-stop adjacency does, is still the rest of #2041. When it lands it replaces `riddenRouteHue`'s fallback and every surface follows, since they all read it there.
- The map's own route labels take their line's fill but pick ink by luminance (`MarkerRendering.legibleOn`) rather than the chip's paired text tone — legible, but not the same pairing the chip guarantees.
- The corridor drawn on drill-in still stamps chevrons and wears no outline; those are route-view rendering rather than the itinerary's.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved route-line colors across maps, directions, trip results, and route badges.
  * Added theme-aware coloring for light and dark modes, including better handling of colorless routes.
  * Enhanced route highlighting with distinct outline and selection styles.
  * Route line widths now adapt more accurately to each highlight style.

* **Bug Fixes**
  * Improved consistency between route colors shown in maps, directions, and trip details.
  * Improved badge text/background contrast and fallback colors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->