### PR TITLE
Mark stay-aboard interline cutovers on the directions map (#2127)

### DIFF
--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
@@ -54,6 +54,7 @@ import org.onebusaway.android.map.render.BikeMarker
 import org.onebusaway.android.map.render.ContinuationBadge
 import org.onebusaway.android.map.render.ContinuationBadgeBitmaps
 import org.onebusaway.android.map.render.CorrectionSmoother
+import org.onebusaway.android.map.render.InterlineSeamMark
 import org.onebusaway.android.map.render.METERS_PER_PIXEL_AT_EQUATOR_ZOOM_ZERO
 import org.onebusaway.android.map.render.MapPing
 import org.onebusaway.android.map.render.MapRenderSnapshot
@@ -366,6 +367,9 @@ class GoogleMapRenderer(
             if (polyline.roundStartCap) options.startCap(bulb)
             if (polyline.roundEndCap) options.endCap(bulb)
         }
+        // A stay-aboard interline's cutover (#2127) — never together with a start bulb, since the join it
+        // marks is precisely the one the bulbs are withheld at.
+        if (polyline.startSeam) options.startCap(interlineSeamCap(polyline.resolvedColor))
         if (polyline.directional) {
             // Advanced spans are substantially more expensive for Maps to retessellate while
             // zooming. Reserve that path for the lines that actually need repeated chevrons.
@@ -394,6 +398,22 @@ class GoogleMapRenderer(
             bitmap
         }
         return CustomCap(descriptor, ENDPOINT_BULB_REFERENCE_WIDTH_PX)
+    }
+
+    /**
+     * The slash cut across a line where the rider's vehicle changes route mid-ride (#2127), in that line's
+     * own case colour — the mark separates itself from the corridor exactly as the ride's hairline case
+     * separates the corridor from the basemap, and follows the theme for the same reason (see
+     * [mapRouteLineCaseColor]).
+     *
+     * A [CustomCap] like the endpoint bulb above, so Maps scales it with the line's stroke at every zoom and
+     * orients it along the line itself — which is what spares this mark the camera-settle re-stamp a
+     * marker-based one (the route labels) needs.
+     */
+    private fun interlineSeamCap(lineColor: Int): CustomCap {
+        val color = mapRouteLineCaseColor(lineColor, ThemeUtils.isInDarkMode(context))
+        val descriptor = descriptorCache.get("interline-seam:$color") { InterlineSeamMark.bitmap(color) }
+        return CustomCap(descriptor, InterlineSeamMark.REFERENCE_WIDTH_PX)
     }
 
     /**

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
@@ -65,6 +65,7 @@ import org.onebusaway.android.map.render.PingTarget
 import org.onebusaway.android.map.render.RouteBadge
 import org.onebusaway.android.map.render.RouteContinuation
 import org.onebusaway.android.map.render.RouteLineDash
+import org.onebusaway.android.map.render.RouteLineMark
 import org.onebusaway.android.map.render.RoutePolyline
 import org.onebusaway.android.map.render.RoutePolylineReconciler
 import org.onebusaway.android.map.render.StopMarker
@@ -362,14 +363,8 @@ class GoogleMapRenderer(
             .width(widthPx)
             .addPoints(polyline.points)
             .applyDashPattern(polyline)
-        if (polyline.roundStartCap || polyline.roundEndCap) {
-            val bulb = endpointBulbCap(polyline.resolvedColor)
-            if (polyline.roundStartCap) options.startCap(bulb)
-            if (polyline.roundEndCap) options.endCap(bulb)
-        }
-        // A stay-aboard interline's cutover (#2127) — never together with a start bulb, since the join it
-        // marks is precisely the one the bulbs are withheld at.
-        if (polyline.startSeam) options.startCap(interlineSeamCap(polyline.resolvedColor))
+        endCapFor(polyline, polyline.startMark)?.let { options.startCap(it) }
+        endCapFor(polyline, polyline.endMark)?.let { options.endCap(it) }
         if (polyline.directional) {
             // Advanced spans are substantially more expensive for Maps to retessellate while
             // zooming. Reserve that path for the lines that actually need repeated chevrons.
@@ -383,6 +378,18 @@ class GoogleMapRenderer(
             options.color(polyline.resolvedColor)
         }
         return map.addPolyline(options)
+    }
+
+    /**
+     * The cap [mark] asks for on [polyline], or null for a flat end. Both marks are [CustomCap]s, which is
+     * what lets them be requested per end and stay right at every zoom: Maps scales a custom cap with the
+     * line's stroke and orients it along the line itself, so neither needs the camera-settle re-stamp a
+     * marker-based mark (the route labels) does.
+     */
+    private fun endCapFor(polyline: RoutePolyline, mark: RouteLineMark): CustomCap? = when (mark) {
+        RouteLineMark.NONE -> null
+        RouteLineMark.BULB -> endpointBulbCap(polyline.resolvedColor)
+        RouteLineMark.INTERLINE_CUT -> interlineSeamCap(polyline.resolvedColor)
     }
 
     /** A circle 2x the stroke width, scaled by Maps together with the line at every zoom. */
@@ -401,14 +408,9 @@ class GoogleMapRenderer(
     }
 
     /**
-     * The slash cut across a line where the rider's vehicle changes route mid-ride (#2127), in that line's
-     * own case colour — the mark separates itself from the corridor exactly as the ride's hairline case
-     * separates the corridor from the basemap, and follows the theme for the same reason (see
+     * The interline cutover slash ([InterlineSeamMark]), drawn in the cut line's own case colour — resolved
+     * here rather than by the producer because it follows the theme, exactly as a line's case does (see
      * [mapRouteLineCaseColor]).
-     *
-     * A [CustomCap] like the endpoint bulb above, so Maps scales it with the line's stroke at every zoom and
-     * orients it along the line itself — which is what spares this mark the camera-settle re-stamp a
-     * marker-based one (the route labels) needs.
      */
     private fun interlineSeamCap(lineColor: Int): CustomCap {
         val color = mapRouteLineCaseColor(lineColor, ThemeUtils.isInDarkMode(context))

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/DirectionsMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/DirectionsMapController.kt
@@ -133,8 +133,13 @@ class DirectionsMapController(private val host: MapHost) {
         }
         // Every leg's points run in travel order, but no itinerary leg stamps chevrons any more — see
         // [itineraryLegStyle], which also decides the hairline case a ride wears.
+        //
+        // The cross-route cutovers (#2127) are resolved once for the whole plan rather than per leg: they
+        // are one reading of the leg list ([Interlines.chains]), which is also what keeps them the same
+        // joins the drawer tells the rider to stay on board through.
+        val seamLegs = interlineSeamLegs(legs)
         legLines = drawableLegs.map { (legIndex, _, points, style) ->
-            val caps = itineraryLegCaps(legs, legIndex)
+            val caps = itineraryLegCaps(legs, legIndex, seamLegs)
             ItineraryLegLine(
                 legIndex,
                 RoutePolyline(
@@ -144,7 +149,8 @@ class DirectionsMapController(private val host: MapHost) {
                     dash = style.dash,
                     case = style.case,
                     roundStartCap = style.roundCaps && caps.start,
-                    roundEndCap = style.roundCaps && caps.end
+                    roundEndCap = style.roundCaps && caps.end,
+                    startSeam = caps.startSeam
                 )
             )
         }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/DirectionsMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/DirectionsMapController.kt
@@ -22,6 +22,7 @@ import org.onebusaway.android.directions.model.TripMode
 import org.onebusaway.android.directions.model.TripVertexType
 import org.onebusaway.android.directions.model.decodedPoints
 import org.onebusaway.android.directions.model.substitutableRoutes
+import org.onebusaway.android.map.render.RouteLineMark
 import org.onebusaway.android.map.render.RoutePolyline
 import org.onebusaway.android.models.ObaShape
 import org.onebusaway.android.util.GeoPoint
@@ -133,13 +134,9 @@ class DirectionsMapController(private val host: MapHost) {
         }
         // Every leg's points run in travel order, but no itinerary leg stamps chevrons any more — see
         // [itineraryLegStyle], which also decides the hairline case a ride wears.
-        //
-        // The cross-route cutovers (#2127) are resolved once for the whole plan rather than per leg: they
-        // are one reading of the leg list ([Interlines.chains]), which is also what keeps them the same
-        // joins the drawer tells the rider to stay on board through.
-        val seamLegs = interlineSeamLegs(legs)
+        val caps = itineraryLegCaps(legs)
         legLines = drawableLegs.map { (legIndex, _, points, style) ->
-            val caps = itineraryLegCaps(legs, legIndex, seamLegs)
+            val legCaps = caps[legIndex]
             ItineraryLegLine(
                 legIndex,
                 RoutePolyline(
@@ -148,9 +145,15 @@ class DirectionsMapController(private val host: MapHost) {
                     widthProfile = style.widthProfile,
                     dash = style.dash,
                     case = style.case,
-                    roundStartCap = style.roundCaps && caps.start,
-                    roundEndCap = style.roundCaps && caps.end,
-                    startSeam = caps.startSeam
+                    // A cutover (#2127) and a bulb are alternatives, not additions — the cut goes precisely
+                    // where the ride runs on and the bulb is therefore withheld, which is what this `when`
+                    // says and what a pair of booleans left each renderer to decide for itself.
+                    startMark = when {
+                        legCaps.startSeam -> RouteLineMark.INTERLINE_CUT
+                        style.roundCaps && legCaps.start -> RouteLineMark.BULB
+                        else -> RouteLineMark.NONE
+                    },
+                    endMark = if (style.roundCaps && legCaps.end) RouteLineMark.BULB else RouteLineMark.NONE
                 )
             )
         }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/ItineraryLegStyle.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/ItineraryLegStyle.kt
@@ -32,6 +32,7 @@ import org.onebusaway.android.map.render.RouteBadge
 import org.onebusaway.android.map.render.RouteBadgeTap
 import org.onebusaway.android.map.render.RouteLineCase
 import org.onebusaway.android.map.render.RouteLineDash
+import org.onebusaway.android.map.render.RouteLineMark
 import org.onebusaway.android.map.render.RouteLineWidthProfile
 import org.onebusaway.android.map.render.RoutePolyline
 import org.onebusaway.android.util.COLOURLESS_RIDE_HUE_ANCHOR
@@ -147,38 +148,37 @@ internal data class ItineraryLegLine(val legIndex: Int, val line: RoutePolyline)
  * Bulb-bearing ends of one itinerary leg, plus whether it begins at an interline **cutover** (#2127).
  *
  * An interline continuation has no visible internal seam — no bulbs, because the rider never gets off — but
- * a continuation onto a *different* route is cut across at that join ([RoutePolyline.startSeam]). The two
+ * a continuation onto a *different* route is cut across at that join ([RouteLineMark.INTERLINE_CUT]). The two
  * are one decision made in one place: a bulb pair says "alight here, board there", so the join a rider
  * stays seated through has to be marked as something else or not at all, and until now it was not at all.
+ * [startSeam] therefore never coincides with [start] — a cut goes exactly where the bulb is withheld.
  */
 internal data class ItineraryLegCaps(val start: Boolean, val end: Boolean, val startSeam: Boolean = false)
 
 /**
- * The legs a stay-aboard interline hands over to on a **different** route — the cutover points to mark.
- * Exactly the transitions [Interlines.chains] reports, so the map cuts the line in the same places the
- * drawer tells the rider to stay on board, and nowhere else. A self-interline (the same route reversing
- * onto itself) contributes none: nothing about the ride changed there, so there is nothing to say.
+ * How every leg of [legs] is finished at each end, index-aligned to it.
  *
- * Resolved for the whole itinerary at once rather than per leg, since that is what the analysis reads;
- * [itineraryLegCaps] takes the result.
+ * Whole-itinerary rather than per leg because that is what the questions read: which legs a ride continues
+ * through, and which of those joins change route. The cutovers are exactly the transitions
+ * [Interlines.chains] reports, so the map cuts the line in the same places the drawer tells the rider to stay
+ * on board, and nowhere else — a self-interline (the same route reversing onto itself) contributes none,
+ * since nothing about the ride changed there.
  */
-internal fun interlineSeamLegs(legs: List<TripLeg>): Set<Int> = Interlines.chains(legs)
-    .flatMapTo(mutableSetOf()) { it.transitionLegIndices }
-
-/** [seamLegs] is [interlineSeamLegs] for the same [legs] — see [ItineraryLegCaps]. */
-internal fun itineraryLegCaps(legs: List<TripLeg>, index: Int, seamLegs: Set<Int>): ItineraryLegCaps {
-    val leg = legs[index]
-    val transit = leg.mode?.isTransit == true
-    val continuesPrevious = transit &&
-        leg.interlineWithPreviousLeg &&
-        legs.getOrNull(index - 1)?.mode?.isTransit == true
-    val next = legs.getOrNull(index + 1)
-    val continuesIntoNext = transit && next?.mode?.isTransit == true && next.interlineWithPreviousLeg
-    return ItineraryLegCaps(
-        start = !continuesPrevious,
-        end = !continuesIntoNext,
-        startSeam = index in seamLegs
-    )
+internal fun itineraryLegCaps(legs: List<TripLeg>): List<ItineraryLegCaps> {
+    val seamLegs = Interlines.chains(legs).flatMapTo(mutableSetOf()) { it.transitionLegIndices }
+    return legs.mapIndexed { index, leg ->
+        val transit = leg.mode?.isTransit == true
+        val continuesPrevious = transit &&
+            leg.interlineWithPreviousLeg &&
+            legs.getOrNull(index - 1)?.mode?.isTransit == true
+        val next = legs.getOrNull(index + 1)
+        val continuesIntoNext = transit && next?.mode?.isTransit == true && next.interlineWithPreviousLeg
+        ItineraryLegCaps(
+            start = !continuesPrevious,
+            end = !continuesIntoNext,
+            startSeam = index in seamLegs
+        )
+    }
 }
 
 /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/ItineraryLegStyle.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/ItineraryLegStyle.kt
@@ -16,6 +16,7 @@
 package org.onebusaway.android.map
 
 import org.onebusaway.android.directions.model.InterchangeableRoute
+import org.onebusaway.android.directions.model.Interlines
 import org.onebusaway.android.directions.model.TripLeg
 import org.onebusaway.android.directions.model.TripMode
 import org.onebusaway.android.directions.model.TripVertexType
@@ -142,10 +143,30 @@ internal fun itineraryLegStyle(
  */
 internal data class ItineraryLegLine(val legIndex: Int, val line: RoutePolyline)
 
-/** Bulb-bearing ends of one itinerary leg; an interline continuation has no visible internal seam. */
-internal data class ItineraryLegCaps(val start: Boolean, val end: Boolean)
+/**
+ * Bulb-bearing ends of one itinerary leg, plus whether it begins at an interline **cutover** (#2127).
+ *
+ * An interline continuation has no visible internal seam — no bulbs, because the rider never gets off — but
+ * a continuation onto a *different* route is cut across at that join ([RoutePolyline.startSeam]). The two
+ * are one decision made in one place: a bulb pair says "alight here, board there", so the join a rider
+ * stays seated through has to be marked as something else or not at all, and until now it was not at all.
+ */
+internal data class ItineraryLegCaps(val start: Boolean, val end: Boolean, val startSeam: Boolean = false)
 
-internal fun itineraryLegCaps(legs: List<TripLeg>, index: Int): ItineraryLegCaps {
+/**
+ * The legs a stay-aboard interline hands over to on a **different** route — the cutover points to mark.
+ * Exactly the transitions [Interlines.chains] reports, so the map cuts the line in the same places the
+ * drawer tells the rider to stay on board, and nowhere else. A self-interline (the same route reversing
+ * onto itself) contributes none: nothing about the ride changed there, so there is nothing to say.
+ *
+ * Resolved for the whole itinerary at once rather than per leg, since that is what the analysis reads;
+ * [itineraryLegCaps] takes the result.
+ */
+internal fun interlineSeamLegs(legs: List<TripLeg>): Set<Int> = Interlines.chains(legs)
+    .flatMapTo(mutableSetOf()) { it.transitionLegIndices }
+
+/** [seamLegs] is [interlineSeamLegs] for the same [legs] — see [ItineraryLegCaps]. */
+internal fun itineraryLegCaps(legs: List<TripLeg>, index: Int, seamLegs: Set<Int>): ItineraryLegCaps {
     val leg = legs[index]
     val transit = leg.mode?.isTransit == true
     val continuesPrevious = transit &&
@@ -153,7 +174,11 @@ internal fun itineraryLegCaps(legs: List<TripLeg>, index: Int): ItineraryLegCaps
         legs.getOrNull(index - 1)?.mode?.isTransit == true
     val next = legs.getOrNull(index + 1)
     val continuesIntoNext = transit && next?.mode?.isTransit == true && next.interlineWithPreviousLeg
-    return ItineraryLegCaps(start = !continuesPrevious, end = !continuesIntoNext)
+    return ItineraryLegCaps(
+        start = !continuesPrevious,
+        end = !continuesIntoNext,
+        startSeam = index in seamLegs
+    )
 }
 
 /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
@@ -326,7 +326,7 @@ class MapViewModel @Inject constructor(
         initialDirectionId: Int? = null,
         focusTripId: String? = null,
         preserveStopFocus: Boolean = false,
-        highlightedSegment: List<GeoPoint> = emptyList(),
+        riddenSpans: List<RiddenSpan> = emptyList(),
         extraSegments: List<RouteFocusSegment> = emptyList(),
         itineraryContext: List<RoutePolyline> = emptyList(),
         preserveItinerary: Boolean = false,
@@ -344,7 +344,7 @@ class MapViewModel @Inject constructor(
             directionStopId,
             initialDirectionId,
             focusTripId,
-            highlightedSegment,
+            riddenSpans,
             extraSegments,
             itineraryContext,
             palette
@@ -501,7 +501,7 @@ class MapViewModel @Inject constructor(
                 initialDirectionId = request.initialDirectionId,
                 focusTripId = request.focusTripId,
                 preserveStopFocus = stopScoped,
-                highlightedSegment = request.highlightedSegment,
+                riddenSpans = request.riddenSpans,
                 extraSegments = request.extraSegments,
                 // Read before entering: the transition tears the drawn itinerary down, and this is what
                 // survives it.

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
@@ -514,7 +514,7 @@ class RouteMapController(
 
     /** During selected-leg focus, retain vehicles upstream of or currently on the ride. */
     private fun List<ExtrapolatedVehicle>.filterToFocusedRide(routeId: String): List<ExtrapolatedVehicle> {
-        if (!riddenPath.isDrawableSegment()) return this
+        if (!riddenSpans.isDrawableRide()) return this
         val eligiblePaths = focusedVehiclePathsByRoute[routeId] ?: return emptyList()
         return filter { vehicle ->
             focusedRideKeepsVehicle(

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
@@ -128,10 +128,18 @@ class RouteMapController(
     var directionStopId: String? = null
         private set
 
-    // The board→alight polyline of a trip-plan transit leg drilled into route focus, drawn thick over
-    // the full route (empty for every non-directions route launch). Set in start(); overlaid last in
-    // publishMapPresentation so it survives re-publishes (vehicle polls, direction changes).
-    private var highlightedSegment: List<GeoPoint> = emptyList()
+    // The board→alight ride of a trip-plan transit leg drilled into route focus, drawn thick over the full
+    // route (empty for every non-directions route launch) — one span per route it is ridden on, so a
+    // stay-aboard interline keeps each route's own colour and its cutover marks (see [RiddenSpan]). Set in
+    // start(); overlaid last in publishMapPresentation so it survives re-publishes (vehicle polls,
+    // direction changes).
+    private var riddenSpans: List<RiddenSpan> = emptyList()
+
+    // The same ride as one path — where the rider boards and alights, what to frame, which stops and
+    // vehicles are on it. Those questions are about the ride, not about which route each part of it is
+    // ridden as, so they read this rather than the spans. Derived on read: the spans change rarely and
+    // this is short.
+    private val riddenPath: List<GeoPoint> get() = riddenSpans.riddenPath()
 
     // How this session's route colours are rendered: the basemap palette for an ordinary route launch, the
     // directions one for a leg drilled into from a trip plan, so the corridor keeps the leg's badge colour.
@@ -295,14 +303,14 @@ class RouteMapController(
         directionStopId: String? = null,
         initialDirectionId: Int? = null,
         focusTripId: String? = null,
-        highlightedSegment: List<GeoPoint> = emptyList(),
+        riddenSpans: List<RiddenSpan> = emptyList(),
         extraSegments: List<RouteFocusSegment> = emptyList(),
         itineraryContext: List<RoutePolyline> = emptyList(),
         palette: RouteLinePalette
     ) {
         this.routeId = routeId
         this.directionStopId = directionStopId
-        this.highlightedSegment = highlightedSegment
+        this.riddenSpans = riddenSpans
         this.extraSegments = extraSegments
         this.itineraryContext = itineraryContext
         this.palette = palette
@@ -389,9 +397,9 @@ class RouteMapController(
         // e.g. tapping a different leg of the same route. Re-emphasize the polyline and re-filter the
         // shown stops so a stale segment doesn't linger. start() sets this unconditionally; here we only
         // republish when it actually changes.
-        if (highlightedSegment != request.highlightedSegment || extraSegments != request.extraSegments) {
-            highlightedSegment = request.highlightedSegment
-            // Move both segment fields together so a redraw can't key off a fresh highlightedSegment while
+        if (riddenSpans != request.riddenSpans || extraSegments != request.extraSegments) {
+            riddenSpans = request.riddenSpans
+            // Move both segment fields together so a redraw can't key off fresh riddenSpans while
             // extraSegments stays stale (or vice versa). No reload here (reframe contract), so extra routes
             // aren't re-fetched — in practice this path is only hit for a same-route+direction re-tap where
             // changed extras are already loaded (a new cross-route id requires a full re-enter).
@@ -506,7 +514,7 @@ class RouteMapController(
 
     /** During selected-leg focus, retain vehicles upstream of or currently on the ride. */
     private fun List<ExtrapolatedVehicle>.filterToFocusedRide(routeId: String): List<ExtrapolatedVehicle> {
-        if (!highlightedSegment.isDrawableSegment()) return this
+        if (!riddenPath.isDrawableSegment()) return this
         val eligiblePaths = focusedVehiclePathsByRoute[routeId] ?: return emptyList()
         return filter { vehicle ->
             focusedRideKeepsVehicle(
@@ -560,6 +568,22 @@ class RouteMapController(
      * same colour the itinerary's own line had — which is why the palette travels with the drill-in.
      */
     private fun currentRouteColor(): Int = palette.lineColor((_loadedRoute.value as? LoadedRoute.Loaded)?.route?.color) ?: DEFAULT_ROUTE_LINE_COLOR
+
+    /**
+     * The colour one ridden span draws in: its own route's, through this session's [palette] — the same
+     * resolution [directionPolylines] gives that route's full corridor, so a span and the line it is ridden
+     * over can't disagree. A stay-aboard interline therefore changes colour at its cutover exactly as the
+     * itinerary map and the drawer's badges do, instead of drawing two routes as one.
+     *
+     * Falls back to [leaderColor] for a span whose route isn't identified or hasn't loaded yet: the shown
+     * route's colour is what the whole ride used to draw in, so an unresolved span looks exactly as it did
+     * before rather than dropping to a default the rest of the view isn't using. A late-loading extra route
+     * republishes, so the fallback lasts only as long as the load.
+     */
+    private fun spanColor(span: RiddenSpan, leaderColor: Int): Int {
+        val route = span.routeId?.takeIf { it != routeId }?.let { extraRouteMaps[it] } ?: return leaderColor
+        return palette.lineColor(route.route?.color) ?: leaderColor
+    }
 
     /**
      * Resolve (or clear) the selected vehicle's route continuation (#1691); driven by [selectionJob]'s
@@ -641,7 +665,7 @@ class RouteMapController(
         selectionJob = null
         routeId = null
         directionStopId = null
-        highlightedSegment = emptyList()
+        riddenSpans = emptyList()
         extraSegments = emptyList()
         itineraryContext = emptyList()
         palette = BASEMAP_ROUTE_LINE_PALETTE
@@ -705,13 +729,13 @@ class RouteMapController(
         )
         renderState.setRoutePolylines(
             // Over a highlighted leg segment: the route's approach to the boarding point first, the rider's
-            // remaining itinerary at a middle weight, then the ridden span cased on top (#2048, #2082). The
-            // trip stays out of [framingPolylines] — drilling into a leg frames that leg, not the journey.
+            // remaining itinerary at a middle weight, then the ridden span(s) cased on top (#2048, #2082).
+            // The trip stays out of [framingPolylines] — drilling into a leg frames that leg, not the journey.
             polylines = routePolylinesWithSegment(
                 plan.polylines,
-                highlightedSegment,
-                routeColor,
-                itineraryContext
+                riddenSpans,
+                colorOf = { spanColor(it, leaderColor = routeColor) },
+                itineraryContext = itineraryContext
             ),
             framingPolylines = plan.framingPolylines,
             routeModeScalesStopsWithZoom = plan.routeModeScalesStopsWithZoom
@@ -860,18 +884,18 @@ class RouteMapController(
     }
 
     /**
-     * Frame the highlighted board→alight [segment][highlightedSegment] when one is set (a trip-plan leg
+     * Frame the highlighted board→alight ride ([riddenPath]) when one is set (a trip-plan leg
      * drilled in — zoom to just the ridden part), else the whole route's bounding box.
      */
     private fun frameRouteOrSegment() {
-        val segment = highlightedSegment
+        val segment = riddenPath
         if (segment.isDrawableSegment()) host.frameItineraryLeg(segment) else host.frameRoute()
     }
 
     /**
      * Retain the ride's stops as the base route presentation: the leader route's stops narrowed to
      * [currentDirectionId], plus — for a stay-aboard interline (#2000) — each extra segment's route/
-     * direction stops, all clipped to the ridden [highlightedSegment]. Each stop keeps its own
+     * direction stops, all clipped to the ridden [riddenPath]. Each stop keeps its own
      * route+direction key so cross-route stops colour correctly.
      */
     private fun showDirectionStops() {
@@ -885,7 +909,7 @@ class RouteMapController(
             }
         }
         collect(
-            routeStops.stopsForDirection(currentDirectionId).onSegment(highlightedSegment),
+            routeStops.stopsForDirection(currentDirectionId).onSegment(riddenPath),
             RouteDirectionKey(leaderRoute, currentDirectionId)
         )
         // Every extra contributes its relevant route/direction's stops on the ridden segment. A
@@ -894,7 +918,7 @@ class RouteMapController(
             val route = segment.routeMap() ?: continue
             val directionId = segment.directionId()
             collect(
-                route.stops.stopsForDirection(directionId).onSegment(highlightedSegment),
+                route.stops.stopsForDirection(directionId).onSegment(riddenPath),
                 RouteDirectionKey(segment.routeId, directionId)
             )
         }
@@ -903,10 +927,12 @@ class RouteMapController(
             stops = stops,
             routes = (routeStopRoutes + extraRouteMaps.values.flatMap { it.routes }).distinctBy { it.id },
             routeDirectionsByStopId = keysById.mapValues { it.value.toSet() },
-            // An interline ride spans multiple direction shapes, so project onto the ridden segment (the
-            // emphasized line every leg's stops sit on); a plain leg keeps projecting onto its own shape.
+            // An interline ride spans multiple direction shapes, so project onto the ridden line (the
+            // emphasized one every leg's stops sit on); a plain leg keeps projecting onto its own shape.
+            // Span by span rather than onto the joined path, so no stop can land on the jump between two
+            // spans — that join is a seam in the geometry, not somewhere a vehicle travels.
             projectedPoints = if (isInterlineComposite) {
-                projectStopsOntoPolylines(stops, listOf(highlightedSegment))
+                projectStopsOntoPolylines(stops, riddenSpans.map { it.points })
             } else {
                 projectStopsOntoShape(stops)
             }
@@ -948,8 +974,8 @@ class RouteMapController(
     /** Re-draw the base route for [currentDirectionId]. Called on load and on every direction switch. */
     private fun showDirectionPolylines() {
         if (routeShape == null) return
-        val boardPoint = highlightedSegment.firstOrNull()
-        val isLegFocus = highlightedSegment.isDrawableSegment()
+        val boardPoint = riddenPath.firstOrNull()
+        val isLegFocus = riddenPath.isDrawableSegment()
         val leaderRouteId = routeId ?: return
         fun RouteFocusSegment.polylines(): List<RoutePolyline> = routeMap()?.let { directionPolylines(it, directionId()) }.orEmpty()
         val focusedRouteLines = listOf(
@@ -967,7 +993,7 @@ class RouteMapController(
         focusedVehiclePathsByRoute = if (isLegFocus) {
             // Unlike the drawn context, vehicle eligibility extends through the selected ride. Include
             // stay-aboard continuations too: their vehicles belong until the rider's alighting point.
-            val alightPoint = highlightedSegment.last()
+            val alightPoint = riddenPath.last()
             focusedRouteLines
                 .groupBy(
                     { it.routeId },

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteSegmentHighlight.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteSegmentHighlight.kt
@@ -68,6 +68,10 @@ data class RiddenSpan(
  *  the rider boards and alights, what to frame, which stops are on it. */
 internal fun List<RiddenSpan>.riddenPath(): List<GeoPoint> = flatMap { it.points }
 
+/** Whether [riddenPath] would be drawable, answered without building it — the per-frame vehicle sampler asks
+ *  this once per route per frame, and only wants the emptiness. */
+internal fun List<RiddenSpan>.isDrawableRide(): Boolean = sumOf { it.points.size } >= 2
+
 /**
  * Compose the route's polylines when [spans] are highlighted: the route [base] upstream of the boarding
  * point drawn as the selected line's approach, then the rider's [itineraryContext], then the ridden span(s),

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteSegmentHighlight.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteSegmentHighlight.kt
@@ -16,6 +16,7 @@
 package org.onebusaway.android.map
 
 import org.onebusaway.android.map.render.ITINERARY_RIDE_WIDTH_PROFILE
+import org.onebusaway.android.map.render.RouteLineMark
 import org.onebusaway.android.map.render.RoutePolyline
 import org.onebusaway.android.models.ObaStop
 import org.onebusaway.android.util.GeoPoint
@@ -43,28 +44,63 @@ const val VARIANT_MATCH_TOLERANCE_METERS = 50.0
 internal fun List<GeoPoint>.isDrawableSegment() = size >= 2
 
 /**
- * Compose the route's polylines when [segment] is highlighted: the route [base] upstream of the boarding
- * point drawn as the selected line's approach, then the rider's [itineraryContext], then the ridden segment
- * in [routeColor]. This order makes the visual hierarchy match the semantics: where the vehicle comes from,
- * the committed journey, the current leg. Without a drawable segment, retains the ordinary plain-route
- * ordering: itinerary context beneath [base], with no approach restyle or selected overlay.
+ * One route's share of a ride the rider drilled into — the board→alight span of a single itinerary leg.
  *
- * The segment keeps [ITINERARY_RIDE_WIDTH_PROFILE] — the very weight it had as a leg of the itinerary it
- * was tapped from — and says it is the selected one with a case rather than by out-widening its
- * surroundings (#2082). Its approach carries the same case, so the two read as one route line stepping down
- * where the rider boards. Neither carries direction chevrons (#2129): like every other itinerary line, the
- * ride is marked selected by its case and weight alone.
+ * A ride is a list of these rather than one polyline because a stay-aboard interline (#2000) is one ride on
+ * *several* routes: the vehicle carries on but its route changes underneath the rider. Drawn as a single
+ * line, such a ride had to pick one route's colour for the whole thing and had no interior to mark, so the
+ * cutover the itinerary map shows (#2127) vanished the moment the rider tapped in to look closer. Split, each
+ * span takes its own route's colour and the seam is an end again — which is where a [RouteLineMark] goes.
+ *
+ * [routeId] is the OBA route id the span is ridden as (null when it couldn't be resolved), used to colour it;
+ * [startsCutover] is true when the vehicle *changed route* onto this span, straight off the same
+ * `Interlines.chains` transitions the drawer and the itinerary map read, so all three mark the same joins. A
+ * self-interline — one route reversing onto itself — is a span boundary with no cutover, exactly as it is a
+ * seam the drawer announces nothing at.
+ */
+data class RiddenSpan(
+    val points: List<GeoPoint>,
+    val routeId: String? = null,
+    val startsCutover: Boolean = false
+)
+
+/** The whole ride as one path, for the questions that are about the ride and not about its routes: where
+ *  the rider boards and alights, what to frame, which stops are on it. */
+internal fun List<RiddenSpan>.riddenPath(): List<GeoPoint> = flatMap { it.points }
+
+/**
+ * Compose the route's polylines when [spans] are highlighted: the route [base] upstream of the boarding
+ * point drawn as the selected line's approach, then the rider's [itineraryContext], then the ridden span(s),
+ * each in the colour [colorOf] gives it. This order makes the visual hierarchy match the semantics: where
+ * the vehicle comes from, the committed journey, the current leg. Without a drawable span, retains the
+ * ordinary plain-route ordering: itinerary context beneath [base], with no approach restyle or selected
+ * overlay.
+ *
+ * The ride keeps [ITINERARY_RIDE_WIDTH_PROFILE] — the very weight it had as a leg of the itinerary it was
+ * tapped from — and says it is the selected one with a case rather than by out-widening its surroundings
+ * (#2082). Its approach carries the same case, so the two read as one route line stepping down where the
+ * rider boards. Neither carries direction chevrons (#2129): like every other itinerary line, the ride is
+ * marked selected by its case and weight alone.
+ *
+ * A span the vehicle changed route onto is cut at its start ([RiddenSpan.startsCutover]), the same mark the
+ * itinerary map rules across that join — so drilling into an interlined ride shows the rider *more* about it,
+ * rather than losing the one thing that said the route changes mid-ride.
  */
 internal fun routePolylinesWithSegment(
     base: List<RoutePolyline>,
-    segment: List<GeoPoint>,
-    routeColor: Int?,
+    spans: List<RiddenSpan>,
+    colorOf: (RiddenSpan) -> Int?,
     itineraryContext: List<RoutePolyline> = emptyList()
 ): List<RoutePolyline> {
-    val overlay = segment.takeIf { it.isDrawableSegment() }?.let {
-        RoutePolyline(color = routeColor, points = it, widthProfile = ITINERARY_RIDE_WIDTH_PROFILE)
-            .withCase()
-    } ?: return itineraryContext + base
+    val overlay = spans.filter { it.points.isDrawableSegment() }.map { span ->
+        RoutePolyline(
+            color = colorOf(span),
+            points = span.points,
+            widthProfile = ITINERARY_RIDE_WIDTH_PROFILE,
+            startMark = if (span.startsCutover) RouteLineMark.INTERLINE_CUT else RouteLineMark.NONE
+        ).withCase()
+    }
+    if (overlay.isEmpty()) return itineraryContext + base
     return base.asSelectedRouteApproach() + itineraryContext + overlay
 }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/ShowRouteRequest.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/ShowRouteRequest.kt
@@ -15,8 +15,6 @@
  */
 package org.onebusaway.android.map
 
-import org.onebusaway.android.util.GeoPoint
-
 /**
  * The intent to show a route on the map — the single payload every "show route on map" launcher builds
  * and both UI transports carry opaquely (the navigation reveal in `MapReveal` and the home
@@ -36,9 +34,10 @@ import org.onebusaway.android.util.GeoPoint
  * @property initialDirectionId when non-null (a route-continuation or adjacency-badge tap), the GTFS
  *   direction to show instead of the route's default — validated against the loaded route's directions
  *   by [RouteMapController], falling back to the default when it doesn't match.
- * @property highlightedSegment when non-empty (a trip-plan transit leg drilled into route focus), the
- *   polyline of the board→alight portion the user rides — drawn as a thick line over the full route so
- *   the traveled segment stands out. Empty for every non-directions "show route" caller.
+ * @property riddenSpans when non-empty (a trip-plan transit leg drilled into route focus), the board→alight
+ *   portion the user rides — drawn as a thick line over the full route so the traveled segment stands out.
+ *   One [RiddenSpan] per route the ride is taken on, which is one for an ordinary leg and several across a
+ *   stay-aboard interline. Empty for every non-directions "show route" caller.
  * @property extraSegments route/directions shown alongside the primary route: stay-aboard continuations
  *   (#2000) and interchangeable routes (#2042). Each relationship controls whether vehicles remain
  *   visible across a seam or are filtered to the segment's resolved direction.
@@ -48,6 +47,6 @@ data class ShowRouteRequest(
     val directionStopId: String? = null,
     val focusTripId: String? = null,
     val initialDirectionId: Int? = null,
-    val highlightedSegment: List<GeoPoint> = emptyList(),
+    val riddenSpans: List<RiddenSpan> = emptyList(),
     val extraSegments: List<RouteFocusSegment> = emptyList()
 )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/GeoMath.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/GeoMath.kt
@@ -16,6 +16,7 @@
 package org.onebusaway.android.map.render
 
 import org.onebusaway.android.util.GeoPoint
+import org.onebusaway.android.util.Polyline
 import org.onebusaway.android.util.haversineDistance
 import org.onebusaway.android.util.initialBearing
 
@@ -46,16 +47,11 @@ private const val LEADING_BEARING_WINDOW_METERS = 20.0
  */
 internal fun leadingBearing(points: List<GeoPoint>): Float? {
     val start = points.firstOrNull() ?: return null
-    var travelled = 0.0
-    var ahead: GeoPoint? = null
-    for (index in 1 until points.size) {
-        travelled += haversineMeters(points[index - 1], points[index])
-        ahead = points[index]
-        if (travelled >= LEADING_BEARING_WINDOW_METERS) break
-    }
-    val end = ahead ?: return null
-    if (haversineMeters(start, end) <= 0.0) return null
-    return ((initialBearing(start.latitude, start.longitude, end.latitude, end.longitude) + 360) % 360).toFloat()
+    // [Polyline] owns walking a distance along a shape, and clamps to the end of a line shorter than the
+    // window — which is the right answer here: a short line's whole direction is its leading one.
+    val ahead = Polyline(points).interpolate(LEADING_BEARING_WINDOW_METERS) ?: return null
+    if (haversineMeters(start, ahead) <= 0.0) return null
+    return ((initialBearing(start.latitude, start.longitude, ahead.latitude, ahead.longitude) + 360) % 360).toFloat()
 }
 
 /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/GeoMath.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/GeoMath.kt
@@ -17,6 +17,7 @@ package org.onebusaway.android.map.render
 
 import org.onebusaway.android.util.GeoPoint
 import org.onebusaway.android.util.haversineDistance
+import org.onebusaway.android.util.initialBearing
 
 /**
  * Great-circle distance in meters between two points. Takes flavor-neutral [GeoPoint]s and delegates
@@ -24,6 +25,38 @@ import org.onebusaway.android.util.haversineDistance
  * Earth radius); neither carries an Android dependency, so callers stay pure / JVM-testable.
  */
 fun haversineMeters(a: GeoPoint, b: GeoPoint): Double = haversineDistance(a.latitude, a.longitude, b.latitude, b.longitude)
+
+/**
+ * How much of a line's start [leadingBearing] reads its direction over. A decoded shape's first vertices
+ * can be a metre apart, or duplicated outright, so the first segment alone is a noisy answer to "which way
+ * does this line leave here"; a window a few vertices deep gives the direction of the line rather than of
+ * its first hop. Short enough that it is still the *local* direction at the start — a line that turns a
+ * corner within this distance is turning at the point being marked.
+ */
+private const val LEADING_BEARING_WINDOW_METERS = 20.0
+
+/**
+ * The direction of travel where [points] begins, in compass degrees (0 = north, clockwise), measured as the
+ * chord over the first [LEADING_BEARING_WINDOW_METERS] of the line. Null when that window holds no direction
+ * at all (an empty or single-point line, or one whose vertices all coincide), which is a line no mark can be
+ * oriented against rather than a value to guess at.
+ *
+ * A renderer that anchors a symbol to a line's start uses this to orient it (the maplibre interline seam
+ * mark, #2127); the gms flavor gets the same orientation from the SDK, which aligns a line cap itself.
+ */
+internal fun leadingBearing(points: List<GeoPoint>): Float? {
+    val start = points.firstOrNull() ?: return null
+    var travelled = 0.0
+    var ahead: GeoPoint? = null
+    for (index in 1 until points.size) {
+        travelled += haversineMeters(points[index - 1], points[index])
+        ahead = points[index]
+        if (travelled >= LEADING_BEARING_WINDOW_METERS) break
+    }
+    val end = ahead ?: return null
+    if (haversineMeters(start, end) <= 0.0) return null
+    return ((initialBearing(start.latitude, start.longitude, end.latitude, end.longitude) + 360) % 360).toFloat()
+}
 
 /**
  * Web-Mercator ground resolution at zoom 0 on the equator, in meters per pixel (256px tiles). Scale to

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/InterlineSeamMark.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/InterlineSeamMark.kt
@@ -49,9 +49,9 @@ object InterlineSeamMark {
      */
     const val REFERENCE_WIDTH_PX = 60f
 
-    // Twice the reference width, so the slash has room to overhang the line on both sides. The line's own
-    // edges sit a quarter and three quarters of the way across.
-    private const val BITMAP_PX = 120
+    // Twice the reference width, so the slash has room to overhang the line on both sides: the line's own
+    // edges then sit a quarter and three quarters of the way across the bitmap.
+    private const val BITMAP_PX = REFERENCE_WIDTH_PX * 2f
 
     // How far the slash reaches from the line's centre, as a multiple of the line's width. Past 0.5 it
     // overhangs the corridor, which is what makes the cut legible against a line of the same weight.
@@ -75,7 +75,7 @@ object InterlineSeamMark {
      * renderer anchors it to.
      */
     fun bitmap(color: Int): Bitmap {
-        val bitmap = createBitmap(BITMAP_PX, BITMAP_PX)
+        val bitmap = createBitmap(BITMAP_PX.toInt(), BITMAP_PX.toInt())
         val centre = BITMAP_PX / 2f
         val halfLength = REFERENCE_WIDTH_PX * HALF_LENGTH_SCALE
         // Across the line, and along it: the tilt splits the slash's reach between the two axes.

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/InterlineSeamMark.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/InterlineSeamMark.kt
@@ -19,8 +19,7 @@ import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.Paint
 import androidx.core.graphics.createBitmap
-import kotlin.math.cos
-import kotlin.math.sin
+import kotlin.math.tan
 
 /**
  * The mark drawn across a route line where a stay-aboard interline changes route (#2127) — the cutover
@@ -29,15 +28,17 @@ import kotlin.math.sin
  * rotated symbol (whose classic polyline annotation has no configurable cap — the same gap
  * `MapLibreRouteEndpointBulbLayer` fills for the endpoint bulbs).
  *
- * Drawn as a **slash**, not a bar or a bulb, and that is the whole point of the mark. The rider already
- * reads a round bulb at each end of a ride, so a bulb-to-bulb join means "get off here and board there";
- * a stay-aboard route change is the opposite instruction and must not look like a near-miss of one. A
- * stroke cut diagonally across the corridor reads as one line ruled through rather than two lines meeting
- * — the [45]  \  [75] the issue asks for.
+ * It is the **casing of a mitred joint**: the hairline you would see where two route lines are mitred
+ * together at an angle, drawn in the line's own case colour and reaching exactly its two edges — nothing
+ * added on top of the corridor, just the seam in it made visible. That is why it is a diagonal and not a
+ * blunt perpendicular bar: a perpendicular end is what the rider reads as a line *stopping*, which is the
+ * one thing a stay-aboard route change must not look like. (A bulb pair already means "get off here and
+ * board there"; this is the opposite instruction.)
  *
  * Sized against a **reference stroke width** ([REFERENCE_WIDTH_PX]) rather than in dp: both renderers scale
  * the bitmap by the width of the line it cuts, so the mark keeps its proportions against that line at every
- * zoom rather than needing a schedule (or a camera-settle re-stamp) of its own.
+ * zoom rather than needing a schedule (or a camera-settle re-stamp) of its own. Its own weight is therefore
+ * proportional too — see [STROKE_DP_AT_FULL_WIDTH] for what that costs at a receded zoom.
  */
 object InterlineSeamMark {
 
@@ -49,26 +50,36 @@ object InterlineSeamMark {
      */
     const val REFERENCE_WIDTH_PX = 60f
 
-    // Twice the reference width, so the slash has room to overhang the line on both sides: the line's own
-    // edges then sit a quarter and three quarters of the way across the bitmap.
+    // Square, with room for the tilted slash and its stroke to be drawn without clipping. Only
+    // [REFERENCE_WIDTH_PX] decides how the bitmap maps onto a line's width, so the surplus is transparent
+    // margin and costs nothing but the (cached, once-per-colour) allocation.
     private const val BITMAP_PX = REFERENCE_WIDTH_PX * 2f
 
-    // How far the slash reaches from the line's centre, as a multiple of the line's width. Past 0.5 it
-    // overhangs the corridor, which is what makes the cut legible against a line of the same weight.
-    private const val HALF_LENGTH_SCALE = 0.85f
-
-    // How far the slash leans off perpendicular. Perpendicular would read as the blunt end of a line — the
-    // very thing the mark is drawn to not look like; the lean is what says "ruled through".
+    // How far the slash leans off perpendicular. The lean is what makes it read as a mitre rather than as
+    // the end of a line, and it is the reason the two routes' spans look joined at an angle rather than
+    // butted together.
     private const val TILT_DEGREES = 30.0
 
-    // The slash's own weight, as a multiple of the line's width: heavy enough to hold at an overview zoom,
-    // light enough to leave the line either side of it readable as one continuous ride.
-    private const val STROKE_SCALE = 0.3f
+    /**
+     * The mark's weight where the line it cuts is at its full width, which for every line that carries one
+     * today is [ITINERARY_RIDE_WIDTH_PROFILE]'s close-zoom thickness. A hairline, in the same family as the
+     * cases around these lines ([RouteLineCase.OUTLINE] is 0.75dp per side, [RouteLineCase.SELECTION] 1.5dp)
+     * — because that is what it is: the casing of the joint, not a symbol laid over the corridor.
+     *
+     * Expressed as a ratio of the line's width rather than in absolute dp, since the bitmap scales as a
+     * whole. So the mark thins with its line as the camera pulls back — down to half this at the far end of
+     * the detail ramp. A case proper deliberately does *not* thin (see [RouteLineCase]); this one does,
+     * because holding a constant dp weight inside a uniformly-scaled bitmap would mean re-rasterizing the
+     * cap on every camera settle. At overview zoom the ride is 7.5dp of a trip drawn whole, and a seam
+     * receding with it reads correctly there.
+     */
+    private const val STROKE_DP_AT_FULL_WIDTH = 1f
+
+    private val STROKE_SCALE = STROKE_DP_AT_FULL_WIDTH / ITINERARY_RIDE_WIDTH_PROFILE.thicknessDp
 
     /**
      * The slash bitmap in [color] — the cut line's own case colour, resolved by the renderer against the
-     * current theme, so the mark separates itself from the corridor exactly as the ride's hairline case
-     * separates that corridor from the basemap (see `mapRouteLineCaseColor`).
+     * current theme, so the seam is cased exactly as the corridor around it is (see `mapRouteLineCaseColor`).
      *
      * Drawn for a line running *up* the bitmap (both SDKs orient a line-anchored symbol along the travel
      * direction), and symmetric under a half turn — so it reads the same whichever end of the join a
@@ -77,10 +88,12 @@ object InterlineSeamMark {
     fun bitmap(color: Int): Bitmap {
         val bitmap = createBitmap(BITMAP_PX.toInt(), BITMAP_PX.toInt())
         val centre = BITMAP_PX / 2f
-        val halfLength = REFERENCE_WIDTH_PX * HALF_LENGTH_SCALE
-        // Across the line, and along it: the tilt splits the slash's reach between the two axes.
-        val across = (halfLength * cos(Math.toRadians(TILT_DEGREES))).toFloat()
-        val along = (halfLength * sin(Math.toRadians(TILT_DEGREES))).toFloat()
+        // The slash stops at the line's two edges — half a line width either side of its centre. Its length
+        // follows from the tilt rather than being its own knob: what has to be exact is where it *ends*, and
+        // a mitre's casing ends on the edge it mitres. Butt caps for the same reason (a round cap would
+        // bulge half a stroke past it).
+        val across = REFERENCE_WIDTH_PX / 2f
+        val along = (across * tan(Math.toRadians(TILT_DEGREES))).toFloat()
         Canvas(bitmap).drawLine(
             centre - across,
             centre - along,
@@ -90,7 +103,7 @@ object InterlineSeamMark {
                 this.color = color
                 style = Paint.Style.STROKE
                 strokeWidth = REFERENCE_WIDTH_PX * STROKE_SCALE
-                strokeCap = Paint.Cap.ROUND
+                strokeCap = Paint.Cap.BUTT
             }
         )
         return bitmap

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/InterlineSeamMark.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/InterlineSeamMark.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.map.render
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Paint
+import androidx.core.graphics.createBitmap
+import kotlin.math.cos
+import kotlin.math.sin
+
+/**
+ * The mark drawn across a route line where a stay-aboard interline changes route (#2127) — the cutover
+ * point of [RoutePolyline.startSeam]. Resource-free and flavor-neutral, like [ContinuationBadgeBitmaps], so
+ * each renderer only has to wrap the [Bitmap]: on gms as a `CustomCap` on the line's start, on maplibre as a
+ * rotated symbol (whose classic polyline annotation has no configurable cap — the same gap
+ * `MapLibreRouteEndpointBulbLayer` fills for the endpoint bulbs).
+ *
+ * Drawn as a **slash**, not a bar or a bulb, and that is the whole point of the mark. The rider already
+ * reads a round bulb at each end of a ride, so a bulb-to-bulb join means "get off here and board there";
+ * a stay-aboard route change is the opposite instruction and must not look like a near-miss of one. A
+ * stroke cut diagonally across the corridor reads as one line ruled through rather than two lines meeting
+ * — the [45]  \  [75] the issue asks for.
+ *
+ * Sized against a **reference stroke width** ([REFERENCE_WIDTH_PX]) rather than in dp: both renderers scale
+ * the bitmap by the width of the line it cuts, so the mark keeps its proportions against that line at every
+ * zoom rather than needing a schedule (or a camera-settle re-stamp) of its own.
+ */
+object InterlineSeamMark {
+
+    /**
+     * The stroke width, in bitmap pixels, that [bitmap] is drawn for: a renderer scales the bitmap by
+     * `lineWidthPx / REFERENCE_WIDTH_PX`, which puts the corridor's two edges at ±half of this about the
+     * bitmap's centre. Deliberately a large value — the bitmap is rasterized once and cached, and a mark
+     * drawn at reference size would have to be scaled *up* on a dense screen at close zoom.
+     */
+    const val REFERENCE_WIDTH_PX = 60f
+
+    // Twice the reference width, so the slash has room to overhang the line on both sides. The line's own
+    // edges sit a quarter and three quarters of the way across.
+    private const val BITMAP_PX = 120
+
+    // How far the slash reaches from the line's centre, as a multiple of the line's width. Past 0.5 it
+    // overhangs the corridor, which is what makes the cut legible against a line of the same weight.
+    private const val HALF_LENGTH_SCALE = 0.85f
+
+    // How far the slash leans off perpendicular. Perpendicular would read as the blunt end of a line — the
+    // very thing the mark is drawn to not look like; the lean is what says "ruled through".
+    private const val TILT_DEGREES = 30.0
+
+    // The slash's own weight, as a multiple of the line's width: heavy enough to hold at an overview zoom,
+    // light enough to leave the line either side of it readable as one continuous ride.
+    private const val STROKE_SCALE = 0.3f
+
+    /**
+     * The slash bitmap in [color] — the cut line's own case colour, resolved by the renderer against the
+     * current theme, so the mark separates itself from the corridor exactly as the ride's hairline case
+     * separates that corridor from the basemap (see `mapRouteLineCaseColor`).
+     *
+     * Drawn for a line running *up* the bitmap (both SDKs orient a line-anchored symbol along the travel
+     * direction), and symmetric under a half turn — so it reads the same whichever end of the join a
+     * renderer anchors it to.
+     */
+    fun bitmap(color: Int): Bitmap {
+        val bitmap = createBitmap(BITMAP_PX, BITMAP_PX)
+        val centre = BITMAP_PX / 2f
+        val halfLength = REFERENCE_WIDTH_PX * HALF_LENGTH_SCALE
+        // Across the line, and along it: the tilt splits the slash's reach between the two axes.
+        val across = (halfLength * cos(Math.toRadians(TILT_DEGREES))).toFloat()
+        val along = (halfLength * sin(Math.toRadians(TILT_DEGREES))).toFloat()
+        Canvas(bitmap).drawLine(
+            centre - across,
+            centre - along,
+            centre + across,
+            centre + along,
+            Paint(Paint.ANTI_ALIAS_FLAG).apply {
+                this.color = color
+                style = Paint.Style.STROKE
+                strokeWidth = REFERENCE_WIDTH_PX * STROKE_SCALE
+                strokeCap = Paint.Cap.ROUND
+            }
+        )
+        return bitmap
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/InterlineSeamMark.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/InterlineSeamMark.kt
@@ -22,11 +22,11 @@ import androidx.core.graphics.createBitmap
 import kotlin.math.tan
 
 /**
- * The mark drawn across a route line where a stay-aboard interline changes route (#2127) — the cutover
- * point of [RoutePolyline.startSeam]. Resource-free and flavor-neutral, like [ContinuationBadgeBitmaps], so
- * each renderer only has to wrap the [Bitmap]: on gms as a `CustomCap` on the line's start, on maplibre as a
- * rotated symbol (whose classic polyline annotation has no configurable cap — the same gap
- * `MapLibreRouteEndpointBulbLayer` fills for the endpoint bulbs).
+ * The mark drawn across a route line where a stay-aboard interline changes route (#2127) — a
+ * [RouteLineMark.INTERLINE_CUT] on the line's [RoutePolyline.startMark]. Resource-free and flavor-neutral,
+ * like [ContinuationBadgeBitmaps], so each renderer only has to wrap the [Bitmap]: on gms as a `CustomCap`
+ * on the line's start, on maplibre as a rotated symbol (whose classic polyline annotation has no
+ * configurable cap — the same gap `MapLibreRouteEndpointBulbLayer` fills for the endpoint bulbs).
  *
  * It is the **casing of a mitred joint**: the hairline you would see where two route lines are mitred
  * together at an angle, drawn in the line's own case colour and reaching exactly its two edges — nothing

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/InterlineSeamMark.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/InterlineSeamMark.kt
@@ -62,7 +62,7 @@ object InterlineSeamMark {
 
     /**
      * The mark's weight where the line it cuts is at its full width, which for every line that carries one
-     * today is [ITINERARY_RIDE_WIDTH_PROFILE]'s close-zoom thickness. A hairline, in the same family as the
+     * today is [ITINERARY_RIDE_WIDTH_PROFILE]'s close-zoom thickness. A ruled line, in the same family as the
      * cases around these lines ([RouteLineCase.OUTLINE] is 0.75dp per side, [RouteLineCase.SELECTION] 1.5dp)
      * — because that is what it is: the casing of the joint, not a symbol laid over the corridor.
      *
@@ -73,7 +73,7 @@ object InterlineSeamMark {
      * cap on every camera settle. At overview zoom the ride is 7.5dp of a trip drawn whole, and a seam
      * receding with it reads correctly there.
      */
-    private const val STROKE_DP_AT_FULL_WIDTH = 1f
+    private const val STROKE_DP_AT_FULL_WIDTH = 2f
 
     private val STROKE_SCALE = STROKE_DP_AT_FULL_WIDTH / ITINERARY_RIDE_WIDTH_PROFILE.thicknessDp
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
@@ -136,6 +136,16 @@ enum class RouteLineCase(val widthDp: Float) {
  * segmented even when their agencies publish the same GTFS color. Separate ends let a stay-aboard
  * interline hide its internal seam while retaining bulbs at the beginning and end of the combined ride.
  *
+ * [startSeam] says this line *begins* at an interline cutover (#2127) — the point where the vehicle the
+ * rider is already aboard changes route mid-ride — and asks the renderer to cut across the line there.
+ * The mark is deliberately nothing like a bulb: a bulb-to-bulb join is two rides meeting at a stop, which
+ * the rider has to act on (get off, get on), and a stay-aboard route change must not be read as one. It goes
+ * exactly where the bulbs above are withheld — the ride runs on through this join, so the line does too, and
+ * the cut is the only thing saying the route it is drawn for changed here.
+ *
+ * Like [case], only the *request* lives here: the mark's colour and size are the renderer's, taken from the
+ * line's own colour and stroke width so the cut tones and scales with the line it interrupts.
+ *
  * [transforms] opts this line into renderer-bound geometry processing. Canonical [points] stay intact in
  * [MapRenderState] for framing and other consumers; both native adapters apply the requested transforms
  * only to the list they render. An empty set is a strict pass-through.
@@ -149,6 +159,7 @@ data class RoutePolyline(
     val case: RouteLineCase = RouteLineCase.NONE,
     val roundStartCap: Boolean = false,
     val roundEndCap: Boolean = false,
+    val startSeam: Boolean = false,
     val transforms: Set<RoutePolylineTransform> = emptySet()
 ) {
     /** The [color] to draw, applying the [DEFAULT_ROUTE_LINE_COLOR] fallback in one place for every renderer. */

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
@@ -105,6 +105,32 @@ enum class RouteLineCase(val widthDp: Float) {
 }
 
 /**
+ * How a line's end is finished — what the rider is being told happens to them there. One value per end
+ * ([RoutePolyline.startMark], [RoutePolyline.endMark]), because an end is one thing: these were two
+ * independent booleans while a cut end was the only alternative to a bulb, which let a producer ask for
+ * both at once and left each renderer to break the tie its own way.
+ *
+ *  - [NONE] — a flat cut, the ordinary route line, and every end of a line that runs on past this point.
+ *  - [BULB] — a circle at the end, twice the stroke width. Directions transit legs use these so consecutive
+ *    rides stay visibly segmented even when their agencies publish the same GTFS colour, and a bulb pair
+ *    therefore reads as "alight here, board there" — a join the rider has to act on.
+ *  - [INTERLINE_CUT] — the mark for a stay-aboard interline cutover (#2127), where the vehicle the rider is
+ *    already aboard changes route mid-ride: a slash ruled across the corridor ([InterlineSeamMark]).
+ *    Deliberately nothing like a bulb, since a route change the rider sits through must not read as the
+ *    alight-and-board a bulb pair means, and it goes exactly where the bulbs are withheld — the ride runs on
+ *    through the join, so the line does too, and the cut is the only thing saying the route changed here.
+ *
+ * A mark carries no colour or size: like [case], only the *request* lives here. A bulb takes its line's own
+ * colour, a cut its line's case colour, and both are sized from the line's stroke width — resolved by the
+ * renderer, which is also where the theme a case colour depends on is known.
+ */
+enum class RouteLineMark {
+    NONE,
+    BULB,
+    INTERLINE_CUT
+}
+
+/**
  * One route/itinerary polyline: an ordered list of points and an optional [color]. A null [color]
  * means "use the [DEFAULT_ROUTE_LINE_COLOR]" — choosing the fallback is a display decision, so producers
  * can pass a route's raw (possibly absent) GTFS color straight through and renderers draw [resolvedColor].
@@ -131,20 +157,9 @@ enum class RouteLineCase(val widthDp: Float) {
  * basemap flips with the theme, so its colour is the one route colour that has to be resolved against the
  * current theme at draw time (`mapRouteLineCaseColor`) rather than when the line is produced.
  *
- * [roundStartCap] and [roundEndCap] ask the renderer to finish that end with a circle rather than a
- * flat cut. Directions transit legs use these endpoint bulbs so consecutive rides remain visibly
- * segmented even when their agencies publish the same GTFS color. Separate ends let a stay-aboard
- * interline hide its internal seam while retaining bulbs at the beginning and end of the combined ride.
- *
- * [startSeam] says this line *begins* at an interline cutover (#2127) — the point where the vehicle the
- * rider is already aboard changes route mid-ride — and asks the renderer to cut across the line there.
- * The mark is deliberately nothing like a bulb: a bulb-to-bulb join is two rides meeting at a stop, which
- * the rider has to act on (get off, get on), and a stay-aboard route change must not be read as one. It goes
- * exactly where the bulbs above are withheld — the ride runs on through this join, so the line does too, and
- * the cut is the only thing saying the route it is drawn for changed here.
- *
- * Like [case], only the *request* lives here: the mark's colour and size are the renderer's, taken from the
- * line's own colour and stroke width so the cut tones and scales with the line it interrupts.
+ * [startMark] and [endMark] say how each end is finished — see [RouteLineMark] for what each one means to a
+ * rider. Marked per end rather than per line so a stay-aboard interline can hide its internal seam while
+ * keeping bulbs at the beginning and end of the combined ride.
  *
  * [transforms] opts this line into renderer-bound geometry processing. Canonical [points] stay intact in
  * [MapRenderState] for framing and other consumers; both native adapters apply the requested transforms
@@ -157,9 +172,8 @@ data class RoutePolyline(
     val directional: Boolean = false,
     val dash: RouteLineDash = RouteLineDash.NONE,
     val case: RouteLineCase = RouteLineCase.NONE,
-    val roundStartCap: Boolean = false,
-    val roundEndCap: Boolean = false,
-    val startSeam: Boolean = false,
+    val startMark: RouteLineMark = RouteLineMark.NONE,
+    val endMark: RouteLineMark = RouteLineMark.NONE,
     val transforms: Set<RoutePolylineTransform> = emptySet()
 ) {
     /** The [color] to draw, applying the [DEFAULT_ROUTE_LINE_COLOR] fallback in one place for every renderer. */

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/RoutePolylineReconciler.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/RoutePolylineReconciler.kt
@@ -138,20 +138,31 @@ class RoutePolylineReconciler<NativeLine>(
 }
 
 /**
- * The line model a case is drawn from: the same geometry and dash in the case [color], minus the travel
- * chevrons — a case is an outline, and stamping the arrows into it would only double the ones its own line
- * carries. Routed back through the renderer's ordinary line creation so a case inherits every line feature
- * (its dash rhythm, and on gms the cheap solid-colour draw path a non-directional line takes) rather than each
- * flavor rebuilding a parallel one that has to be kept in step.
+ * The line model a case is drawn from: a case is geometry, weight, dash and its own [color], and nothing
+ * else. Built field by field rather than `copy()`-minus-a-list so that is true by construction — a new
+ * [RoutePolyline] feature is then absent from a case unless someone adds it here, which is the safe default
+ * (a feature that quietly rode along would draw twice, once at each width). Routed back through the
+ * renderer's ordinary line creation so a case still inherits every *drawing* feature — its dash rhythm, and
+ * on gms the cheap solid-colour path a non-directional line takes — rather than each flavor rebuilding a
+ * parallel one that has to be kept in step.
  *
- * The interline cut ([RoutePolyline.startSeam]) drops out for the same reason the chevrons do, and one more:
- * it is already drawn *in* the case colour, so a copy of it stroked wider underneath would only fringe the
- * mark on the line above with a bigger version of itself. The endpoint bulbs deliberately stay — those are in
- * the line's own colour, so their case is a ring that reads exactly like the case around the line.
+ * Travel chevrons are the clearest thing left out: a case is an outline, and stamping the arrows into it
+ * would only double the ones its own line carries.
  */
-private fun RoutePolyline.asCase(color: Int) = copy(
+private fun RoutePolyline.asCase(color: Int) = RoutePolyline(
     color = color,
-    directional = false,
-    case = RouteLineCase.NONE,
-    startSeam = false
+    points = points,
+    widthProfile = widthProfile,
+    dash = dash,
+    startMark = startMark.asCaseMark(),
+    endMark = endMark.asCaseMark(),
+    transforms = transforms
 )
+
+/**
+ * What an end mark becomes on a case. A [RouteLineMark.BULB] stays — it is drawn in the line's own colour, so
+ * casing it is a ring that reads exactly like the case around the line it caps. An interline cut doesn't: it
+ * is *already* drawn in the case colour, so a wider copy of it underneath would only fringe the mark on the
+ * line above with a bigger version of itself.
+ */
+private fun RouteLineMark.asCaseMark() = if (this == RouteLineMark.BULB) this else RouteLineMark.NONE

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/RoutePolylineReconciler.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/RoutePolylineReconciler.kt
@@ -143,5 +143,15 @@ class RoutePolylineReconciler<NativeLine>(
  * carries. Routed back through the renderer's ordinary line creation so a case inherits every line feature
  * (its dash rhythm, and on gms the cheap solid-colour draw path a non-directional line takes) rather than each
  * flavor rebuilding a parallel one that has to be kept in step.
+ *
+ * The interline cut ([RoutePolyline.startSeam]) drops out for the same reason the chevrons do, and one more:
+ * it is already drawn *in* the case colour, so a copy of it stroked wider underneath would only fringe the
+ * mark on the line above with a bigger version of itself. The endpoint bulbs deliberately stay — those are in
+ * the line's own colour, so their case is a ring that reads exactly like the case around the line.
  */
-private fun RoutePolyline.asCase(color: Int) = copy(color = color, directional = false, case = RouteLineCase.NONE)
+private fun RoutePolyline.asCase(color: Int) = copy(
+    color = color,
+    directional = false,
+    case = RouteLineCase.NONE,
+    startSeam = false
+)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -770,7 +770,7 @@ fun HomeScreen(
                                                     onShowTrip = onShowTrip,
                                                     onEditReminder = onEditReminder,
                                                     onFocusVehicle = { request ->
-                                                        homeViewModel.focusDirectionsRouteVehicle(request, ride.legPoints)
+                                                        homeViewModel.focusDirectionsRouteVehicle(request, ride.routeLeg.riddenSpans)
                                                     }
                                                 )
                                             },

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -770,7 +770,7 @@ fun HomeScreen(
                                                     onShowTrip = onShowTrip,
                                                     onEditReminder = onEditReminder,
                                                     onFocusVehicle = { request ->
-                                                        homeViewModel.focusDirectionsRouteVehicle(request, ride.routeLeg.riddenSpans)
+                                                        homeViewModel.focusDirectionsRouteVehicle(request, ride.routeLeg, ride.legPoints)
                                                     }
                                                 )
                                             },

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
@@ -34,6 +34,7 @@ import kotlinx.coroutines.launch
 import org.onebusaway.android.directions.model.TripItinerary
 import org.onebusaway.android.location.LocationRepository
 import org.onebusaway.android.map.ItineraryPins
+import org.onebusaway.android.map.RiddenSpan
 import org.onebusaway.android.map.RouteFocusRelationship
 import org.onebusaway.android.map.RouteFocusSegment
 import org.onebusaway.android.map.ShowRouteRequest
@@ -715,7 +716,7 @@ class HomeViewModel @Inject constructor(
         }
         focusItineraryRouteLegOnMap(
             routeId,
-            segment = fallbackLeg.points,
+            spans = routeLeg.riddenSpans(fallbackLeg),
             directionStopId = routeLeg.board?.stopId,
             extraSegments = routeLeg.extraSegments + alternativeSegments
         )
@@ -725,20 +726,28 @@ class HomeViewModel @Inject constructor(
      * A pill tap in a directions leg's inline ETA strip: enter that leg's route focus and focus/animate/
      * ping the tapped trip's live vehicle — [request] already carries the route, direction-anchor stop,
      * and focusTripId (built by the shared arrivals handler), so this just rides the same ShowRoute path
-     * as the arrivals drawer, adding the traveled [segment] over the route.
+     * as the arrivals drawer, adding the traveled ride ([spans]) over the route.
      */
-    fun focusDirectionsRouteVehicle(request: ShowRouteRequest, segment: List<GeoPoint>) {
-        enterDirectionsRouteFocus(request.copy(highlightedSegment = segment))
+    fun focusDirectionsRouteVehicle(request: ShowRouteRequest, spans: List<RiddenSpan>) {
+        enterDirectionsRouteFocus(request.copy(riddenSpans = spans))
     }
 
     /**
-     * Recontextualizes the map onto [routeId] with the traveled [segment] drawn thick over it, and
+     * The ride to draw over the route, preferring the per-route spans the leg was built with (#2127) and
+     * falling back to the tapped row's own joined geometry as a single span. The fallback covers a ride
+     * whose ref carries no spans at all — an OTP1 plan, or a leg the results repository couldn't resolve —
+     * where one undivided span is exactly what the map drew before there were spans to divide.
+     */
+    private fun RouteLegRef.riddenSpans(fallbackLeg: FocusedLeg): List<RiddenSpan> = riddenSpans.ifEmpty { listOf(RiddenSpan(fallbackLeg.points)) }
+
+    /**
+     * Recontextualizes the map onto [routeId] with the traveled ride ([spans]) drawn thick over it, and
      * records the overview as the back target so a map-background tap (or Back) returns to the itinerary.
      * Ids are already OBA-format.
      */
     fun focusItineraryRouteLegOnMap(
         routeId: String,
-        segment: List<GeoPoint> = emptyList(),
+        spans: List<RiddenSpan> = emptyList(),
         directionStopId: String? = null,
         directionId: Int? = null,
         extraSegments: List<RouteFocusSegment> = emptyList(),
@@ -749,7 +758,7 @@ class HomeViewModel @Inject constructor(
                 routeId = routeId,
                 directionStopId = directionStopId,
                 initialDirectionId = directionId,
-                highlightedSegment = segment,
+                riddenSpans = spans,
                 extraSegments = extraSegments
             ),
             undoViewport

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
@@ -716,7 +716,7 @@ class HomeViewModel @Inject constructor(
         }
         focusItineraryRouteLegOnMap(
             routeId,
-            spans = routeLeg.riddenSpans(fallbackLeg),
+            spans = routeLeg.riddenSpansOr(fallbackLeg.points),
             directionStopId = routeLeg.board?.stopId,
             extraSegments = routeLeg.extraSegments + alternativeSegments
         )
@@ -726,19 +726,26 @@ class HomeViewModel @Inject constructor(
      * A pill tap in a directions leg's inline ETA strip: enter that leg's route focus and focus/animate/
      * ping the tapped trip's live vehicle — [request] already carries the route, direction-anchor stop,
      * and focusTripId (built by the shared arrivals handler), so this just rides the same ShowRoute path
-     * as the arrivals drawer, adding the traveled ride ([spans]) over the route.
+     * as the arrivals drawer, adding the ride [routeLeg] is travelled on over the route. Takes the same
+     * ref-plus-fallback pair the drawer's leg tap does, so a pill and the leg card it sits in draw the
+     * same ride.
      */
-    fun focusDirectionsRouteVehicle(request: ShowRouteRequest, spans: List<RiddenSpan>) {
-        enterDirectionsRouteFocus(request.copy(riddenSpans = spans))
+    fun focusDirectionsRouteVehicle(
+        request: ShowRouteRequest,
+        routeLeg: RouteLegRef,
+        fallbackPoints: List<GeoPoint>
+    ) {
+        enterDirectionsRouteFocus(request.copy(riddenSpans = routeLeg.riddenSpansOr(fallbackPoints)))
     }
 
     /**
      * The ride to draw over the route, preferring the per-route spans the leg was built with (#2127) and
-     * falling back to the tapped row's own joined geometry as a single span. The fallback covers a ride
-     * whose ref carries no spans at all — an OTP1 plan, or a leg the results repository couldn't resolve —
-     * where one undivided span is exactly what the map drew before there were spans to divide.
+     * falling back to the tapped row's own joined geometry ([fallbackPoints]) as a single span. The fallback
+     * covers a ride whose ref carries no spans at all — an OTP1 plan, or a leg the results repository
+     * couldn't resolve — where one undivided span is exactly what the map drew before there were spans to
+     * divide.
      */
-    private fun RouteLegRef.riddenSpans(fallbackLeg: FocusedLeg): List<RiddenSpan> = riddenSpans.ifEmpty { listOf(RiddenSpan(fallbackLeg.points)) }
+    private fun RouteLegRef.riddenSpansOr(fallbackPoints: List<GeoPoint>): List<RiddenSpan> = riddenSpans.ifEmpty { listOf(RiddenSpan(fallbackPoints)) }
 
     /**
      * Recontextualizes the map onto [routeId] with the traveled ride ([spans]) drawn thick over it, and

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsRepository.kt
@@ -26,10 +26,12 @@ import org.onebusaway.android.directions.model.Interlines
 import org.onebusaway.android.directions.model.TripItinerary
 import org.onebusaway.android.directions.model.TripLeg
 import org.onebusaway.android.directions.model.TripPlace
+import org.onebusaway.android.directions.model.decodedPoints
 import org.onebusaway.android.directions.model.interchangeableRoutes
 import org.onebusaway.android.directions.model.routeDisplayName
 import org.onebusaway.android.directions.model.substitutableRoutes
 import org.onebusaway.android.directions.util.DirectionsGenerator
+import org.onebusaway.android.map.RiddenSpan
 import org.onebusaway.android.map.RouteFocusSegment
 import org.onebusaway.android.util.geoPointOrNull
 import org.onebusaway.android.util.runCatchingCancellable
@@ -133,6 +135,20 @@ class DefaultTripResultsRepository @Inject constructor(
                     directionHeadsign = legs[j].headsign
                 )
             }
+            // The ride's own geometry, one span per leg it is ridden as, in travel order — the map draws the
+            // drilled-into ride from these (#2127). Built here rather than by splitting the joined focus
+            // geometry later because this is where both halves are known at once: the leg's shape, and the
+            // OBA route id that colours it. `startsCutover` reads the same chain transitions the drawer's
+            // "stay on board" rows do, so the two mark one ride's route changes identically. A leg with no
+            // geometry contributes an empty span rather than being dropped — the spans stay aligned to the
+            // ride's legs, and the map skips one it can't draw.
+            val riddenSpans = (chain.leaderIndex..chain.alightIndex).map { j ->
+                RiddenSpan(
+                    points = legs[j].legGeometry?.decodedPoints().orEmpty(),
+                    routeId = otpObaIdResolver.obaRouteId(legs[j].routeId, legs[j].agencyId, legs[j].agencyName),
+                    startsCutover = j in chain.transitionLegIndices
+                )
+            }
             val alternatives = substitutable[chain.leaderIndex]
             refs[chain.leaderIndex] = RouteLegRef(
                 routeId = otpObaIdResolver.obaRouteId(leader.routeId, leader.agencyId, leader.agencyName),
@@ -141,6 +157,7 @@ class DefaultTripResultsRepository @Inject constructor(
                 alight = legs[chain.alightIndex].to.resolveStop(legs[chain.alightIndex]),
                 interlineTransitions = transitions,
                 extraSegments = extraSegments,
+                riddenSpans = riddenSpans,
                 alternatives = alternatives.map { it.resolve() },
                 // Kept separately from the joined badge: natural-name ordering means the joined form
                 // cannot identify which segment was planned, and same-named routes may collapse to one.

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
@@ -18,6 +18,7 @@ package org.onebusaway.android.ui.tripresults
 import androidx.annotation.StringRes
 import org.onebusaway.android.R
 import org.onebusaway.android.directions.model.TripMode
+import org.onebusaway.android.map.RiddenSpan
 import org.onebusaway.android.map.RouteFocusSegment
 import org.onebusaway.android.time.ServerTime
 import org.onebusaway.android.ui.compose.components.RouteBadge
@@ -395,6 +396,12 @@ data class RouteLegRef(
     // there. The map focus draws each segment's shape + stops and the shared vehicle across them.
     // Empty for an ordinary leg. Carried straight onto [org.onebusaway.android.map.ShowRouteRequest].
     val extraSegments: List<RouteFocusSegment> = emptyList(),
+    // The geometry the rider actually travels on this card, split at each route it is ridden as — one span
+    // for an ordinary leg, one per leg of a folded interline chain (#2000). Drawing the ride from these
+    // rather than from one joined polyline is what lets each span keep its own route's colour and lets the
+    // cutover between them be marked (#2127); built beside [extraSegments] from the same chain analysis, so
+    // the two can't disagree about where a ride changes route. Empty where no ref was resolved.
+    val riddenSpans: List<RiddenSpan> = emptyList(),
     val alternatives: List<AlternativeRouteRef> = emptyList(),
     val plannedBadge: RouteBadge? = null,
     val badge: LegBadge? = null

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreInterlineSeamLayer.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreInterlineSeamLayer.kt
@@ -30,19 +30,20 @@ import org.maplibre.geojson.Feature
 import org.maplibre.geojson.FeatureCollection
 import org.maplibre.geojson.Point
 import org.onebusaway.android.map.render.InterlineSeamMark
+import org.onebusaway.android.map.render.RouteLineMark
 import org.onebusaway.android.map.render.RoutePolyline
 import org.onebusaway.android.map.render.leadingBearing
 
 /**
- * Draws the interline cutover mark (#2127) across the start of every line that asks for one
- * ([RoutePolyline.startSeam]) — the maplibre counterpart of the gms flavor's `CustomCap`, which the classic
- * polyline annotation has no equivalent of. The same gap [MapLibreRouteEndpointBulbLayer] fills for the
- * endpoint bulbs, and rendered on the same schedule: features are rebuilt from the reconciled line list and
- * re-sized on each camera settle, since the mark is sized against the line's current stroke width.
+ * Draws the interline cutover mark (#2127) across every line end that asks for one
+ * ([RouteLineMark.INTERLINE_CUT]) — the maplibre counterpart of the gms flavor's `CustomCap`, which the
+ * classic polyline annotation has no equivalent of. The same gap [MapLibreRouteEndpointBulbLayer] fills for
+ * the endpoint bulbs, and rendered on the same schedule: features are rebuilt from the reconciled line list
+ * and re-sized on each camera settle, since the mark is sized against the line's current stroke width.
  *
  * A symbol rather than a circle, because unlike a bulb this mark has an orientation: it is rotated to the
- * line's own leading direction ([leadingBearing]) and rotates with the map, so the slash always crosses the
- * corridor rather than lying along it.
+ * line's own direction at that end ([leadingBearing]) and rotates with the map, so the slash always crosses
+ * the corridor rather than lying along it.
  *
  * [caseColorOf] resolves a line's case colour (theme-dependent, so it is read at draw time rather than
  * carried on the line) and [density] converts maplibre's dp line widths into the screen pixels the mark's
@@ -78,17 +79,24 @@ internal class MapLibreInterlineSeamLayer(
     }
 
     fun render(polylines: List<RoutePolyline>, widthOf: (RoutePolyline) -> Float) {
-        val features = polylines.mapNotNull { line ->
-            if (!line.startSeam) return@mapNotNull null
-            val point = line.points.firstOrNull() ?: return@mapNotNull null
-            // A line with no direction at its start has nothing to cross — see [leadingBearing].
-            val bearing = leadingBearing(line.points) ?: return@mapNotNull null
-            Feature.fromGeometry(Point.fromLngLat(point.longitude, point.latitude)).apply {
-                addStringProperty(IMAGE_PROPERTY, imageFor(caseColorOf(line)))
-                // The bitmap is drawn for a line [InterlineSeamMark.REFERENCE_WIDTH_PX] wide, so this puts
-                // the mark's own corridor on this line's actual stroke at the current zoom.
-                addNumberProperty(SIZE_PROPERTY, widthOf(line) * density / InterlineSeamMark.REFERENCE_WIDTH_PX)
-                addNumberProperty(BEARING_PROPERTY, bearing)
+        val features = polylines.flatMap { line ->
+            buildList {
+                // Read from whichever end is cut: the line's points run away from its start and *into* its
+                // end, so the far end's direction is read down the reversed list. That the two disagree by a
+                // half turn doesn't matter — the slash is symmetric under one (see [InterlineSeamMark]).
+                if (line.startMark == RouteLineMark.INTERLINE_CUT) add(line.points)
+                if (line.endMark == RouteLineMark.INTERLINE_CUT) add(line.points.asReversed())
+            }.mapNotNull { fromCutEnd ->
+                val point = fromCutEnd.firstOrNull() ?: return@mapNotNull null
+                // A line with no direction at that end has nothing to cross — see [leadingBearing].
+                val bearing = leadingBearing(fromCutEnd) ?: return@mapNotNull null
+                Feature.fromGeometry(Point.fromLngLat(point.longitude, point.latitude)).apply {
+                    addStringProperty(IMAGE_PROPERTY, imageFor(caseColorOf(line)))
+                    // The bitmap is drawn for a line [InterlineSeamMark.REFERENCE_WIDTH_PX] wide, so this
+                    // puts the mark's own corridor on this line's actual stroke at the current zoom.
+                    addNumberProperty(SIZE_PROPERTY, widthOf(line) * density / InterlineSeamMark.REFERENCE_WIDTH_PX)
+                    addNumberProperty(BEARING_PROPERTY, bearing)
+                }
             }
         }
         source.setGeoJson(FeatureCollection.fromFeatures(features))

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreInterlineSeamLayer.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreInterlineSeamLayer.kt
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.map.maplibre
+
+import org.maplibre.android.maps.Style
+import org.maplibre.android.style.expressions.Expression.get
+import org.maplibre.android.style.layers.Property
+import org.maplibre.android.style.layers.PropertyFactory.iconAllowOverlap
+import org.maplibre.android.style.layers.PropertyFactory.iconIgnorePlacement
+import org.maplibre.android.style.layers.PropertyFactory.iconImage
+import org.maplibre.android.style.layers.PropertyFactory.iconRotate
+import org.maplibre.android.style.layers.PropertyFactory.iconRotationAlignment
+import org.maplibre.android.style.layers.PropertyFactory.iconSize
+import org.maplibre.android.style.layers.SymbolLayer
+import org.maplibre.android.style.sources.GeoJsonSource
+import org.maplibre.geojson.Feature
+import org.maplibre.geojson.FeatureCollection
+import org.maplibre.geojson.Point
+import org.onebusaway.android.map.render.InterlineSeamMark
+import org.onebusaway.android.map.render.RoutePolyline
+import org.onebusaway.android.map.render.leadingBearing
+
+/**
+ * Draws the interline cutover mark (#2127) across the start of every line that asks for one
+ * ([RoutePolyline.startSeam]) — the maplibre counterpart of the gms flavor's `CustomCap`, which the classic
+ * polyline annotation has no equivalent of. The same gap [MapLibreRouteEndpointBulbLayer] fills for the
+ * endpoint bulbs, and rendered on the same schedule: features are rebuilt from the reconciled line list and
+ * re-sized on each camera settle, since the mark is sized against the line's current stroke width.
+ *
+ * A symbol rather than a circle, because unlike a bulb this mark has an orientation: it is rotated to the
+ * line's own leading direction ([leadingBearing]) and rotates with the map, so the slash always crosses the
+ * corridor rather than lying along it.
+ *
+ * [caseColorOf] resolves a line's case colour (theme-dependent, so it is read at draw time rather than
+ * carried on the line) and [density] converts maplibre's dp line widths into the screen pixels the mark's
+ * bitmap is measured in.
+ */
+internal class MapLibreInterlineSeamLayer(
+    private val style: Style,
+    private val density: Float,
+    private val caseColorOf: (RoutePolyline) -> Int
+) {
+    private val source = GeoJsonSource(SOURCE_ID, FeatureCollection.fromFeatures(emptyList<Feature>()))
+
+    // The colours whose slash bitmap is registered with the style. A style image can't be given per feature,
+    // only named by one, so each case colour that turns up gets its own — a handful per session (a directions
+    // plan has few rides, and a ride's colour survives a redraw), all released in [dispose].
+    private val registeredImages = HashSet<String>()
+
+    init {
+        style.addSource(source)
+        style.addLayer(
+            SymbolLayer(LAYER_ID, SOURCE_ID).withProperties(
+                iconImage(get(IMAGE_PROPERTY)),
+                iconSize(get(SIZE_PROPERTY)),
+                iconRotate(get(BEARING_PROPERTY)),
+                // Rotated with the map, not with the viewport: the mark's angle means "across this line".
+                iconRotationAlignment(Property.ICON_ROTATION_ALIGNMENT_MAP),
+                // The mark belongs to its line, so it is drawn wherever that line is — never dropped, and
+                // never displacing a label, the way an ordinary symbol's collision handling would.
+                iconAllowOverlap(true),
+                iconIgnorePlacement(true)
+            )
+        )
+    }
+
+    fun render(polylines: List<RoutePolyline>, widthOf: (RoutePolyline) -> Float) {
+        val features = polylines.mapNotNull { line ->
+            if (!line.startSeam) return@mapNotNull null
+            val point = line.points.firstOrNull() ?: return@mapNotNull null
+            // A line with no direction at its start has nothing to cross — see [leadingBearing].
+            val bearing = leadingBearing(line.points) ?: return@mapNotNull null
+            Feature.fromGeometry(Point.fromLngLat(point.longitude, point.latitude)).apply {
+                addStringProperty(IMAGE_PROPERTY, imageFor(caseColorOf(line)))
+                // The bitmap is drawn for a line [InterlineSeamMark.REFERENCE_WIDTH_PX] wide, so this puts
+                // the mark's own corridor on this line's actual stroke at the current zoom.
+                addNumberProperty(SIZE_PROPERTY, widthOf(line) * density / InterlineSeamMark.REFERENCE_WIDTH_PX)
+                addNumberProperty(BEARING_PROPERTY, bearing)
+            }
+        }
+        source.setGeoJson(FeatureCollection.fromFeatures(features))
+    }
+
+    fun dispose() {
+        style.removeLayer(LAYER_ID)
+        style.removeSource(SOURCE_ID)
+        registeredImages.forEach { style.removeImage(it) }
+        registeredImages.clear()
+    }
+
+    private fun imageFor(color: Int): String {
+        val id = "$IMAGE_ID_PREFIX$color"
+        if (registeredImages.add(id)) style.addImage(id, InterlineSeamMark.bitmap(color))
+        return id
+    }
+
+    private companion object {
+        const val SOURCE_ID = "oba-interline-seams-source"
+        const val LAYER_ID = "oba-interline-seams-layer"
+        const val IMAGE_ID_PREFIX = "oba-interline-seam-"
+        const val IMAGE_PROPERTY = "image"
+        const val SIZE_PROPERTY = "size"
+        const val BEARING_PROPERTY = "bearing"
+    }
+}

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
@@ -100,14 +100,22 @@ class MapLibreRenderer(
     private val renderState: MapRenderState
 ) : PingTarget {
     private val stopMarkerLayer = MapLibreStopMarkerLayer(map, context)
+
+    // A line's case colour, read at draw time rather than carried on the line: it follows the theme, because
+    // the basemap it separates its line from does (see [mapRouteLineCaseColor]). Shared by everything that
+    // draws in it — the case itself, and the interline cut, which is why they can't drift apart.
+    private val caseColorOf: (RoutePolyline) -> Int =
+        { mapRouteLineCaseColor(it.resolvedColor, ThemeUtils.isInDarkMode(context)) }
+
+    // The marks on a route line's ends, drawn as style layers because the classic polyline annotation has no
+    // configurable cap: the endpoint bulbs, and the interline cutover slashes (#2127). Rendered together
+    // (see [renderLineDecorations]) — both are sized from the line's stroke width, so both answer the camera.
     private val routeEndpointBulbLayer = MapLibreRouteEndpointBulbLayer(mapStyle)
 
-    // The interline cutover marks (#2127), sized and coloured from the lines they cut exactly as the bulbs
-    // above are — the same theme-resolved case colour the reconciler draws a line's own case in.
     private val interlineSeamLayer = MapLibreInterlineSeamLayer(
         mapStyle,
         context.resources.displayMetrics.density,
-        caseColorOf = { mapRouteLineCaseColor(it.resolvedColor, ThemeUtils.isInDarkMode(context)) }
+        caseColorOf = caseColorOf
     )
     private val bikeByMarker = HashMap<Marker, BikeMarker>()
 
@@ -162,9 +170,7 @@ class MapLibreRenderer(
         },
         removeLines = { lines -> map.removeAnnotations(lines) },
         setWidth = { line, width -> line.width = width },
-        // Resolved per line rather than once, and here rather than by the producer: a case's colour follows the
-        // theme, because the basemap it separates its line from does.
-        caseColorOf = { mapRouteLineCaseColor(it.resolvedColor, ThemeUtils.isInDarkMode(context)) },
+        caseColorOf = caseColorOf,
         // maplibre annotation widths are already in dp, so no density conversion is involved.
         caseExtraWidth = { it.case.extraWidthDp }
     )
@@ -326,8 +332,13 @@ class MapLibreRenderer(
     fun renderRoutePolylines(next: List<RoutePolyline> = renderState.snapshot.value.routePolylines) {
         val zoom = map.cameraPosition.zoom.toFloat()
         routePolylineReconciler.reconcile(next, zoom)
-        routeEndpointBulbLayer.render(next) { routeWidth(it, zoom) }
-        interlineSeamLayer.render(next) { routeWidth(it, zoom) }
+        renderLineDecorations(next, zoom)
+    }
+
+    /** Redraw the end marks of [lines] for a camera at [zoom] — see the decoration layers above. */
+    private fun renderLineDecorations(lines: List<RoutePolyline>, zoom: Float) {
+        routeEndpointBulbLayer.render(lines) { routeWidth(it, zoom) }
+        interlineSeamLayer.render(lines) { routeWidth(it, zoom) }
     }
 
     private fun PolylineOptions.addPoints(points: List<GeoPoint>): PolylineOptions {
@@ -337,9 +348,7 @@ class MapLibreRenderer(
 
     fun onCameraSettled(zoom: Float) {
         routePolylineReconciler.resyncWidths(zoom)
-        val lines = renderState.snapshot.value.routePolylines
-        routeEndpointBulbLayer.render(lines) { routeWidth(it, zoom) }
-        interlineSeamLayer.render(lines) { routeWidth(it, zoom) }
+        renderLineDecorations(renderState.snapshot.value.routePolylines, zoom)
         val detailScale = routeLineWidthScale(zoom)
         updateVehicleScale(detailScale)
         updateRouteBadgeScale(zoom)

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
@@ -101,6 +101,14 @@ class MapLibreRenderer(
 ) : PingTarget {
     private val stopMarkerLayer = MapLibreStopMarkerLayer(map, context)
     private val routeEndpointBulbLayer = MapLibreRouteEndpointBulbLayer(mapStyle)
+
+    // The interline cutover marks (#2127), sized and coloured from the lines they cut exactly as the bulbs
+    // above are — the same theme-resolved case colour the reconciler draws a line's own case in.
+    private val interlineSeamLayer = MapLibreInterlineSeamLayer(
+        mapStyle,
+        context.resources.displayMetrics.density,
+        caseColorOf = { mapRouteLineCaseColor(it.resolvedColor, ThemeUtils.isInDarkMode(context)) }
+    )
     private val bikeByMarker = HashMap<Marker, BikeMarker>()
 
     private val vehicleByMarker = HashMap<Marker, VehicleMarker>()
@@ -319,6 +327,7 @@ class MapLibreRenderer(
         val zoom = map.cameraPosition.zoom.toFloat()
         routePolylineReconciler.reconcile(next, zoom)
         routeEndpointBulbLayer.render(next) { routeWidth(it, zoom) }
+        interlineSeamLayer.render(next) { routeWidth(it, zoom) }
     }
 
     private fun PolylineOptions.addPoints(points: List<GeoPoint>): PolylineOptions {
@@ -328,7 +337,9 @@ class MapLibreRenderer(
 
     fun onCameraSettled(zoom: Float) {
         routePolylineReconciler.resyncWidths(zoom)
-        routeEndpointBulbLayer.render(renderState.snapshot.value.routePolylines) { routeWidth(it, zoom) }
+        val lines = renderState.snapshot.value.routePolylines
+        routeEndpointBulbLayer.render(lines) { routeWidth(it, zoom) }
+        interlineSeamLayer.render(lines) { routeWidth(it, zoom) }
         val detailScale = routeLineWidthScale(zoom)
         updateVehicleScale(detailScale)
         updateRouteBadgeScale(zoom)
@@ -355,6 +366,7 @@ class MapLibreRenderer(
         stopMarkerLayer.dispose()
         routeStopCircleLayer.dispose()
         routeEndpointBulbLayer.dispose()
+        interlineSeamLayer.dispose()
         // Clear the route lines first (removes them from the map), then mass-remove the rest.
         routePolylineReconciler.clear()
         map.removeAnnotations()

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRouteEndpointBulbLayer.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRouteEndpointBulbLayer.kt
@@ -11,6 +11,7 @@ import org.maplibre.android.style.sources.GeoJsonSource
 import org.maplibre.geojson.Feature
 import org.maplibre.geojson.FeatureCollection
 import org.maplibre.geojson.Point
+import org.onebusaway.android.map.render.RouteLineMark
 import org.onebusaway.android.map.render.RoutePolyline
 
 /** Draws screen-sized circular caps that MapLibre's classic polyline annotation cannot configure. */
@@ -29,10 +30,10 @@ internal class MapLibreRouteEndpointBulbLayer(private val style: Style) {
 
     fun render(polylines: List<RoutePolyline>, widthOf: (RoutePolyline) -> Float) {
         val features = polylines.flatMap { line ->
-            if ((!line.roundStartCap && !line.roundEndCap) || line.points.isEmpty()) return@flatMap emptyList()
+            if (line.points.isEmpty()) return@flatMap emptyList()
             buildList {
-                if (line.roundStartCap) add(line.points.first())
-                if (line.roundEndCap) add(line.points.last())
+                if (line.startMark == RouteLineMark.BULB) add(line.points.first())
+                if (line.endMark == RouteLineMark.BULB) add(line.points.last())
             }.distinct().map { point ->
                 Feature.fromGeometry(Point.fromLngLat(point.longitude, point.latitude)).apply {
                     addNumberProperty(RADIUS_PROPERTY, widthOf(line) * ENDPOINT_BULB_RADIUS_SCALE)

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/ItineraryLegStyleTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/ItineraryLegStyleTest.kt
@@ -94,14 +94,62 @@ class ItineraryLegStyleTest {
 
     @Test
     fun `an interline hides only the shared bulbs`() {
-        val first = TripLeg(mode = TripMode.BUS)
-        val continuation = TripLeg(mode = TripMode.RAIL, interlineWithPreviousLeg = true)
+        val first = TripLeg(mode = TripMode.BUS, routeId = "45")
+        val continuation = TripLeg(mode = TripMode.RAIL, routeId = "75", interlineWithPreviousLeg = true)
         val walk = TripLeg(mode = TripMode.WALK)
         val legs = listOf(first, continuation, walk)
+        val seams = interlineSeamLegs(legs)
 
-        assertEquals(ItineraryLegCaps(start = true, end = false), itineraryLegCaps(legs, 0))
-        assertEquals(ItineraryLegCaps(start = false, end = true), itineraryLegCaps(legs, 1))
-        assertEquals(ItineraryLegCaps(start = true, end = true), itineraryLegCaps(legs, 2))
+        assertEquals(ItineraryLegCaps(start = true, end = false), itineraryLegCaps(legs, 0, seams))
+        assertEquals(ItineraryLegCaps(start = false, end = true, startSeam = true), itineraryLegCaps(legs, 1, seams))
+        assertEquals(ItineraryLegCaps(start = true, end = true), itineraryLegCaps(legs, 2, seams))
+    }
+
+    @Test
+    fun `only a route change is cut, and it is cut where the drawer says stay on board`() {
+        // #2127: the rider's vehicle keeps going but its route changes, which no bulb can say — a bulb pair
+        // means alight and board. The cut goes on the leg continued *onto*, and only when the route really
+        // changed: a 12 reversing onto itself (a self-interline) leaves the ride unchanged, so there's
+        // nothing to mark, exactly as the drawer announces no transition for one.
+        val crossRoute = listOf(
+            TripLeg(mode = TripMode.BUS, routeId = "45"),
+            TripLeg(mode = TripMode.BUS, routeId = "75", interlineWithPreviousLeg = true)
+        )
+        val selfInterline = listOf(
+            TripLeg(mode = TripMode.BUS, routeId = "12"),
+            TripLeg(mode = TripMode.BUS, routeId = "12", interlineWithPreviousLeg = true)
+        )
+
+        assertEquals(setOf(1), interlineSeamLegs(crossRoute))
+        assertEquals(emptySet<Int>(), interlineSeamLegs(selfInterline))
+        // Two legs that name no route at all are the same route as far as anything can tell, so they are
+        // read as a self-interline — the exact-id rule [Interlines] states, not a second guess at it here.
+        assertEquals(
+            emptySet<Int>(),
+            interlineSeamLegs(listOf(TripLeg(mode = TripMode.BUS), TripLeg(mode = TripMode.RAIL, interlineWithPreviousLeg = true)))
+        )
+        // And nothing is cut where two separate rides meet — that join keeps its two bulbs.
+        assertEquals(
+            emptySet<Int>(),
+            interlineSeamLegs(listOf(TripLeg(mode = TripMode.BUS, routeId = "45"), TripLeg(mode = TripMode.BUS, routeId = "75")))
+        )
+    }
+
+    @Test
+    fun `a cut line is never also bulbed at that end`() {
+        // The two marks answer the same question — what happens to the rider at this join — so a line that
+        // carries both would be saying "stay aboard" and "get off" in one place.
+        val legs = listOf(
+            TripLeg(mode = TripMode.BUS, routeId = "45"),
+            TripLeg(mode = TripMode.BUS, routeId = "75", interlineWithPreviousLeg = true),
+            TripLeg(mode = TripMode.BUS, routeId = "8", interlineWithPreviousLeg = true)
+        )
+        val seams = interlineSeamLegs(legs)
+
+        legs.indices.forEach { index ->
+            val caps = itineraryLegCaps(legs, index, seams)
+            assertFalse("leg $index was both cut and bulbed", caps.startSeam && caps.start)
+        }
     }
 
     @Test

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/ItineraryLegStyleTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/ItineraryLegStyleTest.kt
@@ -16,6 +16,7 @@ import org.onebusaway.android.map.render.ITINERARY_RIDE_WIDTH_PROFILE
 import org.onebusaway.android.map.render.ITINERARY_STREET_WIDTH_PROFILE
 import org.onebusaway.android.map.render.RouteLineCase
 import org.onebusaway.android.map.render.RouteLineDash
+import org.onebusaway.android.map.render.RouteLineMark
 import org.onebusaway.android.map.render.RoutePolyline
 import org.onebusaway.android.util.ACHROMATIC_ROUTE_CHROMA
 import org.onebusaway.android.util.GeoPoint
@@ -97,12 +98,15 @@ class ItineraryLegStyleTest {
         val first = TripLeg(mode = TripMode.BUS, routeId = "45")
         val continuation = TripLeg(mode = TripMode.RAIL, routeId = "75", interlineWithPreviousLeg = true)
         val walk = TripLeg(mode = TripMode.WALK)
-        val legs = listOf(first, continuation, walk)
-        val seams = interlineSeamLegs(legs)
 
-        assertEquals(ItineraryLegCaps(start = true, end = false), itineraryLegCaps(legs, 0, seams))
-        assertEquals(ItineraryLegCaps(start = false, end = true, startSeam = true), itineraryLegCaps(legs, 1, seams))
-        assertEquals(ItineraryLegCaps(start = true, end = true), itineraryLegCaps(legs, 2, seams))
+        assertEquals(
+            listOf(
+                ItineraryLegCaps(start = true, end = false),
+                ItineraryLegCaps(start = false, end = true, startSeam = true),
+                ItineraryLegCaps(start = true, end = true)
+            ),
+            itineraryLegCaps(listOf(first, continuation, walk))
+        )
     }
 
     @Test
@@ -120,18 +124,18 @@ class ItineraryLegStyleTest {
             TripLeg(mode = TripMode.BUS, routeId = "12", interlineWithPreviousLeg = true)
         )
 
-        assertEquals(setOf(1), interlineSeamLegs(crossRoute))
-        assertEquals(emptySet<Int>(), interlineSeamLegs(selfInterline))
+        assertEquals(listOf(false, true), cutLegs(crossRoute))
+        assertEquals(listOf(false, false), cutLegs(selfInterline))
         // Two legs that name no route at all are the same route as far as anything can tell, so they are
         // read as a self-interline — the exact-id rule [Interlines] states, not a second guess at it here.
         assertEquals(
-            emptySet<Int>(),
-            interlineSeamLegs(listOf(TripLeg(mode = TripMode.BUS), TripLeg(mode = TripMode.RAIL, interlineWithPreviousLeg = true)))
+            listOf(false, false),
+            cutLegs(listOf(TripLeg(mode = TripMode.BUS), TripLeg(mode = TripMode.RAIL, interlineWithPreviousLeg = true)))
         )
         // And nothing is cut where two separate rides meet — that join keeps its two bulbs.
         assertEquals(
-            emptySet<Int>(),
-            interlineSeamLegs(listOf(TripLeg(mode = TripMode.BUS, routeId = "45"), TripLeg(mode = TripMode.BUS, routeId = "75")))
+            listOf(false, false),
+            cutLegs(listOf(TripLeg(mode = TripMode.BUS, routeId = "45"), TripLeg(mode = TripMode.BUS, routeId = "75")))
         )
     }
 
@@ -144,13 +148,14 @@ class ItineraryLegStyleTest {
             TripLeg(mode = TripMode.BUS, routeId = "75", interlineWithPreviousLeg = true),
             TripLeg(mode = TripMode.BUS, routeId = "8", interlineWithPreviousLeg = true)
         )
-        val seams = interlineSeamLegs(legs)
 
-        legs.indices.forEach { index ->
-            val caps = itineraryLegCaps(legs, index, seams)
+        itineraryLegCaps(legs).forEachIndexed { index, caps ->
             assertFalse("leg $index was both cut and bulbed", caps.startSeam && caps.start)
         }
     }
+
+    /** Which legs begin at an interline cutover, in leg order. */
+    private fun cutLegs(legs: List<TripLeg>) = itineraryLegCaps(legs).map { it.startSeam }
 
     @Test
     fun `on the basemap palette a ride keeps its agency's hue, at the map's own chroma and tone`() {
@@ -380,8 +385,8 @@ class ItineraryLegStyleTest {
                 widthProfile = style.widthProfile,
                 dash = style.dash,
                 case = style.case,
-                roundStartCap = style.roundCaps,
-                roundEndCap = style.roundCaps
+                startMark = if (style.roundCaps) RouteLineMark.BULB else RouteLineMark.NONE,
+                endMark = if (style.roundCaps) RouteLineMark.BULB else RouteLineMark.NONE
             )
         )
     }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteSegmentHighlightTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteSegmentHighlightTest.kt
@@ -28,6 +28,7 @@ import org.onebusaway.android.map.render.ITINERARY_CONTEXT_WIDTH_PROFILE
 import org.onebusaway.android.map.render.ITINERARY_RIDE_WIDTH_PROFILE
 import org.onebusaway.android.map.render.RouteLineCase
 import org.onebusaway.android.map.render.RouteLineDash
+import org.onebusaway.android.map.render.RouteLineMark
 import org.onebusaway.android.map.render.RoutePolyline
 import org.onebusaway.android.util.EARTH_RADIUS_METERS
 import org.onebusaway.android.util.GeoPoint
@@ -39,6 +40,9 @@ class RouteSegmentHighlightTest {
     private val segment = listOf(GeoPoint(47.60, -122.33), GeoPoint(47.62, -122.33))
 
     private fun stop(id: String, lat: Double, lon: Double) = ObaStopElement(id = id, lat = lat, lon = lon)
+
+    /** An ordinary ride: one route, so one span, cut nowhere. */
+    private fun ride(points: List<GeoPoint>) = listOf(RiddenSpan(points))
 
     /**
      * A point [meters] due east of ([lat], [lon]), so a tolerance test can state the distance it means
@@ -70,7 +74,7 @@ class RouteSegmentHighlightTest {
     @Test
     fun routePolylinesWithSegment_noSegment_returnsBaseUnchanged() {
         val base = listOf(RoutePolyline(color = 0xFF0000FF.toInt(), points = segment))
-        assertEquals(base, routePolylinesWithSegment(base, emptyList(), routeColor = 0xFF00FF00.toInt()))
+        assertEquals(base, routePolylinesWithSegment(base, emptyList(), colorOf = { 0xFF00FF00.toInt() }))
     }
 
     @Test
@@ -83,7 +87,7 @@ class RouteSegmentHighlightTest {
                 directional = true
             )
         )
-        val result = routePolylinesWithSegment(base, segment, routeColor = 0xFF00FF00.toInt())
+        val result = routePolylinesWithSegment(base, ride(segment), colorOf = { 0xFF00FF00.toInt() })
 
         assertEquals(2, result.size)
         // The approach steps down to its own thinnest itinerary weight, loses its arrows, and is solid rather
@@ -116,7 +120,7 @@ class RouteSegmentHighlightTest {
             )
         )
 
-        val result = routePolylinesWithSegment(base, segment, routeColor = 3, itineraryContext = journey)
+        val result = routePolylinesWithSegment(base, ride(segment), colorOf = { 3 }, itineraryContext = journey)
 
         assertEquals(listOf(1, 2, 3), result.map { it.color })
         assertEquals(ITINERARY_APPROACH_WIDTH_PROFILE, result[0].widthProfile)
@@ -128,6 +132,61 @@ class RouteSegmentHighlightTest {
         assertNotEquals(RouteLineCase.SELECTION, result[1].case)
         assertEquals(RouteLineCase.SELECTION, result[0].case)
         assertEquals(RouteLineCase.SELECTION, result[2].case)
+    }
+
+    @Test
+    fun routePolylinesWithSegment_drawsAnInterlinedRideAsOneSpanPerRoute_cutAtEachCutover() {
+        // #2127: one ride, two routes. Drawn as a single line it had to pick one route's colour for the
+        // whole thing and had no interior to mark, so the cutover the itinerary map shows disappeared the
+        // moment the rider tapped in. Each span now takes its own colour, and the seam is an end to cut.
+        val north = listOf(GeoPoint(47.60, -122.33), GeoPoint(47.62, -122.33))
+        val east = listOf(GeoPoint(47.62, -122.33), GeoPoint(47.62, -122.30))
+        val spans = listOf(
+            RiddenSpan(north, routeId = "45"),
+            RiddenSpan(east, routeId = "75", startsCutover = true)
+        )
+
+        val result = routePolylinesWithSegment(
+            base = emptyList(),
+            spans = spans,
+            colorOf = { if (it.routeId == "45") 45 else 75 }
+        )
+
+        assertEquals(listOf(45, 75), result.map { it.color })
+        // The cut goes on the span the vehicle *changed route onto*, and only there: the ride's own start
+        // is a boarding, which this view marks with the stop the rider gets on at.
+        assertEquals(listOf(RouteLineMark.NONE, RouteLineMark.INTERLINE_CUT), result.map { it.startMark })
+        // Both spans are still the selected ride: same weight, same case, no bulb between them — the
+        // rider does not get off here.
+        result.forEach {
+            assertEquals(ITINERARY_RIDE_WIDTH_PROFILE, it.widthProfile)
+            assertEquals(RouteLineCase.SELECTION, it.case)
+            assertEquals(RouteLineMark.NONE, it.endMark)
+        }
+    }
+
+    @Test
+    fun routePolylinesWithSegment_selfInterlineSpansAreNotCut() {
+        // The same route reversing onto itself: two spans, but nothing changed under the rider, so the
+        // boundary is silent — exactly as the drawer announces no transition for one.
+        val spans = listOf(
+            RiddenSpan(segment, routeId = "12"),
+            RiddenSpan(segment.reversed(), routeId = "12")
+        )
+
+        val result = routePolylinesWithSegment(emptyList(), spans, colorOf = { 12 })
+
+        assertTrue(result.all { it.startMark == RouteLineMark.NONE })
+    }
+
+    @Test
+    fun routePolylinesWithSegment_skipsASpanWithNoDrawableGeometry() {
+        // A leg that carried no shape draws nothing, and must not take the whole ride's overlay with it.
+        val spans = listOf(RiddenSpan(emptyList(), routeId = "45"), RiddenSpan(segment, routeId = "75"))
+
+        val result = routePolylinesWithSegment(emptyList(), spans, colorOf = { 7 })
+
+        assertEquals(listOf(segment), result.map { it.points })
     }
 
     @Test

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteViewGeometryTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteViewGeometryTest.kt
@@ -65,8 +65,8 @@ class RouteViewGeometryTest {
         // The ridden segment under a tapped route, drawn in the shown route's colour.
         val riddenSegment = routePolylinesWithSegment(
             base = emptyList(),
-            segment = listOf(GeoPoint(0.0, 0.0), GeoPoint(0.0, 1.0)),
-            routeColor = mapRouteLineColorOrNull(gtfs)
+            spans = listOf(RiddenSpan(listOf(GeoPoint(0.0, 0.0), GeoPoint(0.0, 1.0)))),
+            colorOf = { mapRouteLineColorOrNull(gtfs) }
         ).single().color
 
         assertEquals(mapRouteLineColorOrNull(gtfs), adjacencyLine)

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/render/GeoMathTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/render/GeoMathTest.kt
@@ -55,7 +55,10 @@ class GeoMathTest {
             GeoPoint(47.602, -122.29999)
         )
 
-        assertEquals(0f, leadingBearing(jitteryStart)!!, 1f)
+        // Not exactly 0: the first hop's 0.7 m of east survives in the chord, as ~2° over the 20 m window.
+        // That residue shrinking as the window grows is the whole mechanism — off the first hop alone this
+        // line reads due east.
+        assertEquals(0f, leadingBearing(jitteryStart)!!, 3f)
     }
 
     @Test

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/render/GeoMathTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/render/GeoMathTest.kt
@@ -16,10 +16,11 @@
 package org.onebusaway.android.map.render
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 import org.onebusaway.android.util.GeoPoint
 
-/** Unit tests for [haversineMeters] — the pure great-circle distance. */
+/** Unit tests for [haversineMeters] — the pure great-circle distance — and [leadingBearing]. */
 class GeoMathTest {
 
     @Test
@@ -32,5 +33,42 @@ class GeoMathTest {
         // 1° of latitude ≈ 111.2 km on a 6_371_010 m sphere.
         val d = haversineMeters(GeoPoint(0.0, 0.0), GeoPoint(1.0, 0.0))
         assertEquals(111_195.0, d, 50.0)
+    }
+
+    @Test
+    fun `a line's leading bearing is a compass heading`() {
+        // Due north and due east from the same origin, each far enough to fill the window.
+        assertEquals(0f, leadingBearing(listOf(GeoPoint(47.6, -122.3), GeoPoint(47.61, -122.3)))!!, BEARING_TOLERANCE)
+        assertEquals(90f, leadingBearing(listOf(GeoPoint(47.6, -122.3), GeoPoint(47.6, -122.29)))!!, BEARING_TOLERANCE)
+        // West is 270, not -90: the caller rotates a symbol by this, so the whole circle is positive.
+        assertEquals(270f, leadingBearing(listOf(GeoPoint(47.6, -122.3), GeoPoint(47.6, -122.31)))!!, BEARING_TOLERANCE)
+    }
+
+    @Test
+    fun `the direction is read over a window, not off the first hop`() {
+        // A decoded shape's first vertices can be centimetres apart and point anywhere. Here the first hop
+        // goes east and everything after it goes north; over the window the line is heading north.
+        val jitteryStart = listOf(
+            GeoPoint(47.6, -122.3),
+            GeoPoint(47.6, -122.29999), // ~0.7 m east
+            GeoPoint(47.601, -122.29999),
+            GeoPoint(47.602, -122.29999)
+        )
+
+        assertEquals(0f, leadingBearing(jitteryStart)!!, 1f)
+    }
+
+    @Test
+    fun `a line with no direction at its start reports none`() {
+        assertNull(leadingBearing(emptyList()))
+        assertNull(leadingBearing(listOf(GeoPoint(47.6, -122.3))))
+        // Every vertex on top of the first: there is no heading here to guess at.
+        assertNull(leadingBearing(List(3) { GeoPoint(47.6, -122.3) }))
+    }
+
+    private companion object {
+        // The window's chord is measured over a spherical earth; a degree of slack is far tighter than any
+        // difference that would matter to a mark drawn across a line.
+        const val BEARING_TOLERANCE = 0.5f
     }
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
@@ -180,6 +180,32 @@ class HomeViewModelTest {
         job.cancel()
     }
 
+    @Test
+    fun `focusing an ETA pill draws the same ride the leg card would, spans or fallback`() = runTest {
+        // An ETA pill enters the same route focus as the leg card it sits in, so it has to resolve the ride
+        // the same way: the ref's spans when it has them, and the row's own geometry as one span when it
+        // doesn't (an OTP1 plan, or a leg the repository couldn't resolve) — otherwise tapping a pill on an
+        // unresolved ride would drop the traveled line the leg tap draws.
+        val vm = viewModel()
+        val map = MapDirectiveRecorder(vm)
+        val job = launch { map.collect() }
+        advanceUntilIdle()
+        val spans = listOf(RiddenSpan(listOf(GeoPoint(47.60, -122.33), GeoPoint(47.62, -122.33)), routeId = "1_45"))
+        val legPoints = listOf(GeoPoint(47.55, -122.31), GeoPoint(47.58, -122.32))
+        val request = ShowRouteRequest(routeId = "1_45", focusTripId = "1_trip")
+        val ref = RouteLegRef(routeId = "1_45", headsign = "Downtown", board = null, alight = null)
+
+        vm.focusDirectionsRouteVehicle(request, ref.copy(riddenSpans = spans), legPoints)
+        vm.focusDirectionsRouteVehicle(request, ref, legPoints)
+        advanceUntilIdle()
+
+        assertEquals(
+            listOf(spans, listOf(RiddenSpan(legPoints))),
+            map.routeRequests.map { it.riddenSpans }
+        )
+        job.cancel()
+    }
+
     // A tapped on-street leg. Only [legIndices] distinguishes one from another to the focus model, so the
     // geometry is shared; [walkLeg] gives each test the leg it needs without restating the coordinates.
     private fun walkLeg(vararg legIndices: Int) = FocusedLeg(listOf(GeoPoint(47.6, -122.3), GeoPoint(47.61, -122.31)), legIndices.toSet())

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
@@ -29,6 +29,7 @@ import org.onebusaway.android.api.adapters.ObaStopElement
 import org.onebusaway.android.directions.model.TripItinerary
 import org.onebusaway.android.location.FakeLocationRepository
 import org.onebusaway.android.map.ItineraryPins
+import org.onebusaway.android.map.RiddenSpan
 import org.onebusaway.android.map.RouteFocusRelationship
 import org.onebusaway.android.map.RouteFocusSegment
 import org.onebusaway.android.map.ShowRouteRequest
@@ -134,7 +135,9 @@ class HomeViewModelTest {
             ShowRouteRequest(
                 routeId = "40_2LINE",
                 directionStopId = board.stopId,
-                highlightedSegment = points,
+                // No spans on the ref (this fixture resolves none), so the tapped row's own geometry
+                // stands in as one undivided span — what the map drew before rides had spans.
+                riddenSpans = listOf(RiddenSpan(points)),
                 extraSegments = listOf(
                     RouteFocusSegment(
                         "40_1LINE",
@@ -146,6 +149,34 @@ class HomeViewModelTest {
             ),
             map.routeRequests.single()
         )
+        job.cancel()
+    }
+
+    @Test
+    fun `focusing an interlined ride hands the map its per-route spans, not the joined geometry`() = runTest {
+        // #2127: the ride's own spans carry where it changes route, so drilling in can draw each route in
+        // its own colour and cut the line between them. The tapped row's joined geometry is only the
+        // fallback for a ride that resolved no spans at all.
+        val vm = viewModel()
+        val map = MapDirectiveRecorder(vm)
+        val job = launch { map.collect() }
+        advanceUntilIdle()
+        val spans = listOf(
+            RiddenSpan(listOf(GeoPoint(47.60, -122.33), GeoPoint(47.62, -122.33)), routeId = "1_45"),
+            RiddenSpan(listOf(GeoPoint(47.62, -122.33), GeoPoint(47.62, -122.30)), routeId = "1_75", startsCutover = true)
+        )
+        val routeLeg = RouteLegRef(
+            routeId = "1_45",
+            headsign = "Downtown",
+            board = null,
+            alight = null,
+            riddenSpans = spans
+        )
+
+        vm.focusItineraryRouteLeg(routeLeg, FocusedLeg(listOf(GeoPoint(0.0, 0.0), GeoPoint(1.0, 1.0)), setOf(1, 2)))
+        advanceUntilIdle()
+
+        assertEquals(spans, map.routeRequests.single().riddenSpans)
         job.cancel()
     }
 


### PR DESCRIPTION
## What changed

- Split an interlined ride into per-route map spans while keeping it focused as one ride.
- Generalized route-line endpoint marks and added an angled cutover slash at cross-route interline seams.
- Rendered the slash consistently in both Google Maps and MapLibre using the route casing color.
- Doubled the slash weight from 1 dp to 2 dp for better legibility.

## Why

A stay-aboard route change previously lacked a clear map transition. The slash makes the route-color cutover visible without suggesting that the rider should alight or reboard.

## Validation

- `./gradlew :onebusaway-android:compileObaGoogleDebugKotlin :onebusaway-android:compileObaMaplibreDebugKotlin`
- `./gradlew :onebusaway-android:assembleObaGoogleDebug`
- Installed and visually checked the OBA Google debug APK on the shared physical phone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved route highlighting for rides spanning multiple routes, with route-specific colors and geometry.
  * Added visual seam markers where interlined routes change.
  * Added refined endpoint styling for route lines, including bulbs and seam cuts.
  * Improved map framing and vehicle focus for interlined trips, with geometry fallbacks when needed.
* **Bug Fixes**
  * Prevented incorrect seam markers and endpoint bulbs on same-route interlines.
  * Improved route rendering consistency across supported map providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->