### PR TITLE
Remove chevrons from the focused route in the directions view

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteSegmentHighlight.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteSegmentHighlight.kt
@@ -52,7 +52,8 @@ internal fun List<GeoPoint>.isDrawableSegment() = size >= 2
  * The segment keeps [ITINERARY_RIDE_WIDTH_PROFILE] — the very weight it had as a leg of the itinerary it
  * was tapped from — and says it is the selected one with a case rather than by out-widening its
  * surroundings (#2082). Its approach carries the same case, so the two read as one route line stepping down
- * where the rider boards.
+ * where the rider boards. Neither carries direction chevrons (#2129): like every other itinerary line, the
+ * ride is marked selected by its case and weight alone.
  */
 internal fun routePolylinesWithSegment(
     base: List<RoutePolyline>,
@@ -61,7 +62,7 @@ internal fun routePolylinesWithSegment(
     itineraryContext: List<RoutePolyline> = emptyList()
 ): List<RoutePolyline> {
     val overlay = segment.takeIf { it.isDrawableSegment() }?.let {
-        RoutePolyline(color = routeColor, points = it, widthProfile = ITINERARY_RIDE_WIDTH_PROFILE, directional = true)
+        RoutePolyline(color = routeColor, points = it, widthProfile = ITINERARY_RIDE_WIDTH_PROFILE)
             .withCase()
     } ?: return itineraryContext + base
     return base.asSelectedRouteApproach() + itineraryContext + overlay

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteSegmentHighlightTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteSegmentHighlightTest.kt
@@ -128,6 +128,9 @@ class RouteSegmentHighlightTest {
         assertNotEquals(RouteLineCase.SELECTION, result[1].case)
         assertEquals(RouteLineCase.SELECTION, result[0].case)
         assertEquals(RouteLineCase.SELECTION, result[2].case)
+        // No layer of the composition carries direction chevrons — not even a base line that had them
+        // in plain route focus (#2129).
+        assertEquals(listOf(false, false, false), result.map { it.directional })
     }
 
     @Test

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteSegmentHighlightTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteSegmentHighlightTest.kt
@@ -128,9 +128,6 @@ class RouteSegmentHighlightTest {
         assertNotEquals(RouteLineCase.SELECTION, result[1].case)
         assertEquals(RouteLineCase.SELECTION, result[0].case)
         assertEquals(RouteLineCase.SELECTION, result[2].case)
-        // No layer of the composition carries direction chevrons — not even a base line that had them
-        // in plain route focus (#2129).
-        assertEquals(listOf(false, false, false), result.map { it.directional })
     }
 
     @Test

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteSegmentHighlightTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteSegmentHighlightTest.kt
@@ -93,11 +93,11 @@ class RouteSegmentHighlightTest {
         assertEquals(RouteLineDash.NONE, approach.dash)
         assertFalse(approach.directional)
         // The ridden span rides on top at the weight it had as an itinerary leg, in the route colour,
-        // directional — so drilling in doesn't make the ride itself thinner than it just was.
+        // and — like every itinerary line — without direction chevrons (#2129).
         val overlay = result.last()
         assertEquals(ITINERARY_RIDE_WIDTH_PROFILE, overlay.widthProfile)
         assertEquals(0xFF00FF00.toInt(), overlay.color)
-        assertEquals(true, overlay.directional)
+        assertFalse(overlay.directional)
         // Both halves of the selected route carry a case, so the approach and the ride read as one line
         // rather than as two things that happen to meet.
         assertEquals(RouteLineCase.SELECTION, approach.case)


### PR DESCRIPTION
Fixes #2129.

When a transit leg is tapped in the directions view, the map enters route focus and draws the ridden board→alight segment cased on top of the route (#2048/#2082). That overlay was the one itinerary line that stamped travel-direction chevrons (`directional = true` in `routePolylinesWithSegment`). This drops the flag, so the ridden segment — like the approach, the itinerary context, and every itinerary-overview leg — is marked selected by its `RouteLineCase.SELECTION` case and itinerary-ride weight alone.

No other chevron producer changes: the plain route view, the emphasized route in stop focus, and the selected vehicle's trip shape keep theirs.

- `RouteSegmentHighlight.kt`: overlay no longer sets `directional`; KDoc updated.
- `RouteSegmentHighlightTest.kt`: the case/weight test now asserts the overlay is non-directional.

Verified: `testObaGoogleDebugUnitTest --tests '*RouteSegmentHighlight*'` green; `compileObaGoogleDebugKotlin -PwarningsAsErrors=true` clean. Visual difference is google-flavor only — the MapLibre renderer never drew chevrons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated route highlighting so selected ride segments display without directional chevrons, matching approach segments.
  * Improved consistency in how highlighted routes are rendered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->