### PR TITLE
Make naming a directions endpoint end the edit

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripplan/TripPlanFormRenderTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripplan/TripPlanFormRenderTest.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toPixelMap
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotFocused
 import androidx.compose.ui.test.captureToImage
 import androidx.compose.ui.test.getUnclippedBoundsInRoot
 import androidx.compose.ui.test.onAllNodesWithContentDescription
@@ -177,6 +178,37 @@ class TripPlanFormRenderTest {
 
         composeRule.onNodeWithTag(FROM_MY_LOCATION).assertIsDisplayed()
         composeRule.onNodeWithTag(FROM_PICK_ON_MAP).assertIsDisplayed()
+    }
+
+    /**
+     * Naming an endpoint from the menu ends the edit. The field is a text box only while a place is
+     * being chosen, so a choice that leaves it focused leaves the keyboard standing over the map with
+     * nothing left for the rider to type — worst with "Your location", which they reach for precisely
+     * to avoid typing. Both kinds of row are checked, since a geocoded result names the endpoint just
+     * as completely. The keyboard itself isn't assertable here; the focus that raises it is.
+     */
+    @Test
+    fun choosingFromTheMenuEndsTheEdit() {
+        renderForm(
+            plannedState.copy(
+                from = TripEndpoint.FreeText(""),
+                toSuggestions = listOf(TripEndpoint.Geocoded("Pike Brewing Company", 47.60, -122.34))
+            )
+        )
+
+        composeRule.onNodeWithTag(FROM_FIELD).performClick()
+        composeRule.waitForIdle()
+        composeRule.onNodeWithTag(FROM_MY_LOCATION).performClick()
+        composeRule.waitForIdle()
+        composeRule.onNodeWithTag(FROM_FIELD).assertIsNotFocused()
+
+        // The second half is also the handoff: the row is editable again after the first choice let go
+        // of the focus it shares with its sibling.
+        composeRule.onNodeWithTag(TO_FIELD).performClick()
+        composeRule.waitForIdle()
+        composeRule.onNodeWithText("Pike Brewing Company").performClick()
+        composeRule.waitForIdle()
+        composeRule.onNodeWithTag(TO_FIELD).assertIsNotFocused()
     }
 
     @Test

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripplan/TripPlanFormRenderTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripplan/TripPlanFormRenderTest.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performImeAction
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.height
 import kotlin.math.absoluteValue
@@ -209,6 +210,48 @@ class TripPlanFormRenderTest {
         composeRule.onNodeWithText("Pike Brewing Company").performClick()
         composeRule.waitForIdle()
         composeRule.onNodeWithTag(TO_FIELD).assertIsNotFocused()
+    }
+
+    /**
+     * The keyboard's accept key takes the top result. It used to be wired to nothing: it closed the
+     * keyboard and left the endpoint as the free text the rider had typed, which no plan can be made
+     * from — so the one key that says "that's the one" was the one way of leaving the field that
+     * didn't name a place.
+     */
+    @Test
+    fun theAcceptKeyTakesTheTopSuggestion() {
+        val top = TripEndpoint.Geocoded("Pike St & 3rd Ave", 47.61, -122.33, isTransit = true)
+        var chosen: TripEndpoint.Geocoded? = null
+        renderForm(
+            state = {
+                plannedState.copy(
+                    from = TripEndpoint.FreeText("Pike"),
+                    fromSuggestions = listOf(top, TripEndpoint.Geocoded("Pike Brewing Company", 47.60, -122.34))
+                )
+            },
+            onSelect = { slot, place -> if (slot == TripEndpointSlot.FROM) chosen = place }
+        )
+
+        composeRule.onNodeWithTag(FROM_FIELD).performClick()
+        composeRule.waitForIdle()
+        composeRule.onNodeWithTag(FROM_FIELD).performImeAction()
+        composeRule.waitForIdle()
+
+        assertEquals("the accept key should resolve the endpoint", top, chosen)
+        composeRule.onNodeWithTag(FROM_FIELD).assertIsNotFocused()
+    }
+
+    /** With nothing to accept, the key still ends the edit rather than leaving the keyboard standing. */
+    @Test
+    fun theAcceptKeyEndsTheEditWithNoSuggestions() {
+        renderForm(plannedState.copy(from = TripEndpoint.FreeText("Pike")))
+
+        composeRule.onNodeWithTag(FROM_FIELD).performClick()
+        composeRule.waitForIdle()
+        composeRule.onNodeWithTag(FROM_FIELD).performImeAction()
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithTag(FROM_FIELD).assertIsNotFocused()
     }
 
     @Test

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanForm.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanForm.kt
@@ -31,6 +31,8 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -67,6 +69,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -269,6 +272,12 @@ private fun EndpointRow(
         action()
     }
 
