### PR TITLE
Unify the directions date and time pickers (#2117)

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripplan/TripDateTimeDialogTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripplan/TripDateTimeDialogTest.kt
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.tripplan
+
+import androidx.compose.ui.test.assertTextContains
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Rule
+import org.junit.Test
+import org.onebusaway.android.ui.compose.createUnconfinedComposeRule
+import org.onebusaway.android.ui.compose.theme.ObaTheme
+
+/**
+ * The combined date/time picker (#2117), which replaced the two menu rows that each set the whole
+ * instant from one of its halves.
+ *
+ * What's asserted here is the seam the merge created: the day and the time are settled separately but
+ * reported as one instant, so moving the day must carry the time across untouched and vice versa. The
+ * dial itself is Material's and isn't re-tested; the time is left at whatever the dialog opened on,
+ * which is exactly the half a day-only change must not disturb.
+ */
+class TripDateTimeDialogTest {
+
+    // See createUnconfinedComposeRule for why Unconfined composition is used here (issue #1792).
+    @get:Rule
+    val composeRule = createUnconfinedComposeRule()
+
+    private val zone: ZoneId = ZoneId.systemDefault()
+    private val today: LocalDate = LocalDate.now(zone)
+
+    /** Local wall-clock [date] at 15:45, as the epoch millis the form carries. */
+    private fun atQuarterToFour(date: LocalDate): Long = date.atTime(15, 45).atZone(zone).toInstant().toEpochMilli()
+
+    @Test
+    fun theDayDropdownOpensOnTheDayItWasGiven() {
+        showDialog(atQuarterToFour(today))
+
+        composeRule.onNodeWithTag(TripPlanTestTags.PICKER_DAY).assertTextContains("Today")
+    }
+
+    /** Naming tomorrow moves only the day: the time the dialog opened on rides across with it. */
+    @Test
+    fun namingTomorrowKeepsTheTimeAndReportsOneInstant() {
+        var confirmed: Long? = null
+        showDialog(atQuarterToFour(today), onConfirm = { confirmed = it })
+
+        composeRule.onNodeWithTag(TripPlanTestTags.PICKER_DAY).performClick()
+        composeRule.onNodeWithText("Tomorrow").performClick()
+        composeRule.onNodeWithTag(TripPlanTestTags.PICKER_DAY).assertTextContains("Tomorrow")
+        composeRule.onNodeWithText("OK").performClick()
+
+        composeRule.runOnIdle {
+            assertEquals(atQuarterToFour(today.plusDays(1)), confirmed)
+        }
+    }
+
+    /** Any other day is the date itself, so the button always states the day it holds. */
+    @Test
+    fun aDayBeyondTomorrowShowsItsOwnDate() {
+        val later = today.plusDays(5)
+        showDialog(atQuarterToFour(later))
+
+        composeRule.onNodeWithTag(TripPlanTestTags.PICKER_DAY).assertTextContains(
+            later.format(DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM))
+        )
+    }
+
+    /** Cancelling pins nothing — the trip keeps whatever anchor it had. */
+    @Test
+    fun cancellingReportsNoInstant() {
+        var confirmed: Long? = null
+        var dismissed = false
+        showDialog(
+            atQuarterToFour(today),
+            onConfirm = { confirmed = it },
+            onDismiss = { dismissed = true }
+        )
+
+        composeRule.onNodeWithTag(TripPlanTestTags.PICKER_DAY).performClick()
+        composeRule.onNodeWithText("Tomorrow").performClick()
+        composeRule.onNodeWithText("Cancel").performClick()
+
+        composeRule.runOnIdle {
+            assertNull("cancelling should report no instant", confirmed)
+            assertEquals(true, dismissed)
+        }
+    }
+
+    /** The instant a confirmed pick reports is the chosen day at the chosen wall-clock time. */
+    @Test
+    fun theConfirmedInstantIsTheDayAndTimeTogether() {
+        var confirmed: Long? = null
+        val start = LocalDateTime.of(today, LocalTime.of(7, 5))
+        showDialog(start.atZone(zone).toInstant().toEpochMilli(), onConfirm = { confirmed = it })
+
+        composeRule.onNodeWithText("OK").performClick()
+
+        composeRule.runOnIdle {
+            assertEquals(start.atZone(zone).toInstant().toEpochMilli(), confirmed)
+        }
+    }
+
+    private fun showDialog(
+        initialMillis: Long,
+        onDismiss: () -> Unit = {},
+        onConfirm: (Long) -> Unit = {}
+    ) {
+        composeRule.setContent {
+            ObaTheme {
+                TripDateTimeDialog(
+                    initialMillis = initialMillis,
+                    onDismiss = onDismiss,
+                    onConfirm = onConfirm
+                )
+            }
+        }
+    }
+}

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripplan/TripPlanFormRenderTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripplan/TripPlanFormRenderTest.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.test.assertIsNotFocused
 import androidx.compose.ui.test.captureToImage
 import androidx.compose.ui.test.getUnclippedBoundsInRoot
 import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
