### PR TITLE
Interleave interchangeable routes in the directions ETA strip

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/arrivals/EtaStripRenderTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/arrivals/EtaStripRenderTest.kt
@@ -26,6 +26,7 @@ import org.onebusaway.android.SmokeTest
 import org.onebusaway.android.ui.arrivals.components.EtaStrip
 import org.onebusaway.android.ui.arrivals.components.previewArrival
 import org.onebusaway.android.ui.arrivals.components.previewRowCallbacks
+import org.onebusaway.android.ui.compose.components.RouteBadge
 import org.onebusaway.android.ui.compose.createUnconfinedComposeRule
 
 /**
@@ -54,7 +55,10 @@ class EtaStripRenderTest {
                         previewArrival("40", "Northgate", etaMinutes = 12, tripId = "trip_3")
                     ),
                     actionsFor = { null },
-                    callbacks = previewRowCallbacks()
+                    callbacks = previewRowCallbacks(),
+                    routeBadgeFor = {
+                        RouteBadge(it.shortName ?: error("preview route must have a name"), null)
+                    }
                 )
             }
         }
@@ -66,5 +70,7 @@ class EtaStripRenderTest {
         // The value is stable for the test's duration: previewArrival anchors serverNow at 0 and
         // liveEta divides each side into whole minutes, so the pill reads exactly -2 for the first 60s.
         composeRule.onNodeWithText("-2", substring = true).assertExists()
+        // Route identity is inside each pill when the caller supplies it (#2099).
+        composeRule.onNodeWithText("40").assertExists()
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
@@ -270,10 +270,11 @@ class RouteMapController(
     // The ETA-pill trip exempt from the selected-leg geometry filter (#2099). Unlike [pendingFocus] —
     // a one-shot the FIT/DROP resolution consumes — this lives as long as the focus context itself:
     // the per-frame sampler re-runs the filter continuously, so an exemption keyed to the pending
-    // focus would drop the tapped vehicle on the very next sample after the camera fits it. Set with
-    // every focus request (start/reframe/requestFocus, mirroring the request's focusTripId, including
-    // null); cleared only when the focus context ends — leaving route mode ([stop]) or a deliberate
-    // direction switch ([selectDirection]).
+    // focus would drop the tapped vehicle on the very next sample after the camera fits it. Set
+    // alongside [pendingFocus] wherever a focus is installed ([start], [requestFocus] — which is how
+    // [reframe] installs one too); cleared when the focus context ends — leaving route mode ([stop]),
+    // a deliberate direction switch ([selectDirection]), or a [reframe] onto a request carrying no
+    // focus of its own.
     private var focusExemptTripId: String? = null
 
     /**
@@ -381,6 +382,14 @@ class RouteMapController(
      * reachable here — though [start]'s own parameter list still needs a matching update (#1797).
      */
     fun reframe(request: ShowRouteRequest, frameRoute: Boolean = true) {
+        // [request] carries the whole desired focus state, so a previous request's focus ends here —
+        // and it must end *before* the segment refresh below, which republishes the vehicle set and so
+        // reads both fields: against the new geometry, a stale exemption would admit the old leg's
+        // vehicle and a stale pending focus could fly the camera to it. [requestFocus] in the tail
+        // installs this request's own focus; a request carrying none leaves focus cleared, the same
+        // unconditional set [start] does.
+        pendingFocus = null
+        focusExemptTripId = null
         // A reframe onto the same route+direction-stop can still carry a different (or empty) segment —
         // e.g. tapping a different leg of the same route. Re-emphasize the polyline and re-filter the
         // shown stops so a stale segment doesn't linger. start() sets this unconditionally; here we only
@@ -398,10 +407,6 @@ class RouteMapController(
             showDirectionPolylines()
         }
         request.initialDirectionId?.let { selectDirection(it) }
-        // The exemption mirrors this request's focus intent: a reframe without a focusTripId (e.g.
-        // tapping a different leg of the same route) ends any prior pill focus, so its exempted
-        // vehicle doesn't leak through the new leg's geometry filter.
-        focusExemptTripId = request.focusTripId
         request.focusTripId?.let { requestFocus(it) } ?: if (frameRoute) frameRouteOrSegment() else Unit
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
@@ -492,7 +492,14 @@ class RouteMapController(
     private fun List<ExtrapolatedVehicle>.filterToFocusedRide(routeId: String): List<ExtrapolatedVehicle> {
         if (!highlightedSegment.isDrawableSegment()) return this
         val eligiblePaths = focusedVehiclePathsByRoute[routeId] ?: return emptyList()
-        return filter { vehicle -> eligiblePaths.containsRoutePoint(vehicle.point) }
+        return filter { vehicle ->
+            focusedRideKeepsVehicle(
+                vehicleTripId = vehicle.status.activeTripId,
+                pendingFocusTripId = pendingFocus,
+                eligiblePaths = eligiblePaths,
+                point = vehicle.point
+            )
+        }
     }
 
     /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
@@ -267,6 +267,15 @@ class RouteMapController(
     // set from an ETA-pill tap ([ShowRouteRequest.focusTripId]).
     private var pendingFocus: String? = null
 
+    // The ETA-pill trip exempt from the selected-leg geometry filter (#2099). Unlike [pendingFocus] —
+    // a one-shot the FIT/DROP resolution consumes — this lives as long as the focus context itself:
+    // the per-frame sampler re-runs the filter continuously, so an exemption keyed to the pending
+    // focus would drop the tapped vehicle on the very next sample after the camera fits it. Set with
+    // every focus request (start/reframe/requestFocus, mirroring the request's focusTripId, including
+    // null); cleared only when the focus context ends — leaving route mode ([stop]) or a deliberate
+    // direction switch ([selectDirection]).
+    private var focusExemptTripId: String? = null
+
     /**
      * Show route [routeId]: load the route + header and start the vehicle poll. [zoomToRoute] frames
      * the shape once it loads (consumed once). [directionStopId], when non-null, narrows the overlay to
@@ -307,6 +316,7 @@ class RouteMapController(
         this.focusedVehiclePathsByRoute = emptyMap()
         this.initialDirectionOverride = initialDirectionId
         this.pendingFocus = focusTripId
+        this.focusExemptTripId = focusTripId
         // A whole-route launch has no direction to wait for, so its vehicles show as soon as they poll;
         // a direction-anchored launch (an anchor stop or a restored direction) stays Pending until the
         // route load resolves the filter (below).
@@ -355,6 +365,7 @@ class RouteMapController(
      */
     fun requestFocus(tripId: String) {
         pendingFocus = tripId
+        focusExemptTripId = tripId
         tryFocusVehicle(currentVehicleLayer())
     }
 
@@ -387,6 +398,10 @@ class RouteMapController(
             showDirectionPolylines()
         }
         request.initialDirectionId?.let { selectDirection(it) }
+        // The exemption mirrors this request's focus intent: a reframe without a focusTripId (e.g.
+        // tapping a different leg of the same route) ends any prior pill focus, so its exempted
+        // vehicle doesn't leak through the new leg's geometry filter.
+        focusExemptTripId = request.focusTripId
         request.focusTripId?.let { requestFocus(it) } ?: if (frameRoute) frameRouteOrSegment() else Unit
     }
 
@@ -495,7 +510,7 @@ class RouteMapController(
         return filter { vehicle ->
             focusedRideKeepsVehicle(
                 vehicleTripId = vehicle.status.activeTripId,
-                pendingFocusTripId = pendingFocus,
+                focusedTripId = focusExemptTripId,
                 eligiblePaths = eligiblePaths,
                 point = vehicle.point
             )
@@ -645,6 +660,7 @@ class RouteMapController(
         directionState = DirectionState.Resolved(null)
         latestPoll = null
         pendingFocus = null
+        focusExemptTripId = null
         publishMapPresentation()
         // setVehicleSet(null) is what clears the vehicle markers (the renderer reconciles the empty set);
         // it must be nulled together with the motion sampler, which only moves already-reconciled markers.
@@ -1074,10 +1090,12 @@ class RouteMapController(
     fun selectDirection(directionId: Int?): Boolean {
         if (routeId == null || directionId == currentDirectionId) return false
         directionState = DirectionState.Resolved(directionId)
-        // A vehicle selected in the old direction is now filtered out — drop the selection, and drop any
-        // still-pending vehicle+stop focus (the switch is a deliberate "show the other direction" action).
+        // A vehicle selected in the old direction is now filtered out — drop the selection, any
+        // still-pending vehicle+stop focus, and the pill trip's geometry-filter exemption (the switch
+        // is a deliberate "show the other direction" action).
         renderState.setSelectedVehicle(null)
         pendingFocus = null
+        focusExemptTripId = null
         showDirectionStops()
         showDirectionPolylines()
         // Re-filter the vehicle set against the same poll and push it — the renderer reconciles markers on

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteSegmentHighlight.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteSegmentHighlight.kt
@@ -96,6 +96,22 @@ internal fun List<BoundedRoutePath>.containsRoutePoint(
     projection.distanceToPoint <= toleranceMeters && projection.distanceAlong <= path.maxDistanceAlong
 }
 
+/**
+ * Whether a route-focus vehicle survives the selected leg's spatial filter. The explicitly requested
+ * ETA-pill trip always survives: its pin is derived from the arrivals response's exact active-trip +
+ * GPS identity, while the eligible path is reconstructed independently from route-wide geometry and
+ * can miss a legitimate trip variant. Without this exception the route poll can contain the tapped
+ * vehicle yet discard it before [RouteMapController] gets the chance to frame it.
+ */
+internal fun focusedRideKeepsVehicle(
+    vehicleTripId: String?,
+    pendingFocusTripId: String?,
+    eligiblePaths: List<BoundedRoutePath>,
+    point: GeoPoint
+): Boolean = vehicleTripId != null &&
+    vehicleTripId == pendingFocusTripId ||
+    eligiblePaths.containsRoutePoint(point)
+
 private fun List<RoutePolyline>.closestProjection(anchor: GeoPoint) = mapIndexedNotNull { index, line ->
     val projection = Polyline(line.points).nearestProjection(anchor.latitude, anchor.longitude)
         ?: return@mapIndexedNotNull null

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteSegmentHighlight.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteSegmentHighlight.kt
@@ -98,18 +98,22 @@ internal fun List<BoundedRoutePath>.containsRoutePoint(
 
 /**
  * Whether a route-focus vehicle survives the selected leg's spatial filter. The explicitly requested
- * ETA-pill trip always survives: its pin is derived from the arrivals response's exact active-trip +
- * GPS identity, while the eligible path is reconstructed independently from route-wide geometry and
- * can miss a legitimate trip variant. Without this exception the route poll can contain the tapped
- * vehicle yet discard it before [RouteMapController] gets the chance to frame it.
+ * ETA-pill trip ([focusedTripId]) always survives: its pin is derived from the arrivals response's
+ * exact active-trip + GPS identity, while the eligible path is reconstructed independently from
+ * route-wide geometry and can miss a legitimate trip variant. Without this exception the route poll
+ * can contain the tapped vehicle yet discard it before [RouteMapController] gets the chance to frame
+ * it.
+ *
+ * [focusedTripId] must be the trip's exemption for the whole focus context, not the one-shot pending
+ * camera fit: this filter re-runs on every vehicle sample, so keying it to a focus that resolves
+ * (and clears) on the first fit would drop the framed vehicle again on the very next sample (#2099).
  */
 internal fun focusedRideKeepsVehicle(
     vehicleTripId: String?,
-    pendingFocusTripId: String?,
+    focusedTripId: String?,
     eligiblePaths: List<BoundedRoutePath>,
     point: GeoPoint
-): Boolean = vehicleTripId != null &&
-    vehicleTripId == pendingFocusTripId ||
+): Boolean = (vehicleTripId != null && vehicleTripId == focusedTripId) ||
     eligiblePaths.containsRoutePoint(point)
 
 private fun List<RoutePolyline>.closestProjection(anchor: GeoPoint) = mapIndexedNotNull { index, line ->

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStrip.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStrip.kt
@@ -74,6 +74,8 @@ import org.onebusaway.android.ui.arrivals.ArrivalInfo
 import org.onebusaway.android.ui.compose.components.CenteredLongPressMenu
 import org.onebusaway.android.ui.compose.components.MaterialSymbols
 import org.onebusaway.android.ui.compose.components.MenuRow
+import org.onebusaway.android.ui.compose.components.RouteBadge
+import org.onebusaway.android.ui.compose.components.RouteBadgeChip
 import org.onebusaway.android.ui.compose.components.ScrollChevronGutter
 import org.onebusaway.android.ui.compose.components.tightLineStyle
 import org.onebusaway.android.ui.compose.theme.ObaTheme
@@ -103,6 +105,7 @@ internal fun EtaStrip(
     callbacks: ArrivalRowCallbacks,
     modifier: Modifier = Modifier,
     firstPillModifier: Modifier = Modifier,
+    routeBadgeFor: (ArrivalInfo) -> RouteBadge? = { null },
     // Hoisted for previews/tests ONLY (both real call sites use the default) so a caller can start
     // the strip mid-scroll.
     state: LazyListState = rememberLazyListState()
@@ -112,6 +115,7 @@ internal fun EtaStrip(
     // a redundant per-pill ticker/coroutine (issue #1781). ServerTime(0) is an inert placeholder for
     // the (pill-less) empty-trips case; nothing reads it since the pill loop below never runs.
     val liveNow = rememberLiveServerTime(trips.firstOrNull()?.serverNow ?: ServerTime(0L))
+    val hasRouteBadges = trips.any { routeBadgeFor(it) != null }
 
     // The strip viewport width in px, for the one-viewport chevron jump below.
     var viewportPx by remember { mutableIntStateOf(0) }
@@ -149,7 +153,13 @@ internal fun EtaStrip(
                 // An invisible tallest-variant pill (two-line ETA + clock subline), measured to size
                 // the row and never placed — so it's never drawn, takes no input, adds no semantics.
                 // Constant params, so it never recomposes on the live clock tick.
-                EtaPill(eta = 10, color = Color.Transparent, predicted = false, clockTime = "0:00")
+                EtaPill(
+                    eta = 10,
+                    color = Color.Transparent,
+                    predicted = false,
+                    clockTime = "0:00",
+                    routeBadge = if (hasRouteBadges) RouteBadge("00", null) else null
+                )
             }
         ) {
             LazyRow(
@@ -161,16 +171,16 @@ internal fun EtaStrip(
             ) {
                 itemsIndexed(
                     trips,
-                    // Trip-instance identity, so a poll that drops an aged-out leading trip keeps the
+                    // Route + trip-instance identity, so a poll that drops an aged-out leading trip keeps the
                     // viewport on the surviving pills instead of shifting by an index. It's the SAME
                     // (tripId, serviceDate, stopSequence) triple the arrivals dedup collapses to one
-                    // entry (see collapseDuplicateTripInstances) — tripId alone is NOT unique (a loop
-                    // route's two genuine visits to one stop share it), and a duplicate LazyRow key
-                    // is a fatal throw at measure time, so uniqueness here rests on that dedup rather
-                    // than on the feed being well-behaved (#2012). The NUL separator is the same
-                    // can't-occur-in-an-id joiner routeRowKey uses, written as an escape rather than pasted
-                    // raw, which had made this file binary to grep and code review (#2012).
-                    key = { _, trip -> "${trip.tripId}\u0000${trip.serviceDate}\u0000${trip.stopSequence}" }
+                    // entry within one route (see collapseDuplicateTripInstances); routeId keeps that
+                    // invariant valid when the directions drawer interleaves several routes (#2099).
+                    // tripId alone is NOT unique (a loop route's two genuine visits to one stop share
+                    // it), and a duplicate LazyRow key is a fatal throw at measure time. The NUL
+                    // separator is the same can't-occur-in-an-id joiner routeRowKey uses, written as an
+                    // escape rather than pasted raw, which had made this file binary to grep (#2012).
+                    key = { _, trip -> "${trip.routeId}\u0000${trip.tripId}\u0000${trip.serviceDate}\u0000${trip.stopSequence}" }
                 ) { index, trip ->
                     // The first pill carries the caller's anchor modifier (e.g. the tutorial spotlight).
                     val pillModifier = if (index == 0) firstPillModifier else Modifier
@@ -179,6 +189,7 @@ internal fun EtaStrip(
                         liveNow = liveNow,
                         actions = actionsFor(trip),
                         callbacks = callbacks,
+                        routeBadge = routeBadgeFor(trip),
                         modifier = pillModifier
                     )
                 }
@@ -268,6 +279,7 @@ private fun EtaPillWithMenu(
     liveNow: ServerTime,
     actions: ArrivalActions?,
     callbacks: ArrivalRowCallbacks,
+    routeBadge: RouteBadge? = null,
     modifier: Modifier = Modifier
 ) {
     var expanded by remember { mutableStateOf(false) }
@@ -292,6 +304,7 @@ private fun EtaPillWithMenu(
             onMap = trip.vehicleOnMap,
             canceled = trip.status == Status.CANCELED,
             clockTime = clockTime,
+            routeBadge = routeBadge,
             onClick = { callbacks.onEtaClick(trip) },
             onLongClick = { expanded = true }
         )
@@ -346,6 +359,7 @@ internal fun EtaPill(
     color: Color,
     predicted: Boolean,
     modifier: Modifier = Modifier,
+    routeBadge: RouteBadge? = null,
     // The trip's live vehicle is drawn on the map right now (#1992): show the "on the map" pin instead of
     // the rss glyph, cueing that a tap on this pill reframes the map to that vehicle. Implies [predicted]
     // (a drawn vehicle is always real-time), so it wins when both would apply.
@@ -398,14 +412,24 @@ internal fun EtaPill(
             // guessed independently of the actual text metrics.
             Column(
                 modifier = Modifier.padding(
-                    start = 6.dp,
-                    end = 6.dp,
+                    // A badged direction pill puts another element at its top edge. Reserve the live
+                    // indicator's overlaid corner on both sides so it cannot cover the roundel and the
+                    // roundel remains visually centered.
+                    start = if (routeBadge == null) 6.dp else indicatorSize,
+                    end = if (routeBadge == null) 6.dp else indicatorSize,
                     top = topPadding,
                     bottom = bottomPadding
                 ),
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.spacedBy(clockTimeGap)
             ) {
+                if (routeBadge != null) {
+                    RouteBadgeChip(
+                        shortName = routeBadge.shortName,
+                        routeColor = routeBadge.routeColor,
+                        scale = 0.8f
+                    )
+                }
                 if (etaParts == null) {
                     Text(
                         text = stringResource(R.string.stop_info_eta_now),

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStrip.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStrip.kt
@@ -115,7 +115,10 @@ internal fun EtaStrip(
     // a redundant per-pill ticker/coroutine (issue #1781). ServerTime(0) is an inert placeholder for
     // the (pill-less) empty-trips case; nothing reads it since the pill loop below never runs.
     val liveNow = rememberLiveServerTime(trips.firstOrNull()?.serverNow ?: ServerTime(0L))
-    val hasRouteBadges = trips.any { routeBadgeFor(it) != null }
+    // Remembered because reading the live clock above recomposes this whole body once a second, and
+    // this would otherwise re-run the caller's lambda over every trip on each of those ticks. It only
+    // changes when the trips or the badge source do.
+    val hasRouteBadges = remember(trips, routeBadgeFor) { trips.any { routeBadgeFor(it) != null } }
 
     // The strip viewport width in px, for the one-viewport chevron jump below.
     var viewportPx by remember { mutableIntStateOf(0) }
@@ -341,6 +344,15 @@ internal fun TripActionsMenu(
 }
 
 /**
+ * How wide a pill's route roundel may grow before its name ellipsizes — the option cards' own
+ * OPTION_BADGE_MAX_WIDTH rule (TripResultsScreen), at pill scale. Only bites on a route badged by its
+ * long name (one publishing no short name — both badge sources feeding a pill fall back to the long
+ * name), which would otherwise stretch one pill far past its neighbours and turn the strip's even
+ * rhythm into a single wide outlier. A route number never comes near it. Tune here.
+ */
+private val PILL_BADGE_MAX_WIDTH = 72.dp
+
+/**
  * The prominent white-on-lateness ETA pill — one per trip in a route row's strip (and the Home legend
  * dialog, which passes no clicks). [onClick] taps focus that trip's vehicle + stop; [onLongClick]
  * opens the trip menu; [canceled] strikes the text through. [clockTime] is the small "1:10pm"-style
@@ -427,7 +439,8 @@ internal fun EtaPill(
                     RouteBadgeChip(
                         shortName = routeBadge.shortName,
                         routeColor = routeBadge.routeColor,
-                        scale = 0.8f
+                        scale = 0.8f,
+                        maxWidth = PILL_BADGE_MAX_WIDTH
                     )
                 }
                 if (etaParts == null) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
@@ -97,7 +97,7 @@ import org.onebusaway.android.ui.arrivals.RouteRowGroup
 import org.onebusaway.android.ui.arrivals.components.EtaStrip
 import org.onebusaway.android.ui.arrivals.rememberArrivalRowCallbacks
 import org.onebusaway.android.ui.compose.components.DRAG_HANDLE_TOUCH_TARGET_HEIGHT
-import org.onebusaway.android.ui.compose.components.RouteBadgeChip
+import org.onebusaway.android.ui.compose.components.RouteBadge
 import org.onebusaway.android.ui.compose.components.SheetDragHandle
 import org.onebusaway.android.ui.compose.components.SwitchRow
 import org.onebusaway.android.ui.compose.findActivity
@@ -353,12 +353,12 @@ fun DirectionsResultsSheet(
  * Spins up a per-stop arrivals session keyed to [stop] — so it polls only while shown — and picks the
  * route group matching the leg (by route id, then headsign). Ids on [routeLeg]/[stop] are OBA-format.
  *
- * A leg with interchangeable routes ([RouteLegRef.alternatives], #2010) gets one further strip per such
- * route below the planned one, each behind its own route badge so the pills can't be mistaken for the
- * planned route's — that badge is the only thing distinguishing them, since a pill shows an ETA and no
- * route. All of them read the one arrivals poll this stop already runs, so the extra routes cost no
- * extra request. An alternative with no OBA id, or with nothing upcoming at this stop, is simply left
- * out — its name still appears on the card's "or …" line.
+ * A leg with interchangeable routes ([RouteLegRef.alternatives], #2010) combines every matching route
+ * into this one strip in arrival order. Each ETA pill carries its route's small badge, so the rider can
+ * scan one timeline to see which interchangeable route comes first without losing the route identity.
+ * All routes read the one arrivals poll this stop already runs, so alternatives cost no extra request.
+ * An alternative with no OBA id, or with nothing upcoming at this stop, is simply left out — its name
+ * still appears on the card's "or …" line.
  */
 @Composable
 fun DirectionStopEtaStrip(
@@ -400,38 +400,46 @@ fun DirectionStopEtaStrip(
         content.routeGroups.pickRoute(alternative.routeId, alternative.headsign)
             ?.let { alternative to it }
     }
-    if (plannedGroup == null && alternativeGroups.isEmpty()) {
+    val plannedBadge = plannedGroup?.let { group ->
+        routeLeg.etaPlannedBadge(group.representative.lineName)
+    }
+    val routeTrips = buildList {
+        if (plannedGroup != null && plannedBadge != null) add(plannedBadge to plannedGroup.trips)
+        alternativeGroups.forEach { (alternative, group) ->
+            add(RouteBadge(alternative.shortName, alternative.routeColor) to group.trips)
+        }
+    }
+    val interleaved = interleaveRouteItems(routeTrips) { it.displayTime.epochMs }
+    if (interleaved.isEmpty()) {
         NoEtasText(rowPadding)
         return
     }
-    Column(modifier) {
-        if (plannedGroup == null) {
-            NoEtasText(rowPadding)
-        } else {
-            EtaStrip(
-                trips = plannedGroup.trips,
-                actionsFor = { content.actions[it.tripId] },
-                callbacks = callbacks,
-                modifier = rowPadding
-            )
-        }
-        alternativeGroups.forEach { (alternative, group) ->
-            Row(
-                modifier = rowPadding,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                RouteBadgeChip(alternative.shortName, alternative.routeColor)
-                Spacer(Modifier.width(8.dp))
-                EtaStrip(
-                    trips = group.trips,
-                    actionsFor = { content.actions[it.tripId] },
-                    callbacks = callbacks,
-                    modifier = Modifier.weight(1f)
-                )
-            }
-        }
-    }
+    val badgesByTrip = interleaved.associate { (trip, badge) -> trip to badge }
+    EtaStrip(
+        trips = interleaved.map { it.first },
+        actionsFor = { content.actions[it.tripId] },
+        callbacks = callbacks,
+        modifier = modifier.then(rowPadding),
+        routeBadgeFor = { badgesByTrip[it] }
+    )
 }
+
+/**
+ * Flattens route-specific, already-ordered arrival lists into one chronological strip. Kotlin's sort
+ * is stable, so equal-time arrivals retain route order (planned first, then alternatives), avoiding
+ * visual jitter when two interchangeable routes share an ETA.
+ */
+internal fun <T> interleaveRouteItems(
+    routes: List<Pair<RouteBadge, List<T>>>,
+    timeOf: (T) -> Long
+): List<Pair<T, RouteBadge>> = routes
+    .flatMap { (badge, items) -> items.map { it to badge } }
+    .sortedBy { (item, _) -> timeOf(item) }
+
+/** The planned route's own badge, falling back to the arrivals display name only for legacy fixtures.
+ * It is carried explicitly rather than recovered from the joined badge by name: distinct routes may
+ * publish the same name, and the joined badge deliberately deduplicates those names. */
+internal fun RouteLegRef.etaPlannedBadge(fallbackLineName: String): RouteBadge = plannedBadge ?: RouteBadge(fallbackLineName, null)
 
 /** The group for [routeId] at this stop: matched by OBA route id, preferring [headsign]'s direction.
  *  Null when the route has no OBA id (unresolved) or nothing upcoming at the stop. */

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
@@ -400,11 +400,8 @@ fun DirectionStopEtaStrip(
         content.routeGroups.pickRoute(alternative.routeId, alternative.headsign)
             ?.let { alternative to it }
     }
-    val plannedBadge = plannedGroup?.let { group ->
-        routeLeg.etaPlannedBadge(group.representative.lineName)
-    }
     val routeTrips = buildList {
-        if (plannedGroup != null && plannedBadge != null) add(plannedBadge to plannedGroup.trips)
+        plannedGroup?.let { add(routeLeg.etaPlannedBadge(it.representative.lineName) to it.trips) }
         alternativeGroups.forEach { (alternative, group) ->
             add(RouteBadge(alternative.shortName, alternative.routeColor) to group.trips)
         }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsRepository.kt
@@ -144,6 +144,10 @@ class DefaultTripResultsRepository @Inject constructor(
                 interlineTransitions = transitions,
                 extraSegments = extraSegments,
                 alternatives = alternatives.map { it.resolve() },
+                // Kept separately from the joined badge: natural-name ordering means the joined form
+                // cannot identify which segment was planned, and same-named routes may collapse to one.
+                // The route-badged ETA strip needs this route's own color even in either case (#2099).
+                plannedBadge = leader.plannedBadge(),
                 // Built here, alongside the option cards' badges, so the drawer renders one rather than
                 // deriving it per row (#2010). The drawer's board row draws only the interchangeable
                 // form; on an interlined ride it names each segment at its own row instead (#2071), so

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
@@ -1582,7 +1582,7 @@ private fun ColumnScope.BoardContent(
             }
         )
         // What an interchangeable badge means: any of those routes will do, so board the first to
-        // arrive. Each one's own ETA strip sits under the board stop below (#2010). A ride that changes
+        // arrive. Their arrivals share one route-badged ETA strip under the board stop (#2010/#2099). A ride that changes
         // route under the rider carries the opposite instruction — board this one and stay on it — and
         // gives it in its own row further down the ride (TransitionContent); its badge never reaches
         // this header, so it cannot pick this caption up.

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
@@ -307,8 +307,11 @@ sealed interface RealtimeState {
  * .OtpObaIdResolver]); [routeId]/[RouteStopRef.stopId] are null when they couldn't be resolved (an
  * unknown agency, or the OTP1 path). [headsign] disambiguates which direction group's ETAs to show.
  *
- * [alternatives] are the interchangeable routes for this leg (#2010) — the board stop shows each
- * one's live ETA strip under the planned route's, so the rider can see which of them comes first.
+ * [alternatives] are the interchangeable routes for this leg (#2010) — the board stop interleaves
+ * their live arrivals with the planned route's in one ETA strip, badging each pill by route (#2099),
+ * so the rider can see which of them comes first.
+ * [plannedBadge] identifies the planned route's own segment independently of [badge], whose routes are
+ * name-sorted and may deduplicate two distinct routes publishing the same public name.
  * [badge] is the leg's finished roundel (planned route joined by those alternatives), built once by
  * the repository rather than re-derived per row while composing; null where no badge was built at all
  * (fixtures), which is not the same as a badge that found no route to name.
@@ -331,6 +334,7 @@ data class RouteLegRef(
     // Empty for an ordinary leg. Carried straight onto [org.onebusaway.android.map.ShowRouteRequest].
     val extraSegments: List<RouteFocusSegment> = emptyList(),
     val alternatives: List<AlternativeRouteRef> = emptyList(),
+    val plannedBadge: RouteBadge? = null,
     val badge: LegBadge? = null
 )
 
@@ -358,8 +362,8 @@ data class InterlineTransition(
 )
 
 /**
- * An interchangeable route on a transit leg: its display name and color for the badge beside its ETA
- * strip, plus the same OBA-id/headsign pair [RouteLegRef] carries for the planned route, used to pick
+ * An interchangeable route on a transit leg: its display name and color for the badge inside each ETA
+ * pill, plus the same OBA-id/headsign pair [RouteLegRef] carries for the planned route, used to pick
  * that route's direction group out of the board stop's arrivals. [routeId] is null when the OTP route
  * couldn't be resolved onto an OBA id — the route still names itself on the leg's badge, but has no
  * ETA strip to show.

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteSegmentHighlightTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteSegmentHighlightTest.kt
@@ -158,5 +158,7 @@ class RouteSegmentHighlightTest {
 
         assertFalse(focusedRideKeepsVehicle("other-trip", "tapped-trip", eligible, offPath))
         assertTrue(focusedRideKeepsVehicle("tapped-trip", "tapped-trip", eligible, offPath))
+        // No focused trip at all: a schedule-only vehicle (null trip id) must not match a null focus.
+        assertFalse(focusedRideKeepsVehicle(null, null, eligible, offPath))
     }
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteSegmentHighlightTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteSegmentHighlightTest.kt
@@ -145,4 +145,18 @@ class RouteSegmentHighlightTest {
         // Only ~11 m beyond alighting: spatial tolerance alone must not leak this downstream vehicle.
         assertFalse(throughSelectedLeg.containsRoutePoint(GeoPoint(47.6401, -122.33)))
     }
+
+    @Test
+    fun explicitlyFocusedEtaTripSurvivesAPlannedLegGeometryMismatch() {
+        val eligible = listOf(
+            RoutePolyline(
+                color = 1,
+                points = listOf(GeoPoint(47.58, -122.33), GeoPoint(47.64, -122.33))
+            )
+        ).boundedThrough(GeoPoint(47.62, -122.33))
+        val offPath = GeoPoint(47.70, -122.40)
+
+        assertFalse(focusedRideKeepsVehicle("other-trip", "tapped-trip", eligible, offPath))
+        assertTrue(focusedRideKeepsVehicle("tapped-trip", "tapped-trip", eligible, offPath))
+    }
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/directions/InterleaveRouteItemsTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/directions/InterleaveRouteItemsTest.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.home.directions
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.onebusaway.android.ui.compose.components.RouteBadge
+import org.onebusaway.android.ui.compose.components.RouteBadgeJoin
+import org.onebusaway.android.ui.tripresults.AlternativeRouteRef
+import org.onebusaway.android.ui.tripresults.LegBadge
+import org.onebusaway.android.ui.tripresults.RouteLegRef
+import org.onebusaway.android.ui.tripresults.TransitMode
+
+class InterleaveRouteItemsTest {
+
+    private val route1 = RouteBadge("1 Line", 0xFF00AA00.toInt())
+    private val route2 = RouteBadge("2 Line", 0xFF0000AA.toInt())
+
+    @Test
+    fun `interchangeable routes become one chronological sequence with their badges`() {
+        val result = interleaveRouteItems(
+            routes = listOf(route1 to listOf(3L, 12L), route2 to listOf(5L, 8L)),
+            timeOf = { it }
+        )
+
+        assertEquals(listOf(3L, 5L, 8L, 12L), result.map { it.first })
+        assertEquals(listOf(route1, route2, route2, route1), result.map { it.second })
+    }
+
+    @Test
+    fun `equal arrival times keep planned route first`() {
+        val result = interleaveRouteItems(
+            routes = listOf(route1 to listOf(5L), route2 to listOf(5L)),
+            timeOf = { it }
+        )
+
+        assertEquals(listOf(route1, route2), result.map { it.second })
+    }
+
+    @Test
+    fun `same-named alternative does not erase planned route color`() {
+        val planned = RouteBadge("A Line", 0xFF0066CC.toInt())
+        val alternative = RouteBadge("A Line", 0xFFCC6600.toInt())
+        val routeLeg = RouteLegRef(
+            routeId = "1_planned",
+            headsign = "Downtown",
+            board = null,
+            alight = null,
+            alternatives = listOf(
+                AlternativeRouteRef("1_alternative", "Downtown", alternative.shortName, alternative.routeColor)
+            ),
+            plannedBadge = planned,
+            // The joined presentation deduplicates identical public names, so it cannot be used to
+            // recover which route was planned.
+            badge = LegBadge(listOf(alternative), TransitMode.RAIL, RouteBadgeJoin.ANY_OF)
+        )
+
+        assertEquals(planned, routeLeg.etaPlannedBadge("A Line"))
+    }
+}


### PR DESCRIPTION
## Summary

- combine the planned and interchangeable routes into one chronologically interleaved ETA strip in the directions drawer
- place each route’s compact badge inside its ETA pill
- preserve stable ordering for equal ETAs and unique Compose keys across route groups
- carry the planned route badge explicitly so same-named alternatives cannot erase its color
- preserve an explicitly tapped ETA trip through the selected-leg geometry filter so a valid pinned vehicle can be focused

Closes #2099.

## Why

Separate ETA strips make riders compare multiple timelines to determine which interchangeable route arrives first. One time-ordered strip makes that choice immediate while the badge inside every pill preserves route identity.

During device verification, a valid route-2 vehicle was present in both the arrivals response and route-vehicle poll but was removed by the directions selected-leg geometry filter before focus. The narrow safeguard in this PR trusts the explicitly requested active trip identity. The underlying multi-variant route-polyline modeling issue is tracked separately in #2104.

## User impact

Directions for interchangeable routes now present a single “take whichever comes first” ETA timeline. Tapping a pin-marked pill continues into route focus and can frame the requested live vehicle even when reconstructed route-wide geometry does not match that trip variant.

## Validation

- `./gradlew spotlessCheck`
- `./gradlew :onebusaway-android:testObaGoogleDebugUnitTest`
- `./gradlew :onebusaway-android:assembleObaGoogleDebugAndroidTest`
- `git diff --check`
- installed and manually exercised the debug APK on the shared physical phone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ETA arrival strips now combine planned and alternative routes in chronological order.
  * Individual ETA pills display route badges and colors for clearer route identification.
  * Focused vehicles remain visible even when temporarily outside planned route geometry.

* **Bug Fixes**
  * Improved handling of route-specific badges and vehicle filtering.
  * Prevented display conflicts when routes share names or arrival times.

* **Tests**
  * Added coverage for route interleaving, badge rendering, ordering, and focused vehicle visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->