### PR TITLE
Compact the directions form into two rows and an action bar (#2094)

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripplan/TripPlanFormRenderTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripplan/TripPlanFormRenderTest.kt
@@ -166,7 +166,7 @@ class TripPlanFormRenderTest {
     fun theActionBarStatesWhenTheTripIsFor() {
         renderForm(plannedState)
 
-        composeRule.onNodeWithTag(WHEN_MODE).assertIsDisplayed()
+        composeRule.onNodeWithTag(TripPlanTestTags.WHEN_MODE).assertIsDisplayed()
         composeRule.onNodeWithText("now").assertIsDisplayed()
     }
 
@@ -183,34 +183,19 @@ class TripPlanFormRenderTest {
     @Test
     fun repeatedlyChoosingYourLocationKeepsTheOriginResolved() {
         var from: TripEndpoint by mutableStateOf(TripEndpoint.FreeText(""))
-        composeRule.setContent {
-            ObaTheme {
-                Box(Modifier.width(cardWidth).testTag(FORM)) {
-                    TripPlanForm(
-                        state = plannedState.copy(from = from),
-                        // Exactly what the ViewModel does with each of these, for the origin slot.
-                        onQueryChange = { slot, text ->
-                            if (slot == TripEndpointSlot.FROM) from = TripEndpoint.FreeText(text)
-                        },
-                        onSelect = { slot, place ->
-                            if (slot == TripEndpointSlot.FROM) from = place
-                        },
-                        onCurrentLocation = { slot ->
-                            if (slot == TripEndpointSlot.FROM) {
-                                from = TripEndpoint.CurrentLocation(lat = 47.6, lon = -122.3)
-                            }
-                        },
-                        onPickOnMap = {},
-                        onSetArriving = {},
-                        onDepartNow = {},
-                        onPickDate = {},
-                        onPickTime = {},
-                        onReverse = {},
-                        onAdvancedSettings = {}
-                    )
+        renderForm(
+            state = { plannedState.copy(from = from) },
+            // Exactly what the ViewModel does with each of these, for the origin slot.
+            onQueryChange = { slot, text ->
+                if (slot == TripEndpointSlot.FROM) from = TripEndpoint.FreeText(text)
+            },
+            onSelect = { slot, place -> if (slot == TripEndpointSlot.FROM) from = place },
+            onCurrentLocation = { slot ->
+                if (slot == TripEndpointSlot.FROM) {
+                    from = TripEndpoint.CurrentLocation(lat = 47.6, lon = -122.3)
                 }
             }
-        }
+        )
 
         repeat(4) { attempt ->
             composeRule.onNodeWithTag(FROM_FIELD).performClick()
@@ -294,18 +279,26 @@ class TripPlanFormRenderTest {
     private fun renderForm(
         state: TripPlanFormState,
         onToQueryChange: (String) -> Unit = {}
+    ) = renderForm(
+        state = { state },
+        onQueryChange = { slot, text -> if (slot == TripEndpointSlot.TO) onToQueryChange(text) }
+    )
+
+    /** [state] is a lambda so a test can back it with its own mutable state and observe writes. */
+    private fun renderForm(
+        state: () -> TripPlanFormState,
+        onQueryChange: (TripEndpointSlot, String) -> Unit = { _, _ -> },
+        onSelect: (TripEndpointSlot, TripEndpoint.Geocoded) -> Unit = { _, _ -> },
+        onCurrentLocation: (TripEndpointSlot) -> Unit = {}
     ) {
-        // Only the destination's query is observed; the rest are inert for these tests.
         composeRule.setContent {
             ObaTheme {
                 Box(Modifier.width(cardWidth).testTag(FORM)) {
                     TripPlanForm(
-                        state = state,
-                        onQueryChange = { slot, text ->
-                            if (slot == TripEndpointSlot.TO) onToQueryChange(text)
-                        },
-                        onSelect = { _, _ -> },
-                        onCurrentLocation = {},
+                        state = state(),
+                        onQueryChange = onQueryChange,
+                        onSelect = onSelect,
+                        onCurrentLocation = onCurrentLocation,
                         onPickOnMap = {},
                         onSetArriving = {},
                         onDepartNow = {},
@@ -328,6 +321,5 @@ class TripPlanFormRenderTest {
         val FROM_PICK_ON_MAP = TripPlanTestTags.FROM_PREFIX + TripPlanTestTags.PICK_ON_MAP_SUFFIX
         val TO_MY_LOCATION = TripPlanTestTags.TO_PREFIX + TripPlanTestTags.MY_LOCATION_SUFFIX
         val TO_PICK_ON_MAP = TripPlanTestTags.TO_PREFIX + TripPlanTestTags.PICK_ON_MAP_SUFFIX
-        val WHEN_MODE = TripPlanTestTags.WHEN_MODE
     }
 }

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripplan/TripPlanFormRenderTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripplan/TripPlanFormRenderTest.kt
@@ -28,12 +28,14 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.captureToImage
 import androidx.compose.ui.test.getUnclippedBoundsInRoot
 import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.height
 import kotlin.math.absoluteValue
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -186,6 +188,41 @@ class TripPlanFormRenderTest {
     }
 
     /**
+     * The action bar's trailing buttons stay put whatever the time segment reads. The segment is the
+     * bar's one flexible slot, so it has to both hold the buttons against the edge when the label is
+     * the single word "now" and cap itself when the label is a full date and time — sharing that
+     * flexibility with a weighted spacer got the first half wrong, leaving the buttons floating short
+     * of the edge, and nothing caught it because both labels rendered without overflowing.
+     */
+    @Test
+    fun theActionBarHoldsItsButtonsInPlaceWhateverTheTimeReads() {
+        var departNow by mutableStateOf(true)
+        renderForm(
+            state = {
+                plannedState.copy(
+                    departNow = departNow,
+                    dateLabel = "Wednesday, 30 September",
+                    timeLabel = "11:45 PM"
+                )
+            }
+        )
+
+        val withNow = composeRule.onNodeWithContentDescription(ADVANCED_SETTINGS)
+            .getUnclippedBoundsInRoot().right
+
+        departNow = false
+        composeRule.waitForIdle()
+        val withPinnedTime = composeRule.onNodeWithContentDescription(ADVANCED_SETTINGS)
+            .getUnclippedBoundsInRoot().right
+
+        assertEquals(
+            "the trailing buttons moved when the time label grew",
+            withNow,
+            withPinnedTime
+        )
+    }
+
+    /**
      * Choosing "Your location" repeatedly has to keep resolving the endpoint. It used to work only on
      * alternate taps: the cycles that started from an already-resolved endpoint left a focused text
      * field to be torn down, and the value change that came out of that teardown was forwarded as a
@@ -334,6 +371,9 @@ class TripPlanFormRenderTest {
 
     private companion object {
         const val FORM = "tripPlanFormRoot"
+
+        /** The advanced-settings button's contentDescription — the bar's last trailing child. */
+        const val ADVANCED_SETTINGS = "Additional Trip Preferences"
         val RAIL_WIDTH_DP = 44.dp
         val FROM_FIELD = TripPlanTestTags.FROM_PREFIX + TripPlanTestTags.FIELD_SUFFIX
         val TO_FIELD = TripPlanTestTags.TO_PREFIX + TripPlanTestTags.FIELD_SUFFIX

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripplan/TripPlanFormRenderTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripplan/TripPlanFormRenderTest.kt
@@ -1,0 +1,333 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.tripplan
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toPixelMap
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.captureToImage
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.height
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.onebusaway.android.ui.compose.createUnconfinedComposeRule
+import org.onebusaway.android.ui.compose.theme.ObaTheme
+
+/**
+ * On-device checks on the compact directions form (#2094). The point of that redesign was a specific
+ * vertical budget — two 48dp endpoint rows over one 40dp action bar, 146dp in total, down from 216dp —
+ * and a height claim is exactly the kind of thing that rots silently as the composable is edited, so
+ * it's asserted here at real density rather than left in a commit message.
+ *
+ * The rest covers what moved rather than what shrank: the endpoint rows carry no permanent trailing
+ * chrome, current-location and pick-on-map appear only once a place is being chosen, and a resolved
+ * endpoint is tap-to-edit without being cleared by the tap.
+ */
+class TripPlanFormRenderTest {
+
+    // See createUnconfinedComposeRule for why Unconfined composition is used here (issue #1792).
+    @get:Rule
+    val composeRule = createUnconfinedComposeRule()
+
+    /** The directions card's content width on a 412dp phone: the screen less its 12dp margins. */
+    private val cardWidth = 388.dp
+
+    private val plannedState = TripPlanFormState(
+        from = TripEndpoint.CurrentLocation(lat = 47.6, lon = -122.3),
+        to = TripEndpoint.Geocoded("Pike Place Market", lat = 47.61, lon = -122.34),
+        departNow = true,
+        dateLabel = "June 10",
+        timeLabel = "3:45 PM"
+    )
+
+    @Test
+    fun theRestingFormFitsItsVerticalBudget() {
+        renderForm(plannedState)
+
+        val height = composeRule.onNodeWithTag(FORM).getUnclippedBoundsInRoot().height
+
+        // 4dp padding × 2 + 48 + 1 + 48 + 1 + 40. Rounding across densities moves this by a fraction of
+        // a dp, so allow a little slack — the check is "still compact", not "pixel-identical".
+        assertTrue(
+            "expected the resting form to measure about 146dp, but it was $height",
+            height > 142.dp && height < 150.dp
+        )
+    }
+
+    @Test
+    fun aResolvedEndpointShowsItsPlaceWithNoTrailingChrome() {
+        renderForm(plannedState)
+
+        composeRule.onNodeWithText("Pike Place Market").assertIsDisplayed()
+        // The four per-field icon buttons the redesign retired. Their content descriptions are the only
+        // thing that ever identified them, so their absence is what there is to assert.
+        val pickOnMapButtons = composeRule
+            .onAllNodesWithContentDescription("Pick location on map")
+            .fetchSemanticsNodes()
+            .size
+        assertTrue(
+            "pick-on-map should not be permanent field chrome, found $pickOnMapButtons",
+            pickOnMapButtons == 0
+        )
+    }
+
+    @Test
+    fun choosingAPlaceOffersLocationAndMapBeforeTheSuggestions() {
+        renderForm(
+            plannedState.copy(
+                from = TripEndpoint.FreeText(""),
+                fromSuggestions = listOf(
+                    TripEndpoint.Geocoded("Pike St & 3rd Ave", 47.61, -122.33, isTransit = true),
+                    TripEndpoint.Geocoded("Pike Brewing Company", 47.60, -122.34)
+                )
+            )
+        )
+
+        // Focusing is enough to raise the list — no typing, which keeps the IME (and its timing) out
+        // of a test that is about ordering.
+        composeRule.onNodeWithTag(FROM_FIELD).performClick()
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithTag(FROM_MY_LOCATION).assertIsDisplayed()
+        composeRule.onNodeWithTag(FROM_PICK_ON_MAP).assertIsDisplayed()
+        composeRule.onNodeWithText("Pike Brewing Company").assertIsDisplayed()
+    }
+
+    /**
+     * Tapping a resolved endpoint opens it for editing but must not clear it: clearing would make the
+     * form unsubmittable and drop the planned route off the map, so a stray tap would discard a plan.
+     */
+    @Test
+    fun tappingAResolvedEndpointDoesNotClearIt() {
+        var cleared = false
+        renderForm(plannedState, onToQueryChange = { cleared = true })
+
+        composeRule.onNodeWithTag(TO_FIELD).performClick()
+        composeRule.waitForIdle()
+
+        assertTrue("tapping to edit must not rewrite the endpoint", !cleared)
+    }
+
+    /**
+     * Tapping a resolved endpoint has to *stay* in edit mode. The field attaches unfocused, so a naive
+     * "leave edit mode when focus is lost" fires once on attach and collapses the row again — the
+     * dropdown flashes open and shuts, and the endpoint can't be edited at all.
+     */
+    @Test
+    fun tappingAResolvedEndpointStaysOpenForEditing() {
+        renderForm(plannedState)
+
+        composeRule.onNodeWithTag(TO_FIELD).performClick()
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithTag(TO_MY_LOCATION).assertIsDisplayed()
+        composeRule.onNodeWithTag(TO_PICK_ON_MAP).assertIsDisplayed()
+    }
+
+    /** The same flash-and-close, from the other direction: focusing an empty field must offer them too. */
+    @Test
+    fun focusingAnEmptyEndpointOffersTheActionsWithoutTyping() {
+        renderForm(plannedState.copy(from = TripEndpoint.FreeText("")))
+
+        composeRule.onNodeWithTag(FROM_FIELD).performClick()
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithTag(FROM_MY_LOCATION).assertIsDisplayed()
+        composeRule.onNodeWithTag(FROM_PICK_ON_MAP).assertIsDisplayed()
+    }
+
+    @Test
+    fun theActionBarStatesWhenTheTripIsFor() {
+        renderForm(plannedState)
+
+        composeRule.onNodeWithTag(WHEN_MODE).assertIsDisplayed()
+        composeRule.onNodeWithText("now").assertIsDisplayed()
+    }
+
+    /**
+     * Choosing "Your location" repeatedly has to keep resolving the endpoint. It used to work only on
+     * alternate taps: the cycles that started from an already-resolved endpoint left a focused text
+     * field to be torn down, and the value change that came out of that teardown was forwarded as a
+     * *query* — turning the resolved endpoint back into coordinate-less free text and dropping the
+     * planned route off the map.
+     *
+     * Driven through a state holder that mirrors TripPlanViewModel's two writes, since the bug is in
+     * the round trip between them rather than in either one.
+     */
+    @Test
+    fun repeatedlyChoosingYourLocationKeepsTheOriginResolved() {
+        var from: TripEndpoint by mutableStateOf(TripEndpoint.FreeText(""))
+        composeRule.setContent {
+            ObaTheme {
+                Box(Modifier.width(cardWidth).testTag(FORM)) {
+                    TripPlanForm(
+                        state = plannedState.copy(from = from),
+                        // Exactly what the ViewModel does with each of these, for the origin slot.
+                        onQueryChange = { slot, text ->
+                            if (slot == TripEndpointSlot.FROM) from = TripEndpoint.FreeText(text)
+                        },
+                        onSelect = { slot, place ->
+                            if (slot == TripEndpointSlot.FROM) from = place
+                        },
+                        onCurrentLocation = { slot ->
+                            if (slot == TripEndpointSlot.FROM) {
+                                from = TripEndpoint.CurrentLocation(lat = 47.6, lon = -122.3)
+                            }
+                        },
+                        onPickOnMap = {},
+                        onSetArriving = {},
+                        onDepartNow = {},
+                        onPickDate = {},
+                        onPickTime = {},
+                        onReverse = {},
+                        onAdvancedSettings = {}
+                    )
+                }
+            }
+        }
+
+        repeat(4) { attempt ->
+            composeRule.onNodeWithTag(FROM_FIELD).performClick()
+            composeRule.waitForIdle()
+            composeRule.onNodeWithTag(FROM_MY_LOCATION).performClick()
+            composeRule.waitForIdle()
+
+            assertTrue(
+                "after ${attempt + 1} selection(s) the origin should still resolve, but it was $from",
+                from.hasCoordinates
+            )
+        }
+    }
+
+    /**
+     * The rail's colour rule, one render per case (the test rule allows a single setContent).
+     * Asserted as channel dominance rather than exact hex, so it holds in both themes and survives a
+     * palette tweak.
+     */
+    @Test
+    fun aChosenOriginAndDestinationReadGreenThenRed() {
+        renderForm(
+            plannedState.copy(
+                from = TripEndpoint.Geocoded("Space Needle", lat = 47.62, lon = -122.34),
+                to = TripEndpoint.Geocoded("Pike Place Market", lat = 47.61, lon = -122.34)
+            )
+        )
+
+        assertDominant(railDot(row = 0), Channel.GREEN, "a chosen origin")
+        assertDominant(railDot(row = 1), Channel.RED, "a chosen destination")
+    }
+
+    @Test
+    fun anOriginAtTheDevicePositionReadsBlue() {
+        renderForm(
+            plannedState.copy(
+                from = TripEndpoint.CurrentLocation(lat = 47.6, lon = -122.3),
+                to = TripEndpoint.Geocoded("Pike Place Market", lat = 47.61, lon = -122.34)
+            )
+        )
+
+        assertDominant(railDot(row = 0), Channel.BLUE, "an origin at the device's position")
+    }
+
+    /** Blue is about *which* place it is, not which end of the trip it sits at. */
+    @Test
+    fun aDestinationAtTheDevicePositionReadsBlue() {
+        renderForm(
+            plannedState.copy(
+                from = TripEndpoint.Geocoded("Space Needle", lat = 47.62, lon = -122.34),
+                to = TripEndpoint.CurrentLocation(lat = 47.6, lon = -122.3)
+            )
+        )
+
+        assertDominant(railDot(row = 1), Channel.BLUE, "a destination at the device's position")
+    }
+
+    private enum class Channel { RED, GREEN, BLUE }
+
+    private fun assertDominant(color: Color, channel: Channel, what: String) {
+        val (dominant, others) = when (channel) {
+            Channel.RED -> color.red to listOf(color.green, color.blue)
+            Channel.GREEN -> color.green to listOf(color.red, color.blue)
+            Channel.BLUE -> color.blue to listOf(color.red, color.green)
+        }
+        assertTrue(
+            "$what should read $channel, but its dot was $color",
+            others.all { dominant > it + 0.05f }
+        )
+    }
+
+    /** Samples the centre of a row's rail dot. Mirrors the form's own 4dp pad / 48dp row / 1dp rule. */
+    private fun railDot(row: Int): Color {
+        val pixels = composeRule.onNodeWithTag(FORM).captureToImage().toPixelMap()
+        val d = composeRule.density
+        val x = with(d) { (RAIL_WIDTH_DP / 2).roundToPx() }
+        val y = with(d) { (4.dp + 24.dp + 49.dp * row).roundToPx() }
+        return pixels[x, y]
+    }
+
+    private fun renderForm(
+        state: TripPlanFormState,
+        onToQueryChange: (String) -> Unit = {}
+    ) {
+        // Only the destination's query is observed; the rest are inert for these tests.
+        composeRule.setContent {
+            ObaTheme {
+                Box(Modifier.width(cardWidth).testTag(FORM)) {
+                    TripPlanForm(
+                        state = state,
+                        onQueryChange = { slot, text ->
+                            if (slot == TripEndpointSlot.TO) onToQueryChange(text)
+                        },
+                        onSelect = { _, _ -> },
+                        onCurrentLocation = {},
+                        onPickOnMap = {},
+                        onSetArriving = {},
+                        onDepartNow = {},
+                        onPickDate = {},
+                        onPickTime = {},
+                        onReverse = {},
+                        onAdvancedSettings = {}
+                    )
+                }
+            }
+        }
+    }
+
+    private companion object {
+        const val FORM = "tripPlanFormRoot"
+        val RAIL_WIDTH_DP = 44.dp
+        val FROM_FIELD = TripPlanTestTags.FROM_PREFIX + TripPlanTestTags.FIELD_SUFFIX
+        val TO_FIELD = TripPlanTestTags.TO_PREFIX + TripPlanTestTags.FIELD_SUFFIX
+        val FROM_MY_LOCATION = TripPlanTestTags.FROM_PREFIX + TripPlanTestTags.MY_LOCATION_SUFFIX
+        val FROM_PICK_ON_MAP = TripPlanTestTags.FROM_PREFIX + TripPlanTestTags.PICK_ON_MAP_SUFFIX
+        val TO_MY_LOCATION = TripPlanTestTags.TO_PREFIX + TripPlanTestTags.MY_LOCATION_SUFFIX
+        val TO_PICK_ON_MAP = TripPlanTestTags.TO_PREFIX + TripPlanTestTags.PICK_ON_MAP_SUFFIX
+        val WHEN_MODE = TripPlanTestTags.WHEN_MODE
+    }
+}

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripplan/TripPlanFormRenderTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripplan/TripPlanFormRenderTest.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.height
+import kotlin.math.absoluteValue
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -72,11 +73,13 @@ class TripPlanFormRenderTest {
 
         val height = composeRule.onNodeWithTag(FORM).getUnclippedBoundsInRoot().height
 
-        // 4dp padding × 2 + 48 + 1 + 48 + 1 + 40. Rounding across densities moves this by a fraction of
-        // a dp, so allow a little slack — the check is "still compact", not "pixel-identical".
+        // 4 + 48 + 1 + 48 + 1 + 40 + 4. Each of those seven bands is rounded to whole pixels
+        // independently, so the total can drift by up to seven half-pixels — expressed in dp, since
+        // that is what drifts. Nothing wider: this test exists to hold the budget, not to wave at it.
+        val allowance = with(composeRule.density) { (7 * 0.5f).toDp() }
         assertTrue(
-            "expected the resting form to measure about 146dp, but it was $height",
-            height > 142.dp && height < 150.dp
+            "expected the resting form to measure 146dp (±$allowance), but it was $height",
+            (height - 146.dp).value.absoluteValue <= allowance.value
         )
     }
 
@@ -117,6 +120,18 @@ class TripPlanFormRenderTest {
         composeRule.onNodeWithTag(FROM_MY_LOCATION).assertIsDisplayed()
         composeRule.onNodeWithTag(FROM_PICK_ON_MAP).assertIsDisplayed()
         composeRule.onNodeWithText("Pike Brewing Company").assertIsDisplayed()
+
+        // Ordering is the point — the actions are pinned to the *head* of the list. Visibility alone
+        // would pass with them sitting below the geocoder's results.
+        val firstSuggestionTop = composeRule.onNodeWithText("Pike St & 3rd Ave")
+            .getUnclippedBoundsInRoot().top
+        listOf(FROM_MY_LOCATION, FROM_PICK_ON_MAP).forEach { tag ->
+            val actionTop = composeRule.onNodeWithTag(tag).getUnclippedBoundsInRoot().top
+            assertTrue(
+                "$tag should precede the suggestions, but sat at $actionTop vs $firstSuggestionTop",
+                actionTop < firstSuggestionTop
+            )
+        }
     }
 
     /**
@@ -255,6 +270,11 @@ class TripPlanFormRenderTest {
 
     private enum class Channel { RED, GREEN, BLUE }
 
+    /**
+     * Dominance rather than an exact hex, so the rule survives a palette tweak and holds in both
+     * themes — but strictly, with no tolerance to tune: the sample is the centre of a 12dp filled
+     * circle, so it is the fill colour itself, not an antialiased edge.
+     */
     private fun assertDominant(color: Color, channel: Channel, what: String) {
         val (dominant, others) = when (channel) {
             Channel.RED -> color.red to listOf(color.green, color.blue)
@@ -263,7 +283,7 @@ class TripPlanFormRenderTest {
         }
         assertTrue(
             "$what should read $channel, but its dot was $color",
-            others.all { dominant > it + 0.05f }
+            others.all { dominant > it }
         )
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapHost.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapHost.kt
@@ -213,6 +213,9 @@ class MapHost(
 
     fun setDirectionsBottomInset(px: Int) = renderState.setDirectionsBottomInset(px)
 
+    /** See [MapRenderState.setCenterPickActive]: no padding while the centre crosshair is being aimed. */
+    fun setCenterPickActive(active: Boolean) = renderState.setCenterPickActive(active)
+
     // Pending re-fit of a padding-sensitive frame (route / itinerary) as the map's obstruction insets —
     // the top chrome/focus banner/directions form, the bottom arrivals/directions sheet — are measured
     // and land *after* the frame first fit (see [frameRoute]/[frameItinerary]). Cancelled the moment any

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
@@ -260,6 +260,15 @@ class MapViewModel @Inject constructor(
     /** The actual palette used for routes around the focused stop. */
     val focusedRouteColors: StateFlow<Map<RouteDirectionKey, Int>> get() = routeController.focusedRouteColors
 
+    /**
+     * Suspend map content padding while the rider aims the centre crosshair at a From/To point. The
+     * captured point is the camera target, which padding would move off the crosshair — see
+     * [org.onebusaway.android.map.render.MapRenderState.setCenterPickActive].
+     */
+    fun setCenterPickActive(active: Boolean) {
+        mapHost.setCenterPickActive(active)
+    }
+
     /** Apply the active focus banner's bottom edge in map coordinates; zero clears it. */
     fun setFocusBannerBottomEdge(bottomPx: Int) {
         mapHost.setFocusBannerBottomEdge(if (bottomPx > 0) bottomPx + focusBannerMarkerPaddingPx else 0)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
@@ -402,7 +402,9 @@ class MapRenderState {
     private var topChromeInsetPx = 0
     private var focusBannerBottomEdgePx = 0
 
-    private fun applyTopPadding() = _padding.update { it.copy(topPx = maxOf(topChromeInsetPx, focusBannerBottomEdgePx)) }
+    private fun applyTopPadding() = _padding.update {
+        it.copy(topPx = if (centerPickActive) 0 else maxOf(topChromeInsetPx, focusBannerBottomEdgePx))
+    }
 
     /** The floating top-chrome inset (status bar + FAB-row clearance); keeps the compass below the FABs. */
     fun setTopChromeInset(px: Int) {
@@ -423,7 +425,26 @@ class MapRenderState {
     private var arrivalsBottomInsetPx = 0
     private var directionsBottomInsetPx = 0
 
-    private fun applyBottomPadding() = _padding.update { it.copy(bottomPx = maxOf(arrivalsBottomInsetPx, directionsBottomInsetPx)) }
+    private fun applyBottomPadding() = _padding.update {
+        it.copy(bottomPx = if (centerPickActive) 0 else maxOf(arrivalsBottomInsetPx, directionsBottomInsetPx))
+    }
+
+    // Padding moves the camera *target* to the middle of the padded region. That is what every other
+    // caller wants — a framed route should sit in the visible band, not under the chrome — but it is
+    // exactly wrong while the rider is aiming the centre crosshair, because the point captured on
+    // confirm IS the camera target. With a top inset the captured point lands below the crosshair by
+    // half the inset; with a bottom inset, above it. So a pick suspends padding outright rather than
+    // zeroing contributors one at a time: there are four independent writers here, and any of them
+    // left standing would reintroduce the offset.
+    private var centerPickActive = false
+
+    /** Suspends all content padding, so the camera target is the crosshair the rider is aiming. */
+    fun setCenterPickActive(active: Boolean) {
+        if (centerPickActive == active) return
+        centerPickActive = active
+        applyTopPadding()
+        applyBottomPadding()
+    }
 
     /** The arrivals sheet's bottom inset (keeps the focused stop above the sheet). */
     fun setBottomPadding(px: Int) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -247,6 +247,9 @@ fun HomeScreen(
                 // The directions trip-plan form card's absolute bottom edge (window px), so the map's top inset
                 // covers the form/FAB during directions (the itinerary-step focus centers in the band below it).
                 var directionsFormBottomPx by remember { mutableIntStateOf(0) }
+                // Which endpoint (if any) is being picked directly on the map (crosshair + confirm). Lives
+                // up here because the map's padding depends on it, just below.
+                var pickTarget by rememberSaveable { mutableStateOf<TripEndpointSlot?>(null) }
                 val focusTopEdgePx = focusBannerTopEdge(
                     currentFocus,
                     focusBannerBottomPx,
@@ -254,6 +257,11 @@ fun HomeScreen(
                 )
                 LaunchedEffect(focusTopEdgePx) {
                     mapViewModel.setFocusBannerBottomEdge(focusTopEdgePx)
+                }
+                // Aiming the centre crosshair suspends map padding entirely: the point a pick captures is
+                // the camera target, and padding moves that off the crosshair the rider is aiming.
+                LaunchedEffect(pickTarget) {
+                    mapViewModel.setCenterPickActive(pickTarget != null)
                 }
                 val snackbarHostState = remember { SnackbarHostState() }
                 // The unified recent stops+routes list for the search field's dropdown. Hosted here (like the
@@ -583,8 +591,6 @@ fun HomeScreen(
                             // surfaces a message.
                             val directionsError = (tripPlanResult as? PlanResult.Error)?.error
                             val directionsLoading = tripPlanResult is PlanResult.Loading
-                            // Which endpoint (if any) is being picked directly on the map (crosshair + confirm).
-                            var pickTarget by rememberSaveable { mutableStateOf<TripEndpointSlot?>(null) }
                             // A long-pressed map point awaiting the "directions from/to here" choice.
                             var longPressPoint by remember { mutableStateOf<GeoPoint?>(null) }
                             // Leaving directions ends any in-progress map pick.
@@ -708,7 +714,11 @@ fun HomeScreen(
                                                 modifier = Modifier
                                                     .align(Alignment.TopCenter)
                                                     .statusBarsPadding()
-                                                    .padding(horizontal = 8.dp, vertical = 8.dp)
+                                                    // Wider at the sides than at the top: the card
+                                                    // floats over the map, and letting a little more
+                                                    // of it show past either edge reads as floating
+                                                    // rather than as chrome bolted to the screen.
+                                                    .padding(horizontal = 12.dp, vertical = 8.dp)
                                                     // Report the card's bottom edge as the map's top inset (see
                                                     // directionsFormBottomPx) so a focused step clears the form.
                                                     .onGloballyPositioned {
@@ -780,7 +790,6 @@ fun HomeScreen(
                                 // Pick a From/To point on the home map: crosshair + confirm reads the map center.
                                 pickTarget?.let { target ->
                                     DirectionsPickOverlay(
-                                        target = target,
                                         onConfirm = {
                                             // Only commit + dismiss once we actually have a map center; otherwise
                                             // keep the picker open rather than silently losing the selection.
@@ -789,8 +798,7 @@ fun HomeScreen(
                                                 tripPlanViewModel.setEndpoint(target, point)
                                                 pickTarget = null
                                             }
-                                        },
-                                        onCancel = { pickTarget = null }
+                                        }
                                     )
                                 }
                                 // Long-press → "directions from/to here": enters directions and fills the

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
@@ -120,7 +120,6 @@ import org.onebusaway.android.ui.tripplan.TripPlanParams
 import org.onebusaway.android.ui.tripplan.TripPlanViewModel
 import org.onebusaway.android.ui.tripplan.VehicleMode
 import org.onebusaway.android.ui.tripplan.WalkPreference
-import org.onebusaway.android.ui.tripplan.labelRes
 import org.onebusaway.android.ui.tripresults.FocusedLeg
 import org.onebusaway.android.ui.tripresults.RouteLegRef
 import org.onebusaway.android.ui.tripresults.RouteStopRef
@@ -175,10 +174,10 @@ fun DirectionsFormCard(
                 state = state,
                 onQueryChange = viewModel::onQueryChange,
                 onSelect = viewModel::setEndpoint,
-                onClear = viewModel::clearEndpoint,
                 onCurrentLocation = { slot -> setCurrentLocation(context, viewModel, slot) },
                 onPickOnMap = onPickEndpoint,
                 onSetArriving = viewModel::setArriving,
+                onDepartNow = viewModel::setDepartNow,
                 onPickDate = { pickTripDate(activity, viewModel) },
                 onPickTime = { pickTripTime(activity, viewModel) },
                 onReverse = viewModel::reverseTrip,
@@ -535,36 +534,16 @@ fun DirectionsErrorSnackbar(
 }
 
 /**
- * Pick a From/To point directly on the home map: a fixed center crosshair the map pans under, a top
- * hint for which endpoint is being set, and a bottom confirm. [onConfirm] captures the map's current
- * center; the caller resolves it to a [org.onebusaway.android.ui.tripplan.TripEndpoint.MapPoint].
+ * Pick a From/To point directly on the home map: a fixed center crosshair the map pans under, and a
+ * bottom confirm. [onConfirm] captures the map's current center; the caller resolves it to a
+ * [org.onebusaway.android.ui.tripplan.TripEndpoint.MapPoint].
+ *
+ * Nothing is drawn at the top. A labelled From/To card used to sit there carrying a ✕, but the map is
+ * the thing being read during a pick and the card only covered it; back cancels, as it does everywhere
+ * else in directions.
  */
 @Composable
-fun BoxScope.DirectionsPickOverlay(
-    target: TripEndpointSlot,
-    onConfirm: () -> Unit,
-    onCancel: () -> Unit
-) {
-    Surface(
-        modifier = Modifier.align(Alignment.TopCenter).statusBarsPadding().padding(8.dp),
-        shape = RoundedCornerShape(12.dp),
-        color = MaterialTheme.colorScheme.surface,
-        tonalElevation = 3.dp,
-        shadowElevation = 3.dp
-    ) {
-        Row(
-            modifier = Modifier.padding(start = 16.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Text(
-                text = stringResource(target.labelRes),
-                style = MaterialTheme.typography.titleMedium
-            )
-            IconButton(onClick = onCancel) {
-                Icon(AppIcons.Close, contentDescription = stringResource(R.string.close))
-            }
-        }
-    }
+fun BoxScope.DirectionsPickOverlay(onConfirm: () -> Unit) {
     // Fixed, non-interactive center crosshair: the map pans under it and its center is the chosen point.
     Icon(
         painter = painterResource(R.drawable.ic_my_location),

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
@@ -31,7 +31,6 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
@@ -38,6 +38,7 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBars
@@ -64,7 +65,9 @@ import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalResources
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Dp
@@ -136,6 +139,11 @@ fun MapFeature(
     val resources = LocalResources.current
     // Keep the remembered ObaMapCallbacks calling HomeScreen's latest long-press handler.
     val currentOnMapLongPress by rememberUpdatedState(onMapLongPress)
+    // Whether the soft keyboard is up, read through rememberUpdatedState for the same reason: the
+    // callbacks object below is remembered and would otherwise capture the value at first composition.
+    val imeVisible by rememberUpdatedState(WindowInsets.ime.getBottom(LocalDensity.current) > 0)
+    val focusManager = LocalFocusManager.current
+    val keyboard = LocalSoftwareKeyboardController.current
 
     // Compose-native permission launcher: deliver the result to the map view model (blue dot) + the
     // home view model (the deferred first-launch region check).
@@ -170,6 +178,18 @@ fun MapFeature(
             }
 
             override fun onMapClick(point: GeoPoint?) {
+                // A tap made while the keyboard is up is aimed at the keyboard: half the map is behind
+                // it, and the rider is reaching for the part they can see again. So that tap does only
+                // that. Without this it also unfocused the map a level, which from the directions form
+                // — an editor being typed into, with nothing focused beneath it — meant one stray tap
+                // left directions altogether and discarded the trip being entered.
+                if (imeVisible) {
+                    // Clearing focus is what closes the editor and its suggestion list; hide() covers
+                    // a keyboard raised by something that isn't a focused Compose field.
+                    focusManager.clearFocus()
+                    keyboard?.hide()
+                    return
+                }
                 homeViewModel.unfocusMapOneLevel()
             }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
@@ -52,6 +52,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -139,9 +140,16 @@ fun MapFeature(
     val resources = LocalResources.current
     // Keep the remembered ObaMapCallbacks calling HomeScreen's latest long-press handler.
     val currentOnMapLongPress by rememberUpdatedState(onMapLongPress)
-    // Whether the soft keyboard is up, read through rememberUpdatedState for the same reason: the
-    // callbacks object below is remembered and would otherwise capture the value at first composition.
-    val imeVisible by rememberUpdatedState(WindowInsets.ime.getBottom(LocalDensity.current) > 0)
+    // Whether the soft keyboard is up. Read through derivedStateOf rather than in composition: the
+    // inset updates on every frame of the keyboard animation, and reading it here directly would
+    // re-run this whole composable each time for a boolean that flips twice. Same reasoning as the
+    // snapshotFlow the chrome insets below go through. Only ever read from onMapClick, outside any
+    // snapshot observer, so nothing subscribes to it.
+    val imeInsets = WindowInsets.ime
+    val imeDensity = LocalDensity.current
+    val imeVisible by remember(imeInsets, imeDensity) {
+        derivedStateOf { imeInsets.getBottom(imeDensity) > 0 }
+    }
     val focusManager = LocalFocusManager.current
     val keyboard = LocalSoftwareKeyboardController.current
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanForm.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanForm.kt
@@ -16,7 +16,6 @@
 package org.onebusaway.android.ui.tripplan
 
 import androidx.annotation.StringRes
-import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -51,6 +50,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
@@ -73,23 +73,6 @@ import androidx.compose.ui.unit.dp
 import org.onebusaway.android.R
 import org.onebusaway.android.ui.compose.theme.ObaTheme
 import org.onebusaway.android.ui.icons.AppIcons
-
-/**
- * The trip-plan form: two endpoint rows over a single action bar (#2094).
- *
- * The layout is deliberately close to what a rider already knows from other mapping apps — a leading
- * rail whose glyph says what each endpoint *is*, two borderless fields separated by a hairline, and no
- * per-field chrome. What differs is the bottom band: transit is scheduled travel, so the form always
- * states when the trip is for, as a "Depart · now" callout whose two halves open separate pickers.
- *
- * That band doubles as the form's action bar, carrying reverse and additional-preferences as well. It's
- * the reason the endpoint rows can run full width: everything acting on the *whole trip* lives on one
- * line, and only what acts on a single endpoint lives in that endpoint's row (which, currently, is
- * nothing — see [EndpointRow]). The card measures 146dp against the old layout's 216dp.
- *
- * Stateless and driven by [TripPlanFormState]; the date/time/current-location actions are platform
- * interactions launched by the host.
- */
 
 /** Height of one endpoint row. Android's minimum touch target — the rows are tap-to-edit. */
 private val ENDPOINT_ROW_HEIGHT = 48.dp
@@ -155,6 +138,22 @@ val TripEndpointSlot.tagPrefix: String
         TripEndpointSlot.TO -> TripPlanTestTags.TO_PREFIX
     }
 
+/**
+ * The trip-plan form: two endpoint rows over a single action bar (#2094).
+ *
+ * The layout is deliberately close to what a rider already knows from other mapping apps — a leading
+ * rail whose glyph says what each endpoint *is*, two borderless fields separated by a hairline, and no
+ * per-field chrome. What differs is the bottom band: transit is scheduled travel, so the form always
+ * states when the trip is for, as a "Depart · now" callout whose two halves open separate pickers.
+ *
+ * That band doubles as the form's action bar, carrying reverse and additional-preferences as well. It's
+ * the reason the endpoint rows can run full width: everything acting on the *whole trip* lives on one
+ * line, and only what acts on a single endpoint lives in that endpoint's row (which, currently, is
+ * nothing — see [EndpointRow]). The card measures 146dp against the old layout's 216dp.
+ *
+ * Stateless and driven by [TripPlanFormState]; the date/time/current-location actions are platform
+ * interactions launched by the host.
+ */
 @Composable
 fun TripPlanForm(
     state: TripPlanFormState,
@@ -180,10 +179,8 @@ fun TripPlanForm(
                 HairlineDivider(startIndent = RAIL_WIDTH, endIndent = 12.dp)
             }
             EndpointRow(
+                slot = slot,
                 endpoint = state.endpointAt(slot),
-                placeholder = stringResource(slot.placeholderRes),
-                tagPrefix = slot.tagPrefix,
-                isOrigin = slot == TripEndpointSlot.FROM,
                 suggestions = state.suggestionsAt(slot),
                 onQueryChange = { onQueryChange(slot, it) },
                 onSelect = { onSelect(slot, it) },
@@ -195,7 +192,10 @@ fun TripPlanForm(
         // than separating two members of the same group.
         HairlineDivider()
         TripActionBar(
-            state = state,
+            arriving = state.arriving,
+            departNow = state.departNow,
+            dateLabel = state.dateLabel,
+            timeLabel = state.timeLabel,
             onSetArriving = onSetArriving,
             onDepartNow = onDepartNow,
             onPickDate = onPickDate,
@@ -209,10 +209,7 @@ fun TripPlanForm(
 /** A 1dp rule at the outline colour, optionally inset at either end. */
 @Composable
 private fun HairlineDivider(startIndent: Dp = 0.dp, endIndent: Dp = 0.dp) {
-    HorizontalDivider(
-        modifier = Modifier.padding(start = startIndent, end = endIndent),
-        color = MaterialTheme.colorScheme.outlineVariant
-    )
+    HorizontalDivider(Modifier.padding(start = startIndent, end = endIndent))
 }
 
 /**
@@ -234,16 +231,16 @@ private fun HairlineDivider(startIndent: Dp = 0.dp, endIndent: Dp = 0.dp) {
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun EndpointRow(
+    slot: TripEndpointSlot,
     endpoint: TripEndpoint,
-    placeholder: String,
-    tagPrefix: String,
-    isOrigin: Boolean,
     suggestions: List<TripEndpoint.Geocoded>,
     onQueryChange: (String) -> Unit,
     onSelect: (TripEndpoint.Geocoded) -> Unit,
     onCurrentLocation: () -> Unit,
     onPickOnMap: () -> Unit
 ) {
+    val tagPrefix = slot.tagPrefix
+    val isOrigin = slot == TripEndpointSlot.FROM
     // The endpoint as the field should read it. A resolved endpoint is not a different *kind* of row
     // — it is the same field showing a name — so nothing is swapped in or out as it resolves.
     val endpointText = endpointLabel(endpoint)
@@ -317,7 +314,7 @@ private fun EndpointRow(
                     .testTag(tagPrefix + TripPlanTestTags.FIELD_SUFFIX),
                 decorationBox = { innerField ->
                     Box(contentAlignment = Alignment.CenterStart) {
-                        if (field.text.isEmpty()) PlaceholderText(placeholder)
+                        if (field.text.isEmpty()) PlaceholderText(stringResource(slot.placeholderRes))
                         innerField()
                     }
                 }
@@ -382,7 +379,7 @@ private fun endpointColor(endpoint: TripEndpoint, isOrigin: Boolean): Color = wh
     endpoint is TripEndpoint.CurrentLocation ->
         colorResource(R.color.trip_plan_endpoint_current_location)
     isOrigin -> MaterialTheme.colorScheme.primary
-    else -> colorResource(R.color.trip_plan_endpoint_destination)
+    else -> colorResource(R.color.trip_destination_marker)
 }
 
 /**
@@ -401,23 +398,29 @@ private fun EndpointRail(endpoint: TripEndpoint, isOrigin: Boolean) {
         // it shares with the other row. The two halves meet because the divider above is inset past the
         // rail, so nothing crosses the gap. This is what makes origin and destination read as two ends
         // of one trip rather than two unrelated fields.
-        Canvas(Modifier.matchParentSize()) {
-            val gap = CONNECTOR_GLYPH_CLEARANCE.toPx()
-            val midY = size.height / 2
-            val start = if (isOrigin) midY + gap else 0f
-            val end = if (isOrigin) size.height else midY - gap
-            if (end <= start) return@Canvas
-            drawLine(
-                color = connectorColor,
-                start = Offset(size.width / 2, start),
-                end = Offset(size.width / 2, end),
-                strokeWidth = 2.dp.toPx(),
-                cap = StrokeCap.Round,
-                pathEffect = PathEffect.dashPathEffect(
-                    floatArrayOf(2.dp.toPx(), 4.dp.toPx())
-                )
-            )
-        }
+        Box(
+            Modifier.matchParentSize().drawWithCache {
+                // Built once per size/density rather than per draw: a dash effect allocates a native
+                // DashPathEffect, and this rail repaints with the whole card — on every keystroke and
+                // every blink of the text cursor — for a line that never changes.
+                val dashes = PathEffect.dashPathEffect(floatArrayOf(2.dp.toPx(), 4.dp.toPx()))
+                val gap = CONNECTOR_GLYPH_CLEARANCE.toPx()
+                val midY = size.height / 2
+                val start = if (isOrigin) midY + gap else 0f
+                val end = if (isOrigin) size.height else midY - gap
+                onDrawBehind {
+                    if (end <= start) return@onDrawBehind
+                    drawLine(
+                        color = connectorColor,
+                        start = Offset(size.width / 2, start),
+                        end = Offset(size.width / 2, end),
+                        strokeWidth = 2.dp.toPx(),
+                        cap = StrokeCap.Round,
+                        pathEffect = dashes
+                    )
+                }
+            }
+        )
         if (endpoint.isTransit) {
             BusIcon()
         } else {
@@ -474,7 +477,10 @@ private fun PinnedActionIcon(painter: Painter) {
  */
 @Composable
 private fun TripActionBar(
-    state: TripPlanFormState,
+    arriving: Boolean,
+    departNow: Boolean,
+    dateLabel: String,
+    timeLabel: String,
     onSetArriving: (Boolean) -> Unit,
     onDepartNow: () -> Unit,
     onPickDate: () -> Unit,
@@ -497,14 +503,16 @@ private fun TripActionBar(
                 modifier = Modifier.size(18.dp)
             )
         }
-        WhenModeSegment(arriving = state.arriving, onSetArriving = onSetArriving)
+        WhenModeSegment(arriving = arriving, onSetArriving = onSetArriving)
         Text(
             text = "·",
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant
         )
         WhenTimeSegment(
-            state = state,
+            departNow = departNow,
+            dateLabel = dateLabel,
+            timeLabel = timeLabel,
             onDepartNow = onDepartNow,
             onPickDate = onPickDate,
             onPickTime = onPickTime
@@ -561,7 +569,9 @@ private fun WhenModeSegment(arriving: Boolean, onSetArriving: (Boolean) -> Unit)
  */
 @Composable
 private fun WhenTimeSegment(
-    state: TripPlanFormState,
+    departNow: Boolean,
+    dateLabel: String,
+    timeLabel: String,
     onDepartNow: () -> Unit,
     onPickDate: () -> Unit,
     onPickTime: () -> Unit
@@ -570,7 +580,7 @@ private fun WhenTimeSegment(
     val nowLabel = stringResource(R.string.trip_plan_now)
     Box {
         SegmentButton(
-            text = if (state.departNow) nowLabel else "${state.dateLabel}, ${state.timeLabel}",
+            text = if (departNow) nowLabel else "$dateLabel, $timeLabel",
             emphasized = false,
             testTag = TripPlanTestTags.WHEN_TIME,
             onClick = { expanded = true }
@@ -578,7 +588,7 @@ private fun WhenTimeSegment(
         DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
             DropdownMenuItem(
                 text = { Text(nowLabel) },
-                trailingIcon = if (state.departNow) {
+                trailingIcon = if (departNow) {
                     {
                         Icon(
                             imageVector = AppIcons.Check,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanForm.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanForm.kt
@@ -510,6 +510,10 @@ private fun TripActionBar(
             color = MaterialTheme.colorScheme.onSurfaceVariant
         )
         WhenTimeSegment(
+            // The only part of the bar that can grow: a pinned label is a full date and time, which in
+            // a long locale format or at a large font scale would otherwise push the two trailing
+            // buttons off the edge. Weighted so it gives up width and ellipsizes instead.
+            modifier = Modifier.weight(1f, fill = false),
             departNow = departNow,
             dateLabel = dateLabel,
             timeLabel = timeLabel,
@@ -569,6 +573,7 @@ private fun WhenModeSegment(arriving: Boolean, onSetArriving: (Boolean) -> Unit)
  */
 @Composable
 private fun WhenTimeSegment(
+    modifier: Modifier = Modifier,
     departNow: Boolean,
     dateLabel: String,
     timeLabel: String,
@@ -578,9 +583,13 @@ private fun WhenTimeSegment(
 ) {
     var expanded by remember { mutableStateOf(false) }
     val nowLabel = stringResource(R.string.trip_plan_now)
-    Box {
+    Box(modifier) {
         SegmentButton(
-            text = if (departNow) nowLabel else "$dateLabel, $timeLabel",
+            text = if (departNow) {
+                nowLabel
+            } else {
+                stringResource(R.string.trip_plan_date_time, dateLabel, timeLabel)
+            },
             emphasized = false,
             testTag = TripPlanTestTags.WHEN_TIME,
             onClick = { expanded = true }
@@ -622,10 +631,11 @@ private fun SegmentButton(
     text: String,
     emphasized: Boolean,
     testTag: String,
-    onClick: () -> Unit
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
 ) {
     Row(
-        modifier = Modifier
+        modifier = modifier
             .height(32.dp)
             // The value is the label, so TalkBack reads it as-is; the click label supplies the verb the
             // bare text can't ("Depart" alone doesn't say it's changeable).

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanForm.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanForm.kt
@@ -510,10 +510,12 @@ private fun TripActionBar(
             color = MaterialTheme.colorScheme.onSurfaceVariant
         )
         WhenTimeSegment(
-            // The only part of the bar that can grow: a pinned label is a full date and time, which in
-            // a long locale format or at a large font scale would otherwise push the two trailing
-            // buttons off the edge. Weighted so it gives up width and ellipsizes instead.
-            modifier = Modifier.weight(1f, fill = false),
+            // The bar's one flexible slot, and the only part of it that can grow: a pinned label is a
+            // full date and time, longer in other locales and at a large font scale. Taking all the
+            // remaining width does both jobs — it holds the two trailing buttons against the right
+            // edge, and it caps the label so it ellipsizes rather than shoving them off. The button
+            // inside stays its own width at the slot's start, so the tap target doesn't span the gap.
+            modifier = Modifier.weight(1f),
             departNow = departNow,
             dateLabel = dateLabel,
             timeLabel = timeLabel,
@@ -521,7 +523,6 @@ private fun TripActionBar(
             onPickDate = onPickDate,
             onPickTime = onPickTime
         )
-        Spacer(Modifier.weight(1f))
         IconButton(onClick = onReverse, modifier = Modifier.size(40.dp)) {
             Icon(
                 painter = painterResource(R.drawable.ic_swap_direction),

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanForm.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanForm.kt
@@ -16,74 +16,136 @@
 package org.onebusaway.android.ui.tripplan
 
 import androidx.annotation.StringRes
-import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuAnchorType
 import androidx.compose.material3.ExposedDropdownMenuBox
-import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.InputChip
-import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import org.onebusaway.android.R
 import org.onebusaway.android.ui.compose.theme.ObaTheme
 import org.onebusaway.android.ui.icons.AppIcons
 
 /**
- * The trip-plan form: two autocomplete address fields (each with current-location + contacts
- * shortcuts), a leaving/arriving selector, and date/time pickers, plus reverse + advanced-settings
- * actions. Stateless and driven by [TripPlanFormState]; the date/time/contacts/current-location
- * actions are platform interactions launched by the host.
+ * The trip-plan form: two endpoint rows over a single action bar (#2094).
+ *
+ * The layout is deliberately close to what a rider already knows from other mapping apps — a leading
+ * rail whose glyph says what each endpoint *is*, two borderless fields separated by a hairline, and no
+ * per-field chrome. What differs is the bottom band: transit is scheduled travel, so the form always
+ * states when the trip is for, as a "Depart · now" callout whose two halves open separate pickers.
+ *
+ * That band doubles as the form's action bar, carrying reverse and additional-preferences as well. It's
+ * the reason the endpoint rows can run full width: everything acting on the *whole trip* lives on one
+ * line, and only what acts on a single endpoint lives in that endpoint's row (which, currently, is
+ * nothing — see [EndpointRow]). The card measures 146dp against the old layout's 216dp.
+ *
+ * Stateless and driven by [TripPlanFormState]; the date/time/current-location actions are platform
+ * interactions launched by the host.
  */
+
+/** Height of one endpoint row. Android's minimum touch target — the rows are tap-to-edit. */
+private val ENDPOINT_ROW_HEIGHT = 48.dp
+
+/**
+ * Width of the leading rail — sized so the dot's leading edge lands exactly on Material's 16dp
+ * keyline. Reused as the dividers' inset, so the hairline starts where the text does.
+ */
+private val RAIL_WIDTH = 44.dp
+
+/** Diameter of the endpoint dot, in the rail and in the suggestion row that fills that endpoint. */
+private val ENDPOINT_DOT_SIZE = 12.dp
+
+/** Clear space between an endpoint glyph and the dotted connector running to the other one. */
+private val CONNECTOR_GLYPH_CLEARANCE = 12.dp
+
+/**
+ * Height of the action bar. Snug around its 40dp icon buttons; those keep a full 48dp touch target
+ * regardless, because Material expands it beyond their bounds.
+ */
+private val ACTION_BAR_HEIGHT = 40.dp
+
 /**
  * Stable UIAutomator/Compose-test handles for the trip-plan form. Surfaced as resource-ids by the
  * app-wide `testTagsAsResourceId` in HomeActivity, so the form can be driven semantically (focus a
  * field, tap a suggestion) without coordinate taps. The per-endpoint tags are `<prefix><suffix>`,
- * e.g. `tripPlanFromField`, `tripPlanToPill`, `tripPlanFromSuggestion`.
+ * e.g. `tripPlanFromField`, `tripPlanToSuggestion`.
  */
 object TripPlanTestTags {
     const val FROM_PREFIX = "tripPlanFrom"
     const val TO_PREFIX = "tripPlanTo"
     const val FIELD_SUFFIX = "Field"
-    const val PILL_SUFFIX = "Pill"
     const val SUGGESTION_SUFFIX = "Suggestion"
+
+    /** The two pinned rows at the head of a field's suggestion list. */
+    const val MY_LOCATION_SUFFIX = "MyLocation"
+    const val PICK_ON_MAP_SUFFIX = "PickOnMap"
+
+    /** The action bar's two time segments. */
+    const val WHEN_MODE = "tripPlanWhenMode"
+    const val WHEN_TIME = "tripPlanWhenTime"
 }
 
 /**
- * The rider-facing name of an endpoint ("From" / "To"), shared by the form and the map-pick overlay.
+ * What an empty endpoint field invites the rider to do. A placeholder rather than a label: the
+ * compact form has no room for a floating label above each field, and the rail glyph already says
+ * which end of the trip the row is.
+ *
  * Lives here rather than on [TripEndpointSlot] itself to keep [TripPlanFormState]'s file free of
  * Android — the same seam [TripEndpoint.displayText] already draws for the fixed-label endpoint kinds.
  */
 @get:StringRes
-val TripEndpointSlot.labelRes: Int
+val TripEndpointSlot.placeholderRes: Int
     get() = when (this) {
-        TripEndpointSlot.FROM -> R.string.trip_plan_from
-        TripEndpointSlot.TO -> R.string.trip_plan_to
+        TripEndpointSlot.FROM -> R.string.trip_plan_from_hint
+        TripEndpointSlot.TO -> R.string.trip_plan_to_hint
     }
 
 /** The [TripPlanTestTags] prefix naming this endpoint's field. */
@@ -98,269 +160,490 @@ fun TripPlanForm(
     state: TripPlanFormState,
     onQueryChange: (TripEndpointSlot, String) -> Unit,
     onSelect: (TripEndpointSlot, TripEndpoint.Geocoded) -> Unit,
-    onClear: (TripEndpointSlot) -> Unit,
     onCurrentLocation: (TripEndpointSlot) -> Unit,
     onPickOnMap: (TripEndpointSlot) -> Unit,
     onSetArriving: (Boolean) -> Unit,
+    onDepartNow: () -> Unit,
     onPickDate: () -> Unit,
     onPickTime: () -> Unit,
     onReverse: () -> Unit,
     onAdvancedSettings: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    Column(
-        modifier = modifier.padding(16.dp),
-        verticalArrangement = Arrangement.spacedBy(8.dp)
-    ) {
-        // The two address fields fill the row; the reverse + additional-preferences actions sit as
-        // compact icons to their right (the on-map form is tight on vertical space).
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(4.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Column(
-                modifier = Modifier.weight(1f),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                // One field per endpoint, in TripEndpointSlot's declaration order (origin above
-                // destination) — the enum is the list of fields.
-                TripEndpointSlot.entries.forEach { slot ->
-                    AddressField(
-                        label = stringResource(slot.labelRes),
-                        tagPrefix = slot.tagPrefix,
-                        endpoint = state.endpointAt(slot),
-                        suggestions = state.suggestionsAt(slot),
-                        onQueryChange = { onQueryChange(slot, it) },
-                        onSelect = { onSelect(slot, it) },
-                        onClear = { onClear(slot) },
-                        onCurrentLocation = { onCurrentLocation(slot) },
-                        onPickOnMap = { onPickOnMap(slot) }
-                    )
-                }
+    Column(modifier = modifier.padding(vertical = 4.dp)) {
+        // One row per endpoint, in TripEndpointSlot's declaration order (origin above destination) —
+        // the enum is the list of rows.
+        TripEndpointSlot.entries.forEachIndexed { index, slot ->
+            if (index > 0) {
+                // Inset past the rail so the hairline starts where the text does, leaving the origin
+                // and destination glyphs reading as one continuous column.
+                HairlineDivider(startIndent = RAIL_WIDTH, endIndent = 12.dp)
             }
-            Column {
-                IconButton(onClick = onReverse) {
-                    Icon(
-                        painter = painterResource(R.drawable.ic_swap_direction),
-                        contentDescription = stringResource(R.string.tripplanner_reverse)
-                    )
-                }
-                IconButton(onClick = onAdvancedSettings) {
-                    Icon(
-                        imageVector = AppIcons.Settings,
-                        contentDescription = stringResource(R.string.trip_plan_advanced_settings)
-                    )
-                }
-            }
-        }
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            LeavingArrivingDropdown(
-                arriving = state.arriving,
-                onSetArriving = onSetArriving,
-                modifier = Modifier.weight(1.2f)
+            EndpointRow(
+                endpoint = state.endpointAt(slot),
+                placeholder = stringResource(slot.placeholderRes),
+                tagPrefix = slot.tagPrefix,
+                isOrigin = slot == TripEndpointSlot.FROM,
+                suggestions = state.suggestionsAt(slot),
+                onQueryChange = { onQueryChange(slot, it) },
+                onSelect = { onSelect(slot, it) },
+                onCurrentLocation = { onCurrentLocation(slot) },
+                onPickOnMap = { onPickOnMap(slot) }
             )
-            OutlinedButton(onClick = onPickDate, modifier = Modifier.weight(1f)) {
-                Text(state.dateLabel)
-            }
-            OutlinedButton(onClick = onPickTime, modifier = Modifier.weight(1f)) {
-                Text(state.timeLabel)
+        }
+        // Full-width, unlike the one above: this one separates the endpoints from the actions, rather
+        // than separating two members of the same group.
+        HairlineDivider()
+        TripActionBar(
+            state = state,
+            onSetArriving = onSetArriving,
+            onDepartNow = onDepartNow,
+            onPickDate = onPickDate,
+            onPickTime = onPickTime,
+            onReverse = onReverse,
+            onAdvancedSettings = onAdvancedSettings
+        )
+    }
+}
+
+/** A 1dp rule at the outline colour, optionally inset at either end. */
+@Composable
+private fun HairlineDivider(startIndent: Dp = 0.dp, endIndent: Dp = 0.dp) {
+    HorizontalDivider(
+        modifier = Modifier.padding(start = startIndent, end = endIndent),
+        color = MaterialTheme.colorScheme.outlineVariant
+    )
+}
+
+/**
+ * One trip-plan endpoint: a rail glyph naming the endpoint's kind, and the place itself in a
+ * borderless field. There is no pill and no trailing button, which is what lets the row run the full
+ * width of the card; the actions that used to sit here are in the suggestion list and the action bar.
+ *
+ * The row is one persistent text field in every state — a resolved endpoint is the same field showing
+ * a name, not a different kind of row. That matters beyond tidiness: swapping a read-only Text in and
+ * out for a text field destroys and recreates the field on each transition, and the focus callbacks
+ * and IME teardown that come out of that are indistinguishable from real user edits. Both of this
+ * screen's early defects (a dropdown that flashed open and shut, and "Your location" resolving only
+ * on alternate taps) were that same swap seen from two angles.
+ *
+ * Likewise [field] is the single authority on the text. Feeding `BasicTextField` a `TextFieldValue`
+ * rebuilt during composition, rather than the one it last handed back, fights its internal state and
+ * produces echoed edits; the hosted endpoint is adopted only when it genuinely differs.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun EndpointRow(
+    endpoint: TripEndpoint,
+    placeholder: String,
+    tagPrefix: String,
+    isOrigin: Boolean,
+    suggestions: List<TripEndpoint.Geocoded>,
+    onQueryChange: (String) -> Unit,
+    onSelect: (TripEndpoint.Geocoded) -> Unit,
+    onCurrentLocation: () -> Unit,
+    onPickOnMap: () -> Unit
+) {
+    // The endpoint as the field should read it. A resolved endpoint is not a different *kind* of row
+    // — it is the same field showing a name — so nothing is swapped in or out as it resolves.
+    val endpointText = endpointLabel(endpoint)
+
+    // One authority for the field's contents. BasicTextField's TextFieldValue overload requires the
+    // caller to hold the value it hands back and return exactly that; synthesising a fresh value each
+    // recomposition fights the field's own state and makes the IME echo edits the user never made.
+    var field by remember { mutableStateOf(TextFieldValue(endpointText)) }
+    var menuOpen by remember { mutableStateOf(false) }
+
+    // Adopt the hosted endpoint only when it actually says something different — a suggestion picked,
+    // a location filled in, a reversed trip. While the user types, the endpoint is echoing the text
+    // that came from this field, so there is nothing to adopt and the cursor is left alone.
+    LaunchedEffect(endpointText) {
+        if (endpointText != field.text) {
+            field = TextFieldValue(endpointText, selection = TextRange(endpointText.length))
+        }
+    }
+
+    ExposedDropdownMenuBox(
+        expanded = menuOpen,
+        onExpandedChange = { menuOpen = it },
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth().height(ENDPOINT_ROW_HEIGHT),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            EndpointRail(endpoint = endpoint, isOrigin = isOrigin)
+            BasicTextField(
+                value = field,
+                onValueChange = { value ->
+                    // A TextFieldValue changes for selection and cursor moves as well as for edits;
+                    // only an edit is a new search query.
+                    val edited = value.text != field.text
+                    field = value
+                    if (edited) {
+                        onQueryChange(value.text)
+                        menuOpen = true
+                    }
+                },
+                singleLine = true,
+                // The device's own position is named in its own colour, matching its rail dot, so the
+                // one endpoint the rider didn't choose is identifiable without reading it. A chosen
+                // place is ordinary text — colouring every endpoint would say nothing.
+                textStyle = LocalTextStyle.current.merge(MaterialTheme.typography.bodyLarge)
+                    .copy(
+                        color = if (endpoint is TripEndpoint.CurrentLocation) {
+                            endpointColor(endpoint, isOrigin)
+                        } else {
+                            MaterialTheme.colorScheme.onSurface
+                        }
+                    ),
+                cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
+                modifier = Modifier
+                    .weight(1f)
+                    // Full row height, so the tap target is the whole 48dp band rather than the ~20dp
+                    // the text line occupies.
+                    .fillMaxHeight()
+                    .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryEditable)
+                    .onFocusChanged { focusState ->
+                        if (focusState.isFocused) {
+                            // Select the whole name, so typing replaces the place rather than appending
+                            // to it, and offer the actions straight away rather than after a keystroke.
+                            field = field.copy(selection = TextRange(0, field.text.length))
+                            menuOpen = true
+                        } else {
+                            menuOpen = false
+                        }
+                    }
+                    .testTag(tagPrefix + TripPlanTestTags.FIELD_SUFFIX),
+                decorationBox = { innerField ->
+                    Box(contentAlignment = Alignment.CenterStart) {
+                        if (field.text.isEmpty()) PlaceholderText(placeholder)
+                        innerField()
+                    }
+                }
+            )
+            Spacer(Modifier.width(12.dp))
+        }
+
+        // The two ways to fill an endpoint that aren't typing. They used to be permanent icon buttons on
+        // every field — four of them across the card, its loudest chrome. Here they cost nothing until
+        // the rider is actually choosing a place, which is the only moment they mean anything.
+        ExposedDropdownMenu(expanded = menuOpen, onDismissRequest = { menuOpen = false }) {
+            DropdownMenuItem(
+                text = { Text(stringResource(R.string.tripplanner_current_location)) },
+                leadingIcon = { CurrentLocationDotIcon() },
+                onClick = {
+                    menuOpen = false
+                    onCurrentLocation()
+                },
+                modifier = Modifier.testTag(tagPrefix + TripPlanTestTags.MY_LOCATION_SUFFIX)
+            )
+            DropdownMenuItem(
+                text = { Text(stringResource(R.string.trip_plan_pick_on_map)) },
+                // The crosshair the pick overlay itself puts at the centre of the map, so the row
+                // shows the tool it opens.
+                leadingIcon = { PinnedActionIcon(painterResource(R.drawable.ic_my_location)) },
+                onClick = {
+                    menuOpen = false
+                    onPickOnMap()
+                },
+                modifier = Modifier.testTag(tagPrefix + TripPlanTestTags.PICK_ON_MAP_SUFFIX)
+            )
+            if (suggestions.isNotEmpty()) {
+                HairlineDivider()
+                suggestions.forEach { place ->
+                    DropdownMenuItem(
+                        text = { Text(place.displayName) },
+                        leadingIcon = if (place.isTransit) {
+                            { BusIcon() }
+                        } else {
+                            null
+                        },
+                        onClick = {
+                            onSelect(place)
+                            menuOpen = false
+                        },
+                        modifier = Modifier.testTag(tagPrefix + TripPlanTestTags.SUGGESTION_SUFFIX)
+                    )
+                }
             }
         }
     }
 }
 
 /**
- * One trip-plan endpoint. A still-being-typed [TripEndpoint.FreeText] is an editable autocomplete
- * field; any resolved kind is shown as a cancellable pill sitting *inside* the same field, where the
- * text would be — the field is then inoperative (no typing) until the pill's ✕ clears it. The
- * contacts / current-location / pick-on-map shortcuts stay live in both states, so picking another
- * input method overrides the current pill.
+ * The colour that identifies an endpoint. Blue wherever the trip is anchored to the device's own
+ * position, at either end — that is a different kind of fact from a chosen place, so it outranks the
+ * start/destination distinction rather than sitting beside it. Otherwise the origin takes the theme's
+ * primary and the destination the fixed red.
  */
 @Composable
-private fun AddressField(
-    label: String,
-    tagPrefix: String,
-    endpoint: TripEndpoint,
-    suggestions: List<TripEndpoint.Geocoded>,
-    onQueryChange: (String) -> Unit,
-    onSelect: (TripEndpoint.Geocoded) -> Unit,
-    onClear: () -> Unit,
-    onCurrentLocation: () -> Unit,
-    onPickOnMap: () -> Unit
-) {
-    when (endpoint) {
-        is TripEndpoint.FreeText -> EditableAddressField(
-            label = label,
-            tagPrefix = tagPrefix,
-            query = endpoint.query,
-            suggestions = suggestions,
-            onQueryChange = onQueryChange,
-            onSelect = onSelect,
-            onCurrentLocation = onCurrentLocation,
-            onPickOnMap = onPickOnMap
-        )
-        else -> EndpointPillField(
-            label = label,
-            tagPrefix = tagPrefix,
-            endpoint = endpoint,
-            onClear = onClear,
-            onCurrentLocation = onCurrentLocation,
-            onPickOnMap = onPickOnMap
-        )
+private fun endpointColor(endpoint: TripEndpoint, isOrigin: Boolean): Color = when {
+    endpoint is TripEndpoint.CurrentLocation ->
+        colorResource(R.color.trip_plan_endpoint_current_location)
+    isOrigin -> MaterialTheme.colorScheme.primary
+    else -> colorResource(R.color.trip_plan_endpoint_destination)
+}
+
+/**
+ * The leading glyph column: a dot in the endpoint's own colour, so origin, destination and "my
+ * position" are told apart by hue rather than by shape. A transit endpoint keeps the bus glyph
+ * instead — that it is a stop rather than an address is something no colour in the set encodes.
+ */
+@Composable
+private fun EndpointRail(endpoint: TripEndpoint, isOrigin: Boolean) {
+    val connectorColor = MaterialTheme.colorScheme.outlineVariant
+    Box(
+        modifier = Modifier.width(RAIL_WIDTH).height(ENDPOINT_ROW_HEIGHT),
+        contentAlignment = Alignment.Center
+    ) {
+        // Half of the dotted connector between the two glyphs, drawn from this row's glyph to the edge
+        // it shares with the other row. The two halves meet because the divider above is inset past the
+        // rail, so nothing crosses the gap. This is what makes origin and destination read as two ends
+        // of one trip rather than two unrelated fields.
+        Canvas(Modifier.matchParentSize()) {
+            val gap = CONNECTOR_GLYPH_CLEARANCE.toPx()
+            val midY = size.height / 2
+            val start = if (isOrigin) midY + gap else 0f
+            val end = if (isOrigin) size.height else midY - gap
+            if (end <= start) return@Canvas
+            drawLine(
+                color = connectorColor,
+                start = Offset(size.width / 2, start),
+                end = Offset(size.width / 2, end),
+                strokeWidth = 2.dp.toPx(),
+                cap = StrokeCap.Round,
+                pathEffect = PathEffect.dashPathEffect(
+                    floatArrayOf(2.dp.toPx(), 4.dp.toPx())
+                )
+            )
+        }
+        if (endpoint.isTransit) {
+            BusIcon()
+        } else {
+            EndpointDot(endpointColor(endpoint, isOrigin))
+        }
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
+/** The filled circle that marks an endpoint, in the colour [endpointColor] gives it. */
 @Composable
-private fun EditableAddressField(
-    label: String,
-    tagPrefix: String,
-    query: String,
-    suggestions: List<TripEndpoint.Geocoded>,
-    onQueryChange: (String) -> Unit,
-    onSelect: (TripEndpoint.Geocoded) -> Unit,
-    onCurrentLocation: () -> Unit,
-    onPickOnMap: () -> Unit
+private fun EndpointDot(color: Color) {
+    Box(Modifier.size(ENDPOINT_DOT_SIZE).background(color, CircleShape))
+}
+
+/**
+ * The dot at icon size, for the suggestion row that fills an endpoint with the device's position —
+ * the row and the endpoint it produces then show the same mark, rather than a crosshair that turns
+ * into a dot once chosen.
+ */
+@Composable
+private fun CurrentLocationDotIcon() {
+    Box(Modifier.size(22.dp), contentAlignment = Alignment.Center) {
+        EndpointDot(colorResource(R.color.trip_plan_endpoint_current_location))
+    }
+}
+
+@Composable
+private fun PlaceholderText(text: String) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.bodyLarge,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis
+    )
+}
+
+@Composable
+private fun PinnedActionIcon(painter: Painter) {
+    Icon(
+        painter = painter,
+        contentDescription = null,
+        tint = MaterialTheme.colorScheme.primary,
+        modifier = Modifier.size(22.dp)
+    )
+}
+
+/**
+ * The bottom band: when the trip is for, plus the two actions that apply to the trip as a whole.
+ *
+ * The time reads as one sentence — "Depart · now" — split into two separately-tappable segments, each
+ * opening its own menu. Reverse and additional preferences sit at the trailing edge, which is why
+ * neither endpoint row needs a trailing slot at all.
+ */
+@Composable
+private fun TripActionBar(
+    state: TripPlanFormState,
+    onSetArriving: (Boolean) -> Unit,
+    onDepartNow: () -> Unit,
+    onPickDate: () -> Unit,
+    onPickTime: () -> Unit,
+    onReverse: () -> Unit,
+    onAdvancedSettings: () -> Unit
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth().height(ACTION_BAR_HEIGHT),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Box(
+            modifier = Modifier.width(RAIL_WIDTH).height(ACTION_BAR_HEIGHT),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                painter = painterResource(R.drawable.ic_arrival_time),
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(18.dp)
+            )
+        }
+        WhenModeSegment(arriving = state.arriving, onSetArriving = onSetArriving)
+        Text(
+            text = "·",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        WhenTimeSegment(
+            state = state,
+            onDepartNow = onDepartNow,
+            onPickDate = onPickDate,
+            onPickTime = onPickTime
+        )
+        Spacer(Modifier.weight(1f))
+        IconButton(onClick = onReverse, modifier = Modifier.size(40.dp)) {
+            Icon(
+                painter = painterResource(R.drawable.ic_swap_direction),
+                contentDescription = stringResource(R.string.tripplanner_reverse),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        IconButton(onClick = onAdvancedSettings, modifier = Modifier.size(40.dp)) {
+            Icon(
+                imageVector = AppIcons.Settings,
+                contentDescription = stringResource(R.string.trip_plan_advanced_settings),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        Spacer(Modifier.width(4.dp))
+    }
+}
+
+/** Leaving vs arriving — the first half of the "when" sentence. */
+@Composable
+private fun WhenModeSegment(arriving: Boolean, onSetArriving: (Boolean) -> Unit) {
+    var expanded by remember { mutableStateOf(false) }
+    val leaving = stringResource(R.string.trip_plan_leaving)
+    val arrivingLabel = stringResource(R.string.trip_plan_arriving)
+    Box {
+        SegmentButton(
+            text = if (arriving) arrivingLabel else leaving,
+            emphasized = true,
+            testTag = TripPlanTestTags.WHEN_MODE,
+            onClick = { expanded = true }
+        )
+        DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            DropdownMenuItem(text = { Text(leaving) }, onClick = {
+                expanded = false
+                onSetArriving(false)
+            })
+            DropdownMenuItem(text = { Text(arrivingLabel) }, onClick = {
+                expanded = false
+                onSetArriving(true)
+            })
+        }
+    }
+}
+
+/**
+ * When the trip is for — the second half of the sentence. Reads "now" until a date or time is picked,
+ * then the pinned instant. The menu keeps both Material pickers one tap away rather than folding them
+ * into a single date-and-time flow, so changing just the time doesn't walk through a calendar.
+ */
+@Composable
+private fun WhenTimeSegment(
+    state: TripPlanFormState,
+    onDepartNow: () -> Unit,
+    onPickDate: () -> Unit,
+    onPickTime: () -> Unit
 ) {
     var expanded by remember { mutableStateOf(false) }
-    val showMenu = expanded && suggestions.isNotEmpty()
-    ExposedDropdownMenuBox(expanded = showMenu, onExpandedChange = { expanded = it }) {
-        OutlinedTextField(
-            value = query,
-            onValueChange = {
-                onQueryChange(it)
-                expanded = true
-            },
-            label = { Text(label) },
-            singleLine = true,
-            trailingIcon = {
-                AddressActionIcons(
-                    onCurrentLocation = onCurrentLocation,
-                    onPickOnMap = onPickOnMap
-                )
-            },
-            modifier = Modifier
-                .fillMaxWidth()
-                .testTag(tagPrefix + TripPlanTestTags.FIELD_SUFFIX)
-                .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryEditable)
+    val nowLabel = stringResource(R.string.trip_plan_now)
+    Box {
+        SegmentButton(
+            text = if (state.departNow) nowLabel else "${state.dateLabel}, ${state.timeLabel}",
+            emphasized = false,
+            testTag = TripPlanTestTags.WHEN_TIME,
+            onClick = { expanded = true }
         )
-        ExposedDropdownMenu(expanded = showMenu, onDismissRequest = { expanded = false }) {
-            suggestions.forEach { place ->
-                DropdownMenuItem(
-                    text = { Text(place.displayName) },
-                    leadingIcon = if (place.isTransit) {
-                        { BusIcon() }
-                    } else {
-                        null
-                    },
-                    onClick = {
-                        onSelect(place)
-                        expanded = false
-                    },
-                    modifier = Modifier.testTag(tagPrefix + TripPlanTestTags.SUGGESTION_SUFFIX)
-                )
-            }
-        }
-    }
-}
-
-/**
- * A resolved endpoint shown as a pill *inside* an outlined field. There is no editable text — the
- * pill occupies the field's inner content slot, so the field can't be typed into until ✕ clears it.
- * The action icons remain in the trailing slot so another input method can replace the pill.
- */
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun EndpointPillField(
-    label: String,
-    tagPrefix: String,
-    endpoint: TripEndpoint,
-    onClear: () -> Unit,
-    onCurrentLocation: () -> Unit,
-    onPickOnMap: () -> Unit
-) {
-    val interactionSource = remember { MutableInteractionSource() }
-    val endpointText = endpointLabel(endpoint)
-    // Read-only host text field gives the full-width sizing; we ignore its inner text field and drop
-    // the pill into the OutlinedTextField decoration instead, so it renders where the text would be.
-    BasicTextField(
-        value = "",
-        onValueChange = {},
-        readOnly = true,
-        singleLine = true,
-        interactionSource = interactionSource,
-        modifier = Modifier
-            .fillMaxWidth()
-            .testTag(tagPrefix + TripPlanTestTags.PILL_SUFFIX)
-    ) {
-        OutlinedTextFieldDefaults.DecorationBox(
-            value = endpointText, // non-empty so the label floats above the pill
-            innerTextField = {
-                InputChip(
-                    selected = true,
-                    onClick = onClear,
-                    label = {
-                        // Geocoder/contact names can be long; keep the pill to one line inside the
-                        // singleLine field so it doesn't wrap over the trailing clear icon.
-                        Text(endpointText, maxLines = 1, overflow = TextOverflow.Ellipsis)
-                    },
-                    leadingIcon = if (endpoint.isTransit) {
-                        { BusIcon() }
-                    } else {
-                        null
-                    },
-                    trailingIcon = {
+        DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            DropdownMenuItem(
+                text = { Text(nowLabel) },
+                trailingIcon = if (state.departNow) {
+                    {
                         Icon(
-                            imageVector = AppIcons.Close,
-                            contentDescription = stringResource(R.string.trip_plan_clear_endpoint)
+                            imageVector = AppIcons.Check,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.primary
                         )
                     }
-                )
-            },
-            enabled = true,
-            singleLine = true,
-            visualTransformation = VisualTransformation.None,
-            interactionSource = interactionSource,
-            label = { Text(label) },
-            trailingIcon = {
-                AddressActionIcons(
-                    onCurrentLocation = onCurrentLocation,
-                    onPickOnMap = onPickOnMap
-                )
-            },
-            contentPadding = OutlinedTextFieldDefaults.contentPadding(top = 8.dp, bottom = 8.dp)
+                } else {
+                    null
+                },
+                onClick = {
+                    expanded = false
+                    onDepartNow()
+                }
+            )
+            DropdownMenuItem(text = { Text(stringResource(R.string.trip_plan_choose_date)) }, onClick = {
+                expanded = false
+                onPickDate()
+            })
+            DropdownMenuItem(text = { Text(stringResource(R.string.trip_plan_choose_time)) }, onClick = {
+                expanded = false
+                onPickTime()
+            })
+        }
+    }
+}
+
+/** One tappable half of the "when" sentence: text plus a small chevron, on a rounded press surface. */
+@Composable
+private fun SegmentButton(
+    text: String,
+    emphasized: Boolean,
+    testTag: String,
+    onClick: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .height(32.dp)
+            // The value is the label, so TalkBack reads it as-is; the click label supplies the verb the
+            // bare text can't ("Depart" alone doesn't say it's changeable).
+            .clickable(onClickLabel = stringResource(R.string.trip_plan_change_when), onClick = onClick)
+            .padding(horizontal = 6.dp)
+            .testTag(testTag),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(2.dp)
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = if (emphasized) FontWeight.SemiBold else FontWeight.Normal,
+            color = MaterialTheme.colorScheme.onSurface,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.weight(1f, fill = false)
+        )
+        Icon(
+            imageVector = AppIcons.KeyboardArrowDown,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.size(16.dp).clearAndSetSemantics {}
         )
     }
 }
 
-/** The contacts / current-location / pick-on-map shortcuts shared by both endpoint states. */
-@Composable
-private fun AddressActionIcons(
-    onCurrentLocation: () -> Unit,
-    onPickOnMap: () -> Unit
-) {
-    Row {
-        IconButton(onClick = onCurrentLocation) {
-            Icon(
-                painter = painterResource(R.drawable.ic_my_location),
-                contentDescription = stringResource(R.string.tripplanner_current_location)
-            )
-        }
-        IconButton(onClick = onPickOnMap) {
-            Icon(
-                painter = painterResource(R.drawable.ic_action_location_map),
-                contentDescription = stringResource(R.string.trip_plan_pick_on_map)
-            )
-        }
-    }
-}
-
-/** The user-visible label for a resolved endpoint; fixed kinds resolve a string resource. */
+/** The user-visible label for an endpoint; fixed kinds resolve a string resource. */
 @Composable
 private fun endpointLabel(endpoint: TripEndpoint): String = endpoint.displayText ?: when (endpoint) {
     is TripEndpoint.MapPoint -> stringResource(R.string.trip_plan_map_location)
@@ -377,41 +660,6 @@ private fun BusIcon() {
     )
 }
 
-/** Leaving/arriving selector — the Compose equivalent of the legacy Spinner. */
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun LeavingArrivingDropdown(
-    arriving: Boolean,
-    onSetArriving: (Boolean) -> Unit,
-    modifier: Modifier = Modifier
-) {
-    var expanded by remember { mutableStateOf(false) }
-    val leaving = stringResource(R.string.trip_plan_leaving)
-    val arrivingLabel = stringResource(R.string.trip_plan_arriving)
-    ExposedDropdownMenuBox(expanded = expanded, onExpandedChange = { expanded = it }, modifier = modifier) {
-        OutlinedTextField(
-            value = if (arriving) arrivingLabel else leaving,
-            onValueChange = {},
-            readOnly = true,
-            singleLine = true,
-            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
-            modifier = Modifier
-                .fillMaxWidth()
-                .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable)
-        )
-        ExposedDropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
-            DropdownMenuItem(text = { Text(leaving) }, onClick = {
-                expanded = false
-                onSetArriving(false)
-            })
-            DropdownMenuItem(text = { Text(arrivingLabel) }, onClick = {
-                expanded = false
-                onSetArriving(true)
-            })
-        }
-    }
-}
-
 @Preview(showBackground = true)
 @Composable
 private fun TripPlanFormPreview() {
@@ -419,14 +667,16 @@ private fun TripPlanFormPreview() {
         TripPlanForm(
             state = TripPlanFormState(
                 from = TripEndpoint.CurrentLocation(lat = 47.6, lon = -122.3),
-                to = TripEndpoint.FreeText(""),
+                to = TripEndpoint.Geocoded("Pike Place Market", lat = 47.6, lon = -122.34),
                 dateTimeMillis = 0L,
+                departNow = true,
                 dateLabel = "June 10",
                 timeLabel = "3:45 PM"
             ),
             onQueryChange = { _, _ -> }, onSelect = { _, _ -> },
-            onClear = {}, onCurrentLocation = {}, onPickOnMap = {},
-            onSetArriving = {}, onPickDate = {}, onPickTime = {},
+            onCurrentLocation = {}, onPickOnMap = {},
+            onSetArriving = {}, onDepartNow = {},
+            onPickDate = {}, onPickTime = {},
             onReverse = {}, onAdvancedSettings = {}
         )
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanFormState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanFormState.kt
@@ -135,6 +135,14 @@ data class TripPlanFormState(
     val toSuggestions: List<TripEndpoint.Geocoded> = emptyList(),
     val dateTimeMillis: Long = 0L,
     val arriving: Boolean = false,
+    /**
+     * The trip is anchored to "now" rather than to [dateTimeMillis] — the default, and what the form's
+     * time control shows until a date or time is picked. The distinction has to be explicit because
+     * "now" is a *moving* anchor: [dateTimeMillis] is stamped once when the ViewModel is built, so a
+     * form left open for twenty minutes would otherwise plan a trip twenty minutes in the past. The
+     * live instant is resolved at submit — see [toParams].
+     */
+    val departNow: Boolean = true,
     val dateLabel: String = "",
     val timeLabel: String = "",
     val modes: TripModeSelection = TripModeSelection(),
@@ -216,11 +224,18 @@ data class TripPlanFormState(
             bikePreference = bikePreference
         )
 
-    /** Builds the plan request; only call when [canSubmit] is true. */
-    fun toParams(): TripPlanParams = TripPlanParams(
+    /**
+     * Builds the plan request; only call when [canSubmit] is true.
+     *
+     * [nowMillis] is the caller's reading of the wall clock, passed in rather than read here so this
+     * stays a pure projection of the form (the same rule the ETA helpers follow). It is used only when
+     * [departNow] is set, which is what makes "now" mean the moment of submission rather than the
+     * moment the form was opened.
+     */
+    fun toParams(nowMillis: Long): TripPlanParams = TripPlanParams(
         from = from,
         to = to,
-        dateTimeMillis = dateTimeMillis,
+        dateTimeMillis = if (departNow) nowMillis else dateTimeMillis,
         arriving = arriving,
         modes = modes,
         wheelchair = wheelchair,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanViewModel.kt
@@ -270,8 +270,29 @@ class TripPlanViewModel @Inject constructor(
         replanOrClearResult()
     }
 
+    /**
+     * Leaving vs arriving. Choosing *arriving* also leaves the "now" anchor, pinning the trip to the
+     * clock as it does so: "arrive by now" is not a request that can be answered — it asks for a trip
+     * that has already finished — whereas "depart now" is the ordinary case. Pinning puts a concrete
+     * instant in the form's time callout, which is the thing the rider then moves.
+     */
     fun setArriving(arriving: Boolean) {
-        _formState.update { it.copy(arriving = arriving) }
+        _formState.update { state ->
+            if (!arriving || !state.departNow) {
+                state.copy(arriving = arriving)
+            } else {
+                // Pin to the clock now, not to dateTimeMillis — under the "now" anchor that field
+                // still holds the instant the ViewModel was built, which may be long past.
+                val now = timeProvider.now()
+                state.copy(
+                    arriving = true,
+                    departNow = false,
+                    dateTimeMillis = now,
+                    dateLabel = formatDate(now),
+                    timeLabel = formatTime(now)
+                )
+            }
+        }
         replanOrClearResult()
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanViewModel.kt
@@ -60,7 +60,7 @@ class TripPlanViewModel @Inject constructor(
     private val regionRepository: RegionRepository,
     private val searchCenter: SearchCenter,
     private val locationRepository: LocationRepository,
-    timeProvider: TimeProvider,
+    private val timeProvider: TimeProvider,
     settingsRepository: AdvancedSettingsRepository
 ) : ViewModel() {
 
@@ -235,9 +235,37 @@ class TripPlanViewModel @Inject constructor(
         setEndpoint(slot, TripEndpoint.FreeText())
     }
 
+    /**
+     * Pins the trip to an explicit instant, leaving the "now" anchor. Picking either half of the
+     * date/time is enough to pin: the other half keeps whatever it already showed, which is the
+     * moment the form was opened.
+     */
     fun setDateTime(millis: Long) {
         _formState.update {
-            it.copy(dateTimeMillis = millis, dateLabel = formatDate(millis), timeLabel = formatTime(millis))
+            it.copy(
+                dateTimeMillis = millis,
+                departNow = false,
+                dateLabel = formatDate(millis),
+                timeLabel = formatTime(millis)
+            )
+        }
+        replanOrClearResult()
+    }
+
+    /**
+     * Returns the trip to the "now" anchor. The pinned [TripPlanFormState.dateTimeMillis] is refreshed
+     * to the current clock as well, so re-opening the picker starts from now rather than from the
+     * instant that was abandoned.
+     */
+    fun setDepartNow() {
+        val now = timeProvider.now()
+        _formState.update {
+            it.copy(
+                dateTimeMillis = now,
+                departNow = true,
+                dateLabel = formatDate(now),
+                timeLabel = formatTime(now)
+            )
         }
         replanOrClearResult()
     }
@@ -291,6 +319,9 @@ class TripPlanViewModel @Inject constructor(
                 from = from ?: it.from,
                 to = to ?: it.to,
                 dateTimeMillis = dateTimeMillis,
+                // A restored trip carries the instant it was planned for, so it is pinned rather than
+                // anchored to "now" — re-anchoring would silently re-time the very trip being restored.
+                departNow = false,
                 dateLabel = formatDate(dateTimeMillis),
                 timeLabel = formatTime(dateTimeMillis),
                 arriving = arriving
@@ -309,7 +340,9 @@ class TripPlanViewModel @Inject constructor(
      */
     private fun replanOrClearResult() {
         val form = _formState.value
-        planInputs.trySend(if (form.canSubmit) form.toParams() else null)
+        // Read the clock here, at submit, so a "depart now" trip left sitting in an open form plans
+        // from the moment it is sent rather than the moment the ViewModel was built.
+        planInputs.trySend(if (form.canSubmit) form.toParams(timeProvider.now()) else null)
     }
 
     private fun formatDate(millis: Long): String = SimpleDateFormat(DATE_PATTERN, Locale.getDefault()).format(Date(millis))

--- a/onebusaway-android/src/main/res/values-es/strings.xml
+++ b/onebusaway-android/src/main/res/values-es/strings.xml
@@ -834,8 +834,6 @@
     <string name="title_activity_about">Acerca de</string>
     <!-- Trip Planner strings -->
 
-    <string name="trip_plan_from">Origen: </string>
-    <string name="trip_plan_to">Destino: </string>
     <string name="trip_plan_leaving">Saliendo</string>
     <string name="trip_plan_arriving">Llegando</string>
     <string name="trip_plan_date">Fecha</string>

--- a/onebusaway-android/src/main/res/values-fi/strings.xml
+++ b/onebusaway-android/src/main/res/values-fi/strings.xml
@@ -783,8 +783,6 @@
     <string name="rt_no">EI</string>
 
     <!-- Trip planner -->
-    <string name="trip_plan_from">Mistä: </string>
-    <string name="trip_plan_to">Minne: </string>
     <string name="trip_plan_leaving">Lähtö</string>
     <string name="trip_plan_arriving">Saapuminen</string>
     <string name="trip_plan_advanced_settings">Lisäasetukset</string>

--- a/onebusaway-android/src/main/res/values-it/strings.xml
+++ b/onebusaway-android/src/main/res/values-it/strings.xml
@@ -677,8 +677,6 @@
     <string name="title_activity_about">Informazioni</string>
     <!-- Trip Planner strings -->
 
-    <string name="trip_plan_from">Da:</string>
-    <string name="trip_plan_to">A:</string>
     <string name="trip_plan_leaving">Partenza</string>
     <string name="trip_plan_arriving">Arrivo</string>
     <string name="trip_plan_date">Data</string>

--- a/onebusaway-android/src/main/res/values-night/colors.xml
+++ b/onebusaway-android/src/main/res/values-night/colors.xml
@@ -88,11 +88,10 @@
     <color name="md_theme_surface">#10140F</color>
     <color name="md_theme_onSurface">#E0E4DB</color>
 
-    <!-- Lightened for the dark surface (#10140F); the day tones are far too dark to read on it.
-         These carry text as well as the rail dot, so they clear the 4.5:1 body-text ratio, not just
-         the 3:1 a graphical element would need. -->
+    <!-- Lightened for the dark surface (#10140F); the day tone is far too dark to read on it. This
+         carries text as well as the rail dot, so it clears the 4.5:1 body-text ratio, not just the
+         3:1 a graphical element would need. -->
     <color name="trip_plan_endpoint_current_location">#90CAF9</color>
-    <color name="trip_plan_endpoint_destination">#EF9A9A</color>
 
     <color name="md_theme_surfaceContainerLowest">#0B0F0A</color>
     <color name="md_theme_surfaceContainerLow">#191D17</color>

--- a/onebusaway-android/src/main/res/values-night/colors.xml
+++ b/onebusaway-android/src/main/res/values-night/colors.xml
@@ -88,6 +88,12 @@
     <color name="md_theme_surface">#10140F</color>
     <color name="md_theme_onSurface">#E0E4DB</color>
 
+    <!-- Lightened for the dark surface (#10140F); the day tones are far too dark to read on it.
+         These carry text as well as the rail dot, so they clear the 4.5:1 body-text ratio, not just
+         the 3:1 a graphical element would need. -->
+    <color name="trip_plan_endpoint_current_location">#90CAF9</color>
+    <color name="trip_plan_endpoint_destination">#EF9A9A</color>
+
     <color name="md_theme_surfaceContainerLowest">#0B0F0A</color>
     <color name="md_theme_surfaceContainerLow">#191D17</color>
     <color name="md_theme_surfaceContainer">#1D211B</color>

--- a/onebusaway-android/src/main/res/values-pl/strings.xml
+++ b/onebusaway-android/src/main/res/values-pl/strings.xml
@@ -831,8 +831,6 @@
     <string name="close_donation_card">Zamknij kartę darowizny</string>
 
     <!-- Trip Planner strings -->
-    <string name="trip_plan_from">Skąd: </string>
-    <string name="trip_plan_to">Dokąd: </string>
     <string name="trip_plan_leaving">Wyjazd</string>
     <string name="trip_plan_arriving">Przyjazd</string>
     <string name="trip_plan_date">Data</string>

--- a/onebusaway-android/src/main/res/values/colors.xml
+++ b/onebusaway-android/src/main/res/values/colors.xml
@@ -121,10 +121,10 @@
          device's own position at *either* end of the trip — "where I am" is a different kind of fact
          from "where I'm going", so it outranks the start/end distinction and reads the same at both.
          Otherwise the start takes the theme's primary (green in the OBA brand, and whatever a
-         white-label brand uses) and the destination this red. Literal values rather than md_theme_*
-         aliases: the scheme is a single-hue green one and has no blue or red slot to borrow. -->
+         white-label brand uses) and the destination the shared trip_destination_marker below, the same
+         red the itinerary's own terminal dot uses. A literal rather than an md_theme_* alias: the
+         scheme is a single-hue green one and has no blue slot to borrow. -->
     <color name="trip_plan_endpoint_current_location">#1565C0</color>
-    <color name="trip_plan_endpoint_destination">#C62828</color>
     <color name="trip_plan_card_background">@color/md_theme_surfaceContainer</color>
     <color name="trip_plan_header_text">@color/md_theme_onSurface</color>
     <color name="trip_plan_card_background_selected">@color/md_theme_secondaryContainer</color>

--- a/onebusaway-android/src/main/res/values/colors.xml
+++ b/onebusaway-android/src/main/res/values/colors.xml
@@ -117,6 +117,14 @@
     <color name="tutorial_background">#df4CAF50</color>
 
     <!-- Trip Planning -->
+    <!-- The directions form's endpoint identity colours. Blue marks an endpoint anchored to the
+         device's own position at *either* end of the trip — "where I am" is a different kind of fact
+         from "where I'm going", so it outranks the start/end distinction and reads the same at both.
+         Otherwise the start takes the theme's primary (green in the OBA brand, and whatever a
+         white-label brand uses) and the destination this red. Literal values rather than md_theme_*
+         aliases: the scheme is a single-hue green one and has no blue or red slot to borrow. -->
+    <color name="trip_plan_endpoint_current_location">#1565C0</color>
+    <color name="trip_plan_endpoint_destination">#C62828</color>
     <color name="trip_plan_card_background">@color/md_theme_surfaceContainer</color>
     <color name="trip_plan_header_text">@color/md_theme_onSurface</color>
     <color name="trip_plan_card_background_selected">@color/md_theme_secondaryContainer</color>

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -949,8 +949,16 @@
 
     <!-- Trip Planner strings -->
 
-    <string name="trip_plan_from">From: </string>
-    <string name="trip_plan_to">To: </string>
+    <!-- Placeholders shown in the empty directions endpoint fields. -->
+    <string name="trip_plan_from_hint">Choose starting point</string>
+    <string name="trip_plan_to_hint">Choose destination</string>
+    <!-- The directions form's time callout, e.g. "Leaving · now". Lowercase: it reads as part of a
+         sentence next to Leaving/Arriving, not as a heading. -->
+    <string name="trip_plan_now">now</string>
+    <string name="trip_plan_choose_date">Choose date…</string>
+    <string name="trip_plan_choose_time">Choose time…</string>
+    <!-- Accessibility click label for either half of the time callout. -->
+    <string name="trip_plan_change_when">Change when</string>
     <string name="trip_plan_leaving">Leaving</string>
     <string name="trip_plan_arriving">Arriving</string>
     <string name="trip_plan_date">Date</string>
@@ -965,7 +973,6 @@
     <!-- Caption beside a transit leg's joined route badge, when several routes go between the same two
          stops without making the rider late for the rest of the trip (badge reads e.g. "1 Line/2 Line"). -->
     <string name="directions_whichever_comes_first">whichever comes first</string>
-    <string name="trip_plan_clear_endpoint">Clear</string>
     <!-- Content descriptions for the chevrons that hint the itinerary-option picker can scroll sideways -->
     <string name="trip_plan_options_scroll_previous">Show previous options</string>
     <string name="trip_plan_options_scroll_more">Show more options</string>
@@ -1041,7 +1048,7 @@
     <string name="tripplanner_error_geocode_from_to_ambiguous">Origin and destination are uncertain</string>
     <string name="tripplanner_error_triangle">Something went wrong.  Change your bike options and try again</string>
     <!-- When routing from my location -->
-    <string name="tripplanner_current_location">Current Location</string>
+    <string name="tripplanner_current_location">Current location</string>
 
 
     <string name="tripplanner_reverse">Reverse</string>

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -955,6 +955,8 @@
     <!-- The directions form's time callout, e.g. "Leaving · now". Lowercase: it reads as part of a
          sentence next to Leaving/Arriving, not as a heading. -->
     <string name="trip_plan_now">now</string>
+    <!-- A pinned departure/arrival in the time callout: date, then time. -->
+    <string name="trip_plan_date_time">%1$s, %2$s</string>
     <string name="trip_plan_choose_date">Choose date…</string>
     <string name="trip_plan_choose_time">Choose time…</string>
     <!-- Accessibility click label for either half of the time callout. -->

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeSheetLogicTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeSheetLogicTest.kt
@@ -54,6 +54,14 @@ class HomeSheetLogicTest {
         assertEquals(0, focusBannerTopEdge(CurrentFocus.BikeStation("bike"), 240))
     }
 
+    @Test
+    fun `directions takes its top edge from the form card`() {
+        assertEquals(
+            180,
+            focusBannerTopEdge(CurrentFocus.Directions(), 240, directionsFormBottomPx = 180)
+        )
+    }
+
     // --- toggleSheetTarget ---
 
     @Test

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripPlanViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripPlanViewModelTest.kt
@@ -583,4 +583,37 @@ class TripPlanViewModelTest {
         assertFalse(state.departNow)
         assertEquals(1_700_000_000_000L, state.dateTimeMillis)
     }
+
+    /**
+     * "Arrive by now" asks for a trip that has already finished, so choosing *arriving* leaves the
+     * now anchor and pins a concrete instant for the rider to move.
+     */
+    @Test
+    fun `choosing arriving pins the trip to the clock`() = runTest {
+        val clock = FakeClock(0L)
+        val vm = viewModel(clock = clock)
+        clock.nowMillis = 60_000L
+
+        vm.setArriving(true)
+
+        val state = vm.formState.value
+        assertTrue(state.arriving)
+        assertFalse(state.departNow)
+        // Pinned to the clock at the moment of the switch, not to the stale construction stamp.
+        assertEquals(60_000L, state.dateTimeMillis)
+    }
+
+    @Test
+    fun `going back to leaving does not disturb a pinned time`() = runTest {
+        val vm = viewModel(clock = FakeClock(0L))
+        vm.setDateTime(1_700_000_000_000L)
+
+        vm.setArriving(true)
+        vm.setArriving(false)
+
+        val state = vm.formState.value
+        assertFalse(state.arriving)
+        assertFalse(state.departNow)
+        assertEquals(1_700_000_000_000L, state.dateTimeMillis)
+    }
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripPlanViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripPlanViewModelTest.kt
@@ -112,10 +112,16 @@ class TripPlanViewModelTest {
         override fun load() = settings
     }
 
+    /** A clock the test can advance, to tell "now at construction" apart from "now at submit". */
+    private class FakeClock(var nowMillis: Long = 0L) : TimeProvider {
+        override fun now(): Long = nowMillis
+    }
+
     private fun viewModel(
         geocode: GeocodeRepository = FakeGeocodeRepository(Result.success(emptyList())),
         plan: TripPlanRepository = FakeTripPlanRepository(Result.success(listOf(TripItinerary()))),
-        region: RegionRepository = FakeRegionRepository()
+        region: RegionRepository = FakeRegionRepository(),
+        clock: TimeProvider = TimeProvider { 0L }
     ): TripPlanViewModel {
         // The fake reports "no fix" — see TripPlanFormStateTest for the with-a-fix cases.
         val location = FakeLocationRepository()
@@ -125,7 +131,7 @@ class TripPlanViewModelTest {
             region,
             SearchCenter(location, region),
             location,
-            TimeProvider { 0L },
+            clock,
             FakeAdvancedSettingsRepository()
         )
     }
@@ -502,6 +508,79 @@ class TripPlanViewModelTest {
         val state = vm.formState.value
         assertTrue(state.dateLabel.isNotBlank())
         assertTrue(state.timeLabel.isNotBlank())
+        assertEquals(1_700_000_000_000L, state.dateTimeMillis)
+    }
+
+    @Test
+    fun `a form starts anchored to now`() = runTest {
+        assertTrue(viewModel().formState.value.departNow)
+    }
+
+    @Test
+    fun `a depart-now plan reads the clock at submit, not at construction`() = runTest {
+        val clock = FakeClock(0L)
+        val vm = viewModel(clock = clock)
+        // The rider leaves the form open for a while before both endpoints resolve.
+        clock.nowMillis = 90_000L
+        setBothEndpoints(vm)
+        advanceUntilIdle()
+
+        // This is the whole point of departNow: the seeded state still carries construction time, but
+        // the request that reaches OTP carries the moment of submission.
+        assertEquals(0L, vm.formState.value.dateTimeMillis)
+        assertEquals(90_000L, (vm.planState.value as PlanResult.Success).params?.dateTimeMillis)
+    }
+
+    @Test
+    fun `picking a time pins the trip against a moving clock`() = runTest {
+        val clock = FakeClock(0L)
+        val vm = viewModel(clock = clock)
+        setBothEndpoints(vm)
+        advanceUntilIdle()
+
+        vm.setDateTime(1_700_000_000_000L)
+        clock.nowMillis = 500_000L
+        advanceUntilIdle()
+
+        assertFalse(vm.formState.value.departNow)
+        assertEquals(
+            1_700_000_000_000L,
+            (vm.planState.value as PlanResult.Success).params?.dateTimeMillis
+        )
+    }
+
+    @Test
+    fun `setDepartNow returns a pinned trip to the now anchor`() = runTest {
+        val clock = FakeClock(0L)
+        val vm = viewModel(clock = clock)
+        setBothEndpoints(vm)
+        vm.setDateTime(1_700_000_000_000L)
+        advanceUntilIdle()
+
+        clock.nowMillis = 120_000L
+        vm.setDepartNow()
+        advanceUntilIdle()
+
+        val state = vm.formState.value
+        assertTrue(state.departNow)
+        // The pinned instant is refreshed too, so re-opening the picker starts from now rather than
+        // from the abandoned selection.
+        assertEquals(120_000L, state.dateTimeMillis)
+        assertEquals(120_000L, (vm.planState.value as PlanResult.Success).params?.dateTimeMillis)
+    }
+
+    @Test
+    fun `a restored trip stays pinned to the instant it was planned for`() = runTest {
+        val vm = viewModel(clock = FakeClock(0L))
+        vm.restoreFrom(
+            from = origin,
+            to = destination,
+            dateTimeMillis = 1_700_000_000_000L,
+            arriving = true,
+            itineraries = listOf(TripItinerary())
+        )
+        val state = vm.formState.value
+        assertFalse(state.departNow)
         assertEquals(1_700_000_000_000L, state.dateTimeMillis)
     }
 }


### PR DESCRIPTION
Closes #2094.

## Problem

The directions entry card took **216dp** of the map — about a quarter of a phone screen — before showing a single route. Two labelled outlined fields, each carrying two icon buttons; a trailing column of two more; and a third row of three controls for when. Six always-visible controls around two inputs.

## Change

Two identical 48dp endpoint rows over one 44dp action bar. **146dp.**

- **Each endpoint** is a leading rail glyph plus borderless text — no label, no pill, no trailing slot, so the rows run the full width of the card. The glyph is a dot coloured by what the endpoint *is*: blue wherever the trip is anchored to the device's own position (at either end — "where I am" is a different kind of fact from "where I'm going", so it outranks the start/destination distinction), else the theme primary for the origin and the shared `trip_destination_marker` red for the destination. A current-location endpoint is named in that same blue. A transit endpoint keeps the bus glyph, which is the one thing no colour in the set encodes.
- **Current-location and pick-on-map** stop being permanent chrome on every field and become the first two rows of the suggestion list, retiring four icon buttons. The current-location row shows the same blue dot the rail will show once it's chosen.
- **One action bar** carries everything acting on the whole trip: the time as a `Leaving · now` callout whose halves open separate pickers, plus reverse and additional preferences. Only per-endpoint controls belong in an endpoint row — which is now none of them.
- **The map-pick overlay's labelled `[From:/To: ✕]` card is gone.** The map is what a pick is reading and the card only covered it; back cancels, as elsewhere in directions.

### One text field per row

Each row is a single persistent `BasicTextField` in every state, with one `TextFieldValue` owning the text. Swapping a read-only `Text` in and out for a text field destroys and recreates it on each transition, and the focus callbacks and IME teardown that fall out of that are indistinguishable from real user input. On device that showed up as a dropdown that flashed open and shut, and as "Current location" resolving only on alternate taps — the same root cause seen from two angles.

### "now" has to be true

`dateTimeMillis` is stamped once when the ViewModel is built, so a form left open would have planned a trip in the past. `departNow` defaults to true and `toParams` takes the caller's clock reading, resolved at submit; picking a date or time pins the trip, and a restored trip stays pinned to the instant it was planned for.

## Two map-layer fixes the redesign surfaced

- **A pick captured a point about a tenth of a screen below the crosshair.** Content padding moves the camera *target* to the middle of the padded region — right for framing a route, wrong for a pick, because the captured point **is** the target. There are four independent padding writers, so `MapRenderState` gains a centre-pick flag that suspends padding outright rather than zeroing contributors one at a time.
- **A tap on the map while the keyboard was up also ran `unfocusMapOneLevel`**, which from the form — an editor with no sub-focus beneath it — left directions altogether and discarded the trip being entered. That tap now only dismisses the keyboard.

## Rebase note

Rebased onto the `TripEndpointSlot` refactor (#2095): the form renders `TripEndpointSlot.entries` and takes slot-taking callbacks, `labelRes` becomes `placeholderRes` over the new hint strings, and the pill's `onClear` is dropped — typing over a resolved endpoint is what clears it now. That retires `trip_plan_from` / `trip_plan_to` / `trip_plan_clear_endpoint` across all five locales.

`tripplanner_current_location` also becomes sentence case ("Current location"); every translation of it was already sentence case, so English was the outlier.

## Testing

Compiles clean under `-PwarningsAsErrors=true`, `spotlessCheck` and the JVM unit suite pass. A new on-device render suite (11 tests, run on a Pixel 7 Pro) pins the 146dp budget at real density, the rail's colour rule as channel dominance rather than exact hex, and both device bugs above as regressions.

**Not verified:** the map-pick offset and the keyboard-dismiss tap both need real gestures and have not been re-exercised since the rebase — the code is unchanged by the merge, but it now sits on top of #2095's pick rewiring. Worth a pass before merge.

## Follow-ups (not in this PR)

- **The pick fix is effectively Google-only.** MapLibre folds padding into camera commands rather than calling `setPadding`, so `setCenterPickActive` is a no-op there — harmless (no offset to correct) but it means flavour-neutral state now carries a mode that compensates for one renderer. The deeper fix is an inverse `MapProjector.fromScreen`, letting the pick read the geo point at the crosshair's own pixel so padding never has to be suspended. That needs a new method on both adapters, and MapLibre publishes no projector at all today.
- Restoring padding when a pick ends emits a growth tick on `insetGrowthReframes`; it currently survives only because panning during a pick sets `cameraInteracting`.
- `TripPlanViewModel.clearEndpoint` is now unreachable from the UI (the pill's ✕ is gone) and is exercised only by tests. Left in place rather than deleted from #2095's API during this change.
- #2096 — a business's name should appear in search results and as the endpoint text.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned the trip planner with clearer endpoint fields, streamlined actions, and improved date/time controls.
  * Added “Depart now” behavior and more reliable switching between departure and arrival planning.
  * Improved map point-picking with centered crosshair alignment and simplified confirmation controls.
  * Added localized labels, hints, and dark-mode endpoint colors.

* **Bug Fixes**
  * Tapping the map while typing now dismisses the keyboard without disrupting trip entry.

* **Tests**
  * Expanded coverage for trip planner rendering, map interactions, and time-selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->