### PR TITLE
Don't pin a trip endpoint the rider set to their current location (#2111)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/DirectionsMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/DirectionsMapController.kt
@@ -28,6 +28,13 @@ import org.onebusaway.android.util.GeoPoint
 import org.onebusaway.android.util.parseObaHexColor
 
 /**
+ * Which of a drawn itinerary's two terminus pins to draw. A terminus the rider set to their current
+ * location goes unpinned: the map's location layer already marks that exact point with the blue dot, so
+ * a pin on top of it is redundant (#2111). Both pins are drawn unless a terminus says otherwise.
+ */
+data class ItineraryPins(val start: Boolean = true, val end: Boolean = true)
+
+/**
  * The trip-plan directions use case (the legacy `DirectionsMapController`): draws an itinerary's legs
  * (each polyline styled by [itineraryLegStyle], each ride labelled by [itineraryRouteBadges]) plus
  * start/end pins, and frames the whole itinerary. A
@@ -73,9 +80,11 @@ class DirectionsMapController(private val host: MapHost) {
      * Draw [itinerary]'s leg polylines + start/end pins and frame it, stroking every leg through
      * [palette] — the directions view's own, which is the theme-aware colour the drawer badges this leg
      * with (see [directionsRouteLinePalette]). Passed per draw rather than held, so the palette that
-     * resolved the current theme is the one this itinerary was drawn with.
+     * resolved the current theme is the one this itinerary was drawn with. [pins] withholds a terminus
+     * pin the trip's own endpoint made redundant (see [ItineraryPins]); framing is unaffected, since a
+     * withheld pin doesn't move where the trip starts.
      */
