### PR TITLE
Auto-fill the paired endpoint with current location on "directions from/to here" (#2092)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -94,7 +94,6 @@ import org.onebusaway.android.ui.home.directions.DirectionsErrorSnackbar
 import org.onebusaway.android.ui.home.directions.DirectionsFormCard
 import org.onebusaway.android.ui.home.directions.DirectionsLongPressMenu
 import org.onebusaway.android.ui.home.directions.DirectionsPickOverlay
-import org.onebusaway.android.ui.home.directions.DirectionsPickTarget
 import org.onebusaway.android.ui.home.directions.DirectionsResultsSheet
 import org.onebusaway.android.ui.home.donation.DonationFeature
 import org.onebusaway.android.ui.home.donation.DonationViewModel
@@ -120,6 +119,7 @@ import org.onebusaway.android.ui.survey.SurveyFeature
 import org.onebusaway.android.ui.survey.SurveyViewModel
 import org.onebusaway.android.ui.tripplan.PlanResult
 import org.onebusaway.android.ui.tripplan.TripEndpoint
+import org.onebusaway.android.ui.tripplan.TripEndpointSlot
 import org.onebusaway.android.ui.tripplan.TripPlanViewModel
 import org.onebusaway.android.ui.tripresults.TripResultsViewModel
 import org.onebusaway.android.ui.tutorial.ArrivalTutorial
@@ -585,7 +585,7 @@ fun HomeScreen(
                             val directionsError = (tripPlanResult as? PlanResult.Error)?.error
                             val directionsLoading = tripPlanResult is PlanResult.Loading
                             // Which endpoint (if any) is being picked directly on the map (crosshair + confirm).
-                            var pickTarget by rememberSaveable { mutableStateOf<DirectionsPickTarget?>(null) }
+                            var pickTarget by rememberSaveable { mutableStateOf<TripEndpointSlot?>(null) }
                             // A long-pressed map point awaiting the "directions from/to here" choice.
                             var longPressPoint by remember { mutableStateOf<GeoPoint?>(null) }
                             // Leaving directions ends any in-progress map pick.
@@ -705,8 +705,8 @@ fun HomeScreen(
                                             DirectionsFormCard(
                                                 viewModel = tripPlanViewModel,
                                                 state = tripPlanFormState,
-                                                onPickFrom = { pickTarget = DirectionsPickTarget.FROM },
-                                                onPickTo = { pickTarget = DirectionsPickTarget.TO },
+                                                onPickFrom = { pickTarget = TripEndpointSlot.FROM },
+                                                onPickTo = { pickTarget = TripEndpointSlot.TO },
                                                 modifier = Modifier
                                                     .align(Alignment.TopCenter)
                                                     .statusBarsPadding()
@@ -787,8 +787,8 @@ fun HomeScreen(
                                             mapViewModel.camera.value?.center?.let { c ->
                                                 val point = TripEndpoint.MapPoint(c.latitude, c.longitude)
                                                 when (target) {
-                                                    DirectionsPickTarget.FROM -> tripPlanViewModel.setFrom(point)
-                                                    DirectionsPickTarget.TO -> tripPlanViewModel.setTo(point)
+                                                    TripEndpointSlot.FROM -> tripPlanViewModel.setFrom(point)
+                                                    TripEndpointSlot.TO -> tripPlanViewModel.setTo(point)
                                                 }
                                                 pickTarget = null
                                             }
@@ -797,18 +797,19 @@ fun HomeScreen(
                                     )
                                 }
                                 // Long-press → "directions from/to here": enters directions and fills the endpoint
-                                // with the pressed point (which auto-plans once both endpoints are set).
+                                // with the pressed point. On a fresh session the trip's other end is paired with
+                                // the rider's current location, so the plan runs off the one long-press (#2092).
                                 longPressPoint?.let { point ->
                                     val mapPoint = TripEndpoint.MapPoint(point.latitude, point.longitude)
                                     DirectionsLongPressMenu(
                                         onFromHere = {
                                             homeViewModel.enterDirections(mapViewModel.viewport)
-                                            tripPlanViewModel.setFrom(mapPoint)
+                                            tripPlanViewModel.setEndpointFromMap(TripEndpointSlot.FROM, mapPoint)
                                             longPressPoint = null
                                         },
                                         onToHere = {
                                             homeViewModel.enterDirections(mapViewModel.viewport)
-                                            tripPlanViewModel.setTo(mapPoint)
+                                            tripPlanViewModel.setEndpointFromMap(TripEndpointSlot.TO, mapPoint)
                                             longPressPoint = null
                                         },
                                         onDismiss = { longPressPoint = null }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -786,10 +786,7 @@ fun HomeScreen(
                                             // keep the picker open rather than silently losing the selection.
                                             mapViewModel.camera.value?.center?.let { c ->
                                                 val point = TripEndpoint.MapPoint(c.latitude, c.longitude)
-                                                when (target) {
-                                                    TripEndpointSlot.FROM -> tripPlanViewModel.setFrom(point)
-                                                    TripEndpointSlot.TO -> tripPlanViewModel.setTo(point)
-                                                }
+                                                tripPlanViewModel.setEndpoint(target, point)
                                                 pickTarget = null
                                             }
                                         },
@@ -797,8 +794,8 @@ fun HomeScreen(
                                     )
                                 }
                                 // Long-press → "directions from/to here": enters directions and fills the endpoint
-                                // with the pressed point. On a fresh session the trip's other end is paired with
-                                // the rider's current location, so the plan runs off the one long-press (#2092).
+                                // with the pressed point (see setEndpointFromMap, which pairs the trip's other
+                                // end with current location so the one long-press plans a trip).
                                 longPressPoint?.let { point ->
                                     val mapPoint = TripEndpoint.MapPoint(point.latitude, point.longitude)
                                     DirectionsLongPressMenu(

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -705,8 +705,7 @@ fun HomeScreen(
                                             DirectionsFormCard(
                                                 viewModel = tripPlanViewModel,
                                                 state = tripPlanFormState,
-                                                onPickFrom = { pickTarget = TripEndpointSlot.FROM },
-                                                onPickTo = { pickTarget = TripEndpointSlot.TO },
+                                                onPickEndpoint = { pickTarget = it },
                                                 modifier = Modifier
                                                     .align(Alignment.TopCenter)
                                                     .statusBarsPadding()
@@ -799,14 +798,9 @@ fun HomeScreen(
                                 longPressPoint?.let { point ->
                                     val mapPoint = TripEndpoint.MapPoint(point.latitude, point.longitude)
                                     DirectionsLongPressMenu(
-                                        onFromHere = {
+                                        onChooseSlot = { slot ->
                                             homeViewModel.enterDirections(mapViewModel.viewport)
-                                            tripPlanViewModel.setEndpointFromMap(TripEndpointSlot.FROM, mapPoint)
-                                            longPressPoint = null
-                                        },
-                                        onToHere = {
-                                            homeViewModel.enterDirections(mapViewModel.viewport)
-                                            tripPlanViewModel.setEndpointFromMap(TripEndpointSlot.TO, mapPoint)
+                                            tripPlanViewModel.setEndpointFromMap(slot, mapPoint)
                                             longPressPoint = null
                                         },
                                         onDismiss = { longPressPoint = null }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -792,15 +792,14 @@ fun HomeScreen(
                                         onCancel = { pickTarget = null }
                                     )
                                 }
-                                // Long-press → "directions from/to here": enters directions and fills the endpoint
-                                // with the pressed point (see setEndpointFromMap, which pairs the trip's other
-                                // end with current location so the one long-press plans a trip).
+                                // Long-press → "directions from/to here": enters directions and fills the
+                                // chosen endpoint with the pressed point (see setEndpointFromLongPress).
                                 longPressPoint?.let { point ->
                                     val mapPoint = TripEndpoint.MapPoint(point.latitude, point.longitude)
                                     DirectionsLongPressMenu(
                                         onChooseSlot = { slot ->
                                             homeViewModel.enterDirections(mapViewModel.viewport)
-                                            tripPlanViewModel.setEndpointFromMap(slot, mapPoint)
+                                            tripPlanViewModel.setEndpointFromLongPress(slot, mapPoint)
                                             longPressPoint = null
                                         },
                                         onDismiss = { longPressPoint = null }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
@@ -87,7 +87,6 @@ import java.util.TimeZone
 import kotlin.math.roundToInt
 import kotlin.math.roundToLong
 import org.onebusaway.android.R
-import org.onebusaway.android.app.di.LocationEntryPoint
 import org.onebusaway.android.directions.model.TripItinerary
 import org.onebusaway.android.directions.util.ConversionUtils
 import org.onebusaway.android.directions.util.OtpTarget
@@ -112,7 +111,6 @@ import org.onebusaway.android.ui.tripplan.AdvancedSettings
 import org.onebusaway.android.ui.tripplan.BikePreference
 import org.onebusaway.android.ui.tripplan.CyclingPreference
 import org.onebusaway.android.ui.tripplan.StreetMode
-import org.onebusaway.android.ui.tripplan.TripEndpoint
 import org.onebusaway.android.ui.tripplan.TripEndpointSlot
 import org.onebusaway.android.ui.tripplan.TripModeSelection
 import org.onebusaway.android.ui.tripplan.TripPlanError
@@ -181,8 +179,8 @@ fun DirectionsFormCard(
                 onSelectTo = viewModel::setTo,
                 onClearFrom = viewModel::clearFrom,
                 onClearTo = viewModel::clearTo,
-                onFromCurrentLocation = { setCurrentLocation(context, viewModel::setFrom) },
-                onToCurrentLocation = { setCurrentLocation(context, viewModel::setTo) },
+                onFromCurrentLocation = { setCurrentLocation(context, viewModel, TripEndpointSlot.FROM) },
+                onToCurrentLocation = { setCurrentLocation(context, viewModel, TripEndpointSlot.TO) },
                 onFromPickOnMap = onPickFrom,
                 onToPickOnMap = onPickTo,
                 onSetArriving = viewModel::setArriving,
@@ -198,25 +196,21 @@ fun DirectionsFormCard(
     }
 }
 
-/** Set an endpoint to the device's last-known location, or toast if none is available. */
-private fun setCurrentLocation(context: Context, target: (TripEndpoint) -> Unit) {
-    val location = LocationEntryPoint.get(context.applicationContext).lastKnownLocation()
-    if (location == null) {
-        // A null fix means "no permission" only when permission is actually denied; with permission
-        // granted it just means we don't have a fix yet, which is a different (recoverable) message.
-        val messageRes = if (PermissionUtils.hasGrantedAtLeastOnePermission(
-                context,
-                PermissionUtils.LOCATION_PERMISSIONS
-            )
-        ) {
-            R.string.main_waiting_for_location
-        } else {
-            R.string.no_location_permission
-        }
-        Toast.makeText(context, messageRes, Toast.LENGTH_SHORT).show()
-        return
+/** Set [slot] to the device's last-known location, or toast if none is available. */
+private fun setCurrentLocation(context: Context, viewModel: TripPlanViewModel, slot: TripEndpointSlot) {
+    if (viewModel.setEndpointToCurrentLocation(slot)) return
+    // A null fix means "no permission" only when permission is actually denied; with permission
+    // granted it just means we don't have a fix yet, which is a different (recoverable) message.
+    val messageRes = if (PermissionUtils.hasGrantedAtLeastOnePermission(
+            context,
+            PermissionUtils.LOCATION_PERMISSIONS
+        )
+    ) {
+        R.string.main_waiting_for_location
+    } else {
+        R.string.no_location_permission
     }
-    target(TripEndpoint.CurrentLocation(lat = location.latitude, lon = location.longitude))
+    Toast.makeText(context, messageRes, Toast.LENGTH_SHORT).show()
 }
 
 private fun pickTripDate(activity: AppCompatActivity, viewModel: TripPlanViewModel) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
@@ -120,6 +120,7 @@ import org.onebusaway.android.ui.tripplan.TripPlanParams
 import org.onebusaway.android.ui.tripplan.TripPlanViewModel
 import org.onebusaway.android.ui.tripplan.VehicleMode
 import org.onebusaway.android.ui.tripplan.WalkPreference
+import org.onebusaway.android.ui.tripplan.labelRes
 import org.onebusaway.android.ui.tripresults.FocusedLeg
 import org.onebusaway.android.ui.tripresults.RouteLegRef
 import org.onebusaway.android.ui.tripresults.RouteStopRef
@@ -138,8 +139,8 @@ import org.onebusaway.android.util.PreferenceUtils
  * [MapViewModel] directions controller — driven by [TripResultsSheet]'s selection.
  *
  * The address-book (contacts) picker was removed (#1936 tracks accepting place intents from other apps
- * instead). Map-pick is hoisted to the caller ([onPickFrom]/[onPickTo]); current-location, date/time,
- * and advanced settings are wired here.
+ * instead). Map-pick is hoisted to the caller ([DirectionsFormCard]'s `onPickEndpoint`);
+ * current-location, date/time, and advanced settings are wired here.
  */
 
 /**
@@ -150,8 +151,7 @@ import org.onebusaway.android.util.PreferenceUtils
 fun DirectionsFormCard(
     viewModel: TripPlanViewModel,
     state: TripPlanFormState,
-    onPickFrom: () -> Unit,
-    onPickTo: () -> Unit,
+    onPickEndpoint: (TripEndpointSlot) -> Unit,
     modifier: Modifier = Modifier
 ) {
     val context = LocalContext.current
@@ -173,16 +173,11 @@ fun DirectionsFormCard(
         Column(Modifier.heightIn(max = maxHeight).verticalScroll(rememberScrollState())) {
             TripPlanForm(
                 state = state,
-                onFromQueryChange = viewModel::onFromQueryChange,
-                onToQueryChange = viewModel::onToQueryChange,
-                onSelectFrom = viewModel::setFrom,
-                onSelectTo = viewModel::setTo,
-                onClearFrom = viewModel::clearFrom,
-                onClearTo = viewModel::clearTo,
-                onFromCurrentLocation = { setCurrentLocation(context, viewModel, TripEndpointSlot.FROM) },
-                onToCurrentLocation = { setCurrentLocation(context, viewModel, TripEndpointSlot.TO) },
-                onFromPickOnMap = onPickFrom,
-                onToPickOnMap = onPickTo,
+                onQueryChange = viewModel::onQueryChange,
+                onSelect = viewModel::setEndpoint,
+                onClear = viewModel::clearEndpoint,
+                onCurrentLocation = { slot -> setCurrentLocation(context, viewModel, slot) },
+                onPickOnMap = onPickEndpoint,
                 onSetArriving = viewModel::setArriving,
                 onPickDate = { pickTripDate(activity, viewModel) },
                 onPickTime = { pickTripTime(activity, viewModel) },
@@ -457,8 +452,7 @@ private fun NoEtasText(modifier: Modifier) {
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DirectionsLongPressMenu(
-    onFromHere: () -> Unit,
-    onToHere: () -> Unit,
+    onChooseSlot: (TripEndpointSlot) -> Unit,
     onDismiss: () -> Unit
 ) {
     ModalBottomSheet(onDismissRequest = onDismiss) {
@@ -468,12 +462,12 @@ fun DirectionsLongPressMenu(
                 leadingContent = {
                     Icon(painterResource(R.drawable.ic_my_location), contentDescription = null)
                 },
-                modifier = Modifier.clickable(onClick = onFromHere)
+                modifier = Modifier.clickable { onChooseSlot(TripEndpointSlot.FROM) }
             )
             ListItem(
                 headlineContent = { Text(stringResource(R.string.directions_to_here)) },
                 leadingContent = { Icon(AppIcons.Place, contentDescription = null) },
-                modifier = Modifier.clickable(onClick = onToHere)
+                modifier = Modifier.clickable { onChooseSlot(TripEndpointSlot.TO) }
             )
         }
     }
@@ -554,12 +548,7 @@ fun BoxScope.DirectionsPickOverlay(
             verticalAlignment = Alignment.CenterVertically
         ) {
             Text(
-                text = stringResource(
-                    when (target) {
-                        TripEndpointSlot.FROM -> R.string.trip_plan_from
-                        TripEndpointSlot.TO -> R.string.trip_plan_to
-                    }
-                ),
+                text = stringResource(target.labelRes),
                 style = MaterialTheme.typography.titleMedium
             )
             IconButton(onClick = onCancel) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
@@ -113,6 +113,7 @@ import org.onebusaway.android.ui.tripplan.BikePreference
 import org.onebusaway.android.ui.tripplan.CyclingPreference
 import org.onebusaway.android.ui.tripplan.StreetMode
 import org.onebusaway.android.ui.tripplan.TripEndpoint
+import org.onebusaway.android.ui.tripplan.TripEndpointSlot
 import org.onebusaway.android.ui.tripplan.TripModeSelection
 import org.onebusaway.android.ui.tripplan.TripPlanError
 import org.onebusaway.android.ui.tripplan.TripPlanForm
@@ -142,9 +143,6 @@ import org.onebusaway.android.util.PreferenceUtils
  * instead). Map-pick is hoisted to the caller ([onPickFrom]/[onPickTo]); current-location, date/time,
  * and advanced settings are wired here.
  */
-
-/** Which endpoint a map-pick is currently choosing. */
-enum class DirectionsPickTarget { FROM, TO }
 
 /**
  * The compact trip-plan form, shown in the top chrome (in place of the search field) while planning.
@@ -546,7 +544,7 @@ fun DirectionsErrorSnackbar(
  */
 @Composable
 fun BoxScope.DirectionsPickOverlay(
-    target: DirectionsPickTarget,
+    target: TripEndpointSlot,
     onConfirm: () -> Unit,
     onCancel: () -> Unit
 ) {
@@ -563,10 +561,9 @@ fun BoxScope.DirectionsPickOverlay(
         ) {
             Text(
                 text = stringResource(
-                    if (target == DirectionsPickTarget.FROM) {
-                        R.string.trip_plan_from
-                    } else {
-                        R.string.trip_plan_to
+                    when (target) {
+                        TripEndpointSlot.FROM -> R.string.trip_plan_from
+                        TripEndpointSlot.TO -> R.string.trip_plan_to
                     }
                 ),
                 style = MaterialTheme.typography.titleMedium

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanForm.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanForm.kt
@@ -72,20 +72,25 @@ object TripPlanTestTags {
     const val FIELD_SUFFIX = "Field"
     const val PILL_SUFFIX = "Pill"
     const val SUGGESTION_SUFFIX = "Suggestion"
-
-    /** The tag prefix naming [slot]'s field. */
-    fun prefixFor(slot: TripEndpointSlot): String = when (slot) {
-        TripEndpointSlot.FROM -> FROM_PREFIX
-        TripEndpointSlot.TO -> TO_PREFIX
-    }
 }
 
-/** The rider-facing name of an endpoint ("From" / "To"), shared by the form and the map-pick overlay. */
+/**
+ * The rider-facing name of an endpoint ("From" / "To"), shared by the form and the map-pick overlay.
+ * Lives here rather than on [TripEndpointSlot] itself to keep [TripPlanFormState]'s file free of
+ * Android — the same seam [TripEndpoint.displayText] already draws for the fixed-label endpoint kinds.
+ */
 @get:StringRes
 val TripEndpointSlot.labelRes: Int
     get() = when (this) {
         TripEndpointSlot.FROM -> R.string.trip_plan_from
         TripEndpointSlot.TO -> R.string.trip_plan_to
+    }
+
+/** The [TripPlanTestTags] prefix naming this endpoint's field. */
+val TripEndpointSlot.tagPrefix: String
+    get() = when (this) {
+        TripEndpointSlot.FROM -> TripPlanTestTags.FROM_PREFIX
+        TripEndpointSlot.TO -> TripPlanTestTags.TO_PREFIX
     }
 
 @Composable
@@ -118,11 +123,12 @@ fun TripPlanForm(
                 modifier = Modifier.weight(1f),
                 verticalArrangement = Arrangement.spacedBy(8.dp)
             ) {
-                // Origin then destination, in declaration order — the enum is the list of fields.
+                // One field per endpoint, in TripEndpointSlot's declaration order (origin above
+                // destination) — the enum is the list of fields.
                 TripEndpointSlot.entries.forEach { slot ->
                     AddressField(
                         label = stringResource(slot.labelRes),
-                        tagPrefix = TripPlanTestTags.prefixFor(slot),
+                        tagPrefix = slot.tagPrefix,
                         endpoint = state.endpointAt(slot),
                         suggestions = state.suggestionsAt(slot),
                         onQueryChange = { onQueryChange(slot, it) },

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanForm.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanForm.kt
@@ -15,6 +15,7 @@
  */
 package org.onebusaway.android.ui.tripplan
 
+import androidx.annotation.StringRes
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -71,21 +72,30 @@ object TripPlanTestTags {
     const val FIELD_SUFFIX = "Field"
     const val PILL_SUFFIX = "Pill"
     const val SUGGESTION_SUFFIX = "Suggestion"
+
+    /** The tag prefix naming [slot]'s field. */
+    fun prefixFor(slot: TripEndpointSlot): String = when (slot) {
+        TripEndpointSlot.FROM -> FROM_PREFIX
+        TripEndpointSlot.TO -> TO_PREFIX
+    }
 }
+
+/** The rider-facing name of an endpoint ("From" / "To"), shared by the form and the map-pick overlay. */
+@get:StringRes
+val TripEndpointSlot.labelRes: Int
+    get() = when (this) {
+        TripEndpointSlot.FROM -> R.string.trip_plan_from
+        TripEndpointSlot.TO -> R.string.trip_plan_to
+    }
 
 @Composable
 fun TripPlanForm(
     state: TripPlanFormState,
-    onFromQueryChange: (String) -> Unit,
-    onToQueryChange: (String) -> Unit,
-    onSelectFrom: (TripEndpoint.Geocoded) -> Unit,
-    onSelectTo: (TripEndpoint.Geocoded) -> Unit,
-    onClearFrom: () -> Unit,
-    onClearTo: () -> Unit,
-    onFromCurrentLocation: () -> Unit,
-    onToCurrentLocation: () -> Unit,
-    onFromPickOnMap: () -> Unit,
-    onToPickOnMap: () -> Unit,
+    onQueryChange: (TripEndpointSlot, String) -> Unit,
+    onSelect: (TripEndpointSlot, TripEndpoint.Geocoded) -> Unit,
+    onClear: (TripEndpointSlot) -> Unit,
+    onCurrentLocation: (TripEndpointSlot) -> Unit,
+    onPickOnMap: (TripEndpointSlot) -> Unit,
     onSetArriving: (Boolean) -> Unit,
     onPickDate: () -> Unit,
     onPickTime: () -> Unit,
@@ -108,28 +118,20 @@ fun TripPlanForm(
                 modifier = Modifier.weight(1f),
                 verticalArrangement = Arrangement.spacedBy(8.dp)
             ) {
-                AddressField(
-                    label = stringResource(R.string.trip_plan_from),
-                    tagPrefix = TripPlanTestTags.FROM_PREFIX,
-                    endpoint = state.from,
-                    suggestions = state.fromSuggestions,
-                    onQueryChange = onFromQueryChange,
-                    onSelect = onSelectFrom,
-                    onClear = onClearFrom,
-                    onCurrentLocation = onFromCurrentLocation,
-                    onPickOnMap = onFromPickOnMap
-                )
-                AddressField(
-                    label = stringResource(R.string.trip_plan_to),
-                    tagPrefix = TripPlanTestTags.TO_PREFIX,
-                    endpoint = state.to,
-                    suggestions = state.toSuggestions,
-                    onQueryChange = onToQueryChange,
-                    onSelect = onSelectTo,
-                    onClear = onClearTo,
-                    onCurrentLocation = onToCurrentLocation,
-                    onPickOnMap = onToPickOnMap
-                )
+                // Origin then destination, in declaration order — the enum is the list of fields.
+                TripEndpointSlot.entries.forEach { slot ->
+                    AddressField(
+                        label = stringResource(slot.labelRes),
+                        tagPrefix = TripPlanTestTags.prefixFor(slot),
+                        endpoint = state.endpointAt(slot),
+                        suggestions = state.suggestionsAt(slot),
+                        onQueryChange = { onQueryChange(slot, it) },
+                        onSelect = { onSelect(slot, it) },
+                        onClear = { onClear(slot) },
+                        onCurrentLocation = { onCurrentLocation(slot) },
+                        onPickOnMap = { onPickOnMap(slot) }
+                    )
+                }
             }
             Column {
                 IconButton(onClick = onReverse) {
@@ -416,11 +418,8 @@ private fun TripPlanFormPreview() {
                 dateLabel = "June 10",
                 timeLabel = "3:45 PM"
             ),
-            onFromQueryChange = {}, onToQueryChange = {},
-            onSelectFrom = {}, onSelectTo = {},
-            onClearFrom = {}, onClearTo = {},
-            onFromCurrentLocation = {}, onToCurrentLocation = {},
-            onFromPickOnMap = {}, onToPickOnMap = {},
+            onQueryChange = { _, _ -> }, onSelect = { _, _ -> },
+            onClear = {}, onCurrentLocation = {}, onPickOnMap = {},
             onSetArriving = {}, onPickDate = {}, onPickTime = {},
             onReverse = {}, onAdvancedSettings = {}
         )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanFormState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanFormState.kt
@@ -33,11 +33,7 @@ sealed interface TripEndpoint {
     /** Mirrors CustomAddress.isSet(): a usable endpoint must have coordinates. */
     val hasCoordinates: Boolean get() = lat != null && lon != null
 
-    /**
-     * Nothing entered here yet — an empty editable field. A resolved pill and a half-typed query are
-     * both the rider's own work, so neither counts as empty (see
-     * [TripPlanFormState.withMapEndpointPaired]).
-     */
+    /** Nothing here — an empty editable field. A half-typed query is content, so it isn't empty. */
     val isEmpty: Boolean get() = this is FreeText && query.isBlank()
 
     /** The geocoder flagged this as a public-transit location (drives the pill/suggestion icon). */
@@ -163,16 +159,19 @@ data class TripPlanFormState(
     }
 
     /**
-     * This form after the map's "directions from/to here" filled [slot] with [endpoint] (#2092).
+     * This form with [slot] set to [endpoint], and the trip's other end filled with [here] (the
+     * device's current location) if — and only if — that end is [TripEndpoint.isEmpty] right now (#2092).
      *
-     * A long-press names one end of a trip, and in a fresh directions session the other end is
-     * overwhelmingly the rider's own position — so [here] (the device's current location) is filled in
-     * for them, which makes the form submittable and plans the trip on the spot rather than leaving a
-     * half-filled form. Strictly a convenience: an endpoint the rider already set or started typing is
-     * never overwritten, and with no fix available ([here] null) that side is simply left empty, exactly
-     * as before.
+     * Naming one end of a trip on its own leaves a form nobody can submit, and the other end is
+     * overwhelmingly the rider's own position, so it's filled in for them and the trip plans on the
+     * spot. Strictly a convenience: an endpoint carrying anything at all — a resolved pill, a half-typed
+     * query — is left untouched, and with no fix available ([here] null) that end simply stays empty.
+     *
+     * The test is what the field holds now, not whether the rider ever touched it: an end they cleared
+     * with the pill's ✕ is empty again and will be paired. That's deliberate — the ✕ says "not this
+     * place", and a form the rider then leaves half-filled is no more useful for having been edited.
      */
-    fun withMapEndpointPaired(
+    fun withEndpointPaired(
         slot: TripEndpointSlot,
         endpoint: TripEndpoint,
         here: TripEndpoint.CurrentLocation?

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanFormState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanFormState.kt
@@ -152,10 +152,31 @@ data class TripPlanFormState(
         TripEndpointSlot.TO -> to
     }
 
+    /** The autocomplete suggestions currently offered for [slot]. */
+    fun suggestionsAt(slot: TripEndpointSlot): List<TripEndpoint.Geocoded> = when (slot) {
+        TripEndpointSlot.FROM -> fromSuggestions
+        TripEndpointSlot.TO -> toSuggestions
+    }
+
     /** This form with [slot] set to [endpoint], dropping that field's now-stale suggestions. */
     fun withEndpoint(slot: TripEndpointSlot, endpoint: TripEndpoint): TripPlanFormState = when (slot) {
         TripEndpointSlot.FROM -> copy(from = endpoint, fromSuggestions = emptyList())
         TripEndpointSlot.TO -> copy(to = endpoint, toSuggestions = emptyList())
+    }
+
+    /**
+     * This form with [slot] being typed into. Unlike [withEndpoint] the suggestions stay put — they're
+     * what the rider is picking from, and the debounced lookup replaces them a moment later.
+     */
+    fun withTypedQuery(slot: TripEndpointSlot, query: String): TripPlanFormState = when (slot) {
+        TripEndpointSlot.FROM -> copy(from = TripEndpoint.FreeText(query))
+        TripEndpointSlot.TO -> copy(to = TripEndpoint.FreeText(query))
+    }
+
+    /** This form with [slot]'s autocomplete suggestions replaced by [suggestions]. */
+    fun withSuggestions(slot: TripEndpointSlot, suggestions: List<TripEndpoint.Geocoded>): TripPlanFormState = when (slot) {
+        TripEndpointSlot.FROM -> copy(fromSuggestions = suggestions)
+        TripEndpointSlot.TO -> copy(toSuggestions = suggestions)
     }
 
     /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanFormState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanFormState.kt
@@ -81,7 +81,10 @@ sealed interface TripEndpoint {
     data class MapPoint(override val lat: Double, override val lon: Double) : TripEndpoint
 }
 
-/** Which of the form's two endpoints an action targets. */
+/**
+ * Which of the form's two endpoints an action targets. Declaration order is the form's field order
+ * (origin above destination) — [org.onebusaway.android.ui.tripplan.TripPlanForm] renders `entries`.
+ */
 enum class TripEndpointSlot {
     FROM,
     TO;
@@ -185,8 +188,7 @@ data class TripPlanFormState(
      *
      * Naming one end of a trip on its own leaves a form nobody can submit, and the other end is
      * overwhelmingly the rider's own position, so it's filled in for them and the trip plans on the
-     * spot. Strictly a convenience: an endpoint carrying anything at all — a resolved pill, a half-typed
-     * query — is left untouched, and with no fix available ([here] null) that end simply stays empty.
+     * spot. Strictly a convenience — it only ever fills a field that was empty anyway.
      *
      * The test is what the field holds now, not whether the rider ever touched it: an end they cleared
      * with the pill's ✕ is empty again and will be paired. That's deliberate — the ✕ says "not this

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanFormState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanFormState.kt
@@ -33,6 +33,13 @@ sealed interface TripEndpoint {
     /** Mirrors CustomAddress.isSet(): a usable endpoint must have coordinates. */
     val hasCoordinates: Boolean get() = lat != null && lon != null
 
+    /**
+     * Nothing entered here yet — an empty editable field. A resolved pill and a half-typed query are
+     * both the rider's own work, so neither counts as empty (see
+     * [TripPlanFormState.withMapEndpointPaired]).
+     */
+    val isEmpty: Boolean get() = this is FreeText && query.isBlank()
+
     /** The geocoder flagged this as a public-transit location (drives the pill/suggestion icon). */
     val isTransit: Boolean get() = false
 
@@ -76,6 +83,15 @@ sealed interface TripEndpoint {
 
     /** A point chosen on the map. Its label is a fixed string resolved by the UI. */
     data class MapPoint(override val lat: Double, override val lon: Double) : TripEndpoint
+}
+
+/** Which of the form's two endpoints an action targets. */
+enum class TripEndpointSlot {
+    FROM,
+    TO;
+
+    /** The endpoint at the trip's other end. */
+    val other: TripEndpointSlot get() = if (this == FROM) TO else FROM
 }
 
 /**
@@ -133,6 +149,38 @@ data class TripPlanFormState(
     /** Mirrors TripRequestBuilder.ready(): both endpoints must resolve to coordinates. */
     val canSubmit: Boolean
         get() = from.hasCoordinates && to.hasCoordinates
+
+    /** The endpoint currently in [slot]. */
+    fun endpointAt(slot: TripEndpointSlot): TripEndpoint = when (slot) {
+        TripEndpointSlot.FROM -> from
+        TripEndpointSlot.TO -> to
+    }
+
+    /** This form with [slot] set to [endpoint], dropping that field's now-stale suggestions. */
+    fun withEndpoint(slot: TripEndpointSlot, endpoint: TripEndpoint): TripPlanFormState = when (slot) {
+        TripEndpointSlot.FROM -> copy(from = endpoint, fromSuggestions = emptyList())
+        TripEndpointSlot.TO -> copy(to = endpoint, toSuggestions = emptyList())
+    }
+
+    /**
+     * This form after the map's "directions from/to here" filled [slot] with [endpoint] (#2092).
+     *
+     * A long-press names one end of a trip, and in a fresh directions session the other end is
+     * overwhelmingly the rider's own position — so [here] (the device's current location) is filled in
+     * for them, which makes the form submittable and plans the trip on the spot rather than leaving a
+     * half-filled form. Strictly a convenience: an endpoint the rider already set or started typing is
+     * never overwritten, and with no fix available ([here] null) that side is simply left empty, exactly
+     * as before.
+     */
+    fun withMapEndpointPaired(
+        slot: TripEndpointSlot,
+        endpoint: TripEndpoint,
+        here: TripEndpoint.CurrentLocation?
+    ): TripPlanFormState {
+        val filled = withEndpoint(slot, endpoint)
+        if (here == null || !endpointAt(slot.other).isEmpty) return filled
+        return filled.withEndpoint(slot.other, here)
+    }
 
     /** The current advanced options, for persistence by the host. */
     val advancedSettings: AdvancedSettings

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanViewModel.kt
@@ -201,8 +201,9 @@ class TripPlanViewModel @Inject constructor(
     }
 
     /**
-     * Sets [slot] to the device's current location, or returns false when there's no fix to set it to
-     * — the caller says why (no permission vs. no fix yet), which only it can tell apart.
+     * Sets [slot] to the device's current location, returning false when there's no fix to set it to.
+     * Saying *why* there's none is left to the caller, whose business it is: the field's own button
+     * explains itself with a toast, while the long-press path below pairs silently.
      */
     fun setEndpointToCurrentLocation(slot: TripEndpointSlot): Boolean {
         val here = currentLocation() ?: return false
@@ -211,11 +212,14 @@ class TripPlanViewModel @Inject constructor(
     }
 
     /**
-     * Sets the endpoint the map's "directions from/to here" named, pairing the trip's other end with
-     * the device's current location when that end is empty — [TripPlanFormState.withEndpointPaired]
-     * owns the rule (#2092). Both ends land in one form update, so the pair submits as a single plan.
+     * Sets the endpoint a map long-press named ("directions from/to here"), pairing the trip's other
+     * end with the device's current location — [TripPlanFormState.withEndpointPaired] owns the rule
+     * (#2092). Both ends land in one form update, so the pair submits as a single plan.
+     *
+     * Distinct from [setEndpoint], which the crosshair pick-on-map path uses: that one is an edit
+     * within a form the rider is already filling, so it pairs nothing.
      */
-    fun setEndpointFromMap(slot: TripEndpointSlot, endpoint: TripEndpoint) {
+    fun setEndpointFromLongPress(slot: TripEndpointSlot, endpoint: TripEndpoint) {
         val here = currentLocation()
         _formState.update { it.withEndpointPaired(slot, endpoint, here) }
         replanOrClearResult()
@@ -259,13 +263,9 @@ class TripPlanViewModel @Inject constructor(
     }
 
     fun reverseTrip() {
+        // Both reads are of the pre-swap `it`, so this is a swap and not a double-assignment.
         _formState.update {
-            it.copy(
-                from = it.to,
-                to = it.from,
-                fromSuggestions = emptyList(),
-                toSuggestions = emptyList()
-            )
+            it.withEndpoint(TripEndpointSlot.FROM, it.to).withEndpoint(TripEndpointSlot.TO, it.from)
         }
         replanOrClearResult()
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanViewModel.kt
@@ -201,40 +201,50 @@ class TripPlanViewModel @Inject constructor(
         replanOrClearResult()
     }
 
-    /** Sets the origin (from a suggestion, current location, contacts, or map) and re-plans if ready. */
-    fun setFrom(endpoint: TripEndpoint) {
-        _formState.update { it.copy(from = endpoint, fromSuggestions = emptyList()) }
+    /** Sets one endpoint (from a suggestion, current location, contacts, or map) and re-plans if ready. */
+    fun setEndpoint(slot: TripEndpointSlot, endpoint: TripEndpoint) {
+        _formState.update { it.withEndpoint(slot, endpoint) }
         replanOrClearResult()
     }
 
-    fun setTo(endpoint: TripEndpoint) {
-        _formState.update { it.copy(to = endpoint, toSuggestions = emptyList()) }
-        replanOrClearResult()
+    fun setFrom(endpoint: TripEndpoint) = setEndpoint(TripEndpointSlot.FROM, endpoint)
+
+    fun setTo(endpoint: TripEndpoint) = setEndpoint(TripEndpointSlot.TO, endpoint)
+
+    /**
+     * Sets [slot] to the device's current location, or returns false when there's no fix to set it to
+     * — the caller says why (no permission vs. no fix yet), which only it can tell apart.
+     */
+    fun setEndpointToCurrentLocation(slot: TripEndpointSlot): Boolean {
+        val here = currentLocation() ?: return false
+        setEndpoint(slot, here)
+        return true
     }
 
     /**
      * Sets the endpoint the map's "directions from/to here" named, pairing the trip's other end with
-     * the device's current location when it's still empty — see [TripPlanFormState.withMapEndpointPaired]
-     * for the rule (#2092). Both ends land in a single form update, so the paired trip submits as one plan.
+     * the device's current location when that end is empty — [TripPlanFormState.withEndpointPaired]
+     * owns the rule (#2092). Both ends land in one form update, so the pair submits as a single plan.
      */
     fun setEndpointFromMap(slot: TripEndpointSlot, endpoint: TripEndpoint) {
-        val here = locationRepository.lastKnownLocation()
-            ?.let { TripEndpoint.CurrentLocation(lat = it.latitude, lon = it.longitude) }
-        _formState.update { it.withMapEndpointPaired(slot, endpoint, here) }
+        val here = currentLocation()
+        _formState.update { it.withEndpointPaired(slot, endpoint, here) }
         replanOrClearResult()
     }
+
+    /** The device's last known fix as a plan endpoint, or null when there is none (or no permission). */
+    private fun currentLocation(): TripEndpoint.CurrentLocation? = locationRepository.lastKnownLocation()
+        ?.let { TripEndpoint.CurrentLocation(lat = it.latitude, lon = it.longitude) }
 
     /** Clears the origin back to an empty editable field (the pill's ✕), dropping any stale result. */
     fun clearFrom() {
-        _formState.update { it.copy(from = TripEndpoint.FreeText(), fromSuggestions = emptyList()) }
         fromQueries.value = ""
-        replanOrClearResult()
+        setEndpoint(TripEndpointSlot.FROM, TripEndpoint.FreeText())
     }
 
     fun clearTo() {
-        _formState.update { it.copy(to = TripEndpoint.FreeText(), toSuggestions = emptyList()) }
         toQueries.value = ""
-        replanOrClearResult()
+        setEndpoint(TripEndpointSlot.TO, TripEndpoint.FreeText())
     }
 
     fun setDateTime(millis: Long) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanViewModel.kt
@@ -40,6 +40,7 @@ import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.withTimeoutOrNull
 import org.onebusaway.android.directions.model.TripItinerary
+import org.onebusaway.android.location.LocationRepository
 import org.onebusaway.android.location.SearchCenter
 import org.onebusaway.android.region.RegionRepository
 import org.onebusaway.android.util.TimeProvider
@@ -58,6 +59,7 @@ class TripPlanViewModel @Inject constructor(
     private val planRepository: TripPlanRepository,
     private val regionRepository: RegionRepository,
     private val searchCenter: SearchCenter,
+    private val locationRepository: LocationRepository,
     timeProvider: TimeProvider,
     settingsRepository: AdvancedSettingsRepository
 ) : ViewModel() {
@@ -207,6 +209,18 @@ class TripPlanViewModel @Inject constructor(
 
     fun setTo(endpoint: TripEndpoint) {
         _formState.update { it.copy(to = endpoint, toSuggestions = emptyList()) }
+        replanOrClearResult()
+    }
+
+    /**
+     * Sets the endpoint the map's "directions from/to here" named, pairing the trip's other end with
+     * the device's current location when it's still empty — see [TripPlanFormState.withMapEndpointPaired]
+     * for the rule (#2092). Both ends land in a single form update, so the paired trip submits as one plan.
+     */
+    fun setEndpointFromMap(slot: TripEndpointSlot, endpoint: TripEndpoint) {
+        val here = locationRepository.lastKnownLocation()
+            ?.let { TripEndpoint.CurrentLocation(lat = it.latitude, lon = it.longitude) }
+        _formState.update { it.withMapEndpointPaired(slot, endpoint, here) }
         replanOrClearResult()
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanViewModel.kt
@@ -101,8 +101,9 @@ class TripPlanViewModel @Inject constructor(
     private val _planState = MutableStateFlow<PlanResult>(PlanResult.Idle)
     val planState: StateFlow<PlanResult> = _planState.asStateFlow()
 
-    private val fromQueries = MutableStateFlow("")
-    private val toQueries = MutableStateFlow("")
+    // The in-progress autocomplete query per endpoint, each feeding its own debounced suggestion
+    // pipeline below. Keyed by slot rather than held as a from/to pair so the pipeline is written once.
+    private val queries = TripEndpointSlot.entries.associateWith { MutableStateFlow("") }
 
     // Reverse-geocoded names, keyed by the coordinate that produced them. Re-planning re-submits the same
     // points — a date or arrive-by change, an advanced-settings apply, or editing *the other* endpoint all
@@ -121,16 +122,13 @@ class TripPlanViewModel @Inject constructor(
     private val planInputs = Channel<TripPlanParams?>(Channel.CONFLATED)
 
     init {
-        fromQueries
-            .debounce(SUGGEST_DEBOUNCE_MS)
-            .mapLatest(::suggestionsFor)
-            .onEach { suggestions -> _formState.update { it.copy(fromSuggestions = suggestions) } }
-            .launchIn(viewModelScope)
-        toQueries
-            .debounce(SUGGEST_DEBOUNCE_MS)
-            .mapLatest(::suggestionsFor)
-            .onEach { suggestions -> _formState.update { it.copy(toSuggestions = suggestions) } }
-            .launchIn(viewModelScope)
+        queries.forEach { (slot, typed) ->
+            typed
+                .debounce(SUGGEST_DEBOUNCE_MS)
+                .mapLatest(::suggestionsFor)
+                .onEach { suggestions -> _formState.update { it.withSuggestions(slot, suggestions) } }
+                .launchIn(viewModelScope)
+        }
         planInputs.receiveAsFlow()
             .mapLatest { params ->
                 if (params == null) {
@@ -188,16 +186,11 @@ class TripPlanViewModel @Inject constructor(
         return name?.also { reverseNames[lat to lon] = it }
     }
 
-    fun onFromQueryChange(query: String) {
-        _formState.update { it.copy(from = TripEndpoint.FreeText(query)) }
-        fromQueries.value = query
+    /** Types into [slot]'s field, which starts a debounced autocomplete lookup for it. */
+    fun onQueryChange(slot: TripEndpointSlot, query: String) {
+        _formState.update { it.withTypedQuery(slot, query) }
+        queries.getValue(slot).value = query
         // Editing over a resolved endpoint makes the form non-submittable — drop any stale route too.
-        replanOrClearResult()
-    }
-
-    fun onToQueryChange(query: String) {
-        _formState.update { it.copy(to = TripEndpoint.FreeText(query)) }
-        toQueries.value = query
         replanOrClearResult()
     }
 
@@ -206,10 +199,6 @@ class TripPlanViewModel @Inject constructor(
         _formState.update { it.withEndpoint(slot, endpoint) }
         replanOrClearResult()
     }
-
-    fun setFrom(endpoint: TripEndpoint) = setEndpoint(TripEndpointSlot.FROM, endpoint)
-
-    fun setTo(endpoint: TripEndpoint) = setEndpoint(TripEndpointSlot.TO, endpoint)
 
     /**
      * Sets [slot] to the device's current location, or returns false when there's no fix to set it to
@@ -236,15 +225,10 @@ class TripPlanViewModel @Inject constructor(
     private fun currentLocation(): TripEndpoint.CurrentLocation? = locationRepository.lastKnownLocation()
         ?.let { TripEndpoint.CurrentLocation(lat = it.latitude, lon = it.longitude) }
 
-    /** Clears the origin back to an empty editable field (the pill's ✕), dropping any stale result. */
-    fun clearFrom() {
-        fromQueries.value = ""
-        setEndpoint(TripEndpointSlot.FROM, TripEndpoint.FreeText())
-    }
-
-    fun clearTo() {
-        toQueries.value = ""
-        setEndpoint(TripEndpointSlot.TO, TripEndpoint.FreeText())
+    /** Clears an endpoint back to an empty editable field (the pill's ✕), dropping any stale result. */
+    fun clearEndpoint(slot: TripEndpointSlot) {
+        queries.getValue(slot).value = ""
+        setEndpoint(slot, TripEndpoint.FreeText())
     }
 
     fun setDateTime(millis: Long) {

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripPlanFormStateTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripPlanFormStateTest.kt
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.tripplan
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The "directions from/to here" pairing rule (#2092), which the ViewModel delegates to. Kept here
+ * rather than in the ViewModel test because a real fix means an `android.location.Location`, which a
+ * plain JVM test can't build — this side of the seam is plain coordinates.
+ */
+class TripPlanFormStateTest {
+
+    private val here = TripEndpoint.CurrentLocation(lat = 47.6, lon = -122.3)
+    private val pressed = TripEndpoint.MapPoint(lat = 47.7, lon = -122.2)
+    private val named = TripEndpoint.Geocoded("Pike Place Market", lat = 47.61, lon = -122.34)
+
+    @Test
+    fun `a long-pressed destination pairs an empty origin with the current location`() {
+        val paired = TripPlanFormState().withMapEndpointPaired(TripEndpointSlot.TO, pressed, here)
+
+        assertEquals(pressed, paired.to)
+        assertEquals(here, paired.from)
+        assertTrue(paired.canSubmit) // both ends resolved: the host plans without further input
+    }
+
+    @Test
+    fun `a long-pressed origin pairs an empty destination with the current location`() {
+        val paired = TripPlanFormState().withMapEndpointPaired(TripEndpointSlot.FROM, pressed, here)
+
+        assertEquals(pressed, paired.from)
+        assertEquals(here, paired.to)
+        assertTrue(paired.canSubmit)
+    }
+
+    @Test
+    fun `pairing never overwrites an endpoint the rider already resolved`() {
+        val form = TripPlanFormState(from = named)
+
+        val paired = form.withMapEndpointPaired(TripEndpointSlot.TO, pressed, here)
+
+        assertEquals(named, paired.from)
+        assertEquals(pressed, paired.to)
+    }
+
+    @Test
+    fun `pairing never overwrites a half-typed query`() {
+        val form = TripPlanFormState(to = TripEndpoint.FreeText("pike pl"))
+
+        val paired = form.withMapEndpointPaired(TripEndpointSlot.FROM, pressed, here)
+
+        assertEquals(TripEndpoint.FreeText("pike pl"), paired.to)
+        assertEquals(pressed, paired.from)
+        assertFalse(paired.canSubmit)
+    }
+
+    @Test
+    fun `without a location fix the other endpoint is left empty`() {
+        val paired = TripPlanFormState().withMapEndpointPaired(TripEndpointSlot.TO, pressed, here = null)
+
+        assertEquals(pressed, paired.to)
+        assertEquals(TripEndpoint.FreeText(), paired.from)
+        assertFalse(paired.canSubmit)
+    }
+
+    @Test
+    fun `pairing drops both endpoints' stale suggestions`() {
+        val form = TripPlanFormState(fromSuggestions = listOf(named), toSuggestions = listOf(named))
+
+        val paired = form.withMapEndpointPaired(TripEndpointSlot.TO, pressed, here)
+
+        assertTrue(paired.fromSuggestions.isEmpty())
+        assertTrue(paired.toSuggestions.isEmpty())
+    }
+
+    @Test
+    fun `only a blank free-text endpoint counts as empty`() {
+        assertTrue(TripEndpoint.FreeText().isEmpty)
+        assertTrue(TripEndpoint.FreeText("   ").isEmpty)
+        assertFalse(TripEndpoint.FreeText("pike").isEmpty)
+        assertFalse(named.isEmpty)
+        assertFalse(pressed.isEmpty)
+        assertFalse(here.isEmpty)
+    }
+
+    @Test
+    fun `each slot names the trip's other end`() {
+        assertEquals(TripEndpointSlot.TO, TripEndpointSlot.FROM.other)
+        assertEquals(TripEndpointSlot.FROM, TripEndpointSlot.TO.other)
+    }
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripPlanFormStateTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripPlanFormStateTest.kt
@@ -33,7 +33,7 @@ class TripPlanFormStateTest {
 
     @Test
     fun `a long-pressed destination pairs an empty origin with the current location`() {
-        val paired = TripPlanFormState().withMapEndpointPaired(TripEndpointSlot.TO, pressed, here)
+        val paired = TripPlanFormState().withEndpointPaired(TripEndpointSlot.TO, pressed, here)
 
         assertEquals(pressed, paired.to)
         assertEquals(here, paired.from)
@@ -42,7 +42,7 @@ class TripPlanFormStateTest {
 
     @Test
     fun `a long-pressed origin pairs an empty destination with the current location`() {
-        val paired = TripPlanFormState().withMapEndpointPaired(TripEndpointSlot.FROM, pressed, here)
+        val paired = TripPlanFormState().withEndpointPaired(TripEndpointSlot.FROM, pressed, here)
 
         assertEquals(pressed, paired.from)
         assertEquals(here, paired.to)
@@ -53,7 +53,7 @@ class TripPlanFormStateTest {
     fun `pairing never overwrites an endpoint the rider already resolved`() {
         val form = TripPlanFormState(from = named)
 
-        val paired = form.withMapEndpointPaired(TripEndpointSlot.TO, pressed, here)
+        val paired = form.withEndpointPaired(TripEndpointSlot.TO, pressed, here)
 
         assertEquals(named, paired.from)
         assertEquals(pressed, paired.to)
@@ -63,7 +63,7 @@ class TripPlanFormStateTest {
     fun `pairing never overwrites a half-typed query`() {
         val form = TripPlanFormState(to = TripEndpoint.FreeText("pike pl"))
 
-        val paired = form.withMapEndpointPaired(TripEndpointSlot.FROM, pressed, here)
+        val paired = form.withEndpointPaired(TripEndpointSlot.FROM, pressed, here)
 
         assertEquals(TripEndpoint.FreeText("pike pl"), paired.to)
         assertEquals(pressed, paired.from)
@@ -71,8 +71,18 @@ class TripPlanFormStateTest {
     }
 
     @Test
+    fun `an endpoint the rider cleared is empty again, so it pairs`() {
+        // The ✕ leaves exactly the never-set state, and pairing reads what the field holds now.
+        val form = TripPlanFormState(from = named).withEndpoint(TripEndpointSlot.FROM, TripEndpoint.FreeText())
+
+        val paired = form.withEndpointPaired(TripEndpointSlot.TO, pressed, here)
+
+        assertEquals(here, paired.from)
+    }
+
+    @Test
     fun `without a location fix the other endpoint is left empty`() {
-        val paired = TripPlanFormState().withMapEndpointPaired(TripEndpointSlot.TO, pressed, here = null)
+        val paired = TripPlanFormState().withEndpointPaired(TripEndpointSlot.TO, pressed, here = null)
 
         assertEquals(pressed, paired.to)
         assertEquals(TripEndpoint.FreeText(), paired.from)
@@ -83,7 +93,7 @@ class TripPlanFormStateTest {
     fun `pairing drops both endpoints' stale suggestions`() {
         val form = TripPlanFormState(fromSuggestions = listOf(named), toSuggestions = listOf(named))
 
-        val paired = form.withMapEndpointPaired(TripEndpointSlot.TO, pressed, here)
+        val paired = form.withEndpointPaired(TripEndpointSlot.TO, pressed, here)
 
         assertTrue(paired.fromSuggestions.isEmpty())
         assertTrue(paired.toSuggestions.isEmpty())
@@ -97,11 +107,5 @@ class TripPlanFormStateTest {
         assertFalse(named.isEmpty)
         assertFalse(pressed.isEmpty)
         assertFalse(here.isEmpty)
-    }
-
-    @Test
-    fun `each slot names the trip's other end`() {
-        assertEquals(TripEndpointSlot.TO, TripEndpointSlot.FROM.other)
-        assertEquals(TripEndpointSlot.FROM, TripEndpointSlot.TO.other)
     }
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripPlanViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripPlanViewModelTest.kt
@@ -132,8 +132,8 @@ class TripPlanViewModelTest {
 
     /** Sets both resolved endpoints (which auto-submits a plan once both have coordinates). */
     private fun setBothEndpoints(vm: TripPlanViewModel) {
-        vm.setFrom(origin)
-        vm.setTo(destination)
+        vm.setEndpoint(TripEndpointSlot.FROM, origin)
+        vm.setEndpoint(TripEndpointSlot.TO, destination)
     }
 
     @Test
@@ -151,7 +151,7 @@ class TripPlanViewModelTest {
     fun `a query change populates suggestions after the debounce`() = runTest {
         val geocode = FakeGeocodeRepository(Result.success(listOf(origin, destination)))
         val vm = viewModel(geocode = geocode)
-        vm.onFromQueryChange("down")
+        vm.onQueryChange(TripEndpointSlot.FROM, "down")
         advanceUntilIdle()
         assertEquals("down", geocode.lastQuery)
         assertEquals(listOf(origin, destination), vm.formState.value.fromSuggestions)
@@ -160,7 +160,7 @@ class TripPlanViewModelTest {
     @Test
     fun `a query change makes the origin a FreeText endpoint`() = runTest {
         val vm = viewModel()
-        vm.onFromQueryChange("downtown")
+        vm.onQueryChange(TripEndpointSlot.FROM, "downtown")
         assertEquals(TripEndpoint.FreeText("downtown"), vm.formState.value.from)
         assertFalse(vm.formState.value.canSubmit)
     }
@@ -168,9 +168,9 @@ class TripPlanViewModelTest {
     @Test
     fun `selecting a geocoded suggestion stores the resolved endpoint`() = runTest {
         val vm = viewModel()
-        vm.onFromQueryChange("orig")
+        vm.onQueryChange(TripEndpointSlot.FROM, "orig")
         advanceUntilIdle()
-        vm.setFrom(origin)
+        vm.setEndpoint(TripEndpointSlot.FROM, origin)
         advanceUntilIdle()
         val state = vm.formState.value
         assertEquals(origin, state.from)
@@ -178,14 +178,14 @@ class TripPlanViewModelTest {
     }
 
     @Test
-    fun `clearFrom resets the origin to empty FreeText and does not submit`() = runTest {
+    fun `clearing the origin resets it to empty FreeText and does not submit`() = runTest {
         val plan = FakeTripPlanRepository(Result.success(listOf(TripItinerary())))
         val vm = viewModel(plan = plan)
         setBothEndpoints(vm)
         advanceUntilIdle()
         assertEquals(1, plan.calls)
 
-        vm.clearFrom()
+        vm.clearEndpoint(TripEndpointSlot.FROM)
         advanceUntilIdle()
         val state = vm.formState.value
         assertEquals(TripEndpoint.FreeText(), state.from)
@@ -198,11 +198,11 @@ class TripPlanViewModelTest {
         val plan = FakeTripPlanRepository(Result.success(listOf(TripItinerary())))
         val vm = viewModel(plan = plan)
 
-        vm.setFrom(origin)
+        vm.setEndpoint(TripEndpointSlot.FROM, origin)
         advanceUntilIdle()
         assertEquals(0, plan.calls) // destination still missing
 
-        vm.setTo(destination)
+        vm.setEndpoint(TripEndpointSlot.TO, destination)
         advanceUntilIdle()
         assertTrue(vm.formState.value.canSubmit)
         assertEquals(1, plan.calls)
@@ -216,7 +216,7 @@ class TripPlanViewModelTest {
         advanceUntilIdle()
         assertTrue(vm.planState.value is PlanResult.Success)
 
-        vm.clearTo()
+        vm.clearEndpoint(TripEndpointSlot.TO)
         advanceUntilIdle()
         assertFalse(vm.formState.value.canSubmit)
         assertEquals(PlanResult.Idle, vm.planState.value)
@@ -229,7 +229,7 @@ class TripPlanViewModelTest {
         advanceUntilIdle()
         assertTrue(vm.planState.value is PlanResult.Success)
 
-        vm.onFromQueryChange("typing over the pill")
+        vm.onQueryChange(TripEndpointSlot.FROM, "typing over the pill")
         advanceUntilIdle()
         assertFalse(vm.formState.value.canSubmit)
         assertEquals(PlanResult.Idle, vm.planState.value)
@@ -243,7 +243,7 @@ class TripPlanViewModelTest {
         advanceUntilIdle()
         assertEquals(PlanResult.Loading, vm.planState.value)
 
-        vm.clearTo() // form no longer submittable: invalidates the in-flight plan
+        vm.clearEndpoint(TripEndpointSlot.TO) // form no longer submittable: invalidates the in-flight plan
         advanceUntilIdle()
         assertEquals(PlanResult.Idle, vm.planState.value)
 
@@ -258,12 +258,12 @@ class TripPlanViewModelTest {
         // Seed a stale success, then reset both endpoints to empty as a fresh start.
         setBothEndpoints(vm)
         advanceUntilIdle()
-        vm.clearFrom()
-        vm.clearTo()
+        vm.clearEndpoint(TripEndpointSlot.FROM)
+        vm.clearEndpoint(TripEndpointSlot.TO)
         advanceUntilIdle()
 
         // Selecting just one endpoint must not bring back the old route.
-        vm.setFrom(origin)
+        vm.setEndpoint(TripEndpointSlot.FROM, origin)
         advanceUntilIdle()
         assertFalse(vm.formState.value.canSubmit)
         assertEquals(PlanResult.Idle, vm.planState.value)
@@ -274,8 +274,8 @@ class TripPlanViewModelTest {
         val plan = FakeTripPlanRepository(Result.success(listOf(TripItinerary())))
         val vm = viewModel(plan = plan)
 
-        vm.setFrom(TripEndpoint.AddressBook("Contact A", lat = null, lon = null))
-        vm.setTo(TripEndpoint.AddressBook("Contact B", lat = null, lon = null))
+        vm.setEndpoint(TripEndpointSlot.FROM, TripEndpoint.AddressBook("Contact A", lat = null, lon = null))
+        vm.setEndpoint(TripEndpointSlot.TO, TripEndpoint.AddressBook("Contact B", lat = null, lon = null))
         advanceUntilIdle()
 
         assertFalse(vm.formState.value.canSubmit)
@@ -301,7 +301,7 @@ class TripPlanViewModelTest {
     fun `a long-pressed endpoint does not disturb an origin the rider already set`() = runTest {
         val plan = FakeTripPlanRepository(Result.success(listOf(TripItinerary())))
         val vm = viewModel(plan = plan)
-        vm.setFrom(origin)
+        vm.setEndpoint(TripEndpointSlot.FROM, origin)
         advanceUntilIdle()
 
         vm.setEndpointFromMap(TripEndpointSlot.TO, TripEndpoint.MapPoint(lat = 47.7, lon = -122.2))
@@ -390,8 +390,8 @@ class TripPlanViewModelTest {
         )
         val vm = viewModel(geocode = geocode, plan = FakeTripPlanRepository(Result.success(plannedTrip)))
 
-        vm.setFrom(TripEndpoint.CurrentLocation(lat = 47.6, lon = -122.3))
-        vm.setTo(TripEndpoint.MapPoint(lat = 47.7, lon = -122.2))
+        vm.setEndpoint(TripEndpointSlot.FROM, TripEndpoint.CurrentLocation(lat = 47.6, lon = -122.3))
+        vm.setEndpoint(TripEndpointSlot.TO, TripEndpoint.MapPoint(lat = 47.7, lon = -122.2))
         advanceUntilIdle()
 
         val legs = (vm.planState.value as PlanResult.Success).itineraries.first().legs
@@ -424,8 +424,8 @@ class TripPlanViewModelTest {
         )
         val vm = viewModel(geocode = geocode, plan = FakeTripPlanRepository(Result.success(plannedTrip)))
 
-        vm.setFrom(TripEndpoint.CurrentLocation(lat = 47.6, lon = -122.3))
-        vm.setTo(destination)
+        vm.setEndpoint(TripEndpointSlot.FROM, TripEndpoint.CurrentLocation(lat = 47.6, lon = -122.3))
+        vm.setEndpoint(TripEndpointSlot.TO, destination)
         advanceUntilIdle()
 
         assertEquals(OTP_PLACEHOLDER_ORIGIN, plannedOriginName(vm))
@@ -438,8 +438,8 @@ class TripPlanViewModelTest {
             plan = FakeTripPlanRepository(Result.success(plannedTrip))
         )
 
-        vm.setFrom(TripEndpoint.CurrentLocation(lat = 47.6, lon = -122.3))
-        vm.setTo(destination)
+        vm.setEndpoint(TripEndpointSlot.FROM, TripEndpoint.CurrentLocation(lat = 47.6, lon = -122.3))
+        vm.setEndpoint(TripEndpointSlot.TO, destination)
         advanceUntilIdle()
 
         assertTrue(vm.planState.value is PlanResult.Success)
@@ -453,8 +453,8 @@ class TripPlanViewModelTest {
             reverseResult = Result.success("Pike Place Market")
         )
         val vm = viewModel(geocode = geocode, plan = FakeTripPlanRepository(Result.success(plannedTrip)))
-        vm.setFrom(TripEndpoint.CurrentLocation(lat = 47.6, lon = -122.3))
-        vm.setTo(destination)
+        vm.setEndpoint(TripEndpointSlot.FROM, TripEndpoint.CurrentLocation(lat = 47.6, lon = -122.3))
+        vm.setEndpoint(TripEndpointSlot.TO, destination)
         advanceUntilIdle()
         assertEquals(1, geocode.reverseCalls.size)
 
@@ -474,8 +474,8 @@ class TripPlanViewModelTest {
             plan = FakeTripPlanRepository(Result.failure(IOException("boom")))
         )
 
-        vm.setFrom(TripEndpoint.CurrentLocation(lat = 47.6, lon = -122.3))
-        vm.setTo(destination)
+        vm.setEndpoint(TripEndpointSlot.FROM, TripEndpoint.CurrentLocation(lat = 47.6, lon = -122.3))
+        vm.setEndpoint(TripEndpointSlot.TO, destination)
         // No advanceUntilIdle: only the plan is allowed to complete. A naming lookup still in flight must
         // not hold the error behind its timeout.
         runCurrent()

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripPlanViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripPlanViewModelTest.kt
@@ -287,7 +287,7 @@ class TripPlanViewModelTest {
         val plan = FakeTripPlanRepository(Result.success(listOf(TripItinerary())))
         val vm = viewModel(plan = plan)
 
-        vm.setEndpointFromMap(TripEndpointSlot.TO, TripEndpoint.MapPoint(lat = 47.7, lon = -122.2))
+        vm.setEndpointFromLongPress(TripEndpointSlot.TO, TripEndpoint.MapPoint(lat = 47.7, lon = -122.2))
         advanceUntilIdle()
 
         val state = vm.formState.value
@@ -297,19 +297,20 @@ class TripPlanViewModelTest {
         assertEquals(0, plan.calls)
     }
 
+    // Not a test of the don't-overwrite rule — with no fix the pairing branch is never reached at all.
+    // That rule is TripPlanFormStateTest's; this pins the one submission the completed form makes.
     @Test
-    fun `a long-pressed endpoint does not disturb an origin the rider already set`() = runTest {
+    fun `a long-pressed endpoint completing the pair plans exactly once`() = runTest {
         val plan = FakeTripPlanRepository(Result.success(listOf(TripItinerary())))
         val vm = viewModel(plan = plan)
         vm.setEndpoint(TripEndpointSlot.FROM, origin)
         advanceUntilIdle()
 
-        vm.setEndpointFromMap(TripEndpointSlot.TO, TripEndpoint.MapPoint(lat = 47.7, lon = -122.2))
+        vm.setEndpointFromLongPress(TripEndpointSlot.TO, TripEndpoint.MapPoint(lat = 47.7, lon = -122.2))
         advanceUntilIdle()
 
-        assertEquals(origin, vm.formState.value.from)
         assertTrue(vm.formState.value.canSubmit)
-        assertEquals(1, plan.calls) // the completed pair plans exactly once
+        assertEquals(1, plan.calls)
     }
 
     @Test

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripPlanViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripPlanViewModelTest.kt
@@ -117,9 +117,7 @@ class TripPlanViewModelTest {
         plan: TripPlanRepository = FakeTripPlanRepository(Result.success(listOf(TripItinerary()))),
         region: RegionRepository = FakeRegionRepository()
     ): TripPlanViewModel {
-        // Location isn't constructible in a plain JVM test, so the fake reports "no fix" — which is the
-        // path the VM itself owns. The paired-endpoint rule it delegates to is covered, with a fix, by
-        // TripPlanFormStateTest.
+        // The fake reports "no fix" — see TripPlanFormStateTest for the with-a-fix cases.
         val location = FakeLocationRepository()
         return TripPlanViewModel(
             geocode,

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripPlanViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripPlanViewModelTest.kt
@@ -116,14 +116,21 @@ class TripPlanViewModelTest {
         geocode: GeocodeRepository = FakeGeocodeRepository(Result.success(emptyList())),
         plan: TripPlanRepository = FakeTripPlanRepository(Result.success(listOf(TripItinerary()))),
         region: RegionRepository = FakeRegionRepository()
-    ) = TripPlanViewModel(
-        geocode,
-        plan,
-        region,
-        SearchCenter(FakeLocationRepository(), region),
-        TimeProvider { 0L },
-        FakeAdvancedSettingsRepository()
-    )
+    ): TripPlanViewModel {
+        // Location isn't constructible in a plain JVM test, so the fake reports "no fix" — which is the
+        // path the VM itself owns. The paired-endpoint rule it delegates to is covered, with a fix, by
+        // TripPlanFormStateTest.
+        val location = FakeLocationRepository()
+        return TripPlanViewModel(
+            geocode,
+            plan,
+            region,
+            SearchCenter(location, region),
+            location,
+            TimeProvider { 0L },
+            FakeAdvancedSettingsRepository()
+        )
+    }
 
     /** Sets both resolved endpoints (which auto-submits a plan once both have coordinates). */
     private fun setBothEndpoints(vm: TripPlanViewModel) {
@@ -275,6 +282,36 @@ class TripPlanViewModelTest {
 
         assertFalse(vm.formState.value.canSubmit)
         assertEquals(0, plan.calls)
+    }
+
+    @Test
+    fun `a long-pressed endpoint with no location fix leaves the other end empty`() = runTest {
+        val plan = FakeTripPlanRepository(Result.success(listOf(TripItinerary())))
+        val vm = viewModel(plan = plan)
+
+        vm.setEndpointFromMap(TripEndpointSlot.TO, TripEndpoint.MapPoint(lat = 47.7, lon = -122.2))
+        advanceUntilIdle()
+
+        val state = vm.formState.value
+        assertEquals(TripEndpoint.MapPoint(lat = 47.7, lon = -122.2), state.to)
+        assertEquals(TripEndpoint.FreeText(), state.from)
+        assertFalse(state.canSubmit)
+        assertEquals(0, plan.calls)
+    }
+
+    @Test
+    fun `a long-pressed endpoint does not disturb an origin the rider already set`() = runTest {
+        val plan = FakeTripPlanRepository(Result.success(listOf(TripItinerary())))
+        val vm = viewModel(plan = plan)
+        vm.setFrom(origin)
+        advanceUntilIdle()
+
+        vm.setEndpointFromMap(TripEndpointSlot.TO, TripEndpoint.MapPoint(lat = 47.7, lon = -122.2))
+        advanceUntilIdle()
+
+        assertEquals(origin, vm.formState.value.from)
+        assertTrue(vm.formState.value.canSubmit)
+        assertEquals(1, plan.calls) // the completed pair plans exactly once
     }
 
     @Test


### PR DESCRIPTION
Fixes #2092.

## The change

Long-pressing the map and choosing **"Directions from here"** / **"Directions to here"** filled one endpoint and dropped the rider on a half-filled form they couldn't submit. Now the trip's *other* end is filled with the device's current location when it's empty — which makes the form submittable, so the one long-press plans the trip and lands on the itinerary.

Strictly a convenience, so it never takes anything away:

- An endpoint carrying anything — a resolved pill, a half-typed query — is left untouched.
- With no fix available (permission denied, or no fix yet) that end simply stays empty, exactly as before. No toast: the form is right there with the empty field, and this is opportunistic, not a requested action.
- The filled end shows the ordinary **"My Location"** pill, so it's visible and one tap to clear.

Both ends land in a single form update, so the pair submits as one plan rather than a discarded one followed by the real one.

The rule tests **what the field holds now**, not whether the rider ever touched it — so an end they cleared with the pill's ✕ is empty again and will be paired. That's deliberate and documented at the rule: the ✕ says "not this place", and a form left half-filled is no more useful for having been edited.

## Shape

The rule is a pure function on `TripPlanFormState` (`withEndpointPaired`). An `android.location.Location` can't be constructed in a plain JVM test, so the decision lives on the coordinate side of that seam and is unit-tested there; `TripPlanViewModel` owns only the fix read (constructor-injected `LocationRepository` — `SearchCenter` won't do, it falls back to the *region centre*, which would label a centroid "my location" and submit a plan from it).

## The endpoint slot becomes a value (commits 2–3)

The feature needed to name "which endpoint", which surfaced that the codebase had been spelling that in identifiers all along. `DirectionsPickTarget` and the form's FROM/TO were the same enum declared twice; folding them into one `TripEndpointSlot` then made a pile of twins collapsible:

| before | after |
|---|---|
| `TripPlanForm` — 10 callbacks (5 from/to pairs), 2 near-identical `AddressField` calls | 5 slot-taking callbacks, renders `TripEndpointSlot.entries` |
| VM — `fromQueries`/`toQueries` + 2 copies of the debounced suggestion pipeline | one map of query flows, one pipeline |
| VM — `onFrom`/`onToQueryChange`, `setFrom`/`setTo`, `clearFrom`/`clearTo` | `onQueryChange(slot, …)`, `setEndpoint(slot, …)`, `clearEndpoint(slot)` |
| `DirectionsFormCard` — 10 hand-wired callbacks; `onPickFrom`/`onPickTo` | 5; `onPickEndpoint(slot)` |
| long-press menu — `onFromHere`/`onToHere` | `onChooseSlot(slot)` |
| From/To label resolved by hand in the form *and* the pick overlay | one `TripEndpointSlot.labelRes` |

`TripPlanFormState` now owns the slot→field mapping in one place, so adding a third endpoint would be exhaustive-`when` errors pointing at every site that must change, rather than silent half-support.

Also moved the current-location read out of the composable: the form's "use my location" button reached through the `LocationEntryPoint` service locator and built its own endpoint. That's `setEndpointToCurrentLocation(slot)` on the VM now, leaving the composable only the part it alone can do — telling "no permission" apart from "no fix yet" for its toast.

No behaviour change in commits 2–3: `setEndpoint`'s suggestion-clearing and `onQueryChange`'s suggestion-keeping are preserved as separate named state transitions rather than folded together.

## Testing

- New `TripPlanFormStateTest` — 8 cases over the pairing rule: both slots, resolved pill and half-typed query left alone, cleared endpoint pairs, no fix leaves it empty, suggestions dropped, `isEmpty` across all five sealed endpoint kinds.
- `TripPlanViewModelTest` — the no-fix path the VM itself owns, and that a completed pair plans exactly once; the rest migrated to the slot API.
- Full JVM unit suite green; `compileObaGoogleDebugKotlin -PwarningsAsErrors=true` and `spotlessCheck` clean.
- **Not yet exercised on device** — the long-press → plan flow wants a real fix, which the JVM tests can't supply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improved Directions**
  - Streamlined origin and destination selection into a consistent flow.
  - Updated the directions form, map-picking overlay, and long-press actions for easier endpoint selection.
  - Improved “use current location” behavior, including handling when a location fix is unavailable.
  - Preserved existing endpoint entries and partially typed searches during automatic pairing.
  - Cleared outdated suggestions when endpoints change.

- **Bug Fixes**
  - Improved route planning and result clearing after endpoint edits.
  - Added more reliable handling for long-press route selection and endpoint pairing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->