### PR TITLE
Make the directions map's route badges focus their ride (#2101)

### DIFF
--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
@@ -124,9 +124,9 @@ class GoogleMapRenderer(
     // the single selected vehicle), but kept as a map like the other *ByMarker lookups for symmetry.
     private val continuationBadgeByMarker = HashMap<Marker, ContinuationBadge>()
 
-    // Adjacency route badge tap targets (#1827), mirrored by the maplibre flavor (#1913). Their
-    // geographic anchors are laid out once upstream; these markers then move naturally with the map
-    // through pan and zoom.
+    // Route badge tap targets — adjacency (#1827) and a directions ride (#2101) — mirrored by the
+    // maplibre flavor (#1913). Their geographic anchors are laid out once upstream; these markers then
+    // move naturally with the map through pan and zoom.
     private val routeBadgeByMarker = HashMap<Marker, RouteBadge>()
 
     // The latest trips-for-route poll, published as it changes (after the markers are reconciled). The

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleComposeAdapter.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleComposeAdapter.kt
@@ -61,7 +61,6 @@ import org.onebusaway.android.map.compose.drivePings
 import org.onebusaway.android.map.googlemapsv2.GoogleMapRenderer
 import org.onebusaway.android.map.render.CameraSnapshot
 import org.onebusaway.android.map.render.MapProjector
-import org.onebusaway.android.map.render.RouteBadgeTap
 import org.onebusaway.android.map.render.ScreenOffset
 import org.onebusaway.android.map.render.routePolylineRenderFlow
 import org.onebusaway.android.time.WallTime
@@ -386,22 +385,12 @@ private fun routeMarkerTap(
         )
         return true
     }
+    // Only a label that leads somewhere is registered as a tap target, so this hands the badge over
+    // whole and lets the host read where it leads — see [ObaMapCallbacks.onRouteBadgeClick].
     val routeBadge = renderer.routeBadgeForMarker(marker)