@@ -284,6 +285,28 @@ class TripPlanFormRenderTest {
     }
 
     /**
+     * The time menu offers the two answers a rider has — leave now, or say when — and the second is one
+     * row, not the separate "Choose date…"/"Choose time…" pair it replaced (#2117). Both of those set
+     * the *whole* instant from one of its halves, so pinning tomorrow evening cost two trips through
+     * the menu and two re-plans.
+     */
+    @Test
+    fun theTimeMenuPinsAnInstantInOneRow() {
+        var picks = 0
+        renderForm(state = { plannedState }, onPickDateTime = { picks++ })
+
+        composeRule.onNodeWithTag(TripPlanTestTags.WHEN_TIME).performClick()
+        composeRule.onNodeWithText("Choose date and time…").performClick()
+
+        assertEquals("the one row should open the combined picker", 1, picks)
+        assertEquals(
+            "the split date/time rows should be gone",
+            0,
+            composeRule.onAllNodesWithText("Choose time…").fetchSemanticsNodes().size
+        )
+    }
+
+    /**
      * The action bar's trailing buttons stay put whatever the time segment reads. The segment is the
      * bar's one flexible slot, so it has to both hold the buttons against the edge when the label is
      * the single word "now" and cap itself when the label is a full date and time — sharing that
@@ -425,7 +448,8 @@ class TripPlanFormRenderTest {
         onSelect: (TripEndpointSlot, TripEndpoint.Geocoded) -> Unit = { _, _ -> },
         onCurrentLocation: (TripEndpointSlot) -> Unit = {},
         onVehicleModeSelected: (VehicleMode) -> Unit = {},
-        onStreetModeSelected: (StreetMode) -> Unit = {}
+        onStreetModeSelected: (StreetMode) -> Unit = {},
+        onPickDateTime: () -> Unit = {}
     ) {
         composeRule.setContent {
             ObaTheme {
@@ -438,8 +462,7 @@ class TripPlanFormRenderTest {
                         onPickOnMap = {},
                         onSetArriving = {},
                         onDepartNow = {},
-                        onPickDate = {},
-                        onPickTime = {},
+                        onPickDateTime = onPickDateTime,
                         availableStreetModes = StreetMode.entries,
                         onVehicleModeSelected = onVehicleModeSelected,
                         onStreetModeSelected = onStreetModeSelected,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
@@ -56,6 +56,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
@@ -157,7 +158,9 @@ fun DirectionsFormCard(
     // The instant the picker opens on, captured when it is opened rather than read from the form on
     // each recomposition: under the "now" anchor the form's own dateTimeMillis is the moment the
     // ViewModel was built, which a form left open has long outrun (see [TripPlanViewModel.pickerStartMillis]).
-    var pickerStartMillis by remember { mutableStateOf<Long?>(null) }
+    // Saved, not merely remembered, so a rotation mid-pick doesn't close the dialog on the rider — the
+    // fragment-based pickers this replaced survived one, and the dialog's own state is saveable too.
+    var pickerStartMillis by rememberSaveable { mutableStateOf<Long?>(null) }
     val usesOtp2 = remember { OtpTarget.resolve(context).usesOtp2 }
     val bikeshare = remember { BikeshareAvailability.isTripPlanningEnabled(context) }
     val availableStreetModes = StreetMode.entries.filter { it.isAvailableIn(bikeshare, usesOtp2) }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
@@ -16,9 +16,7 @@
 package org.onebusaway.android.ui.home.directions
 
 import android.content.Context
-import android.text.format.DateFormat
 import android.widget.Toast
-import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
@@ -78,11 +76,6 @@ import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.google.android.material.datepicker.MaterialDatePicker
-import com.google.android.material.timepicker.MaterialTimePicker
-import com.google.android.material.timepicker.TimeFormat
-import java.util.Calendar
-import java.util.TimeZone
 import kotlin.math.roundToInt
 import kotlin.math.roundToLong
 import kotlinx.coroutines.flow.Flow
@@ -102,7 +95,6 @@ import org.onebusaway.android.ui.compose.components.MenuRow
 import org.onebusaway.android.ui.compose.components.RouteBadge
 import org.onebusaway.android.ui.compose.components.SheetDragHandle
 import org.onebusaway.android.ui.compose.components.SwitchRow
-import org.onebusaway.android.ui.compose.findActivity
 import org.onebusaway.android.ui.compose.navigationBarBottomPadding
 import org.onebusaway.android.ui.home.FocusedStop
 import org.onebusaway.android.ui.home.arrivals.rememberArrivalsSession
@@ -112,6 +104,7 @@ import org.onebusaway.android.ui.tripplan.AdvancedSettings
 import org.onebusaway.android.ui.tripplan.BikePreference
 import org.onebusaway.android.ui.tripplan.CyclingPreference
 import org.onebusaway.android.ui.tripplan.StreetMode
+import org.onebusaway.android.ui.tripplan.TripDateTimeDialog
 import org.onebusaway.android.ui.tripplan.TripEndpointDotIcon
 import org.onebusaway.android.ui.tripplan.TripEndpointSlot
 import org.onebusaway.android.ui.tripplan.TripModeSelection
@@ -160,8 +153,11 @@ fun DirectionsFormCard(
     modifier: Modifier = Modifier
 ) {
     val context = LocalContext.current
-    val activity = context.findActivity()
     var showAdvanced by remember { mutableStateOf(false) }
+    // The instant the picker opens on, captured when it is opened rather than read from the form on
+    // each recomposition: under the "now" anchor the form's own dateTimeMillis is the moment the
+    // ViewModel was built, which a form left open has long outrun (see [TripPlanViewModel.pickerStartMillis]).
+    var pickerStartMillis by remember { mutableStateOf<Long?>(null) }
     val usesOtp2 = remember { OtpTarget.resolve(context).usesOtp2 }
     val bikeshare = remember { BikeshareAvailability.isTripPlanningEnabled(context) }
     val availableStreetModes = StreetMode.entries.filter { it.isAvailableIn(bikeshare, usesOtp2) }
@@ -189,8 +185,7 @@ fun DirectionsFormCard(
                 onPickOnMap = onPickEndpoint,
                 onSetArriving = viewModel::setArriving,
                 onDepartNow = viewModel::setDepartNow,
-                onPickDate = { pickTripDate(activity, viewModel) },
-                onPickTime = { pickTripTime(activity, viewModel) },
+                onPickDateTime = { pickerStartMillis = viewModel.pickerStartMillis() },
                 availableStreetModes = availableStreetModes,
                 onVehicleModeSelected = { vehicle ->
                     viewModel.setModeSelection(state.modes.copy(vehicle = vehicle))
@@ -207,6 +202,16 @@ fun DirectionsFormCard(
     }
     if (showAdvanced) {
         DirectionsAdvancedSettingsDialog(viewModel = viewModel, onDismiss = { showAdvanced = false })
+    }
+    pickerStartMillis?.let { start ->
+        TripDateTimeDialog(
+            initialMillis = start,
+            onDismiss = { pickerStartMillis = null },
+            onConfirm = { millis ->
+                viewModel.setDateTime(millis)
+                pickerStartMillis = null
+            }
+        )
     }
 }
 
@@ -225,46 +230,6 @@ private fun setCurrentLocation(context: Context, viewModel: TripPlanViewModel, s
         R.string.no_location_permission
     }
     Toast.makeText(context, messageRes, Toast.LENGTH_SHORT).show()
-}
-
-private fun pickTripDate(activity: AppCompatActivity, viewModel: TripPlanViewModel) {
-    val current = viewModel.formState.value.dateTimeMillis
-    val picker = MaterialDatePicker.Builder.datePicker()
-        .setTitleText(R.string.trip_plan_date)
-        .setSelection(current)
-        .build()
-    picker.addOnPositiveButtonClickListener { selection ->
-        // Read the selection in UTC, exactly as the user saw it (matches the legacy form).
-        val utc = Calendar.getInstance(TimeZone.getTimeZone("UTC")).apply { timeInMillis = selection }
-        val calendar = Calendar.getInstance().apply {
-            timeInMillis = current
-            set(Calendar.YEAR, utc.get(Calendar.YEAR))
-            set(Calendar.MONTH, utc.get(Calendar.MONTH))
-            set(Calendar.DAY_OF_MONTH, utc.get(Calendar.DAY_OF_MONTH))
-        }
-        viewModel.setDateTime(calendar.timeInMillis)
-    }
-    picker.show(activity.supportFragmentManager, "DATE_PICKER")
-}
-
-private fun pickTripTime(activity: AppCompatActivity, viewModel: TripPlanViewModel) {
-    val current = viewModel.formState.value.dateTimeMillis
-    val calendar = Calendar.getInstance().apply { timeInMillis = current }
-    val timeFormat =
-        if (DateFormat.is24HourFormat(activity)) TimeFormat.CLOCK_24H else TimeFormat.CLOCK_12H
-    val picker = MaterialTimePicker.Builder()
-        .setTimeFormat(timeFormat)
-        .setHour(calendar.get(Calendar.HOUR_OF_DAY))
-        .setMinute(calendar.get(Calendar.MINUTE))
-        .setTitleText(R.string.trip_plan_time)
-        .setTheme(R.style.ThemeOverlay_App_TimePicker)
-        .build()
-    picker.addOnPositiveButtonClickListener {
-        calendar.set(Calendar.HOUR_OF_DAY, picker.hour)
-        calendar.set(Calendar.MINUTE, picker.minute)
-        viewModel.setDateTime(calendar.timeInMillis)
-    }
-    picker.show(activity.supportFragmentManager, "TIME_PICKER")
 }
 
 /** The expanded directions sheet's share of the window height (the collapsed peek is handle-only). */

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripDateTimeDialog.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripDateTimeDialog.kt
@@ -110,15 +110,10 @@ fun TripDateTimeDialog(
         dismissButton = {
             TextButton(onClick = onDismiss) { Text(stringResource(R.string.cancel)) }
         },
-        // Our own title rather than Material's, which reads "Select time" and so names only one of
-        // this dialog's two halves. Styled as the default is, so it keeps its place in the layout.
-        title = {
-            Text(
-                text = stringResource(R.string.trip_plan_select_date_time),
-                style = MaterialTheme.typography.labelMedium,
-                modifier = Modifier.padding(bottom = 20.dp)
-            )
-        },
+        // No title. Material's default reads "Select time", which names only one of this dialog's two
+        // halves — but any heading here just restates the two controls under it, each of which already
+        // says what it is (a labelled day dropdown, and a clock).
+        title = {},
         modeToggleButton = {
             TimePickerDialogDefaults.DisplayModeToggle(
                 displayMode = displayMode,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripDateTimeDialog.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripDateTimeDialog.kt
@@ -1,0 +1,257 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.tripplan
+
+import android.text.format.DateFormat
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TimeInput
+import androidx.compose.material3.TimePicker
+import androidx.compose.material3.TimePickerDialog
+import androidx.compose.material3.TimePickerDialogDefaults
+import androidx.compose.material3.TimePickerDisplayMode
+import androidx.compose.material3.rememberDatePickerState
+import androidx.compose.material3.rememberTimePickerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
+import org.onebusaway.android.R
+import org.onebusaway.android.ui.icons.AppIcons
+
+/**
+ * When the trip is for, picked in one dialog (#2117).
+ *
+ * The two menu rows this replaces — "Choose date…" and "Choose time…" — each opened a picker that set
+ * the *whole* instant from one of its halves, so pinning a departure for tomorrow evening meant two
+ * trips through the menu and two re-plans, and picking only one of them silently kept whatever the
+ * other half happened to hold. Here they are one answer: a clock, which is what a rider is nearly
+ * always changing, over a compact day dropdown that offers today and tomorrow outright and opens a
+ * calendar only for the rarer case.
+ *
+ * [initialMillis] seeds both halves; the composed instant is reported to [onConfirm] once, on OK, so a
+ * date and a time chosen together cost a single re-plan. Dismissing changes nothing.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TripDateTimeDialog(
+    initialMillis: Long,
+    onDismiss: () -> Unit,
+    onConfirm: (Long) -> Unit
+) {
+    val context = LocalContext.current
+    // The rider is picking a wall-clock date and time, so every conversion in here is in the device's
+    // own zone — the same zone the form's date/time labels are formatted in.
+    val zone = remember { ZoneId.systemDefault() }
+    val initial = remember(initialMillis, zone) { Instant.ofEpochMilli(initialMillis).atZone(zone) }
+
+    // The chosen day, held as an epoch day so it survives a rotation through rememberSaveable (which
+    // stores only Bundle-native types). LocalDate is the working form; this is just its wire shape.
+    var epochDay by rememberSaveable { mutableLongStateOf(initial.toLocalDate().toEpochDay()) }
+    val date = LocalDate.ofEpochDay(epochDay)
+
+    val time = rememberTimePickerState(
+        initialHour = initial.hour,
+        initialMinute = initial.minute,
+        // The device's own 12-/24-hour setting, which is a separate choice from the locale.
+        is24Hour = DateFormat.is24HourFormat(context)
+    )
+    // Material's two ways to state a time: the dial, and the keyboard entry its toggle switches to.
+    var typing by rememberSaveable { mutableStateOf(false) }
+    var showCalendar by rememberSaveable { mutableStateOf(false) }
+    val displayMode = if (typing) TimePickerDisplayMode.Input else TimePickerDisplayMode.Picker
+
+    TimePickerDialog(
+        onDismissRequest = onDismiss,
+        confirmButton = {
+            TextButton(onClick = {
+                onConfirm(date.atTime(time.hour, time.minute).atZone(zone).toInstant().toEpochMilli())
+            }) { Text(stringResource(R.string.ok)) }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.cancel)) }
+        },
+        // Our own title rather than Material's, which reads "Select time" and so names only one of
+        // this dialog's two halves. Styled as the default is, so it keeps its place in the layout.
+        title = {
+            Text(
+                text = stringResource(R.string.trip_plan_select_date_time),
+                style = MaterialTheme.typography.labelMedium,
+                modifier = Modifier.padding(bottom = 20.dp)
+            )
+        },
+        modeToggleButton = {
+            TimePickerDialogDefaults.DisplayModeToggle(
+                displayMode = displayMode,
+                onDisplayModeChange = { typing = !typing }
+            )
+        }
+    ) {
+        DaySelector(
+            date = date,
+            onDateChange = { epochDay = it.toEpochDay() },
+            onChooseDate = { showCalendar = true }
+        )
+        if (typing) TimeInput(state = time) else TimePicker(state = time)
+    }
+
+    if (showCalendar) {
+        DayCalendarDialog(
+            date = date,
+            onDismiss = { showCalendar = false },
+            onDateChange = {
+                epochDay = it.toEpochDay()
+                showCalendar = false
+            }
+        )
+    }
+}
+
+/**
+ * Which day the trip is on: the two days a rider nearly always means, named outright, with the
+ * calendar behind a third row rather than in front of every pick. Any other day shows as its own
+ * date, so the button always states the day it holds rather than "Choose date…".
+ */
+@Composable
+private fun DaySelector(
+    date: LocalDate,
+    onDateChange: (LocalDate) -> Unit,
+    onChooseDate: () -> Unit
+) {
+    var expanded by rememberSaveable { mutableStateOf(false) }
+    // Read once, not per recomposition: the two named days have to keep meaning the same days for as
+    // long as the dialog is open, or a rider who opened it at 23:59 could tap "Today" and get the
+    // date the button no longer says.
+    val today = remember { LocalDate.now() }
+    val tomorrow = remember(today) { today.plusDays(1) }
+
+    // Deliberately wrap-content, not fillMaxWidth: the dialog's layout sizes itself to its widest
+    // child, so a row that claims all the width it is offered stretches the whole dialog past the
+    // window and clips the clock. The layout centres what it is given, so wrapping is also what
+    // centres this row.
+    Row(
+        modifier = Modifier.padding(bottom = 8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = stringResource(R.string.trip_plan_date),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Box {
+            TextButton(
+                onClick = { expanded = true },
+                modifier = Modifier.testTag(TripPlanTestTags.PICKER_DAY)
+            ) {
+                Text(dayLabel(date, today, tomorrow))
+                Icon(
+                    imageVector = AppIcons.KeyboardArrowDown,
+                    contentDescription = null,
+                    modifier = Modifier.padding(start = 4.dp).size(18.dp)
+                )
+            }
+            DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+                DropdownMenuItem(
+                    text = { Text(stringResource(R.string.trip_plan_date_today)) },
+                    onClick = {
+                        expanded = false
+                        onDateChange(today)
+                    }
+                )
+                DropdownMenuItem(
+                    text = { Text(stringResource(R.string.trip_plan_date_tomorrow)) },
+                    onClick = {
+                        expanded = false
+                        onDateChange(tomorrow)
+                    }
+                )
+                DropdownMenuItem(
+                    text = { Text(stringResource(R.string.trip_plan_choose_date)) },
+                    onClick = {
+                        expanded = false
+                        onChooseDate()
+                    }
+                )
+            }
+        }
+    }
+}
+
+/** The full calendar, reached from the day dropdown's third row. */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun DayCalendarDialog(
+    date: LocalDate,
+    onDismiss: () -> Unit,
+    onDateChange: (LocalDate) -> Unit
+) {
+    // Material states a calendar selection as UTC midnight of the day the rider tapped — a day, not an
+    // instant — so the day is read back out of UTC rather than the device zone. Reading it locally
+    // would land on the previous day for every rider east of Greenwich.
+    val state = rememberDatePickerState(
+        initialSelectedDateMillis = date.atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli()
+    )
+    DatePickerDialog(
+        onDismissRequest = onDismiss,
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    val selected = state.selectedDateMillis ?: return@TextButton onDismiss()
+                    onDateChange(Instant.ofEpochMilli(selected).atZone(ZoneOffset.UTC).toLocalDate())
+                }
+            ) { Text(stringResource(R.string.ok)) }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.cancel)) }
+        }
+    ) {
+        DatePicker(state = state)
+    }
+}
+
+/** [date] as the rider would say it: "Today", "Tomorrow", or the date itself. */
+@Composable
+private fun dayLabel(date: LocalDate, today: LocalDate, tomorrow: LocalDate): String = when (date) {
+    today -> stringResource(R.string.trip_plan_date_today)
+    tomorrow -> stringResource(R.string.trip_plan_date_tomorrow)
+    else -> date.format(DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM))
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanForm.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanForm.kt
@@ -137,6 +137,9 @@ object TripPlanTestTags {
     const val WHEN_TIME = "tripPlanWhenTime"
     const val VEHICLE_MODE = "tripPlanVehicleMode"
     const val STREET_MODE = "tripPlanStreetMode"
+
+    /** The day dropdown inside the combined date/time picker ([TripDateTimeDialog]). */
+    const val PICKER_DAY = "tripPlanPickerDay"
 }
 
 /**
@@ -186,8 +189,7 @@ fun TripPlanForm(
     onPickOnMap: (TripEndpointSlot) -> Unit,
     onSetArriving: (Boolean) -> Unit,
     onDepartNow: () -> Unit,
-    onPickDate: () -> Unit,
-    onPickTime: () -> Unit,
+    onPickDateTime: () -> Unit,
     availableStreetModes: List<StreetMode>,
     onVehicleModeSelected: (VehicleMode) -> Unit,
     onStreetModeSelected: (StreetMode) -> Unit,
@@ -226,8 +228,7 @@ fun TripPlanForm(
             availableStreetModes = availableStreetModes,
             onSetArriving = onSetArriving,
             onDepartNow = onDepartNow,
-            onPickDate = onPickDate,
-            onPickTime = onPickTime,
+            onPickDateTime = onPickDateTime,
             onVehicleModeSelected = onVehicleModeSelected,
             onStreetModeSelected = onStreetModeSelected,
             onReverse = onReverse,
@@ -558,8 +559,7 @@ private fun TripActionBar(
     availableStreetModes: List<StreetMode>,
     onSetArriving: (Boolean) -> Unit,
     onDepartNow: () -> Unit,
-    onPickDate: () -> Unit,
-    onPickTime: () -> Unit,
+    onPickDateTime: () -> Unit,
     onVehicleModeSelected: (VehicleMode) -> Unit,
     onStreetModeSelected: (StreetMode) -> Unit,
     onReverse: () -> Unit,
@@ -597,8 +597,7 @@ private fun TripActionBar(
             dateLabel = dateLabel,
             timeLabel = timeLabel,
             onDepartNow = onDepartNow,
-            onPickDate = onPickDate,
-            onPickTime = onPickTime
+            onPickDateTime = onPickDateTime
         )
         ModePicker(
             selected = modes.vehicle,
@@ -746,9 +745,10 @@ private fun WhenModeSegment(arriving: Boolean, onSetArriving: (Boolean) -> Unit)
 }
 
 /**
- * When the trip is for — the second half of the sentence. Reads "now" until a date or time is picked,
- * then the pinned instant. The menu keeps both Material pickers one tap away rather than folding them
- * into a single date-and-time flow, so changing just the time doesn't walk through a calendar.
+ * When the trip is for — the second half of the sentence. Reads "now" until an instant is pinned, then
+ * that instant. The menu is the two answers a rider actually has — leave now, or say when — with the
+ * date and the time settled together in one dialog ([TripDateTimeDialog], #2117) rather than as two
+ * menu rows that each set the whole instant from one of its halves.
  */
 @Composable
 private fun WhenTimeSegment(
@@ -757,8 +757,7 @@ private fun WhenTimeSegment(
     dateLabel: String,
     timeLabel: String,
     onDepartNow: () -> Unit,
-    onPickDate: () -> Unit,
-    onPickTime: () -> Unit
+    onPickDateTime: () -> Unit
 ) {
     var expanded by remember { mutableStateOf(false) }
     val nowLabel = stringResource(R.string.trip_plan_now)
@@ -792,14 +791,24 @@ private fun WhenTimeSegment(
                     onDepartNow()
                 }
             )
-            DropdownMenuItem(text = { Text(stringResource(R.string.trip_plan_choose_date)) }, onClick = {
-                expanded = false
-                onPickDate()
-            })
-            DropdownMenuItem(text = { Text(stringResource(R.string.trip_plan_choose_time)) }, onClick = {
-                expanded = false
-                onPickTime()
-            })
+            DropdownMenuItem(
+                text = { Text(stringResource(R.string.trip_plan_choose_date_time)) },
+                trailingIcon = if (!departNow) {
+                    {
+                        Icon(
+                            imageVector = AppIcons.Check,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.primary
+                        )
+                    }
+                } else {
+                    null
+                },
+                onClick = {
+                    expanded = false
+                    onPickDateTime()
+                }
+            )
         }
     }
 }
