### PR TITLE
Rule the directions ETA row at the rider's arrival at the stop (#2125)

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/arrivals/EtaStripMarkerRenderTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/arrivals/EtaStripMarkerRenderTest.kt
@@ -19,11 +19,14 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.hasStateDescription
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
+import org.onebusaway.android.time.ServerTime
 import org.onebusaway.android.ui.arrivals.components.ETA_STRIP_MARKER_TAG
 import org.onebusaway.android.ui.arrivals.components.EtaStrip
 import org.onebusaway.android.ui.arrivals.components.EtaStripMarker
@@ -45,13 +48,15 @@ class EtaStripMarkerRenderTest {
     val composeRule = createUnconfinedComposeRule()
 
     private val description = "You get to this stop at 3:19pm"
+    private val passedDescription = "Leaves before you get here"
 
     /**
-     * A strip of [names].size departures, one route each, with the rule before the pill at [markerIndex].
+     * A strip of [names].size departures, one route each, leaving 3, 11, 19… minutes out, with the rule
+     * at [reachStopMinutes] minutes out.
      * Each pill wears its route's badge so a pill can be located by a string no other node holds — an ETA
      * or clock-time match would risk colliding with a neighbour's subline.
      */
-    private fun setContent(vararg names: String, markerIndex: Int) = composeRule.setContent {
+    private fun setContent(vararg names: String, reachStopMinutes: Long) = composeRule.setContent {
         Box(Modifier.fillMaxWidth()) {
             EtaStrip(
                 trips = names.mapIndexed { i, name ->
@@ -60,7 +65,12 @@ class EtaStripMarkerRenderTest {
                 actionsFor = { null },
                 callbacks = previewRowCallbacks(),
                 routeBadgeFor = { RouteBadge(it.shortName ?: error("preview route must have a name"), null) },
-                marker = EtaStripMarker(index = markerIndex, contentDescription = description)
+                // previewArrival anchors serverNow at 0, so a departure N minutes out sits at N * 60_000.
+                marker = EtaStripMarker(
+                    at = ServerTime(reachStopMinutes * 60_000L),
+                    contentDescription = description,
+                    passedStateDescription = passedDescription
+                )
             )
         }
     }
@@ -69,40 +79,45 @@ class EtaStripMarkerRenderTest {
 
     @Test
     fun theRuleSitsBetweenTheDepartureItFollowsAndTheOneItPrecedes() {
-        setContent("A", "B", markerIndex = 1)
+        // A leaves 3 min out, B 11 min out; the rider gets there at 6 min.
+        setContent("A", "B", reachStopMinutes = 6)
 
         val rule = composeRule.onNodeWithTag(ETA_STRIP_MARKER_TAG).getUnclippedBoundsInRoot()
         val missed = boundsOf("A")
         val catchable = boundsOf("B")
 
-        assert(missed.right <= rule.left) { "rule at ${rule.left} must follow route A, which ends at ${missed.right}" }
-        assert(rule.right <= catchable.left) { "rule ending at ${rule.right} must precede route B, which starts at ${catchable.left}" }
+        assertTrue("rule at ${rule.left} must follow route A, which ends at ${missed.right}", missed.right <= rule.left)
+        assertTrue("rule ending at ${rule.right} must precede route B, which starts at ${catchable.left}", rule.right <= catchable.left)
     }
 
     @Test
     fun aRiderWhoIsAlreadyThereGetsTheRuleAheadOfEveryDeparture() {
-        setContent("A", markerIndex = 0)
+        // A leaves 3 min out and the rider is there now.
+        setContent("A", reachStopMinutes = 0)
 
         val rule = composeRule.onNodeWithTag(ETA_STRIP_MARKER_TAG).getUnclippedBoundsInRoot()
 
-        assert(rule.right <= boundsOf("A").left) { "rule ending at ${rule.right} must precede route A" }
+        assertTrue("rule ending at ${rule.right} must precede route A", rule.right <= boundsOf("A").left)
     }
 
     @Test
     fun aRiderArrivingAfterEveryDepartureStillGetsARule() {
-        // The index is past the last pill — every departure shown is out of reach. The rule closes the
-        // strip rather than being dropped, which would leave the row looking unmarked.
-        setContent("A", markerIndex = 1)
+        // The moment falls past the last pill — every departure shown is out of reach. The rule closes
+        // the strip rather than being dropped, which would leave the row looking unmarked.
+        setContent("A", reachStopMinutes = 30)
 
         val rule = composeRule.onNodeWithTag(ETA_STRIP_MARKER_TAG).getUnclippedBoundsInRoot()
 
-        assert(boundsOf("A").right <= rule.left) { "rule at ${rule.left} must follow route A" }
+        assertTrue("rule at ${rule.left} must follow route A", boundsOf("A").right <= rule.left)
     }
 
     @Test
     fun theRuleReadsAsOneSentenceToAScreenReader() {
-        setContent("A", "B", markerIndex = 1)
+        setContent("A", "B", reachStopMinutes = 6)
 
         composeRule.onNodeWithContentDescription(description).assertExists()
+        // ...and the pill it passed says so itself, where a screen reader actually meets it — the rule
+        // is read after that pill, too late to explain it.
+        composeRule.onNode(hasStateDescription(passedDescription)).assertExists()
     }
 }

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/arrivals/EtaStripMarkerRenderTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/arrivals/EtaStripMarkerRenderTest.kt
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.arrivals
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import org.junit.Rule
+import org.junit.Test
+import org.onebusaway.android.ui.arrivals.components.ETA_STRIP_MARKER_TAG
+import org.onebusaway.android.ui.arrivals.components.EtaStrip
+import org.onebusaway.android.ui.arrivals.components.EtaStripMarker
+import org.onebusaway.android.ui.arrivals.components.previewArrival
+import org.onebusaway.android.ui.arrivals.components.previewRowCallbacks
+import org.onebusaway.android.ui.compose.components.RouteBadge
+import org.onebusaway.android.ui.compose.createUnconfinedComposeRule
+
+/**
+ * The strip's [EtaStripMarker] (#2125) — the rule the directions drawer draws at the moment the rider
+ * reaches the stop. What matters is that it lands *between* the right two pills, since a rule on the
+ * wrong side of a departure tells the rider the opposite of the truth, and that a screen reader gets the
+ * whole sentence (the rule is a bare bar, and the dimming beside it carries no semantics of its own).
+ */
+class EtaStripMarkerRenderTest {
+
+    // Unconfined composition — see createUnconfinedComposeRule (issue #1792).
+    @get:Rule
+    val composeRule = createUnconfinedComposeRule()
+
+    private val description = "You get to this stop at 3:19pm"
+
+    /**
+     * A strip of [names].size departures, one route each, with the rule before the pill at [markerIndex].
+     * Each pill wears its route's badge so a pill can be located by a string no other node holds — an ETA
+     * or clock-time match would risk colliding with a neighbour's subline.
+     */
+    private fun setContent(vararg names: String, markerIndex: Int) = composeRule.setContent {
+        Box(Modifier.fillMaxWidth()) {
+            EtaStrip(
+                trips = names.mapIndexed { i, name ->
+                    previewArrival(name, "Rainier Beach", etaMinutes = 3L + i * 8, tripId = "trip_$i")
+                },
+                actionsFor = { null },
+                callbacks = previewRowCallbacks(),
+                routeBadgeFor = { RouteBadge(it.shortName ?: error("preview route must have a name"), null) },
+                marker = EtaStripMarker(index = markerIndex, contentDescription = description)
+            )
+        }
+    }
+
+    private fun boundsOf(text: String) = composeRule.onNodeWithText(text).getUnclippedBoundsInRoot()
+
+    @Test
+    fun theRuleSitsBetweenTheDepartureItFollowsAndTheOneItPrecedes() {
+        setContent("A", "B", markerIndex = 1)
+
+        val rule = composeRule.onNodeWithTag(ETA_STRIP_MARKER_TAG).getUnclippedBoundsInRoot()
+        val missed = boundsOf("A")
+        val catchable = boundsOf("B")
+
+        assert(missed.right <= rule.left) { "rule at ${rule.left} must follow route A, which ends at ${missed.right}" }
+        assert(rule.right <= catchable.left) { "rule ending at ${rule.right} must precede route B, which starts at ${catchable.left}" }
+    }
+
+    @Test
+    fun aRiderWhoIsAlreadyThereGetsTheRuleAheadOfEveryDeparture() {
+        setContent("A", markerIndex = 0)
+
+        val rule = composeRule.onNodeWithTag(ETA_STRIP_MARKER_TAG).getUnclippedBoundsInRoot()
+
+        assert(rule.right <= boundsOf("A").left) { "rule ending at ${rule.right} must precede route A" }
+    }
+
+    @Test
+    fun aRiderArrivingAfterEveryDepartureStillGetsARule() {
+        // The index is past the last pill — every departure shown is out of reach. The rule closes the
+        // strip rather than being dropped, which would leave the row looking unmarked.
+        setContent("A", markerIndex = 1)
+
+        val rule = composeRule.onNodeWithTag(ETA_STRIP_MARKER_TAG).getUnclippedBoundsInRoot()
+
+        assert(boundsOf("A").right <= rule.left) { "rule at ${rule.left} must follow route A" }
+    }
+
+    @Test
+    fun theRuleReadsAsOneSentenceToAScreenReader() {
+        setContent("A", "B", markerIndex = 1)
+
+        composeRule.onNodeWithContentDescription(description).assertExists()
+    }
+}

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/home/directions/DirectionStopEtaStripTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/home/directions/DirectionStopEtaStripTest.kt
@@ -20,6 +20,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import org.junit.Rule
 import org.junit.Test
 import org.onebusaway.android.R
+import org.onebusaway.android.time.ServerTime
 import org.onebusaway.android.ui.arrivals.ArrivalsViewModel
 import org.onebusaway.android.ui.compose.createUnconfinedComposeRule
 import org.onebusaway.android.ui.tripresults.RouteLegRef
@@ -57,6 +58,7 @@ class DirectionStopEtaStripTest {
         DirectionStopEtaStrip(
             routeLeg = routeLeg,
             stop = stop,
+            reachStopTime = ServerTime(4 * 60_000L),
             arrivalsViewModelFactory = failingFactory,
             onShowTrip = { _, _ -> },
             onEditReminder = {},

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/DirectionRowAlternativeRoutesTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/DirectionRowAlternativeRoutesTest.kt
@@ -81,6 +81,7 @@ class DirectionRowAlternativeRoutesTest {
         mode = TransitMode.RAIL,
         routeColorHex = "0075C4",
         headsign = "Downtown Redmond",
+        reachStopTime = ServerTime(60_000L),
         boardTime = ServerTime(2 * 60_000L),
         exitTime = ServerTime(32 * 60_000L),
         durationMinutes = 30,

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/DirectionRowFocusTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/DirectionRowFocusTest.kt
@@ -83,6 +83,7 @@ class DirectionRowFocusTest {
         mode = TransitMode.BUS,
         routeColorHex = "1B6EF3",
         headsign = "Rainier Beach",
+        reachStopTime = ServerTime(3 * 60_000L),
         boardTime = ServerTime(4 * 60_000L),
         exitTime = ServerTime(20 * 60_000L),
         durationMinutes = 16,
@@ -212,7 +213,7 @@ class DirectionRowFocusTest {
         composeRule.setContent {
             TripResultsList(
                 state = fullState,
-                stopEtaStrip = { _, stop, _ -> Text("ETASTRIP@${stop.name}") }
+                stopEtaStrip = { _, stop -> Text("ETASTRIP@${stop.name}") }
             )
         }
 

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/DirectionRowInterlineBadgeTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/DirectionRowInterlineBadgeTest.kt
@@ -87,6 +87,7 @@ class DirectionRowInterlineBadgeTest {
         mode = TransitMode.BUS,
         routeColorHex = "1B6EF3",
         headsign = "Rainier Beach",
+        reachStopTime = ServerTime(60_000L),
         boardTime = ServerTime(2 * 60_000L),
         exitTime = ServerTime(32 * 60_000L),
         durationMinutes = 30,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStrip.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStrip.kt
@@ -16,7 +16,6 @@
 package org.onebusaway.android.ui.arrivals.components
 
 import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.gestures.animateScrollBy
 import androidx.compose.foundation.layout.Arrangement
@@ -28,7 +27,6 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
@@ -38,6 +36,7 @@ import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -64,6 +63,7 @@ import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
@@ -98,16 +98,38 @@ import org.onebusaway.android.util.DisplayFormat
 // not a gesture on this strip.
 
 /**
- * A moment marked across the strip's timeline: a vertical rule drawn *before* the pill at [index]
- * ([index] == `trips.size` puts it after the last pill), with the pills ahead of it dimmed as ones the
- * rule has already ruled out. The directions drawer marks when the rider reaches the stop (#2125), so a
- * plan whose walk lands after the next two departures reads as such instead of as if the rider were
- * standing at the stop already.
+ * A moment ruled across the strip's timeline: a vertical rule standing where [at] falls among the
+ * departures, with the pills before it dimmed as ones the moment has already passed. The directions
+ * drawer rules when the rider reaches the stop (#2125), so a plan whose walk lands after the next two
+ * departures reads as such instead of as if the rider were standing at the stop already.
  *
- * [contentDescription] is the whole rule for a screen reader — the dimming carries no semantics of its
- * own, so this sentence has to say what it means on its own.
+ * The marker names the *moment*, not a pill position: [EtaStrip] places it against the very list it
+ * draws, so the rule cannot come to disagree with the pills it is drawn between. It reads them in
+ * order, so the strip's trips must be chronological for the rule to divide them into a before and an
+ * after — which is what the pill order means anyway.
+ *
+ * [contentDescription] is what a screen reader reads for the rule itself; [passedStateDescription] is
+ * what it reads on each pill the rule has passed, since a pill's dimming is otherwise invisible to it
+ * and a rule further down the row comes too late to explain a departure already announced.
  */
-internal data class EtaStripMarker(val index: Int, val contentDescription: String)
+internal data class EtaStripMarker(
+    val at: ServerTime,
+    val contentDescription: String,
+    val passedStateDescription: String
+)
+
+/**
+ * How many of [items] fall before [moment] — i.e. the index the strip's marker rule stands at, given
+ * chronologically-ordered items. Kept as a pure function (and JVM-tested) because the boundary rule is
+ * the whole meaning of the marker: an item exactly *at* [moment] counts as not-yet-passed and stays
+ * after the rule, so a trip plan whose walk is timed to the vehicle — OTP hands back the identical
+ * instant for both — cannot rule out the very departure it boards.
+ *
+ * Generic over the item, taking its time as [timeOf], so the caller needn't build a throwaway list of
+ * times to count over (the same shape [interleaveRouteItems][
+ * org.onebusaway.android.ui.home.directions.interleaveRouteItems] uses).
+ */
+internal fun <T> countBefore(items: List<T>, moment: ServerTime, timeOf: (T) -> ServerTime): Int = items.count { timeOf(it) < moment }
 
 /**
  * The horizontally-scrollable strip of per-trip ETA pills below the direction name. Pills are shown
@@ -141,6 +163,9 @@ internal fun EtaStrip(
     // this would otherwise re-run the caller's lambda over every trip on each of those ticks. It only
     // changes when the trips or the badge source do.
     val hasRouteBadges = remember(trips, routeBadgeFor) { trips.any { routeBadgeFor(it) != null } }
+    // Where the marker's moment falls among these departures. Remembered for the same reason: the live
+    // clock recomposes this body every second, but the answer only moves when a poll brings new trips.
+    val markerIndex = remember(trips, marker) { marker?.let { countBefore(trips, it.at) { trip -> trip.displayTime } } }
 
     // The strip viewport width in px, for the one-viewport chevron jump below.
     var viewportPx by remember { mutableIntStateOf(0) }
@@ -209,32 +234,23 @@ internal fun EtaStrip(
                 ) { index, trip ->
                     // The first pill carries the caller's anchor modifier (e.g. the tutorial spotlight).
                     val pillModifier = if (index == 0) firstPillModifier else Modifier
-                    // A pill the marker has already passed is dimmed: it's still readable (and still
-                    // tappable — it's a real departure, just not one this plan can use), but it reads as
-                    // background against the ones the rider can actually catch.
-                    val dimmed = marker != null && index < marker.index
-                    val pill = @Composable {
+                    // The rule rides inside the item it precedes: a LazyListScope can't emit a lone item
+                    // partway through an itemsIndexed block without splitting the trips in two and
+                    // duplicating the pill below. Null on every other item, so only one carries it.
+                    MarkedItem(marker?.takeIf { markerIndex == index }) {
                         EtaPillWithMenu(
                             trip = trip,
                             liveNow = liveNow,
                             actions = actionsFor(trip),
                             callbacks = callbacks,
                             routeBadge = routeBadgeFor(trip),
-                            modifier = pillModifier.alpha(if (dimmed) PASSED_PILL_ALPHA else 1f)
+                            modifier = pillModifier.passedByMarker(marker, isPassed = index < (markerIndex ?: 0))
                         )
-                    }
-                    // The rule rides inside the item it precedes rather than being an item of its own, so
-                    // the pills' LazyRow keys — trip identity, which a poll must be able to match across
-                    // updates — stay exactly what they were.
-                    if (marker != null && marker.index == index) {
-                        MarkedItem(marker) { pill() }
-                    } else {
-                        pill()
                     }
                 }
                 // A marker past the last departure — the rider gets to the stop after everything the feed
                 // knows about — closes the strip instead of vanishing.
-                if (marker != null && marker.index >= trips.size) {
+                if (marker != null && markerIndex != null && markerIndex >= trips.size) {
                     item(key = ETA_STRIP_MARKER_TAG) { EtaStripMarkerRule(marker) }
                 }
             }
@@ -265,10 +281,16 @@ private val MARKER_WIDTH = 3.dp
  *  is a NUL-joined tuple of OBA ids, so a bare word can't collide with one. */
 internal const val ETA_STRIP_MARKER_TAG = "etaStripMarker"
 
-/** One LazyRow item holding the marker rule and the pill it precedes, spaced as two adjacent pills
- *  would be so the rule doesn't crowd the strip's rhythm. */
+/** One LazyRow item: [pill], preceded by [marker]'s rule when this is the pill it stands before. Spaced
+ *  as two adjacent pills would be, so the rule doesn't crowd the strip's rhythm. A [marker] of null —
+ *  every other pill, and every pill on the unmarked arrivals path — emits the pill alone, adding no
+ *  layout node of its own. */
 @Composable
-private fun MarkedItem(marker: EtaStripMarker, pill: @Composable () -> Unit) {
+private fun MarkedItem(marker: EtaStripMarker?, pill: @Composable () -> Unit) {
+    if (marker == null) {
+        pill()
+        return
+    }
     Row(
         Modifier.fillMaxHeight(),
         horizontalArrangement = Arrangement.spacedBy(PILL_SPACING),
@@ -281,20 +303,34 @@ private fun MarkedItem(marker: EtaStripMarker, pill: @Composable () -> Unit) {
 
 /**
  * The marker itself: a full-height rounded rule in the theme's primary colour, standing between the
- * departures on either side of the moment it marks. It carries the marker's whole meaning for a screen
- * reader as its content description, since a rule says nothing on its own.
+ * departures on either side of the moment it marks. It names that moment for a screen reader, since a
+ * rule says nothing on its own; what the dimming beside it means is said on the dimmed pills
+ * ([passedByMarker]), where a screen reader actually meets it.
  */
 @Composable
 private fun EtaStripMarkerRule(marker: EtaStripMarker) {
-    Box(
-        Modifier
+    VerticalDivider(
+        modifier = Modifier
             .testTag(ETA_STRIP_MARKER_TAG)
-            .fillMaxHeight()
-            .width(MARKER_WIDTH)
             .clip(RoundedCornerShape(MARKER_WIDTH / 2))
-            .background(MaterialTheme.colorScheme.primary)
-            .semantics { contentDescription = marker.contentDescription }
+            .semantics { contentDescription = marker.contentDescription },
+        thickness = MARKER_WIDTH,
+        color = MaterialTheme.colorScheme.primary
     )
+}
+
+/**
+ * Marks this pill as one the strip's [marker] has already passed: dimmed, and — because the dimming is
+ * invisible to a screen reader — carrying the marker's own words for what being on that side of the rule
+ * means. Still fully readable and tappable: it's a real departure, just not one this plan can use.
+ *
+ * A no-op when [isPassed] is false or there is no marker, and free on that path — `Modifier.alpha`
+ * returns the receiver unchanged at 1f, so the unmarked arrivals strip grows no graphics layer.
+ */
+private fun Modifier.passedByMarker(marker: EtaStripMarker?, isPassed: Boolean): Modifier = if (marker == null || !isPassed) {
+    this
+} else {
+    alpha(PASSED_PILL_ALPHA).semantics { stateDescription = marker.passedStateDescription }
 }
 
 /**
@@ -645,11 +681,16 @@ private fun EtaStripScrolledPreview() {
 @Preview(showBackground = true, widthDp = 240, name = "EtaStrip · marked (rider arrives)")
 @Composable
 private fun EtaStripMarkedPreview() {
-    // The directions case: the rider's walk lands after the first two departures, so the rule stands
-    // before the third and the two it has passed are dimmed.
+    // The directions case: the rider's walk lands after the first two departures (northgatePills run
+    // 3, 11, 19, 27 minutes out against a serverNow of 0), so the rule stands before the third and the
+    // two it has passed are dimmed.
     EtaStripPreviewFrame(
         trips = northgatePills(4),
-        marker = EtaStripMarker(index = 2, contentDescription = "You get to the stop at 3:19pm")
+        marker = EtaStripMarker(
+            at = ServerTime(16 * 60_000L),
+            contentDescription = "You get to this stop at 3:19pm",
+            passedStateDescription = "Leaves before you get here"
+        )
     )
 }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStrip.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStrip.kt
@@ -16,6 +16,7 @@
 package org.onebusaway.android.ui.arrivals.components
 
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.gestures.animateScrollBy
 import androidx.compose.foundation.layout.Arrangement
@@ -27,6 +28,7 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
@@ -45,6 +47,8 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.IntrinsicMeasurable
 import androidx.compose.ui.layout.IntrinsicMeasureScope
@@ -55,8 +59,11 @@ import androidx.compose.ui.layout.MeasureScope
 import androidx.compose.ui.layout.MultiContentMeasurePolicy
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
@@ -91,12 +98,26 @@ import org.onebusaway.android.util.DisplayFormat
 // not a gesture on this strip.
 
 /**
+ * A moment marked across the strip's timeline: a vertical rule drawn *before* the pill at [index]
+ * ([index] == `trips.size` puts it after the last pill), with the pills ahead of it dimmed as ones the
+ * rule has already ruled out. The directions drawer marks when the rider reaches the stop (#2125), so a
+ * plan whose walk lands after the next two departures reads as such instead of as if the rider were
+ * standing at the stop already.
+ *
+ * [contentDescription] is the whole rule for a screen reader — the dimming carries no semantics of its
+ * own, so this sentence has to say what it means on its own.
+ */
+internal data class EtaStripMarker(val index: Int, val contentDescription: String)
+
+/**
  * The horizontally-scrollable strip of per-trip ETA pills below the direction name. Pills are shown
  * in feed order from the first one; the strip never auto-scrolls, so a trip whose ETA has gone
  * negative just keeps counting down in place. When the pills overflow the row, a chevron appears at
  * that edge to signal there's more to scroll to; tapping it moves the strip one viewport that
  * direction (or to the end, whichever is closer). The chevron's own tap target is a narrow side
  * gutter separate from the pills, so it never blocks the strip's own drag-to-scroll.
+ *
+ * [marker] optionally rules one moment across the strip — see [EtaStripMarker].
  */
 @Composable
 internal fun EtaStrip(
@@ -106,6 +127,7 @@ internal fun EtaStrip(
     modifier: Modifier = Modifier,
     firstPillModifier: Modifier = Modifier,
     routeBadgeFor: (ArrivalInfo) -> RouteBadge? = { null },
+    marker: EtaStripMarker? = null,
     // Hoisted for previews/tests ONLY (both real call sites use the default) so a caller can start
     // the strip mid-scroll.
     state: LazyListState = rememberLazyListState()
@@ -187,14 +209,33 @@ internal fun EtaStrip(
                 ) { index, trip ->
                     // The first pill carries the caller's anchor modifier (e.g. the tutorial spotlight).
                     val pillModifier = if (index == 0) firstPillModifier else Modifier
-                    EtaPillWithMenu(
-                        trip = trip,
-                        liveNow = liveNow,
-                        actions = actionsFor(trip),
-                        callbacks = callbacks,
-                        routeBadge = routeBadgeFor(trip),
-                        modifier = pillModifier
-                    )
+                    // A pill the marker has already passed is dimmed: it's still readable (and still
+                    // tappable — it's a real departure, just not one this plan can use), but it reads as
+                    // background against the ones the rider can actually catch.
+                    val dimmed = marker != null && index < marker.index
+                    val pill = @Composable {
+                        EtaPillWithMenu(
+                            trip = trip,
+                            liveNow = liveNow,
+                            actions = actionsFor(trip),
+                            callbacks = callbacks,
+                            routeBadge = routeBadgeFor(trip),
+                            modifier = pillModifier.alpha(if (dimmed) PASSED_PILL_ALPHA else 1f)
+                        )
+                    }
+                    // The rule rides inside the item it precedes rather than being an item of its own, so
+                    // the pills' LazyRow keys — trip identity, which a poll must be able to match across
+                    // updates — stay exactly what they were.
+                    if (marker != null && marker.index == index) {
+                        MarkedItem(marker) { pill() }
+                    } else {
+                        pill()
+                    }
+                }
+                // A marker past the last departure — the rider gets to the stop after everything the feed
+                // knows about — closes the strip instead of vanishing.
+                if (marker != null && marker.index >= trips.size) {
+                    item(key = ETA_STRIP_MARKER_TAG) { EtaStripMarkerRule(marker) }
                 }
             }
         }
@@ -211,6 +252,50 @@ internal fun EtaStrip(
 
 /** The gap between adjacent ETA pills, for the LazyRow's [Arrangement.spacedBy]. */
 private val PILL_SPACING = 6.dp
+
+/** How faint a pill the strip's [EtaStripMarker] has already passed goes. Still legible — it's a real
+ *  departure — but clearly behind the ones after the rule. */
+private const val PASSED_PILL_ALPHA = 0.38f
+
+/** The marker rule's width. */
+private val MARKER_WIDTH = 3.dp
+
+/** A stable handle on the marker rule, so a render test can sample it without matching on its colour.
+ *  Doubles as its LazyRow key on the one path where the rule is an item of its own — a trip-identity key
+ *  is a NUL-joined tuple of OBA ids, so a bare word can't collide with one. */
+internal const val ETA_STRIP_MARKER_TAG = "etaStripMarker"
+
+/** One LazyRow item holding the marker rule and the pill it precedes, spaced as two adjacent pills
+ *  would be so the rule doesn't crowd the strip's rhythm. */
+@Composable
+private fun MarkedItem(marker: EtaStripMarker, pill: @Composable () -> Unit) {
+    Row(
+        Modifier.fillMaxHeight(),
+        horizontalArrangement = Arrangement.spacedBy(PILL_SPACING),
+        verticalAlignment = Alignment.Bottom
+    ) {
+        EtaStripMarkerRule(marker)
+        pill()
+    }
+}
+
+/**
+ * The marker itself: a full-height rounded rule in the theme's primary colour, standing between the
+ * departures on either side of the moment it marks. It carries the marker's whole meaning for a screen
+ * reader as its content description, since a rule says nothing on its own.
+ */
+@Composable
+private fun EtaStripMarkerRule(marker: EtaStripMarker) {
+    Box(
+        Modifier
+            .testTag(ETA_STRIP_MARKER_TAG)
+            .fillMaxHeight()
+            .width(MARKER_WIDTH)
+            .clip(RoundedCornerShape(MARKER_WIDTH / 2))
+            .background(MaterialTheme.colorScheme.primary)
+            .semantics { contentDescription = marker.contentDescription }
+    )
+}
 
 /**
  * Wraps [content] (the strip's LazyRow) in a layout whose height is fixed to a measured [reference]
@@ -518,6 +603,7 @@ private fun northgatePills(count: Int) = List(count) { previewArrival("40", "Nor
 @Composable
 private fun EtaStripPreviewFrame(
     trips: List<ArrivalInfo>,
+    marker: EtaStripMarker? = null,
     state: LazyListState = rememberLazyListState()
 ) {
     ObaTheme {
@@ -530,6 +616,7 @@ private fun EtaStripPreviewFrame(
                     trips = trips,
                     actionsFor = { null },
                     callbacks = previewRowCallbacks(),
+                    marker = marker,
                     state = state
                 )
             }
@@ -552,6 +639,17 @@ private fun EtaStripScrolledPreview() {
     EtaStripPreviewFrame(
         trips = northgatePills(7),
         state = remember { LazyListState(firstVisibleItemIndex = 2, firstVisibleItemScrollOffset = 30) }
+    )
+}
+
+@Preview(showBackground = true, widthDp = 240, name = "EtaStrip · marked (rider arrives)")
+@Composable
+private fun EtaStripMarkedPreview() {
+    // The directions case: the rider's walk lands after the first two departures, so the rule stands
+    // before the third and the two it has passed are dimmed.
+    EtaStripPreviewFrame(
+        trips = northgatePills(4),
+        marker = EtaStripMarker(index = 2, contentDescription = "You get to the stop at 3:19pm")
     )
 }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -759,16 +759,18 @@ fun HomeScreen(
                                             onFocusRouteLeg = homeViewModel::focusItineraryRouteLeg,
                                             onFocusLeg = homeViewModel::focusItineraryLegOnMap,
                                             onFocusPoint = homeViewModel::focusItineraryPointOnMap,
-                                            // Each transit leg's Board/Alight row shows that stop's live ETA strip inline.
-                                            stopEtaStrip = { routeLeg, stop, segment ->
+                                            // Each transit leg's Board/Alight row shows that stop's live ETA strip inline,
+                                            // ruled at the moment the plan has the rider reach the stop (#2125).
+                                            stopEtaStrip = { ride, stop ->
                                                 DirectionStopEtaStrip(
-                                                    routeLeg = routeLeg,
+                                                    routeLeg = ride.routeLeg,
                                                     stop = stop,
+                                                    reachStopTime = ride.reachStopTime,
                                                     arrivalsViewModelFactory = arrivalsViewModelFactory,
                                                     onShowTrip = onShowTrip,
                                                     onEditReminder = onEditReminder,
                                                     onFocusVehicle = { request ->
-                                                        homeViewModel.focusDirectionsRouteVehicle(request, segment)
+                                                        homeViewModel.focusDirectionsRouteVehicle(request, ride.legPoints)
                                                     }
                                                 )
                                             },

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
@@ -85,10 +85,12 @@ import org.onebusaway.android.directions.model.TripItinerary
 import org.onebusaway.android.directions.util.ConversionUtils
 import org.onebusaway.android.directions.util.OtpTarget
 import org.onebusaway.android.map.ShowRouteRequest
+import org.onebusaway.android.time.ServerTime
 import org.onebusaway.android.ui.arrivals.ArrivalsUiState
 import org.onebusaway.android.ui.arrivals.ArrivalsViewModel
 import org.onebusaway.android.ui.arrivals.RouteRowGroup
 import org.onebusaway.android.ui.arrivals.components.EtaStrip
+import org.onebusaway.android.ui.arrivals.components.EtaStripMarker
 import org.onebusaway.android.ui.arrivals.rememberArrivalRowCallbacks
 import org.onebusaway.android.ui.compose.components.CenteredLongPressMenu
 import org.onebusaway.android.ui.compose.components.DRAG_HANDLE_TOUCH_TARGET_HEIGHT
@@ -126,6 +128,7 @@ import org.onebusaway.android.ui.tripresults.TripResultsViewModel
 import org.onebusaway.android.ui.tripresults.focusTransit
 import org.onebusaway.android.ui.tripresults.rideCoveringLegs
 import org.onebusaway.android.util.BikeshareAvailability
+import org.onebusaway.android.util.DisplayFormat
 import org.onebusaway.android.util.GeoPoint
 import org.onebusaway.android.util.PermissionUtils
 import org.onebusaway.android.util.PreferenceUtils
@@ -267,7 +270,7 @@ fun DirectionsResultsSheet(
     onFocusRouteLeg: (RouteLegRef, FocusedLeg) -> Unit,
     onFocusLeg: (FocusedLeg) -> Unit,
     onFocusPoint: (GeoPoint) -> Unit,
-    stopEtaStrip: @Composable (RouteLegRef, RouteStopRef, List<GeoPoint>) -> Unit,
+    stopEtaStrip: @Composable (TripLogEntry.Transit, RouteStopRef) -> Unit,
     onSheetHeightPx: (Int) -> Unit,
     // The itinerary leg indices of a route label tapped on the map, as they arrive. Required rather than
     // defaulted to an empty flow: omitting it leaves the map's labels dead, which is a wiring bug that
@@ -377,11 +380,16 @@ fun DirectionsResultsSheet(
  * All routes read the one arrivals poll this stop already runs, so alternatives cost no extra request.
  * An alternative with no OBA id, or with nothing upcoming at this stop, is simply left out — its name
  * still appears on the card's "or …" line.
+ *
+ * The strip is live arrivals *as of now*, but the rider is somewhere up the plan, so [reachStopTime] —
+ * when the plan has them reach this stop — is ruled across it (#2125): departures before it are ones
+ * they can't be here for, and the first pill after the rule is the soonest one they can actually board.
  */
 @Composable
 fun DirectionStopEtaStrip(
     routeLeg: RouteLegRef,
     stop: RouteStopRef,
+    reachStopTime: ServerTime,
     arrivalsViewModelFactory: ArrivalsViewModel.Factory,
     onShowTrip: (tripId: String, stopId: String) -> Unit,
     onEditReminder: (ReminderEditorArgs) -> Unit,
@@ -430,14 +438,30 @@ fun DirectionStopEtaStrip(
         return
     }
     val badgesByTrip = interleaved.associate { (trip, badge) -> trip to badge }
+    val trips = interleaved.map { it.first }
+    val context = LocalContext.current
+    val reachStopClock = remember(reachStopTime, context) { DisplayFormat.formatTime(context, reachStopTime.epochMs) }
     EtaStrip(
-        trips = interleaved.map { it.first },
+        trips = trips,
         actionsFor = { content.actions[it.tripId] },
         callbacks = callbacks,
         modifier = modifier.then(rowPadding),
-        routeBadgeFor = { badgesByTrip[it] }
+        routeBadgeFor = { badgesByTrip[it] },
+        marker = EtaStripMarker(
+            index = departuresBefore(trips.map { it.displayTime }, reachStopTime),
+            contentDescription = stringResource(R.string.directions_stop_eta_reach_stop, reachStopClock)
+        )
     )
 }
+
+/**
+ * How many of [departureTimes] (in strip order, i.e. chronological) leave before the rider gets to the
+ * stop — which is where the strip's "you reach the stop" rule goes: after those, before the rest.
+ *
+ * A departure exactly *at* [reachStopTime] counts as catchable and stays after the rule; a plan that
+ * boards a departure it also says the rider arrives for would otherwise rule out its own ride.
+ */
+internal fun departuresBefore(departureTimes: List<ServerTime>, reachStopTime: ServerTime): Int = departureTimes.count { it < reachStopTime }
 
 /**
  * Flattens route-specific, already-ordered arrival lists into one chronological strip. Kotlin's sort

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
@@ -384,12 +384,14 @@ fun DirectionsResultsSheet(
  * The strip is live arrivals *as of now*, but the rider is somewhere up the plan, so [reachStopTime] —
  * when the plan has them reach this stop — is ruled across it (#2125): departures before it are ones
  * they can't be here for, and the first pill after the rule is the soonest one they can actually board.
+ * Null when the plan puts nothing before this ride (the rider is at the stop from the start, so every
+ * departure is theirs to take) — the strip then draws no rule rather than one placed at a guess.
  */
 @Composable
 fun DirectionStopEtaStrip(
     routeLeg: RouteLegRef,
     stop: RouteStopRef,
-    reachStopTime: ServerTime,
+    reachStopTime: ServerTime?,
     arrivalsViewModelFactory: ArrivalsViewModel.Factory,
     onShowTrip: (tripId: String, stopId: String) -> Unit,
     onEditReminder: (ReminderEditorArgs) -> Unit,
@@ -438,30 +440,28 @@ fun DirectionStopEtaStrip(
         return
     }
     val badgesByTrip = interleaved.associate { (trip, badge) -> trip to badge }
-    val trips = interleaved.map { it.first }
-    val context = LocalContext.current
-    val reachStopClock = remember(reachStopTime, context) { DisplayFormat.formatTime(context, reachStopTime.epochMs) }
     EtaStrip(
-        trips = trips,
+        trips = interleaved.map { it.first },
         actionsFor = { content.actions[it.tripId] },
         callbacks = callbacks,
         modifier = modifier.then(rowPadding),
         routeBadgeFor = { badgesByTrip[it] },
-        marker = EtaStripMarker(
-            index = departuresBefore(trips.map { it.displayTime }, reachStopTime),
-            contentDescription = stringResource(R.string.directions_stop_eta_reach_stop, reachStopClock)
-        )
+        marker = reachStopTime?.let { rememberReachStopMarker(it) }
     )
 }
 
-/**
- * How many of [departureTimes] (in strip order, i.e. chronological) leave before the rider gets to the
- * stop — which is where the strip's "you reach the stop" rule goes: after those, before the rest.
- *
- * A departure exactly *at* [reachStopTime] counts as catchable and stays after the rule; a plan that
- * boards a departure it also says the rider arrives for would otherwise rule out its own ride.
- */
-internal fun departuresBefore(departureTimes: List<ServerTime>, reachStopTime: ServerTime): Int = departureTimes.count { it < reachStopTime }
+/** The strip's "you get here at …" rule for [reachStopTime]. The clock string is memoized because the
+ *  format call is locale work that only changes with the plan, not with each arrivals poll. */
+@Composable
+private fun rememberReachStopMarker(reachStopTime: ServerTime): EtaStripMarker {
+    val context = LocalContext.current
+    val clock = remember(reachStopTime, context) { DisplayFormat.formatTime(context, reachStopTime.epochMs) }
+    return EtaStripMarker(
+        at = reachStopTime,
+        contentDescription = stringResource(R.string.directions_stop_eta_reach_stop, clock),
+        passedStateDescription = stringResource(R.string.directions_stop_eta_departure_missed)
+    )
+}
 
 /**
  * Flattens route-specific, already-ordered arrival lists into one chronological strip. Kotlin's sort

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripLogBuilder.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripLogBuilder.kt
@@ -103,9 +103,11 @@ object TripLogBuilder {
                         legIndex = legIndex,
                         // When the rider gets to the board stop: the end of the leg that brought them
                         // there (a walk, or the ride they transfer off). An itinerary that opens on a
-                        // transit leg has no such leg — the rider is at the stop from the start — so the
-                        // ride's own departure stands in, leaving no planned wait.
-                        reachStopTime = legs.getOrNull(legIndex - 1)?.endTime ?: leg.startTime,
+                        // transit leg has no such leg — the rider is at the stop from the start — and
+                        // that is a genuine absence, not a moment to substitute for: see
+                        // TripLogEntry.Transit.reachStopTime for what standing in the ride's own
+                        // departure would tell the rider.
+                        reachStopTime = legs.getOrNull(legIndex - 1)?.endTime,
                         ref = routeLegRefs.getOrNull(legIndex)
                     )
                 }
@@ -181,7 +183,7 @@ object TripLogBuilder {
         board: Direction,
         legPoints: List<GeoPoint>,
         legIndex: Int,
-        reachStopTime: ServerTime,
+        reachStopTime: ServerTime?,
         ref: RouteLegRef?
     ): TripLogEntry.Transit {
         val routeLeg = ref ?: fallbackRouteLeg(leg)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripLogBuilder.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripLogBuilder.kt
@@ -21,6 +21,7 @@ import org.onebusaway.android.directions.model.TripLeg
 import org.onebusaway.android.directions.model.decodedPoints
 import org.onebusaway.android.directions.model.routeDisplayName
 import org.onebusaway.android.directions.model.routeDisplayShortName
+import org.onebusaway.android.time.ServerTime
 import org.onebusaway.android.util.GeoPoint
 import org.onebusaway.android.util.ScheduleDeviation
 import org.onebusaway.android.util.geoPointOrNull
@@ -95,7 +96,18 @@ object TripLogBuilder {
                     // in TripResultsRepository).
                     foldIntoLeader(entries, leg, board, legPoints, legIndex, transitionByLeg[legIndex])
                 } else {
-                    entries += transitEntry(leg, board, legPoints, legIndex, routeLegRefs.getOrNull(legIndex))
+                    entries += transitEntry(
+                        leg = leg,
+                        board = board,
+                        legPoints = legPoints,
+                        legIndex = legIndex,
+                        // When the rider gets to the board stop: the end of the leg that brought them
+                        // there (a walk, or the ride they transfer off). An itinerary that opens on a
+                        // transit leg has no such leg — the rider is at the stop from the start — so the
+                        // ride's own departure stands in, leaving no planned wait.
+                        reachStopTime = legs.getOrNull(legIndex - 1)?.endTime ?: leg.startTime,
+                        ref = routeLegRefs.getOrNull(legIndex)
+                    )
                 }
             }
         }
@@ -169,6 +181,7 @@ object TripLogBuilder {
         board: Direction,
         legPoints: List<GeoPoint>,
         legIndex: Int,
+        reachStopTime: ServerTime,
         ref: RouteLegRef?
     ): TripLogEntry.Transit {
         val routeLeg = ref ?: fallbackRouteLeg(leg)
@@ -178,6 +191,7 @@ object TripLogBuilder {
             mode = leg.mode.transitMode(),
             routeColorHex = leg.routeColor,
             headsign = leg.headsign ?: routeLeg.headsign,
+            reachStopTime = reachStopTime,
             boardTime = leg.startTime,
             exitTime = leg.endTime,
             durationMinutes = leg.duration.inWholeMinutes,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
@@ -804,7 +804,7 @@ fun TripResultsList(
     onFocusRouteLeg: (RouteLegRef, FocusedLeg) -> Unit = { _, _ -> },
     onFocusLeg: (FocusedLeg) -> Unit = {},
     onFocusPoint: (GeoPoint) -> Unit = {},
-    stopEtaStrip: @Composable (RouteLegRef, RouteStopRef, List<GeoPoint>) -> Unit = { _, _, _ -> },
+    stopEtaStrip: @Composable (TripLogEntry.Transit, RouteStopRef) -> Unit = { _, _ -> },
     reminderControl: @Composable () -> Unit = {}
 ) {
     Box(
@@ -859,7 +859,7 @@ fun TripResultsSheet(
     onFocusRouteLeg: (RouteLegRef, FocusedLeg) -> Unit,
     onFocusLeg: (FocusedLeg) -> Unit,
     onFocusPoint: (GeoPoint) -> Unit,
-    stopEtaStrip: @Composable (RouteLegRef, RouteStopRef, List<GeoPoint>) -> Unit,
+    stopEtaStrip: @Composable (TripLogEntry.Transit, RouteStopRef) -> Unit,
     modifier: Modifier = Modifier,
     listBottomInset: Dp = 0.dp
 ) {
@@ -995,7 +995,7 @@ private fun TripLogList(
     onFocusRouteLeg: (RouteLegRef, FocusedLeg) -> Unit,
     onFocusLeg: (FocusedLeg) -> Unit,
     onFocusPoint: (GeoPoint) -> Unit,
-    stopEtaStrip: @Composable (RouteLegRef, RouteStopRef, List<GeoPoint>) -> Unit,
+    stopEtaStrip: @Composable (TripLogEntry.Transit, RouteStopRef) -> Unit,
     reminderControl: @Composable () -> Unit
 ) {
     val entries = state.directions
@@ -1051,7 +1051,7 @@ private fun LogRow(
     onFocusRouteLeg: (RouteLegRef, FocusedLeg) -> Unit,
     onFocusLeg: (FocusedLeg) -> Unit,
     onFocusPoint: (GeoPoint) -> Unit,
-    stopEtaStrip: @Composable (RouteLegRef, RouteStopRef, List<GeoPoint>) -> Unit
+    stopEtaStrip: @Composable (TripLogEntry.Transit, RouteStopRef) -> Unit
 ) {
     val i = model.entryIndex
     when (val content = model.content) {
@@ -1579,7 +1579,7 @@ private fun ColumnScope.BoardContent(
     entry: TripLogEntry.Transit,
     onFocus: () -> Unit,
     onFocusPoint: (GeoPoint) -> Unit,
-    stopEtaStrip: @Composable (RouteLegRef, RouteStopRef, List<GeoPoint>) -> Unit
+    stopEtaStrip: @Composable (TripLogEntry.Transit, RouteStopRef) -> Unit
 ) {
     val context = LocalContext.current
     // The route/headsign/meta block highlights the leg on the map; expanding its steps is the scaffold's
@@ -1642,7 +1642,9 @@ private fun ColumnScope.BoardContent(
             stopName = stop.name,
             onClick = { stop.point?.let(onFocusPoint) }
         )
-        stopEtaStrip(entry.routeLeg, stop, entry.legPoints)
+        // The whole ride, not just its route/stop: the strip also rules the plan's own arrival at this
+        // stop across the live ETAs (#2125), and a pill tap frames the ride's geometry on the map.
+        stopEtaStrip(entry, stop)
     }
 }
 
@@ -1935,6 +1937,7 @@ private fun TripResultsPreview() {
                     mode = TransitMode.BUS,
                     routeColorHex = "1B6EF3",
                     headsign = "Rainier Beach",
+                    reachStopTime = ServerTime(3 * 60_000L),
                     boardTime = ServerTime(4 * 60_000L),
                     exitTime = ServerTime(20 * 60_000L),
                     durationMinutes = 16,
@@ -1978,6 +1981,7 @@ private fun TripResultsPreview() {
                     mode = TransitMode.FERRY,
                     routeColorHex = null,
                     headsign = "Bremerton",
+                    reachStopTime = ServerTime(20 * 60_000L),
                     boardTime = ServerTime(24 * 60_000L),
                     exitTime = ServerTime(84 * 60_000L),
                     durationMinutes = 60,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
@@ -185,7 +185,11 @@ sealed interface TripLogEntry {
      * [reachStopTime] and [boardTime] are different moments and both matter: the rider gets to the stop
      * at the first (the end of whatever leg precedes this one) and the vehicle leaves at the second. The
      * gap between them is the planned wait, and it's what the Board node's live ETA strip marks (#2125) —
-     * without it the strip reads as if the rider were standing at the stop already.
+     * without it the strip reads as if the rider were standing at the stop already. It is **null** when
+     * nothing precedes the ride: the plan then puts the rider at the stop from the start, so there is no
+     * wait, and — crucially — no departure is out of their reach. Substituting [boardTime] there would
+     * dim every departure earlier than the one the plan happened to pick, which for a "leave at 5pm" plan
+     * read at 3pm is the whole strip, and is the opposite of the truth.
      */
     data class Transit(
         val routeShortName: String?,
@@ -193,7 +197,7 @@ sealed interface TripLogEntry {
         val mode: TransitMode,
         val routeColorHex: String?,
         val headsign: String?,
-        val reachStopTime: ServerTime,
+        val reachStopTime: ServerTime?,
         val boardTime: ServerTime,
         val exitTime: ServerTime,
         val durationMinutes: Long,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
@@ -181,6 +181,11 @@ sealed interface TripLogEntry {
      * then draws no roundel and leads with [routeDisplayName]; see
      * [routeDisplayShortName][org.onebusaway.android.directions.model.routeDisplayShortName]. [mode] is
      * what the rider boards, and picks the Board node's glyph — a ferry leg must not read as a bus.
+     *
+     * [reachStopTime] and [boardTime] are different moments and both matter: the rider gets to the stop
+     * at the first (the end of whatever leg precedes this one) and the vehicle leaves at the second. The
+     * gap between them is the planned wait, and it's what the Board node's live ETA strip marks (#2125) —
+     * without it the strip reads as if the rider were standing at the stop already.
      */
     data class Transit(
         val routeShortName: String?,
@@ -188,6 +193,7 @@ sealed interface TripLogEntry {
         val mode: TransitMode,
         val routeColorHex: String?,
         val headsign: String?,
+        val reachStopTime: ServerTime,
         val boardTime: ServerTime,
         val exitTime: ServerTime,
         val durationMinutes: Long,

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -973,6 +973,10 @@
     <!-- Caption beside a transit leg's joined route badge, when several routes go between the same two
          stops without making the rider late for the rest of the trip (badge reads e.g. "1 Line/2 Line"). -->
     <string name="directions_whichever_comes_first">whichever comes first</string>
+    <!-- Content description for the rule drawn across a Board row's live ETA strip at the moment the
+         plan has the rider reach that stop. %1$s is a clock time, e.g. "3:19pm". Departures drawn
+         before the rule are ones the rider cannot be there for. -->
+    <string name="directions_stop_eta_reach_stop">You get to this stop at %1$s; departures before this point are shown dimmed</string>
     <!-- Content descriptions for the chevrons that hint the itinerary-option picker can scroll sideways -->
     <string name="trip_plan_options_scroll_previous">Show previous options</string>
     <string name="trip_plan_options_scroll_more">Show more options</string>

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -974,9 +974,11 @@
          stops without making the rider late for the rest of the trip (badge reads e.g. "1 Line/2 Line"). -->
     <string name="directions_whichever_comes_first">whichever comes first</string>
     <!-- Content description for the rule drawn across a Board row's live ETA strip at the moment the
-         plan has the rider reach that stop. %1$s is a clock time, e.g. "3:19pm". Departures drawn
-         before the rule are ones the rider cannot be there for. -->
-    <string name="directions_stop_eta_reach_stop">You get to this stop at %1$s; departures before this point are shown dimmed</string>
+         plan has the rider reach that stop. %1$s is a clock time, e.g. "3:19pm". -->
+    <string name="directions_stop_eta_reach_stop">You get to this stop at %1$s</string>
+    <!-- Spoken state of each departure drawn before that rule: one leaving before the rider can be at
+         the stop. Read on the departure itself, since its dimmed appearance says nothing aloud. -->
+    <string name="directions_stop_eta_departure_missed">Leaves before you get here</string>
     <!-- Content descriptions for the chevrons that hint the itinerary-option picker can scroll sideways -->
     <string name="trip_plan_options_scroll_previous">Show previous options</string>
     <string name="trip_plan_options_scroll_more">Show more options</string>

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/components/CountBeforeTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/components/CountBeforeTest.kt
@@ -13,34 +13,37 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.onebusaway.android.ui.home.directions
+package org.onebusaway.android.ui.arrivals.components
 
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.onebusaway.android.time.ServerTime
 
 /**
- * Where the "you get to this stop" rule lands in a Board row's live ETA strip (#2125): after every
- * departure the rider can't be there for, before the first one they can.
+ * Where an [EtaStripMarker]'s rule lands among the strip's departures (#2125) — in the directions
+ * drawer, after every departure the rider can't be there for and before the first one they can.
  */
-class DeparturesBeforeTest {
+class CountBeforeTest {
 
     private fun minutes(vararg m: Long) = m.map { ServerTime(it * 60_000L) }
 
+    /** The times are already [ServerTime]s here, so the item *is* its own time. */
+    private fun ruleAt(departures: List<ServerTime>, moment: ServerTime) = countBefore(departures, moment) { it }
+
     @Test
-    fun `the rule follows the departures that leave before the rider gets there`() {
+    fun `the rule follows the departures that leave before the moment`() {
         // Departures at 2, 9 and 17 minutes; the rider's walk lands at 10.
-        assertEquals(2, departuresBefore(minutes(2, 9, 17), ServerTime(10 * 60_000L)))
+        assertEquals(2, ruleAt(minutes(2, 9, 17), ServerTime(10 * 60_000L)))
     }
 
     @Test
     fun `a rider already at the stop puts the rule ahead of every departure`() {
-        assertEquals(0, departuresBefore(minutes(2, 9, 17), ServerTime(0L)))
+        assertEquals(0, ruleAt(minutes(2, 9, 17), ServerTime(0L)))
     }
 
     @Test
     fun `a rider arriving after everything the feed knows puts the rule at the end`() {
-        assertEquals(3, departuresBefore(minutes(2, 9, 17), ServerTime(60 * 60_000L)))
+        assertEquals(3, ruleAt(minutes(2, 9, 17), ServerTime(60 * 60_000L)))
     }
 
     @Test
@@ -48,11 +51,11 @@ class DeparturesBeforeTest {
         // An exact tie is the common case, not an edge one: an OTP plan whose walk is timed to the
         // vehicle hands back the same instant for both. Counting it as missed would dim the very ride
         // the row is about.
-        assertEquals(1, departuresBefore(minutes(2, 9, 17), ServerTime(9 * 60_000L)))
+        assertEquals(1, ruleAt(minutes(2, 9, 17), ServerTime(9 * 60_000L)))
     }
 
     @Test
     fun `an empty strip has nothing to rule`() {
-        assertEquals(0, departuresBefore(emptyList(), ServerTime(9 * 60_000L)))
+        assertEquals(0, ruleAt(emptyList(), ServerTime(9 * 60_000L)))
     }
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/directions/DeparturesBeforeTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/directions/DeparturesBeforeTest.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.home.directions
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.onebusaway.android.time.ServerTime
+
+/**
+ * Where the "you get to this stop" rule lands in a Board row's live ETA strip (#2125): after every
+ * departure the rider can't be there for, before the first one they can.
+ */
+class DeparturesBeforeTest {
+
+    private fun minutes(vararg m: Long) = m.map { ServerTime(it * 60_000L) }
+
+    @Test
+    fun `the rule follows the departures that leave before the rider gets there`() {
+        // Departures at 2, 9 and 17 minutes; the rider's walk lands at 10.
+        assertEquals(2, departuresBefore(minutes(2, 9, 17), ServerTime(10 * 60_000L)))
+    }
+
+    @Test
+    fun `a rider already at the stop puts the rule ahead of every departure`() {
+        assertEquals(0, departuresBefore(minutes(2, 9, 17), ServerTime(0L)))
+    }
+
+    @Test
+    fun `a rider arriving after everything the feed knows puts the rule at the end`() {
+        assertEquals(3, departuresBefore(minutes(2, 9, 17), ServerTime(60 * 60_000L)))
+    }
+
+    @Test
+    fun `the departure the plan boards is not ruled out by its own arrival time`() {
+        // An exact tie is the common case, not an edge one: an OTP plan whose walk is timed to the
+        // vehicle hands back the same instant for both. Counting it as missed would dim the very ride
+        // the row is about.
+        assertEquals(1, departuresBefore(minutes(2, 9, 17), ServerTime(9 * 60_000L)))
+    }
+
+    @Test
+    fun `an empty strip has nothing to rule`() {
+        assertEquals(0, departuresBefore(emptyList(), ServerTime(9 * 60_000L)))
+    }
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/RideCoveringLegsTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/RideCoveringLegsTest.kt
@@ -46,6 +46,7 @@ class RideCoveringLegsTest {
         mode = TransitMode.BUS,
         routeColorHex = null,
         headsign = "Downtown",
+        reachStopTime = ServerTime(3 * 60_000L),
         boardTime = ServerTime(4 * 60_000L),
         exitTime = ServerTime(20 * 60_000L),
         durationMinutes = 16,

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/TripLogBuilderTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/TripLogBuilderTest.kt
@@ -239,6 +239,36 @@ class TripLogBuilderTest {
     }
 
     @Test
+    fun transitEntry_reachesTheStopWhenTheLegBeforeItEnds() {
+        // The rider is at the board stop when the walk that got them there finishes — 4 minutes in —
+        // which is a different moment from the ride's own departure whenever the plan builds in a wait.
+        // The Board row's ETA strip rules the live departures at this instant (#2125).
+        val transit = TripLogBuilder
+            .build(
+                legs = listOf(walkLeg, transitLeg.copy(startTime = ServerTime(9 * 60_000L))),
+                flatDirections = listOf(walkDir, boardDir, alightDir),
+                routeLegRefs = listOf(null, transitRef)
+            )
+            .filterIsInstance<TripLogEntry.Transit>()
+            .single()
+
+        assertEquals(walkLeg.endTime, transit.reachStopTime)
+        assertEquals(ServerTime(9 * 60_000L), transit.boardTime)
+    }
+
+    @Test
+    fun anItineraryOpeningOnTransit_reachesTheStopAtItsOwnDeparture() {
+        // Nothing precedes the ride, so the plan puts the rider at the stop from the start and there is
+        // no wait to mark — the rule sits ahead of the departure the plan boards rather than nowhere.
+        val transit = TripLogBuilder
+            .build(listOf(transitLeg), listOf(boardDir, alightDir), listOf(transitRef))
+            .filterIsInstance<TripLogEntry.Transit>()
+            .single()
+
+        assertEquals(transitLeg.startTime, transit.reachStopTime)
+    }
+
+    @Test
     fun anUnlabelledIntermediateStop_isDroppedRatherThanDrawnBlank() {
         // A stop the generator could name neither by name nor code yields empty text; carrying it would
         // put a node and an empty line on the spine, and inflate the "N stops" summary past what the

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/TripLogBuilderTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/TripLogBuilderTest.kt
@@ -257,15 +257,17 @@ class TripLogBuilderTest {
     }
 
     @Test
-    fun anItineraryOpeningOnTransit_reachesTheStopAtItsOwnDeparture() {
-        // Nothing precedes the ride, so the plan puts the rider at the stop from the start and there is
-        // no wait to mark — the rule sits ahead of the departure the plan boards rather than nowhere.
+    fun anItineraryOpeningOnTransit_hasNoArrivalAtTheStopToMark() {
+        // Nothing precedes the ride, so the rider is at the stop from the start: there is no wait, and
+        // no departure is out of their reach. Standing the ride's own departure in would dim every
+        // earlier one — for a "leave at 5pm" plan read at 3pm, the whole strip — so the absence is
+        // carried as null rather than substituted for.
         val transit = TripLogBuilder
             .build(listOf(transitLeg), listOf(boardDir, alightDir), listOf(transitRef))
             .filterIsInstance<TripLogEntry.Transit>()
             .single()
 
-        assertEquals(transitLeg.startTime, transit.reachStopTime)
+        assertNull(transit.reachStopTime)
     }
 
     @Test

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/TripLogRowsTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/TripLogRowsTest.kt
@@ -66,6 +66,7 @@ class TripLogRowsTest {
         mode = TransitMode.BUS,
         routeColorHex = "1B6EF3",
         headsign = "Rainier Beach",
+        reachStopTime = ServerTime(3 * 60_000L),
         boardTime = ServerTime(4 * 60_000L),
         exitTime = ServerTime(20 * 60_000L),
         durationMinutes = 16,


### PR DESCRIPTION
Closes #2125.

A transit leg's **Get on …** row shows that stop's live arrivals *as of now* — but the rider is somewhere up the plan, often a ten-minute walk away. The leading pills are departures they can't be there for, and nothing on the row said so.

This rules the strip at the moment the plan has the rider **reach that stop**: a vertical bar between the departures that leave before they get there and the ones they can actually board, with the passed pills dimmed.


## What changed

- **`TripLogEntry.Transit.reachStopTime`** — when the rider gets to the board stop, which is a different moment from `boardTime` whenever the plan builds in a wait. `TripLogBuilder` fills it from the end of whatever leg precedes the ride (the walk that gets them there, or the ride they transfer off). An itinerary that *opens* on a transit leg has no such leg — the rider is at the stop from the start — so the ride's own departure stands in, leaving no planned wait.
- **`EtaStrip` gains an optional `EtaStripMarker(index, contentDescription)`.** The rule rides *inside* the LazyRow item it precedes rather than being an item of its own, so the pills' trip-identity keys — which a poll has to match across updates — are untouched. A marker landing past the last pill (the rider arrives after everything the feed knows) becomes a trailing item so it closes the strip instead of vanishing.
- **The Board row's `stopEtaStrip` slot** went from `(RouteLegRef, RouteStopRef, List<GeoPoint>)` to `(TripLogEntry.Transit, RouteStopRef)`. The strip needed a fourth thing off that same entry, and the entry is the one honest source for all four.

## Two judgment calls

- **Dimming the passed pills** isn't literally in the issue. A bare bar between two identical-looking pills doesn't say which side is which; the dim is what makes the rule mean something at a glance. One constant (`PASSED_PILL_ALPHA`), easy to drop.
- **No auto-scroll.** If the plan boards far out, the rule can sit off the right edge until the rider scrolls. I kept the strip user-driven per its existing "never auto-scrolls" note (#1801/#1974); in practice the arrivals window is ~35 min, so the rule usually lands within the first pill or two.

Accessibility: the bar carries the whole sentence as its content description ("You get to this stop at 3:19pm; departures before this point are shown dimmed") — the dimming has no semantics of its own.

## Testing

- `spotlessCheck` + `compileObaGoogleDebugKotlin` / `compileObaMaplibreDebugKotlin` clean under `-PwarningsAsErrors=true`.
- Full JVM unit suite green, including new `DeparturesBeforeTest` (rule placement, incl. the exact-tie case where a plan must not rule out its own ride) and two new `TripLogBuilderTest` cases (`reachStopTime` from the preceding leg; the opens-on-transit fallback).
- New `EtaStripMarkerRenderTest` (4 cases: the rule lands between the right two pills, the already-there case, the arrives-after-everything case, and the screen-reader sentence) plus the affected existing instrumented tests — 15/15 green on a Pixel 7 Pro.
- Installed and exercised on device.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a timeline marker to trip departure times showing when riders reach a stop.
  * Departures before arrival are visibly dimmed and clearly identified as missed.
  * Improved screen-reader descriptions for arrival times, missed departures, and marker status.
  * Added localized accessibility text for the new departure timeline information.

* **Tests**
  * Added coverage for marker placement, accessibility announcements, arrival timing, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->