### PR TITLE
Redesign the map long-press menu as a centered modal (#2112)

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/compose/ColorChannelAssertions.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/compose/ColorChannelAssertions.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.compose
+
+import androidx.compose.ui.graphics.Color
+import org.junit.Assert.assertTrue
+
+/** The channel a rendered colour is expected to lead on. */
+enum class Channel { RED, GREEN, BLUE }
+
+/**
+ * Asserts a sampled pixel reads as [channel]: dominance rather than an exact hex, so the assertion
+ * survives a palette tweak and holds in both themes — but strictly, with no tolerance to tune, since
+ * callers sample the centre of a filled shape and get the fill colour itself, not an antialiased edge.
+ *
+ * Shared because the directions endpoint dots are now drawn in two places — the trip-plan form's rail
+ * and the map long-press menu (#2112) — and "green origin, red destination" is asserted of both.
+ */
+fun assertDominant(color: Color, channel: Channel, what: String) {
+    val (dominant, others) = when (channel) {
+        Channel.RED -> color.red to listOf(color.green, color.blue)
+        Channel.GREEN -> color.green to listOf(color.red, color.blue)
+        Channel.BLUE -> color.blue to listOf(color.red, color.green)
+    }
+    assertTrue(
+        "$what should read $channel, but its dot was $color",
+        others.all { dominant > it }
+    )
+}

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/home/directions/DirectionsLongPressMenuRenderTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/home/directions/DirectionsLongPressMenuRenderTest.kt
@@ -29,6 +29,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
+import org.onebusaway.android.R
 import org.onebusaway.android.ui.compose.Channel
 import org.onebusaway.android.ui.compose.assertDominant
 import org.onebusaway.android.ui.compose.components.LONG_PRESS_MENU_EDGE_MARGIN
@@ -49,18 +50,22 @@ class DirectionsLongPressMenuRenderTest {
     @get:Rule
     val composeRule = createUnconfinedComposeRule()
 
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext
+    private val fromLabel = context.getString(R.string.directions_from_here)
+    private val toLabel = context.getString(R.string.directions_to_here)
+
     @Test
     fun bothEndsOfTheTripAreOfferedAndReportTheirSlot() {
         var chosen: TripEndpointSlot? = null
         renderMenu(onChooseSlot = { chosen = it })
 
-        composeRule.onNodeWithText(FROM_LABEL).assertIsDisplayed()
-        composeRule.onNodeWithText(TO_LABEL).assertIsDisplayed()
+        composeRule.onNodeWithText(fromLabel).assertIsDisplayed()
+        composeRule.onNodeWithText(toLabel).assertIsDisplayed()
 
-        composeRule.onNodeWithText(FROM_LABEL).performClick()
+        composeRule.onNodeWithText(fromLabel).performClick()
         assertEquals(TripEndpointSlot.FROM, chosen)
 
-        composeRule.onNodeWithText(TO_LABEL).performClick()
+        composeRule.onNodeWithText(toLabel).performClick()
         assertEquals(TripEndpointSlot.TO, chosen)
     }
 
@@ -79,10 +84,9 @@ class DirectionsLongPressMenuRenderTest {
     fun theMenuIsACompactCardRatherThanAFullWidthSheet() {
         renderMenu()
 
-        val rowWidth = composeRule.onNodeWithText(FROM_LABEL).getUnclippedBoundsInRoot().width
+        val rowWidth = composeRule.onNodeWithText(fromLabel).getUnclippedBoundsInRoot().width
         val screenWidth = with(composeRule.density) {
-            InstrumentationRegistry.getInstrumentation()
-                .targetContext.resources.displayMetrics.widthPixels.toDp()
+            context.resources.displayMetrics.widthPixels.toDp()
         }
         val widest = minOf(
             LONG_PRESS_MENU_MAX_WIDTH,
@@ -100,8 +104,8 @@ class DirectionsLongPressMenuRenderTest {
     fun theRowsAreMarkedWithTheRailsEndpointDots() {
         renderMenu()
 
-        assertDominant(dot(DirectionsLongPressMenuTestTags.FROM_DOT), Channel.GREEN, FROM_LABEL)
-        assertDominant(dot(DirectionsLongPressMenuTestTags.TO_DOT), Channel.RED, TO_LABEL)
+        assertDominant(dot(DirectionsLongPressMenuTestTags.FROM_DOT), Channel.GREEN, fromLabel)
+        assertDominant(dot(DirectionsLongPressMenuTestTags.TO_DOT), Channel.RED, toLabel)
     }
 
     /**
@@ -123,10 +127,5 @@ class DirectionsLongPressMenuRenderTest {
                 DirectionsLongPressMenu(onChooseSlot = onChooseSlot, onDismiss = {})
             }
         }
-    }
-
-    private companion object {
-        const val FROM_LABEL = "Directions from here"
-        const val TO_LABEL = "Directions to here"
     }
 }

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/home/directions/DirectionsLongPressMenuRenderTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/home/directions/DirectionsLongPressMenuRenderTest.kt
@@ -31,6 +31,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.onebusaway.android.ui.compose.Channel
 import org.onebusaway.android.ui.compose.assertDominant
+import org.onebusaway.android.ui.compose.components.LONG_PRESS_MENU_EDGE_MARGIN
 import org.onebusaway.android.ui.compose.components.LONG_PRESS_MENU_MAX_WIDTH
 import org.onebusaway.android.ui.compose.createUnconfinedComposeRule
 import org.onebusaway.android.ui.compose.theme.ObaTheme
@@ -65,9 +66,14 @@ class DirectionsLongPressMenuRenderTest {
 
     /**
      * A compact centered card, not a sheet. Width is what separates the two: the shared
-     * `CenteredLongPressMenu` caps itself at 320dp, while a bottom sheet spans the screen. Dialog
-     * semantics would not do — a `ModalBottomSheet` reports `isDialog()` too (verified on device), so
-     * asserting that would pass for the layout this issue replaced.
+     * `CenteredLongPressMenu` caps itself at 320dp and keeps a margin from both screen edges, while a
+     * bottom sheet spans the screen. Dialog semantics would not do — a `ModalBottomSheet` reports
+     * `isDialog()` too (verified on device), so asserting that would pass for the layout this issue
+     * replaced.
+     *
+     * The bound is the cap *or* the inset screen, whichever is smaller, because the two swap places:
+     * the CI emulator's screen is 320dp — the cap itself — so on that device only the margin tells a
+     * card from a sheet, and asserting against the cap alone would pass for a full-width sheet.
      */
     @Test
     fun theMenuIsACompactCardRatherThanAFullWidthSheet() {
@@ -78,10 +84,14 @@ class DirectionsLongPressMenuRenderTest {
             InstrumentationRegistry.getInstrumentation()
                 .targetContext.resources.displayMetrics.widthPixels.toDp()
         }
+        val widest = minOf(
+            LONG_PRESS_MENU_MAX_WIDTH,
+            screenWidth - LONG_PRESS_MENU_EDGE_MARGIN * 2f
+        )
         assertTrue(
-            "the menu should be a card capped at $LONG_PRESS_MENU_MAX_WIDTH, not a $screenWidth " +
+            "the menu should be a card no wider than $widest on this $screenWidth screen, not a " +
                 "sheet, but its rows measured $rowWidth",
-            rowWidth <= LONG_PRESS_MENU_MAX_WIDTH && rowWidth < screenWidth
+            rowWidth <= widest
         )
     }
 

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/home/directions/DirectionsLongPressMenuRenderTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/home/directions/DirectionsLongPressMenuRenderTest.kt
@@ -23,7 +23,6 @@ import androidx.compose.ui.test.getUnclippedBoundsInRoot
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.width
 import androidx.test.platform.app.InstrumentationRegistry
 import org.junit.Assert.assertEquals
@@ -32,11 +31,10 @@ import org.junit.Rule
 import org.junit.Test
 import org.onebusaway.android.ui.compose.Channel
 import org.onebusaway.android.ui.compose.assertDominant
+import org.onebusaway.android.ui.compose.components.LONG_PRESS_MENU_MAX_WIDTH
 import org.onebusaway.android.ui.compose.createUnconfinedComposeRule
 import org.onebusaway.android.ui.compose.theme.ObaTheme
 import org.onebusaway.android.ui.tripplan.TripEndpointSlot
-import org.onebusaway.android.ui.tripplan.TripPlanTestTags
-import org.onebusaway.android.ui.tripplan.tagPrefix
 
 /**
  * On-device checks on the map's long-press menu (#2112). The redesign made two claims that only a
@@ -81,9 +79,9 @@ class DirectionsLongPressMenuRenderTest {
                 .targetContext.resources.displayMetrics.widthPixels.toDp()
         }
         assertTrue(
-            "the menu should be a card capped at $MENU_MAX_WIDTH, not a $screenWidth sheet, " +
-                "but its rows measured $rowWidth",
-            rowWidth <= MENU_MAX_WIDTH && rowWidth < screenWidth
+            "the menu should be a card capped at $LONG_PRESS_MENU_MAX_WIDTH, not a $screenWidth " +
+                "sheet, but its rows measured $rowWidth",
+            rowWidth <= LONG_PRESS_MENU_MAX_WIDTH && rowWidth < screenWidth
         )
     }
 
@@ -92,18 +90,18 @@ class DirectionsLongPressMenuRenderTest {
     fun theRowsAreMarkedWithTheRailsEndpointDots() {
         renderMenu()
 
-        assertDominant(dot(TripEndpointSlot.FROM), Channel.GREEN, "directions from here")
-        assertDominant(dot(TripEndpointSlot.TO), Channel.RED, "directions to here")
+        assertDominant(dot(DirectionsLongPressMenuTestTags.FROM_DOT), Channel.GREEN, FROM_LABEL)
+        assertDominant(dot(DirectionsLongPressMenuTestTags.TO_DOT), Channel.RED, TO_LABEL)
     }
 
     /**
-     * The centre of a row's endpoint dot. Captured from the dot's own 24dp box, so nothing here
-     * depends on Material's internal menu-item padding; unmerged because the clickable row merges
-     * its children's semantics.
+     * The centre of a row's endpoint dot. Captured from the dot's own box, so nothing here depends
+     * on Material's internal menu-item padding; unmerged because the clickable row merges its
+     * children's semantics.
      */
-    private fun dot(slot: TripEndpointSlot): Color {
+    private fun dot(tag: String): Color {
         val pixels = composeRule
-            .onNodeWithTag(slot.tagPrefix + TripPlanTestTags.DOT_SUFFIX, useUnmergedTree = true)
+            .onNodeWithTag(tag, useUnmergedTree = true)
             .captureToImage()
             .toPixelMap()
         return pixels[pixels.width / 2, pixels.height / 2]
@@ -120,8 +118,5 @@ class DirectionsLongPressMenuRenderTest {
     private companion object {
         const val FROM_LABEL = "Directions from here"
         const val TO_LABEL = "Directions to here"
-
-        /** CenteredLongPressMenu's own cap — the shape every long-press menu in the app shares. */
-        val MENU_MAX_WIDTH = 320.dp
     }
 }

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/home/directions/DirectionsLongPressMenuRenderTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/home/directions/DirectionsLongPressMenuRenderTest.kt
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.home.directions
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toPixelMap
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.captureToImage
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.width
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.onebusaway.android.ui.compose.Channel
+import org.onebusaway.android.ui.compose.assertDominant
+import org.onebusaway.android.ui.compose.createUnconfinedComposeRule
+import org.onebusaway.android.ui.compose.theme.ObaTheme
+import org.onebusaway.android.ui.tripplan.TripEndpointSlot
+import org.onebusaway.android.ui.tripplan.TripPlanTestTags
+import org.onebusaway.android.ui.tripplan.tagPrefix
+
+/**
+ * On-device checks on the map's long-press menu (#2112). The redesign made two claims that only a
+ * render can hold: the menu is the same centered modal every other long-press menu in the app opens
+ * (it was a bottom sheet, which on the map covers the very point that was pressed), and its rows are
+ * marked with the trip-plan rail's own green/red endpoint dots rather than generic pin icons.
+ */
+class DirectionsLongPressMenuRenderTest {
+
+    // See createUnconfinedComposeRule for why Unconfined composition is used here (issue #1792).
+    @get:Rule
+    val composeRule = createUnconfinedComposeRule()
+
+    @Test
+    fun bothEndsOfTheTripAreOfferedAndReportTheirSlot() {
+        var chosen: TripEndpointSlot? = null
+        renderMenu(onChooseSlot = { chosen = it })
+
+        composeRule.onNodeWithText(FROM_LABEL).assertIsDisplayed()
+        composeRule.onNodeWithText(TO_LABEL).assertIsDisplayed()
+
+        composeRule.onNodeWithText(FROM_LABEL).performClick()
+        assertEquals(TripEndpointSlot.FROM, chosen)
+
+        composeRule.onNodeWithText(TO_LABEL).performClick()
+        assertEquals(TripEndpointSlot.TO, chosen)
+    }
+
+    /**
+     * A compact centered card, not a sheet. Width is what separates the two: the shared
+     * `CenteredLongPressMenu` caps itself at 320dp, while a bottom sheet spans the screen. Dialog
+     * semantics would not do — a `ModalBottomSheet` reports `isDialog()` too (verified on device), so
+     * asserting that would pass for the layout this issue replaced.
+     */
+    @Test
+    fun theMenuIsACompactCardRatherThanAFullWidthSheet() {
+        renderMenu()
+
+        val rowWidth = composeRule.onNodeWithText(FROM_LABEL).getUnclippedBoundsInRoot().width
+        val screenWidth = with(composeRule.density) {
+            InstrumentationRegistry.getInstrumentation()
+                .targetContext.resources.displayMetrics.widthPixels.toDp()
+        }
+        assertTrue(
+            "the menu should be a card capped at $MENU_MAX_WIDTH, not a $screenWidth sheet, " +
+                "but its rows measured $rowWidth",
+            rowWidth <= MENU_MAX_WIDTH && rowWidth < screenWidth
+        )
+    }
+
+    /** The rows carry the rail's endpoint dots — green for the origin, red for the destination. */
+    @Test
+    fun theRowsAreMarkedWithTheRailsEndpointDots() {
+        renderMenu()
+
+        assertDominant(dot(TripEndpointSlot.FROM), Channel.GREEN, "directions from here")
+        assertDominant(dot(TripEndpointSlot.TO), Channel.RED, "directions to here")
+    }
+
+    /**
+     * The centre of a row's endpoint dot. Captured from the dot's own 24dp box, so nothing here
+     * depends on Material's internal menu-item padding; unmerged because the clickable row merges
+     * its children's semantics.
+     */
+    private fun dot(slot: TripEndpointSlot): Color {
+        val pixels = composeRule
+            .onNodeWithTag(slot.tagPrefix + TripPlanTestTags.DOT_SUFFIX, useUnmergedTree = true)
+            .captureToImage()
+            .toPixelMap()
+        return pixels[pixels.width / 2, pixels.height / 2]
+    }
+
+    private fun renderMenu(onChooseSlot: (TripEndpointSlot) -> Unit = {}) {
+        composeRule.setContent {
+            ObaTheme {
+                DirectionsLongPressMenu(onChooseSlot = onChooseSlot, onDismiss = {})
+            }
+        }
+    }
+
+    private companion object {
+        const val FROM_LABEL = "Directions from here"
+        const val TO_LABEL = "Directions to here"
+
+        /** CenteredLongPressMenu's own cap — the shape every long-press menu in the app shares. */
+        val MENU_MAX_WIDTH = 320.dp
+    }
+}

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripplan/TripPlanFormRenderTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripplan/TripPlanFormRenderTest.kt
@@ -41,6 +41,8 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
+import org.onebusaway.android.ui.compose.Channel
+import org.onebusaway.android.ui.compose.assertDominant
 import org.onebusaway.android.ui.compose.createUnconfinedComposeRule
 import org.onebusaway.android.ui.compose.theme.ObaTheme
 
@@ -397,25 +399,6 @@ class TripPlanFormRenderTest {
         )
 
         assertDominant(railDot(row = 1), Channel.BLUE, "a destination at the device's position")
-    }
-
-    private enum class Channel { RED, GREEN, BLUE }
-
-    /**
-     * Dominance rather than an exact hex, so the rule survives a palette tweak and holds in both
-     * themes — but strictly, with no tolerance to tune: the sample is the centre of a 12dp filled
-     * circle, so it is the fill colour itself, not an antialiased edge.
-     */
-    private fun assertDominant(color: Color, channel: Channel, what: String) {
-        val (dominant, others) = when (channel) {
-            Channel.RED -> color.red to listOf(color.green, color.blue)
-            Channel.GREEN -> color.green to listOf(color.red, color.blue)
-            Channel.BLUE -> color.blue to listOf(color.red, color.green)
-        }
-        assertTrue(
-            "$what should read $channel, but its dot was $color",
-            others.all { dominant > it }
-        )
     }
 
     /** Samples the centre of a row's rail dot. Mirrors the form's own 4dp pad / 48dp row / 1dp rule. */

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/CenteredLongPressMenu.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/CenteredLongPressMenu.kt
@@ -33,6 +33,13 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 
 /**
+ * The menu's width band. The maximum is named because it is what makes the menu read as a card
+ * rather than a full-width sheet, which is asserted on device.
+ */
+internal val LONG_PRESS_MENU_MIN_WIDTH = 196.dp
+internal val LONG_PRESS_MENU_MAX_WIDTH = 320.dp
+
+/**
  * A secondary-action menu opened by long press. A dialog supplies one consistent screen-centered
  * position regardless of which row or horizontally scrolled ETA pill launched it; the content stays
  * ordinary Material [androidx.compose.material3.DropdownMenuItem] rows.
@@ -46,7 +53,10 @@ internal fun CenteredLongPressMenu(
     if (!expanded) return
     Dialog(onDismissRequest = onDismissRequest) {
         Surface(
-            modifier = Modifier.widthIn(min = 196.dp, max = 320.dp),
+            modifier = Modifier.widthIn(
+                min = LONG_PRESS_MENU_MIN_WIDTH,
+                max = LONG_PRESS_MENU_MAX_WIDTH
+            ),
             shape = MaterialTheme.shapes.large,
             color = MaterialTheme.colorScheme.surfaceContainer,
             border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
@@ -61,19 +71,20 @@ internal fun CenteredLongPressMenu(
 /** A labelled menu item with an optional decorative leading [icon]. */
 @Composable
 internal fun MenuRow(textRes: Int, icon: ImageVector? = null, onClick: () -> Unit) {
-    DropdownMenuItem(
-        text = { Text(stringResource(textRes)) },
-        onClick = onClick,
-        leadingIcon = icon?.let { { Icon(imageVector = it, contentDescription = null) } }
+    MenuRow(
+        textRes = textRes,
+        leadingIcon = icon?.let { { Icon(imageVector = it, contentDescription = null) } },
+        onClick = onClick
     )
 }
 
 /**
  * A labelled menu item whose leading slot the caller draws, for a mark no tinted [ImageVector]
- * carries — the directions endpoint dots, which are identified by their own hue.
+ * carries — the directions endpoint dots, which are identified by their own hue. Deliberately
+ * without a default, so the two-argument `MenuRow(textRes) { … }` form still resolves above.
  */
 @Composable
-internal fun MenuRow(textRes: Int, leadingIcon: @Composable () -> Unit, onClick: () -> Unit) {
+internal fun MenuRow(textRes: Int, leadingIcon: (@Composable () -> Unit)?, onClick: () -> Unit) {
     DropdownMenuItem(
         text = { Text(stringResource(textRes)) },
         onClick = onClick,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/CenteredLongPressMenu.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/CenteredLongPressMenu.kt
@@ -67,3 +67,16 @@ internal fun MenuRow(textRes: Int, icon: ImageVector? = null, onClick: () -> Uni
         leadingIcon = icon?.let { { Icon(imageVector = it, contentDescription = null) } }
     )
 }
+
+/**
+ * A labelled menu item whose leading slot the caller draws, for a mark no tinted [ImageVector]
+ * carries — the directions endpoint dots, which are identified by their own hue.
+ */
+@Composable
+internal fun MenuRow(textRes: Int, leadingIcon: @Composable () -> Unit, onClick: () -> Unit) {
+    DropdownMenuItem(
+        text = { Text(stringResource(textRes)) },
+        onClick = onClick,
+        leadingIcon = leadingIcon
+    )
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/CenteredLongPressMenu.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/CenteredLongPressMenu.kt
@@ -40,6 +40,13 @@ internal val LONG_PRESS_MENU_MIN_WIDTH = 196.dp
 internal val LONG_PRESS_MENU_MAX_WIDTH = 320.dp
 
 /**
+ * The gap the card keeps from the screen edges. The maximum width alone does not make a card on a
+ * narrow screen: a 320dp-wide phone is exactly the cap, so the menu would reach both edges and read
+ * as the sheet this component exists to replace. Held as a margin so the card is a card everywhere.
+ */
+internal val LONG_PRESS_MENU_EDGE_MARGIN = 24.dp
+
+/**
  * A secondary-action menu opened by long press. A dialog supplies one consistent screen-centered
  * position regardless of which row or horizontally scrolled ETA pill launched it; the content stays
  * ordinary Material [androidx.compose.material3.DropdownMenuItem] rows.
@@ -53,10 +60,12 @@ internal fun CenteredLongPressMenu(
     if (!expanded) return
     Dialog(onDismissRequest = onDismissRequest) {
         Surface(
-            modifier = Modifier.widthIn(
-                min = LONG_PRESS_MENU_MIN_WIDTH,
-                max = LONG_PRESS_MENU_MAX_WIDTH
-            ),
+            modifier = Modifier
+                .padding(horizontal = LONG_PRESS_MENU_EDGE_MARGIN)
+                .widthIn(
+                    min = LONG_PRESS_MENU_MIN_WIDTH,
+                    max = LONG_PRESS_MENU_MAX_WIDTH
+                ),
             shape = MaterialTheme.shapes.large,
             color = MaterialTheme.colorScheme.surfaceContainer,
             border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline),

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
@@ -19,7 +19,6 @@ import android.content.Context
 import android.text.format.DateFormat
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
@@ -44,9 +43,7 @@ import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Slider
@@ -98,7 +95,9 @@ import org.onebusaway.android.ui.arrivals.ArrivalsViewModel
 import org.onebusaway.android.ui.arrivals.RouteRowGroup
 import org.onebusaway.android.ui.arrivals.components.EtaStrip
 import org.onebusaway.android.ui.arrivals.rememberArrivalRowCallbacks
+import org.onebusaway.android.ui.compose.components.CenteredLongPressMenu
 import org.onebusaway.android.ui.compose.components.DRAG_HANDLE_TOUCH_TARGET_HEIGHT
+import org.onebusaway.android.ui.compose.components.MenuRow
 import org.onebusaway.android.ui.compose.components.RouteBadge
 import org.onebusaway.android.ui.compose.components.SheetDragHandle
 import org.onebusaway.android.ui.compose.components.SwitchRow
@@ -112,6 +111,7 @@ import org.onebusaway.android.ui.tripplan.AdvancedSettings
 import org.onebusaway.android.ui.tripplan.BikePreference
 import org.onebusaway.android.ui.tripplan.CyclingPreference
 import org.onebusaway.android.ui.tripplan.StreetMode
+import org.onebusaway.android.ui.tripplan.TripEndpointDotIcon
 import org.onebusaway.android.ui.tripplan.TripEndpointSlot
 import org.onebusaway.android.ui.tripplan.TripModeSelection
 import org.onebusaway.android.ui.tripplan.TripPlanError
@@ -507,30 +507,34 @@ private fun NoEtasText(modifier: Modifier) {
 }
 
 /**
- * The modal menu shown when the user long-presses the map: "directions from here" / "directions to
- * here", each of which enters directions focus and fills that endpoint with the pressed point.
+ * The menu shown when the user long-presses the map: "directions from here" / "directions to here",
+ * each of which enters directions focus and fills that endpoint with the pressed point.
+ *
+ * The same centered dialog every other long-press menu in the app uses (#2112), rather than the
+ * bottom sheet it was: a long press means the same thing wherever the rider does it, and the map is
+ * the one surface where a sheet rising from the bottom also covers what was just pressed. The rows
+ * are marked with the trip-plan rail's own endpoint dots, so the row names the end of the trip it
+ * fills by the same green/red the form will show once it is filled.
+ *
+ * Always expanded — the host renders this only while there is a pressed point, and dismissal clears
+ * it (see HomeScreen).
  */
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DirectionsLongPressMenu(
     onChooseSlot: (TripEndpointSlot) -> Unit,
     onDismiss: () -> Unit
 ) {
-    ModalBottomSheet(onDismissRequest = onDismiss) {
-        Column(Modifier.navigationBarsPadding()) {
-            ListItem(
-                headlineContent = { Text(stringResource(R.string.directions_from_here)) },
-                leadingContent = {
-                    Icon(painterResource(R.drawable.ic_my_location), contentDescription = null)
-                },
-                modifier = Modifier.clickable { onChooseSlot(TripEndpointSlot.FROM) }
-            )
-            ListItem(
-                headlineContent = { Text(stringResource(R.string.directions_to_here)) },
-                leadingContent = { Icon(AppIcons.Place, contentDescription = null) },
-                modifier = Modifier.clickable { onChooseSlot(TripEndpointSlot.TO) }
-            )
-        }
+    CenteredLongPressMenu(expanded = true, onDismissRequest = onDismiss) {
+        MenuRow(
+            textRes = R.string.directions_from_here,
+            leadingIcon = { TripEndpointDotIcon(TripEndpointSlot.FROM) },
+            onClick = { onChooseSlot(TripEndpointSlot.FROM) }
+        )
+        MenuRow(
+            textRes = R.string.directions_to_here,
+            leadingIcon = { TripEndpointDotIcon(TripEndpointSlot.TO) },
+            onClick = { onChooseSlot(TripEndpointSlot.TO) }
+        )
     }
 }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
@@ -66,6 +66,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalWindowInfo
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -507,6 +508,15 @@ private fun NoEtasText(modifier: Modifier) {
 }
 
 /**
+ * Stable handles for [DirectionsLongPressMenu]'s endpoint dots, so a render can sample the dot
+ * itself rather than guessing at Material's menu-row padding.
+ */
+object DirectionsLongPressMenuTestTags {
+    const val FROM_DOT = "directionsFromHereDot"
+    const val TO_DOT = "directionsToHereDot"
+}
+
+/**
  * The menu shown when the user long-presses the map: "directions from here" / "directions to here",
  * each of which enters directions focus and fills that endpoint with the pressed point.
  *
@@ -527,12 +537,22 @@ fun DirectionsLongPressMenu(
     CenteredLongPressMenu(expanded = true, onDismissRequest = onDismiss) {
         MenuRow(
             textRes = R.string.directions_from_here,
-            leadingIcon = { TripEndpointDotIcon(TripEndpointSlot.FROM) },
+            leadingIcon = {
+                TripEndpointDotIcon(
+                    TripEndpointSlot.FROM,
+                    Modifier.testTag(DirectionsLongPressMenuTestTags.FROM_DOT)
+                )
+            },
             onClick = { onChooseSlot(TripEndpointSlot.FROM) }
         )
         MenuRow(
             textRes = R.string.directions_to_here,
-            leadingIcon = { TripEndpointDotIcon(TripEndpointSlot.TO) },
+            leadingIcon = {
+                TripEndpointDotIcon(
+                    TripEndpointSlot.TO,
+                    Modifier.testTag(DirectionsLongPressMenuTestTags.TO_DOT)
+                )
+            },
             onClick = { onChooseSlot(TripEndpointSlot.TO) }
         )
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanForm.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanForm.kt
@@ -91,6 +91,9 @@ private val RAIL_WIDTH = 44.dp
 /** Diameter of the endpoint dot, in the rail and in the suggestion row that fills that endpoint. */
 private val ENDPOINT_DOT_SIZE = 12.dp
 
+/** The box the endpoint dot occupies when it stands in a menu row's leading icon slot. */
+private val ENDPOINT_DOT_ICON_SIZE = 22.dp
+
 /** Clear space between an endpoint glyph and the dotted connector running to the other one. */
 private val CONNECTOR_GLYPH_CLEARANCE = 12.dp
 
@@ -128,9 +131,6 @@ object TripPlanTestTags {
     /** The two pinned rows at the head of a field's suggestion list. */
     const val MY_LOCATION_SUFFIX = "MyLocation"
     const val PICK_ON_MAP_SUFFIX = "PickOnMap"
-
-    /** The endpoint dot [TripEndpointDotIcon] draws, wherever a row stands for one end of the trip. */
-    const val DOT_SUFFIX = "Dot"
 
     /** The action bar's two time segments. */
     const val WHEN_MODE = "tripPlanWhenMode"
@@ -492,30 +492,32 @@ private fun EndpointDot(color: Color) {
 }
 
 /**
- * The dot at icon size, for the suggestion row that fills an endpoint with the device's position —
- * the row and the endpoint it produces then show the same mark, rather than a crosshair that turns
- * into a dot once chosen.
+ * The dot in a menu row's leading icon slot. Every row that *offers* to fill an endpoint shows the
+ * mark that endpoint will carry once filled, rather than a separate glyph that turns into a dot on
+ * being chosen.
  */
 @Composable
-private fun CurrentLocationDotIcon() {
-    Box(Modifier.size(22.dp), contentAlignment = Alignment.Center) {
-        EndpointDot(colorResource(R.color.trip_plan_endpoint_current_location))
+private fun EndpointDotIcon(color: Color, modifier: Modifier = Modifier) {
+    Box(modifier.size(ENDPOINT_DOT_ICON_SIZE), contentAlignment = Alignment.Center) {
+        EndpointDot(color)
     }
 }
 
+/** [EndpointDotIcon] for the suggestion row that fills an endpoint with the device's position. */
+@Composable
+private fun CurrentLocationDotIcon() {
+    EndpointDotIcon(colorResource(R.color.trip_plan_endpoint_current_location))
+}
+
 /**
- * The rail's endpoint dot in a Material icon slot, for a row elsewhere that offers to fill this end
- * of the trip — the map long-press menu's "directions from/to here". Same reasoning as
- * [CurrentLocationDotIcon]: what the rider taps carries the mark of the endpoint it produces.
+ * [EndpointDotIcon] for a row elsewhere that offers to fill one named end of the trip — the map
+ * long-press menu's "directions from/to here" (#2112). Takes a [modifier] rather than tagging
+ * itself: the tag belongs to whichever feature draws the row, since more than one of them can be
+ * on screen at once.
  */
 @Composable
-fun TripEndpointDotIcon(slot: TripEndpointSlot) {
-    Box(
-        Modifier.size(24.dp).testTag(slot.tagPrefix + TripPlanTestTags.DOT_SUFFIX),
-        contentAlignment = Alignment.Center
-    ) {
-        EndpointDot(endpointSlotColor(slot))
-    }
+fun TripEndpointDotIcon(slot: TripEndpointSlot, modifier: Modifier = Modifier) {
+    EndpointDotIcon(endpointSlotColor(slot), modifier)
 }
 
 @Composable

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanForm.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanForm.kt
@@ -129,6 +129,9 @@ object TripPlanTestTags {
     const val MY_LOCATION_SUFFIX = "MyLocation"
     const val PICK_ON_MAP_SUFFIX = "PickOnMap"
 
+    /** The endpoint dot [TripEndpointDotIcon] draws, wherever a row stands for one end of the trip. */
+    const val DOT_SUFFIX = "Dot"
+
     /** The action bar's two time segments. */
     const val WHEN_MODE = "tripPlanWhenMode"
     const val WHEN_TIME = "tripPlanWhenTime"
@@ -267,7 +270,6 @@ private fun EndpointRow(
     onPickOnMap: () -> Unit
 ) {
     val tagPrefix = slot.tagPrefix
-    val isOrigin = slot == TripEndpointSlot.FROM
     // The endpoint as the field should read it. A resolved endpoint is not a different *kind* of row
     // — it is the same field showing a name — so nothing is swapped in or out as it resolves.
     val endpointText = endpointLabel(endpoint)
@@ -318,7 +320,7 @@ private fun EndpointRow(
             modifier = Modifier.fillMaxWidth().height(ENDPOINT_ROW_HEIGHT),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            EndpointRail(endpoint = endpoint, isOrigin = isOrigin)
+            EndpointRail(endpoint = endpoint, slot = slot)
             BasicTextField(
                 value = field,
                 onValueChange = { value ->
@@ -340,7 +342,7 @@ private fun EndpointRow(
                 textStyle = LocalTextStyle.current.merge(MaterialTheme.typography.bodyLarge)
                     .copy(
                         color = if (endpoint is TripEndpoint.CurrentLocation) {
-                            endpointColor(endpoint, isOrigin)
+                            endpointColor(endpoint, slot)
                         } else {
                             MaterialTheme.colorScheme.onSurface
                         }
@@ -411,17 +413,28 @@ private fun EndpointRow(
 }
 
 /**
- * The colour that identifies an endpoint. Blue wherever the trip is anchored to the device's own
- * position, at either end — that is a different kind of fact from a chosen place, so it outranks the
- * start/destination distinction rather than sitting beside it. Otherwise the origin takes the theme's
- * primary and the destination the fixed red.
+ * The colour that says which end of the trip an endpoint is: the theme's primary for the origin
+ * (green in the OBA brand, whatever a white-label brand sets) and the fixed red for the destination.
+ *
+ * Public because the rail is not the only place a rider names an endpoint — the map long-press menu
+ * offers the same two ends, and marks its rows with these same hues so the row and the endpoint it
+ * fills read as one thing.
  */
 @Composable
-private fun endpointColor(endpoint: TripEndpoint, isOrigin: Boolean): Color = when {
-    endpoint is TripEndpoint.CurrentLocation ->
-        colorResource(R.color.trip_plan_endpoint_current_location)
-    isOrigin -> MaterialTheme.colorScheme.primary
-    else -> colorResource(R.color.trip_destination_marker)
+fun endpointSlotColor(slot: TripEndpointSlot): Color = when (slot) {
+    TripEndpointSlot.FROM -> MaterialTheme.colorScheme.primary
+    TripEndpointSlot.TO -> colorResource(R.color.trip_destination_marker)
+}
+
+/**
+ * The colour that identifies an endpoint. Blue wherever the trip is anchored to the device's own
+ * position, at either end — that is a different kind of fact from a chosen place, so it outranks the
+ * start/destination distinction rather than sitting beside it. Otherwise it is the slot's own colour.
+ */
+@Composable
+private fun endpointColor(endpoint: TripEndpoint, slot: TripEndpointSlot): Color = when (endpoint) {
+    is TripEndpoint.CurrentLocation -> colorResource(R.color.trip_plan_endpoint_current_location)
+    else -> endpointSlotColor(slot)
 }
 
 /**
@@ -430,7 +443,8 @@ private fun endpointColor(endpoint: TripEndpoint, isOrigin: Boolean): Color = wh
  * instead — that it is a stop rather than an address is something no colour in the set encodes.
  */
 @Composable
-private fun EndpointRail(endpoint: TripEndpoint, isOrigin: Boolean) {
+private fun EndpointRail(endpoint: TripEndpoint, slot: TripEndpointSlot) {
+    val isOrigin = slot == TripEndpointSlot.FROM
     val connectorColor = MaterialTheme.colorScheme.outlineVariant
     Box(
         modifier = Modifier.width(RAIL_WIDTH).height(ENDPOINT_ROW_HEIGHT),
@@ -466,7 +480,7 @@ private fun EndpointRail(endpoint: TripEndpoint, isOrigin: Boolean) {
         if (endpoint.isTransit) {
             BusIcon()
         } else {
-            EndpointDot(endpointColor(endpoint, isOrigin))
+            EndpointDot(endpointColor(endpoint, slot))
         }
     }
 }
@@ -486,6 +500,21 @@ private fun EndpointDot(color: Color) {
 private fun CurrentLocationDotIcon() {
     Box(Modifier.size(22.dp), contentAlignment = Alignment.Center) {
         EndpointDot(colorResource(R.color.trip_plan_endpoint_current_location))
+    }
+}
+
+/**
+ * The rail's endpoint dot in a Material icon slot, for a row elsewhere that offers to fill this end
+ * of the trip — the map long-press menu's "directions from/to here". Same reasoning as
+ * [CurrentLocationDotIcon]: what the rider taps carries the mark of the endpoint it produces.
+ */
+@Composable
+fun TripEndpointDotIcon(slot: TripEndpointSlot) {
+    Box(
+        Modifier.size(24.dp).testTag(slot.tagPrefix + TripPlanTestTags.DOT_SUFFIX),
+        contentAlignment = Alignment.Center
+    ) {
+        EndpointDot(endpointSlotColor(slot))
     }
 }
 


### PR DESCRIPTION
Fixes #2112.

Long-pressing the map opened a `ModalBottomSheet` — the one long-press menu in the app that wasn't the shared centered dialog every other one uses (arrivals rows, ETA strip, focus banner, my-lists, route search, route info). On the map that's also the worst place for it: a sheet rising from the bottom covers the very point the rider just pressed.

It now opens `CenteredLongPressMenu`, and its two rows are marked with the trip-plan rail's own endpoint dots — green origin, red destination — instead of a my-location crosshair and a place pin. The row the rider taps carries the same mark as the endpoint it fills.

### Sharing the dots

`TripPlanForm`'s start/destination colour rule is lifted into a public `endpointSlotColor(slot)` and exposed at icon size as `TripEndpointDotIcon`; `endpointColor` and `EndpointRail` now take the slot rather than an `isOrigin` flag, so there's one source of truth for the hue rather than the menu keeping its own copy of "green and red". `MenuRow` gains an overload taking a composable leading slot (no tinted `ImageVector` carries a coloured dot), with the existing `ImageVector` form delegating to it.

Note this deliberately uses the rail's origin colour — `MaterialTheme.colorScheme.primary`, green in the OBA brand and whatever a white-label brand sets — not the fixed `trip_origin_marker` green the trip-log timeline uses. The two greens were already forked before this change; the point here is that the menu matches the rail it feeds.

### Tests

`DirectionsLongPressMenuRenderTest` covers the three claims on device:

- both ends of the trip are offered and report their slot,
- the rows' dots read green and red,
- the menu is a compact card, not a full-width sheet.

Width is what that last one asserts. Dialog semantics would have been the obvious check and it does not work — a `ModalBottomSheet` reports `isDialog()` too (verified on device with a throwaway probe), so asserting that would have passed for exactly the layout this issue replaces.

The channel-dominance helper moved out of `TripPlanFormRenderTest` into a shared `androidTest` assertion, now that "green origin, red destination" is claimed in two places.

Verified: `compileObaGoogleDebugKotlin -PwarningsAsErrors=true`, `spotlessCheck`, and `DirectionsLongPressMenuRenderTest` + `TripPlanFormRenderTest` (19 tests) green on a Pixel 7 Pro. Not yet exercised by hand in the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the directions long-press menu to appear as a compact centered card.
  - Added clear, color-coded dots for the trip’s starting and ending points.
  - Improved endpoint selection handling for “From” and “To” actions.

- **Bug Fixes**
  - Ensured endpoint colors and labels remain consistent across directions and trip-planning views.

- **Tests**
  - Added coverage verifying menu layout, endpoint actions, and color rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->