@@ -875,7 +884,7 @@ private fun TripPlanFormPreview() {
             onQueryChange = { _, _ -> }, onSelect = { _, _ -> },
             onCurrentLocation = {}, onPickOnMap = {},
             onSetArriving = {}, onDepartNow = {},
-            onPickDate = {}, onPickTime = {},
+            onPickDateTime = {},
             availableStreetModes = StreetMode.entries,
             onVehicleModeSelected = {}, onStreetModeSelected = {},
             onReverse = {}, onAdvancedSettings = {}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanViewModel.kt
@@ -236,9 +236,19 @@ class TripPlanViewModel @Inject constructor(
     }
 
     /**
-     * Pins the trip to an explicit instant, leaving the "now" anchor. Picking either half of the
-     * date/time is enough to pin: the other half keeps whatever it already showed, which is the
-     * moment the form was opened.
+     * The instant the date/time picker should open on: the pinned one when the trip is already pinned,
+     * and the live clock while it is anchored to "now". Under that anchor
+     * [TripPlanFormState.dateTimeMillis] still holds the instant this ViewModel was built, so a form
+     * left open would otherwise offer the rider a clock reading twenty minutes ago as their starting
+     * point — the same moving-anchor distinction [TripPlanFormState.departNow] exists for.
+     */
+    fun pickerStartMillis(): Long = _formState.value.let {
+        if (it.departNow) timeProvider.now() else it.dateTimeMillis
+    }
+
+    /**
+     * Pins the trip to an explicit instant, leaving the "now" anchor. The picker settles the date and
+     * the time together, so this is one write and one re-plan for both halves.
      */
     fun setDateTime(millis: Long) {
         _formState.update {

--- a/onebusaway-android/src/main/res/values-es/strings.xml
+++ b/onebusaway-android/src/main/res/values-es/strings.xml
@@ -831,7 +831,6 @@
     <string name="trip_plan_leaving">Saliendo</string>
     <string name="trip_plan_arriving">Llegando</string>
     <string name="trip_plan_date">Fecha</string>
-    <string name="trip_plan_time">Tiempo</string>
 
 
     <string name="tripplanner_no_server_selected_error">No hay ninguna región seleccionada</string>

--- a/onebusaway-android/src/main/res/values-fi/strings.xml
+++ b/onebusaway-android/src/main/res/values-fi/strings.xml
@@ -715,7 +715,6 @@
 
     <!-- Trip Planner strings -->
     <string name="trip_plan_date">Päivämäärä</string>
-    <string name="trip_plan_time">Aika</string>
     <string name="map_option_zoom_out">Loitontaa</string>
     <string name="map_option_zoom_in">Lähentää</string>
     <string name="map_option_layers_close">Sulje karttatasojen painike</string>

--- a/onebusaway-android/src/main/res/values-it/strings.xml
+++ b/onebusaway-android/src/main/res/values-it/strings.xml
@@ -676,7 +676,6 @@
     <string name="trip_plan_leaving">Partenza</string>
     <string name="trip_plan_arriving">Arrivo</string>
     <string name="trip_plan_date">Data</string>
-    <string name="trip_plan_time">Tempo</string>
 
 
 

--- a/onebusaway-android/src/main/res/values-pl/strings.xml
+++ b/onebusaway-android/src/main/res/values-pl/strings.xml
@@ -829,7 +829,6 @@
     <string name="trip_plan_leaving">Wyjazd</string>
     <string name="trip_plan_arriving">Przyjazd</string>
     <string name="trip_plan_date">Data</string>
-    <string name="trip_plan_time">Czas</string>
 
     <string name="tripplanner_no_server_selected_error">Nie wybrano regionu</string>
     <!-- Errors -->

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -953,8 +953,6 @@
     <string name="trip_plan_date_time">%1$s, %2$s</string>
     <!-- The one row of the time callout's menu that opens the combined date/time picker. -->
     <string name="trip_plan_choose_date_time">Choose date and time…</string>
-    <!-- That picker's title. Replaces Material's stock "Select time", which names only one of its halves. -->
-    <string name="trip_plan_select_date_time">Select date and time</string>
     <!-- The third row of that picker's day dropdown, which opens the calendar. -->
     <string name="trip_plan_choose_date">Choose date…</string>
     <!-- The two days that dropdown names outright; any other day shows as its own date. -->

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -951,14 +951,20 @@
     <string name="trip_plan_now">now</string>
     <!-- A pinned departure/arrival in the time callout: date, then time. -->
     <string name="trip_plan_date_time">%1$s, %2$s</string>
+    <!-- The one row of the time callout's menu that opens the combined date/time picker. -->
+    <string name="trip_plan_choose_date_time">Choose date and time…</string>
+    <!-- That picker's title. Replaces Material's stock "Select time", which names only one of its halves. -->
+    <string name="trip_plan_select_date_time">Select date and time</string>
+    <!-- The third row of that picker's day dropdown, which opens the calendar. -->
     <string name="trip_plan_choose_date">Choose date…</string>
-    <string name="trip_plan_choose_time">Choose time…</string>
+    <!-- The two days that dropdown names outright; any other day shows as its own date. -->
+    <string name="trip_plan_date_today">Today</string>
+    <string name="trip_plan_date_tomorrow">Tomorrow</string>
     <!-- Accessibility click label for either half of the time callout. -->
     <string name="trip_plan_change_when">Change when</string>
     <string name="trip_plan_leaving">Leaving</string>
     <string name="trip_plan_arriving">Arriving</string>
     <string name="trip_plan_date">Date</string>
-    <string name="trip_plan_time">Time</string>
     <string name="trip_plan_pick_on_map">Pick location on map</string>
     <string name="trip_plan_use_this_location">Use this location</string>
     <string name="trip_plan_map_location">Selected location</string>

--- a/onebusaway-android/src/main/res/values/themes.xml
+++ b/onebusaway-android/src/main/res/values/themes.xml
@@ -57,12 +57,6 @@
         <item name="colorSurfaceContainerHighest">@color/md_theme_surfaceContainerHighest</item>
     </style>
 
-    <!-- Time Picker Style  -->
-    <style name="ThemeOverlay.App.TimePicker" parent="ThemeOverlay.Material3.MaterialTimePicker">
-        <item name="colorTertiaryContainer">?attr/colorSecondary</item>
-        <item name="colorOnTertiaryContainer">?attr/colorOnSecondary</item>
-    </style>
-
     <!-- Clear Dialog Theming  -->
     <style name="ThemeOverlay.App.DeleteDialog" parent="ThemeOverlay.Material3.MaterialAlertDialog">
         <item name="materialAlertDialogTitleIconStyle">@style/Widget.App.DialogIcon.Error</item>


### PR DESCRIPTION
Fixes #2117.

## The problem

The directions time callout's menu offered **"Choose date…"** and **"Choose time…"** — two rows that each opened a picker setting the *whole* pinned instant from one of its halves. Pinning a departure for tomorrow evening therefore meant two trips through the menu and two re-plans, and picking only one half silently kept whatever the other happened to hold: under the "now" anchor, the moment the ViewModel was built.

## The change

They are now **one row opening one dialog**: a clock — the half a rider is nearly always changing — over a compact day dropdown that names **Today / Tomorrow** outright and opens a calendar only for the rarer case, as the issue describes. The composed instant is reported once, on OK, so a date and a time chosen together cost a single re-plan.

- **`TripDateTimeDialog`** (new) — Material 3's Compose `TimePickerDialog` (dial plus keyboard entry via its mode toggle) with the day dropdown in its content slot, and M3's `DatePickerDialog` behind "Choose date…". This replaces the two View-system `MaterialDatePicker`/`MaterialTimePicker` flows, so the host no longer needs an `AppCompatActivity` or its fragment manager.
- The picker opens on the **live clock** while the trip is anchored to "now" (`TripPlanViewModel.pickerStartMillis`), rather than on the stamp the form has been carrying since it opened.
- The dialog has no heading: Material's default reads "Select time", naming only one of its two halves, and any heading just restates the two controls under it — each of which already says what it is.
- Dropped with their last callers: `R.string.trip_plan_time` (and its four translations) and the `ThemeOverlay.App.TimePicker` style, which existed only to theme the View-system time picker. Both would otherwise fail the unused-resource lint gate.

## Verification

Verified on a physical device (Pixel 7 Pro, Android 16), including screenshots of the dial, the day dropdown, and the nested calendar — which confirmed the calendar's UTC round-trip lands on the right day, and caught one layout bug that only showed on device (a `fillMaxWidth()` on the date row stretched the dialog past the window and clipped the clock).

- 22 instrumented tests pass, including 5 new ones in `TripDateTimeDialogTest` covering the seam the merge creates: moving the day must carry the time across untouched, and the confirmed instant is the two together.
- `TripPlanFormRenderTest` gains a case asserting the menu pins an instant in one row.
- Compiles clean under `-PwarningsAsErrors=true`; `spotlessCheck` and the trip-plan unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a combined date-and-time picker for trip planning.
  - Users can select today, tomorrow, or another calendar date while choosing a time.
  - The picker respects device time format, time zone, and preserves selections during recreation.
  - Added clearer date labels and a single “Choose date and time…” option.

- **Bug Fixes**
  - Canceling the picker leaves the original trip date and time unchanged.
  - Confirming selections applies one combined departure date and time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->