-    when (val routeBadgeTap = routeBadge?.tap) {
-        is RouteBadgeTap.ShowRoute -> {
-            cb.onRouteBadgeClick(
-                routeBadgeTap.route.routeId,
-                routeBadge.tappedRouteShortName,
-                routeBadgeTap.route.directionId
-            )
-            return true
-        }
-        is RouteBadgeTap.FocusItineraryRide -> {
-            cb.onItineraryRideBadgeClick(routeBadgeTap.legIndices)
-            return true
-        }
-        // An inert label, or not a label at all: fall through to the default marker handling below.
-        null -> Unit
+    if (routeBadge != null) {
+        cb.onRouteBadgeClick(routeBadge)
+        return true
     }
     // Trip-focus estimate markers + the most-recent-data dot (titled markers): the SDK's default
     // title/snippet info window, which dismisses any open custom bubble.

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleComposeAdapter.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleComposeAdapter.kt
@@ -61,6 +61,7 @@ import org.onebusaway.android.map.compose.drivePings
 import org.onebusaway.android.map.googlemapsv2.GoogleMapRenderer
 import org.onebusaway.android.map.render.CameraSnapshot
 import org.onebusaway.android.map.render.MapProjector
+import org.onebusaway.android.map.render.RouteBadgeTap
 import org.onebusaway.android.map.render.ScreenOffset
 import org.onebusaway.android.map.render.routePolylineRenderFlow
 import org.onebusaway.android.time.WallTime
@@ -386,10 +387,21 @@ private fun routeMarkerTap(
         return true
     }
     val routeBadge = renderer.routeBadgeForMarker(marker)
-    val routeBadgeTap = routeBadge?.tap
-    if (routeBadge != null && routeBadgeTap != null) {
-        cb.onRouteBadgeClick(routeBadgeTap.routeId, routeBadge.tappedRouteShortName, routeBadgeTap.directionId)
-        return true
+    when (val routeBadgeTap = routeBadge?.tap) {
+        is RouteBadgeTap.ShowRoute -> {
+            cb.onRouteBadgeClick(
+                routeBadgeTap.route.routeId,
+                routeBadge.tappedRouteShortName,
+                routeBadgeTap.route.directionId
+            )
+            return true
+        }
+        is RouteBadgeTap.FocusItineraryRide -> {
+            cb.onItineraryRideBadgeClick(routeBadgeTap.legIndices)
+            return true
+        }
+        // An inert label, or not a label at all: fall through to the default marker handling below.
+        null -> Unit
     }
     // Trip-focus estimate markers + the most-recent-data dot (titled markers): the SDK's default
     // title/snippet info window, which dismisses any open custom bubble.

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/ItineraryLegStyle.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/ItineraryLegStyle.kt
@@ -27,6 +27,7 @@ import org.onebusaway.android.map.render.BadgedRoute
 import org.onebusaway.android.map.render.ITINERARY_RIDE_WIDTH_PROFILE
 import org.onebusaway.android.map.render.ITINERARY_STREET_WIDTH_PROFILE
 import org.onebusaway.android.map.render.RouteBadge
+import org.onebusaway.android.map.render.RouteBadgeTap
 import org.onebusaway.android.map.render.RouteLineCase
 import org.onebusaway.android.map.render.RouteLineDash
 import org.onebusaway.android.map.render.RouteLineWidthProfile
@@ -211,6 +212,11 @@ internal data class ItinerarySubstitute(val route: InterchangeableRoute, val rou
  * order ([inInterchangeableOrder]) — rather than naming one route on a line the rider is being told to
  * board either of two. A leg with no alternatives is labelled with its planned route alone, which is what
  * an OTP1 plan (no candidates at all) yields for every leg.
+ *
+ * Each label is a tap target for its own ride (#2101), carrying the legs it names so the tap lands on the
+ * same focus the drawer's row for that ride does. It deliberately does *not* lead to the route's own map,
+ * which is what a label on this view must never do: the rider is reading a trip, and a stray tap must not
+ * trade the whole itinerary for one route (see [RouteBadgeTap]).
  */
 internal fun itineraryRouteBadges(
     legs: List<ItineraryDrawableLeg>,
@@ -240,8 +246,8 @@ internal fun itineraryRouteBadges(
             val ride = ridden.first()
             RouteBadgeRequest(
                 routes = ride.badgedRoutes(palette),
-                paths = ridden.map { RouteBadgePath(it.drawable.points) }
-                // No tap target: see [RouteBadge.tap].
+                paths = ridden.map { RouteBadgePath(it.drawable.points) },
+                tap = RouteBadgeTap.FocusItineraryRide(ridden.mapTo(mutableSetOf()) { it.drawable.index })
             )
         }
     )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteViewGeometry.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteViewGeometry.kt
@@ -16,6 +16,7 @@ import org.onebusaway.android.map.render.FOCUSED_ROUTE_LINE_WIDTH_PROFILE
 import org.onebusaway.android.map.render.ITINERARY_APPROACH_WIDTH_PROFILE
 import org.onebusaway.android.map.render.ITINERARY_CONTEXT_WIDTH_PROFILE
 import org.onebusaway.android.map.render.RouteBadge
+import org.onebusaway.android.map.render.RouteBadgeTap
 import org.onebusaway.android.map.render.RouteLineCase
 import org.onebusaway.android.map.render.RouteLineDash
 import org.onebusaway.android.map.render.RoutePolyline
@@ -177,7 +178,7 @@ internal fun FocusedTripGeometry.toRouteBadges(
                 routes = listOf(BadgedRoute(spec.name, color)),
                 paths = spec.shapes.map { shape -> RouteBadgePath(shape.points) },
                 // An adjacency label is the way into its route: it names a route the rider hasn't opened.
-                tap = spec.key
+                tap = RouteBadgeTap.ShowRoute(spec.key)
             )
         }
     )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/compose/ObaMapCallbacks.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/compose/ObaMapCallbacks.kt
@@ -16,6 +16,7 @@
 package org.onebusaway.android.map.compose
 
 import org.onebusaway.android.map.bike.BikeStation
+import org.onebusaway.android.map.render.RouteBadge
 import org.onebusaway.android.map.render.StopMarker
 import org.onebusaway.android.models.ObaTripStatus
 import org.onebusaway.android.util.GeoPoint
@@ -45,15 +46,17 @@ interface ObaMapCallbacks {
     /** The route-continuation badge tap (#1691) — the host navigates the map to [routeId]'s [directionId]. */
     fun onRouteContinuationClick(routeId: String, routeShortName: String, directionId: Int?) {}
 
-    /** An adjacency route badge tap (#1827) — enter route mode on the badge's line direction. */
-    fun onRouteBadgeClick(routeId: String, routeShortName: String, directionId: Int?) {}
-
     /**
-     * A directions route badge tap (#2101) — focus the ride these itinerary [legIndices] belong to,
-     * without leaving the trip the rider is reading (see
-     * [org.onebusaway.android.map.render.RouteBadgeTap.FocusItineraryRide]).
+     * A route badge tap — an adjacency label opening its route (#1827), or a directions label focusing
+     * the ride it names (#2101).
+     *
+     * The whole [badge] is passed, not its destination flattened into fields, because what a tap does is
+     * the label's own to say ([RouteBadge.tap]) and the host is where that is read. Flattening it would
+     * put the `when` over that sealed type in each flavor's marker dispatch instead — mirrored code that
+     * a new kind of label has to be added to twice, and that would silently ignore it in the flavor that
+     * was missed. Same shape as [onStopClick], which likewise hands over the render model.
      */
-    fun onItineraryRideBadgeClick(legIndices: Set<Int>) {}
+    fun onRouteBadgeClick(badge: RouteBadge) {}
 
     /** The vehicle info-window "more info" tap — the host navigates (e.g. to TripDetails). */
     fun onVehicleInfoWindowClick(status: ObaTripStatus)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/compose/ObaMapCallbacks.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/compose/ObaMapCallbacks.kt
@@ -48,6 +48,13 @@ interface ObaMapCallbacks {
     /** An adjacency route badge tap (#1827) — enter route mode on the badge's line direction. */
     fun onRouteBadgeClick(routeId: String, routeShortName: String, directionId: Int?) {}
 
+    /**
+     * A directions route badge tap (#2101) — focus the ride these itinerary [legIndices] belong to,
+     * without leaving the trip the rider is reading (see
+     * [org.onebusaway.android.map.render.RouteBadgeTap.FocusItineraryRide]).
+     */
+    fun onItineraryRideBadgeClick(legIndices: Set<Int>) {}
+
     /** The vehicle info-window "more info" tap — the host navigates (e.g. to TripDetails). */
     fun onVehicleInfoWindowClick(status: ObaTripStatus)
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/layout/RouteBadgeLayout.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/layout/RouteBadgeLayout.kt
@@ -21,6 +21,7 @@ import kotlin.math.sin
 import kotlin.math.sqrt
 import org.onebusaway.android.map.render.BadgedRoute
 import org.onebusaway.android.map.render.RouteBadge
+import org.onebusaway.android.map.render.RouteBadgeTap
 import org.onebusaway.android.map.render.haversineMeters
 import org.onebusaway.android.models.RouteDirectionKey
 import org.onebusaway.android.util.EARTH_RADIUS_METERS
@@ -85,13 +86,13 @@ fun <K> layoutRouteBadges(
 
 /**
  * One route label to place: the route(s) it names (stacked, in reading order — see [RouteBadge.routes]),
- * where a tap on it navigates (null for an informational label — see [RouteBadge.tap]), and the shapes it
- * may be anchored on. List order is collision priority, as in [layoutRouteBadges].
+ * what a tap on it does (null for an inert label — see [RouteBadge.tap]), and the shapes it may be
+ * anchored on. List order is collision priority, as in [layoutRouteBadges].
  */
 internal data class RouteBadgeRequest(
     val routes: List<BadgedRoute>,
     val paths: List<RouteBadgePath>,
-    val tap: RouteDirectionKey? = null
+    val tap: RouteBadgeTap? = null
 )
 
 /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
@@ -252,6 +252,42 @@ data class ContinuationBadge(
 data class BadgedRoute(val routeShortName: String, val color: Int)
 
 /**
+ * What a tap on a [RouteBadge] does. The two map views that label their lines want different things of
+ * a tap, and the difference is not cosmetic: an adjacency label names a route the rider has not opened
+ * yet, so tapping it opens that route; a directions label names a ride of the trip the rider is already
+ * reading, so tapping it must stay inside that trip (#2101) rather than trade the whole itinerary for a
+ * single route's map.
+ */
+sealed interface RouteBadgeTap {
+
+    /**
+     * Show the route this label names — the route-direction to open, preferring the drawn line's own
+     * direction over the route's default. Focused-stop adjacency (#1827).
+     */
+    data class ShowRoute(val route: RouteDirectionKey) : RouteBadgeTap
+
+    /**
+     * Focus the ride this label names, within the itinerary already drawn (#2101) — exactly as tapping
+     * that ride's row in the directions drawer does, so the two ways to reach one ride can't disagree.
+     *
+     * [legIndices] are the itinerary leg indices the label covers, which need not be a whole ride and
+     * need not be only one: a label is per *route*, a ride is what the rider boards once, and a
+     * stay-aboard interline (#2000) makes the two differ in both directions — the ride's legs carry
+     * different routes, so each gets its own label, while an itinerary that rides one route on several
+     * legs draws a single label over all of them (see `itineraryRouteBadges`). Naming legs rather than a
+     * ride is what lets the label say what it knows and leave resolving the ride to the side that has
+     * the rides (`rideCoveringLegs`).
+     */
+    data class FocusItineraryRide(val legIndices: Set<Int>) : RouteBadgeTap {
+        init {
+            // A focus target that names no leg would silently do nothing on tap, which reads to the rider
+            // as a dead label rather than as the bug in a badge builder that it is.
+            require(legIndices.isNotEmpty()) { "an itinerary ride badge names at least one leg" }
+        }
+    }
+}
+
+/**
  * A label naming the route(s) on the line it is drawn on — in focused-stop adjacency view (#1827), and
  * on a directions itinerary's rides (#2066). Anchored once in geographic space so the map SDK naturally
  * carries it through pan and zoom. Rendered by both flavors (#1913).
@@ -266,27 +302,26 @@ data class RouteBadge(
     val routes: List<BadgedRoute>,
     val point: GeoPoint,
     /**
-     * Where a tap on this label navigates — the route-direction to show, preferring the drawn line's own
-     * direction over the route's default. Null makes the label informational: a directions itinerary's
-     * labels name legs of a trip the rider is already reading, so a stray tap must not drop the whole
-     * itinerary for a single route's map. Null is also the default, so a label is inert until a producer
-     * says where it leads, and no producer needs a navigable id it doesn't have.
+     * What a tap on this label does — see [RouteBadgeTap]. Null makes the label inert, which is also the
+     * default, so a label leads nowhere until a producer says where, and no producer needs a destination
+     * it doesn't have.
      */
-    val tap: RouteDirectionKey? = null
+    val tap: RouteBadgeTap? = null
 ) {
     init {
         // Both stated rather than trusted: a label with nothing to read is a marker the rider can't
-        // account for, and a navigable label naming several routes would leave the tap handler picking
-        // one of them — the destination has to be as unambiguous as the name. Producer-side invariants
-        // (only adjacency labels navigate, and each names its one route), so a violation is a bug in a
-        // badge builder, which is where the message points.
+        // account for, and a *route-navigating* label naming several routes would leave the tap handler
+        // picking one of them — that destination has to be as unambiguous as the name. (A ride focus is
+        // not so constrained: an interchangeable ride is one ride however many routes it may be taken
+        // on.) Producer-side invariants, so a violation is a bug in a badge builder, which is where the
+        // message points.
         require(routes.isNotEmpty()) { "a route badge names at least one route" }
-        require(tap == null || routes.size == 1) {
+        require(tap !is RouteBadgeTap.ShowRoute || routes.size == 1) {
             "a badge naming ${routes.size} routes has no single route to navigate to"
         }
     }
 
-    /** The one route a navigable badge names — see the [tap] invariant above. */
+    /** The one route a [RouteBadgeTap.ShowRoute] badge names — see the [tap] invariant above. */
     val tappedRouteShortName: String get() = routes.single().routeShortName
 }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -770,7 +770,10 @@ fun HomeScreen(
                                             // size: the sheet now hosts a full-screen scaffold over the
                                             // map, so the composable's own bounds are the whole screen.
                                             onSheetHeightPx = { directionsSheetHeightPx = it },
-                                            modifier = Modifier.fillMaxSize()
+                                            modifier = Modifier.fillMaxSize(),
+                                            // A route label tapped on the drawn itinerary (#2101): the
+                                            // sheet resolves it to the ride it names and focuses it.
+                                            rideBadgeTaps = homeViewModel.itineraryRideBadgeTaps
                                         )
                                         directionsError != null -> DirectionsErrorSnackbar(
                                             error = directionsError,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -771,7 +771,9 @@ fun HomeScreen(
                                             // map, so the composable's own bounds are the whole screen.
                                             onSheetHeightPx = { directionsSheetHeightPx = it },
                                             // A route label tapped on the drawn itinerary (#2101): the
-                                            // sheet resolves it to the ride it names and focuses it.
+                                            // sheet resolves it to the ride it names and focuses it —
+                                            // the first in travel order where one label covers the
+                                            // same route ridden twice.
                                             rideBadgeTaps = homeViewModel.itineraryRideBadgeTaps,
                                             modifier = Modifier.fillMaxSize()
                                         )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -770,10 +770,10 @@ fun HomeScreen(
                                             // size: the sheet now hosts a full-screen scaffold over the
                                             // map, so the composable's own bounds are the whole screen.
                                             onSheetHeightPx = { directionsSheetHeightPx = it },
-                                            modifier = Modifier.fillMaxSize(),
                                             // A route label tapped on the drawn itinerary (#2101): the
                                             // sheet resolves it to the ride it names and focuses it.
-                                            rideBadgeTaps = homeViewModel.itineraryRideBadgeTaps
+                                            rideBadgeTaps = homeViewModel.itineraryRideBadgeTaps,
+                                            modifier = Modifier.fillMaxSize()
                                         )
                                         directionsError != null -> DirectionsErrorSnackbar(
                                             error = directionsError,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
@@ -608,6 +608,24 @@ class HomeViewModel @Inject constructor(
     private val directionsSubFocus: DirectionsSubFocus?
         get() = (_currentFocus.value as? CurrentFocus.Directions)?.subFocus
 
+    // A route label tapped on the drawn itinerary (#2101), carrying the itinerary legs that label names.
+    // Inbound (map -> the directions drawer), so it runs the other way from [mapDirectives] and can't be a
+    // directive: turning a tapped ride into a focus needs the drawer's own resolved leg refs (route ids,
+    // board stops), which live in the results VM, not here. So this VM only relays the tap to the sheet,
+    // which spends it through exactly the handler its own row tap uses.
+    //
+    // A SharedFlow rather than a Channel — the opposite call from [mapDirectives], for the opposite
+    // reason: an itinerary label only exists while the sheet showing that itinerary is composed, so a tap
+    // with no collector is a tap with no trip to focus into, and dropping it is the honest outcome. A
+    // queued one would land on whatever the rider had moved on to.
+    private val _itineraryRideBadgeTaps = MutableSharedFlow<Set<Int>>(extraBufferCapacity = 1)
+    val itineraryRideBadgeTaps: SharedFlow<Set<Int>> = _itineraryRideBadgeTaps.asSharedFlow()
+
+    /** A route label tapped on the drawn itinerary: relay the legs it names to the directions sheet. */
+    fun onItineraryRideBadgeTapped(legIndices: Set<Int>) {
+        _itineraryRideBadgeTaps.tryEmit(legIndices)
+    }
+
     /** Recenter the map on a tapped itinerary step's point (only while in [CurrentFocus.Directions]). */
     fun focusItineraryPointOnMap(point: GeoPoint) = emitMapDirective(MapDirective.FocusItineraryPoint(point))
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
@@ -270,7 +270,9 @@ private const val DIRECTIONS_SHEET_HEIGHT_FRACTION = 0.4f
  *
  * It also answers the map's own tap on a ride ([rideBadgeTaps], #2101) — the sheet is where a ride's
  * resolved identity lives, so this is the one place that can spend a map tap the same way the drawer's
- * own row tap is spent.
+ * own row tap is spent. Where a label covers the same route ridden twice, it resolves to the first of
+ * those rides in travel order (see
+ * [rideCoveringLegs][org.onebusaway.android.ui.tripresults.rideCoveringLegs]).
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -325,7 +327,8 @@ fun DirectionsResultsSheet(
     // list below does — the same handler, so one ride can't mean two things depending on where the rider
     // reached for it. The label names legs of the itinerary it is drawn on, and the drawn itinerary is
     // this VM's own selection, so the indices are read against the plan that produced them; a set naming
-    // no ride here focuses nothing rather than guessing.
+    // no ride here focuses nothing rather than guessing, and one naming several (the same route ridden
+    // twice under a single label) focuses the first in travel order.
     //
     // The handlers are read through rememberUpdatedState so this long-lived collector spends the latest
     // ones rather than those it first captured.

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
@@ -88,7 +88,6 @@ import java.util.TimeZone
 import kotlin.math.roundToInt
 import kotlin.math.roundToLong
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.emptyFlow
 import org.onebusaway.android.R
 import org.onebusaway.android.directions.model.TripItinerary
 import org.onebusaway.android.directions.util.ConversionUtils
@@ -285,9 +284,11 @@ fun DirectionsResultsSheet(
     onFocusPoint: (GeoPoint) -> Unit,
     stopEtaStrip: @Composable (RouteLegRef, RouteStopRef, List<GeoPoint>) -> Unit,
     onSheetHeightPx: (Int) -> Unit,
-    modifier: Modifier = Modifier,
-    // The itinerary leg indices of a route label tapped on the map, as they arrive.
-    rideBadgeTaps: Flow<Set<Int>> = emptyFlow()
+    // The itinerary leg indices of a route label tapped on the map, as they arrive. Required rather than
+    // defaulted to an empty flow: omitting it leaves the map's labels dead, which is a wiring bug that
+    // would otherwise type-check.
+    rideBadgeTaps: Flow<Set<Int>>,
+    modifier: Modifier = Modifier
 ) {
     // The system nav-bar inset: the sheet reaches the bottom edge (continuous background), but its
     // content is padded above the nav chrome so the collapsed handle (and the last list row) aren't

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
@@ -60,6 +60,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
@@ -86,6 +87,8 @@ import java.util.Calendar
 import java.util.TimeZone
 import kotlin.math.roundToInt
 import kotlin.math.roundToLong
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
 import org.onebusaway.android.R
 import org.onebusaway.android.directions.model.TripItinerary
 import org.onebusaway.android.directions.util.ConversionUtils
@@ -122,8 +125,12 @@ import org.onebusaway.android.ui.tripplan.WalkPreference
 import org.onebusaway.android.ui.tripresults.FocusedLeg
 import org.onebusaway.android.ui.tripresults.RouteLegRef
 import org.onebusaway.android.ui.tripresults.RouteStopRef
+import org.onebusaway.android.ui.tripresults.TripLogEntry
 import org.onebusaway.android.ui.tripresults.TripResultsSheet
+import org.onebusaway.android.ui.tripresults.TripResultsUiState
 import org.onebusaway.android.ui.tripresults.TripResultsViewModel
+import org.onebusaway.android.ui.tripresults.focusTransit
+import org.onebusaway.android.ui.tripresults.rideCoveringLegs
 import org.onebusaway.android.util.BikeshareAvailability
 import org.onebusaway.android.util.GeoPoint
 import org.onebusaway.android.util.PermissionUtils
@@ -261,6 +268,10 @@ private const val DIRECTIONS_SHEET_HEIGHT_FRACTION = 0.4f
  * the caller drew underneath shows through and keeps receiving its own gestures (M3 builds the scaffold
  * root from a plain `Box`, not a touch-intercepting `Surface`). [onSheetHeightPx] reports the sheet's
  * settled on-screen height for the map's bottom inset.
+ *
+ * It also answers the map's own tap on a ride ([rideBadgeTaps], #2101) — the sheet is where a ride's
+ * resolved identity lives, so this is the one place that can spend a map tap the same way the drawer's
+ * own row tap is spent.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -274,7 +285,9 @@ fun DirectionsResultsSheet(
     onFocusPoint: (GeoPoint) -> Unit,
     stopEtaStrip: @Composable (RouteLegRef, RouteStopRef, List<GeoPoint>) -> Unit,
     onSheetHeightPx: (Int) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    // The itinerary leg indices of a route label tapped on the map, as they arrive.
+    rideBadgeTaps: Flow<Set<Int>> = emptyFlow()
 ) {
     // The system nav-bar inset: the sheet reaches the bottom edge (continuous background), but its
     // content is padded above the nav chrome so the collapsed handle (and the last list row) aren't
@@ -304,6 +317,24 @@ fun DirectionsResultsSheet(
         snapshotFlow { sheetState.currentValue }.collect { value ->
             val resting = if (value == SheetValue.Expanded) fullHeight else peekHeight
             onSheetHeightPx(with(density) { resting.roundToPx() })
+        }
+    }
+
+    // A route label tapped on the drawn itinerary focuses that ride exactly as tapping its row in the
+    // list below does — the same handler, so one ride can't mean two things depending on where the rider
+    // reached for it. The label names legs of the itinerary it is drawn on, and the drawn itinerary is
+    // this VM's own selection, so the indices are read against the plan that produced them; a set naming
+    // no ride here focuses nothing rather than guessing.
+    //
+    // The handlers are read through rememberUpdatedState so this long-lived collector spends the latest
+    // ones rather than those it first captured.
+    val focusRide by rememberUpdatedState({ ride: TripLogEntry.Transit ->
+        focusTransit(ride, onFocusRouteLeg, onFocusLeg, onFocusPoint)
+    })
+    LaunchedEffect(resultsViewModel, rideBadgeTaps) {
+        rideBadgeTaps.collect { legIndices ->
+            val directions = (resultsViewModel.state.value as? TripResultsUiState.Success)?.directions.orEmpty()
+            directions.rideCoveringLegs(legIndices)?.let(focusRide)
         }
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
@@ -91,6 +91,8 @@ import org.onebusaway.android.map.StopsBanner
 import org.onebusaway.android.map.bike.BikeStation
 import org.onebusaway.android.map.compose.ObaMap
 import org.onebusaway.android.map.compose.ObaMapCallbacks
+import org.onebusaway.android.map.render.RouteBadge
+import org.onebusaway.android.map.render.RouteBadgeTap
 import org.onebusaway.android.map.render.StopMarker
 import org.onebusaway.android.map.render.routeLineWidthScale
 import org.onebusaway.android.models.ObaTripStatus
@@ -241,21 +243,24 @@ fun MapFeature(
                 )
             }
 
-            override fun onRouteBadgeClick(
-                routeId: String,
-                routeShortName: String,
-                directionId: Int?
-            ) {
-                homeViewModel.requestShowFocusedStopRouteOnMap(
-                    routeId,
-                    directionId,
-                    routeShortName,
-                    undoViewport = mapViewModel.viewport
-                )
-            }
-
-            override fun onItineraryRideBadgeClick(legIndices: Set<Int>) {
-                homeViewModel.onItineraryRideBadgeTapped(legIndices)
+            override fun onRouteBadgeClick(badge: RouteBadge) {
+                when (val tap = badge.tap) {
+                    // An adjacency label (#1827) names a route the rider hasn't opened: open it.
+                    is RouteBadgeTap.ShowRoute -> homeViewModel.requestShowFocusedStopRouteOnMap(
+                        tap.route.routeId,
+                        tap.route.directionId,
+                        badge.tappedRouteShortName,
+                        undoViewport = mapViewModel.viewport
+                    )
+                    // A directions label (#2101) names a ride of the trip already being read: focus it
+                    // where it is, without trading the itinerary for one route's map.
+                    is RouteBadgeTap.FocusItineraryRide ->
+                        homeViewModel.onItineraryRideBadgeTapped(tap.legIndices)
+                    // A label a producer left inert is never registered as a tap target, so this can't
+                    // arrive — named rather than swallowed by an else, so a third kind of tap is a
+                    // compile error here (the one place that reads them) instead of a silent no-op.
+                    null -> Unit
+                }
             }
 
             override fun onVehicleInfoWindowClick(status: ObaTripStatus) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
@@ -254,6 +254,10 @@ fun MapFeature(
                 )
             }
 
+            override fun onItineraryRideBadgeClick(legIndices: Set<Int>) {
+                homeViewModel.onItineraryRideBadgeTapped(legIndices)
+            }
+
             override fun onVehicleInfoWindowClick(status: ObaTripStatus) {
                 MapNavigation.openVehicleTripDetails(
                     context,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
@@ -1101,8 +1101,12 @@ private fun expandLabel(model: LogRowModel): String? = when {
 /**
  * Tapping a transit leg: highlight its route on the map when the route id resolved (the usual case),
  * else frame the leg polyline, else recentre on the board stop. Mirrors the old leg-body behaviour.
+ *
+ * Not private, because the drawer's row is no longer the only way to tap a ride: the route label drawn on
+ * that ride's line on the map is one too (#2101), and it spends this same function so the two can't
+ * drift into meaning different things.
  */
-private fun focusTransit(
+internal fun focusTransit(
     entry: TripLogEntry.Transit,
     onFocusRouteLeg: (RouteLegRef, FocusedLeg) -> Unit,
     onFocusLeg: (FocusedLeg) -> Unit,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
@@ -214,7 +214,8 @@ sealed interface TripLogEntry {
  * an itinerary that rides one route twice is two rides under a single label, and — one label being one
  * tap target — it resolves to the first in travel order, the ride the rider reaches first.
  */
-fun List<TripLogEntry>.rideCoveringLegs(legIndices: Set<Int>): TripLogEntry.Transit? = filterIsInstance<TripLogEntry.Transit>().firstOrNull { entry -> entry.legIndices.any(legIndices::contains) }
+internal fun List<TripLogEntry>.rideCoveringLegs(legIndices: Set<Int>): TripLogEntry.Transit? = filterIsInstance<TripLogEntry.Transit>()
+    .firstOrNull { entry -> entry.legIndices.any(legIndices::contains) }
 
 /**
  * Something that happens between boarding and exiting a ride, in travel order: an intermediate [Stop]

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
@@ -203,6 +203,20 @@ sealed interface TripLogEntry {
 }
 
 /**
+ * The ride these itinerary [legIndices] belong to, or null when they name none — how a tap on the map's
+ * route label for a ride (#2101) finds the drawer entry that owns it, so the tap can spend the same
+ * focus that entry's own row does instead of a second, subtly different one.
+ *
+ * Matched by intersection rather than equality, because a label is per *route* and a ride is what the
+ * rider boards once, so the two need not cover the same legs (see
+ * [itineraryRouteBadges][org.onebusaway.android.map.itineraryRouteBadges]). A stay-aboard interline onto
+ * another route (#2000) is one ride wearing a label per route, and either label focuses the whole ride;
+ * an itinerary that rides one route twice is two rides under a single label, and — one label being one
+ * tap target — it resolves to the first in travel order, the ride the rider reaches first.
+ */
+fun List<TripLogEntry>.rideCoveringLegs(legIndices: Set<Int>): TripLogEntry.Transit? = filterIsInstance<TripLogEntry.Transit>().firstOrNull { entry -> entry.legIndices.any(legIndices::contains) }
+
+/**
  * Something that happens between boarding and exiting a ride, in travel order: an intermediate [Stop]
  * passed, or a stay-aboard [Transition] onto another route mid-vehicle (#2000). They interleave — a
  * folded interline chain is `stops… → transition → stops… → transition → stops…` — which is why they

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
@@ -104,9 +104,9 @@ class MapLibreRenderer(
 
     private val vehicleByMarker = HashMap<Marker, VehicleMarker>()
 
-    // Adjacency route badge tap targets (#1827), mirroring the Google flavor's routeBadgeByMarker.
-    // Their geographic anchors are laid out once upstream; these markers then move naturally with the
-    // map through pan and zoom.
+    // Route badge tap targets — adjacency (#1827) and a directions ride (#2101) — mirroring the Google
+    // flavor's routeBadgeByMarker. Their geographic anchors are laid out once upstream; these markers
+    // then move naturally with the map through pan and zoom.
     private val routeBadgeByMarker = HashMap<Marker, RouteBadge>()
 
     // The non-route static annotations added by the last [renderStatic], removed (not map.clear()) on

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreComposeAdapter.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreComposeAdapter.kt
@@ -62,6 +62,7 @@ import org.onebusaway.android.map.compose.VehicleInfoWindow
 import org.onebusaway.android.map.compose.drivePings
 import org.onebusaway.android.map.maplibre.MapLibreRenderer
 import org.onebusaway.android.map.render.CameraSnapshot
+import org.onebusaway.android.map.render.RouteBadgeTap
 import org.onebusaway.android.map.render.routePolylineRenderFlow
 import org.onebusaway.android.util.GeoPoint
 import org.onebusaway.android.util.PermissionUtils
@@ -329,10 +330,21 @@ private fun wireClicks(
             return@setOnMarkerClickListener true
         }
         val routeBadge = renderer.routeBadgeForMarker(marker)
-        val routeBadgeTap = routeBadge?.tap
-        if (routeBadge != null && routeBadgeTap != null) {
-            callbacks.onRouteBadgeClick(routeBadgeTap.routeId, routeBadge.tappedRouteShortName, routeBadgeTap.directionId)
-            return@setOnMarkerClickListener true
+        when (val routeBadgeTap = routeBadge?.tap) {
+            is RouteBadgeTap.ShowRoute -> {
+                callbacks.onRouteBadgeClick(
+                    routeBadgeTap.route.routeId,
+                    routeBadge.tappedRouteShortName,
+                    routeBadgeTap.route.directionId
+                )
+                return@setOnMarkerClickListener true
+            }
+            is RouteBadgeTap.FocusItineraryRide -> {
+                callbacks.onItineraryRideBadgeClick(routeBadgeTap.legIndices)
+                return@setOnMarkerClickListener true
+            }
+            // An inert label, or not a label at all: fall through to the default marker handling below.
+            null -> Unit
         }
         // Titled markers (the trip-focus estimate markers + the most-recent-data dot) fall through to
         // the SDK's default title window. Untitled decorations (generic start/end markers) have

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreComposeAdapter.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreComposeAdapter.kt
@@ -62,7 +62,6 @@ import org.onebusaway.android.map.compose.VehicleInfoWindow
 import org.onebusaway.android.map.compose.drivePings
 import org.onebusaway.android.map.maplibre.MapLibreRenderer
 import org.onebusaway.android.map.render.CameraSnapshot
-import org.onebusaway.android.map.render.RouteBadgeTap
 import org.onebusaway.android.map.render.routePolylineRenderFlow
 import org.onebusaway.android.util.GeoPoint
 import org.onebusaway.android.util.PermissionUtils
@@ -329,22 +328,12 @@ private fun wireClicks(
             }
             return@setOnMarkerClickListener true
         }
+        // Only a label that leads somewhere is registered as a tap target, so this hands the badge over
+        // whole and lets the host read where it leads — see [ObaMapCallbacks.onRouteBadgeClick].
         val routeBadge = renderer.routeBadgeForMarker(marker)
-        when (val routeBadgeTap = routeBadge?.tap) {
-            is RouteBadgeTap.ShowRoute -> {
-                callbacks.onRouteBadgeClick(
-                    routeBadgeTap.route.routeId,
-                    routeBadge.tappedRouteShortName,
-                    routeBadgeTap.route.directionId
-                )
-                return@setOnMarkerClickListener true
-            }
-            is RouteBadgeTap.FocusItineraryRide -> {
-                callbacks.onItineraryRideBadgeClick(routeBadgeTap.legIndices)
-                return@setOnMarkerClickListener true
-            }
-            // An inert label, or not a label at all: fall through to the default marker handling below.
-            null -> Unit
+        if (routeBadge != null) {
+            callbacks.onRouteBadgeClick(routeBadge)
+            return@setOnMarkerClickListener true
         }
         // Titled markers (the trip-focus estimate markers + the most-recent-data dot) fall through to
         // the SDK's default title window. Untitled decorations (generic start/end markers) have

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/ItineraryRouteBadgesTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/ItineraryRouteBadgesTest.kt
@@ -17,6 +17,10 @@ import org.onebusaway.android.util.GeoPoint
  * label names *a ride* — one per route, however many legs it spans, and every route the rider may board
  * for it (#2083) — takes the colour of the line it names, and leads back into that ride rather than away
  * from the trip being read (#2101).
+ *
+ * One label is not always one ride, though: a label is per route, so an itinerary that rides the same
+ * route twice wears a single label covering both. One label being one tap target, it leads to the first
+ * of them in travel order — the ride the rider reaches first. `rideCoveringLegs` owns that rule.
  */
 class ItineraryRouteBadgesTest {
 

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/ItineraryRouteBadgesTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/ItineraryRouteBadgesTest.kt
@@ -3,20 +3,20 @@ package org.onebusaway.android.map
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
-import org.junit.Assert.assertNull
 import org.junit.Test
 import org.onebusaway.android.directions.model.InterchangeableRoute
 import org.onebusaway.android.directions.model.TripLeg
 import org.onebusaway.android.directions.model.TripMode
 import org.onebusaway.android.map.render.BadgedRoute
 import org.onebusaway.android.map.render.RouteBadge
+import org.onebusaway.android.map.render.RouteBadgeTap
 import org.onebusaway.android.util.GeoPoint
 
 /**
  * The route labels drawn on a directions itinerary's transit lines (#2066). The point of these is that a
  * label names *a ride* — one per route, however many legs it spans, and every route the rider may board
- * for it (#2083) — takes the colour of the line it names, and never becomes a tap target that would
- * navigate away from the trip being read.
+ * for it (#2083) — takes the colour of the line it names, and leads back into that ride rather than away
+ * from the trip being read (#2101).
  */
 class ItineraryRouteBadgesTest {
 
@@ -25,7 +25,7 @@ class ItineraryRouteBadgesTest {
     private val northward = listOf(GeoPoint(0.0, 0.0), GeoPoint(1.0, 0.0))
 
     @Test
-    fun `each ridden route is labelled at its midpoint, in its own line colour, and is not tappable`() {
+    fun `each ridden route is labelled at its midpoint, in its own line colour, and focuses its own ride`() {
         val ride = TripLeg(mode = TripMode.BUS, routeId = "route-45", routeShortName = "45")
         val rideStyle = itineraryLegStyle(ItineraryLegKind.TRANSIT, routeColor = 0xFF0000FF.toInt(), palette = PALETTE)
 
@@ -39,8 +39,8 @@ class ItineraryRouteBadgesTest {
         // Exactly the colour its own line is stroked with, so a label and its line can't disagree.
         assertEquals(listOf(BadgedRoute("45", rideStyle.color)), badge.routes)
         assertEquals(GeoPoint(0.0, 0.5), badge.point)
-        // No tap target at all, so there is nothing for a stray tap to navigate to.
-        assertNull(badge.tap)
+        // A tap lands back on the ride it names, never on that route's own map.
+        assertEquals(RouteBadgeTap.FocusItineraryRide(setOf(1)), badge.tap)
     }
 
     @Test
@@ -53,6 +53,9 @@ class ItineraryRouteBadgesTest {
         )
 
         assertEquals(listOf(listOf("5")), badges.map(::names))
+        // One label, so one tap target — carrying both legs, which `rideCoveringLegs` resolves to the
+        // ride the rider reaches first.
+        assertEquals(listOf(RouteBadgeTap.FocusItineraryRide(setOf(0, 2))), badges.map { it.tap })
     }
 
     @Test
@@ -108,8 +111,8 @@ class ItineraryRouteBadgesTest {
         ).single()
 
         assertEquals(listOf("1 Line", "2 Line"), names(badge))
-        // Still informational: naming several routes doesn't turn the label into a navigation target.
-        assertNull(badge.tap)
+        // Naming several routes doesn't make it several rides: the tap is still the one ride it sits on.
+        assertEquals(RouteBadgeTap.FocusItineraryRide(setOf(0)), badge.tap)
     }
 
     @Test

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteMapPresentationPlanTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteMapPresentationPlanTest.kt
@@ -22,6 +22,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.onebusaway.android.map.render.ROUTE_LINE_WIDTH_PROFILE
 import org.onebusaway.android.map.render.RouteBadge
+import org.onebusaway.android.map.render.RouteBadgeTap
 import org.onebusaway.android.map.render.RoutePolyline
 import org.onebusaway.android.models.FocusedTrip
 import org.onebusaway.android.models.ObaRoute
@@ -144,7 +145,7 @@ class RouteMapPresentationPlanTest {
         )
 
         // No emphasized route -> route badges are emitted, and there's no active base route to frame to.
-        assertEquals(listOf("79"), plan.badges.map { it.tap?.routeId })
+        assertEquals(listOf("79"), plan.badges.map { (it.tap as? RouteBadgeTap.ShowRoute)?.route?.routeId })
         assertEquals(emptyList<RoutePolyline>(), plan.framingPolylines)
         assertEquals(1, plan.polylines.size)
     }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteViewGeometryTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteViewGeometryTest.kt
@@ -10,6 +10,8 @@ import org.onebusaway.android.map.render.DEEMPHASIZED_ROUTE_LINE_WIDTH_PROFILE
 import org.onebusaway.android.map.render.FOCUSED_ROUTE_LINE_WIDTH_PROFILE
 import org.onebusaway.android.map.render.ITINERARY_CONTEXT_WIDTH_PROFILE
 import org.onebusaway.android.map.render.ROUTE_LINE_WIDTH_PROFILE
+import org.onebusaway.android.map.render.RouteBadge
+import org.onebusaway.android.map.render.RouteBadgeTap
 import org.onebusaway.android.map.render.RouteLineDash
 import org.onebusaway.android.map.render.RoutePolyline
 import org.onebusaway.android.map.render.RoutePolylineTransform
@@ -276,12 +278,12 @@ class RouteViewGeometryTest {
             )
         )
 
-        assertEquals(listOf("route-b", "route-a", "route-a"), badges.map { it.tap?.routeId })
+        assertEquals(listOf("route-b", "route-a", "route-a"), badges.map { it.showRouteTap?.routeId })
         // An adjacency label names its one route: only a directions ride the rider may board any of
         // several routes for stacks more than one name (#2083).
         assertEquals(listOf("B", "A", "A"), badges.map { it.routes.single().routeShortName })
         assertEquals(listOf(20, 10, 30), badges.map { it.routes.single().color })
-        assertEquals(listOf(1, 0, 1), badges.map { it.tap?.directionId })
+        assertEquals(listOf(1, 0, 1), badges.map { it.showRouteTap?.directionId })
         assertEquals(GeoPoint(0.0, 0.5), badges[0].point)
         assertTrue(haversineMeters(badges[0].point, badges[1].point) >= 299.9)
     }
@@ -301,8 +303,12 @@ class RouteViewGeometryTest {
             listOf(route("known-route", "Known"), route("degenerate-route", "Degenerate"))
         )
 
-        assertEquals(listOf("known-route"), badges.map { it.tap?.routeId })
+        assertEquals(listOf("known-route"), badges.map { it.showRouteTap?.routeId })
     }
+
+    /** The route-direction an adjacency label opens; null if the label leads elsewhere or nowhere. */
+    private val RouteBadge.showRouteTap: RouteDirectionKey?
+        get() = (tap as? RouteBadgeTap.ShowRoute)?.route
 
     private fun route(id: String, shortName: String, routeColor: Int? = null) = object : ObaRoute {
         override val id = id

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/render/RouteBadgeInvariantsTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/render/RouteBadgeInvariantsTest.kt
@@ -22,10 +22,10 @@ import org.onebusaway.android.models.RouteDirectionKey
 import org.onebusaway.android.util.GeoPoint
 
 /**
- * The two invariants [RouteBadge] states about what a map label may be (#2083): it names at least one
- * route, and a navigable one names exactly one. Both are producer-side — only adjacency labels navigate,
- * and each names its own route — so these pin the contract a badge builder has to keep rather than
- * behaviour a rider sees.
+ * The invariants [RouteBadge] and [RouteBadgeTap] state about what a map label may be (#2083, #2101): it
+ * names at least one route, a *route-navigating* one names exactly one, and a ride focus names at least
+ * one leg. All producer-side, so these pin the contract a badge builder has to keep rather than behaviour
+ * a rider sees.
  */
 class RouteBadgeInvariantsTest {
 
@@ -41,15 +41,20 @@ class RouteBadgeInvariantsTest {
     }
 
     @Test
-    fun `a navigable label naming several routes is rejected`() {
-        // Where would the tap lead? A label that stacks routes is informational for exactly this reason.
+    fun `a route-navigating label naming several routes is rejected`() {
+        // Where would the tap lead? A label that stacks routes may only lead somewhere that is about the
+        // stack as a whole — which a ride focus is, and a single route's map isn't.
         assertThrows(IllegalArgumentException::class.java) {
-            RouteBadge(routes = listOf(oneLine, twoLine), point = point, tap = RouteDirectionKey("route-1", 0))
+            RouteBadge(
+                routes = listOf(oneLine, twoLine),
+                point = point,
+                tap = RouteBadgeTap.ShowRoute(RouteDirectionKey("route-1", 0))
+            )
         }
     }
 
     @Test
-    fun `an informational label may name several routes, in the order given`() {
+    fun `an inert label may name several routes, in the order given`() {
         val badge = RouteBadge(routes = listOf(oneLine, twoLine), point = point)
 
         assertEquals(listOf(oneLine, twoLine), badge.routes)
@@ -57,11 +62,27 @@ class RouteBadgeInvariantsTest {
     }
 
     @Test
-    fun `a navigable label names its one route`() {
-        val tap = RouteDirectionKey("route-1", 0)
+    fun `a route-navigating label names its one route`() {
+        val tap = RouteBadgeTap.ShowRoute(RouteDirectionKey("route-1", 0))
         val badge = RouteBadge(routes = listOf(oneLine), point = point, tap = tap)
 
         assertEquals(tap, badge.tap)
         assertEquals("1 Line", badge.tappedRouteShortName)
+    }
+
+    @Test
+    fun `a ride focus may name several routes - an interchangeable ride is still one ride`() {
+        // The stacked-name rule is about the *destination*, not the label: the rider boards whichever of
+        // these comes first, and either way it is the one ride this label sits on (#2010).
+        val tap = RouteBadgeTap.FocusItineraryRide(setOf(2))
+        val badge = RouteBadge(routes = listOf(oneLine, twoLine), point = point, tap = tap)
+
+        assertEquals(tap, badge.tap)
+    }
+
+    @Test
+    fun `a ride focus naming no leg is rejected`() {
+        // It would read as a dead label rather than as the badge-builder bug it is.
+        assertThrows(IllegalArgumentException::class.java) { RouteBadgeTap.FocusItineraryRide(emptySet()) }
     }
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/RideCoveringLegsTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/RideCoveringLegsTest.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.tripresults
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Test
+import org.onebusaway.android.time.ServerTime
+
+/**
+ * [rideCoveringLegs] — how a route label tapped on the map (#2101) finds the drawer entry for the ride it
+ * names. The map knows an itinerary only by leg index; the drawer knows a ride, which may be several legs
+ * (a folded interline, #2000). This is the join between them, and getting it wrong focuses the wrong ride
+ * rather than failing visibly, so each way the two can disagree is pinned here.
+ */
+class RideCoveringLegsTest {
+
+    private val start = TripLogEntry.Terminal(TerminalKind.START, ServerTime(0L), "Origin")
+    private val arrive = TripLogEntry.Terminal(TerminalKind.ARRIVE, ServerTime(40 * 60_000L), "Destination")
+
+    private val walk = TripLogEntry.Walk(
+        mode = StreetMode.WALK,
+        durationMinutes = 4,
+        distanceMeters = 320.0,
+        isTransfer = false,
+        steps = emptyList(),
+        legIndices = setOf(0)
+    )
+
+    private fun ride(shortName: String, legIndices: Set<Int>) = TripLogEntry.Transit(
+        routeShortName = shortName,
+        routeDisplayName = "Route $shortName",
+        mode = TransitMode.BUS,
+        routeColorHex = null,
+        headsign = "Downtown",
+        boardTime = ServerTime(4 * 60_000L),
+        exitTime = ServerTime(20 * 60_000L),
+        durationMinutes = 16,
+        realtime = RealtimeState.Unknown,
+        rideEvents = emptyList(),
+        routeLeg = RouteLegRef("1_$shortName", "Downtown", null, null),
+        legIndices = legIndices
+    )
+
+    @Test
+    fun `a label names the ride whose legs it carries`() {
+        val eight = ride("8", setOf(1))
+        val fortyNine = ride("49", setOf(3))
+        val directions = listOf(start, walk, eight, walk, fortyNine, arrive)
+
+        assertSame(eight, directions.rideCoveringLegs(setOf(1)))
+        assertSame(fortyNine, directions.rideCoveringLegs(setOf(3)))
+    }
+
+    @Test
+    fun `every leg of a folded interline finds the one ride it is part of`() {
+        // The rider never gets off, so legs 1 and 2 are a single drawer entry — but the vehicle runs as a
+        // different route after the seam, so the map labels each leg separately ("5", then "12"). Either
+        // label, naming only its own leg, has to reach the whole ride: that is the tap the rider means.
+        val chain = ride("5", setOf(1, 2))
+        val directions = listOf(start, chain, arrive)
+
+        assertSame(chain, directions.rideCoveringLegs(setOf(1)))
+        assertSame(chain, directions.rideCoveringLegs(setOf(2)))
+    }
+
+    @Test
+    fun `a label shared by two rides of one route resolves to the earlier`() {
+        // One label is one tap target, so the itinerary that boards the 40 twice can only lead somewhere
+        // once: the ride the rider reaches first.
+        val first = ride("40", setOf(1))
+        val second = ride("40", setOf(5))
+        val directions = listOf(start, first, walk, second, arrive)
+
+        assertSame(first, directions.rideCoveringLegs(setOf(1, 5)))
+    }
+
+    @Test
+    fun `legs this itinerary does not have name no ride`() {
+        // Nothing to focus, and nothing is focused — the caller has a null to act on rather than a
+        // nearest-match ride the rider never tapped.
+        val directions = listOf(start, ride("8", setOf(1)), arrive)
+
+        assertNull(directions.rideCoveringLegs(setOf(7)))
+        assertNull(emptyList<TripLogEntry>().rideCoveringLegs(setOf(1)))
+    }
+
+    @Test
+    fun `an on-street leg is not a ride`() {
+        // Walks carry leg indices too, but the map draws no label on one, so a tap can never name one —
+        // and if it somehow did, it is not a ride to focus.
+        val directions = listOf(start, walk, arrive)
+
+        assertNull(directions.rideCoveringLegs(setOf(0)))
+        assertEquals(emptyList<TripLogEntry>(), directions.filterIsInstance<TripLogEntry.Transit>())
+    }
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/RideCoveringLegsTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/RideCoveringLegsTest.kt
@@ -15,7 +15,6 @@
  */
 package org.onebusaway.android.ui.tripresults
 
-import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
 import org.junit.Test
@@ -106,6 +105,5 @@ class RideCoveringLegsTest {
         val directions = listOf(start, walk, arrive)
 
         assertNull(directions.rideCoveringLegs(setOf(0)))
-        assertEquals(emptyList<TripLogEntry>(), directions.filterIsInstance<TripLogEntry.Transit>())
     }
 }


### PR DESCRIPTION
Closes #2101.

The route label drawn on an itinerary's transit line named the ride but led nowhere — it was built with no tap target at all, deliberately, so a stray tap could not trade the whole trip the rider was reading for one route's map. That left the most direct thing on screen inert: the rider sees the `[40]` sitting on the line and reaches for it.

A label now leads somewhere, and somewhere is **inside** the trip: it focuses the ride it names, exactly as tapping that ride's row in the directions drawer does. Both spend the same `focusTransit`, so one ride can't mean two things depending on where the rider reached for it — route focus with the ridden segment drawn over it, degrading to leg framing and then to the board stop just as the row does.

### How it fits together

- **`RouteBadge.tap` widens** from a `RouteDirectionKey?` to a sealed `RouteBadgeTap`. The two map views that label their lines now want different things of a tap: adjacency (#1827) opens a route the rider hasn't opened, directions (#2101) stays in the trip. Only the `ShowRoute` form carries the "a navigable label names exactly one route" invariant — an interchangeable ride is one ride however many routes it may be taken on.
- **`ObaMapCallbacks.onRouteBadgeClick` takes the badge whole**, as `onStopClick` already takes a `StopMarker`, so the `when` over that sealed type lives once in `MapFeature` rather than mirrored in both flavor adapters. Both adapters end up *simpler* than before this change.
- **A label is per route; a ride is what the rider boards once** — so the two don't always cover the same legs. A stay-aboard interline onto another route (#2000) is one ride wearing a label per route; an itinerary that rides one route twice is two rides under a single label. The label therefore carries the leg indices it knows, and `rideCoveringLegs` resolves them against the drawer's own entries — the side that has the rides.
- **The tap crosses map → drawer**, the opposite way from `mapDirectives`, and can't be a directive: resolving a ride needs the results VM's leg refs. `HomeViewModel` relays it as a `SharedFlow` the results sheet collects. A tap with no collector is a tap with no trip to focus into, so dropping it is right where queueing it would not be — notably, a badge tap while the map-point picker is up (itinerary still drawn, sheet not composed) correctly does nothing.

### Reviewer's attention, please

One judgment call worth a second opinion: where a single label covers **two separate rides of the same route**, it resolves to the first in travel order. One label is one tap target, so it can only lead somewhere once, and the earlier ride is the one the rider reaches first — but it is a tie-break, documented at `rideCoveringLegs` and pinned by a test, not a fact off the wire.

### Verification

- Compiles clean under `-PwarningsAsErrors=true` on `obaGoogle` and `obaMaplibre`, plus both test source sets.
- Full JVM unit suite passes. Updated `RouteBadgeInvariantsTest`, `ItineraryRouteBadgesTest`, `RouteViewGeometryTest`, `RouteMapPresentationPlanTest`; new `RideCoveringLegsTest` covers the interline, shared-label, empty and no-match cases.
- **Not yet exercised on a device.** Installed on a Pixel 7 Pro but not driven through a real plan, so the badge's hit area and the resulting focus are unconfirmed by eye. Worth a pass before merge — and worth doing alongside #2102, which changes badge sizing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Route badges on itineraries are now tappable and focus the corresponding ride.
  * Route badges can open route details or focus specific itinerary legs, depending on their context.
  * Tapping a route badge now provides consistent behavior across supported map views.

* **Bug Fixes**
  * Improved handling of grouped, multi-leg, interchangeable, and non-transit itinerary routes.
  * Inert badges no longer trigger unintended navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->