### PR TITLE
Measure every street mode on the directions picker cards (#2122)

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/ItineraryWinnerHighlightTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/ItineraryWinnerHighlightTest.kt
@@ -56,7 +56,7 @@ class ItineraryWinnerHighlightTest {
         durationMinutes = durationMinutes,
         startTime = ServerTime(departureMinutes * 60_000L),
         endTime = ServerTime(arrivalMinutes * 60_000L),
-        walkDistanceMeters = walkMeters
+        streetDistanceMeters = mapOf(StreetMode.WALK to walkMeters)
     )
 
     private val state = TripResultsUiState.Success(

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/OptionCardStreetMetricsTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/OptionCardStreetMetricsTest.kt
@@ -16,10 +16,12 @@
 package org.onebusaway.android.ui.tripresults
 
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasStateDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.platform.app.InstrumentationRegistry
 import org.junit.Rule
 import org.junit.Test
+import org.onebusaway.android.R
 import org.onebusaway.android.directions.util.ConversionUtils
 import org.onebusaway.android.time.ServerTime
 import org.onebusaway.android.ui.compose.createUnconfinedComposeRule
@@ -28,7 +30,9 @@ import org.onebusaway.android.ui.compose.theme.ObaTheme
 /**
  * Coverage for the option card's street-distance metric lines (#2122): a card measures **every** street
  * mode the trip travels on, so a bikeshare trip says how far it rides as well as how far it walks, and a
- * bike-only trip says how far it bikes instead of reporting "0 ft" of walking as its whole street cost.
+ * bike-only trip says how far it bikes instead of reporting "0 ft" of walking as its whole street cost —
+ * and each of those lines can win its own "least" category, so the emphasis follows whatever the plan is
+ * actually made of rather than always landing on the walking line.
  *
  * The distances are asserted as the text a rider reads (`ConversionUtils`-formatted, in whatever units
  * the device is set to) rather than as raw meters, since the formatting is the point of a distance line.
@@ -59,6 +63,22 @@ class OptionCardStreetMetricsTest {
         composeRule.onNodeWithText(distance(0.0)).assertDoesNotExist()
     }
 
+    /**
+     * The win the walking line has always had, now on the mode a bikeshare plan is really compared on.
+     * The two options are identical but for how far they ride, so nothing else can be won.
+     */
+    @Test
+    fun theOptionThatRidesLeastAnnouncesItsBikeshareWin() {
+        show(
+            option(StreetMode.WALK to WALK_METERS, StreetMode.BIKESHARE to BIKE_METERS),
+            option(StreetMode.WALK to WALK_METERS, StreetMode.BIKESHARE to BIKE_METERS * 2)
+        )
+
+        composeRule
+            .onNode(hasStateDescription(context.getString(R.string.trip_plan_winner_least_bikesharing)))
+            .assertExists()
+    }
+
     // ---- fixtures -----------------------------------------------------------------------------------
 
     /** The distance line's text, assembled from its parts exactly as the card draws them. */
@@ -73,12 +93,12 @@ class OptionCardStreetMetricsTest {
         streetDistanceMeters = distances.toMap()
     )
 
-    private fun show(option: ItineraryOption) {
+    private fun show(vararg options: ItineraryOption) {
         composeRule.setContent {
             ObaTheme {
                 TripResultsHeader(
                     TripResultsUiState.Success(
-                        options = listOf(option),
+                        options = options.toList(),
                         selectedIndex = 0,
                         directions = emptyList()
                     ),

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/OptionCardStreetMetricsTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/OptionCardStreetMetricsTest.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.tripresults
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Rule
+import org.junit.Test
+import org.onebusaway.android.directions.util.ConversionUtils
+import org.onebusaway.android.time.ServerTime
+import org.onebusaway.android.ui.compose.createUnconfinedComposeRule
+import org.onebusaway.android.ui.compose.theme.ObaTheme
+
+/**
+ * Coverage for the option card's street-distance metric lines (#2122): a card measures **every** street
+ * mode the trip travels on, so a bikeshare trip says how far it rides as well as how far it walks, and a
+ * bike-only trip says how far it bikes instead of reporting "0 ft" of walking as its whole street cost.
+ *
+ * The distances are asserted as the text a rider reads (`ConversionUtils`-formatted, in whatever units
+ * the device is set to) rather than as raw meters, since the formatting is the point of a distance line.
+ */
+class OptionCardStreetMetricsTest {
+
+    // See createUnconfinedComposeRule for why Unconfined composition is used here (issue #1792).
+    @get:Rule
+    val composeRule = createUnconfinedComposeRule()
+
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext
+
+    @Test
+    fun aBikeshareTripMeasuresBothItsRideAndItsWalk() {
+        show(option(StreetMode.WALK to WALK_METERS, StreetMode.BIKESHARE to BIKE_METERS))
+
+        composeRule.onNodeWithText(distance(WALK_METERS)).assertIsDisplayed()
+        composeRule.onNodeWithText(distance(BIKE_METERS)).assertIsDisplayed()
+    }
+
+    @Test
+    fun aBikeOnlyTripMeasuresItsBiking_andSaysNothingAboutWalking() {
+        show(option(StreetMode.BIKE to BIKE_METERS))
+
+        composeRule.onNodeWithText(distance(BIKE_METERS)).assertIsDisplayed()
+        // A single option wins no category, so nothing forces the zero-walk line a LEAST_WALKING
+        // winner keeps.
+        composeRule.onNodeWithText(distance(0.0)).assertDoesNotExist()
+    }
+
+    // ---- fixtures -----------------------------------------------------------------------------------
+
+    /** The distance line's text, assembled from its parts exactly as the card draws them. */
+    private fun distance(meters: Double) = ConversionUtils.getFormattedDistanceParts(meters, context)
+        .joinToString(separator = "") { it.text }
+
+    private fun option(vararg distances: Pair<StreetMode, Double>) = ItineraryOption(
+        symbols = listOf(ModeSymbol.Street(distances.first().first)),
+        durationMinutes = 18L,
+        startTime = ServerTime(0L),
+        endTime = ServerTime(18 * 60_000L),
+        streetDistanceMeters = distances.toMap()
+    )
+
+    private fun show(option: ItineraryOption) {
+        composeRule.setContent {
+            ObaTheme {
+                TripResultsHeader(
+                    TripResultsUiState.Success(
+                        options = listOf(option),
+                        selectedIndex = 0,
+                        directions = emptyList()
+                    ),
+                    onSelectOption = {}
+                )
+            }
+        }
+        composeRule.waitForIdle()
+    }
+}
+
+/** Two distances far enough apart to format differently whichever units the device uses. */
+private const val WALK_METERS = 400.0
+private const val BIKE_METERS = 2300.0

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/OptionCardSummaryTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/OptionCardSummaryTest.kt
@@ -160,7 +160,7 @@ class OptionCardSummaryTest {
         durationMinutes = DURATION_MINUTES,
         startTime = ServerTime(0L),
         endTime = ServerTime(DURATION_MINUTES * 60_000L),
-        walkDistanceMeters = 400.0
+        streetDistanceMeters = mapOf(StreetMode.WALK to 400.0)
     )
 
     private fun show(vararg options: ItineraryOption) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/ItineraryWinners.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/ItineraryWinners.kt
@@ -24,8 +24,8 @@ import org.onebusaway.android.R
  *
  * Every street mode a card can draw a distance for has its own "least" category, so the emphasis is on
  * whatever the trip actually costs the rider: a bikeshare plan's cards compete on how far they make you
- * ride, exactly as a walking plan's compete on how far they make you walk (#2122). [StreetMode.CAR] has
- * none, for the same reason it has no metric line at all — see [streetDistanceCategory].
+ * ride, exactly as a walking plan's compete on how far they make you walk (#2122). Which mode owns which
+ * category — and which modes have one at all — is [StreetMetric]'s to say, not this enum's.
  *
  * The declaration order is the order a card reads its wins in, so keep related categories together.
  */
@@ -36,18 +36,6 @@ enum class WinnerCategory(@StringRes val labelRes: Int) {
     LEAST_BIKESHARING(R.string.trip_plan_winner_least_bikesharing),
     EARLIEST_ARRIVAL(R.string.trip_plan_winner_earliest_arrival),
     LATEST_DEPARTURE(R.string.trip_plan_winner_latest_departure)
-}
-
-/**
- * Which category a street mode's distance is compared in — null for a mode the cards draw no distance
- * line for ([StreetMode.CAR]; see `streetMetricGlyph`), since a win with nothing to outline would be
- * announced and never seen.
- */
-fun StreetMode.streetDistanceCategory(): WinnerCategory? = when (this) {
-    StreetMode.WALK -> WinnerCategory.LEAST_WALKING
-    StreetMode.BIKE -> WinnerCategory.LEAST_BIKING
-    StreetMode.BIKESHARE -> WinnerCategory.LEAST_BIKESHARING
-    StreetMode.CAR -> null
 }
 
 /** Which clock-time comparison is useful for the request that produced the options. */
@@ -93,12 +81,11 @@ fun itineraryWinnerCategories(
     // needs no bikeshare at all" is a real answer to how much bikesharing it costs, and it is how a
     // trip that never walks has always won LEAST_WALKING. The card draws the winning line even at zero
     // (see `streetMetrics`), so the outline always has a value under it.
-    for (mode in StreetMode.entries) {
-        val category = mode.streetDistanceCategory() ?: continue
-        val distances = options.map { it.streetDistanceMeters[mode] ?: 0.0 }
+    for (metric in StreetMetric.entries) {
+        val distances = options.map { it.streetDistanceMeters[metric.mode] ?: 0.0 }
         // A non-finite distance is not comparable enough to declare a winner for the whole result set.
         if (distances.all(Double::isFinite)) {
-            award(category, distances) { it.min() }
+            award(metric.winner, distances) { it.min() }
         }
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/ItineraryWinners.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/ItineraryWinners.kt
@@ -15,12 +15,39 @@
  */
 package org.onebusaway.android.ui.tripresults
 
-/** A comparison an itinerary option can win in the route picker. */
-enum class WinnerCategory {
-    SHORTEST_TRAVEL_TIME,
-    LEAST_WALKING,
-    EARLIEST_ARRIVAL,
-    LATEST_DEPARTURE
+import androidx.annotation.StringRes
+import org.onebusaway.android.R
+
+/**
+ * A comparison an itinerary option can win in the route picker, and what that win is called aloud
+ * ([labelRes] — the card announces its wins as a `stateDescription`).
+ *
+ * Every street mode a card can draw a distance for has its own "least" category, so the emphasis is on
+ * whatever the trip actually costs the rider: a bikeshare plan's cards compete on how far they make you
+ * ride, exactly as a walking plan's compete on how far they make you walk (#2122). [StreetMode.CAR] has
+ * none, for the same reason it has no metric line at all — see [streetDistanceCategory].
+ *
+ * The declaration order is the order a card reads its wins in, so keep related categories together.
+ */
+enum class WinnerCategory(@StringRes val labelRes: Int) {
+    SHORTEST_TRAVEL_TIME(R.string.trip_plan_winner_shortest_travel_time),
+    LEAST_WALKING(R.string.trip_plan_winner_least_walking),
+    LEAST_BIKING(R.string.trip_plan_winner_least_biking),
+    LEAST_BIKESHARING(R.string.trip_plan_winner_least_bikesharing),
+    EARLIEST_ARRIVAL(R.string.trip_plan_winner_earliest_arrival),
+    LATEST_DEPARTURE(R.string.trip_plan_winner_latest_departure)
+}
+
+/**
+ * Which category a street mode's distance is compared in — null for a mode the cards draw no distance
+ * line for ([StreetMode.CAR]; see `streetMetricGlyph`), since a win with nothing to outline would be
+ * announced and never seen.
+ */
+fun StreetMode.streetDistanceCategory(): WinnerCategory? = when (this) {
+    StreetMode.WALK -> WinnerCategory.LEAST_WALKING
+    StreetMode.BIKE -> WinnerCategory.LEAST_BIKING
+    StreetMode.BIKESHARE -> WinnerCategory.LEAST_BIKESHARING
+    StreetMode.CAR -> null
 }
 
 /** Which clock-time comparison is useful for the request that produced the options. */
@@ -59,10 +86,20 @@ fun itineraryWinnerCategories(
 
     award(WinnerCategory.SHORTEST_TRAVEL_TIME, options.map { it.durationMinutes }) { it.min() }
 
-    // A non-finite distance is not comparable enough to declare a winner for the whole result set.
-    val walks = options.map { it.walkDistanceMeters }
-    if (walks.all(Double::isFinite)) {
-        award(WinnerCategory.LEAST_WALKING, walks) { it.min() }
+    // One "least" per street mode the cards measure, rather than walking alone: whichever modes a plan
+    // is made of, the rider can see which option asks least of them on each.
+    //
+    // A mode an option never uses counts as **zero** of it, which is the best value there is — "this one
+    // needs no bikeshare at all" is a real answer to how much bikesharing it costs, and it is how a
+    // trip that never walks has always won LEAST_WALKING. The card draws the winning line even at zero
+    // (see `streetMetrics`), so the outline always has a value under it.
+    for (mode in StreetMode.entries) {
+        val category = mode.streetDistanceCategory() ?: continue
+        val distances = options.map { it.streetDistanceMeters[mode] ?: 0.0 }
+        // A non-finite distance is not comparable enough to declare a winner for the whole result set.
+        if (distances.all(Double::isFinite)) {
+            award(category, distances) { it.min() }
+        }
     }
 
     if (scheduleMode == ScheduleWinnerMode.EARLIEST_ARRIVAL || scheduleMode == ScheduleWinnerMode.BOTH) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/ModeSymbols.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/ModeSymbols.kt
@@ -124,3 +124,20 @@ internal fun TripLeg.streetMode(): StreetMode = when (mode) {
     TripMode.CAR -> StreetMode.CAR
     else -> StreetMode.WALK
 }
+
+/**
+ * How far the trip covers on each street mode it uses, in meters — the option card's metric lines
+ * (#2122). Split by the same [streetMode] the card's symbols are drawn from, so a card cannot show a
+ * bikeshare glyph and then count that ride's distance as walking.
+ *
+ * A mode the trip never travels on is **absent**, not zero: the card draws a line per entry, and "0 ft
+ * of biking" on a plain transit trip is a line about something that didn't happen. Every on-street leg
+ * counts, including the ones too short for a symbol ([ModeSymbols.NEGLIGIBLE_STREET_METERS]) — the
+ * threshold is about what's worth *drawing* as a step of the trip, while these are totals, and dropping
+ * a 100 m transfer walk from them would under-report the walking a rider is being asked to do.
+ *
+ * Pure, like the rest of this file, so `ModeSymbolsTest` covers it without a `Context`.
+ */
+internal fun List<TripLeg>.streetDistancesMeters(): Map<StreetMode, Double> = filter { it.mode?.isOnStreetNonTransit == true }
+    .groupBy { it.streetMode() }
+    .mapValues { (_, legs) -> legs.sumOf { it.distance } }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/ModeSymbols.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/ModeSymbols.kt
@@ -93,7 +93,7 @@ internal object ModeSymbols {
     private fun TripLeg.streetSymbolOrNull(): ModeSymbol.Street? = if (distance >= NEGLIGIBLE_STREET_METERS) ModeSymbol.Street(streetMode()) else null
 
     /** The longest on-street leg, i.e. the one a street-only trip is really about; null if there is none. */
-    private fun List<TripLeg>.longestStreetLeg(): TripLeg? = filter { it.mode?.isOnStreetNonTransit == true }.maxByOrNull { it.distance }
+    private fun List<TripLeg>.longestStreetLeg(): TripLeg? = streetLegs().maxByOrNull { it.distance }
 
     private fun List<ModeSymbol>.filterConsecutiveDuplicateStreets(): List<ModeSymbol> = filterIndexed { i, symbol ->
         symbol !is ModeSymbol.Street || getOrNull(i - 1) != symbol
@@ -138,6 +138,9 @@ internal fun TripLeg.streetMode(): StreetMode = when (mode) {
  *
  * Pure, like the rest of this file, so `ModeSymbolsTest` covers it without a `Context`.
  */
-internal fun List<TripLeg>.streetDistancesMeters(): Map<StreetMode, Double> = filter { it.mode?.isOnStreetNonTransit == true }
+internal fun List<TripLeg>.streetDistancesMeters(): Map<StreetMode, Double> = streetLegs()
     .groupBy { it.streetMode() }
     .mapValues { (_, legs) -> legs.sumOf { it.distance } }
+
+/** The legs the rider covers under their own power — the ones [streetMode] can speak for. */
+private fun List<TripLeg>.streetLegs(): List<TripLeg> = filter { it.mode?.isOnStreetNonTransit == true }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsRepository.kt
@@ -25,7 +25,6 @@ import org.onebusaway.android.directions.model.InterchangeableRoute
 import org.onebusaway.android.directions.model.Interlines
 import org.onebusaway.android.directions.model.TripItinerary
 import org.onebusaway.android.directions.model.TripLeg
-import org.onebusaway.android.directions.model.TripMode
 import org.onebusaway.android.directions.model.TripPlace
 import org.onebusaway.android.directions.model.interchangeableRoutes
 import org.onebusaway.android.directions.model.routeDisplayName
@@ -38,7 +37,7 @@ import org.onebusaway.android.util.runCatchingCancellable
 /**
  * Projects [TripItinerary] objects onto the Compose results model. The turn-by-turn directions reuse
  * the legacy [DirectionsGenerator] (which needs a [Context] for resources), and the option cards carry
- * structured data (mode symbols / duration / time range / walk distance) formatted by the UI. All
+ * structured data (mode symbols / duration / time range / street distances) formatted by the UI. All
  * on the IO thread so [TripResultsViewModel] stays JVM-testable.
  */
 interface TripResultsRepository {
@@ -72,10 +71,9 @@ class DefaultTripResultsRepository @Inject constructor(
         durationMinutes = itinerary.duration.inWholeMinutes,
         startTime = itinerary.startTime,
         endTime = itinerary.startTime + itinerary.duration,
-        // Total walking (meters) across the trip's WALK legs; the card formats it to the user's units.
-        walkDistanceMeters = itinerary.legs
-            .filter { it.mode == TripMode.WALK }
-            .sumOf { it.distance }
+        // How far the trip goes on each street mode it uses (meters), one metric line each on the card
+        // (#2122); the card formats them to the user's units.
+        streetDistanceMeters = itinerary.legs.streetDistancesMeters()
     )
 
     override suspend fun directionsFor(

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
@@ -567,20 +567,26 @@ private fun ModeSymbolContent(symbol: ModeSymbol) {
 }
 
 /**
- * The lower half of an option card: what the trip costs (duration, walking) and when it runs, each metric
- * outlined where it wins its category. Takes the [winners] set itself rather than a flag per category, so
- * a new [WinnerCategory] is one line here and nothing at the call site.
+ * The lower half of an option card: what the trip costs (duration, and the ground the rider covers under
+ * their own power) and when it runs, each metric outlined where it wins its category. Takes the [winners]
+ * set itself rather than a flag per category, so a new [WinnerCategory] is one line here and nothing at
+ * the call site.
  */
 @Composable
 private fun StatsColumn(option: ItineraryOption, winners: Set<WinnerCategory>) {
     val context = LocalContext.current
     val leastWalking = WinnerCategory.LEAST_WALKING in winners
     val winnerOutlineColor = MaterialTheme.colorScheme.outline.copy(alpha = WINNER_OUTLINE_ALPHA)
+    // A line per street mode the trip travels on, plus the walking line a zero-distance LEAST_WALKING
+    // winner has to keep showing (there is nothing to outline otherwise).
+    val metrics = remember(option.streetDistanceMeters, leastWalking) {
+        streetMetrics(option.streetDistanceMeters, keepZeroWalk = leastWalking)
+    }
     Column(
         modifier = Modifier.padding(CARD_SECTION_PADDING),
         verticalArrangement = Arrangement.spacedBy(4.dp)
     ) {
-        // Duration + walk distance read as one stat group, so they sit tighter together than the
+        // Duration + the street distances read as one stat group, so they sit tighter together than the
         // card's other lines.
         Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
             // Duration — a leading hourglass + the ETA-pill-formatted trip length.
@@ -597,18 +603,21 @@ private fun StatsColumn(option: ItineraryOption, winners: Set<WinnerCategory>) {
                     unitSize = METRIC_UNIT_SIZE
                 )
             }
-            // Total walking for the trip — a leading walk glyph mirroring the duration row's hourglass,
-            // with the distance styled like the duration (bold value + smaller unit). In the user's units
-            // (miles/km, or feet/meters for short walks). Hidden when the trip has no walking.
-            if (option.walkDistanceMeters > 0.0 || leastWalking) {
+            // How far the trip goes on each street mode, one line each (#2122) — a leading mode glyph
+            // mirroring the duration row's hourglass, with the distance styled like the duration (bold
+            // value + smaller unit) and in the user's units (miles/km, or feet/meters for short hops).
+            // A card used to say only how far it walked, which left a bikeshare trip's ride unmeasured
+            // and a bike-only one claiming "0 ft" as its whole street distance.
+            metrics.forEach { metric ->
                 MetricRow(
-                    MetricGlyph.WALK,
-                    contentDescription = stringResource(R.string.step_by_step_non_transit_mode_walk_action),
-                    winner = leastWalking,
+                    metric.glyph,
+                    contentDescription = stringResource(streetModeLabel(metric.mode)),
+                    // Only walking is compared across the row, so only its line can be a winner.
+                    winner = leastWalking && metric.mode == StreetMode.WALK,
                     outlineColor = winnerOutlineColor
                 ) {
                     EtaPartsText(
-                        ConversionUtils.getFormattedDistanceParts(option.walkDistanceMeters, context),
+                        ConversionUtils.getFormattedDistanceParts(metric.meters, context),
                         modifier = Modifier.alignByBaseline(),
                         numberSize = METRIC_NUMBER_SIZE,
                         unitSize = METRIC_UNIT_SIZE
@@ -625,6 +634,32 @@ private fun StatsColumn(option: ItineraryOption, winners: Set<WinnerCategory>) {
             ScheduleMetric(endText, winner = WinnerCategory.EARLIEST_ARRIVAL in winners, outlineColor = winnerOutlineColor)
         }
     }
+}
+
+/** One street-distance line on a card: how far the trip goes on [mode], behind the [glyph] that leads it. */
+private data class StreetMetric(val mode: StreetMode, val meters: Double, val glyph: MetricGlyph)
+
+/**
+ * Which street-distance lines a card draws, from the per-mode totals it carries — in [StreetMode]
+ * declaration order rather than in travel order, so cards measuring the same modes list them in the same
+ * order and the row reads across (walking first, since it is the mode nearly every option has and the
+ * one they are ranked on). Cards measuring *different* modes do stagger below their first line — a
+ * bikeshare option carries a line its walk-only neighbour hasn't got — but that difference is itself
+ * what the rider is choosing between.
+ *
+ * A mode the trip doesn't use draws no line. The one exception is [keepZeroWalk]: an option that wins
+ * [WinnerCategory.LEAST_WALKING] by walking nowhere still shows its "0 ft", since the outline needs a
+ * value to sit on and the win is worth saying.
+ *
+ * [StreetMode.CAR] is dropped here for the same reason it draws no symbol — the app ships no car glyph
+ * and its planner never asks for car legs (see [streetModeIcon]) — so a car total would be a line with
+ * nothing leading it.
+ */
+private fun streetMetrics(distances: Map<StreetMode, Double>, keepZeroWalk: Boolean): List<StreetMetric> = StreetMode.entries.mapNotNull { mode ->
+    val meters = distances[mode] ?: 0.0
+    val glyph = streetMetricGlyph(mode)
+    val drawn = meters > 0.0 || (keepZeroWalk && mode == StreetMode.WALK)
+    if (drawn && glyph != null) StreetMetric(mode, meters, glyph) else null
 }
 
 /**
@@ -675,21 +710,24 @@ private fun MetricRow(
 
 /**
  * A metric row's leading glyph, together with where the glyph's ink actually sits inside its 24-unit
- * vector viewport — read off the asset's `pathData` bounds, and *not* the same for both: the hourglass
- * inks y[2, 22], the walker y[1.5, 23]. Carrying the bounds is what lets [MetricRow] work in ink.
+ * vector viewport — read off the asset's `pathData` bounds, and no two of them the same: the hourglass
+ * inks y[2, 22], the walker y[1.5, 23], the bicycle y[1.5, 22], the rental bike y[1, 22.497]. Carrying
+ * the bounds is what lets [MetricRow] work in ink.
  *
- * These four numbers are transcribed by hand from the asset, so re-read them whenever you swap a
- * drawable, edit its path, or re-import it from Material — nothing checks them for you, and a stale
- * reading un-levels its row quietly rather than loudly.
+ * These numbers are transcribed by hand from the asset, so re-read them whenever you swap a drawable,
+ * edit its path, or re-import it from Material — nothing checks them for you, and a stale reading
+ * un-levels its row quietly rather than loudly.
  *
  * The assets stay uncropped — cropping would only delete the ink fraction, not the levelling — and for
- * the walker it can't be done at all: `ic_directions_walk` is also a mode glyph ([streetModeIcon]) and
- * a step icon, where it has to sit at the same visual weight as the uncropped bus/rail glyphs beside
- * it, so a crop would mean a second copy of its path.
+ * the street glyphs it can't be done at all: each is also a mode glyph ([streetModeIcon]) and a step
+ * icon, where it has to sit at the same visual weight as the uncropped bus/rail glyphs beside it, so a
+ * crop would mean a second copy of its path.
  */
 private enum class MetricGlyph(@DrawableRes val iconRes: Int, val inkTop: Float, val inkBottom: Float) {
     DURATION(R.drawable.hourglass_24, inkTop = 2f, inkBottom = 22f),
-    WALK(R.drawable.ic_directions_walk, inkTop = 1.5f, inkBottom = 23f);
+    WALK(R.drawable.ic_directions_walk, inkTop = 1.5f, inkBottom = 23f),
+    BIKE(R.drawable.ic_directions_bike, inkTop = 1.5f, inkBottom = 22f),
+    BIKESHARE(R.drawable.ic_bike_rental, inkTop = 1f, inkBottom = 22.497f);
 
     /** What the icon box has to be scaled by for this glyph's ink alone to stand a wanted height. */
     val boxFactor: Float = GLYPH_VIEWPORT / (inkBottom - inkTop)
@@ -1301,20 +1339,26 @@ private class RowChrome(density: Density, private val model: LogRowModel, timeWi
 }
 
 /**
- * The glyph for an on-street leg — inside its node on the spine, and as its symbol on an option card.
+ * The glyph for an on-street leg — inside its node on the spine, as its symbol on an option card, and
+ * leading that mode's distance line ([streetMetricGlyph], the one place the drawables are named, so a
+ * mode can't be drawn one way as a symbol and another as a metric).
+ *
  * A rented bike takes a rental glyph (`ic_bike_rental`: Material Symbols' `car_rental` key over a
  * bicycle instead of a car) rather than the plain bicycle, so a shared bike doesn't read as the one the
  * rider brought — the same distinction the map draws between a bikeshare dock and a bike.
  *
  * Null for [StreetMode.CAR]: the app ships no car drawable because its planner never asks OTP for car
  * modes (the mode picker offers none — see `org.onebusaway.android.ui.tripplan.TripModeSelection`), and
- * a bare ring is honest where a walking figure would be wrong. Add `ic_directions_car` here if car
- * planning is ever offered.
+ * a bare ring is honest where a walking figure would be wrong. Add `ic_directions_car` here — as a
+ * [MetricGlyph], with its ink bounds — if car planning is ever offered.
  */
-private fun streetModeIcon(mode: StreetMode): Int? = when (mode) {
-    StreetMode.WALK -> R.drawable.ic_directions_walk
-    StreetMode.BIKE -> R.drawable.ic_directions_bike
-    StreetMode.BIKESHARE -> R.drawable.ic_bike_rental
+private fun streetModeIcon(mode: StreetMode): Int? = streetMetricGlyph(mode)?.iconRes
+
+/** The metric line's leading glyph for a street mode: the same art as [streetModeIcon], levelled by ink. */
+private fun streetMetricGlyph(mode: StreetMode): MetricGlyph? = when (mode) {
+    StreetMode.WALK -> MetricGlyph.WALK
+    StreetMode.BIKE -> MetricGlyph.BIKE
+    StreetMode.BIKESHARE -> MetricGlyph.BIKESHARE
     StreetMode.CAR -> null
 }
 
@@ -1860,7 +1904,7 @@ private fun TripResultsPreview() {
                     durationMinutes = 32,
                     startTime = ServerTime(0L),
                     endTime = ServerTime(32 * 60_000L),
-                    walkDistanceMeters = 800.0
+                    streetDistanceMeters = mapOf(StreetMode.WALK to 800.0)
                 ),
                 ItineraryOption(
                     // The second leg is a ferry, which publishes no route short name — so it badges its
@@ -1873,7 +1917,7 @@ private fun TripResultsPreview() {
                     durationMinutes = 41,
                     startTime = ServerTime(0L),
                     endTime = ServerTime(41 * 60_000L),
-                    walkDistanceMeters = 400.0
+                    streetDistanceMeters = mapOf(StreetMode.WALK to 400.0)
                 ),
                 ItineraryOption(
                     // A bikeshare trip: walk to the dock, ride, walk from it (#2047).
@@ -1885,7 +1929,8 @@ private fun TripResultsPreview() {
                     durationMinutes = 18,
                     startTime = ServerTime(0L),
                     endTime = ServerTime(18 * 60_000L),
-                    walkDistanceMeters = 500.0
+                    // Both of its street modes measured, the ride as well as the walk (#2122).
+                    streetDistanceMeters = mapOf(StreetMode.WALK to 500.0, StreetMode.BIKESHARE to 2300.0)
                 )
             ),
             selectedIndex = 0,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
@@ -346,12 +346,10 @@ private fun OptionCard(
     val textColor = colorResource(
         if (selected) R.color.trip_plan_header_text_selected else R.color.trip_plan_header_text
     )
-    val winnerDescriptions = buildList {
-        if (WinnerCategory.SHORTEST_TRAVEL_TIME in winners) add(stringResource(R.string.trip_plan_winner_shortest_travel_time))
-        if (WinnerCategory.LEAST_WALKING in winners) add(stringResource(R.string.trip_plan_winner_least_walking))
-        if (WinnerCategory.EARLIEST_ARRIVAL in winners) add(stringResource(R.string.trip_plan_winner_earliest_arrival))
-        if (WinnerCategory.LATEST_DEPARTURE in winners) add(stringResource(R.string.trip_plan_winner_latest_departure))
-    }
+    // Read off the categories themselves, in their declaration order, so a category added to the enum
+    // is announced without a second list here having to be remembered — which is exactly how the bike
+    // distances went un-announced when they first got their own lines.
+    val winnerDescriptions = WinnerCategory.entries.filter { it in winners }.map { stringResource(it.labelRes) }
     Surface(
         color = background,
         contentColor = textColor,
@@ -575,12 +573,11 @@ private fun ModeSymbolContent(symbol: ModeSymbol) {
 @Composable
 private fun StatsColumn(option: ItineraryOption, winners: Set<WinnerCategory>) {
     val context = LocalContext.current
-    val leastWalking = WinnerCategory.LEAST_WALKING in winners
     val winnerOutlineColor = MaterialTheme.colorScheme.outline.copy(alpha = WINNER_OUTLINE_ALPHA)
-    // A line per street mode the trip travels on, plus the walking line a zero-distance LEAST_WALKING
-    // winner has to keep showing (there is nothing to outline otherwise).
-    val metrics = remember(option.streetDistanceMeters, leastWalking) {
-        streetMetrics(option.streetDistanceMeters, keepZeroWalk = leastWalking)
+    // A line per street mode the trip travels on, plus any mode this option wins outright by not using
+    // it at all — a zero-distance win still needs a value to outline.
+    val metrics = remember(option.streetDistanceMeters, winners) {
+        streetMetrics(option.streetDistanceMeters, winners)
     }
     Column(
         modifier = Modifier.padding(CARD_SECTION_PADDING),
@@ -612,8 +609,7 @@ private fun StatsColumn(option: ItineraryOption, winners: Set<WinnerCategory>) {
                 MetricRow(
                     metric.glyph,
                     contentDescription = stringResource(streetModeLabel(metric.mode)),
-                    // Only walking is compared across the row, so only its line can be a winner.
-                    winner = leastWalking && metric.mode == StreetMode.WALK,
+                    winner = metric.winner,
                     outlineColor = winnerOutlineColor
                 ) {
                     EtaPartsText(
@@ -636,30 +632,35 @@ private fun StatsColumn(option: ItineraryOption, winners: Set<WinnerCategory>) {
     }
 }
 
-/** One street-distance line on a card: how far the trip goes on [mode], behind the [glyph] that leads it. */
-private data class StreetMetric(val mode: StreetMode, val meters: Double, val glyph: MetricGlyph)
+/**
+ * One street-distance line on a card: how far the trip goes on [mode], behind the [glyph] that leads it,
+ * and whether that distance is the least of any option in the picker ([winner], which outlines it).
+ */
+private data class StreetMetric(val mode: StreetMode, val meters: Double, val glyph: MetricGlyph, val winner: Boolean)
 
 /**
  * Which street-distance lines a card draws, from the per-mode totals it carries — in [StreetMode]
  * declaration order rather than in travel order, so cards measuring the same modes list them in the same
- * order and the row reads across (walking first, since it is the mode nearly every option has and the
- * one they are ranked on). Cards measuring *different* modes do stagger below their first line — a
- * bikeshare option carries a line its walk-only neighbour hasn't got — but that difference is itself
- * what the rider is choosing between.
+ * order and the row reads across (walking first, since it is the mode nearly every option has). Cards
+ * measuring *different* modes do stagger below their first line — a bikeshare option carries a line its
+ * walk-only neighbour hasn't got — but that difference is itself what the rider is choosing between.
  *
- * A mode the trip doesn't use draws no line. The one exception is [keepZeroWalk]: an option that wins
- * [WinnerCategory.LEAST_WALKING] by walking nowhere still shows its "0 ft", since the outline needs a
- * value to sit on and the win is worth saying.
+ * A mode the trip doesn't use draws no line, unless this option **won** that mode's category by not
+ * using it: then it shows its "0 ft", since the outline needs a value to sit on and "needs none of it"
+ * is worth saying. Each drawn line is outlined when the option wins its mode ([WinnerCategory]), so a
+ * bikeshare plan's cards compete on how far they make you ride exactly as a walking plan's compete on
+ * how far they make you walk.
  *
  * [StreetMode.CAR] is dropped here for the same reason it draws no symbol — the app ships no car glyph
  * and its planner never asks for car legs (see [streetModeIcon]) — so a car total would be a line with
  * nothing leading it.
  */
-private fun streetMetrics(distances: Map<StreetMode, Double>, keepZeroWalk: Boolean): List<StreetMetric> = StreetMode.entries.mapNotNull { mode ->
+private fun streetMetrics(distances: Map<StreetMode, Double>, winners: Set<WinnerCategory>): List<StreetMetric> = StreetMode.entries.mapNotNull { mode ->
     val meters = distances[mode] ?: 0.0
     val glyph = streetMetricGlyph(mode)
-    val drawn = meters > 0.0 || (keepZeroWalk && mode == StreetMode.WALK)
-    if (drawn && glyph != null) StreetMetric(mode, meters, glyph) else null
+    val category = mode.streetDistanceCategory()
+    val winner = category != null && category in winners
+    if ((meters > 0.0 || winner) && glyph != null) StreetMetric(mode, meters, glyph, winner) else null
 }
 
 /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
@@ -346,9 +346,8 @@ private fun OptionCard(
     val textColor = colorResource(
         if (selected) R.color.trip_plan_header_text_selected else R.color.trip_plan_header_text
     )
-    // Read off the categories themselves, in their declaration order, so a category added to the enum
-    // is announced without a second list here having to be remembered — which is exactly how the bike
-    // distances went un-announced when they first got their own lines.
+    // Read off the categories themselves, in their declaration order, so a category added to the enum is
+    // announced without a second list here having to be kept in step with it.
     val winnerDescriptions = WinnerCategory.entries.filter { it in winners }.map { stringResource(it.labelRes) }
     Surface(
         color = background,
@@ -537,8 +536,8 @@ private fun lineWidth(widths: List<Int>, line: IntRange, gap: Int): Int = line.s
 private fun ModeSymbolContent(symbol: ModeSymbol) {
     when (symbol) {
         // A glyph alone — there is nothing to name about a walk.
-        is ModeSymbol.Street -> streetModeIcon(symbol.mode)?.let { glyph ->
-            ModeGlyph(glyph, stringResource(streetModeLabel(symbol.mode)))
+        is ModeSymbol.Street -> StreetMetric.of(symbol.mode)?.let { metric ->
+            ModeGlyph(metric.glyph.iconRes, stringResource(metric.labelRes))
         }
         // Every badge leads with the mode it's ridden on, which a route number never says on its own. A
         // route publishing no short name badges its long name, capped to [OPTION_BADGE_MAX_WIDTH] and
@@ -574,11 +573,6 @@ private fun ModeSymbolContent(symbol: ModeSymbol) {
 private fun StatsColumn(option: ItineraryOption, winners: Set<WinnerCategory>) {
     val context = LocalContext.current
     val winnerOutlineColor = MaterialTheme.colorScheme.outline.copy(alpha = WINNER_OUTLINE_ALPHA)
-    // A line per street mode the trip travels on, plus any mode this option wins outright by not using
-    // it at all — a zero-distance win still needs a value to outline.
-    val metrics = remember(option.streetDistanceMeters, winners) {
-        streetMetrics(option.streetDistanceMeters, winners)
-    }
     Column(
         modifier = Modifier.padding(CARD_SECTION_PADDING),
         verticalArrangement = Arrangement.spacedBy(4.dp)
@@ -605,15 +599,15 @@ private fun StatsColumn(option: ItineraryOption, winners: Set<WinnerCategory>) {
             // value + smaller unit) and in the user's units (miles/km, or feet/meters for short hops).
             // A card used to say only how far it walked, which left a bikeshare trip's ride unmeasured
             // and a bike-only one claiming "0 ft" as its whole street distance.
-            metrics.forEach { metric ->
+            streetDistanceLines(option.streetDistanceMeters, winners).forEach { (metric, meters) ->
                 MetricRow(
                     metric.glyph,
-                    contentDescription = stringResource(streetModeLabel(metric.mode)),
-                    winner = metric.winner,
+                    contentDescription = stringResource(metric.labelRes),
+                    winner = metric.winner in winners,
                     outlineColor = winnerOutlineColor
                 ) {
                     EtaPartsText(
-                        ConversionUtils.getFormattedDistanceParts(metric.meters, context),
+                        ConversionUtils.getFormattedDistanceParts(meters, context),
                         modifier = Modifier.alignByBaseline(),
                         numberSize = METRIC_NUMBER_SIZE,
                         unitSize = METRIC_UNIT_SIZE
@@ -633,40 +627,32 @@ private fun StatsColumn(option: ItineraryOption, winners: Set<WinnerCategory>) {
 }
 
 /**
- * One street-distance line on a card: how far the trip goes on [mode], behind the [glyph] that leads it,
- * and whether that distance is the least of any option in the picker ([winner], which outlines it).
- */
-private data class StreetMetric(val mode: StreetMode, val meters: Double, val glyph: MetricGlyph, val winner: Boolean)
-
-/**
- * Which street-distance lines a card draws, from the per-mode totals it carries — in [StreetMode]
- * declaration order rather than in travel order, so cards measuring the same modes list them in the same
- * order and the row reads across (walking first, since it is the mode nearly every option has). Cards
- * measuring *different* modes do stagger below their first line — a bikeshare option carries a line its
- * walk-only neighbour hasn't got — but that difference is itself what the rider is choosing between.
+ * Which street-distance lines a card draws, and how far each says — its per-mode totals read in
+ * [StreetMetric] order rather than in travel order, so cards measuring the same modes list them in the
+ * same order and the picker row reads across. Cards measuring *different* modes do stagger below their
+ * first line — a bikeshare option carries a line its walk-only neighbour hasn't got — but that
+ * difference is itself what the rider is choosing between.
  *
  * A mode the trip doesn't use draws no line, unless this option **won** that mode's category by not
  * using it: then it shows its "0 ft", since the outline needs a value to sit on and "needs none of it"
- * is worth saying. Each drawn line is outlined when the option wins its mode ([WinnerCategory]), so a
- * bikeshare plan's cards compete on how far they make you ride exactly as a walking plan's compete on
- * how far they make you walk.
+ * is worth saying.
  *
- * [StreetMode.CAR] is dropped here for the same reason it draws no symbol — the app ships no car glyph
- * and its planner never asks for car legs (see [streetModeIcon]) — so a car total would be a line with
- * nothing leading it.
+ * Only the modes the cards can present are considered at all — [StreetMetric] is that list, so a mode
+ * with no glyph can't reach a line here and a mode with no line can't be announced as a winner.
  */
-private fun streetMetrics(distances: Map<StreetMode, Double>, winners: Set<WinnerCategory>): List<StreetMetric> = StreetMode.entries.mapNotNull { mode ->
-    val meters = distances[mode] ?: 0.0
-    val glyph = streetMetricGlyph(mode)
-    val category = mode.streetDistanceCategory()
-    val winner = category != null && category in winners
-    if ((meters > 0.0 || winner) && glyph != null) StreetMetric(mode, meters, glyph, winner) else null
+private fun streetDistanceLines(
+    distances: Map<StreetMode, Double>,
+    winners: Set<WinnerCategory>
+): List<Pair<StreetMetric, Double>> = StreetMetric.entries.mapNotNull { metric ->
+    val meters = distances[metric.mode] ?: 0.0
+    if (meters > 0.0 || metric.winner in winners) metric to meters else null
 }
 
 /**
  * One option-card stat line: a leading glyph followed by its value [content], drawn so the glyph and
  * the value occupy exactly the same band — same top edge, same bottom edge, both sitting on the value's
- * baseline (#2076). Shared by the duration and walk-distance rows so the two stay in lockstep.
+ * baseline (#2076). Shared by every row of the stat group — the duration and each street distance — so
+ * they all stay in lockstep.
  *
  * The glyph is sized and placed by its *ink*, not by its box: the box is inflated from the wanted ink
  * height by the asset's own ink fraction ([MetricGlyph]), and the row's alignment line is the ink's
@@ -689,8 +675,8 @@ private fun MetricRow(
     val density = LocalDensity.current
     val inkHeight = digitCapHeight(density, METRIC_NUMBER_SIZE)
     val box = glyph.boxFor(inkHeight)
-    // Levelling by ink leaves each glyph a different box width (the two assets ink different fractions
-    // of their viewport), which would step the rows' values apart horizontally. Reserve the widest
+    // Levelling by ink leaves each glyph a different box width (no two assets ink the same fraction of
+    // their viewport), which would step the rows' values apart horizontally. Reserve the widest
     // row's box for every row: Icon fits-and-centres the vector, so the extra width only centres the
     // glyph — the height still drives its scale.
     val column = inkHeight * WIDEST_BOX_FACTOR
@@ -1341,34 +1327,29 @@ private class RowChrome(density: Density, private val model: LogRowModel, timeWi
 
 /**
  * The glyph for an on-street leg — inside its node on the spine, as its symbol on an option card, and
- * leading that mode's distance line ([streetMetricGlyph], the one place the drawables are named, so a
- * mode can't be drawn one way as a symbol and another as a metric).
+ * leading that mode's distance line. All three read the same [StreetMetric.glyph], so a mode can't be
+ * drawn one way as a symbol and another as a metric.
  *
  * A rented bike takes a rental glyph (`ic_bike_rental`: Material Symbols' `car_rental` key over a
  * bicycle instead of a car) rather than the plain bicycle, so a shared bike doesn't read as the one the
  * rider brought — the same distinction the map draws between a bikeshare dock and a bike.
  *
- * Null for [StreetMode.CAR]: the app ships no car drawable because its planner never asks OTP for car
- * modes (the mode picker offers none — see `org.onebusaway.android.ui.tripplan.TripModeSelection`), and
- * a bare ring is honest where a walking figure would be wrong. Add `ic_directions_car` here — as a
- * [MetricGlyph], with its ink bounds — if car planning is ever offered.
+ * Null for [StreetMode.CAR], which [StreetMetric] doesn't list: the app ships no car drawable because
+ * its planner never asks OTP for car modes (the mode picker offers none — see
+ * `org.onebusaway.android.ui.tripplan.TripModeSelection`), and a bare ring is honest where a walking
+ * figure would be wrong. Offering car planning means a [StreetMetric] entry and a [MetricGlyph] with its
+ * ink bounds.
  */
-private fun streetModeIcon(mode: StreetMode): Int? = streetMetricGlyph(mode)?.iconRes
+private fun streetModeIcon(mode: StreetMode): Int? = StreetMetric.of(mode)?.glyph?.iconRes
 
-/** The metric line's leading glyph for a street mode: the same art as [streetModeIcon], levelled by ink. */
-private fun streetMetricGlyph(mode: StreetMode): MetricGlyph? = when (mode) {
-    StreetMode.WALK -> MetricGlyph.WALK
-    StreetMode.BIKE -> MetricGlyph.BIKE
-    StreetMode.BIKESHARE -> MetricGlyph.BIKESHARE
-    StreetMode.CAR -> null
-}
-
-/** What to call [mode] aloud, for a glyph standing on its own on an option card. */
-private fun streetModeLabel(mode: StreetMode): Int = when (mode) {
-    StreetMode.WALK -> R.string.step_by_step_non_transit_mode_walk_action
-    StreetMode.BIKE -> R.string.step_by_step_non_transit_mode_bicycle_action
-    StreetMode.BIKESHARE -> R.string.transit_directions_bikeshare_label
-    StreetMode.CAR -> R.string.step_by_step_non_transit_mode_car_action
+/**
+ * The glyph a presentable street mode is drawn with — total, since [StreetMetric] holds exactly the
+ * modes the cards can show, so the compiler asks for the art whenever one is added.
+ */
+private val StreetMetric.glyph: MetricGlyph get() = when (this) {
+    StreetMetric.WALK -> MetricGlyph.WALK
+    StreetMetric.BIKE -> MetricGlyph.BIKE
+    StreetMetric.BIKESHARE -> MetricGlyph.BIKESHARE
 }
 
 /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
@@ -35,7 +35,8 @@ import org.onebusaway.android.util.ScheduleDeviation
  *    (miles/km, or feet/meters for short distances). A mode the trip never uses is absent rather than
  *    zero, so the card can show what a trip actually does: a bike-only option says how far it rides
  *    instead of printing "0 ft" of walking, and a walk-and-bikeshare one says how far it does each
- *    (#2122).
+ *    (#2122). Comparing options ([itineraryWinnerCategories]) does read an absent mode as zero — none
+ *    of it is the least of it — which is the one place the two spellings mean the same thing.
  */
 data class ItineraryOption(
     val symbols: List<ModeSymbol>,
@@ -43,15 +44,7 @@ data class ItineraryOption(
     val startTime: ServerTime,
     val endTime: ServerTime,
     val streetDistanceMeters: Map<StreetMode, Double> = emptyMap()
-) {
-
-    /**
-     * Just the walking, which is the one street mode compared *across* options
-     * ([WinnerCategory.LEAST_WALKING]) — a trip that never walks has 0 of it, which is a real answer to
-     * "how much walking", unlike the absent key it comes from.
-     */
-    val walkDistanceMeters: Double get() = streetDistanceMeters[StreetMode.WALK] ?: 0.0
-}
+)
 
 /**
  * One symbol on an option card's first line. A card reads as the whole trip in travel order —

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
@@ -30,16 +30,28 @@ import org.onebusaway.android.util.ScheduleDeviation
  *  - [symbols] — the trip as a left-to-right sequence of mode symbols (see [ModeSymbol]).
  *  - [durationMinutes] — whole-minute trip length, formatted like the arrivals ETA pill.
  *  - [startTime]/[endTime] — the server-clock trip endpoints, unwrapped only at the time formatter.
- *  - [walkDistanceMeters] — total walking across the trip's legs, in meters; the card formats it to the
- *    user's units (miles/km, or feet/meters for short walks). 0 when the trip has no walking.
+ *  - [streetDistanceMeters] — how far the trip covers under the rider's own power, in meters, **per
+ *    street mode**; the card draws a metric line for each and formats it to the user's units
+ *    (miles/km, or feet/meters for short distances). A mode the trip never uses is absent rather than
+ *    zero, so the card can show what a trip actually does: a bike-only option says how far it rides
+ *    instead of printing "0 ft" of walking, and a walk-and-bikeshare one says how far it does each
+ *    (#2122).
  */
 data class ItineraryOption(
     val symbols: List<ModeSymbol>,
     val durationMinutes: Long,
     val startTime: ServerTime,
     val endTime: ServerTime,
-    val walkDistanceMeters: Double = 0.0
-)
+    val streetDistanceMeters: Map<StreetMode, Double> = emptyMap()
+) {
+
+    /**
+     * Just the walking, which is the one street mode compared *across* options
+     * ([WinnerCategory.LEAST_WALKING]) — a trip that never walks has 0 of it, which is a real answer to
+     * "how much walking", unlike the absent key it comes from.
+     */
+    val walkDistanceMeters: Double get() = streetDistanceMeters[StreetMode.WALK] ?: 0.0
+}
 
 /**
  * One symbol on an option card's first line. A card reads as the whole trip in travel order —

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
@@ -15,6 +15,8 @@
  */
 package org.onebusaway.android.ui.tripresults
 
+import androidx.annotation.StringRes
+import org.onebusaway.android.R
 import org.onebusaway.android.directions.model.TripMode
 import org.onebusaway.android.map.RouteFocusSegment
 import org.onebusaway.android.time.ServerTime
@@ -250,6 +252,36 @@ enum class TerminalKind { START, ARRIVE }
  * guess. See `ModeSymbols.streetMode`.
  */
 enum class StreetMode { WALK, BIKE, BIKESHARE, CAR }
+
+/**
+ * A street mode the option cards can *present*: what its glyph is called aloud, and the category its
+ * distance competes in across the picker (#2122). One entry per presentable mode, so the two halves
+ * cannot disagree — a mode with a category but no line would announce a win the rider never sees, and a
+ * mode with a line but no category could never be emphasized.
+ *
+ * [StreetMode.CAR] is deliberately absent, which is the single statement of "the cards can't show a car
+ * leg": the app ships no car art and the planner never asks OTP for car modes (see the mode picker,
+ * `org.onebusaway.android.ui.tripplan.TripModeSelection`). Adding car planning means adding an entry
+ * here, its drawable, and its ink bounds — and nothing else has to be remembered.
+ *
+ * Declaration order is the order a card stacks its distance lines, walking first: it is the mode nearly
+ * every option has, so it lands in the same place on every card and the picker row reads across.
+ */
+enum class StreetMetric(
+    val mode: StreetMode,
+    @param:StringRes val labelRes: Int,
+    val winner: WinnerCategory
+) {
+    WALK(StreetMode.WALK, R.string.step_by_step_non_transit_mode_walk_action, WinnerCategory.LEAST_WALKING),
+    BIKE(StreetMode.BIKE, R.string.step_by_step_non_transit_mode_bicycle_action, WinnerCategory.LEAST_BIKING),
+    BIKESHARE(StreetMode.BIKESHARE, R.string.transit_directions_bikeshare_label, WinnerCategory.LEAST_BIKESHARING);
+
+    companion object {
+
+        /** How to present [mode], or null when it is one the cards can't show ([StreetMode.CAR]). */
+        fun of(mode: StreetMode): StreetMetric? = entries.firstOrNull { it.mode == mode }
+    }
+}
 
 /**
  * What a [TripLogEntry.Transit] leg is ridden on, narrowed from [TripMode] to the vehicle families the

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -981,6 +981,8 @@
     <!-- Accessibility announcements for values emphasized as the best among the itinerary options. -->
     <string name="trip_plan_winner_shortest_travel_time">Shortest travel time</string>
     <string name="trip_plan_winner_least_walking">Least walking</string>
+    <string name="trip_plan_winner_least_biking">Least biking</string>
+    <string name="trip_plan_winner_least_bikesharing">Least bikeshare riding</string>
     <string name="trip_plan_winner_earliest_arrival">Earliest arrival</string>
     <string name="trip_plan_winner_latest_departure">Latest departure</string>
     <!-- Content descriptions for the control that expands/collapses a leg's minor events (walk steps / stops) in the trip-log directions -->

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/ItineraryWinnersTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/ItineraryWinnersTest.kt
@@ -26,13 +26,16 @@ class ItineraryWinnersTest {
         durationMinutes: Long,
         walkMeters: Double,
         departureMinutes: Long,
-        arrivalMinutes: Long
+        arrivalMinutes: Long,
+        // Absent rather than zero for a mode the trip doesn't use, as a repository-built option would be
+        // — reading none of it as zero is the comparison's doing, not the model's.
+        distances: Map<StreetMode, Double> = mapOf(StreetMode.WALK to walkMeters)
     ) = ItineraryOption(
         symbols = emptyList(),
         durationMinutes = durationMinutes,
         startTime = ServerTime(departureMinutes * 60_000L),
         endTime = ServerTime(arrivalMinutes * 60_000L),
-        streetDistanceMeters = mapOf(StreetMode.WALK to walkMeters)
+        streetDistanceMeters = distances
     )
 
     /**
@@ -43,12 +46,9 @@ class ItineraryWinnersTest {
         durationMinutes = 20,
         walkMeters = walkMeters,
         departureMinutes = 0,
-        arrivalMinutes = 20
-    ).copy(
-        streetDistanceMeters = buildMap {
+        arrivalMinutes = 20,
+        distances = buildMap {
             put(StreetMode.WALK, walkMeters)
-            // Absent rather than zero, as a repository-built option would be — the comparison is what
-            // reads it as none, not the model.
             if (bikeshareMeters > 0.0) put(StreetMode.BIKESHARE, bikeshareMeters)
         }
     )

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/ItineraryWinnersTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/ItineraryWinnersTest.kt
@@ -35,6 +35,24 @@ class ItineraryWinnersTest {
         streetDistanceMeters = mapOf(StreetMode.WALK to walkMeters)
     )
 
+    /**
+     * A walk-and-bikeshare option, with both its distances. Same duration and clock times throughout, so
+     * only the distance categories can be won.
+     */
+    private fun biked(walkMeters: Double, bikeshareMeters: Double) = option(
+        durationMinutes = 20,
+        walkMeters = walkMeters,
+        departureMinutes = 0,
+        arrivalMinutes = 20
+    ).copy(
+        streetDistanceMeters = buildMap {
+            put(StreetMode.WALK, walkMeters)
+            // Absent rather than zero, as a repository-built option would be — the comparison is what
+            // reads it as none, not the model.
+            if (bikeshareMeters > 0.0) put(StreetMode.BIKESHARE, bikeshareMeters)
+        }
+    )
+
     @Test
     fun `shortest travel time is duration, not earliest arrival`() {
         val options = listOf(
@@ -120,6 +138,50 @@ class ItineraryWinnersTest {
 
         assertEquals(setOf(WinnerCategory.LEAST_WALKING), winners[0])
         assertTrue(winners[1].isEmpty())
+    }
+
+    /**
+     * Every street mode the cards measure is compared, not walking alone (#2122): a bikeshare plan's
+     * options are ranked on how far they make the rider ride, and each mode is its own category — the
+     * option that walks least need not be the one that rides least.
+     */
+    @Test
+    fun `each street mode is compared in its own category`() {
+        val options = listOf(
+            biked(walkMeters = 500.0, bikeshareMeters = 1000.0),
+            biked(walkMeters = 100.0, bikeshareMeters = 4000.0)
+        )
+
+        val winners = itineraryWinnerCategories(options, ScheduleWinnerMode.BOTH)
+
+        assertEquals(setOf(WinnerCategory.LEAST_BIKESHARING), winners[0])
+        assertEquals(setOf(WinnerCategory.LEAST_WALKING), winners[1])
+    }
+
+    /** Not using a mode at all is the least of it, exactly as walking nowhere has always won. */
+    @Test
+    fun `an option that never uses a mode wins its category`() {
+        val options = listOf(
+            biked(walkMeters = 900.0, bikeshareMeters = 0.0),
+            biked(walkMeters = 100.0, bikeshareMeters = 4000.0)
+        )
+
+        val winners = itineraryWinnerCategories(options, ScheduleWinnerMode.BOTH)
+
+        assertTrue(WinnerCategory.LEAST_BIKESHARING in winners[0])
+    }
+
+    /** A mode no option travels on is nothing to choose between, so it decorates nobody. */
+    @Test
+    fun `a mode no option uses awards nothing`() {
+        val options = listOf(
+            option(20, 100.0, 0, 20),
+            option(20, 300.0, 0, 20)
+        )
+
+        val winners = itineraryWinnerCategories(options, ScheduleWinnerMode.BOTH)
+
+        assertTrue(winners.none { WinnerCategory.LEAST_BIKING in it || WinnerCategory.LEAST_BIKESHARING in it })
     }
 
     @Test

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/ItineraryWinnersTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/ItineraryWinnersTest.kt
@@ -32,7 +32,7 @@ class ItineraryWinnersTest {
         durationMinutes = durationMinutes,
         startTime = ServerTime(departureMinutes * 60_000L),
         endTime = ServerTime(arrivalMinutes * 60_000L),
-        walkDistanceMeters = walkMeters
+        streetDistanceMeters = mapOf(StreetMode.WALK to walkMeters)
     )
 
     @Test

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/ModeSymbolsTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/ModeSymbolsTest.kt
@@ -27,6 +27,9 @@ import org.onebusaway.android.directions.model.TripVertexType
  * JVM tests for [ModeSymbols]: an itinerary read as one left-to-right symbol sequence — the on-street
  * legs between the rides included, the negligible ones dropped (#2047) — with the ride-folding rules
  * of #2000 (stay-aboard interlines) and #2010 (interchangeable routes) intact.
+ *
+ * Plus the other card fact this file derives from the same legs, by the same [streetMode] split: how
+ * far the trip covers on each street mode ([streetDistancesMeters], #2122).
  */
 class ModeSymbolsTest {
 
@@ -175,6 +178,42 @@ class ModeSymbolsTest {
         assertEquals(
             listOf(listOf("8")),
             symbolsOf(listOf(TripLeg(mode = TripMode.BOARDING), transit("8"), TripLeg(mode = TripMode.ALIGHTING)))
+        )
+    }
+
+    /**
+     * The card's metric lines (#2122): a total per street mode the trip actually uses, split the same
+     * way the symbols are — so a bikeshare ride is measured as bikeshare rather than swelling the walk.
+     */
+    @Test
+    fun aTripTotalsItsDistanceOnEachStreetModeSeparately() {
+        assertEquals(
+            mapOf(StreetMode.WALK to 900.0, StreetMode.BIKESHARE to 2000.0),
+            listOf(
+                walk(FAR),
+                bike(2000.0, rentedAt = Endpoint.FROM),
+                walk(300.0),
+                transit("8")
+            ).streetDistancesMeters()
+        )
+    }
+
+    /** A mode the trip never travels on has no line to draw, so it isn't reported as zero. */
+    @Test
+    fun aModeTheTripNeverUsesIsAbsentFromTheTotals() {
+        assertEquals(mapOf(StreetMode.BIKE to FAR), listOf(bike(FAR)).streetDistancesMeters())
+        assertEquals(emptyMap<StreetMode, Double>(), listOf(transit("8")).streetDistancesMeters())
+    }
+
+    /**
+     * The totals count every on-street leg, including the ones too short to draw a symbol for: the
+     * threshold says what is worth drawing as a step of the trip, not what the rider covers.
+     */
+    @Test
+    fun aStreetLegTooShortForASymbolStillCountsTowardTheTotal() {
+        assertEquals(
+            mapOf(StreetMode.WALK to FAR + NEAR),
+            listOf(walk(FAR), transit("8"), walk(NEAR)).streetDistancesMeters()
         )
     }
 


### PR DESCRIPTION
Closes #2122.

An option card printed exactly one distance line, always walking. So a bikeshare option's ride went unmeasured (the card said only how far you walked to the dock), and a bike-only option printed "0 ft" of walking as its whole street cost.

### What the card does now

Each card carries a distance **per street mode it travels on** (`ItineraryOption.streetDistanceMeters`, split by the same `TripLeg.streetMode()` the summary's symbols are drawn from, so a bikeshare ride can't be counted as walking) and draws a metric line for each, in `StreetMode` order:

- walk + bikeshare → a bikeshare distance *and* a walk distance;
- bike-only → how far it bikes;
- plain transit → the walking line it always had.

A mode the trip never uses draws no line — no line about something that didn't happen. Legs too short to earn a symbol (`NEGLIGIBLE_STREET_METERS`) still count toward the totals: that threshold is about what's worth drawing as a step, not about what the rider covers.

### Winners follow the modes

`LEAST_WALKING` used to be the only distance category, so on a plan made of riding, the one comparison the rider cares about could never be emphasized. Every measured street mode now has its own category (`LEAST_BIKING`, `LEAST_BIKESHARING`), awarded by `itineraryWinnerCategories`. A mode an option never uses counts as zero of it — the best value there is — and the card draws that winning line even at zero, which is what the walking line already did.

Card announcements are now read off `WinnerCategory` itself (a `labelRes` per entry, in declaration order) rather than a hand-kept list beside it — that list is exactly how the new categories would have gone unannounced.

### Glyphs

`MetricGlyph` gained `BIKE` and `BIKESHARE` with their ink bounds transcribed from the assets' `pathData` (`ic_directions_bike` y[1.5, 22], `ic_bike_rental` y[1, 22.497]), so they baseline-level against their digits the way the walker does (#2076). `streetModeIcon()` now resolves through `streetMetricGlyph()`, leaving one place that names the art — a mode can't be drawn one way as a symbol and another as a metric. Car stays glyph-less and so draws no line; the planner never asks OTP for car legs.

### Notes for review

- Cards measuring different modes stagger below their first street line — a bikeshare option carries a line its walk-only neighbour hasn't got. That's the difference the rider is choosing between, so the summary band's shared height (#2081) is left as it is.
- Two new strings: `trip_plan_winner_least_biking` ("Least biking"), `trip_plan_winner_least_bikesharing` ("Least bikeshare riding").
- No heuristics introduced: the per-mode split reuses the existing structural rental-vertex rule, and distances come straight off the legs.

### Testing

- `compileObaGoogleDebugKotlin -PwarningsAsErrors=true` clean; `spotlessCheck` clean.
- New JVM tests in `ModeSymbolsTest` (per-mode totals; a mode never used is absent; short legs still counted) and `ItineraryWinnersTest` (each mode compared in its own category; not using a mode wins it; a mode nobody uses awards nothing).
- New instrumented `OptionCardStreetMetricsTest` (a bikeshare trip shows both distances; a bike-only trip shows biking and no "0 ft" walk line; the option that rides least announces its bikeshare win), plus the existing card tests — 10 instrumented tests green on a physical Pixel 7 Pro (Android 16).

🤖 Generated with [Claude Code](https://claude.com/claude-code)