### PR TITLE
Bound directions vehicle eligibility per route shape variant

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteSegmentHighlight.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteSegmentHighlight.kt
@@ -75,6 +75,11 @@ internal fun routePolylinesWithSegment(
  * a variant that never touches the boarding point isn't an approach to it and is dropped. When the
  * boarding point is off every variant (a leg-geometry mismatch), the single nearest variant is clipped
  * so the approach still draws.
+ *
+ * Variants that diverge only *after* the boarding point clip to the same approach, so the result is
+ * de-duplicated: the shared trunk is drawn (and cased) once, not once per variant. That only catches
+ * exactly-equal geometry — variants encoding the same street with different vertex sampling stay
+ * distinct and still draw over each other.
  */
 internal fun List<RoutePolyline>.upstreamTo(anchor: GeoPoint?): List<RoutePolyline> {
     anchor ?: return this
@@ -86,6 +91,7 @@ internal fun List<RoutePolyline>.upstreamTo(anchor: GeoPoint?): List<RoutePolyli
                 ?.takeIf { it.isDrawableSegment() && it.first() != it.last() }
                 ?.let { line.copy(points = it) }
         }
+        .distinct()
 }
 
 /** A route line whose eligible travel ends at [maxDistanceAlong]. */
@@ -104,6 +110,20 @@ internal data class BoundedRoutePath(
  * off every variant — the ride continues onto a later stay-aboard route, or the leg geometry doesn't
  * match this route's shape — there is no meaningful bound, and the whole shape stays eligible rather
  * than guessing one.
+ *
+ * That last fallback is deliberately the opposite of [upstreamTo]'s, which narrows to the single nearest
+ * variant. The two answer different questions about the same mismatched anchor: a mismatch must not
+ * multiply the *drawn* approach, and it must not drop a vehicle that is genuinely on the ride. So one
+ * degrades restrictively and the other permissively, on purpose.
+ *
+ * The receiver may be the whole-route **merged** shape rather than a direction's own, since
+ * `RouteMap.shapeForDirection` falls back to it for a direction that carried no shape on the wire. That
+ * set holds both directions, so the alighting point also sits within tolerance of the reverse-direction
+ * shape, which then becomes an eligible path bounded in the *opposite* travel order — a geographically
+ * downstream vehicle projects upstream on it and survives. Ordinarily the poll is already narrowed by
+ * trip `directionId` before this filter runs, so those vehicles never reach here; a stay-aboard
+ * interline composite deliberately drops that direction filter (#2000) and is the case where the
+ * geometry alone would have to exclude them, and can't.
  */
 internal fun List<RoutePolyline>.boundedThrough(anchor: GeoPoint): List<BoundedRoutePath> {
     val projections = variantProjections(anchor)
@@ -112,7 +132,10 @@ internal fun List<RoutePolyline>.boundedThrough(anchor: GeoPoint): List<BoundedR
         .ifEmpty { projections.map { BoundedRoutePath(it.path, Double.POSITIVE_INFINITY) } }
 }
 
-/** Whether [point] is near one of these paths without exceeding its along-route boundary. */
+/** Whether [point] is near one of these paths without exceeding its along-route boundary.
+ *  Runs on the 20 Hz vehicle sampler for every vehicle, and each path costs a full projection —
+ *  a rejected (downstream) vehicle pays all of them, since [any] can only short-circuit a match.
+ *  See #2124 for pre-rejecting on a bounding box or hoisting the verdict off the frame loop. */
 internal fun List<BoundedRoutePath>.containsRoutePoint(
     point: GeoPoint,
     toleranceMeters: Double = SEGMENT_STOP_TOLERANCE_METERS

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteSegmentHighlight.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteSegmentHighlight.kt
@@ -33,6 +33,11 @@ import org.onebusaway.android.util.haversineDistance
  *  spacing, so the nearest off-segment stop is never wrongly included. */
 const val SEGMENT_STOP_TOLERANCE_METERS = 50.0
 
+/** How close a board/alight anchor must sit to a direction shape variant to count as travelling that
+ *  variant ([upstreamTo], [boundedThrough]). Same 50 m drift class as [SEGMENT_STOP_TOLERANCE_METERS],
+ *  but its own knob: retuning stop inclusion must not silently retune variant applicability. */
+const val VARIANT_MATCH_TOLERANCE_METERS = 50.0
+
 /** A ridden segment worth drawing/framing: a polyline needs at least two points. Below that it's the
  *  "no segment" case — plain route focus (whole route drawn/framed, all stops kept). */
 internal fun List<GeoPoint>.isDrawableSegment() = size >= 2
@@ -62,15 +67,25 @@ internal fun routePolylinesWithSegment(
     return base.asSelectedRouteApproach() + itineraryContext + overlay
 }
 
-/** Keep a direction's travel-ordered geometry only through [anchor], including a clipped final line. */
+/**
+ * Keep a direction's geometry only through [anchor], the boarding point. Each receiver entry is an
+ * independent shape **variant** of the direction — stops-for-route supplies one complete travel-ordered
+ * polyline per distinct trip shape (see `RouteMap.polylinesByDirection`), never consecutive fragments of
+ * one line (#2104). Every variant the boarding point sits on is clipped at its own boarding projection;
+ * a variant that never touches the boarding point isn't an approach to it and is dropped. When the
+ * boarding point is off every variant (a leg-geometry mismatch), the single nearest variant is clipped
+ * so the approach still draws.
+ */
 internal fun List<RoutePolyline>.upstreamTo(anchor: GeoPoint?): List<RoutePolyline> {
     anchor ?: return this
-    val (matchIndex, line, projection) = closestProjection(anchor) ?: return emptyList()
-    val clipped = Polyline(line.points)
-        .subPolyline(0.0, projection.distanceAlong)
-        ?.takeIf { it.size >= 2 && it.first() != it.last() }
-        ?.let { line.copy(points = it) }
-    return take(matchIndex) + listOfNotNull(clipped)
+    val projections = variantProjections(anchor)
+    return projections.travelledVariants()
+        .ifEmpty { listOfNotNull(projections.minByOrNull { it.projection.distanceToPoint }) }
+        .mapNotNull { (line, path, projection) ->
+            path.subPolyline(0.0, projection.distanceAlong)
+                ?.takeIf { it.isDrawableSegment() && it.first() != it.last() }
+                ?.let { line.copy(points = it) }
+        }
 }
 
 /** A route line whose eligible travel ends at [maxDistanceAlong]. */
@@ -79,11 +94,22 @@ internal data class BoundedRoutePath(
     val maxDistanceAlong: Double
 )
 
-/** Preserve full geometry for projection while bounding travel at [anchor]. */
+/**
+ * Preserve full geometry for projection while bounding travel at [anchor], the alighting point. As in
+ * [upstreamTo], each receiver entry is an independent shape variant, so every variant the alighting
+ * point sits on becomes its own eligible path bounded at its own alight projection — a vehicle upstream
+ * on *any* variant serving the alighting point stays eligible, while a vehicle past the alighting point
+ * is beyond the bound of every variant it rides and drops out (#2104). A variant that never touches the
+ * alighting point can't carry a rider there, so it forms no eligible path. When the alighting point is
+ * off every variant — the ride continues onto a later stay-aboard route, or the leg geometry doesn't
+ * match this route's shape — there is no meaningful bound, and the whole shape stays eligible rather
+ * than guessing one.
+ */
 internal fun List<RoutePolyline>.boundedThrough(anchor: GeoPoint): List<BoundedRoutePath> {
-    val (matchIndex, _, projection) = closestProjection(anchor) ?: return emptyList()
-    return take(matchIndex).map { BoundedRoutePath(Polyline(it.points), Double.POSITIVE_INFINITY) } +
-        BoundedRoutePath(Polyline(get(matchIndex).points), projection.distanceAlong)
+    val projections = variantProjections(anchor)
+    return projections.travelledVariants()
+        .map { BoundedRoutePath(it.path, it.projection.distanceAlong) }
+        .ifEmpty { projections.map { BoundedRoutePath(it.path, Double.POSITIVE_INFINITY) } }
 }
 
 /** Whether [point] is near one of these paths without exceeding its along-route boundary. */
@@ -99,10 +125,10 @@ internal fun List<BoundedRoutePath>.containsRoutePoint(
 /**
  * Whether a route-focus vehicle survives the selected leg's spatial filter. The explicitly requested
  * ETA-pill trip ([focusedTripId]) always survives: its pin is derived from the arrivals response's
- * exact active-trip + GPS identity, while the eligible path is reconstructed independently from
- * route-wide geometry and can miss a legitimate trip variant. Without this exception the route poll
- * can contain the tapped vehicle yet discard it before [RouteMapController] gets the chance to frame
- * it.
+ * exact active-trip + GPS identity, while the eligible paths are reconstructed independently from
+ * route-wide geometry and can still miss it when the planned leg's geometry doesn't match the route
+ * shape. Without this exception the route poll can contain the tapped vehicle yet discard it before
+ * [RouteMapController] gets the chance to frame it.
  *
  * [focusedTripId] must be the trip's exemption for the whole focus context, not the one-shot pending
  * camera fit: this filter re-runs on every vehicle sample, so keying it to a focus that resolves
@@ -116,11 +142,23 @@ internal fun focusedRideKeepsVehicle(
 ): Boolean = (vehicleTripId != null && vehicleTripId == focusedTripId) ||
     eligiblePaths.containsRoutePoint(point)
 
-private fun List<RoutePolyline>.closestProjection(anchor: GeoPoint) = mapIndexedNotNull { index, line ->
-    val projection = Polyline(line.points).nearestProjection(anchor.latitude, anchor.longitude)
-        ?: return@mapIndexedNotNull null
-    Triple(index, line, projection)
-}.minByOrNull { (_, _, projection) -> projection.distanceToPoint }
+private data class VariantProjection(
+    val line: RoutePolyline,
+    val path: Polyline,
+    val projection: Polyline.Projection
+)
+
+/** Every variant paired with its nearest-[anchor] projection (a variant with no geometry drops out).
+ *  Built once per call so the O(n) [Polyline] construction is shared by the tolerance filter, the
+ *  callers' fallbacks, and the clip/bound they produce. */
+private fun List<RoutePolyline>.variantProjections(anchor: GeoPoint): List<VariantProjection> = mapNotNull { line ->
+    val path = Polyline(line.points)
+    path.nearestProjection(anchor.latitude, anchor.longitude)
+        ?.let { VariantProjection(line, path, it) }
+}
+
+/** The variants the anchor actually travels: those it sits on within [VARIANT_MATCH_TOLERANCE_METERS]. */
+private fun List<VariantProjection>.travelledVariants(): List<VariantProjection> = filter { it.projection.distanceToPoint <= VARIANT_MATCH_TOLERANCE_METERS }
 
 /**
  * Keep only the stops within [toleranceMeters] of [segment]'s path — the ride's stops, not the whole

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteSegmentHighlightTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteSegmentHighlightTest.kt
@@ -15,6 +15,7 @@
  */
 package org.onebusaway.android.map
 
+import kotlin.math.cos
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
@@ -28,6 +29,7 @@ import org.onebusaway.android.map.render.ITINERARY_RIDE_WIDTH_PROFILE
 import org.onebusaway.android.map.render.RouteLineCase
 import org.onebusaway.android.map.render.RouteLineDash
 import org.onebusaway.android.map.render.RoutePolyline
+import org.onebusaway.android.util.EARTH_RADIUS_METERS
 import org.onebusaway.android.util.GeoPoint
 
 /** JVM tests for the pure trip-plan-leg segment highlighting helpers ([onSegment], [routePolylinesWithSegment]). */
@@ -37,6 +39,17 @@ class RouteSegmentHighlightTest {
     private val segment = listOf(GeoPoint(47.60, -122.33), GeoPoint(47.62, -122.33))
 
     private fun stop(id: String, lat: Double, lon: Double) = ObaStopElement(id = id, lat = lat, lon = lon)
+
+    /**
+     * A point [meters] due east of ([lat], [lon]), so a tolerance test can state the distance it means
+     * instead of hiding it in a magic decimal. Uses the same earth radius as the haversine helper the
+     * filter measures with; at these distances the parallel and the great circle through the two points
+     * diverge far below a millimetre, so the offset a test asks for is the distance the filter sees.
+     */
+    private fun eastOf(lat: Double, lon: Double, meters: Double) = GeoPoint(
+        lat,
+        lon + Math.toDegrees(meters / (EARTH_RADIUS_METERS * cos(Math.toRadians(lat))))
+    )
 
     @Test
     fun onSegment_keepsStopsOnThePath_dropsFarOnes() {
@@ -120,10 +133,16 @@ class RouteSegmentHighlightTest {
     @Test
     fun upstreamTo_clipsEveryVariantAtTheBoardingPoint_dropsVariantsThatNeverReachIt() {
         val trunk = RoutePolyline(color = 1, points = listOf(GeoPoint(47.58, -122.33), GeoPoint(47.66, -122.33)))
-        // Same street through the boarding point, then branching east — a second valid approach variant.
+        // Reaches the boarding point up a western street instead, then branches east — a second valid
+        // approach variant, and a different one (a variant sharing the trunk's approach would dedupe).
         val branch = RoutePolyline(
             color = 1,
-            points = listOf(GeoPoint(47.58, -122.33), GeoPoint(47.62, -122.33), GeoPoint(47.62, -122.31))
+            points = listOf(
+                GeoPoint(47.58, -122.36),
+                GeoPoint(47.62, -122.36),
+                GeoPoint(47.62, -122.33),
+                GeoPoint(47.62, -122.31)
+            )
         )
         // Short-turn variant ending ~2 km before the boarding point: not an approach to it.
         val shortTurn = RoutePolyline(color = 1, points = listOf(GeoPoint(47.58, -122.33), GeoPoint(47.60, -122.33)))
@@ -148,6 +167,25 @@ class RouteSegmentHighlightTest {
         assertEquals(1, upstream.size)
         assertEquals(47.62, upstream.single().points.last().latitude, 0.001)
         assertEquals(-122.33, upstream.single().points.last().longitude, 0.000001)
+    }
+
+    @Test
+    fun upstreamTo_variantsSharingTheApproach_drawTheTrunkOnce() {
+        // Two variants that run the same street to the boarding point and only diverge after it: their
+        // clipped approaches are the same line, and the trunk must not be drawn (and cased) twice.
+        val north = RoutePolyline(
+            color = 1,
+            points = listOf(GeoPoint(47.58, -122.33), GeoPoint(47.62, -122.33), GeoPoint(47.66, -122.33))
+        )
+        val east = RoutePolyline(
+            color = 1,
+            points = listOf(GeoPoint(47.58, -122.33), GeoPoint(47.62, -122.33), GeoPoint(47.62, -122.31))
+        )
+
+        val upstream = listOf(north, east).upstreamTo(GeoPoint(47.62, -122.33))
+
+        assertEquals(1, upstream.size)
+        assertEquals(listOf(GeoPoint(47.58, -122.33), GeoPoint(47.62, -122.33)), upstream.single().points)
     }
 
     @Test
@@ -187,6 +225,35 @@ class RouteSegmentHighlightTest {
         assertFalse(eligible.containsRoutePoint(GeoPoint(47.65, -122.33)))
         // Nowhere near any variant.
         assertFalse(eligible.containsRoutePoint(GeoPoint(47.64, -122.36)))
+    }
+
+    @Test
+    fun boundedThrough_variantNotReachingTheAlightingPoint_formsNoEligiblePath() {
+        // A variant that can't carry a rider to the alighting point contributes no eligible path, so a
+        // vehicle on the stretch only that variant serves is filtered out.
+        val through = RoutePolyline(color = 1, points = listOf(GeoPoint(47.58, -122.33), GeoPoint(47.66, -122.33)))
+        val shortTurn = RoutePolyline(color = 1, points = listOf(GeoPoint(47.58, -122.33), GeoPoint(47.60, -122.36)))
+
+        val eligible = listOf(through, shortTurn).boundedThrough(GeoPoint(47.64, -122.33))
+
+        // Mid-way along the short-turn's own spur, and nowhere near the through variant.
+        assertFalse(eligible.containsRoutePoint(GeoPoint(47.59, -122.345)))
+        // Not vacuous: the variant that does reach the alighting point still carries its upstream vehicles.
+        assertTrue(eligible.containsRoutePoint(GeoPoint(47.60, -122.33)))
+    }
+
+    @Test
+    fun boundedThrough_variantMatch_isPinnedToBothSidesOfTheTolerance() {
+        val route = listOf(RoutePolyline(color = 1, points = listOf(GeoPoint(47.58, -122.33), GeoPoint(47.66, -122.33))))
+        val downstream = GeoPoint(47.65, -122.33)
+
+        // Inside the tolerance the anchor travels the variant, so it bounds it and downstream is excluded.
+        val matched = route.boundedThrough(eastOf(47.64, -122.33, VARIANT_MATCH_TOLERANCE_METERS - 5))
+        assertFalse(matched.containsRoutePoint(downstream))
+
+        // Just outside it the anchor travels nothing, so the fallback leaves the whole shape eligible.
+        val unmatched = route.boundedThrough(eastOf(47.64, -122.33, VARIANT_MATCH_TOLERANCE_METERS + 5))
+        assertTrue(unmatched.containsRoutePoint(downstream))
     }
 
     @Test

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteSegmentHighlightTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteSegmentHighlightTest.kt
@@ -118,16 +118,36 @@ class RouteSegmentHighlightTest {
     }
 
     @Test
-    fun upstreamTo_keepsOnlyTheApproachThroughTheBoardingPoint() {
-        val first = RoutePolyline(color = 1, points = listOf(GeoPoint(47.58, -122.33), GeoPoint(47.60, -122.33)))
-        val second = RoutePolyline(color = 1, points = listOf(GeoPoint(47.60, -122.33), GeoPoint(47.64, -122.33)))
+    fun upstreamTo_clipsEveryVariantAtTheBoardingPoint_dropsVariantsThatNeverReachIt() {
+        val trunk = RoutePolyline(color = 1, points = listOf(GeoPoint(47.58, -122.33), GeoPoint(47.66, -122.33)))
+        // Same street through the boarding point, then branching east — a second valid approach variant.
+        val branch = RoutePolyline(
+            color = 1,
+            points = listOf(GeoPoint(47.58, -122.33), GeoPoint(47.62, -122.33), GeoPoint(47.62, -122.31))
+        )
+        // Short-turn variant ending ~2 km before the boarding point: not an approach to it.
+        val shortTurn = RoutePolyline(color = 1, points = listOf(GeoPoint(47.58, -122.33), GeoPoint(47.60, -122.33)))
 
-        val upstream = listOf(first, second).upstreamTo(GeoPoint(47.62, -122.33))
+        val upstream = listOf(trunk, branch, shortTurn).upstreamTo(GeoPoint(47.62, -122.33))
 
         assertEquals(2, upstream.size)
-        assertEquals(first, upstream.first())
-        assertEquals(47.62, upstream.last().points.last().latitude, 0.000001)
-        assertFalse(upstream.last().points.any { it.latitude > 47.62 })
+        upstream.forEach { line ->
+            assertEquals(47.62, line.points.last().latitude, 0.000001)
+            assertFalse(line.points.any { it.latitude > 47.62 || it.longitude > -122.33 })
+        }
+    }
+
+    @Test
+    fun upstreamTo_boardingPointOffEveryVariant_stillClipsTheNearestOne() {
+        val near = RoutePolyline(color = 1, points = listOf(GeoPoint(47.58, -122.33), GeoPoint(47.66, -122.33)))
+        val far = RoutePolyline(color = 1, points = listOf(GeoPoint(47.58, -122.43), GeoPoint(47.66, -122.43)))
+
+        // ~150 m east of the near variant — off both, but the approach should still draw.
+        val upstream = listOf(near, far).upstreamTo(GeoPoint(47.62, -122.328))
+
+        assertEquals(1, upstream.size)
+        assertEquals(47.62, upstream.single().points.last().latitude, 0.001)
+        assertEquals(-122.33, upstream.single().points.last().longitude, 0.000001)
     }
 
     @Test
@@ -144,6 +164,40 @@ class RouteSegmentHighlightTest {
         assertTrue(throughSelectedLeg.containsRoutePoint(GeoPoint(47.63, -122.33))) // selected leg
         // Only ~11 m beyond alighting: spatial tolerance alone must not leak this downstream vehicle.
         assertFalse(throughSelectedLeg.containsRoutePoint(GeoPoint(47.6401, -122.33)))
+    }
+
+    @Test
+    fun boundedThrough_multiVariantDirection_keepsUpstreamVehicleOnAnotherVariant() {
+        // One direction, two shape variants sharing a trunk through the alighting point (#2104): the
+        // through variant, and a variant approaching the trunk on a western spur before joining it.
+        val through = RoutePolyline(color = 1, points = listOf(GeoPoint(47.58, -122.33), GeoPoint(47.66, -122.33)))
+        val western = RoutePolyline(
+            color = 1,
+            points = listOf(GeoPoint(47.60, -122.36), GeoPoint(47.60, -122.33), GeoPoint(47.66, -122.33))
+        )
+
+        val eligible = listOf(through, western).boundedThrough(GeoPoint(47.64, -122.33))
+
+        // An active vehicle on the western variant's own spur is upstream of the alighting point and
+        // must stay eligible — it must not be discarded as if the variants were consecutive fragments.
+        assertTrue(eligible.containsRoutePoint(GeoPoint(47.60, -122.35)))
+        // The shared trunk upstream of alighting stays eligible too.
+        assertTrue(eligible.containsRoutePoint(GeoPoint(47.61, -122.33)))
+        // Past the alighting point on the trunk: downstream on every variant, so still excluded.
+        assertFalse(eligible.containsRoutePoint(GeoPoint(47.65, -122.33)))
+        // Nowhere near any variant.
+        assertFalse(eligible.containsRoutePoint(GeoPoint(47.64, -122.36)))
+    }
+
+    @Test
+    fun boundedThrough_alightingBeyondEveryVariant_keepsTheWholeShapeEligible() {
+        // A stay-aboard interline alights on a later route: this route's whole direction is upstream.
+        val route = listOf(RoutePolyline(color = 1, points = listOf(GeoPoint(47.58, -122.33), GeoPoint(47.62, -122.33))))
+
+        val eligible = route.boundedThrough(GeoPoint(47.70, -122.33))
+
+        assertTrue(eligible.containsRoutePoint(GeoPoint(47.60, -122.33)))
+        assertTrue(eligible.containsRoutePoint(GeoPoint(47.62, -122.33))) // even the shape's very end
     }
 
     @Test


### PR DESCRIPTION
Fixes #2104.

## Problem

When route focus is entered from a directions ETA pill, the selected-leg vehicle filter could drop a valid upstream vehicle whenever the route direction carries multiple polyline variants. `boundedThrough()` treated the direction's `List<RoutePolyline>` as consecutive, travel-ordered fragments of one line: it bounded only the variant nearest the alighting point, kept earlier list entries wholesale, and silently dropped later ones. But the stops-for-route wire model (`RouteMap.polylinesByDirection`, built in `StopsForRouteRepository`) supplies one complete travel-ordered polyline per distinct trip shape — independent variants in arbitrary order. A vehicle actively serving the tapped trip on another variant could land on a dropped entry and vanish from `focusedVehiclePathsByRoute`, making a pin-marked ETA-pill tap do nothing (route 2 repro in the issue).

## Fix

`RouteSegmentHighlight.kt` now models each entry as an independent shape variant:

- **`boundedThrough()`** gives every variant the alighting point sits on its own eligible path, bounded at its own alight projection. Upstream vehicles on *any* serving variant stay eligible; a downstream vehicle is past the bound on every variant it rides, so it's still excluded. A variant that never touches the alighting point forms no eligible path.
- When the alighting point is off **every** variant — a stay-aboard interline that alights on a later route, or a leg-geometry mismatch — the whole shape stays eligible instead of guessing a bound. (This also removes a bogus nearest-point bound the old code produced for interline leader routes.)
- **`upstreamTo()`** (the drawn approach) had the identical fragments assumption and gets the same variant model: each variant through the boarding point is clipped there; variants that never reach it are dropped; an off-every-variant boarding point falls back to clipping the single nearest variant so the approach still draws.
- The exact-trip exemption from #2099 stays as the identity backstop for genuine geometry mismatches.

Both helpers share one projection pass (`variantProjections` / `travelledVariants`), so each variant's `Polyline` is built once per call.

## ⚠️ Human sign-off: variant-match tolerance

Deciding whether a board/alight anchor "travels" a shape variant uses a new named 50 m constant, `VARIANT_MATCH_TOLERANCE_METERS` — the same drift class as the existing `SEGMENT_STOP_TOLERANCE_METERS` (the #1961 sign-off item), but a separate knob so retuning stop inclusion can't silently retune variant applicability. There is no exact source linking an OTP planned leg to OBA shape variants, so a geometric match is unavoidable here; the failure mode (anchor off every variant) deliberately degrades to *permissive* (whole shape eligible) rather than dropping vehicles, and exact trip identity still bypasses geometry entirely.

## Visual note for on-device review

`upstreamTo()`'s approach drawing changes on multi-variant routes: previously the variants drawn whole vs dropped depended on arbitrary wire order; now every variant serving the boarding point draws its own clipped approach, and variants that never reach it don't draw. Worth an on-device look alongside the ETA-pill tap repro.

## Tests

`RouteSegmentHighlightTest` covers the issue's matrix: a multi-variant direction where the anchor sits on the trunk, an upstream vehicle on the other variant's own spur (kept), a downstream vehicle (still excluded), an off-route point (excluded), the whole-shape-eligible fallback, and both `upstreamTo` behaviors. Full obaGoogle unit suite passes; compiled with `-PwarningsAsErrors=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)