### PR TITLE
Move the reverse button out of the action bar

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripplan/TripPlanFormRenderTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripplan/TripPlanFormRenderTest.kt
@@ -29,7 +29,6 @@ import androidx.compose.ui.test.assertIsNotFocused
 import androidx.compose.ui.test.captureToImage
 import androidx.compose.ui.test.getUnclippedBoundsInRoot
 import androidx.compose.ui.test.onAllNodesWithContentDescription
-import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -37,6 +36,7 @@ import androidx.compose.ui.test.performImeAction
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.height
 import kotlin.math.absoluteValue
+import kotlin.math.roundToInt
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -301,13 +301,11 @@ class TripPlanFormRenderTest {
             }
         )
 
-        val withNow = composeRule.onNodeWithContentDescription(ADVANCED_SETTINGS)
-            .getUnclippedBoundsInRoot().right
+        val withNow = bounds(TripPlanTestTags.ADVANCED_SETTINGS).right
 
         departNow = false
         composeRule.waitForIdle()
-        val withPinnedTime = composeRule.onNodeWithContentDescription(ADVANCED_SETTINGS)
-            .getUnclippedBoundsInRoot().right
+        val withPinnedTime = bounds(TripPlanTestTags.ADVANCED_SETTINGS).right
 
         assertEquals(
             "the trailing buttons moved when the time label grew",
@@ -318,32 +316,58 @@ class TripPlanFormRenderTest {
 
     /**
      * Reverse acts on the two endpoints, so it sits beside them rather than in the action bar (#2110):
-     * to the right of both fields and centred across the pair, which puts it on the divider between
-     * them. Position is the whole point of the move, so it's asserted rather than left to the eye —
-     * a later edit that drops it back into a plain column would still render a working button.
+     * clear of both fields and centred across the pair, which puts it on the divider between them.
+     * Position is the whole point of the move, so it's asserted rather than left to the eye.
      */
     @Test
     fun reverseSitsBetweenTheTwoEndpointFields() {
+        renderForm(plannedState)
+
+        val button = bounds(TripPlanTestTags.REVERSE)
+        val from = bounds(FROM_FIELD)
+        val to = bounds(TO_FIELD)
+
+        assertTrue(
+            "reverse should clear both fields, but started at ${button.left} against " +
+                "${from.right} and ${to.right}",
+            button.left >= from.right && button.left >= to.right
+        )
+        // Compared in pixels, because rounding is what the slack is for: the rows and the 1dp rule
+        // between them round to whole pixels independently of the button's own centring, so the
+        // midpoint they define can sit a pixel off it. Anything past that is a real misalignment.
+        val buttonCenter = (button.top + button.bottom) / 2f
+        val betweenRows = (from.bottom + to.top) / 2f
+        val driftPx = with(composeRule.density) { (buttonCenter - betweenRows).toPx() }.roundToInt()
+        assertTrue(
+            "reverse should be centred between the rows at $betweenRows, but sat at $buttonCenter",
+            driftPx.absoluteValue <= 1
+        )
+    }
+
+    /**
+     * Reverse and additional-preferences sit in one trailing column, across two bands that lay
+     * themselves out independently. Nothing in either band's code forces that — it holds only because
+     * both end with the same button size and the same trailing gutter — so it's the part of the move
+     * most able to drift, and the part worth pinning.
+     */
+    @Test
+    fun reverseIsColumnAlignedWithTheActionBarsTrailingButton() {
+        renderForm(plannedState)
+
+        assertEquals(
+            "reverse should share a trailing edge with additional-preferences",
+            bounds(TripPlanTestTags.ADVANCED_SETTINGS).right,
+            bounds(TripPlanTestTags.REVERSE).right
+        )
+    }
+
+    @Test
+    fun tappingReverseSwapsTheEndpoints() {
         var reversed = false
         renderForm(state = { plannedState }, onReverse = { reversed = true })
 
-        val button = composeRule.onNodeWithTag(TripPlanTestTags.REVERSE).getUnclippedBoundsInRoot()
-        val from = composeRule.onNodeWithTag(FROM_FIELD).getUnclippedBoundsInRoot()
-        val to = composeRule.onNodeWithTag(TO_FIELD).getUnclippedBoundsInRoot()
-
-        assertTrue(
-            "reverse should clear both fields, but started at ${button.left} against ${from.right}",
-            button.left >= from.right && button.left >= to.right
-        )
-        // Centred across the pair — i.e. level with the hairline between them.
-        val buttonCenter = (button.top + button.bottom) / 2f
-        val betweenRows = (from.bottom + to.top) / 2f
-        assertTrue(
-            "reverse should be centred between the rows at $betweenRows, but sat at $buttonCenter",
-            (buttonCenter - betweenRows).value.absoluteValue <= 1f
-        )
-
         composeRule.onNodeWithTag(TripPlanTestTags.REVERSE).performClick()
+
         assertTrue("tapping reverse should swap the endpoints", reversed)
     }
 
@@ -449,6 +473,9 @@ class TripPlanFormRenderTest {
         )
     }
 
+    /** Where a tagged node sits in the form, for the tests that are about position. */
+    private fun bounds(tag: String) = composeRule.onNodeWithTag(tag).getUnclippedBoundsInRoot()
+
     /** Samples the centre of a row's rail dot. Mirrors the form's own 4dp pad / 48dp row / 1dp rule. */
     private fun railDot(row: Int): Color {
         val pixels = composeRule.onNodeWithTag(FORM).captureToImage().toPixelMap()
@@ -502,9 +529,6 @@ class TripPlanFormRenderTest {
 
     private companion object {
         const val FORM = "tripPlanFormRoot"
-
-        /** The advanced-settings button's contentDescription — the bar's last trailing child. */
-        const val ADVANCED_SETTINGS = "Additional Trip Preferences"
         val RAIL_WIDTH_DP = 44.dp
         val FROM_FIELD = TripPlanTestTags.FROM_PREFIX + TripPlanTestTags.FIELD_SUFFIX
         val TO_FIELD = TripPlanTestTags.TO_PREFIX + TripPlanTestTags.FIELD_SUFFIX

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripplan/TripPlanFormRenderTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripplan/TripPlanFormRenderTest.kt
@@ -328,7 +328,7 @@ class TripPlanFormRenderTest {
         val to = bounds(TO_FIELD)
 
         assertTrue(
-            "reverse should clear both fields, but started at ${button.left} against " +
+            "reverse should sit clear of both fields, but started at ${button.left} against " +
                 "${from.right} and ${to.right}",
             button.left >= from.right && button.left >= to.right
         )
@@ -346,9 +346,10 @@ class TripPlanFormRenderTest {
 
     /**
      * Reverse and additional-preferences sit in one trailing column, across two bands that lay
-     * themselves out independently. Nothing in either band's code forces that — it holds only because
-     * both end with the same button size and the same trailing gutter — so it's the part of the move
-     * most able to drift, and the part worth pinning.
+     * themselves out independently. The form spells that out — both bands take their width and their
+     * trailing gutter from one shared modifier, and every button one size — but nothing makes a band
+     * keep using either, so the alignment is still the part of the move most able to drift, and the
+     * part worth pinning.
      */
     @Test
     fun reverseIsColumnAlignedWithTheActionBarsTrailingButton() {
@@ -361,14 +362,15 @@ class TripPlanFormRenderTest {
         )
     }
 
+    /** The form is stateless, so the swap itself is the host's; what's checked here is the ask. */
     @Test
-    fun tappingReverseSwapsTheEndpoints() {
+    fun tappingReverseFiresTheReverseCallback() {
         var reversed = false
         renderForm(state = { plannedState }, onReverse = { reversed = true })
 
         composeRule.onNodeWithTag(TripPlanTestTags.REVERSE).performClick()
 
-        assertTrue("tapping reverse should swap the endpoints", reversed)
+        assertTrue("tapping reverse should ask the host to swap the endpoints", reversed)
     }
 
     /**

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripplan/TripPlanFormRenderTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripplan/TripPlanFormRenderTest.kt
@@ -484,6 +484,7 @@ class TripPlanFormRenderTest {
 
     /** Where a tagged node sits in the form, for the tests that are about position. */
     private fun bounds(tag: String) = composeRule.onNodeWithTag(tag).getUnclippedBoundsInRoot()
+
     /** Samples the centre of a row's rail dot. Mirrors the form's own 4dp pad / 48dp row / 1dp rule. */
     private fun railDot(row: Int): Color {
         val pixels = composeRule.onNodeWithTag(FORM).captureToImage().toPixelMap()

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripplan/TripPlanFormRenderTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripplan/TripPlanFormRenderTest.kt
@@ -317,6 +317,37 @@ class TripPlanFormRenderTest {
     }
 
     /**
+     * Reverse acts on the two endpoints, so it sits beside them rather than in the action bar (#2110):
+     * to the right of both fields and centred across the pair, which puts it on the divider between
+     * them. Position is the whole point of the move, so it's asserted rather than left to the eye —
+     * a later edit that drops it back into a plain column would still render a working button.
+     */
+    @Test
+    fun reverseSitsBetweenTheTwoEndpointFields() {
+        var reversed = false
+        renderForm(state = { plannedState }, onReverse = { reversed = true })
+
+        val button = composeRule.onNodeWithTag(TripPlanTestTags.REVERSE).getUnclippedBoundsInRoot()
+        val from = composeRule.onNodeWithTag(FROM_FIELD).getUnclippedBoundsInRoot()
+        val to = composeRule.onNodeWithTag(TO_FIELD).getUnclippedBoundsInRoot()
+
+        assertTrue(
+            "reverse should clear both fields, but started at ${button.left} against ${from.right}",
+            button.left >= from.right && button.left >= to.right
+        )
+        // Centred across the pair — i.e. level with the hairline between them.
+        val buttonCenter = (button.top + button.bottom) / 2f
+        val betweenRows = (from.bottom + to.top) / 2f
+        assertTrue(
+            "reverse should be centred between the rows at $betweenRows, but sat at $buttonCenter",
+            (buttonCenter - betweenRows).value.absoluteValue <= 1f
+        )
+
+        composeRule.onNodeWithTag(TripPlanTestTags.REVERSE).performClick()
+        assertTrue("tapping reverse should swap the endpoints", reversed)
+    }
+
+    /**
      * Choosing "Your location" repeatedly has to keep resolving the endpoint. It used to work only on
      * alternate taps: the cycles that started from an already-resolved endpoint left a focused text
      * field to be torn down, and the value change that came out of that teardown was forwarded as a
@@ -442,7 +473,8 @@ class TripPlanFormRenderTest {
         onSelect: (TripEndpointSlot, TripEndpoint.Geocoded) -> Unit = { _, _ -> },
         onCurrentLocation: (TripEndpointSlot) -> Unit = {},
         onVehicleModeSelected: (VehicleMode) -> Unit = {},
-        onStreetModeSelected: (StreetMode) -> Unit = {}
+        onStreetModeSelected: (StreetMode) -> Unit = {},
+        onReverse: () -> Unit = {}
     ) {
         composeRule.setContent {
             ObaTheme {
@@ -460,7 +492,7 @@ class TripPlanFormRenderTest {
                         availableStreetModes = StreetMode.entries,
                         onVehicleModeSelected = onVehicleModeSelected,
                         onStreetModeSelected = onStreetModeSelected,
-                        onReverse = {},
+                        onReverse = onReverse,
                         onAdvancedSettings = {}
                     )
                 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanForm.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanForm.kt
@@ -129,11 +129,14 @@ object TripPlanTestTags {
     const val MY_LOCATION_SUFFIX = "MyLocation"
     const val PICK_ON_MAP_SUFFIX = "PickOnMap"
 
-    /** The action bar's two time segments. */
+    /** The action bar's two time segments, and its two mode pickers. */
     const val WHEN_MODE = "tripPlanWhenMode"
     const val WHEN_TIME = "tripPlanWhenTime"
     const val VEHICLE_MODE = "tripPlanVehicleMode"
     const val STREET_MODE = "tripPlanStreetMode"
+
+    /** The swap-endpoints button, beside the two endpoint rows rather than in the action bar. */
+    const val REVERSE = "tripPlanReverse"
 }
 
 /**
@@ -166,10 +169,11 @@ val TripEndpointSlot.tagPrefix: String
  * per-field chrome. What differs is the bottom band: transit is scheduled travel, so the form always
  * states when the trip is for, as a "Depart · now" callout whose two halves open separate pickers.
  *
- * That band doubles as the form's action bar, carrying reverse and additional-preferences as well. It's
- * the reason the endpoint rows can run full width: everything acting on the *whole trip* lives on one
- * line, and only what acts on a single endpoint lives in that endpoint's row (which, currently, is
- * nothing — see [EndpointRow]). The card measures 146dp against the old layout's 216dp.
+ * That band doubles as the form's action bar, carrying the mode pickers and additional-preferences as
+ * well. It's the reason the endpoint rows carry no per-field chrome: everything acting on the trip's
+ * *terms* lives on one line, and nothing acts on a single endpoint (see [EndpointRow]). The one action
+ * on the endpoints themselves — reverse — sits beside the pair, centred on the divider between them.
+ * The card measures 146dp against the old layout's 216dp.
  *
  * Stateless and driven by [TripPlanFormState]; the date/time/current-location actions are platform
  * interactions launched by the host.
@@ -193,23 +197,44 @@ fun TripPlanForm(
     modifier: Modifier = Modifier
 ) {
     Column(modifier = modifier.padding(vertical = 4.dp)) {
-        // One row per endpoint, in TripEndpointSlot's declaration order (origin above destination) —
-        // the enum is the list of rows.
-        TripEndpointSlot.entries.forEachIndexed { index, slot ->
-            if (index > 0) {
-                // Inset past the rail so the hairline starts where the text does, leaving the origin
-                // and destination glyphs reading as one continuous column.
-                HairlineDivider(startIndent = RAIL_WIDTH, endIndent = 12.dp)
+        // The two endpoints and the one action that acts on the pair of them. Reverse is centred
+        // against the whole block, so it lands on the divider between the rows — beside the two fields
+        // it swaps rather than in the action bar, where it read as a property of the trip.
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Column(Modifier.weight(1f)) {
+                // One row per endpoint, in TripEndpointSlot's declaration order (origin above
+                // destination) — the enum is the list of rows.
+                TripEndpointSlot.entries.forEachIndexed { index, slot ->
+                    if (index > 0) {
+                        // Inset past the rail so the hairline starts where the text does, leaving the
+                        // origin and destination glyphs reading as one continuous column. The trailing
+                        // end stops short of the reverse button rather than running under it.
+                        HairlineDivider(startIndent = RAIL_WIDTH, endIndent = 4.dp)
+                    }
+                    EndpointRow(
+                        slot = slot,
+                        endpoint = state.endpointAt(slot),
+                        suggestions = state.suggestionsAt(slot),
+                        onQueryChange = { onQueryChange(slot, it) },
+                        onSelect = { onSelect(slot, it) },
+                        onCurrentLocation = { onCurrentLocation(slot) },
+                        onPickOnMap = { onPickOnMap(slot) }
+                    )
+                }
             }
-            EndpointRow(
-                slot = slot,
-                endpoint = state.endpointAt(slot),
-                suggestions = state.suggestionsAt(slot),
-                onQueryChange = { onQueryChange(slot, it) },
-                onSelect = { onSelect(slot, it) },
-                onCurrentLocation = { onCurrentLocation(slot) },
-                onPickOnMap = { onPickOnMap(slot) }
-            )
+            IconButton(
+                onClick = onReverse,
+                modifier = Modifier.size(40.dp).testTag(TripPlanTestTags.REVERSE)
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.ic_swap_direction),
+                    contentDescription = stringResource(R.string.tripplanner_reverse),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            // Matches the action bar's own trailing spacer, so reverse sits in the same column as the
+            // preferences button below it.
+            Spacer(Modifier.width(4.dp))
         }
         // Full-width, unlike the one above: this one separates the endpoints from the actions, rather
         // than separating two members of the same group.
@@ -227,7 +252,6 @@ fun TripPlanForm(
             onPickTime = onPickTime,
             onVehicleModeSelected = onVehicleModeSelected,
             onStreetModeSelected = onStreetModeSelected,
-            onReverse = onReverse,
             onAdvancedSettings = onAdvancedSettings
         )
     }
@@ -241,8 +265,9 @@ private fun HairlineDivider(startIndent: Dp = 0.dp, endIndent: Dp = 0.dp) {
 
 /**
  * One trip-plan endpoint: a rail glyph naming the endpoint's kind, and the place itself in a
- * borderless field. There is no pill and no trailing button, which is what lets the row run the full
- * width of the card; the actions that used to sit here are in the suggestion list and the action bar.
+ * borderless field. There is no pill and no trailing button, which is what lets the row run nearly the
+ * full width of the card; the actions that used to sit here are in the suggestion list and the action
+ * bar, and the one that acts on both endpoints is beside the pair rather than in either row.
  *
  * The row is one persistent text field in every state — a resolved endpoint is the same field showing
  * a name, not a different kind of row. That matters beyond tidiness: swapping a read-only Text in and
@@ -370,7 +395,9 @@ private fun EndpointRow(
                     }
                 }
             )
-            Spacer(Modifier.width(12.dp))
+            // Clear space between the longest place name and the reverse button beside the rows; the
+            // button's own 8dp icon inset makes up the rest of the gap.
+            Spacer(Modifier.width(4.dp))
         }
 
         // The two ways to fill an endpoint that aren't typing. They used to be permanent icon buttons on
@@ -511,11 +538,12 @@ private fun PinnedActionIcon(painter: Painter) {
 }
 
 /**
- * The bottom band: when the trip is for, plus the two actions that apply to the trip as a whole.
+ * The bottom band: when the trip is for, and how it may be travelled.
  *
  * The time reads as one sentence — "Depart · now" — split into two separately-tappable segments, each
- * opening its own menu. Reverse and additional preferences sit at the trailing edge, which is why
- * neither endpoint row needs a trailing slot at all.
+ * opening its own menu. The mode pickers and additional preferences sit at the trailing edge; reverse
+ * is not here, because it acts on the two endpoints rather than on the trip's terms, and so lives
+ * beside them (#2110).
  */
 @Composable
 private fun TripActionBar(
@@ -531,7 +559,6 @@ private fun TripActionBar(
     onPickTime: () -> Unit,
     onVehicleModeSelected: (VehicleMode) -> Unit,
     onStreetModeSelected: (StreetMode) -> Unit,
-    onReverse: () -> Unit,
     onAdvancedSettings: () -> Unit
 ) {
     Row(
@@ -590,13 +617,6 @@ private fun TripActionBar(
             testTag = TripPlanTestTags.STREET_MODE,
             onSelected = onStreetModeSelected
         )
-        IconButton(onClick = onReverse, modifier = Modifier.size(40.dp)) {
-            Icon(
-                painter = painterResource(R.drawable.ic_swap_direction),
-                contentDescription = stringResource(R.string.tripplanner_reverse),
-                tint = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-        }
         IconButton(onClick = onAdvancedSettings, modifier = Modifier.size(40.dp)) {
             Icon(
                 imageVector = AppIcons.Settings,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanForm.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanForm.kt
@@ -60,6 +60,7 @@ import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.testTag
@@ -95,10 +96,25 @@ private val ENDPOINT_DOT_SIZE = 12.dp
 private val CONNECTOR_GLYPH_CLEARANCE = 12.dp
 
 /**
- * Height of the action bar. Snug around its 40dp icon buttons; those keep a full 48dp touch target
+ * Side of every icon button in the form, at both bands. Load-bearing beyond its own size: paired with
+ * [TRAILING_GUTTER] it's what puts the reverse button in the same column as the action bar's buttons.
+ */
+private val ICON_BUTTON_SIZE = 40.dp
+
+/**
+ * Height of the action bar — snug around its icon buttons, which keep a full 48dp touch target
  * regardless, because Material expands it beyond their bounds.
  */
-private val ACTION_BAR_HEIGHT = 40.dp
+private val ACTION_BAR_HEIGHT = ICON_BUTTON_SIZE
+
+/**
+ * Gap between the card's trailing edge and the icon buttons against it. The trailing counterpart of
+ * [RAIL_WIDTH], and shared by both bands for the same reason: so their buttons line up in one column.
+ */
+private val TRAILING_GUTTER = 4.dp
+
+/** Clear space between the endpoint rows' content and the reverse button beside them. */
+private val REVERSE_CLEARANCE = 4.dp
 
 /** Rider-facing order for the two mode menus; intentionally independent of enum declaration order. */
 private val VEHICLE_MODE_ORDER = listOf(
@@ -135,8 +151,11 @@ object TripPlanTestTags {
     const val VEHICLE_MODE = "tripPlanVehicleMode"
     const val STREET_MODE = "tripPlanStreetMode"
 
-    /** The swap-endpoints button, beside the two endpoint rows rather than in the action bar. */
+    /** The swap-endpoints button. */
     const val REVERSE = "tripPlanReverse"
+
+    /** The action bar's trailing button, which reverse is column-aligned with. */
+    const val ADVANCED_SETTINGS = "tripPlanAdvancedSettings"
 }
 
 /**
@@ -197,19 +216,18 @@ fun TripPlanForm(
     modifier: Modifier = Modifier
 ) {
     Column(modifier = modifier.padding(vertical = 4.dp)) {
-        // The two endpoints and the one action that acts on the pair of them. Reverse is centred
-        // against the whole block, so it lands on the divider between the rows — beside the two fields
-        // it swaps rather than in the action bar, where it read as a property of the trip.
         Row(verticalAlignment = Alignment.CenterVertically) {
+            // The rows take the width the button doesn't, rather than running full width beneath it —
+            // which is what stops a long place name, and the divider, from sliding under the button.
+            // Centring the sibling button against the resulting block lands it on that divider.
             Column(Modifier.weight(1f)) {
                 // One row per endpoint, in TripEndpointSlot's declaration order (origin above
                 // destination) — the enum is the list of rows.
                 TripEndpointSlot.entries.forEachIndexed { index, slot ->
                     if (index > 0) {
                         // Inset past the rail so the hairline starts where the text does, leaving the
-                        // origin and destination glyphs reading as one continuous column. The trailing
-                        // end stops short of the reverse button rather than running under it.
-                        HairlineDivider(startIndent = RAIL_WIDTH, endIndent = 4.dp)
+                        // origin and destination glyphs reading as one continuous column.
+                        HairlineDivider(startIndent = RAIL_WIDTH, endIndent = REVERSE_CLEARANCE)
                     }
                     EndpointRow(
                         slot = slot,
@@ -222,19 +240,13 @@ fun TripPlanForm(
                     )
                 }
             }
-            IconButton(
+            FormIconButton(
+                painter = painterResource(R.drawable.ic_swap_direction),
+                contentDescription = stringResource(R.string.tripplanner_reverse),
                 onClick = onReverse,
-                modifier = Modifier.size(40.dp).testTag(TripPlanTestTags.REVERSE)
-            ) {
-                Icon(
-                    painter = painterResource(R.drawable.ic_swap_direction),
-                    contentDescription = stringResource(R.string.tripplanner_reverse),
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
-            // Matches the action bar's own trailing spacer, so reverse sits in the same column as the
-            // preferences button below it.
-            Spacer(Modifier.width(4.dp))
+                modifier = Modifier.testTag(TripPlanTestTags.REVERSE)
+            )
+            Spacer(Modifier.width(TRAILING_GUTTER))
         }
         // Full-width, unlike the one above: this one separates the endpoints from the actions, rather
         // than separating two members of the same group.
@@ -257,6 +269,27 @@ fun TripPlanForm(
     }
 }
 
+/**
+ * The form's one icon-button shape: fixed size, muted tint, the glyph as its own label. Shared rather
+ * than repeated, because reverse now sits in a different band from the rest — the two bands read as one
+ * set of controls only if nothing about the buttons is restated per site and free to drift.
+ */
+@Composable
+private fun FormIconButton(
+    painter: Painter,
+    contentDescription: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    IconButton(onClick = onClick, modifier = modifier.size(ICON_BUTTON_SIZE)) {
+        Icon(
+            painter = painter,
+            contentDescription = contentDescription,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
 /** A 1dp rule at the outline colour, optionally inset at either end. */
 @Composable
 private fun HairlineDivider(startIndent: Dp = 0.dp, endIndent: Dp = 0.dp) {
@@ -265,9 +298,9 @@ private fun HairlineDivider(startIndent: Dp = 0.dp, endIndent: Dp = 0.dp) {
 
 /**
  * One trip-plan endpoint: a rail glyph naming the endpoint's kind, and the place itself in a
- * borderless field. There is no pill and no trailing button, which is what lets the row run nearly the
- * full width of the card; the actions that used to sit here are in the suggestion list and the action
- * bar, and the one that acts on both endpoints is beside the pair rather than in either row.
+ * borderless field. There is no pill and no trailing button, which is what lets the row give its whole
+ * width to the place name; the actions that used to sit here are in the suggestion list and the action
+ * bar.
  *
  * The row is one persistent text field in every state — a resolved endpoint is the same field showing
  * a name, not a different kind of row. That matters beyond tidiness: swapping a read-only Text in and
@@ -395,9 +428,7 @@ private fun EndpointRow(
                     }
                 }
             )
-            // Clear space between the longest place name and the reverse button beside the rows; the
-            // button's own 8dp icon inset makes up the rest of the gap.
-            Spacer(Modifier.width(4.dp))
+            Spacer(Modifier.width(REVERSE_CLEARANCE))
         }
 
         // The two ways to fill an endpoint that aren't typing. They used to be permanent icon buttons on
@@ -617,14 +648,13 @@ private fun TripActionBar(
             testTag = TripPlanTestTags.STREET_MODE,
             onSelected = onStreetModeSelected
         )
-        IconButton(onClick = onAdvancedSettings, modifier = Modifier.size(40.dp)) {
-            Icon(
-                imageVector = AppIcons.Settings,
-                contentDescription = stringResource(R.string.trip_plan_advanced_settings),
-                tint = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-        }
-        Spacer(Modifier.width(4.dp))
+        FormIconButton(
+            painter = rememberVectorPainter(AppIcons.Settings),
+            contentDescription = stringResource(R.string.trip_plan_advanced_settings),
+            onClick = onAdvancedSettings,
+            modifier = Modifier.testTag(TripPlanTestTags.ADVANCED_SETTINGS)
+        )
+        Spacer(Modifier.width(TRAILING_GUTTER))
     }
 }
 
@@ -641,16 +671,12 @@ private fun <T> ModePicker(
     var expanded by remember { mutableStateOf(false) }
     val selectedLabel = label(selected)
     Box {
-        IconButton(
+        FormIconButton(
+            painter = painterResource(icon(selected)),
+            contentDescription = selectedLabel,
             onClick = { expanded = true },
-            modifier = Modifier.size(40.dp).testTag(testTag)
-        ) {
-            Icon(
-                painter = painterResource(icon(selected)),
-                contentDescription = selectedLabel,
-                tint = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-        }
+            modifier = Modifier.testTag(testTag)
+        )
         DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
             options.forEach { option ->
                 DropdownMenuItem(

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanForm.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanForm.kt
@@ -110,11 +110,21 @@ private val ACTION_BAR_HEIGHT = ICON_BUTTON_SIZE
 /**
  * Gap between the card's trailing edge and the icon buttons against it. The trailing counterpart of
  * [RAIL_WIDTH], and shared by both bands for the same reason: so their buttons line up in one column.
+ * Applied through [formBand] rather than by hand, so there is one gutter and not two that agree.
  */
 private val TRAILING_GUTTER = 4.dp
 
 /** Clear space between the endpoint rows' content and the reverse button beside them. */
 private val REVERSE_CLEARANCE = 4.dp
+
+/**
+ * The shape the card's two bands share: full width, inset at the trailing edge by [TRAILING_GUTTER].
+ * One expression rather than a gutter restated per band, because — paired with a single
+ * [ICON_BUTTON_SIZE] — it is the whole reason the reverse button lands in the same column as the
+ * action bar's buttons. Two bands that lay themselves out independently agree on that only if the
+ * measurement they agree on is written once.
+ */
+private fun Modifier.formBand() = fillMaxWidth().padding(end = TRAILING_GUTTER)
 
 /** Rider-facing order for the two mode menus; intentionally independent of enum declaration order. */
 private val VEHICLE_MODE_ORDER = listOf(
@@ -216,7 +226,7 @@ fun TripPlanForm(
     modifier: Modifier = Modifier
 ) {
     Column(modifier = modifier.padding(vertical = 4.dp)) {
-        Row(verticalAlignment = Alignment.CenterVertically) {
+        Row(modifier = Modifier.formBand(), verticalAlignment = Alignment.CenterVertically) {
             // The rows take the width the button doesn't, rather than running full width beneath it —
             // which is what stops a long place name, and the divider, from sliding under the button.
             // Centring the sibling button against the resulting block lands it on that divider.
@@ -246,7 +256,6 @@ fun TripPlanForm(
                 onClick = onReverse,
                 modifier = Modifier.testTag(TripPlanTestTags.REVERSE)
             )
-            Spacer(Modifier.width(TRAILING_GUTTER))
         }
         // Full-width, unlike the one above: this one separates the endpoints from the actions, rather
         // than separating two members of the same group.
@@ -593,7 +602,7 @@ private fun TripActionBar(
     onAdvancedSettings: () -> Unit
 ) {
     Row(
-        modifier = Modifier.fillMaxWidth().height(ACTION_BAR_HEIGHT),
+        modifier = Modifier.formBand().height(ACTION_BAR_HEIGHT),
         verticalAlignment = Alignment.CenterVertically
     ) {
         Box(
@@ -616,7 +625,7 @@ private fun TripActionBar(
         WhenTimeSegment(
             // The bar's one flexible slot, and the only part of it that can grow: a pinned label is a
             // full date and time, longer in other locales and at a large font scale. Taking all the
-            // remaining width does both jobs — it holds the two trailing buttons against the right
+            // remaining width does both jobs — it holds the trailing buttons against the right
             // edge, and it caps the label so it ellipsizes rather than shoving them off. The button
             // inside stays its own width at the slot's start, so the tap target doesn't span the gap.
             modifier = Modifier.weight(1f),
@@ -654,7 +663,6 @@ private fun TripActionBar(
             onClick = onAdvancedSettings,
             modifier = Modifier.testTag(TripPlanTestTags.ADVANCED_SETTINGS)
         )
-        Spacer(Modifier.width(TRAILING_GUTTER))
     }
 }
 


### PR DESCRIPTION
Closes #2110.

Reverse is the one control in the directions form that acts on the two endpoints rather than on the trip's terms, so it now sits beside them instead of at the end of the action bar: to the right of both fields, centred across the pair so it lands on the hairline between them.

### Layout

The two endpoint rows moved into a weighted `Column` inside a `Row`, with the button as that Row's sibling. The rows therefore take the width the button doesn't, rather than running full width beneath it — which is what stops a long place name, or the divider, from sliding under the button. Centring the sibling against the resulting block lands it on the divider without positioning it by hand. The divider between the entry boxes is shortened to match, per the issue.

`TripActionBar` keeps everything that qualifies the trip: when it's for, and by what modes.

### What it costs the endpoint fields

Worth stating plainly, because it's the price of the move: a place name has about 36dp less room than before. The column is 44dp narrower for the button and its gutter, and the row's own trailing spacer drops from 12dp to 4dp now that the button — not the card edge — is what the row has to clear. `BasicTextField(singleLine = true)` scroll-clips rather than ellipsizing, so a name past the width is cut rather than trailed off — that was already true, it just starts sooner. The two placeholders are untranslated (`trip_plan_from_hint` / `trip_plan_to_hint` exist only in `values/`), so they are the same English strings at every locale and still fit; what varies is geocoder output, which is data rather than a resource. The suggestion dropdown is anchored to the field and narrows with it. Not separately measured against a worst-case name — flagging it as the known cost rather than claiming it's bounded.

### Cleanup that came with it

The alignment between the two bands — reverse sitting in the same column as additional-preferences below it — was initially carried by four bare `4.dp` literals and a comment claiming they matched. That is now two named constants, `TRAILING_GUTTER` (the card's trailing edge, the counterpart of the existing `RAIL_WIDTH`) and `REVERSE_CLEARANCE`, so each pair's equality is visible in the code. `ICON_BUTTON_SIZE` replaces the three bare `40.dp` buttons and `ACTION_BAR_HEIGHT` derives from it, rather than restating the number in its KDoc. The `IconButton` + `Icon` block those three shared is extracted as `FormIconButton` — with reverse now in a different band from the rest, the two bands read as one set of controls only if nothing about the buttons is free to drift per site.

The same argument applies to the gutter, so it gets the same treatment: `Modifier.formBand()` is the shape both bands share — full width, inset at the trailing edge — written once instead of a `Spacer` restated per band over an implicit full width. (The endpoint band previously reached full width only because a weighted child forces expansion; the action bar said `fillMaxWidth()` outright. Now both say the same thing.) Geometrically identical — the gutter moves from a trailing sibling to an end inset, so the weighted children measure the same and the right edges land on the same pixel — but the invariant is now structural rather than resting entirely on the test below.

### Testing

`TripPlanFormRenderTest` gains three cases:

- reverse sits clear of both fields and is centred between the rows (compared in pixels — whole-pixel rounding is what the slack is for);
- **reverse and additional-preferences share a trailing edge.** `formBand()` now states the shared measurement, but nothing makes a band keep using it, and the two bands still lay themselves out independently — so this stays the part most able to rot. Pinning it needed a test tag on the settings button, which also replaces the test's dependence on that button's English content description;
- tapping reverse fires the reverse callback. (The form is stateless, so the swap itself is the host's; the test asserts the ask.)

The existing 146dp vertical-budget assertion is unchanged and still passes — the new Row's height is the endpoint column's, and the 40dp button fits inside it.

All 19 `TripPlanFormRenderTest` cases pass on a Pixel 7 Pro (API 36). Compiles clean under `-PwarningsAsErrors=true`, `spotlessCheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Relocated the trip-plan reverse button beside the starting and destination fields for easier access.
  * Improved alignment and spacing for reverse, travel mode, and advanced-settings controls.
  * Added clearer accessibility and test identifiers for trip-plan controls.

* **Bug Fixes**
  * Corrected trailing-edge alignment and endpoint divider spacing in the trip-plan form.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->