+    // The keyboard's own accept key is a choice like any other: by the time it is pressed the geocoder
+    // has already answered, and the rider is confirming the result they can see at the top of the list
+    // rather than asking for it. With nothing to confirm it just ends the edit — which is all it did
+    // before, having been wired to nothing at all.
+    val acceptTopSuggestion = choosing { suggestions.firstOrNull()?.let(onSelect) }
+
     // Adopt the hosted endpoint only when it actually says something different — a suggestion picked,
     // a location filled in, a reversed trip. While the user types, the endpoint is echoing the text
     // that came from this field, so there is nothing to adopt and the cursor is left alone.
@@ -301,6 +310,8 @@ private fun EndpointRow(
                     }
                 },
                 singleLine = true,
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                keyboardActions = KeyboardActions(onDone = { acceptTopSuggestion() }),
                 // The device's own position is named in its own colour, matching its rail dot, so the
                 // one endpoint the rider didn't choose is identifiable without reading it. A chosen
                 // place is ordinary text — colouring every endpoint would say nothing.

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanForm.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanForm.kt
@@ -58,6 +58,8 @@ import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
@@ -251,6 +253,22 @@ private fun EndpointRow(
     var field by remember { mutableStateOf(TextFieldValue(endpointText)) }
     var menuOpen by remember { mutableStateOf(false) }
 
+    val focusManager = LocalFocusManager.current
+    val keyboard = LocalSoftwareKeyboardController.current
+
+    // Choosing any row of the menu below names the endpoint, so it ends the edit rather than being a
+    // step in it: the field gives up focus and the keyboard goes with it. Hung off the choice rather
+    // than off the row's state, because focus is one resource shared with the sibling row — "this row
+    // isn't being edited" is also true the instant the other row takes focus, and reconciling to that
+    // would pull the keyboard down mid-handoff. Wrapping the action keeps a later row from forgetting.
+    fun choosing(action: () -> Unit): () -> Unit = {
+        menuOpen = false
+        // clearFocus() is what closes the keyboard the field raised; hide() is a cheap backstop.
+        focusManager.clearFocus()
+        keyboard?.hide()
+        action()
+    }
+
     // Adopt the hosted endpoint only when it actually says something different — a suggestion picked,
     // a location filled in, a reversed trip. While the user types, the endpoint is echoing the text
     // that came from this field, so there is nothing to adopt and the cursor is left alone.
@@ -329,10 +347,7 @@ private fun EndpointRow(
             DropdownMenuItem(
                 text = { Text(stringResource(R.string.tripplanner_current_location)) },
                 leadingIcon = { CurrentLocationDotIcon() },
-                onClick = {
-                    menuOpen = false
-                    onCurrentLocation()
-                },
+                onClick = choosing(onCurrentLocation),
                 modifier = Modifier.testTag(tagPrefix + TripPlanTestTags.MY_LOCATION_SUFFIX)
             )
             DropdownMenuItem(
@@ -340,10 +355,7 @@ private fun EndpointRow(
                 // The crosshair the pick overlay itself puts at the centre of the map, so the row
                 // shows the tool it opens.
                 leadingIcon = { PinnedActionIcon(painterResource(R.drawable.ic_my_location)) },
-                onClick = {
-                    menuOpen = false
-                    onPickOnMap()
-                },
+                onClick = choosing(onPickOnMap),
                 modifier = Modifier.testTag(tagPrefix + TripPlanTestTags.PICK_ON_MAP_SUFFIX)
             )
             if (suggestions.isNotEmpty()) {
@@ -356,10 +368,7 @@ private fun EndpointRow(
                         } else {
                             null
                         },
-                        onClick = {
-                            onSelect(place)
-                            menuOpen = false
-                        },
+                        onClick = choosing { onSelect(place) },
                         modifier = Modifier.testTag(tagPrefix + TripPlanTestTags.SUGGESTION_SUFFIX)
                     )
                 }


### PR DESCRIPTION
Naming an endpoint left the field acting as an editor. Choosing **Your location** filled it and then left it focused, so the keyboard stayed up over the map with nothing left for the rider to type — the one row they reach for precisely to avoid typing. The same held for a geocoded suggestion, and for **Pick on map**, where the keyboard could end up sitting over the crosshair overlay's own "Use this location" button.

The keyboard's own accept key had the opposite half of the problem: it declared no IME action, so it ran Compose's default handling for an unspecified one — dropped the keyboard, did nothing else. The endpoint stayed as free text no plan can be made from, and the rider had to go back and tap the row they were already looking at.

Both come out the same way: **naming an endpoint ends the edit.** Every row of that menu names the endpoint, and so does the accept key, so each of them closes the row, gives up focus, and takes the keyboard with it.

### How it fits together

- **The rule is wrapped around the actions, not repeated at them.** `choosing(action)` in `EndpointRow` closes the menu, drops focus and hides the keyboard, then runs the row's own action — so `onClick = choosing(onCurrentLocation)` reads as "this row is a choice", and a row added later can't forget the teardown. It replaces three hand-written `menuOpen = false` lines.
- **The accept key is one of those choices**, not a special case: `acceptTopSuggestion = choosing { suggestions.firstOrNull()?.let(onSelect) }`, wired through `KeyboardActions(onDone = …)`. Taking the *top* result is the honest reading of the gesture — the list is already on screen and the rider is confirming what they can see. With no suggestions it degrades to ending the edit, which is all the key did before.
- **It hangs off the choice, not off the row's state.** The declarative-looking alternative — one `editing` flag with a `LaunchedEffect` reconciling focus and the IME to it — is wrong here, and the comment says why: focus is a single resource shared with the sibling row, and `editing` is derived from `onFocusChanged`, so it also goes false the instant the *other* field is tapped. Reconciling to that would clear the focus the sibling just took and pull the keyboard back down mid-handoff. Clearing focus is an outcome of the choice, not a property of the row.
- **`clearFocus()` is what closes the keyboard**; `keyboard?.hide()` follows it as a cheap backstop, matching the pair already in `MapFeature.onMapClick`. Two sites of two lines, with different guards — left un-hoisted rather than papered over with a shared helper.

### Verification

- Compiles clean under `-PwarningsAsErrors=true`, main and androidTest source sets; `spotlessCheck` passes.
- Three new instrumented tests: `choosingFromTheMenuEndsTheEdit` (both kinds of menu row, plus — in its second half — the From→To handoff the design above protects), `theAcceptKeyTakesTheTopSuggestion`, and `theAcceptKeyEndsTheEditWithNoSuggestions`. They assert focus rather than keyboard visibility: the IME isn't assertable from a Compose rule, but the focus that raises it is.
- **Device-verified on a Pixel 7 Pro** for the first commit — picking Your location leaves the field unfocused with the keyboard down, and tapping straight from From to To still keeps it up. The accept-key commit is covered by the tests above but has **not** had its own device pass; worth a minute before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
