### PR TITLE
Fix the nightly lint failures

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStrip.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStrip.kt
@@ -282,8 +282,8 @@ private fun EtaPillWithMenu(
     liveNow: ServerTime,
     actions: ArrivalActions?,
     callbacks: ArrivalRowCallbacks,
-    routeBadge: RouteBadge? = null,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    routeBadge: RouteBadge? = null
 ) {
     var expanded by remember { mutableStateOf(false) }
     // trip.displayTime only changes on a fresh poll, but liveNow (and so this composable) recomposes

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
@@ -659,7 +659,7 @@ private fun MetricRow(
     // glyph — the height still drives its scale.
     val column = inkHeight * WIDEST_BOX_FACTOR
     Row(
-        modifier = winnerOutline(winner, outlineColor),
+        modifier = Modifier.winnerOutline(winner, outlineColor),
         horizontalArrangement = Arrangement.spacedBy(4.dp)
     ) {
         Icon(
@@ -750,17 +750,17 @@ private fun ScheduleMetric(text: String, winner: Boolean, outlineColor: Color) {
         text = text,
         style = MaterialTheme.typography.bodySmall,
         maxLines = 1,
-        modifier = winnerOutline(winner, outlineColor)
+        modifier = Modifier.winnerOutline(winner, outlineColor)
     )
 }
 
 /** Adds no layout or drawing when [winner] is false, preserving the existing ordinary metric rows. */
-private fun winnerOutline(winner: Boolean, color: Color): Modifier = if (winner) {
-    Modifier
+private fun Modifier.winnerOutline(winner: Boolean, color: Color): Modifier = if (winner) {
+    this
         .border(WINNER_OUTLINE_WIDTH, color, RoundedCornerShape(WINNER_OUTLINE_RADIUS))
         .padding(horizontal = 3.dp, vertical = 1.dp)
 } else {
-    Modifier
+    this
 }
 
 /**

--- a/onebusaway-android/src/main/res/values-es/strings.xml
+++ b/onebusaway-android/src/main/res/values-es/strings.xml
@@ -539,12 +539,6 @@
         %1$s\nModel: %2$s\nOS Version: %3$s / %4$d\n\nUnable to plan trip using URL: %5$s\n\n
     </string>
 
-    <!-- Android Maps v2 -->
-    <string name="install_google_maps_positive_button">Instalar</string>
-    <string name="please_install_google_maps_dialog_title">Por favor instala Google Maps</string>
-    <string name="no_play_store">Su dispositivio no tiene Play Store instalado. Por favor encuentra
-        otra manera de instalar Google Maps.
-    </string>
     <string name="ok">Aceptar</string>
     <string name="cancel">Cancelar</string>
     <string name="hide_all">Ocultar todo</string>

--- a/onebusaway-android/src/main/res/values-fi/strings.xml
+++ b/onebusaway-android/src/main/res/values-fi/strings.xml
@@ -438,12 +438,6 @@
     <string name="bug_report_body_trip_plan_without_location_fail">Valitukset, kehut tai virheraportit ovat tervetulleita!\n\n\nSovellusversio: %1$s\nMalli: %2$s\nKäyttöjärjestelmäversio: %3$s / %4$d\n\nMatkan suunnittelu epäonnistui URL-osoitteella: %5$s\n\n</string>
     <string name="custom_otp_api_url_error">Virheellinen URL. Anna toimiva OpenTripPlanner-palvelin.</string>
 
-    <!-- Android Maps v2 -->
-    <string name="install_google_maps_positive_button">Asenna</string>
-    <string name="please_install_google_maps_dialog_title">Ole hyvä ja asenna Google Maps.</string>
-    <string name="no_play_store">Laitteellasi ei ole Play Store asennettu. Valitettavasti joudut
-        keksimään toisen tavan asentaa Google Maps.
-    </string>
     <string name="ok">OK</string>
     <string name="cancel">Peruuta</string>
     <string name="no_thanks">Ei kiitos</string>

--- a/onebusaway-android/src/main/res/values-it/strings.xml
+++ b/onebusaway-android/src/main/res/values-it/strings.xml
@@ -419,10 +419,6 @@
     <string name="bug_report_body_trip_plan_without_location">Ti invitiamo a scriverci per reclami, apprezzamenti, e segnalazioni di bug!\n\n\nVersione app: %1$s\nModello: %2$s\nVersione SO: %3$s / %4$d\n\nPianificare il viaggio utilizzando l’URL: %5$s\n\n</string>
     <string name="bug_report_body_trip_plan_without_location_fail">Ti invitiamo a scriverci per reclami, apprezzamenti, e segnalazioni di bug!\n\n\nVersione app: %1$s\nModello: %2$s\nVersione SO: %3$s / %4$d\n\nImpossibile pianificare il viaggio utilizzando l’URL: %5$s\n\n</string>
 
-    <!-- Android Maps v2 -->
-    <string name="install_google_maps_positive_button">Installa</string>
-    <string name="please_install_google_maps_dialog_title">Installa Google Maps</string>
-    <string name="no_play_store">L’App Play Store non è installata su questo dispositivo. Trova un metodo alternativo per installare Google Maps.</string>
     <string name="ok">OK</string>
 
     <!-- Application Preferences -->

--- a/onebusaway-android/src/main/res/values-pl/strings.xml
+++ b/onebusaway-android/src/main/res/values-pl/strings.xml
@@ -480,11 +480,6 @@
         %1$s\nModel: %2$s\nWersja OS: %3$s / %4$d\n\nNie udało się zaplanować podróży przy użyciu URL: %5$s\n\n
     </string>
 
-    <!-- Android Maps v2 -->
-    <string name="install_google_maps_positive_button">Instaluj</string>
-    <string name="please_install_google_maps_dialog_title">Zainstaluj Google Maps</string>
-    <string name="no_play_store">Twoje urządzenie nie ma zainstalowanego Sklepu Google Play. Znajdź inny sposób by zainstalować Google Maps.
-    </string>
     <string name="ok">OK</string>
 
     <!-- Application Preferences -->

--- a/onebusaway-android/src/main/res/values/donottranslate.xml
+++ b/onebusaway-android/src/main/res/values/donottranslate.xml
@@ -19,7 +19,6 @@
 
     <!-- Android Maps API v2 -->
     <string name="apiv2_key">AIzaSyBxVM57hZ2WLRgtixDs_G5BGbK90mM5S5U</string>
-    <string name="android_maps_v2_market_url">market://details?id=com.google.android.apps.maps</string>
 
     <!-- Preference keys -->
     <string name="preference_key_region">preference_region</string>

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -605,12 +605,6 @@
         %1$s\nModel: %2$s\nOS Version: %3$s / %4$d\n\nUnable to plan trip using URL: %5$s\n\n
     </string>
 
-    <!-- Android Maps v2 -->
-    <string name="install_google_maps_positive_button">Install</string>
-    <string name="please_install_google_maps_dialog_title">Please install Google Maps</string>
-    <string name="no_play_store">Your device doesn’t have the Play Store installed. Please find
-        another way to install Google Maps.
-    </string>
     <string name="ok">OK</string>
 
     <!-- Application Preferences -->
@@ -1238,13 +1232,11 @@
     <!-- Mode selection, split into two independent questions: which vehicles the rider will board,
          and how they cover the street portions. Not every street option is offered everywhere -
          bikeshare needs a rental network, and carrying your own bike needs an OTP2 region. -->
-    <string name="vehicle_mode_label">Ride</string>
     <string name="vehicle_mode_all_transit">Any transit</string>
     <string name="vehicle_mode_bus">Bus only</string>
     <string name="vehicle_mode_rail">Rail only</string>
     <string name="vehicle_mode_none">No transit</string>
 
-    <string name="street_mode_label">Getting around</string>
     <string name="street_mode_walk">Walk</string>
     <string name="street_mode_walk_and_bikeshare">Walk &amp; bikeshare</string>
     <string name="street_mode_bicycle">My own bike</string>


### PR DESCRIPTION
The nightly `lint` job ([run 30614780266](https://github.com/OneBusAway/onebusaway-android/actions/runs/30614780266)) failed with 5 errors. Three more had landed on `main` since that run and would have failed tonight's, so this fixes all 8.

Android Lint doesn't run on the PR/push path — it's heavyweight (~7–15 min), so `android.yml` passes `-x lint` and the nightly `lint` job owns it. That means findings like these are invisible until the nightly.

## Compose lint

- **`ModifierFactoryExtensionFunction`** (`TripResultsScreen.kt`) — `winnerOutline` was a plain factory function returning a `Modifier`. Made it an extension on `Modifier` returning `this` in both branches, so a caller's modifier chains through rather than being silently dropped. Both call sites now read `Modifier.winnerOutline(...)`.
- **`ModifierParameter`** (`EtaStrip.kt`) — `modifier` moved ahead of `routeBadge` so it's the first optional parameter of `EtaPillWithMenu`. Its one call site passes named arguments, so behaviour is unchanged.

## `UnusedResources`

Six strings whose only consumer had been deleted. Each was confirmed dead by `git grep` at the removing commit's parent, rather than trusting the report alone:

- `android_maps_v2_market_url`, `install_google_maps_positive_button`, `please_install_google_maps_dialog_title`, `no_play_store` — orphaned by #2061 ("Eliminate remaining Java sources"), which deleted `ProprietaryMapHelpV2.kt`, their sole consumer. Removed from `values/` plus the `es`/`it`/`pl`/`fi` translations and the emptied `<!-- Android Maps v2 -->` section headers.
- `vehicle_mode_label`, `street_mode_label` — orphaned by #2109 ("Move trip mode selection into action bar"), which dropped the two mode-picker section headers. `DirectionsFeature.kt` was the sole consumer; neither string had translations.

The sibling `vehicle_mode_*` / `street_mode_*` option strings are still in use — only the two section labels went.

## Verification

`./gradlew :onebusaway-android:lintObaGoogleDebug spotlessCheck -PwarningsAsErrors=true` → `BUILD SUCCESSFUL`, run locally against this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)