### PR TITLE
Split vehicle polling and stop focus out of RouteMapController

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/FocusedTripRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/FocusedTripRepository.kt
@@ -46,12 +46,22 @@ data class FocusedTripShape(
     val routeDirection: RouteDirectionKey get() = RouteDirectionKey(routeId, directionId)
 }
 
-data class FocusedTripGeometry(val shapes: List<FocusedTripShape>)
+data class FocusedTripGeometry(val shapes: List<FocusedTripShape>) {
+    companion object {
+        /** No geometry — the pre-load state, and what a failed load falls back to. */
+        val EMPTY = FocusedTripGeometry(emptyList())
+    }
+}
 
 data class FocusedTripStops(
     val stopIdsByTripId: Map<String, List<String>>,
     val stopsById: Map<String, ObaStop>
-)
+) {
+    companion object {
+        /** No stops — the pre-load state, and what a failed load falls back to. */
+        val EMPTY = FocusedTripStops(emptyMap(), emptyMap())
+    }
+}
 
 /** Exact shape and scheduled-stop pass-throughs for the trips displayed at a focused stop. */
 interface FocusedTripRepository {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapDecisions.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapDecisions.kt
@@ -21,6 +21,7 @@ import java.util.concurrent.TimeUnit
 import org.onebusaway.android.map.render.CameraSnapshot
 import org.onebusaway.android.map.render.StopMarker
 import org.onebusaway.android.map.render.haversineMeters
+import org.onebusaway.android.time.ElapsedTime
 import org.onebusaway.android.util.GeoPoint
 import org.onebusaway.android.util.PreferenceUtils
 
@@ -73,18 +74,18 @@ internal val VEHICLE_REFRESH_PERIOD_MS = TimeUnit.SECONDS.toMillis(10)
 
 /**
  * The delay before the next vehicle refresh when (re)starting the poll — e.g. on resume. So resuming
- * mid-period waits only the remainder. Pure and unit-tested; [lastUpdated]/[now] are nanosecond
- * timestamps (`SystemClock.elapsedRealtimeNanos()`).
+ * mid-period waits only the remainder. Pure and unit-tested; both readings are on the monotonic clock
+ * ([ElapsedTime]), the only one that measures a real interval across a backgrounded map.
  *
- *  - never loaded ([lastUpdated] == 0) → a full period
+ *  - never loaded ([lastUpdated] == null) → a full period
  *  - already overdue → a near-immediate refresh (100 ms)
  *  - otherwise → the remaining time in the current period
  */
-internal fun nextVehicleDelay(lastUpdated: Long, now: Long): Long {
-    if (lastUpdated == 0L) {
+internal fun nextVehicleDelay(lastUpdated: ElapsedTime?, now: ElapsedTime): Long {
+    if (lastUpdated == null) {
         return VEHICLE_REFRESH_PERIOD_MS
     }
-    val elapsedMillis = TimeUnit.NANOSECONDS.toMillis(now - lastUpdated)
+    val elapsedMillis = (now - lastUpdated).inWholeMilliseconds
     return if (elapsedMillis > VEHICLE_REFRESH_PERIOD_MS) {
         100L
     } else {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
@@ -15,20 +15,16 @@
  */
 package org.onebusaway.android.map
 
-import android.os.SystemClock
 import java.net.HttpURLConnection
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.supervisorScope
 import org.onebusaway.android.extrapolation.ExtrapolatedVehicle
@@ -68,10 +64,15 @@ import org.onebusaway.android.util.toGeoPoint
  *
  * [routeId] is the single source of truth for "the map is in route mode"; there is no separate mode flag.
  *
- * **Vehicles.** A background job polls trips-for-route on a fixed cadence and stashes each response. The
- * controller installs a per-frame sampler in [MapHost.renderState] that the renderer pulls each display
- * frame to dead-reckon every vehicle forward to the frame's clock — so vehicles glide smoothly between
- * the comparatively slow polls. The poll is suspended and resumed with the map via [onPause]/[onResume].
+ * **Vehicles.** [RouteVehiclePoller] keeps a fresh trips-for-route response coming on a fixed cadence;
+ * this controller turns each one into the drawn layer. It installs a per-frame sampler in
+ * [MapHost.renderState] that the renderer pulls each display frame to dead-reckon every vehicle forward
+ * to the frame's clock — so vehicles glide smoothly between the comparatively slow polls. The poll is
+ * suspended and resumed with the map via [onPause]/[onResume].
+ *
+ * **Stop focus.** The "exact trips arriving at this stop" layer belongs to [StopFocusController]; this
+ * controller merges its [StopFocusPresentation] with the route's own geometry in
+ * [publishMapPresentation] and forwards the focus calls to it.
  *
  * **Display-free.** The controller deals in route data, not presentation: it publishes the raw
  * [loadedRoute] (loading, then the loaded [ObaRoute] and agency) and passes each route's raw GTFS color
@@ -87,9 +88,27 @@ class RouteMapController(
     private val routeRepository: RouteMapRepository,
     private val stopsController: StopsMapController,
     private val tripObservationRepository: TripObservationRepository,
-    private val focusedTripRepository: FocusedTripRepository,
+    focusedTripRepository: FocusedTripRepository,
     private val scope: CoroutineScope
 ) {
+
+    // The real-time vehicle poll for this session (jobs + retained responses). Every landed poll
+    // republishes the vehicle set, which is also where a pending arrivals focus resolves.
+    private val vehiclePoller = RouteVehiclePoller(
+        tripObservationRepository = tripObservationRepository,
+        scope = scope,
+        onPoll = ::publishVehicleSet
+    )
+
+    // The focused-stop layer (the exact trips arriving at one stop). It owns its own load job and
+    // geometry and calls back here to republish; [publishMapPresentation] reads its presentation.
+    private val stopFocus = StopFocusController(
+        focusedTripRepository = focusedTripRepository,
+        stopsController = stopsController,
+        scope = scope,
+        isRouteActive = { isActive },
+        onPresentationChanged = ::publishMapPresentation
+    )
 
     // The raw route load, published while in route mode (the view model formats it into the display
     // header overlay). Loading on entry, the loaded route once it resolves, null outside route mode.
@@ -139,14 +158,6 @@ class RouteMapController(
     // onRouteLoaded; read by the extra-segment shape/stop helpers.
     private var extraRouteMaps: Map<String, RouteMap> = emptyMap()
 
-    // The latest vehicle poll per extra route id — a cross-route interline polls each route so the one
-    // shared block vehicle shows through every phase. Merged with [latestPoll] in sampleVehicles; empty
-    // otherwise.
-    private var extraPolls: Map<String, VehiclePoll> = emptyMap()
-
-    // The per-extra-route vehicle poll jobs, cancelled alongside [vehicleJob].
-    private var extraVehicleJobs: List<Job> = emptyList()
-
     // A restore/deep-link override for the initial direction (the user-selected direction persisted
     // across process death); when set and still valid it wins over the anchor stop's direction.
     private var initialDirectionOverride: Int? = null
@@ -173,26 +184,17 @@ class RouteMapController(
     // the approach and selected ride, but stops at alighting so downstream vehicles stay hidden.
     private var focusedVehiclePathsByRoute: Map<String, List<BoundedRoutePath>> = emptyMap()
 
-    private data class StopFocusSession(
-        val stopId: String,
-        val trips: Set<FocusedTrip>
-    )
-
     private data class FocusedRouteLines(
         val routeId: String,
         val relationship: RouteFocusRelationship?,
         val polylines: List<RoutePolyline>
     )
 
-    private var stopFocusSession: StopFocusSession? = null
-    private var stopFocusJob: Job? = null
-    private var focusedGeometry = FocusedTripGeometry(emptyList())
-    private var focusedStops = FocusedTripStops(emptyMap(), emptyMap())
-    private var focusedRoutes: List<ObaRoute> = emptyList()
-    private val _focusedRouteColors = MutableStateFlow<Map<RouteDirectionKey, Int>>(emptyMap())
-    val focusedRouteColors: StateFlow<Map<RouteDirectionKey, Int>> = _focusedRouteColors.asStateFlow()
+    /** The synthesized hue per focused route/direction — see [StopFocusController.routeColors]. */
+    val focusedRouteColors: StateFlow<Map<RouteDirectionKey, Int>> get() = stopFocus.routeColors
 
-    val focusedStopId: String? get() = stopFocusSession?.stopId
+    /** The stop whose trips are drawn, or null when no stop is focused. */
+    val focusedStopId: String? get() = stopFocus.focusedStopId
 
     // The direction shown now (null = whole route). Derived from [directionState] rather than stored
     // separately, so the stop filter and the vehicle filter can never disagree. Meaningful only once
@@ -228,11 +230,6 @@ class RouteMapController(
     /** Whether a route is currently shown (drives the home map's route-header focus bias). */
     val isActive: Boolean get() = routeId != null
 
-    // The most recent trips-for-route poll and when it landed (nanos). The sampler reads the response to
-    // dead-reckon every vehicle to the frame's clock; the load time lets a resume mid-period wait only
-    // the remainder. Null until the first poll lands (the sampler then yields nothing to draw).
-    private var latestPoll: VehiclePoll? = null
-
     // Memo behind [displayedRouteColor], which the per-frame vehicle sampler calls for every vehicle.
     // Keyed by active trip id (unique across the polls in play); holds nulls, so absence means "not yet
     // resolved" rather than "no color". Invalidated wholesale by [refreshRouteColorMemo] when any input
@@ -243,11 +240,9 @@ class RouteMapController(
     private var routeColorMemoExtras: Map<String, VehiclePoll>? = null
     private var routeColorMemoAssignment: Map<RouteDirectionKey, Int> = emptyMap()
 
-    // routeJob is the one-shot route shape/stops/header load; vehicleJob is the long-running periodic
-    // vehicle poll, suspended/resumed independently with the map lifecycle (onPause cancels only it).
+    // The one-shot route shape/stops/header load. The long-running periodic vehicle poll lives in
+    // [vehiclePoller], suspended/resumed independently with the map lifecycle.
     private var routeJob: Job? = null
-
-    private var vehicleJob: Job? = null
 
     // Drives everything a tap-selected vehicle shows: its exact shape + scheduled stops
     // ([showSelectionPresentation]), the trip overlay (the uncertainty band + fast-estimate marker,
@@ -310,10 +305,9 @@ class RouteMapController(
         this.extraSegments = extraSegments
         this.itineraryContext = itineraryContext
         this.palette = palette
-        // (Re)built as the extra routes load / poll in onRouteLoaded + startVehiclePolling; cleared here
-        // so a prior focus's routes/polls can't leak into this one during the load window.
+        // (Re)built as the extra routes load in onRouteLoaded; cleared here so a prior focus's routes
+        // can't leak into this one during the load window (the poller clears its own polls in start).
         this.extraRouteMaps = emptyMap()
-        this.extraPolls = emptyMap()
         this.focusedVehiclePathsByRoute = emptyMap()
         this.initialDirectionOverride = initialDirectionId
         this.pendingFocus = focusTripId
@@ -353,7 +347,7 @@ class RouteMapController(
         // Defer the on-load framing while a focus is pending: the focus decision (below, once the first
         // set arrives) either fits the vehicle+stop box or, failing that, frames the route itself.
         loadRoute(zoomToRoute && focusTripId == null)
-        startVehiclePolling(0L)
+        vehiclePoller.start(routeId, extraRouteIds)
     }
 
     /**
@@ -419,7 +413,7 @@ class RouteMapController(
     private fun tryFocusVehicle(layer: MapVehicles?) {
         val focus = pendingFocus ?: return
         val marker = layer?.markers?.firstOrNull { it.activeTripId == focus }
-        when (resolveVehicleFocus(directionState is DirectionState.Resolved, latestPoll != null, marker != null)) {
+        when (resolveVehicleFocus(directionState is DirectionState.Resolved, vehiclePoller.leaderPoll != null, marker != null)) {
             FocusResolution.WAIT -> Unit
             FocusResolution.FIT -> {
                 pendingFocus = null
@@ -452,7 +446,8 @@ class RouteMapController(
     private fun sampleVehicles(now: WallTime, includeDataFixPoint: Boolean = false): MapVehicles? {
         val id = routeId ?: return null
         val resolved = directionState as? DirectionState.Resolved ?: return null
-        val poll = latestPoll ?: return null
+        val poll = vehiclePoller.leaderPoll ?: return null
+        val extraPolls = vehiclePoller.extraPolls
         // A stay-aboard interline is one shared block vehicle running consecutive trips across the ridden
         // routes/directions, so don't direction-filter and merge each extra route's poll — the vehicle
         // must show through every phase, not vanish when it flips direction/route at a seam (#2000).
@@ -495,7 +490,7 @@ class RouteMapController(
         } else {
             merged
         }
-        refreshRouteColorMemo(poll, extraPolls, _focusedRouteColors.value)
+        refreshRouteColorMemo(poll, extraPolls, stopFocus.routeColors.value)
         return MapVehicles(
             markers = vehicles.map { (vehicle, source) -> vehicle.toMarker(source) },
             response = poll.response
@@ -546,7 +541,7 @@ class RouteMapController(
     private suspend fun showSelectionPresentation(tripId: String?) {
         if (tripId != null) {
             val state = tripObservationRepository.lookupTripState(tripId)
-            val shapeId = state?.shapeId ?: latestPoll?.response?.trip(tripId)?.shapeId
+            val shapeId = state?.shapeId ?: vehiclePoller.leaderPoll?.response?.trip(tripId)?.shapeId
             // Warm both resources concurrently; supervisorScope joins them and keeps one failing
             // fetch from cancelling the other. selectedTripPresentation() re-reads the results.
             supervisorScope {
@@ -639,12 +634,9 @@ class RouteMapController(
     /** Leave single-route mode. A stop-focus layer, when present, remains visible. */
     fun stop() {
         routeJob?.cancel()
-        vehicleJob?.cancel()
-        extraVehicleJobs.forEach { it.cancel() }
+        vehiclePoller.stop()
         selectionJob?.cancel()
         routeJob = null
-        vehicleJob = null
-        extraVehicleJobs = emptyList()
         selectionJob = null
         routeId = null
         directionStopId = null
@@ -654,7 +646,6 @@ class RouteMapController(
         palette = BASEMAP_ROUTE_LINE_PALETTE
         extraRouteMaps = emptyMap()
         focusedVehiclePathsByRoute = emptyMap()
-        extraPolls = emptyMap()
         initialDirectionOverride = null
         routeStops = emptyList()
         routeStopRoutes = emptyList()
@@ -663,7 +654,6 @@ class RouteMapController(
         basePolylines = emptyList()
         baseStopPresentation = null
         directionState = DirectionState.Resolved(null)
-        latestPoll = null
         pendingFocus = null
         focusExemptTripId = null
         publishMapPresentation()
@@ -678,105 +668,15 @@ class RouteMapController(
         _loadedRoute.value = null
     }
 
-    /**
-     * Show the exact trips currently displayed for a stop. A first focus publishes shape and schedule
-     * results independently; a handoff from an existing stop stages both and swaps them atomically so
-     * the complete old presentation remains visible during loading. An empty trip set is still valid.
-     */
+    /** Show the exact trips currently displayed for a stop — see [StopFocusController.focus]. */
     fun focusStop(
         stopId: String,
         trips: Set<FocusedTrip>,
         routes: List<ObaRoute>
-    ) {
-        val next = StopFocusSession(stopId, LinkedHashSet(trips))
-        if (stopFocusSession == next) {
-            // Route wrappers may be recreated on every arrivals poll; refresh marker metadata without
-            // restarting unchanged shape/schedule work.
-            focusedRoutes = routes
-            publishMapPresentation()
-            return
-        }
-        stopFocusJob?.cancel()
-        val retainCurrentPresentation = stopFocusSession != null
-        if (!retainCurrentPresentation) {
-            applyStopFocus(
-                next,
-                routes,
-                FocusedTripGeometry(emptyList()),
-                FocusedTripStops(emptyMap(), emptyMap())
-            )
-        }
-        stopFocusJob = scope.launch {
-            supervisorScope {
-                val geometry = async {
-                    runCatching { focusedTripRepository.getGeometry(next.trips) }
-                        .getOrElse {
-                            if (it is CancellationException) throw it
-                            FocusedTripGeometry(emptyList())
-                        }
-                        .also {
-                            if (!retainCurrentPresentation && stopFocusSession == next) {
-                                focusedGeometry = it
-                                publishMapPresentation()
-                            }
-                        }
-                }
-                val stops = async {
-                    runCatching { focusedTripRepository.getStops(next.trips) }
-                        .getOrElse {
-                            if (it is CancellationException) throw it
-                            FocusedTripStops(emptyMap(), emptyMap())
-                        }
-                        .also {
-                            if (!retainCurrentPresentation && stopFocusSession == next) {
-                                focusedStops = it
-                                publishMapPresentation()
-                            }
-                        }
-                }
-                val nextGeometry = geometry.await()
-                val nextStops = stops.await()
-                if (retainCurrentPresentation) {
-                    // A stop-to-stop handoff keeps the old complete presentation visible until both
-                    // halves of the replacement are ready, then swaps once. Unrelated focus changes
-                    // clear the old session before reaching here and retain the eager first-load path.
-                    applyStopFocus(next, routes, nextGeometry, nextStops)
-                }
-            }
-        }
-    }
-
-    private fun applyStopFocus(
-        session: StopFocusSession,
-        routes: List<ObaRoute>,
-        geometry: FocusedTripGeometry,
-        stops: FocusedTripStops
-    ) {
-        stopFocusSession = session
-        focusedRoutes = routes
-        _focusedRouteColors.value = adjacencyRouteColors(
-            session.trips.map(FocusedTrip::routeDirection),
-            retained = _focusedRouteColors.value
-        )
-        focusedGeometry = geometry
-        focusedStops = stops
-        stopsController.start()
-        publishMapPresentation()
-    }
+    ) = stopFocus.focus(stopId, trips, routes)
 
     /** Clear focused-stop trips and reveal the base route (or ordinary nearby stops). */
-    fun clearStopFocus() {
-        if (stopFocusSession == null) return
-        stopFocusSession = null
-        stopFocusJob?.cancel()
-        stopFocusJob = null
-        focusedGeometry = FocusedTripGeometry(emptyList())
-        focusedStops = FocusedTripStops(emptyMap(), emptyMap())
-        focusedRoutes = emptyList()
-        _focusedRouteColors.value = emptyMap()
-        if (isActive) stopsController.stop() else stopsController.start()
-        publishMapPresentation()
-    }
+    fun clearStopFocus() = stopFocus.clear()
 
     // Assemble the render plan from the current controller state (pure — see
     // [assembleRouteMapPresentation]) and forward each field to the render/stop layers. IO/retained
@@ -786,20 +686,21 @@ class RouteMapController(
         // Both the selected trip's fallback and the ridden segment draw in the shown route's colour;
         // resolve it once so a publish runs the colour policy a single time.
         val routeColor = currentRouteColor()
+        // One snapshot of the focused-stop layer for the whole publish, so the plan can't read a
+        // half-swapped focus (its geometry and stops resolve independently).
+        val focus = stopFocus.presentation
         val plan = assembleRouteMapPresentation(
             isActive = isActive,
             emphasizedRoute = routeId?.let { RouteDirectionKey(it, presentationDirectionId) },
             basePolylines = basePolylines,
             baseStopPresentation = baseStopPresentation,
-            focusTrips = stopFocusSession?.trips,
-            focusedGeometry = focusedGeometry,
-            focusedStops = focusedStops,
-            focusedRoutes = focusedRoutes,
-            routeColors = _focusedRouteColors.value,
+            focusTrips = focus.trips,
+            focusedGeometry = focus.geometry,
+            focusedStops = focus.stops,
+            focusedRoutes = focus.routes,
+            routeColors = focus.routeColors,
             selected = selectedTripRenderInput(routeColor),
-            projectedFocusStops = {
-                stopFocusSession?.let { projectFocusedStops(it.trips, focusedGeometry, focusedStops) }.orEmpty()
-            }
+            projectedFocusStops = focus::projectedStops
         )
         renderState.setRoutePolylines(
             // Over a highlighted leg segment: the route's approach to the boarding point first, the rider's
@@ -848,7 +749,7 @@ class RouteMapController(
         val polyline = state?.polyline ?: return null
         val schedule = state.schedule ?: return null
         // The marker is keyed by activeTripId, which resolves directly through the poll references.
-        val activeTrip = latestPoll?.response?.trip(tripId)
+        val activeTrip = vehiclePoller.leaderPoll?.response?.trip(tripId)
         return SelectedTripPresentation(
             points = polyline.points,
             stopIds = schedule.stopTimes.map { it.stopId },
@@ -879,15 +780,12 @@ class RouteMapController(
 
     /** Restart the vehicle poll if a route is shown and the poll isn't running (the host's onResume). */
     fun onResume() {
-        if (routeId != null && vehicleJob?.isActive != true) {
-            startVehiclePolling(nextVehicleDelay(latestPoll?.loadNanos ?: 0L, SystemClock.elapsedRealtimeNanos()))
-        }
+        val id = routeId ?: return
+        vehiclePoller.resume(id, extraRouteIds)
     }
 
     /** Stop the vehicle poll while the map is paused (the host's onPause). */
-    fun onPause() {
-        vehicleJob?.cancel()
-    }
+    fun onPause() = vehiclePoller.pause()
 
     private fun loadRoute(zoomToRoute: Boolean) {
         val id = routeId ?: return
@@ -1113,47 +1011,6 @@ class RouteMapController(
     }
 
     /**
-     * (Re)starts the real-time vehicle poll: after [initialDelayMs], reload vehicles every
-     * [VEHICLE_REFRESH_PERIOD_MS] measured from each load's completion (so network time is excluded),
-     * matching the legacy `postDelayed`-after-`onLoadFinished` cadence. The loop continues on a fixed
-     * cadence even if a load fails.
-     */
-    private fun startVehiclePolling(initialDelayMs: Long) {
-        vehicleJob?.cancel()
-        extraVehicleJobs.forEach { it.cancel() }
-        val id = routeId ?: return
-        vehicleJob = scope.launch {
-            if (initialDelayMs > 0L) {
-                delay(initialDelayMs)
-            }
-            // Keep the route's vehicles fresh while route mode is on screen: the repository polls
-            // trips-for-route (backfilling each active trip's schedule + shape into the store) and
-            // records each response. Each emission is a fresh poll — stash it for the motion sampler,
-            // record its time so a resume mid-period waits only the remainder, and push the new vehicle
-            // set so the renderer reconciles the marker set. The renderer's frame loop then pulls the
-            // motion sampler to dead-reckon every vehicle between polls.
-            tripObservationRepository.routeVehiclesStream(id, VEHICLE_REFRESH_PERIOD_MS).collect { response ->
-                latestPoll = VehiclePoll(response, SystemClock.elapsedRealtimeNanos())
-                publishVehicleSet()
-            }
-        }
-        // A cross-route interline (#2000) polls each other route too, so the one shared block vehicle
-        // shows through every phase; sampleVehicles merges these polls. (A self-interline segment shares
-        // the leader's route, so it's excluded — the leader poll already covers it.)
-        extraVehicleJobs = extraRouteIds.map { extraRouteId ->
-            scope.launch {
-                if (initialDelayMs > 0L) {
-                    delay(initialDelayMs)
-                }
-                tripObservationRepository.routeVehiclesStream(extraRouteId, VEHICLE_REFRESH_PERIOD_MS).collect { response ->
-                    extraPolls = extraPolls + (extraRouteId to VehiclePoll(response, SystemClock.elapsedRealtimeNanos()))
-                    publishVehicleSet()
-                }
-            }
-        }
-    }
-
-    /**
      * Builds the render [VehicleMarker] from a display-free [ExtrapolatedVehicle], carrying the
      * draw-time live-vs-scheduled flag through (the renderer picks its icon from it) and the color its
      * route is currently drawn with (the disc rides its own line's color, #2043).
@@ -1282,9 +1139,6 @@ private val CONTINUATION_LINE_WIDTH_PROFILE = RouteLineWidthProfile(
 // Used only when the neighbor route carries no GTFS color to draw the continuation line in its own
 // color with.
 private const val CONTINUATION_FALLBACK_LINE_COLOR = 0xFF9E9E9E.toInt() // opaque gray
-
-/** The latest trips-for-route [response] and the device clock ([loadNanos]) when it landed. */
-private data class VehiclePoll(val response: RouteTrips, val loadNanos: Long)
 
 /**
  * What the vehicle layer should show while in route mode — the single value the per-frame sampler reads

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
@@ -104,7 +104,8 @@ class RouteMapController(
     // geometry and calls back here to republish; [publishMapPresentation] reads its presentation.
     private val stopFocus = StopFocusController(
         focusedTripRepository = focusedTripRepository,
-        stopsController = stopsController,
+        startNearbyStops = stopsController::start,
+        stopNearbyStops = stopsController::stop,
         scope = scope,
         isRouteActive = { isActive },
         onPresentationChanged = ::publishMapPresentation

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteVehiclePoller.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteVehiclePoller.kt
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.map
+
+import android.os.SystemClock
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import org.onebusaway.android.extrapolation.data.TripObservationRepository
+import org.onebusaway.android.models.RouteTrips
+
+/** The latest trips-for-route [response] and the device clock ([loadNanos]) when it landed. */
+internal data class VehiclePoll(val response: RouteTrips, val loadNanos: Long)
+
+/**
+ * Keeps a route session's real-time vehicle responses fresh, and nothing else. Extracted from
+ * [RouteMapController] so the poll's jobs, cadence and retained responses are one small unit rather
+ * than four mutable fields threaded through the controller's route/direction/focus state.
+ *
+ * It polls trips-for-route on a fixed cadence and retains the latest response per route; it does not
+ * know about directions, focus, or how a response becomes markers. [RouteMapController] samples
+ * [leaderPoll]/[extraPolls] to build the vehicle layer, and is told to re-sample via [onPoll].
+ *
+ * **Extra routes.** A cross-route interline (#2000) polls each *other* route alongside the leader, so
+ * the one shared block vehicle shows through every phase of the ride; the controller merges those polls
+ * when it samples. A self-interline segment reuses the leader route and so is not polled separately.
+ *
+ * The poll is suspended and resumed with the map via [pause]/[resume], and torn down with the route
+ * session via [stop].
+ */
+internal class RouteVehiclePoller(
+    private val tripObservationRepository: TripObservationRepository,
+    private val scope: CoroutineScope,
+    private val onPoll: () -> Unit
+) {
+
+    // The long-running periodic polls: the leader route's, plus one per extra route. Started, paused and
+    // resumed together, so the leader's liveness stands in for all of them.
+    private var leaderJob: Job? = null
+    private var extraJobs: List<Job> = emptyList()
+
+    /**
+     * The most recent leader-route poll and when it landed (nanos). The controller's per-frame sampler
+     * reads the response to dead-reckon every vehicle to the frame's clock; the load time lets a resume
+     * mid-period wait only the remainder. Null until the first poll lands.
+     */
+    var leaderPoll: VehiclePoll? = null
+        private set
+
+    /**
+     * The latest poll per extra route id — a cross-route interline polls each route so the one shared
+     * block vehicle shows through every phase. Merged with [leaderPoll] when the controller samples;
+     * empty otherwise.
+     *
+     * Replaced wholesale (never mutated in place) on each landed poll, because
+     * [RouteMapController]'s per-frame vehicle-colour memo invalidates on the map's *reference*
+     * identity — an in-place update would leave the memo holding colours resolved from a stale poll.
+     */
+    var extraPolls: Map<String, VehiclePoll> = emptyMap()
+        private set
+
+    /**
+     * Begin a new route session: drop the previous session's responses so the controller can't sample
+     * them during this one's load window, then poll from now.
+     */
+    fun start(routeId: String, extraRouteIds: List<String>) {
+        leaderPoll = null
+        extraPolls = emptyMap()
+        launchPolls(routeId, extraRouteIds, initialDelayMs = 0L)
+    }
+
+    /**
+     * Restart the polls if they aren't already running (the map's onResume), waiting out only the
+     * remainder of the current period so a brief background trip doesn't cost a full extra poll. The
+     * retained responses survive, so the map redraws from them immediately. [extraRouteIds] is re-read
+     * from the caller rather than remembered, since a reframe can change the session's extra segments
+     * without restarting the poll.
+     */
+    fun resume(routeId: String, extraRouteIds: List<String>) {
+        if (leaderJob?.isActive == true) return
+        launchPolls(routeId, extraRouteIds, nextVehicleDelay(leaderPoll?.loadNanos ?: 0L, SystemClock.elapsedRealtimeNanos()))
+    }
+
+    /**
+     * Suspend polling while the map is paused (the map's onPause) — every route's, not just the leader's.
+     * An off-screen map must not keep hitting the network; an interlined ride polls one job per extra
+     * route (#2000), so cancelling the leader alone would leave those running until the next [resume].
+     */
+    fun pause() = cancelJobs()
+
+    /** Tear down with the route session: cancel every poll and drop the retained responses. */
+    fun stop() {
+        cancelJobs()
+        leaderJob = null
+        extraJobs = emptyList()
+        leaderPoll = null
+        extraPolls = emptyMap()
+    }
+
+    /**
+     * (Re)start every poll after [initialDelayMs]. Each route reloads every [VEHICLE_REFRESH_PERIOD_MS]
+     * measured from its own load's completion (so network time is excluded), matching the legacy
+     * `postDelayed`-after-`onLoadFinished` cadence, and continues on that cadence even if a load fails.
+     */
+    private fun launchPolls(routeId: String, extraRouteIds: List<String>, initialDelayMs: Long) {
+        cancelJobs()
+        leaderJob = pollRoute(routeId, initialDelayMs) { leaderPoll = it }
+        extraJobs = extraRouteIds.map { extraRouteId ->
+            pollRoute(extraRouteId, initialDelayMs) { extraPolls = extraPolls + (extraRouteId to it) }
+        }
+    }
+
+    /**
+     * One route's poll loop: the repository polls trips-for-route (backfilling each active trip's
+     * schedule + shape into the store) and records each response. Each emission is a fresh poll — hand
+     * it to [retain] for the motion sampler, stamped with the time it landed so a resume mid-period
+     * waits only the remainder, then let the controller push the new vehicle set so the renderer
+     * reconciles its markers. The renderer's frame loop dead-reckons every vehicle between polls.
+     */
+    private fun pollRoute(routeId: String, initialDelayMs: Long, retain: (VehiclePoll) -> Unit): Job = scope.launch {
+        if (initialDelayMs > 0L) {
+            delay(initialDelayMs)
+        }
+        tripObservationRepository.routeVehiclesStream(routeId, VEHICLE_REFRESH_PERIOD_MS).collect { response ->
+            retain(VehiclePoll(response, SystemClock.elapsedRealtimeNanos()))
+            onPoll()
+        }
+    }
+
+    private fun cancelJobs() {
+        leaderJob?.cancel()
+        extraJobs.forEach { it.cancel() }
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteVehiclePoller.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteVehiclePoller.kt
@@ -15,16 +15,20 @@
  */
 package org.onebusaway.android.map
 
-import android.os.SystemClock
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.onebusaway.android.extrapolation.data.TripObservationRepository
 import org.onebusaway.android.models.RouteTrips
+import org.onebusaway.android.time.ElapsedTime
 
-/** The latest trips-for-route [response] and the device clock ([loadNanos]) when it landed. */
-internal data class VehiclePoll(val response: RouteTrips, val loadNanos: Long)
+/**
+ * The latest trips-for-route [response] and the monotonic-clock reading ([loadTime]) when it landed.
+ * Monotonic rather than wall-clock because the only thing measured against it is a real elapsed
+ * interval — how much of the refresh period a backgrounded map has already served out.
+ */
+internal data class VehiclePoll(val response: RouteTrips, val loadTime: ElapsedTime)
 
 /**
  * Keeps a route session's real-time vehicle responses fresh, and nothing else. Extracted from
@@ -49,14 +53,15 @@ internal class RouteVehiclePoller(
 ) {
 
     // The long-running periodic polls: the leader route's, plus one per extra route. Started, paused and
-    // resumed together, so the leader's liveness stands in for all of them.
+    // resumed together; [resume] checks all of them rather than treating the leader as a proxy, so a
+    // poll that ended on its own is relaunched instead of staying dead for the rest of the session.
     private var leaderJob: Job? = null
     private var extraJobs: List<Job> = emptyList()
 
     /**
-     * The most recent leader-route poll and when it landed (nanos). The controller's per-frame sampler
-     * reads the response to dead-reckon every vehicle to the frame's clock; the load time lets a resume
-     * mid-period wait only the remainder. Null until the first poll lands.
+     * The most recent leader-route poll and when it landed. The controller's per-frame sampler reads the
+     * response to dead-reckon every vehicle to the frame's clock; the load time lets a resume mid-period
+     * wait only the remainder. Null until the first poll lands.
      */
     var leaderPoll: VehiclePoll? = null
         private set
@@ -89,10 +94,14 @@ internal class RouteVehiclePoller(
      * retained responses survive, so the map redraws from them immediately. [extraRouteIds] is re-read
      * from the caller rather than remembered, since a reframe can change the session's extra segments
      * without restarting the poll.
+     *
+     * "Already running" means *every* poll, not just the leader's: an extra route's poll that ended on
+     * its own would otherwise never be noticed, and that route's vehicles would stop refreshing for the
+     * rest of the session with no way back but leaving and re-entering the route.
      */
     fun resume(routeId: String, extraRouteIds: List<String>) {
-        if (leaderJob?.isActive == true) return
-        launchPolls(routeId, extraRouteIds, nextVehicleDelay(leaderPoll?.loadNanos ?: 0L, SystemClock.elapsedRealtimeNanos()))
+        if (leaderJob?.isActive == true && extraJobs.all { it.isActive }) return
+        launchPolls(routeId, extraRouteIds, nextVehicleDelay(leaderPoll?.loadTime, ElapsedTime.now()))
     }
 
     /**
@@ -136,7 +145,7 @@ internal class RouteVehiclePoller(
             delay(initialDelayMs)
         }
         tripObservationRepository.routeVehiclesStream(routeId, VEHICLE_REFRESH_PERIOD_MS).collect { response ->
-            retain(VehiclePoll(response, SystemClock.elapsedRealtimeNanos()))
+            retain(VehiclePoll(response, ElapsedTime.now()))
             onPoll()
         }
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/StopFocusController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/StopFocusController.kt
@@ -1,0 +1,199 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.map
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.supervisorScope
+import org.onebusaway.android.models.FocusedTrip
+import org.onebusaway.android.models.ObaRoute
+import org.onebusaway.android.models.RouteDirectionKey
+import org.onebusaway.android.util.GeoPoint
+import org.onebusaway.android.util.runCatchingCancellable
+
+/**
+ * Everything a focused stop contributes to the route map's render plan, read as one immutable value so
+ * [RouteMapController]'s publish can't observe a half-swapped focus. [trips] is null when no stop is
+ * focused — the "focus inactive" signal the presentation assembler branches on.
+ */
+internal data class StopFocusPresentation(
+    val trips: Set<FocusedTrip>?,
+    val geometry: FocusedTripGeometry,
+    val stops: FocusedTripStops,
+    val routes: List<ObaRoute>,
+    val routeColors: Map<RouteDirectionKey, Int>
+) {
+    /** The focused trips' scheduled stops snapped onto their own shapes; empty when no stop is focused. */
+    fun projectedStops(): Map<String, GeoPoint> = trips?.let { projectFocusedStops(it, geometry, stops) }.orEmpty()
+}
+
+/**
+ * Owns the "show the exact trips currently arriving at this stop" layer. Extracted from
+ * [RouteMapController] so the focus session, its load job, and the geometry it resolves live together
+ * instead of as six more fields in the route controller's state.
+ *
+ * A focus is a stop id plus the set of trips the arrivals sheet is showing for it. Focusing resolves two
+ * things independently — each trip's shape ([FocusedTripRepository.getGeometry]) and its scheduled stops
+ * ([FocusedTripRepository.getStops]) — and publishes through [onPresentationChanged] as they land.
+ *
+ * **Handoff.** A *first* focus publishes each half as soon as it resolves, so something appears quickly.
+ * A focus that *replaces* an existing one stages both halves and swaps atomically ([apply]), so the
+ * complete old presentation stays on screen instead of blinking through a half-loaded state. An empty
+ * trip set is a valid focus.
+ *
+ * This controller does not draw: it exposes [presentation] and lets [RouteMapController] merge it with
+ * the route's own geometry. It does drive [StopsMapController]'s start/stop, since whether the ordinary
+ * nearby-stops loader should run depends on whether a stop focus (or a route) owns the stop layer.
+ */
+internal class StopFocusController(
+    private val focusedTripRepository: FocusedTripRepository,
+    private val stopsController: StopsMapController,
+    private val scope: CoroutineScope,
+    private val isRouteActive: () -> Boolean,
+    private val onPresentationChanged: () -> Unit
+) {
+
+    /** Which focus this is. Compared to decide whether an incoming request is the same one re-sent. */
+    private data class Session(
+        val stopId: String,
+        val trips: Set<FocusedTrip>
+    )
+
+    /**
+     * The live focus and everything resolved for it so far. One value rather than four fields, since
+     * they only ever move together — [clear] is one assignment, and a reader can't catch a half-swap.
+     */
+    private data class Focus(
+        val session: Session,
+        val routes: List<ObaRoute>,
+        val geometry: FocusedTripGeometry = FocusedTripGeometry.EMPTY,
+        val stops: FocusedTripStops = FocusedTripStops.EMPTY
+    )
+
+    private var focus: Focus? = null
+    private var job: Job? = null
+    private val _routeColors = MutableStateFlow<Map<RouteDirectionKey, Int>>(emptyMap())
+
+    /**
+     * The synthesized hue per focused route/direction, so adjacent routes at one stop stay
+     * distinguishable. Published (rather than folded into [presentation]) because the arrivals UI colours
+     * its rows from the same assignment the map draws with.
+     */
+    val routeColors: StateFlow<Map<RouteDirectionKey, Int>> = _routeColors.asStateFlow()
+
+    /** The stop whose trips are drawn, or null when no stop is focused. */
+    val focusedStopId: String? get() = focus?.session?.stopId
+
+    /** The current focus as one immutable snapshot for the render plan. */
+    val presentation: StopFocusPresentation
+        get() {
+            val current = focus
+            return StopFocusPresentation(
+                trips = current?.session?.trips,
+                geometry = current?.geometry ?: FocusedTripGeometry.EMPTY,
+                stops = current?.stops ?: FocusedTripStops.EMPTY,
+                routes = current?.routes.orEmpty(),
+                // The StateFlow's own map instance, not a copy: RouteMapController's per-frame
+                // vehicle-colour memo invalidates on identity, so a fresh map here would clear it on
+                // every frame.
+                routeColors = _routeColors.value
+            )
+        }
+
+    /** Show the exact trips currently displayed for [stopId] — see the handoff note on the class. */
+    fun focus(
+        stopId: String,
+        trips: Set<FocusedTrip>,
+        routes: List<ObaRoute>
+    ) {
+        val next = Session(stopId, LinkedHashSet(trips))
+        val current = focus
+        if (current?.session == next) {
+            // Route wrappers may be recreated on every arrivals poll; refresh marker metadata without
+            // restarting unchanged shape/schedule work.
+            focus = current.copy(routes = routes)
+            onPresentationChanged()
+            return
+        }
+        job?.cancel()
+        val retainCurrentPresentation = current != null
+        if (!retainCurrentPresentation) {
+            apply(Focus(next, routes))
+        }
+        job = scope.launch {
+            supervisorScope {
+                val geometry = async {
+                    runCatchingCancellable { focusedTripRepository.getGeometry(next.trips) }
+                        .getOrElse { FocusedTripGeometry.EMPTY }
+                        .also { resolved ->
+                            if (!retainCurrentPresentation) publishHalf(next) { it.copy(geometry = resolved) }
+                        }
+                }
+                val stops = async {
+                    runCatchingCancellable { focusedTripRepository.getStops(next.trips) }
+                        .getOrElse { FocusedTripStops.EMPTY }
+                        .also { resolved ->
+                            if (!retainCurrentPresentation) publishHalf(next) { it.copy(stops = resolved) }
+                        }
+                }
+                val nextGeometry = geometry.await()
+                val nextStops = stops.await()
+                if (retainCurrentPresentation) {
+                    // A stop-to-stop handoff keeps the old complete presentation visible until both
+                    // halves of the replacement are ready, then swaps once. Unrelated focus changes
+                    // clear the old session before reaching here and retain the eager first-load path.
+                    apply(Focus(next, routes, nextGeometry, nextStops))
+                }
+            }
+        }
+    }
+
+    /**
+     * Fold one resolved half into the live focus and publish — the eager first-load path, where each
+     * half appears as soon as it lands. Dropped if [session] is no longer the focus being shown.
+     */
+    private fun publishHalf(session: Session, fold: (Focus) -> Focus) {
+        val live = focus?.takeIf { it.session == session } ?: return
+        focus = fold(live)
+        onPresentationChanged()
+    }
+
+    private fun apply(next: Focus) {
+        focus = next
+        _routeColors.value = adjacencyRouteColors(
+            next.session.trips.map(FocusedTrip::routeDirection),
+            retained = _routeColors.value
+        )
+        stopsController.start()
+        onPresentationChanged()
+    }
+
+    /** Clear focused-stop trips and reveal the base route (or ordinary nearby stops). */
+    fun clear() {
+        if (focus == null) return
+        focus = null
+        job?.cancel()
+        job = null
+        _routeColors.value = emptyMap()
+        if (isRouteActive()) stopsController.stop() else stopsController.start()
+        onPresentationChanged()
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/StopFocusController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/StopFocusController.kt
@@ -60,12 +60,15 @@ internal data class StopFocusPresentation(
  * trip set is a valid focus.
  *
  * This controller does not draw: it exposes [presentation] and lets [RouteMapController] merge it with
- * the route's own geometry. It does drive [StopsMapController]'s start/stop, since whether the ordinary
- * nearby-stops loader should run depends on whether a stop focus (or a route) owns the stop layer.
+ * the route's own geometry. It does decide when the ordinary nearby-stops loader runs, since that
+ * depends on whether a stop focus (or a route) owns the stop layer — but it takes that loader as the
+ * two [startNearbyStops]/[stopNearbyStops] calls rather than the whole [StopsMapController], so the
+ * handoff logic is reachable from a JVM test without a map host.
  */
 internal class StopFocusController(
     private val focusedTripRepository: FocusedTripRepository,
-    private val stopsController: StopsMapController,
+    private val startNearbyStops: () -> Unit,
+    private val stopNearbyStops: () -> Unit,
     private val scope: CoroutineScope,
     private val isRouteActive: () -> Boolean,
     private val onPresentationChanged: () -> Unit
@@ -182,7 +185,7 @@ internal class StopFocusController(
             next.session.trips.map(FocusedTrip::routeDirection),
             retained = _routeColors.value
         )
-        stopsController.start()
+        startNearbyStops()
         onPresentationChanged()
     }
 
@@ -193,7 +196,7 @@ internal class StopFocusController(
         job?.cancel()
         job = null
         _routeColors.value = emptyMap()
-        if (isRouteActive()) stopsController.stop() else stopsController.start()
+        if (isRouteActive()) stopNearbyStops() else startNearbyStops()
         onPresentationChanged()
     }
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteVehicleDelayTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteVehicleDelayTest.kt
@@ -15,34 +15,35 @@
  */
 package org.onebusaway.android.map
 
-import java.util.concurrent.TimeUnit
 import org.junit.Assert.assertEquals
 import org.junit.Test
+import org.onebusaway.android.time.ElapsedTime
 
 /**
  * Unit tests for [nextVehicleDelay] — the resume-mid-period timing for the route vehicle poll,
- * ported from the legacy RouteMapController.onResume math. Timestamps are nanoseconds.
+ * ported from the legacy RouteMapController.onResume math. Both readings are monotonic-clock
+ * [ElapsedTime]s, so "never loaded" is the absent reading rather than a zero sentinel.
  */
 class RouteVehicleDelayTest {
 
-    private val base = 1_000_000_000L // arbitrary non-zero nanosecond "lastUpdated"
+    private val base = ElapsedTime(1_000_000L) // arbitrary monotonic "lastUpdated"
 
-    private fun nanosAfter(lastUpdated: Long, elapsedMillis: Long): Long = lastUpdated + TimeUnit.MILLISECONDS.toNanos(elapsedMillis)
+    private fun after(lastUpdated: ElapsedTime, elapsedMillis: Long) = ElapsedTime(lastUpdated.ms + elapsedMillis)
 
     @Test
     fun `never loaded waits a full period`() {
-        assertEquals(VEHICLE_REFRESH_PERIOD_MS, nextVehicleDelay(lastUpdated = 0L, now = base))
+        assertEquals(VEHICLE_REFRESH_PERIOD_MS, nextVehicleDelay(lastUpdated = null, now = base))
     }
 
     @Test
     fun `mid-period waits only the remainder`() {
-        val now = nanosAfter(base, elapsedMillis = 3000)
+        val now = after(base, elapsedMillis = 3000)
         assertEquals(VEHICLE_REFRESH_PERIOD_MS - 3000, nextVehicleDelay(base, now))
     }
 
     @Test
     fun `overdue refreshes almost immediately`() {
-        val now = nanosAfter(base, elapsedMillis = VEHICLE_REFRESH_PERIOD_MS + 5000)
+        val now = after(base, elapsedMillis = VEHICLE_REFRESH_PERIOD_MS + 5000)
         assertEquals(100L, nextVehicleDelay(base, now))
     }
 

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/StopFocusControllerTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/StopFocusControllerTest.kt
@@ -1,0 +1,228 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.map
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.onebusaway.android.api.adapters.ObaStopElement
+import org.onebusaway.android.models.FocusedTrip
+import org.onebusaway.android.models.ObaRoute
+import org.onebusaway.android.util.GeoPoint
+
+/**
+ * Unit tests for [StopFocusController]'s focus handoff — the part of the focused-stop layer that has
+ * real concurrent behaviour: a *first* focus publishes each half the moment it resolves, a *replacing*
+ * focus stages both halves and swaps once, a re-sent identical focus refreshes only its route metadata,
+ * and a [StopFocusController.clear] mid-load must not let the abandoned load publish afterwards.
+ *
+ * The repository's two halves are gated on deferreds so each ordering is exercised deterministically:
+ * on an unconfined dispatcher, completing one half runs the controller's reaction to it before the test
+ * body resumes, so every assertion sees a settled state without advancing a clock. The nearby-stops
+ * loader enters as the two lambdas the controller actually calls.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class StopFocusControllerTest {
+
+    /** A repository whose two halves complete only when the test says so, counting each call. */
+    private class GatedRepository : FocusedTripRepository {
+        var geometry = CompletableDeferred<FocusedTripGeometry>()
+        var stops = CompletableDeferred<FocusedTripStops>()
+        var geometryCalls = 0
+        var stopCalls = 0
+
+        override suspend fun getGeometry(trips: Set<FocusedTrip>): FocusedTripGeometry {
+            geometryCalls++
+            return geometry.await()
+        }
+
+        override suspend fun getStops(trips: Set<FocusedTrip>): FocusedTripStops {
+            stopCalls++
+            return stops.await()
+        }
+
+        /** Re-arm both halves for the next focus, leaving the call counts intact. */
+        fun rearm() {
+            geometry = CompletableDeferred()
+            stops = CompletableDeferred()
+        }
+    }
+
+    private val repository = GatedRepository()
+    private var routeActive = true
+    private var nearbyStarts = 0
+    private var nearbyStops = 0
+    private var publishes = 0
+
+    private fun TestScope.controller() = StopFocusController(
+        focusedTripRepository = repository,
+        startNearbyStops = { nearbyStarts++ },
+        stopNearbyStops = { nearbyStops++ },
+        // A child of backgroundScope (so an unfinished load is torn down with the test) that dispatches
+        // eagerly, mirroring the Main.immediate scope the controller runs on in production.
+        scope = CoroutineScope(backgroundScope.coroutineContext + UnconfinedTestDispatcher(testScheduler)),
+        isRouteActive = { routeActive },
+        onPresentationChanged = { publishes++ }
+    )
+
+    @Test
+    fun `a first focus shows the stop immediately and each half as it lands`() = runTest {
+        val controller = controller()
+
+        controller.focus("stop-1", setOf(trip("trip-1", "route-1")), listOf(route("route-1")))
+
+        // The session itself is applied synchronously — the layer exists before either half resolves.
+        assertEquals("stop-1", controller.focusedStopId)
+        assertEquals(setOf(trip("trip-1", "route-1")), controller.presentation.trips)
+        assertEquals(FocusedTripGeometry.EMPTY, controller.presentation.geometry)
+        assertEquals(1, nearbyStarts)
+
+        repository.geometry.complete(geometryOf("shape-1", "route-1"))
+
+        // The geometry appears on its own rather than waiting for the schedules alongside it.
+        assertEquals(listOf("shape-1"), controller.presentation.geometry.shapes.map { it.shapeId })
+        assertEquals(FocusedTripStops.EMPTY, controller.presentation.stops)
+
+        repository.stops.complete(stopsOf("trip-1", "stop-a"))
+
+        assertEquals(listOf("stop-a"), controller.presentation.stops.stopIdsByTripId["trip-1"])
+    }
+
+    @Test
+    fun `replacing a focus keeps the old presentation whole until both halves are ready`() = runTest {
+        val controller = controller()
+        controller.focus("stop-1", setOf(trip("trip-1", "route-1")), listOf(route("route-1")))
+        repository.geometry.complete(geometryOf("shape-1", "route-1"))
+        repository.stops.complete(stopsOf("trip-1", "stop-a"))
+        repository.rearm()
+
+        controller.focus("stop-2", setOf(trip("trip-2", "route-2")), listOf(route("route-2")))
+
+        // Still the complete first focus — a replacement must not blink through a half-loaded state.
+        assertEquals("stop-1", controller.focusedStopId)
+        assertEquals(listOf("shape-1"), controller.presentation.geometry.shapes.map { it.shapeId })
+
+        // Nor may one resolved half of the replacement leak in ahead of the other.
+        repository.geometry.complete(geometryOf("shape-2", "route-2"))
+        assertEquals("stop-1", controller.focusedStopId)
+        assertEquals(listOf("shape-1"), controller.presentation.geometry.shapes.map { it.shapeId })
+
+        repository.stops.complete(stopsOf("trip-2", "stop-b"))
+
+        assertEquals("stop-2", controller.focusedStopId)
+        assertEquals(listOf("shape-2"), controller.presentation.geometry.shapes.map { it.shapeId })
+        assertEquals(listOf("stop-b"), controller.presentation.stops.stopIdsByTripId["trip-2"])
+    }
+
+    @Test
+    fun `re-sending the same focus refreshes the routes without reloading`() = runTest {
+        val controller = controller()
+        val trips = setOf(trip("trip-1", "route-1"))
+        controller.focus("stop-1", trips, listOf(route("route-1", shortName = "10")))
+        repository.geometry.complete(geometryOf("shape-1", "route-1"))
+        repository.stops.complete(stopsOf("trip-1", "stop-a"))
+        val colors = controller.routeColors.value
+
+        // The arrivals poll hands back equal-but-recreated route wrappers every few seconds.
+        controller.focus("stop-1", trips, listOf(route("route-1", shortName = "10 Express")))
+
+        assertEquals(1, repository.geometryCalls)
+        assertEquals(1, repository.stopCalls)
+        assertEquals(listOf("10 Express"), controller.presentation.routes.map { it.shortName })
+        // The resolved halves survive the metadata refresh, and the colour map keeps its identity so
+        // RouteMapController's per-frame colour memo isn't invalidated by an arrivals poll.
+        assertEquals(listOf("shape-1"), controller.presentation.geometry.shapes.map { it.shapeId })
+        assertSame(colors, controller.routeColors.value)
+    }
+
+    @Test
+    fun `clearing mid-load drops the focus and the abandoned load publishes nothing`() = runTest {
+        val controller = controller()
+        controller.focus("stop-1", setOf(trip("trip-1", "route-1")), listOf(route("route-1")))
+        repository.geometry.complete(geometryOf("shape-1", "route-1"))
+
+        controller.clear()
+        val publishesAtClear = publishes
+
+        assertNull(controller.focusedStopId)
+        assertNull(controller.presentation.trips)
+        assertTrue(controller.routeColors.value.isEmpty())
+        // A route owns the stop layer, so the nearby-stops loader stays off.
+        assertEquals(1, nearbyStops)
+
+        repository.stops.complete(stopsOf("trip-1", "stop-a"))
+
+        assertNull(controller.focusedStopId)
+        assertEquals(FocusedTripStops.EMPTY, controller.presentation.stops)
+        assertEquals(publishesAtClear, publishes)
+    }
+
+    @Test
+    fun `clearing with no route showing hands the stop layer back to the nearby loader`() = runTest {
+        routeActive = false
+        val controller = controller()
+        controller.focus("stop-1", setOf(trip("trip-1", "route-1")), listOf(route("route-1")))
+        val startsWhileFocused = nearbyStarts
+
+        controller.clear()
+
+        assertEquals(0, nearbyStops)
+        assertEquals(startsWhileFocused + 1, nearbyStarts)
+    }
+
+    @Test
+    fun `clearing when nothing is focused is a no-op`() = runTest {
+        val controller = controller()
+
+        controller.clear()
+
+        assertEquals(0, publishes)
+        assertEquals(0, nearbyStops)
+        assertFalse(repository.geometryCalls > 0)
+    }
+
+    private fun trip(tripId: String, routeId: String) = FocusedTrip(tripId, routeId, "shape-$tripId", null)
+
+    private fun geometryOf(shapeId: String, routeId: String) = FocusedTripGeometry(
+        listOf(FocusedTripShape(shapeId, routeId, null, listOf(GeoPoint(47.6, -122.3))))
+    )
+
+    private fun stopsOf(tripId: String, stopId: String) = FocusedTripStops(
+        stopIdsByTripId = mapOf(tripId to listOf(stopId)),
+        stopsById = mapOf(stopId to ObaStopElement(id = stopId, lat = 47.6, lon = -122.3))
+    )
+
+    private fun route(id: String, shortName: String = id) = object : ObaRoute {
+        override val id = id
+        override val shortName = shortName
+        override val longName: String? = null
+        override val description: String? = null
+        override val type = ObaRoute.TYPE_BUS
+        override val url: String? = null
+        override val color: Int? = null
+        override val textColor: Int? = null
+        override val agencyId = "agency"
+    }
+}


### PR DESCRIPTION
## Why

`RouteMapController` had grown to **1320 lines, ~35 mutable fields and 46 methods**, mixing route loading, direction selection, vehicle polling, stop focus, trip selection and continuation resolution. It's four weeks old — it came in with the Compose rewrite at 285 lines and has been accreting since.

Two of those responsibilities are cleanly separable: neither touches the route-shape state.

## What moved

**`RouteVehiclePoller`** — the real-time poll: its jobs, its cadence, and the retained trips-for-route responses (was `vehicleJob`, `extraVehicleJobs`, `latestPoll`, `extraPolls` on the controller). It knows nothing about directions, focus or markers; the controller still samples `leaderPoll`/`extraPolls` to build the vehicle layer.

**`StopFocusController`** — the focused-stop layer: the session, its load job, the geometry/stops/routes it resolves, and the adjacency colour assignment (six controller fields). It exposes `StopFocusPresentation`, one immutable snapshot the render plan reads, so a publish can't observe a focus whose two independently-resolving halves are half-swapped.

`MapViewModel` is **unchanged** — `focusStop`, `clearStopFocus`, `focusedStopId` and `focusedRouteColors` stay on `RouteMapController` as one-line delegations.

`RouteMapController`: 1320 → 1174 lines.

## One behaviour fix rides along

`onPause()` previously cancelled only the leader poll. A cross-route interline (#2000) polls one job per extra route, so those kept firing a trips-for-route request every 10s with the map off screen, until the next `onResume` cancelled and restarted them. For a 2-extra-route interline backgrounded 5 minutes that's ~60 needless round trips.

`RouteVehiclePoller.pause()` now cancels every poll — which is what the controller's own KDoc already claimed happened ("the poll is suspended and resumed with the map via onPause/onResume").

## Otherwise behaviour-preserving

Two deliberate equivalents:
- The focus loads use `runCatchingCancellable` instead of an inline `runCatching { }.getOrElse { if (it is CancellationException) throw it; … }` — identical semantics, and the helper CLAUDE.md requires in coroutine code.
- The poller resets its retained responses in `start()` rather than relying on the caller having called `stop()` first. `MapViewModel.leaveCurrentView` always does, so this is a no-op on the live path; it just keeps the guarantee local to the poller.

The per-frame route-colour memo invalidates on **reference identity** of its inputs, so the extraction had to preserve that: `StopFocusPresentation.routeColors` hands out the StateFlow's own map instance rather than a copy, and `extraPolls` is replaced wholesale rather than mutated. Both are now documented at the site — the split turned a within-class invariant into a cross-class one, and there's no compile error to catch a future `.toMap()`.

## Testing

- `compileObaGoogleDebugKotlin` + `compileObaMaplibreDebugKotlin` with `-PwarningsAsErrors=true`: clean
- `spotlessCheck`: clean
- `testObaGoogleDebugUnitTest`: passing

Not run locally: `lintObaGoogleDebug` (~5–15 min per CLAUDE.md's guidance to let CI own it) and the instrumented suite.

## Known follow-ups (deliberately not in this PR)

- `StopFocusController` still decides *when* `StopsMapController` starts/stops, which is arguably the coordinator's job. (It now takes those as two lambdas rather than the concrete controller, so it is unit-testable — but moving the *decision* means changing when the stop loader restarts on the async handoff path, a behaviour change rather than a cleanup.)
- The `onPoll`/`onPresentationChanged` callbacks are the only push callbacks in a map package otherwise built on `StateFlow`. Converting them moves the publish to the next dispatch.
- The route-colour memo (`routeColorMemo` + three correlated invalidation fields) is still inline in `RouteMapController` — the other cluster worth lifting.

## Review round

- `VehiclePoll` now carries an `ElapsedTime` instead of a raw nanosecond `Long`, and `nextVehicleDelay` takes the domain type — the "never loaded" `0L` sentinel becomes a null reading. Millis rather than nanos, since that's the domain type's unit and `nextVehicleDelay` converted on its first line anyway.
- `RouteVehiclePoller.resume()` checks every poll's liveness, not just the leader's as a proxy for the rest. Not a live bug — the fetcher resolves every failure to null, so the stream neither throws nor completes — but the guard now states the property it means rather than resting on an argument two classes away.
- `StopFocusController` takes the nearby-stops loader as two lambdas rather than a whole `StopsMapController`, which puts the handoff logic within reach of a JVM test. New `StopFocusControllerTest` covers eager first-load publishing, the stop-to-stop stage-and-swap, the same-session route refresh (no reload, colour-map identity preserved), and a `clear()` mid-load that must leave the abandoned half unable to publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved route map vehicle updates and lifecycle handling, including pause, resume, and stop behavior.
  * Preserved vehicle and route information when polling resumes.
  * Improved focused-stop displays by loading trip geometry and scheduled stops incrementally.
  * Replacing a focused stop now updates related map details together for a more consistent presentation.
  * Improved handling of loading failures and outdated results while maintaining stable map behavior.
  * Improved vehicle refresh timing for more reliable update scheduling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