-    fun start(itinerary: TripItinerary, palette: RouteLinePalette) {
+    fun start(itinerary: TripItinerary, palette: RouteLinePalette, pins: ItineraryPins) {
         val legs = itinerary.legs
         if (legs.isEmpty()) {
             return
@@ -143,10 +152,10 @@ class DirectionsMapController(private val host: MapHost) {
         focusedLegIndices = emptySet()
         publishLegs()
 
-        if (startLat != null && startLon != null) {
+        if (pins.start && startLat != null && startLon != null) {
             directionsMarkerIds.add(host.addMarker(startLat, startLon, HUE_GREEN))
         }
-        if (endLat != null && endLon != null) {
+        if (pins.end && endLat != null && endLon != null) {
             directionsMarkerIds.add(host.addMarker(endLat, endLon, HUE_RED))
         }
         // Published after the pins, since the static layer is redrawn wholesale on each emission that

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
@@ -520,9 +520,11 @@ class MapViewModel @Inject constructor(
      * stop/route focus + nearby stops) and enters directions mode; later calls (a different option
      * selected) just redraw the legs/pins. Deliberately does not restart the nearby-stops loader —
      * directions hides nearby stops. Exiting (any other transition → [leaveCurrentView]) tears it down,
-     * except a leg's route sub-focus, which carries the trip on as context (#2048).
+     * except a leg's route sub-focus, which carries the trip on as context (#2048). [pins] carries the
+     * trip's own endpoints' claim on their terminus pins — a current-location terminus wears none
+     * (#2111).
      */
-    fun showItinerary(itinerary: TripItinerary) {
+    fun showItinerary(itinerary: TripItinerary, pins: ItineraryPins) {
         if (!directionsActive) {
             leaveCurrentView(clearStopFocus = true)
             persistRoute(null)
@@ -531,7 +533,7 @@ class MapViewModel @Inject constructor(
         directionsController.clear()
         directionsController.clearEndpoints()
         renderState.clearRoutePolylines()
-        directionsController.start(itinerary, directionsPalette())
+        directionsController.start(itinerary, directionsPalette(), pins)
         bikeController.start(
             directions = true,
             selectedBikeStationIds = DirectionsMapController.bikeStationIdsFromItinerary(itinerary)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -94,6 +94,8 @@ import org.onebusaway.android.ui.home.directions.DirectionsFormCard
 import org.onebusaway.android.ui.home.directions.DirectionsLongPressMenu
 import org.onebusaway.android.ui.home.directions.DirectionsPickOverlay
 import org.onebusaway.android.ui.home.directions.DirectionsResultsSheet
+import org.onebusaway.android.ui.home.directions.itineraryPins
+import org.onebusaway.android.ui.home.directions.pinPoint
 import org.onebusaway.android.ui.home.donation.DonationFeature
 import org.onebusaway.android.ui.home.donation.DonationViewModel
 import org.onebusaway.android.ui.home.drawer.HomeNavDrawerSheet
@@ -129,7 +131,6 @@ import org.onebusaway.android.ui.tutorial.rememberTutorialState
 import org.onebusaway.android.ui.tutorial.tutorialAnchor
 import org.onebusaway.android.util.ExternalIntents
 import org.onebusaway.android.util.GeoPoint
-import org.onebusaway.android.util.geoPointOrNull
 
 /**
  * The home screen's tap/UI callbacks, bundled into one holder (mirrors [org.onebusaway.android.ui.survey.SurveyCallbacks]) so
@@ -605,8 +606,8 @@ fun HomeScreen(
                             // (so a single-endpoint state already shows the point). Only while in directions with
                             // no itinerary yet — the itinerary's own pins supersede these once it draws.
                             val showEndpointPins = directionsActive && directionsResults == null
-                            val fromPoint = if (showEndpointPins) tripPlanFormState.from.toGeoPoint() else null
-                            val toPoint = if (showEndpointPins) tripPlanFormState.to.toGeoPoint() else null
+                            val fromPoint = if (showEndpointPins) tripPlanFormState.from.pinPoint() else null
+                            val toPoint = if (showEndpointPins) tripPlanFormState.to.pinPoint() else null
                             LaunchedEffect(fromPoint, toPoint) {
                                 homeViewModel.setDirectionsEndpointsOnMap(fromPoint, toPoint)
                             }
@@ -749,7 +750,12 @@ fun HomeScreen(
                                             resultsViewModel = tripResultsViewModel,
                                             itineraries = directionsResults.itineraries,
                                             params = directionsResults.params,
-                                            showItinerary = homeViewModel::showItineraryOnMap,
+                                            showItinerary = { itinerary ->
+                                                homeViewModel.showItineraryOnMap(
+                                                    itinerary,
+                                                    directionsResults.params.itineraryPins()
+                                                )
+                                            },
                                             onFocusRouteLeg = homeViewModel::focusItineraryRouteLeg,
                                             onFocusLeg = homeViewModel::focusItineraryLegOnMap,
                                             onFocusPoint = homeViewModel::focusItineraryPointOnMap,
@@ -1056,6 +1062,3 @@ private fun ArrivalsDragHandle(onToggle: () -> Unit, modifier: Modifier = Modifi
         DragHandleBar()
     }
 }
-
-/** A resolved endpoint's map point, or null while it's still free text (no coordinates yet). */
-private fun TripEndpoint.toGeoPoint(): GeoPoint? = geoPointOrNull(lat, lon)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
@@ -33,6 +33,7 @@ import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 import org.onebusaway.android.directions.model.TripItinerary
 import org.onebusaway.android.location.LocationRepository
+import org.onebusaway.android.map.ItineraryPins
 import org.onebusaway.android.map.RouteFocusRelationship
 import org.onebusaway.android.map.RouteFocusSegment
 import org.onebusaway.android.map.ShowRouteRequest
@@ -588,7 +589,7 @@ class HomeViewModel @Inject constructor(
     private fun itineraryOverviewDirective(from: CurrentFocus): MapDirective = if (from.keepsDrawnItinerary) {
         MapDirective.ClearItineraryLegFocus
     } else {
-        shownItinerary?.let { MapDirective.ShowItinerary(it) } ?: MapDirective.ClearFocus
+        shownItinerary ?: MapDirective.ClearFocus
     }
 
     /** Clears the complete focus hierarchy. Used by the focus banner's explicit close control. */
@@ -613,21 +614,25 @@ class HomeViewModel @Inject constructor(
         pushFocus(CurrentFocus.Directions(), undoViewport)
     }
 
-    // The itinerary currently drawn in directions mode, cached so returning from a route sub-focus (a
-    // map-background tap) can redraw it — the results VM's selection flow doesn't re-emit on its own.
-    private var shownItinerary: TripItinerary? = null
+    // The draw of the itinerary currently shown in directions mode, cached so returning from a route
+    // sub-focus (a map-background tap) can redraw it — the results VM's selection flow doesn't re-emit on
+    // its own. Held as the whole directive rather than just the itinerary, so a redraw reproduces the
+    // terminus pins the trip was drawn with instead of quietly restoring a suppressed one.
+    private var shownItinerary: MapDirective.ShowItinerary? = null
 
     /**
      * Draw [itinerary] on the home map and frame the whole trip (only meaningful in
      * [CurrentFocus.Directions]). Showing the full itinerary drops any leg route focus, so an option-card
-     * tap returns to the overview.
+     * tap returns to the overview. [pins] withholds the terminus pin of an endpoint the rider set to
+     * their current location, which the blue dot already marks (#2111).
      */
-    fun showItineraryOnMap(itinerary: TripItinerary) {
-        shownItinerary = itinerary
+    fun showItineraryOnMap(itinerary: TripItinerary, pins: ItineraryPins = ItineraryPins()) {
+        val draw = MapDirective.ShowItinerary(itinerary, pins)
+        shownItinerary = draw
         // Showing the whole trip drops any leg sub-focus; the ShowItinerary below is the redraw. Guarded so
         // a call from outside directions can't push a directions focus.
         if (directionsSubFocus != null) pushFocus(CurrentFocus.Directions())
-        emitMapDirective(MapDirective.ShowItinerary(itinerary))
+        emitMapDirective(draw)
     }
 
     /** The leg the user has drilled into from the itinerary overview, if any. */
@@ -675,7 +680,7 @@ class HomeViewModel @Inject constructor(
      */
     private fun applyLegFocus(leg: FocusedLeg, from: CurrentFocus) {
         if (!from.keepsDrawnItinerary) {
-            shownItinerary?.let { emitMapDirective(MapDirective.ShowItinerary(it)) }
+            shownItinerary?.let { emitMapDirective(it) }
         }
         emitMapDirective(MapDirective.FocusItineraryLeg(leg.points, leg.legIndices))
     }
@@ -1021,7 +1026,11 @@ sealed interface MapDirective {
     ) : MapDirective
 
     /** Draw [itinerary]'s legs + start/end pins on the home map (trip-plan directions focus). */
-    data class ShowItinerary(val itinerary: TripItinerary) : MapDirective
+    data class ShowItinerary(
+        val itinerary: TripItinerary,
+        /** Which terminus pins the trip wears — a current-location endpoint claims none (#2111). */
+        val pins: ItineraryPins = ItineraryPins()
+    ) : MapDirective
 
     /** Recenter the map on a tapped itinerary step's point (recenter + zoom to street level). */
     data class FocusItineraryPoint(val point: GeoPoint) : MapDirective

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsEndpointPins.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsEndpointPins.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.home.directions
+
+import org.onebusaway.android.map.ItineraryPins
+import org.onebusaway.android.ui.tripplan.TripEndpoint
+import org.onebusaway.android.ui.tripplan.TripPlanParams
+import org.onebusaway.android.util.GeoPoint
+import org.onebusaway.android.util.geoPointOrNull
+
+// Which of a trip's two ends the map marks with a pin of its own.
+//
+// An end the rider set to their current location gets none, at either stage of the trip: the map's
+// location layer already marks that exact point with the blue dot, and a pin dropped on top of it says
+// nothing the dot doesn't (#2111). Both stages are decided in this one place so the pin the form
+// withheld doesn't reappear the moment the planned trip draws.
+
+/**
+ * The point to drop an endpoint's standalone From/To pin at while the form is being filled in: null
+ * while the endpoint is still free text (no coordinates yet), and null for the rider's own location.
+ */
+fun TripEndpoint.pinPoint(): GeoPoint? = if (isDeviceLocation) null else geoPointOrNull(lat, lon)
+
+/**
+ * The terminus pins the itinerary a plan produced should wear. Read off the request that produced the
+ * results rather than the live form, which the rider may have edited since; a plan restored from a
+ * notification carries no request ([TripPlanParams] is null there), so both pins are drawn.
+ */
+fun TripPlanParams?.itineraryPins(): ItineraryPins = ItineraryPins(
+    start = this?.from?.isDeviceLocation != true,
+    end = this?.to?.isDeviceLocation != true
+)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
@@ -334,7 +334,7 @@ fun MapFeature(
                         directive.animate
                     )
                 is MapDirective.ShowItinerary ->
-                    mapViewModel.showItinerary(directive.itinerary)
+                    mapViewModel.showItinerary(directive.itinerary, directive.pins)
                 is MapDirective.FocusItineraryPoint ->
                     mapViewModel.focusItineraryPoint(directive.point)
                 is MapDirective.FocusItineraryLeg ->

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanFormState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanFormState.kt
@@ -40,6 +40,14 @@ sealed interface TripEndpoint {
     val isTransit: Boolean get() = false
 
     /**
+     * This endpoint *is* the device's own position, which the map already marks with the location
+     * layer's blue dot. Such an endpoint is given no pin of its own — neither the standalone From/To
+     * pin shown while the form is being filled in nor the drawn itinerary's terminus pin — since a pin
+     * dropped on top of the blue dot says nothing the dot doesn't (#2111).
+     */
+    val isDeviceLocation: Boolean get() = this is CurrentLocation
+
+    /**
      * The text this endpoint carries itself (a typed query or a resolved place name), or null for the
      * fixed-label kinds ([CurrentLocation]/[MapPoint]) whose label is a string resource resolved by the
      * Android layer. Keeps the shared part of the endpoint→label mapping in one place instead of

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
@@ -28,6 +28,7 @@ import org.junit.Test
 import org.onebusaway.android.api.adapters.ObaStopElement
 import org.onebusaway.android.directions.model.TripItinerary
 import org.onebusaway.android.location.FakeLocationRepository
+import org.onebusaway.android.map.ItineraryPins
 import org.onebusaway.android.map.RouteFocusRelationship
 import org.onebusaway.android.map.RouteFocusSegment
 import org.onebusaway.android.map.ShowRouteRequest
@@ -252,6 +253,29 @@ class HomeViewModelTest {
         // Route mode tore the trip down, so returning to the overview redraws it.
         assertEquals(CurrentFocus.Directions(), vm.currentFocus.value)
         assertEquals(listOf(MapDirective.ShowItinerary(itinerary)), map.sent)
+        job.cancel()
+    }
+
+    @Test
+    fun `a redrawn trip keeps the terminus pin its current-location endpoint withheld`() = runTest {
+        val vm = viewModel()
+        val map = MapDirectiveRecorder(vm)
+        val job = launch { map.collect() }
+        advanceUntilIdle()
+        val itinerary = TripItinerary()
+        // A trip planned *from* here: the blue dot marks the start, so it wears no start pin (#2111).
+        val pins = ItineraryPins(start = false)
+        vm.enterDirections()
+        vm.showItineraryOnMap(itinerary, pins)
+        vm.focusItineraryRouteLegOnMap("65")
+        advanceUntilIdle()
+        map.sent.clear()
+
+        vm.navigateBackInDirections()
+        advanceUntilIdle()
+
+        // The redraw reproduces the trip as it was drawn — a suppressed pin doesn't come back with it.
+        assertEquals(listOf(MapDirective.ShowItinerary(itinerary, pins)), map.sent)
         job.cancel()
     }
 

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/directions/DirectionsEndpointPinsTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/directions/DirectionsEndpointPinsTest.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.home.directions
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.onebusaway.android.map.ItineraryPins
+import org.onebusaway.android.ui.tripplan.TripEndpoint
+import org.onebusaway.android.ui.tripplan.TripModeSelection
+import org.onebusaway.android.ui.tripplan.TripPlanParams
+import org.onebusaway.android.util.GeoPoint
+
+/** The current-location endpoint's claim on a map pin, which it gives up to the blue dot (#2111). */
+class DirectionsEndpointPinsTest {
+
+    private val here = TripEndpoint.CurrentLocation(lat = 47.6, lon = -122.3)
+    private val pressed = TripEndpoint.MapPoint(lat = 47.7, lon = -122.2)
+    private val named = TripEndpoint.Geocoded("Pike Place Market", lat = 47.61, lon = -122.34)
+
+    @Test
+    fun `a resolved endpoint is pinned at its own coordinates`() {
+        assertEquals(GeoPoint(47.7, -122.2), pressed.pinPoint())
+        assertEquals(GeoPoint(47.61, -122.34), named.pinPoint())
+    }
+
+    @Test
+    fun `the current location is not pinned - the blue dot already marks it`() {
+        assertNull(here.pinPoint())
+    }
+
+    @Test
+    fun `a half-typed endpoint has nowhere to pin yet`() {
+        assertNull(TripEndpoint.FreeText("Pike Pl").pinPoint())
+    }
+
+    @Test
+    fun `an endpoint the geocoder left without coordinates has nowhere to pin`() {
+        assertNull(TripEndpoint.AddressBook("Mum", lat = null, lon = null).pinPoint())
+    }
+
+    @Test
+    fun `a trip between two named places wears both terminus pins`() {
+        assertEquals(ItineraryPins(start = true, end = true), params(named, pressed).itineraryPins())
+    }
+
+    @Test
+    fun `a trip from the current location drops its start pin only`() {
+        assertEquals(ItineraryPins(start = false, end = true), params(here, named).itineraryPins())
+    }
+
+    @Test
+    fun `a trip to the current location drops its end pin only`() {
+        assertEquals(ItineraryPins(start = true, end = false), params(named, here).itineraryPins())
+    }
+
+    @Test
+    fun `a plan restored without its request wears both pins`() {
+        // A notification re-entry doesn't reconstruct the request, so nothing says an end was the
+        // rider's own location — draw both rather than guess one away.
+        assertEquals(ItineraryPins(start = true, end = true), null.itineraryPins())
+    }
+
+    private fun params(from: TripEndpoint, to: TripEndpoint) = TripPlanParams(
+        from = from,
+        to = to,
+        dateTimeMillis = 0L,
+        arriving = false,
+        modes = TripModeSelection(),
+        wheelchair = false,
+        optimizeTransfers = false,
+        maxWalkMeters = null
+    )
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripPlanFormStateTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripPlanFormStateTest.kt
@@ -100,6 +100,16 @@ class TripPlanFormStateTest {
     }
 
     @Test
+    fun `only the current-location endpoint is the device's own position`() {
+        // What the map's pin suppression turns on (#2111) — a map point the rider happened to press on
+        // top of themselves is still a place they named, not the moving blue dot.
+        assertTrue(here.isDeviceLocation)
+        assertFalse(TripEndpoint.MapPoint(lat = 47.6, lon = -122.3).isDeviceLocation)
+        assertFalse(named.isDeviceLocation)
+        assertFalse(TripEndpoint.FreeText("here").isDeviceLocation)
+    }
+
+    @Test
     fun `only a blank free-text endpoint counts as empty`() {
         assertTrue(TripEndpoint.FreeText().isEmpty)
         assertTrue(TripEndpoint.FreeText("   ").isEmpty)


### PR DESCRIPTION
Closes #2111.

The map's location layer already marks the device's position with the blue dot, so the green/red endpoint pin dropped on top of it says nothing the dot doesn't.

## What changed

An endpoint the rider set to their current location gives up its pin at **both** stages of a trip — otherwise the pin the form withheld would reappear the moment the plan lands:

1. **The form's standalone From/To pins.** `TripEndpoint.pinPoint()` returns null for a current-location endpoint (new `ui/home/directions/DirectionsEndpointPins.kt`, which holds both halves of the decision in one place).
2. **The drawn itinerary's terminus pins.** A new `ItineraryPins(start, end)` rides along `MapDirective.ShowItinerary` → `MapViewModel.showItinerary` → `DirectionsMapController.start`, gating the two `addMarker` calls. Framing is untouched, so a withheld pin doesn't move where the map settles.

The itinerary's pins are read off `PlanResult.Success.params` — the request that produced *those* results — rather than the live form, which the rider may have edited since. A plan restored from a notification carries no params, so it wears both pins rather than guessing one away.

`HomeViewModel` now caches the whole `ShowItinerary` directive instead of just the itinerary, so the redraw on the way back from a leg's route focus reproduces the trip as it was drawn, suppressed pin and all.

The rule turns on the endpoint's own kind (`TripEndpoint.isDeviceLocation`, i.e. `CurrentLocation`), not on a proximity threshold — a map point the rider happened to long-press on top of themselves is still a place they named, and no heuristic is introduced.

## Reviewer's call

- **Scope.** I read "endpoint of a route" as covering the drawn trip as well as the pre-plan pins. If only the pre-plan pins were wanted, the `ItineraryPins` plumbing is the separable part.
- **A real tradeoff.** Once a plan is drawn, the start pin marks where the trip begins. If the rider walks away from that spot, the blue dot moves and nothing marks the trip's origin any more. This follows the issue as written; happy to keep the itinerary's terminus pins if that's the wrong trade.

## Testing

- `compileObaGoogleDebugKotlin -PwarningsAsErrors=true` — clean
- `testObaGoogleDebugUnitTest`, `testObaMaplibreDebugUnitTest`, `spotlessCheck` — pass

New coverage: 8 tests in `DirectionsEndpointPinsTest` (which endpoints get a pin, which terminus pins a plan wears, the no-params restore), one in `HomeViewModelTest` (a redraw keeps the withheld pin withheld), one in `TripPlanFormStateTest` (only `CurrentLocation` is the device's own position).

Not verified on a device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved itinerary maps with accurate start and end pins.
  * Current-location endpoints no longer display redundant standalone pins.
  * Pin visibility is preserved when reopening or redrawing itineraries.

* **Bug Fixes**
  * Fixed endpoint coordinates for map pins, including unresolved locations.
  * Corrected itinerary pin behavior when returning from route-focused views.

* **Tests**
  * Added coverage for endpoint locations, pin visibility, and itinerary redraw behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->