### PR TITLE
Make stops unselectable in directions mode (#2097)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
@@ -53,7 +53,13 @@ import org.onebusaway.android.util.toGeoPoint
 internal enum class StopFocusTransition {
     Unchanged,
     ContinuePresentation,
-    ReplacePresentation
+    ReplacePresentation,
+
+    /**
+     * The focus was refused: directions owns the map, and a stop cannot be selected there (#2097).
+     * Callers must not mark the stop selected on the map either — the refusal is the whole point.
+     */
+    Refused
 }
 
 /**
@@ -217,6 +223,12 @@ class HomeViewModel @Inject constructor(
         stop: FocusedStop,
         continuingRoutes: Set<RouteDirectionKey> = emptySet()
     ): StopFocusTransition {
+        // Directions owns the map while a trip is being planned, so a stop tapped there is refused
+        // rather than allowed to take over (#2097). Letting it through pushed stop focus on top of the
+        // trip, and coming back left the marker still reading as selected underneath a form that knows
+        // nothing about it — a state easier to make unreachable than to unwind. A deliberate reveal
+        // from elsewhere in the app is a different act and leaves directions first; see [revealStop].
+        if (_currentFocus.value is CurrentFocus.Directions) return StopFocusTransition.Refused
         val previousId = _currentFocus.value.focusedStop?.id
         val sameStop = previousId == stop.id
         if (sameStop) return StopFocusTransition.Unchanged
@@ -249,6 +261,11 @@ class HomeViewModel @Inject constructor(
      */
     fun revealStop(stop: FocusedStop, animate: Boolean = false) {
         emitMapDirective(MapDirective.ClearFocus)
+        // Asking for a stop from somewhere else in the app — starred, recents, a deep link — is a
+        // deliberate move to that stop, so it leaves a trip plan behind rather than being refused by
+        // it the way a marker tap on the directions map is. The plan itself survives in
+        // TripPlanViewModel, so re-entering directions picks it back up.
+        if (_currentFocus.value is CurrentFocus.Directions) replaceFocus(CurrentFocus.None)
         onStopFocused(stop)
         markPendingMapFocus(animate)
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
@@ -226,9 +226,23 @@ class HomeViewModel @Inject constructor(
         // Directions owns the map while a trip is being planned, so a stop tapped there is refused
         // rather than allowed to take over (#2097). Letting it through pushed stop focus on top of the
         // trip, and coming back left the marker still reading as selected underneath a form that knows
-        // nothing about it — a state easier to make unreachable than to unwind. A deliberate reveal
-        // from elsewhere in the app is a different act and leaves directions first; see [revealStop].
+        // nothing about it — a state easier to make unreachable than to unwind.
         if (_currentFocus.value is CurrentFocus.Directions) return StopFocusTransition.Refused
+        return focusStop(stop, continuingRoutes)
+    }
+
+    /**
+     * Focus [stop] unconditionally — the shared body of [onStopFocused] and [revealStop], minus the
+     * rule about who may ask. Asking for a stop from elsewhere in the app (starred, recents, a deep
+     * link) is a deliberate move to it rather than a stray tap on a crowded map, so it is never
+     * refused. It also has to reach the focus change *without* the current focus being rewritten
+     * first: [pushFocus] records the focus it replaces, so stepping through None on the way would
+     * drop the trip out of the back stack and leave Back on an empty map instead of the itinerary.
+     */
+    private fun focusStop(
+        stop: FocusedStop,
+        continuingRoutes: Set<RouteDirectionKey> = emptySet()
+    ): StopFocusTransition {
         val previousId = _currentFocus.value.focusedStop?.id
         val sameStop = previousId == stop.id
         if (sameStop) return StopFocusTransition.Unchanged
@@ -261,12 +275,7 @@ class HomeViewModel @Inject constructor(
      */
     fun revealStop(stop: FocusedStop, animate: Boolean = false) {
         emitMapDirective(MapDirective.ClearFocus)
-        // Asking for a stop from somewhere else in the app — starred, recents, a deep link — is a
-        // deliberate move to that stop, so it leaves a trip plan behind rather than being refused by
-        // it the way a marker tap on the directions map is. The plan itself survives in
-        // TripPlanViewModel, so re-entering directions picks it back up.
-        if (_currentFocus.value is CurrentFocus.Directions) replaceFocus(CurrentFocus.None)
-        onStopFocused(stop)
+        focusStop(stop)
         markPendingMapFocus(animate)
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
@@ -172,6 +172,9 @@ fun MapFeature(
                     FocusedStop(stop.id, stop.name, stop.stopCode, marker.point, stop.wheelchairBoarding),
                     continuingRoutes = marker.presentedRoutes
                 )
+                // Refused (directions owns the map): leave before the map marks the stop selected,
+                // which is the render state that used to outlive the focus and confuse the trip.
+                if (transition == StopFocusTransition.Refused) return
                 if (transition == StopFocusTransition.ReplacePresentation) {
                     mapViewModel.clearAllFocus()
                 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
@@ -1386,40 +1386,38 @@ class HomeViewModelTest {
 
     private val someStop = FocusedStop("1", "Main St", "100", GeoPoint(47.6, -122.3))
 
+    /** Started from a leg sub-focus, the hardest state the one `is Directions` guard has to hold. */
     @Test
     fun `a stop tapped on the directions map is refused`() = runTest {
-        val vm = viewModel()
-        vm.enterDirections()
-
-        val transition = vm.onStopFocused(someStop)
-
-        assertEquals(StopFocusTransition.Refused, transition)
-        // The refusal is the point: focus stays on the trip, so there is no stop selection to leave
-        // behind when the rider comes back to it.
-        assertTrue(vm.currentFocus.value is CurrentFocus.Directions)
-    }
-
-    @Test
-    fun `a refused stop does not disturb a focused leg`() = runTest {
         val vm = viewModel()
         vm.enterDirectionsShowing()
         val walk = walkLeg(2)
         vm.focusItineraryLegOnMap(walk)
 
-        vm.onStopFocused(someStop)
+        val transition = vm.onStopFocused(someStop)
 
+        assertEquals(StopFocusTransition.Refused, transition)
+        // The refusal is the point: focus is untouched, so there is no stop selection to leave behind
+        // when the rider comes back to the trip.
         assertEquals(CurrentFocus.Directions(DirectionsSubFocus.Leg(walk)), vm.currentFocus.value)
     }
 
-    /** A reveal from elsewhere is deliberate, so it leaves directions rather than being refused. */
+    /**
+     * A reveal is a deliberate move to that stop, so it is never refused — and it must not rewrite
+     * focus on the way in. pushFocus records the focus it replaces, so stepping through None would
+     * drop the trip out of the back stack: Back would land on an empty map rather than the itinerary.
+     */
     @Test
-    fun `revealing a stop from navigation leaves directions`() = runTest {
+    fun `back after revealing a stop from directions returns to the trip`() = runTest {
         val vm = viewModel()
-        vm.enterDirections()
+        vm.enterDirectionsShowing()
 
         vm.revealStop(someStop)
-
         assertEquals(someStop, vm.currentFocus.value.focusedStop)
+
+        vm.navigateBackFocus()
+
+        assertEquals(CurrentFocus.Directions(), vm.currentFocus.value)
     }
 
     @Test

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
@@ -1381,4 +1381,54 @@ class HomeViewModelTest {
         assertEquals(0, startup.cleared)
         assertEquals(0, region.refreshCount)
     }
+
+    // ---- a stop cannot be selected while directions owns the map (#2097) ----
+
+    private val someStop = FocusedStop("1", "Main St", "100", GeoPoint(47.6, -122.3))
+
+    @Test
+    fun `a stop tapped on the directions map is refused`() = runTest {
+        val vm = viewModel()
+        vm.enterDirections()
+
+        val transition = vm.onStopFocused(someStop)
+
+        assertEquals(StopFocusTransition.Refused, transition)
+        // The refusal is the point: focus stays on the trip, so there is no stop selection to leave
+        // behind when the rider comes back to it.
+        assertTrue(vm.currentFocus.value is CurrentFocus.Directions)
+    }
+
+    @Test
+    fun `a refused stop does not disturb a focused leg`() = runTest {
+        val vm = viewModel()
+        vm.enterDirectionsShowing()
+        val walk = walkLeg(2)
+        vm.focusItineraryLegOnMap(walk)
+
+        vm.onStopFocused(someStop)
+
+        assertEquals(CurrentFocus.Directions(DirectionsSubFocus.Leg(walk)), vm.currentFocus.value)
+    }
+
+    /** A reveal from elsewhere is deliberate, so it leaves directions rather than being refused. */
+    @Test
+    fun `revealing a stop from navigation leaves directions`() = runTest {
+        val vm = viewModel()
+        vm.enterDirections()
+
+        vm.revealStop(someStop)
+
+        assertEquals(someStop, vm.currentFocus.value.focusedStop)
+    }
+
+    @Test
+    fun `a stop tapped outside directions still focuses`() = runTest {
+        val vm = viewModel()
+
+        val transition = vm.onStopFocused(someStop)
+
+        assertEquals(StopFocusTransition.ReplacePresentation, transition)
+        assertEquals(someStop, vm.currentFocus.value.focusedStop)
+    }
 }


### PR DESCRIPTION
Closes #2097.

## Problem

Tapping a stop marker while directions owned the map pushed stop focus on top of the trip. Swiping back returned to directions, but the marker still read as selected underneath a form that knows nothing about it — the confusing state the issue describes.

## Change

`onStopFocused` refuses while the focus is `Directions`, returning a new `StopFocusTransition.Refused`, and the map's click handler leaves on it **before** `onStopTapped`. That second half is half the fix: the map's own `focusedStopId` is the render state that outlived the focus and produced the symptom, so not setting it is what makes the state unreachable rather than merely undone afterwards.

### Why the policy is in the ViewModel and not the tap handler

`onStopFocused` has a second caller. `revealStop` — reached from starred stops, recents, arrivals and deep links — would have gone silently dead whenever a trip was open. So the two entries are deliberately different:

- **A marker tap** on the directions map is refused. You're planning a trip and brushed a marker.
- **A deliberate reveal** from elsewhere in the app is never refused; it goes to a private `focusStop` that carries no policy.

The plan itself lives in `TripPlanViewModel`, so nothing about a trip is lost either way.

### A note on how that shape was arrived at

The first version had `revealStop` clear directions focus so the guard wouldn't fire on it. That was wrong in a way worth recording: `pushFocus` records the focus it *replaces*, so stepping through `None` dropped the trip out of the back stack, and Back after revealing a stop from a trip landed on an empty map instead of the itinerary. The split above removes the focus rewrite entirely, and `back after revealing a stop from directions returns to the trip` pins it — that test was checked against the old code to confirm it actually fails there.

## Testing

`compileObaGoogleDebugKotlin` and `compileObaMaplibreDebugKotlin` under `-PwarningsAsErrors=true`, `spotlessCheck`, and the JVM unit suite all pass. Four cases in `HomeViewModelTest`:

- a stop tapped on the directions map is refused, from a leg sub-focus (the hardest state the single `is Directions` check has to hold), asserting both the transition and that focus is untouched
- Back after revealing a stop from directions returns to the trip
- a reveal from navigation still lands on the stop
- a stop tapped outside directions still focuses — the negative control that the guard doesn't over-fire

Installed and exercised on a Pixel 7 Pro.

## Follow-up (not in this PR)

A refused tap is now a silent dead tap — the marker is still drawn and still hit-testable, it just does nothing. The stronger reading of "unrepresentable" is to stop publishing tappable stop markers while directions owns the map, which is what `showItinerary` already effectively does once a plan exists. That's a UX change beyond this issue and belongs in its own.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tapping a stop while directions mode controls the map no longer changes the selected stop.
  * Stops remain visually unselected when selection is refused in directions mode.
  * Deliberately revealing a stop continues to work and can be undone to return to directions.
  * Tapping stops outside directions mode still updates the current selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->