### PR TITLE
Pre-reject off-route vehicles with padded bounds (#2124)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteSegmentHighlight.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteSegmentHighlight.kt
@@ -15,9 +15,12 @@
  */
 package org.onebusaway.android.map
 
+import kotlin.math.abs
+import kotlin.math.cos
 import org.onebusaway.android.map.render.ITINERARY_RIDE_WIDTH_PROFILE
 import org.onebusaway.android.map.render.RoutePolyline
 import org.onebusaway.android.models.ObaStop
+import org.onebusaway.android.util.EARTH_RADIUS_METERS
 import org.onebusaway.android.util.GeoPoint
 import org.onebusaway.android.util.Polyline
 import org.onebusaway.android.util.haversineDistance
@@ -98,7 +101,62 @@ internal fun List<RoutePolyline>.upstreamTo(anchor: GeoPoint?): List<RoutePolyli
 internal data class BoundedRoutePath(
     val line: Polyline,
     val maxDistanceAlong: Double
-)
+) {
+    /** The common sampler tolerance, paid once here instead of once per vehicle and frame. */
+    private val samplerBounds = PaddedBounds.around(line.points, SEGMENT_STOP_TOLERANCE_METERS)
+
+    fun mayContain(point: GeoPoint, toleranceMeters: Double): Boolean =
+        toleranceMeters != SEGMENT_STOP_TOLERANCE_METERS || samplerBounds.contains(point)
+}
+
+private data class PaddedBounds(
+    val minLatitude: Double,
+    val maxLatitude: Double,
+    val minLongitude: Double,
+    val maxLongitude: Double,
+    val crossesDateLine: Boolean
+) {
+    fun contains(point: GeoPoint): Boolean =
+        point.latitude in minLatitude..maxLatitude &&
+            (crossesDateLine || point.longitude in minLongitude..maxLongitude)
+
+    companion object {
+        fun around(points: List<GeoPoint>, paddingMeters: Double): PaddedBounds {
+            if (points.isEmpty()) {
+                return PaddedBounds(
+                    Double.POSITIVE_INFINITY,
+                    Double.NEGATIVE_INFINITY,
+                    Double.POSITIVE_INFINITY,
+                    Double.NEGATIVE_INFINITY,
+                    crossesDateLine = false
+                )
+            }
+            val minLatitude = points.minOf { it.latitude }
+            val maxLatitude = points.maxOf { it.latitude }
+            val minLongitude = points.minOf { it.longitude }
+            val maxLongitude = points.maxOf { it.longitude }
+            val latitudePadding = Math.toDegrees(paddingMeters / EARTH_RADIUS_METERS)
+            val paddedAbsoluteLatitude = (maxOf(abs(minLatitude), abs(maxLatitude)) + latitudePadding)
+                .coerceAtMost(90.0)
+            val longitudeScale = cos(Math.toRadians(paddedAbsoluteLatitude))
+            val longitudePadding = if (longitudeScale <= 0.0) {
+                180.0
+            } else {
+                Math.toDegrees(paddingMeters / (EARTH_RADIUS_METERS * longitudeScale))
+            }
+            // A conventional min/max longitude box is intentionally disabled for date-line shapes.
+            // Latitude rejection remains valid, and projection supplies the exact answer as before.
+            val crossesDateLine = maxLongitude - minLongitude > 180.0
+            return PaddedBounds(
+                minLatitude - latitudePadding,
+                maxLatitude + latitudePadding,
+                minLongitude - longitudePadding,
+                maxLongitude + longitudePadding,
+                crossesDateLine
+            )
+        }
+    }
+}
 
 /**
  * Preserve full geometry for projection while bounding travel at [anchor], the alighting point. As in
@@ -133,13 +191,13 @@ internal fun List<RoutePolyline>.boundedThrough(anchor: GeoPoint): List<BoundedR
 }
 
 /** Whether [point] is near one of these paths without exceeding its along-route boundary.
- *  Runs on the 20 Hz vehicle sampler for every vehicle, and each path costs a full projection —
- *  a rejected (downstream) vehicle pays all of them, since [any] can only short-circuit a match.
- *  See #2124 for pre-rejecting on a bounding box or hoisting the verdict off the frame loop. */
+ *  Runs on the 20 Hz vehicle sampler for every vehicle. Each path caches a bounding box padded by
+ *  the normal tolerance, so most rejected vehicles skip the full polyline projection (#2124). */
 internal fun List<BoundedRoutePath>.containsRoutePoint(
     point: GeoPoint,
     toleranceMeters: Double = SEGMENT_STOP_TOLERANCE_METERS
 ): Boolean = any { path ->
+    if (!path.mayContain(point, toleranceMeters)) return@any false
     val projection = path.line.nearestProjection(point.latitude, point.longitude)
         ?: return@any false
     projection.distanceToPoint <= toleranceMeters && projection.distanceAlong <= path.maxDistanceAlong

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteSegmentHighlightTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteSegmentHighlightTest.kt
@@ -205,6 +205,23 @@ class RouteSegmentHighlightTest {
     }
 
     @Test
+    fun containsRoutePoint_paddedBounds_keepPointsWithinTolerance() {
+        val route = listOf(
+            RoutePolyline(
+                color = 1,
+                points = listOf(GeoPoint(47.60, -122.33), GeoPoint(47.62, -122.33))
+            )
+        ).boundedThrough(GeoPoint(47.62, -122.33))
+
+        // Both points sit outside the raw vertex bounds, exercising each padded edge of the cache.
+        assertTrue(route.containsRoutePoint(eastOf(47.61, -122.33, SEGMENT_STOP_TOLERANCE_METERS - 1)))
+        assertTrue(route.containsRoutePoint(GeoPoint(47.60 - Math.toDegrees(49.0 / EARTH_RADIUS_METERS), -122.33)))
+        assertFalse(route.containsRoutePoint(eastOf(47.61, -122.33, SEGMENT_STOP_TOLERANCE_METERS + 1)))
+        // Callers choosing another tolerance bypass the bounds cached for the sampler's default.
+        assertTrue(route.containsRoutePoint(eastOf(47.61, -122.33, 75.0), toleranceMeters = 100.0))
+    }
+
+    @Test
     fun boundedThrough_multiVariantDirection_keepsUpstreamVehicleOnAnotherVariant() {
         // One direction, two shape variants sharing a trunk through the alighting point (#2104): the
         // through variant, and a variant approaching the trunk on a western spur before joining it.


### PR DESCRIPTION
## What changed

- Cache a tolerance-padded geographic bounding box for each bounded route path.
- Reject clearly off-route vehicle samples before performing the full polyline projection.
- Preserve exact projection behavior for date-line-crossing shapes and callers using a non-default tolerance.
- Add coverage for every padded edge, outside-tolerance rejection, and custom tolerances.

## Why

The directions route-focus vehicle filter runs at 20 Hz for every vehicle. After the per-shape-variant eligibility work in #2120, rejected vehicles may require a full projection against every eligible path. The cached bounds make the common off-route rejection inexpensive while retaining the projection as the exact test.

## Validation

- `:onebusaway-android:testObaGoogleDebugUnitTest --tests org.onebusaway.android.map.RouteSegmentHighlightTest`
- `:onebusaway-android:testObaMaplibreDebugUnitTest --tests org.onebusaway.android.map.RouteSegmentHighlightTest`