### PR TITLE
Scale the directions map's route badges with zoom (#2102)

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/map/render/RouteBadgeBitmapTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/map/render/RouteBadgeBitmapTest.kt
@@ -62,7 +62,34 @@ class RouteBadgeBitmapTest {
         assertEquals(blue, stacked.getPixel(stacked.width - SAMPLE_INSET_PX, rowCenterY(stacked, row = 0, rows = 2)))
     }
 
-    private fun badge(routes: List<BadgedRoute>): Bitmap = ContinuationBadgeBitmaps.badge(routes, density = 1f, darkMode = false)
+    @Test
+    fun aScaledLabelIsTheSameDrawingAtADifferentSize() {
+        // The directions map's labels recede with the zoom (#2102). What has to hold is that the scale is
+        // *uniform* — type, padding and corner all follow it — so a shrunk label is the same pill, not a
+        // squashed one or a full-size name in a smaller box.
+        val full = badge(listOf(BadgedRoute("1 Line", blue)))
+        val half = badge(listOf(BadgedRoute("1 Line", blue)), scale = 0.5f)
+
+        // A proportionality check, not a pixel-exact one: the row height is rounded up to a whole pixel, the
+        // bitmap is truncated to one, and a font's glyph advances don't have to divide exactly in half.
+        assertEquals(full.width / 2f, half.width.toFloat(), 2f)
+        assertEquals(full.height / 2f, half.height.toFloat(), 2f)
+        // Still the route's own colour inside its (now smaller) padding, so the pill didn't lose its fill or
+        // its casing to the rounding.
+        assertEquals(blue, half.rowFill(row = 0, rows = 1))
+    }
+
+    @Test
+    fun aStackedLabelScalesRowByRow() {
+        val stacked = badge(listOf(BadgedRoute("1 Line", blue), BadgedRoute("2 Line", green)), scale = 0.5f)
+        val single = badge(listOf(BadgedRoute("1 Line", blue)), scale = 0.5f)
+
+        assertEquals(single.height * 2, stacked.height)
+        assertEquals(blue, stacked.rowFill(row = 0, rows = 2))
+        assertEquals(green, stacked.rowFill(row = 1, rows = 2))
+    }
+
+    private fun badge(routes: List<BadgedRoute>, scale: Float = 1f): Bitmap = ContinuationBadgeBitmaps.badge(routes, density = 1f, darkMode = false, scale = scale)
 
     /** The fill colour of one row, read from inside its leading padding. */
     private fun Bitmap.rowFill(row: Int, rows: Int): Int = getPixel(SAMPLE_INSET_PX, rowCenterY(this, row, rows))

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
@@ -127,7 +127,15 @@ class GoogleMapRenderer(
     // Route badge tap targets — adjacency (#1827) and a directions ride (#2101) — mirrored by the
     // maplibre flavor (#1913). Their geographic anchors are laid out once upstream; these markers then
     // move naturally with the map through pan and zoom.
+    // Every route-badge marker the last static render drew, including the inert ones: a camera settle has
+    // to re-stamp a label whose zoom schedule gives it a different size there (#2102) whether or not it
+    // leads anywhere. [routeBadgeForMarker] applies the tappability filter, so this stays one registry
+    // rather than two collections written in the same loop and cleared in the same places.
     private val routeBadgeByMarker = HashMap<Marker, RouteBadge>()
+
+    // The zoom the route-badge icons above were last stamped at. Synced to the live camera by each static
+    // redraw and moved by each settle, so the scale a label draws at always answers the camera it's under.
+    private var renderedBadgeZoom = map.cameraPosition.zoom
 
     // The latest trips-for-route poll, published as it changes (after the markers are reconciled). The
     // change-detector for the vehicle reconcile, the source a vehicle info window reads its content from,
@@ -309,18 +317,37 @@ class GoogleMapRenderer(
     }
 
     private fun renderRouteBadges(badges: List<RouteBadge>) {
+        // Read the camera rather than trusting the last settle: a static redraw can land mid-gesture, and a
+        // label stamped at a stale zoom would keep the wrong size until the camera next moved.
+        renderedBadgeZoom = map.cameraPosition.zoom
         for (badge in badges) {
             val marker = map.addMarkerOrFail(
                 MarkerOptions()
                     .position(badge.point.toLatLng())
-                    .icon(routeBadgeIcon(badge.routes))
+                    .icon(routeBadgeIcon(badge.routes, badge.scale.scaleAt(renderedBadgeZoom)))
+                    // Centered on the anchor, so a label that changes size with zoom grows and shrinks
+                    // about its own placement instead of drifting off it.
                     .anchor(0.5f, 0.5f)
                     .zIndex(ROUTE_BADGE_Z_INDEX)
             )
             staticMarkers += marker
-            // Only a label that leads somewhere becomes a tap target (see [RouteBadge.tap]); an
-            // unregistered marker's tap falls through to the map like any other unclaimed one.
-            if (badge.tap != null) routeBadgeByMarker[marker] = badge
+            routeBadgeByMarker[marker] = badge
+        }
+    }
+
+    /**
+     * Re-stamp the route labels that draw at a different size at the settled [zoom] (#2102). A label on the
+     * fixed profile — every one but a directions itinerary's — resolves to the same scale either side of
+     * the move and is left alone, as is a scheduled one whose camera stayed within a flat end of its ramp
+     * or moved less than one quantization step (see [RouteBadgeScaleProfile.scaleAt]).
+     */
+    private fun updateRouteBadgeScale(zoom: Float) {
+        val previous = renderedBadgeZoom
+        if (zoom == previous) return
+        renderedBadgeZoom = zoom
+        for ((marker, badge) in routeBadgeByMarker) {
+            val scale = badge.scale.scaleAt(zoom)
+            if (scale != badge.scale.scaleAt(previous)) marker.setIcon(routeBadgeIcon(badge.routes, scale))
         }
     }
 
@@ -409,10 +436,14 @@ class GoogleMapRenderer(
         continuationBadgeByMarker[marker] = badge
     }
 
-    private fun routeBadgeIcon(routes: List<BadgedRoute>): BitmapDescriptor {
+    /**
+     * The pill naming [routes], drawn at [scale] — unscaled by default, which is what the fixed-size
+     * route-continuation badge (#1691) above takes; a [RouteBadge] resolves its own from the camera.
+     */
+    private fun routeBadgeIcon(routes: List<BadgedRoute>, scale: Float = 1f): BitmapDescriptor {
         val darkMode = ThemeUtils.isInDarkMode(context)
-        return descriptorCache.get(ContinuationBadgeBitmaps.badgeKey(routes, darkMode)) {
-            ContinuationBadgeBitmaps.badge(routes, density, darkMode)
+        return descriptorCache.get(ContinuationBadgeBitmaps.badgeKey(routes, darkMode, scale)) {
+            ContinuationBadgeBitmaps.badge(routes, density, darkMode, scale)
         }
     }
 
@@ -804,6 +835,7 @@ class GoogleMapRenderer(
         routePolylineReconciler.resyncWidths(zoom)
         val detailScale = routeLineWidthScale(zoom)
         updateVehicleScale(detailScale)
+        updateRouteBadgeScale(zoom)
     }
 
     fun bikeForMarker(marker: Marker): BikeMarker? = bikeByMarker[marker]
@@ -813,8 +845,11 @@ class GoogleMapRenderer(
     /** The route-continuation badge (#1691) tapped, or null if [marker] isn't that badge. */
     fun continuationBadgeForMarker(marker: Marker): ContinuationBadge? = continuationBadgeByMarker[marker]
 
-    /** The adjacency route badge (#1827) tapped, or null if [marker] isn't one. */
-    fun routeBadgeForMarker(marker: Marker): RouteBadge? = routeBadgeByMarker[marker]
+    /**
+     * The route badge tapped, or null if [marker] isn't one — or names a label that leads nowhere (see
+     * [RouteBadge.tap]), whose tap falls through to the map like any other unclaimed one.
+     */
+    fun routeBadgeForMarker(marker: Marker): RouteBadge? = routeBadgeByMarker[marker]?.takeIf { it.tap != null }
 
     /** The live route-vehicle marker for [tripId], or null if that vehicle isn't currently drawn. */
     fun vehicleMarkerForTripId(tripId: String): Marker? = vehicleMarkersByTripId[tripId]

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/ItineraryLegStyle.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/ItineraryLegStyle.kt
@@ -25,6 +25,7 @@ import org.onebusaway.android.map.layout.RouteBadgeRequest
 import org.onebusaway.android.map.layout.placeRouteBadges
 import org.onebusaway.android.map.render.BadgedRoute
 import org.onebusaway.android.map.render.ITINERARY_RIDE_WIDTH_PROFILE
+import org.onebusaway.android.map.render.ITINERARY_ROUTE_BADGE_SCALE_PROFILE
 import org.onebusaway.android.map.render.ITINERARY_STREET_WIDTH_PROFILE
 import org.onebusaway.android.map.render.RouteBadge
 import org.onebusaway.android.map.render.RouteBadgeTap
@@ -217,6 +218,9 @@ internal data class ItinerarySubstitute(val route: InterchangeableRoute, val rou
  * same focus the drawer's row for that ride does. It deliberately does *not* lead to the route's own map,
  * which is what a label on this view must never do: the rider is reading a trip, and a stray tap must not
  * trade the whole itinerary for one route (see [RouteBadgeTap]).
+ *
+ * These are also the map's only labels that follow the zoom (#2102), receding with the lines they name
+ * rather than holding a fixed pixel size — see [ITINERARY_ROUTE_BADGE_SCALE_PROFILE].
  */
 internal fun itineraryRouteBadges(
     legs: List<ItineraryDrawableLeg>,
@@ -247,7 +251,8 @@ internal fun itineraryRouteBadges(
             RouteBadgeRequest(
                 routes = ride.badgedRoutes(palette),
                 paths = ridden.map { RouteBadgePath(it.drawable.points) },
-                tap = RouteBadgeTap.FocusItineraryRide(ridden.mapTo(mutableSetOf()) { it.drawable.index })
+                tap = RouteBadgeTap.FocusItineraryRide(ridden.mapTo(mutableSetOf()) { it.drawable.index }),
+                scale = ITINERARY_ROUTE_BADGE_SCALE_PROFILE
             )
         }
     )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/layout/RouteBadgeLayout.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/layout/RouteBadgeLayout.kt
@@ -20,7 +20,9 @@ import kotlin.math.cos
 import kotlin.math.sin
 import kotlin.math.sqrt
 import org.onebusaway.android.map.render.BadgedRoute
+import org.onebusaway.android.map.render.FIXED_ROUTE_BADGE_SCALE_PROFILE
 import org.onebusaway.android.map.render.RouteBadge
+import org.onebusaway.android.map.render.RouteBadgeScaleProfile
 import org.onebusaway.android.map.render.RouteBadgeTap
 import org.onebusaway.android.map.render.haversineMeters
 import org.onebusaway.android.models.RouteDirectionKey
@@ -86,13 +88,15 @@ fun <K> layoutRouteBadges(
 
 /**
  * One route label to place: the route(s) it names (stacked, in reading order — see [RouteBadge.routes]),
- * what a tap on it does (null for an inert label — see [RouteBadge.tap]), and the shapes it may be
- * anchored on. List order is collision priority, as in [layoutRouteBadges].
+ * what a tap on it does (null for an inert label — see [RouteBadge.tap]), how its size answers the camera
+ * (fixed unless the caller says otherwise — see [RouteBadge.scale]), and the shapes it may be anchored on.
+ * List order is collision priority, as in [layoutRouteBadges].
  */
 internal data class RouteBadgeRequest(
     val routes: List<BadgedRoute>,
     val paths: List<RouteBadgePath>,
-    val tap: RouteBadgeTap? = null
+    val tap: RouteBadgeTap? = null,
+    val scale: RouteBadgeScaleProfile = FIXED_ROUTE_BADGE_SCALE_PROFILE
 )
 
 /**
@@ -109,7 +113,12 @@ internal fun placeRouteBadges(requests: List<RouteBadgeRequest>): List<RouteBadg
     ).associateBy { it.route }
     return requests.mapIndexedNotNull { index, request ->
         placements[index]?.let { placement ->
-            RouteBadge(routes = request.routes, point = placement.point, tap = request.tap)
+            RouteBadge(
+                routes = request.routes,
+                point = placement.point,
+                tap = request.tap,
+                scale = request.scale
+            )
         }
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/ContinuationBadgeBitmaps.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/ContinuationBadgeBitmaps.kt
@@ -36,11 +36,26 @@ import org.onebusaway.android.util.routeCasingColor
  */
 object ContinuationBadgeBitmaps {
 
-    private const val TEXT_SIZE_PX = 38f
-    private const val HORIZONTAL_PADDING_PX = 20f
-    private const val VERTICAL_PADDING_PX = 12f
-    private const val CORNER_RADIUS_PX = 22f
-    private const val OUTLINE_WIDTH_DP = 2f
+    // The pill at its unscaled size, which [badge]'s scale multiplies as a set. Every one of these went up
+    // by half again in #2102: the label was legible but undersized against the lines it names, and moving
+    // them together is what keeps a bigger pill the same drawing rather than a differently-proportioned one.
+    //
+    // Deliberately the *shared* base rather than the directions profile, even though #2102 is a
+    // directions-map issue. Undersized was a claim about route labels generally, so the fixed-1.0x
+    // consumers — focused-stop adjacency (#1827) and the route-continuation badge (#1691) — are meant to
+    // grow with it. The scoped lever exists and was not pulled on purpose: ITINERARY_ROUTE_BADGE_SCALE_
+    // PROFILE(distantScale = 0.75f, closeScale = 1.5f) would have reproduced today's directions labels
+    // against the old constants and left those two alone. A future size change should decide between the
+    // two the same way — base for "every label is wrong", profile for "this view's labels are wrong".
+    //
+    // One consequence worth stating: at 1.5x base against a 0.5 distant scale, a directions label at
+    // overview zoom is 0.75x of its pre-#2102 self — bigger than it was even at the receded end of the
+    // ramp the profile's own KDoc introduces to stop it crowding the itinerary.
+    private const val TEXT_SIZE_PX = 57f
+    private const val HORIZONTAL_PADDING_PX = 30f
+    private const val VERTICAL_PADDING_PX = 18f
+    private const val CORNER_RADIUS_PX = 33f
+    private const val OUTLINE_WIDTH_DP = 3f
     private const val OUTLINE_TONE_LIGHT = 35.0
     private const val OUTLINE_TONE_DARK = 85.0
 
@@ -59,30 +74,38 @@ object ContinuationBadgeBitmaps {
      * (#2010/#2083), not separate lines that happen to meet here. The stack goes downwards rather than
      * across because a map label's neighbour is the basemap — a name-per-column pill grows into the
      * corridor it labels, while rows keep the label roughly as wide as its widest name.
+     *
+     * [scale] multiplies every dimension of the pill — type, padding, corner, casing — so a scaled label
+     * is the same drawing at a different size rather than a differently-proportioned one. A renderer
+     * resolves it from the camera through the label's [RouteBadgeScaleProfile] (#2102).
      */
-    fun badge(routes: List<BadgedRoute>, density: Float, darkMode: Boolean): Bitmap {
+    fun badge(routes: List<BadgedRoute>, density: Float, darkMode: Boolean, scale: Float): Bitmap {
         require(routes.isNotEmpty()) { "a route badge has to name a route to draw one" }
+        // Stated rather than clamped: a non-positive scale has no smallest sensible pill to fall back to,
+        // and would otherwise surface far from its cause as a zero-size bitmap allocation.
+        require(scale > 0f) { "a route badge drawn at scale $scale would have no pixels" }
         // One paint for every row: they share a size and weight, so only the text color changes down the
         // stack — set per row, exactly as the band's is. That also makes the metrics below the whole pill's:
         // its rows are equal bands whatever they read.
         val textPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
-            textSize = TEXT_SIZE_PX
+            textSize = TEXT_SIZE_PX * scale
             isFakeBoldText = true
             textAlign = Paint.Align.CENTER
         }
         val metrics = textPaint.fontMetrics
+        val cornerRadius = CORNER_RADIUS_PX * scale
         // A whole number of pixels, so the bands are identical and the pill is exactly as tall as its rows
         // — the row boundaries are also where the dividers are drawn, and a fractional band would drift
         // away from them down the stack.
-        val rowHeight = ceil((metrics.descent - metrics.ascent) + VERTICAL_PADDING_PX * 2)
+        val rowHeight = ceil((metrics.descent - metrics.ascent) + VERTICAL_PADDING_PX * scale * 2)
         val width = routes
-            .maxOf { route -> textPaint.measureText(route.routeShortName) + HORIZONTAL_PADDING_PX * 2 }
-            .coerceAtLeast(CORNER_RADIUS_PX * 2)
+            .maxOf { route -> textPaint.measureText(route.routeShortName) + HORIZONTAL_PADDING_PX * scale * 2 }
+            .coerceAtLeast(cornerRadius * 2)
         val height = rowHeight * routes.size
 
         val bitmap = createBitmap(width.toInt(), height.toInt())
         val canvas = Canvas(bitmap)
-        val outlineWidth = OUTLINE_WIDTH_DP * density
+        val outlineWidth = OUTLINE_WIDTH_DP * density * scale
         val badgeBounds = RectF(
             outlineWidth / 2f,
             outlineWidth / 2f,
@@ -92,7 +115,7 @@ object ContinuationBadgeBitmaps {
         val band = Paint(Paint.ANTI_ALIAS_FLAG).apply { style = Paint.Style.FILL }
         // The pill's shape clips the bands, so the outermost ones take its rounded corners and the
         // interior ones stay square where they meet.
-        val pill = Path().apply { addRoundRect(badgeBounds, CORNER_RADIUS_PX, CORNER_RADIUS_PX, Path.Direction.CW) }
+        val pill = Path().apply { addRoundRect(badgeBounds, cornerRadius, cornerRadius, Path.Direction.CW) }
         canvas.withClip(pill) {
             routes.forEachIndexed { index, route ->
                 val top = rowHeight * index
@@ -114,7 +137,7 @@ object ContinuationBadgeBitmaps {
             val y = rowHeight * index
             canvas.drawLine(badgeBounds.left, y, badgeBounds.right, y, line)
         }
-        canvas.drawRoundRect(badgeBounds, CORNER_RADIUS_PX, CORNER_RADIUS_PX, line)
+        canvas.drawRoundRect(badgeBounds, cornerRadius, cornerRadius, line)
         return bitmap
     }
 
@@ -125,12 +148,15 @@ object ContinuationBadgeBitmaps {
      *
      * Every name and color on the badge takes part, so two labels differing only in a stacked route can't
      * share a bitmap — and so does [darkMode], which the casing reads: the same routes case differently
-     * either side of a light/dark switch, and a key blind to it would serve the pre-switch pill. Density is
-     * fixed for the lifetime of a renderer's cache, so it distinguishes nothing within one.
+     * either side of a light/dark switch, and a key blind to it would serve the pre-switch pill. [scale]
+     * takes part for the same reason it does in [VehicleBitmaps.iconKey]: a zoom-scheduled label (#2102)
+     * draws the same routes at several sizes over one camera session, and a key blind to the size would
+     * hand back whichever it drew first. Density is fixed for the lifetime of a renderer's cache, so it
+     * distinguishes nothing within one.
      */
-    fun badgeKey(routes: List<BadgedRoute>, darkMode: Boolean): String = routes.joinToString(
+    fun badgeKey(routes: List<BadgedRoute>, darkMode: Boolean, scale: Float): String = routes.joinToString(
         separator = "|",
-        prefix = "route-badge:$darkMode:"
+        prefix = "route-badge:$darkMode:$scale:"
     ) { "${it.routeShortName}:${it.color}" }
 
     /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/DetailZoomRamp.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/DetailZoomRamp.kt
@@ -15,6 +15,8 @@
  */
 package org.onebusaway.android.map.render
 
+import kotlin.math.round
+
 /** Shared zoom interval for route-detail styling. */
 const val DETAIL_RAMP_START_ZOOM = 11f
 const val DETAIL_RAMP_END_ZOOM = 16f
@@ -114,6 +116,77 @@ val ITINERARY_RIDE_WIDTH_PROFILE = FOCUSED_ROUTE_LINE_WIDTH_PROFILE
  */
 val ITINERARY_STREET_WIDTH_PROFILE = ROUTE_LINE_WIDTH_PROFILE.copy(
     thicknessDp = ROUTE_LINE_WIDTH_DP * 0.9f
+)
+
+/**
+ * The number of steps the ramp between a badge profile's two ends is quantized into — see
+ * [RouteBadgeScaleProfile.scaleAt] for why a label's scale is discrete where a line's width is not.
+ */
+private const val ROUTE_BADGE_SCALE_STEPS = 16f
+
+/**
+ * How a route label's drawn size answers the camera: a uniform scale on the pill
+ * [ContinuationBadgeBitmaps.badge] draws, ramped linearly across [rampStartZoom]..[rampEndZoom] and flat
+ * on either side of it.
+ *
+ * A profile rather than a bare function for the reason [RouteLineWidthProfile] is one: the two kinds of
+ * label on the map (adjacency, a directions itinerary's rides) answer the camera differently, and that
+ * difference should be a value one of them carries rather than a branch in each renderer.
+ */
+data class RouteBadgeScaleProfile(
+    val distantScale: Float,
+    val closeScale: Float,
+    val rampStartZoom: Float = DETAIL_RAMP_START_ZOOM,
+    val rampEndZoom: Float = DETAIL_RAMP_END_ZOOM
+) {
+    /**
+     * The scale to draw at under a camera at [zoom], **quantized** to [ROUTE_BADGE_SCALE_STEPS] steps.
+     *
+     * A route line's width can take the ramp's raw value because setting a native polyline's width is
+     * free. A label's can't: its scale sizes a rasterized bitmap and keys the icon cache
+     * ([ContinuationBadgeBitmaps.badgeKey]), so a raw camera float means every settle inside the ramp
+     * yields a scale never seen before — a guaranteed cache miss, a fresh `Canvas` draw and native
+     * texture per badge, and a cache filling with entries that can never be hit again. Discrete steps
+     * bound the whole thing to a handful of bitmaps per label for a session.
+     *
+     * This is the same move [org.onebusaway.android.map.googlemapsv2.GoogleRouteStopBitmapLayer] already
+     * makes for the identical ramp, where it rounds the stop diameter to whole pixels and keys on that.
+     * Sixteenths are fine enough that a step is a ~6% size change — smaller than the jump a settle-only
+     * update makes anyway, since labels resize on camera idle rather than continuously.
+     */
+    fun scaleAt(zoom: Float): Float {
+        val raw = detailZoomRamp(
+            zoom,
+            startZoom = rampStartZoom,
+            endZoom = rampEndZoom,
+            distantValue = distantScale,
+            closeValue = closeScale
+        )
+        return round(raw * ROUTE_BADGE_SCALE_STEPS) / ROUTE_BADGE_SCALE_STEPS
+    }
+}
+
+/**
+ * A label that draws at one size whatever the camera does — every route label but a directions
+ * itinerary's, which is the only one #2102 gave a schedule to.
+ */
+val FIXED_ROUTE_BADGE_SCALE_PROFILE = RouteBadgeScaleProfile(distantScale = 1f, closeScale = 1f)
+
+/**
+ * A directions itinerary's ride labels (#2102), on the shared detail ramp and pointing the same way as
+ * everything else it rides with: half size when zoomed out, full at zoom 16 and above.
+ *
+ * A label is a fixed number of screen pixels, so at an overview zoom it is enormous relative to the
+ * itinerary it annotates — several of them, anchored at leg midpoints that are themselves close together
+ * out there, crowd each other and cover the shape the rider is trying to read. Receding with the route
+ * lines and stop circles around it ([RouteLineWidthProfile], [focusedRouteStopScale]) keeps the whole view
+ * scaling as one thing, and hands the label its full size at the zoom where there's room for it.
+ *
+ * Deliberately a starting point to be tuned against the real map, not a settled value.
+ */
+val ITINERARY_ROUTE_BADGE_SCALE_PROFILE = RouteBadgeScaleProfile(
+    distantScale = ROUTE_DETAIL_DISTANT_SCALE,
+    closeScale = 1f
 )
 
 /** Route-line scale retained for unprofiled lines and vehicle markers. */

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
@@ -306,7 +306,21 @@ data class RouteBadge(
      * default, so a label leads nowhere until a producer says where, and no producer needs a destination
      * it doesn't have.
      */
-    val tap: RouteBadgeTap? = null
+    val tap: RouteBadgeTap? = null,
+    /**
+     * How this label's drawn size answers the camera (#2102) — see [RouteBadgeScaleProfile]. Fixed by
+     * default, so a producer opts its labels into a schedule rather than inheriting one.
+     *
+     * Carried as an unresolved *profile*, exactly as [RoutePolyline.widthProfile] is, with the renderer
+     * resolving it against the live camera. That's the pattern for a **continuous** zoom response;
+     * [stopBand] is the pattern for a **discrete** one, and the difference is what decides between them: a
+     * band takes a handful of values, so a controller can collapse the camera stream with
+     * `distinctUntilChanged` and put the resolved value on the snapshot cheaply. A scale changes on
+     * essentially every camera idle inside the ramp, and every snapshot change re-fires `renderStatic`,
+     * which tears down and rebuilds the whole static layer — bikes, generic pins, the continuation
+     * overlay, every tap map. Resizing a label is not worth that, so the resolution stays in the renderer.
+     */
+    val scale: RouteBadgeScaleProfile = FIXED_ROUTE_BADGE_SCALE_PROFILE
 ) {
     init {
         // Both stated rather than trusted: a label with nothing to read is a marker the rider can't

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
@@ -23,6 +23,7 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.Paint
+import androidx.collection.LruCache
 import androidx.core.content.ContextCompat
 import androidx.core.graphics.createBitmap
 import java.util.concurrent.TimeUnit
@@ -122,9 +123,16 @@ class MapLibreRenderer(
     // carries a full ARGB copy of its bitmap and registers a native sprite, iconFactory mints a fresh id
     // per call so two icons made from equal bitmaps never dedupe, and the SDK doesn't release the icon a
     // marker is replacing. Re-stamping badges on every camera settle without this would retain a bitmap
-    // and a sprite per settle for the life of the map. Bounded because scaleAt is quantized. Freed in
-    // [dispose].
-    private val routeBadgeIcons = HashMap<String, Icon>()
+    // and a sprite per settle for the life of the map. Freed in [dispose].
+    //
+    // An LRU rather than a plain map, for the reason the Google flavor's [BitmapDescriptorCache] is one:
+    // quantizing scaleAt bounds only the *size* dimension of the key, while the label content in it — the
+    // names and colors on the pill — turns over with every route and itinerary shown, and [renderStatic]
+    // drops those markers without dropping their entries. Unbounded, a long session accumulates a bitmap
+    // and a sprite per label it ever drew. Evicting is safe: a marker holds its own reference to the Icon
+    // it was given, so a still-drawn label keeps its sprite and an evicted key is merely re-minted on the
+    // next request. See [BADGE_ICON_CACHE_SIZE] for the sizing.
+    private val routeBadgeIcons = LruCache<String, Icon>(BADGE_ICON_CACHE_SIZE)
 
     // The non-route static annotations added by the last [renderStatic], removed (not map.clear()) on
     // the next so the retained route and per-frame dynamic layers survive a static redraw.
@@ -300,9 +308,10 @@ class MapLibreRenderer(
 
     private fun routeBadgeIcon(routes: List<BadgedRoute>, scale: Float): Icon {
         val darkMode = ThemeUtils.isInDarkMode(context)
-        return routeBadgeIcons.getOrPut(ContinuationBadgeBitmaps.badgeKey(routes, darkMode, scale)) {
-            iconFactory.fromBitmap(ContinuationBadgeBitmaps.badge(routes, density, darkMode, scale))
-        }
+        val key = ContinuationBadgeBitmaps.badgeKey(routes, darkMode, scale)
+        return routeBadgeIcons.get(key) ?: iconFactory
+            .fromBitmap(ContinuationBadgeBitmaps.badge(routes, density, darkMode, scale))
+            .also { routeBadgeIcons.put(key, it) }
     }
 
     /** Reconcile the independently collected route layer, retaining equal native polylines. */
@@ -357,7 +366,7 @@ class MapLibreRenderer(
         vehicleByMarker.clear()
         bikeByMarker.clear()
         routeBadgeByMarker.clear()
-        routeBadgeIcons.clear()
+        routeBadgeIcons.evictAll()
         vehicleIconDirection.clear()
         mostRecentDataMarker = null
         lastVehicleResponse = null
@@ -673,6 +682,13 @@ class MapLibreRenderer(
     companion object {
         private const val ROUTE_WIDTH_DP = 3f
         private const val TRIP_BAND_WIDTH_DP = 6f
+
+        // Sized to hold a whole zoom session's worth of the labels currently on the map, so panning the
+        // ramp end to end never evicts a label that is still drawn: a directions itinerary shows on the
+        // order of ten distinct pills, each of which can be asked for at any of the nine sizes
+        // [RouteBadgeScaleProfile.scaleAt]'s sixteenths quantize its ramp to, in either theme. Matches the
+        // Google flavor's DESCRIPTOR_CACHE_SIZE, which covers the same badges alongside its other icons.
+        private const val BADGE_ICON_CACHE_SIZE = 256
     }
 }
 

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
@@ -107,7 +107,24 @@ class MapLibreRenderer(
     // Route badge tap targets — adjacency (#1827) and a directions ride (#2101) — mirroring the Google
     // flavor's routeBadgeByMarker. Their geographic anchors are laid out once upstream; these markers
     // then move naturally with the map through pan and zoom.
+    // Every route-badge marker the last static render drew, including the inert ones: a camera settle has
+    // to re-stamp a label whose zoom schedule gives it a different size there (#2102) whether or not it
+    // leads anywhere. [routeBadgeForMarker] applies the tappability filter, so this stays one registry
+    // rather than two collections written in the same loop and cleared in the same places.
     private val routeBadgeByMarker = HashMap<Marker, RouteBadge>()
+
+    // The zoom the route-badge icons above were last stamped at. Synced to the live camera by each static
+    // redraw and moved by each settle, so the scale a label draws at always answers the camera it's under.
+    private var renderedBadgeZoom = map.cameraPosition.zoom.toFloat()
+
+    // One Icon per distinct label bitmap, the maplibre counterpart of the Google flavor's descriptorCache
+    // and keyed the same way ([ContinuationBadgeBitmaps.badgeKey]). Not an optimization to taste: an Icon
+    // carries a full ARGB copy of its bitmap and registers a native sprite, iconFactory mints a fresh id
+    // per call so two icons made from equal bitmaps never dedupe, and the SDK doesn't release the icon a
+    // marker is replacing. Re-stamping badges on every camera settle without this would retain a bitmap
+    // and a sprite per settle for the life of the map. Bounded because scaleAt is quantized. Freed in
+    // [dispose].
+    private val routeBadgeIcons = HashMap<String, Icon>()
 
     // The non-route static annotations added by the last [renderStatic], removed (not map.clear()) on
     // the next so the retained route and per-frame dynamic layers survive a static redraw.
@@ -251,26 +268,42 @@ class MapLibreRenderer(
     // .anchor(0.5f, 0.5f)). Draw order is add-order in maplibre (no z-index on classic markers), so
     // adding these last keeps them on top of the stops/bikes/generics drawn above.
     private fun renderRouteBadges(badges: List<RouteBadge>) {
+        // Read the camera rather than trusting the last settle: a static redraw can land mid-gesture, and a
+        // label stamped at a stale zoom would keep the wrong size until the camera next moved.
+        renderedBadgeZoom = map.cameraPosition.zoom.toFloat()
         for (badge in badges) {
             val marker = map.addMarker(
                 MarkerOptions()
                     .position(badge.point.toLatLng())
-                    .icon(routeBadgeIcon(badge.routes))
+                    .icon(routeBadgeIcon(badge.routes, badge.scale.scaleAt(renderedBadgeZoom)))
             )
             staticAnnotations.add(marker)
-            // Only a label that leads somewhere becomes a tap target (see [RouteBadge.tap]); an
-            // unregistered marker's tap falls through to the map like any other unclaimed one.
-            if (badge.tap != null) routeBadgeByMarker[marker] = badge
+            routeBadgeByMarker[marker] = badge
         }
     }
 
-    private fun routeBadgeIcon(routes: List<BadgedRoute>): Icon = iconFactory.fromBitmap(
-        ContinuationBadgeBitmaps.badge(
-            routes,
-            density,
-            darkMode = ThemeUtils.isInDarkMode(context)
-        )
-    )
+    /**
+     * Re-stamp the route labels that draw at a different size at the settled [zoom] (#2102). A label on the
+     * fixed profile — every one but a directions itinerary's — resolves to the same scale either side of
+     * the move and is left alone, as is a scheduled one whose camera stayed within a flat end of its ramp
+     * or moved less than one quantization step (see [RouteBadgeScaleProfile.scaleAt]).
+     */
+    private fun updateRouteBadgeScale(zoom: Float) {
+        val previous = renderedBadgeZoom
+        if (zoom == previous) return
+        renderedBadgeZoom = zoom
+        for ((marker, badge) in routeBadgeByMarker) {
+            val scale = badge.scale.scaleAt(zoom)
+            if (scale != badge.scale.scaleAt(previous)) marker.icon = routeBadgeIcon(badge.routes, scale)
+        }
+    }
+
+    private fun routeBadgeIcon(routes: List<BadgedRoute>, scale: Float): Icon {
+        val darkMode = ThemeUtils.isInDarkMode(context)
+        return routeBadgeIcons.getOrPut(ContinuationBadgeBitmaps.badgeKey(routes, darkMode, scale)) {
+            iconFactory.fromBitmap(ContinuationBadgeBitmaps.badge(routes, density, darkMode, scale))
+        }
+    }
 
     /** Reconcile the independently collected route layer, retaining equal native polylines. */
     fun renderRoutePolylines(next: List<RoutePolyline> = renderState.snapshot.value.routePolylines) {
@@ -289,6 +322,7 @@ class MapLibreRenderer(
         routeEndpointBulbLayer.render(renderState.snapshot.value.routePolylines) { routeWidth(it, zoom) }
         val detailScale = routeLineWidthScale(zoom)
         updateVehicleScale(detailScale)
+        updateRouteBadgeScale(zoom)
     }
 
     private fun routeWidth(polyline: RoutePolyline, zoom: Float): Float = polyline.widthProfile?.thicknessAt(zoom) ?: (ROUTE_WIDTH_DP * routeLineWidthScale(zoom))
@@ -323,6 +357,7 @@ class MapLibreRenderer(
         vehicleByMarker.clear()
         bikeByMarker.clear()
         routeBadgeByMarker.clear()
+        routeBadgeIcons.clear()
         vehicleIconDirection.clear()
         mostRecentDataMarker = null
         lastVehicleResponse = null
@@ -618,8 +653,11 @@ class MapLibreRenderer(
 
     fun vehicleForMarker(marker: Marker): VehicleMarker? = vehicleByMarker[marker]
 
-    /** The adjacency route badge (#1827) tapped, or null if [marker] isn't one. */
-    fun routeBadgeForMarker(marker: Marker): RouteBadge? = routeBadgeByMarker[marker]
+    /**
+     * The route badge tapped, or null if [marker] isn't one — or names a label that leads nowhere (see
+     * [RouteBadge.tap]), whose tap falls through to the map like any other unclaimed one.
+     */
+    fun routeBadgeForMarker(marker: Marker): RouteBadge? = routeBadgeByMarker[marker]?.takeIf { it.tap != null }
 
     /**
      * If [marker] is the ping ripple, the vehicle marker it's centered on (else null) — so a tap on the

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/ItineraryRouteBadgesTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/ItineraryRouteBadgesTest.kt
@@ -8,6 +8,7 @@ import org.onebusaway.android.directions.model.InterchangeableRoute
 import org.onebusaway.android.directions.model.TripLeg
 import org.onebusaway.android.directions.model.TripMode
 import org.onebusaway.android.map.render.BadgedRoute
+import org.onebusaway.android.map.render.ITINERARY_ROUTE_BADGE_SCALE_PROFILE
 import org.onebusaway.android.map.render.RouteBadge
 import org.onebusaway.android.map.render.RouteBadgeTap
 import org.onebusaway.android.util.GeoPoint
@@ -45,6 +46,8 @@ class ItineraryRouteBadgesTest {
         assertEquals(GeoPoint(0.0, 0.5), badge.point)
         // A tap lands back on the ride it names, never on that route's own map.
         assertEquals(RouteBadgeTap.FocusItineraryRide(setOf(1)), badge.tap)
+        // And it follows the zoom (#2102) rather than holding a fixed size, unlike every other label.
+        assertEquals(ITINERARY_ROUTE_BADGE_SCALE_PROFILE, badge.scale)
     }
 
     @Test

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/render/RouteBadgeScaleProfileTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/render/RouteBadgeScaleProfileTest.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.map.render
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** The zoom schedule a route label's drawn size follows (#2102). */
+class RouteBadgeScaleProfileTest {
+
+    @Test
+    fun `an itinerary label grows from half to full between zoom 11 and 16, flat outside`() {
+        assertEquals(0.5f, ITINERARY_ROUTE_BADGE_SCALE_PROFILE.scaleAt(8f), 0f)
+        assertEquals(0.5f, ITINERARY_ROUTE_BADGE_SCALE_PROFILE.scaleAt(11f), 0f)
+        assertEquals(0.75f, ITINERARY_ROUTE_BADGE_SCALE_PROFILE.scaleAt(13.5f), 0f)
+        assertEquals(1f, ITINERARY_ROUTE_BADGE_SCALE_PROFILE.scaleAt(16f), 0f)
+        assertEquals(1f, ITINERARY_ROUTE_BADGE_SCALE_PROFILE.scaleAt(20f), 0f)
+    }
+
+    @Test
+    fun `a label rides the same schedule as the line it names`() {
+        // The point of the schedule is that it's the map's existing one, not a second set of zoom stops
+        // invented for labels — same interval, same magnitude, and crucially the same direction, so a label
+        // and the line under it recede together instead of one swelling as the other thins. Asserting equal
+        // *outputs* rather than equal parameters is what makes this survive a tuning pass on either side:
+        // it fails only when the two actually diverge, which is the thing worth knowing. The quantization
+        // below is coarser than the tolerance here, so these anchors land on exact steps.
+        for (zoom in listOf(8f, 11f, 13.5f, 16f, 20f)) {
+            assertEquals(
+                ITINERARY_RIDE_WIDTH_PROFILE.multiplierAt(zoom),
+                ITINERARY_ROUTE_BADGE_SCALE_PROFILE.scaleAt(zoom),
+                0f
+            )
+        }
+    }
+
+    @Test
+    fun `the scale is quantized, so a settle inside the ramp rarely mints a new bitmap`() {
+        // A label's scale sizes a rasterized bitmap and keys the icon cache, so it is deliberately discrete
+        // where a line's width is continuous. What matters is the count: the whole ramp resolves to a
+        // handful of values, not one per camera idle. Sampled far more finely than a user could pinch.
+        val scales = generateSequence(DETAIL_RAMP_START_ZOOM) { it + 0.01f }
+            .takeWhile { it <= DETAIL_RAMP_END_ZOOM }
+            .map(ITINERARY_ROUTE_BADGE_SCALE_PROFILE::scaleAt)
+            .toSet()
+
+        assertTrue("500 sampled zooms should collapse to a few scales, got ${scales.size}", scales.size <= 12)
+        // And the ends are exact, so a label at either flat end draws at its stated size rather than a
+        // rounded neighbour of it.
+        assertTrue(ROUTE_DETAIL_DISTANT_SCALE in scales)
+        assertTrue(1f in scales)
+    }
+
+    @Test
+    fun `every other label holds one size at every zoom`() {
+        // The default a RouteBadge takes, so adjacency labels (#1827) and the continuation badge (#1691) are
+        // untouched by all this — and a renderer's re-stamp on camera settle can skip them entirely.
+        for (zoom in 1..21) {
+            assertEquals(1f, FIXED_ROUTE_BADGE_SCALE_PROFILE.scaleAt(zoom.toFloat()), 0f)
+        }
+    }
+}


### PR DESCRIPTION
Closes #2102.

The directions map's ride labels drew at a fixed pixel size at every zoom, so at an overview they were enormous relative to the itinerary they annotate — several of them, anchored at leg midpoints that are close together out there, crowding each other and covering the shape the rider is reading.

Put them on the map's shared detail ramp, pointing the same way as the route lines and stop circles around them: **half size at zoom 11 and below, ramping linearly to full at 16**. A label and the line it names now recede together instead of one holding still while the other thins. The interval (11..16) and the magnitude (0.5) are the shared ones, as the issue asked — a starting point to be tuned against the real map.

Separately, the base pill grew **1.5×** (type, padding, corner, casing moved as a set). That is deliberately the *shared* base rather than the directions profile: "undersized against the lines it names" is a claim about route labels generally, so focused-stop adjacency (#1827) and the route-continuation badge (#1691) are meant to grow with it. The scoped lever exists and was not pulled on purpose — the rationale and the alternative are written at the constants.

## Shape

- **`RouteBadgeScaleProfile`** — a policy object beside `RouteLineWidthProfile`, so the two kinds of label answer the camera by carrying a value rather than by a branch in each renderer. Labels are fixed-size by default; only `itineraryRouteBadges` opts in, leaving adjacency and the continuation badge untouched.
- **Carried as an unresolved profile on the snapshot**, exactly as `RoutePolyline.widthProfile` is, with the renderer resolving it against the live camera. That's the pattern for a *continuous* zoom response; `stopBand` is the pattern for a *discrete* one. A resolved scale on the snapshot would re-fire `renderStatic` — a full teardown of the static layer — on essentially every camera idle inside the ramp.
- **The scale is quantized** to sixteenths. It sizes a rasterized bitmap and keys the icon cache, so a raw camera float would mean a guaranteed cache miss and a fresh draw + native texture on every settle. Same move `GoogleRouteStopBitmapLayer` already makes for this ramp, where it rounds the stop diameter to whole pixels.
- **`ContinuationBadgeBitmaps.badge`** takes a uniform scale over type, padding, corner and casing; `badgeKey` folds it in the way `VehicleBitmaps.iconKey` folds its own.
- **Both flavors** stamp from the live camera on a static redraw and re-stamp on camera settle, skipping any label whose scale didn't change. MapLibre gains a `badgeKey`-keyed `Icon` cache it never had — an `Icon` carries a full ARGB copy of its bitmap and registers a native sprite, `iconFactory` mints a fresh id per call so equal bitmaps never dedupe, and the SDK doesn't release the icon a marker is replacing.

## Testing

- `spotlessCheck`, `testObaGoogleDebugUnitTest`, `testObaMaplibreDebugUnitTest`, both flavor compiles and the androidTest compile, all clean under `-PwarningsAsErrors=true`.
- New `RouteBadgeScaleProfileTest` pins the ramp, the quantization step count, and — by asserting equal *outputs* against `ITINERARY_RIDE_WIDTH_PROFILE.multiplierAt` rather than equal parameters — that a label rides the same schedule as the line it names.
- `RouteBadgeBitmapTest` gains two cases checking a scaled pill is the same drawing at a different size, not a squashed one.
- Installed and checked on a physical device.

Not run here: the instrumented suite (`connectedObaGoogleDebugAndroidTest`) — left to CI.

## Follow-ups noted, not done here

- `ContinuationBadgeBitmaps` is now the general route-label bitmap source; five of its six members are label concerns and only `arrow()` is continuation-specific. Worth renaming to `RouteBadgeBitmaps` with `arrow()` moved out.
- The "track a rendered zoom, re-stamp icons on settle" bookkeeping is duplicated per flavor — this is now the second such pair, next to `updateVehicleScale`. `RoutePolylineReconciler` (#1906) is the precedent for collapsing both at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Route badges now resize smoothly with map zoom, improving readability at different viewing levels.
  * Itinerary badges scale consistently with other map detail elements.
  * Badges remain visible on the map even when they do not support tapping.

* **Bug Fixes**
  * Badge sizing now updates reliably as the map moves and settles, preventing outdated icon sizes.
  * Badge rendering and lookup behavior are more consistent across supported map providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->